### PR TITLE
[FOLLOWUP][Misc] Remove unused mypy config for base_communicator

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -27,6 +27,7 @@ on:
       - '**/*.py'
       - '.github/workflows/mypy.yaml'
       - 'tools/mypy.sh'
+      - 'mypy.ini'
   pull_request:
     branches:
       - "main"
@@ -39,6 +40,7 @@ on:
      - '**/*.py'
      - '.github/workflows/mypy.yaml'
      - 'tools/mypy.sh'
+     - 'mypy.ini'
 
 jobs:
   mypy:

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,3 @@ ignore_missing_imports = True
 [mypy-transformers.*]
 ignore_missing_imports = True
 
-; Remove this after https://github.com/vllm-project/vllm/pull/11324 merged
-[mypy-vllm.distributed.device_communicators.base_communicator]
-ignore_missing_imports = True


### PR DESCRIPTION
### What this PR does / why we need it?
- Remove on communicator mypy to address: https://github.com/vllm-project/vllm-ascend/pull/24#issuecomment-2647696781
- Add mypy.ini to trigger list

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed

