### PR TITLE
[Doc] Replace logo official link and update contrib doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center">
   <picture>
-    <!-- TODO: Replace tmp link to logo url after vllm-projects/vllm-ascend ready -->
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/4a958093-58b5-4772-a942-638b51ced646">
-    <img alt="vllm-ascend" src="https://github.com/user-attachments/assets/838afe2f-9a1d-42df-9758-d79b31556de0" width=55%>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm-ascend/main/docs/logos/vllm-ascend-logo-text-dark.png">
+    <img alt="vllm-ascend" src="https://raw.githubusercontent.com/vllm-project/vllm-ascend/main/docs/logos/vllm-ascend-logo-text-light.png" width=55%>
   </picture>
 </p>
 
@@ -143,6 +142,7 @@ The list here is a subset of the supported models. See [supported_models](docs/s
 
 ## Contributing
 We welcome and value any contributions and collaborations:
+- Please feel free comments [here](https://github.com/vllm-project/vllm-ascend/issues/19) about your usage of vLLM Ascend Plugin.
 - Please let us know if you encounter a bug by [filing an issue](https://github.com/vllm-project/vllm-ascend/issues).
 - Please see the guidance on how to contribute in [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,8 +1,7 @@
 <p align="center">
   <picture>
-    <!-- TODO: Replace tmp link to logo url after vllm-projects/vllm-ascend ready -->
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/4a958093-58b5-4772-a942-638b51ced646">
-    <img alt="vllm-ascend" src="https://github.com/user-attachments/assets/838afe2f-9a1d-42df-9758-d79b31556de0" width=55%>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm-ascend/main/docs/logos/vllm-ascend-logo-text-dark.png">
+    <img alt="vllm-ascend" src="https://raw.githubusercontent.com/vllm-project/vllm-ascend/main/docs/logos/vllm-ascend-logo-text-light.png" width=55%>
   </picture>
 </p>
 
@@ -144,8 +143,10 @@ docker build -t vllm-ascend-dev-image -f ./Dockerfile .
 
 ## 贡献
 我们欢迎并重视任何形式的贡献与合作：
+- 您可以在[这里](https://github.com/vllm-project/vllm-ascend/issues/19)反馈您的使用体验。
 - 请通过[提交问题](https://github.com/vllm-project/vllm-ascend/issues)来告知我们您遇到的任何错误。
 - 请参阅 [CONTRIBUTING.zh.md](./CONTRIBUTING.zh.md) 中的贡献指南。
+
 ## 许可证
 
 Apache 许可证 2.0，如 [LICENSE](./LICENSE) 文件中所示。


### PR DESCRIPTION
### What this PR does / why we need it?
Replace logo official link and update contrib doc

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Preview:
- https://github.com/Yikun/vllm-ascend/blob/336055be1a271b5c349d19b0c5dc29e77caadf4f/README.zh.md
- https://github.com/Yikun/vllm-ascend/blob/336055be1a271b5c349d19b0c5dc29e77caadf4f/README.md