### PR TITLE
[Build] remove torch-n-npu in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pyyaml
 scipy
 setuptools
 setuptools-scm
-torch-npu >= 2.5.1rc1


### PR DESCRIPTION
Remove torch-npu in requirements as we should build torch-npu from the wheel specific in installation doc.