### PR TITLE
[DOC] fix feature support

### DIFF
--- a/docs/source/features/suppoted_features.md
+++ b/docs/source/features/suppoted_features.md
@@ -3,17 +3,19 @@
 | Feature | Supported | Note |
 |---------|-----------|------|
 | Chunked Prefill | ✗ | Plan in 2025 Q1 |
-| Automatic Prefix Caching | ✅ | Improve performance in 2025 Q1 |
+| Automatic Prefix Caching | ✅ | Improve performance in 2025 Q1 (Not supported in release version) |
 | LoRA | ✗ | Plan in 2025 Q1 |
-| Prompt adapter | ✅ ||
-| Speculative decoding | ✅ | Improve accuracy in 2025 Q1|
+| Prompt adapter | ✗ | Plan in 2025 Q1 |
+| Speculative decoding | ✗ | Plan in 2025 Q1 |
 | Pooling | ✗ | Plan in 2025 Q1 |
 | Enc-dec | ✗ | Plan in 2025 Q1 |
 | Multi Modality | ✅ (LLaVA/Qwen2-vl/Qwen2-audio/internVL)| Add more model support in 2025 Q1 |
 | LogProbs | ✅ ||
 | Prompt logProbs | ✅ ||
 | Async output | ✅ ||
-| Multi step scheduler | ✅ ||
+| Multi step scheduler | ✗ ||
 | Best of | ✅ ||
 | Beam search | ✅ ||
 | Guided Decoding | ✗ | Plan in 2025 Q1 |
+| Tensor Parallel | ✅ | Only "mp" in main ("ray" and "mp" in release version) |
+| Pipeline Parallel | ✅ | Only "mp" in main ("ray" and "mp" in release version) |


### PR DESCRIPTION
Check and update the feature support table.
- both multi-step and speculative decoding require adaptation of corresponding workers
- prompt adapter (finetune method) require adaption in `worker.py` and `model_runner.py`
