### PR TITLE
The output tensor needs to be created on the same device as the query…

### DIFF
--- a/vllm_ascend/attention.py
+++ b/vllm_ascend/attention.py
@@ -537,7 +537,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                              self.num_heads,
                              self.head_size,
                              dtype=query.dtype,
-                             device="npu")
+                             device=query.device)
 
         if attn_metadata.num_prefills > 0:
 


### PR DESCRIPTION
### What this PR does / why we need it?
In open-r1, the rank 0 process will create an LLM instance and load the model to `npu:7`. We need to force the output tensor to be created on the same device as the query tensor.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test by main branch
