### PR TITLE
[CI] Install vllm test requirement to fix e2e and exclude docs

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -25,6 +25,7 @@ on:
       - '*.txt'
       - '**/*.py'
       - '.github/workflows/vllm_ascend_test.yaml'
+      - '!docs/**'
   pull_request:
     branches:
       - "main"
@@ -32,6 +33,7 @@ on:
       - '*.txt'
       - '**/*.py'
       - '.github/workflows/vllm_ascend_test.yaml'
+      - '!docs/**'
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -103,4 +105,5 @@ jobs:
 
       - name: Run vllm-project/vllm test
         run: |
+          pip install -r vllm-empty/requirements-test.txt
           pytest -sv


### PR DESCRIPTION
### What this PR does / why we need it?
Make CI happy by:
- Install test req to fix https://github.com/vllm-project/vllm-ascend/actions/runs/13304112758/job/37151690770:
  ```
  vllm-empty/tests/mistral_tool_use/conftest.py:4: in <module>
      import pytest_asyncio
  E   ModuleNotFoundError: No module named 'pytest_asyncio'
  ```
- exclude docs PR

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
