### PR TITLE
[v0.7.1][CI] Add container image build ci

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,106 @@
+name: 'image'
+# This is a docker build check and publish job:
+# 1. PR Triggered docker image build check
+#   - is for image build check
+#   - Enable on main/*-dev branch
+#   - push: ${{ github.event_name != 'pull_request' }} ==> false
+# 2. branches push trigger image publish
+#   - is for branch/dev/nightly image
+#   - commits are merge into main/*-dev  ==> vllm-ascend:main / vllm-ascend:*-dev
+# 3. tags push trigger image publish
+#   - is for final release image
+#   - Publish when tag with v* (pep440 version)  ===>  vllm-ascend:v1.2.3|latest / vllm-ascend:v1.2.3rc1
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - '*-dev'
+    paths:
+      - '.github/workflows/image.yml'
+      - 'Dockerfile'
+      - 'vllm_ascend/**'
+  push:
+    # Publish image when tagging, the Dockerfile in tag will be build as tag image
+    branches:
+      - 'main'
+      - '*-dev'
+    tags:
+      - 'v*'
+    paths:
+      - '.github/workflows/image.yml'
+      - 'Dockerfile'
+      - 'vllm_ascend/**'
+jobs:
+
+  build:
+    name: vllm-ascend image
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Prepare
+      run: |
+        REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        echo "REPO_OWNER=${REPO_OWNER}" >> "$GITHUB_ENV"
+
+    - name: Print
+      run: |
+        echo "REPO_OWNER:""${REPO_OWNER}"
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        # TODO(yikun): add more hub image and a note on release policy for container image
+        # The REPO_OWNER will be:
+        # - `vllm-project` in usptream repo
+        # - lowercase github user in your fork repo
+        images: |
+          ghcr.io/${{ env.REPO_OWNER }}/vllm-ascend
+        # Note for test case
+        # https://github.com/marketplace/actions/docker-metadata-action#typeref
+        # 1. branch job pulish per main/*-dev branch commits
+        # 2. main and dev pull_request is build only, so the tag pr-N is fine
+        # 3. only pep440 matched tag will be published:
+        #    - v0.7.1 --> v0.7.1, latest
+        #    - pre/post/dev: v0.7.1rc1/v0.7.1rc1/v0.7.1rc1.dev1/v0.7.1.post1, no latest
+        #      which follow the rule from vLLM with prefix v
+        # TODO(yikun): the post release might be considered as latest release
+        tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=pep440,pattern={{raw}}
+
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: true
+        docker-images: false
+
+    - name: Build - Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      # TODO(yikun): remove this after https://github.com/docker/setup-qemu-action/issues/198 resolved
+      with:
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
+
+    - name: Build - Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Publish - Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        # only trigger when tag, branch/main push
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,15 @@
 # limitations under the License.
 #
 
-FROM quay.io/ascend/cann:8.0.rc3.beta1-910b-ubuntu22.04-py3.10
+FROM quay.io/ascend/cann:8.0.0.beta1-910b-ubuntu22.04-py3.10
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install -y python3-pip git vim
+    apt-get install -y python3-pip git vim && \
+    rm -rf /var/cache/apt/* && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
@@ -35,6 +37,9 @@ RUN git clone --depth 1 $VLLM_REPO /workspace/vllm
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install /workspace/vllm/
 
 # Install vllm-ascend main
-RUN python3 -m pip install /workspace/vllm-ascend/
+RUN python3 -m pip install /workspace/vllm-ascend/ -f https://download.pytorch.org/whl/torch/
+
+# Install modelscope
+RUN python3 -m pip install modelscope
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,12 @@ COPY . /workspace/vllm-ascend/
 
 RUN pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
-# Install vLLM main
+# Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-RUN git clone --depth 1 $VLLM_REPO /workspace/vllm
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install /workspace/vllm/
+ARG VLLM_TAG=v0.7.1
+RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /workspace/vllm
+# Add -f to fix https://github.com/vllm-project/vllm/pull/12874
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install /workspace/vllm/ -f https://download.pytorch.org/whl/torch/
 
 # Install vllm-ascend main
 RUN python3 -m pip install /workspace/vllm-ascend/ -f https://download.pytorch.org/whl/torch/


### PR DESCRIPTION
### What this PR does / why we need it?

Backport https://github.com/vllm-project/vllm-ascend/pull/64 to v0.7.1-dev branch

Add container image build ci:
- Enable branch, tag docker image publish
    - branch image: `vllm-ascend:main`, `vllm-ascend:v0.7.1-dev`
    - tag image: `vllm-ascend:v0.7.1rc1`
- Enable PR docker image build check
- other changes:
    - Prepare the `REPO_OWNER` because the ghcr lowerercase required
    - Add `Free up disk space` step to avoid `No space left on device` like https://github.com/vllm-project/vllm-ascend/issues/27
    - Setup qemu with image to resolve https://github.com/docker/setup-qemu-action/issues/198

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
build: CI passed 