### PR TITLE
[Rope][Platform] optimize the to conversion in rope forward and reset default block_size in platform.py

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -30,7 +30,8 @@ def rope_forward_oot(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     import torch_npu
 
-    self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
+    if self.cos_sin_cache.device != query.device or self.cos_sin_cache.dtype != query.dtype:
+        self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
     if offsets is not None:
         raise NotImplementedError(
             "Batched rotary embedding is currently not supported on NPU.")

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -30,8 +30,10 @@ def rope_forward_oot(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     import torch_npu
 
-    if self.cos_sin_cache.device != query.device or self.cos_sin_cache.dtype != query.dtype:
-        self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
+    if self.cos_sin_cache.device != query.device:
+        self.cos_sin_cache = self.cos_sin_cache.to(query.device)
+    if self.cos_sin_cache.dtype != query.dtype:
+        self.cos_sin_cache = self.cos_sin_cache.to(query.dtype)
     if offsets is not None:
         raise NotImplementedError(
             "Batched rotary embedding is currently not supported on NPU.")

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -103,8 +103,9 @@ class NPUPlatform(Platform):
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm_ascend.worker.NPUWorker"
         cache_config = vllm_config.cache_config
+        # Set default block_size to 128 for better performance on Ascend Devices.
         if cache_config and cache_config.block_size is None:
-            cache_config.block_size = 16
+            cache_config.block_size = 128
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,


### PR DESCRIPTION
This PR makes two changes for better performance:
1. Optimize the 'to' conversion in rope forward. New code only performs 'to' when device or dtype has changed
2. Change the default block_size from 16 to 128 in platform.py, because Ascend Devices have better affinity with block size 128.

