### PR TITLE
[worker] remove unused assertion

### DIFF
--- a/vllm_ascend/worker.py
+++ b/vllm_ascend/worker.py
@@ -84,9 +84,6 @@ class NPUWorker(LocalOrDistributedWorkerBase):
         self.distributed_init_method = distributed_init_method
         self.is_driver_worker = is_driver_worker
 
-        if is_driver_worker:
-            assert rank % self.parallel_config.tensor_parallel_size == 0, \
-                   "Driver worker should be rank 0 of tensor parallel group."
         if self.model_config.trust_remote_code:
             # note: lazy import to avoid importing torch before initializing
             from vllm.utils import init_cached_hf_modules


### PR DESCRIPTION
### What this PR does / why we need it?
Remove unused assertion in `NPUWorker`, as this has been moved to `Executor` in vLLM:
https://github.com/vllm-project/vllm/blob/aabeb2688fba861a39547a2a33649e6330caaafd/vllm/executor/uniproc_executor.py#L43

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with existing test.

