### PR TITLE
[BugFix]add int8 cache dtype when using attention quantization

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from vllm_ascend.patch import patch_cache_dtype  # noqa

--- a/vllm_ascend/patch/patch_cache_dtype.py
+++ b/vllm_ascend/patch/patch_cache_dtype.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is used to monkey patch int8 cache dtype in vllm to support ascend.
+# Remove this file when vllm support int8 cache dtype.
+
+import torch
+from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE
+
+STR_DTYPE_TO_TORCH_DTYPE['int8'] = torch.int8

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -114,7 +114,8 @@ class NPUPlatform(Platform):
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 128
         if vllm_config.quant_config is not None and \
-            'fa_quant_type' in vllm_config.quant_config.quant_description.keys():
+            'fa_quant_type' in vllm_config.quant_config.quant_description.keys() and \
+            vllm_config.quant_config.quant_description['fa_quant_type'] is not None:
             # Ascend attention quant uses int8 dtype.
             cache_config.cache_dtype = 'int8'
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -113,6 +113,10 @@ class NPUPlatform(Platform):
         cache_config = vllm_config.cache_config
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 128
+        if vllm_config.quant_config is not None and \
+            'fa_quant_type' in vllm_config.quant_config.quant_description.keys():
+            # Ascend attention quant uses int8 dtype.
+            cache_config.cache_dtype = 'int8'
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,

--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -91,7 +91,8 @@ class AscendQuantConfig(QuantizationConfig):
             return AscendLinearMethod(self, prefix,
                                       self.packed_modules_mapping)
         if isinstance(layer, Attention) and \
-            'fa_quant_type' in self.quant_description.keys():
+            'fa_quant_type' in self.quant_description.keys() and \
+            self.quant_description['fa_quant_type'] is not None:
             return AscendKVCacheMethod(self, prefix)
         return None
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -65,7 +65,7 @@ class NPUWorker(LocalOrDistributedWorkerBase):
                  distributed_init_method: str,
                  is_driver_worker: bool = False):
         # Register ops when worker init.
-        from vllm_ascend import ops  # noqa: F401
+        from vllm_ascend import ops, patch  # noqa: F401
 
         WorkerBase.__init__(self, vllm_config=vllm_config)
         # Try to import mindie_turbo to accelerate vLLM inference.


### PR DESCRIPTION
1. Ascend attention requires int8 kvcache dtype. It is used in initialization of CacheConfig:
```
if cache_config.cache_dtype == "auto":
    self.dtype = model_config.dtype
else:
    self.dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
```
STR_DTYPE_TO_TORCH_DTYPE is defined in vllm.utils:
```
STR_DTYPE_TO_TORCH_DTYPE = {
    "half": torch.half,
    "bfloat16": torch.bfloat16,
    "float": torch.float,
    "fp8": torch.uint8,
    "fp8_e4m3": torch.uint8,
    "fp8_e5m2": torch.uint8,
}
```
Hence we need to update both cache_dtype and STR_DTYPE_TO_TORCH_DTYPE.

2. Fix a bug that w8a8 without attention quantization is misidentified as using attention quantization.