### PR TITLE
[Misc][Build] Fix packages for finding submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@
 import os
 from typing import List
 
-from setuptools import setup
+from setuptools import find_packages, setup
 from setuptools_scm import get_version
 
 ROOT_DIR = os.path.dirname(__file__)
@@ -95,7 +95,7 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
-    packages=['vllm_ascend'],
+    packages=find_packages(exclude=("docs", "examples", "tests*", "patch")),
     python_requires=">=3.9",
     install_requires=get_requirements(),
     extras_require={},


### PR DESCRIPTION
### What this PR does / why we need it?
fix packages for finding submodule. 
Before this pr, the wheel built by pip not contain submodule `ops` , thus will raise an `ImportError` when importing vllm


### How was this patch tested?
1. build vllm-ascend wheel by pip
```bash
cd ./vllm-ascend
pip wheel ./ --no-deps
pip install vllm_ascend-0.1.dev11+g07f2a16.d20250211-py3-none-any.whl  #change file name according to yours wheel.
```
2. check vllm
```python
import vllm
```