### PR TITLE
[Misc] update the dependency version of torch-npu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ requires = [
     "decorator",
     "pyyaml",
     "scipy",
-    "torch-npu == 2.5.1rc1"
+    "torch-npu >= 2.5.1rc1"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml
 scipy
 setuptools
 setuptools-scm
-torch-npu == 2.5.1rc1
+torch-npu >= 2.5.1rc1


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the dependency version of vllm-ascend on torch-npu, so that the vllm-ascend can be installed in a later version environment (like to torch-npu 2.6.0rc1),

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI Test


