### PR TITLE
[Model] Adapt the MiniCPM-2B model

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -14,10 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-
-def register():
-    """Register the NPU platform."""
-    # To ensure that the module is correctly replaced, add it at the beginning
-    import vllm_ascend.patch_module  # noqa: F401
-    return "vllm_ascend.platform.NPUPlatform"
+import vllm_ascend.patch.patch_minicpm  # noqa

--- a/vllm_ascend/patch/patch_minicpm.py
+++ b/vllm_ascend/patch/patch_minicpm.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from vllm.attention import AttentionMetadata
+from vllm.model_executor.models.minicpm import MiniCPMAttention
+
+
+def forward(
+    self,
+    positions: torch.Tensor,
+    hidden_states: torch.Tensor,
+    kv_cache: torch.Tensor,
+    attn_metadata: AttentionMetadata,
+) -> torch.Tensor:
+    qkv, _ = self.qkv_proj(hidden_states)
+    q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+    q, k = self.rotary_emb(positions, q, k)
+    attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
+    output, _ = self.o_proj(attn_output)
+    return output
+
+
+# The type conversion in the forward function is deleted to support the rope operator.
+MiniCPMAttention.forward = forward

--- a/vllm_ascend/patch_module.py
+++ b/vllm_ascend/patch_module.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import types
 
-
-def register():
-    """Register the NPU platform."""
-    # To ensure that the module is correctly replaced, add it at the beginning
-    import vllm_ascend.patch_module  # noqa: F401
-    return "vllm_ascend.platform.NPUPlatform"
+# prevent errors caused by triton not supported
+sys.modules[
+    'vllm.model_executor.layers.fused_moe.fused_moe'] = types.ModuleType(
+        'fused_moe_module')

--- a/vllm_ascend/worker.py
+++ b/vllm_ascend/worker.py
@@ -68,8 +68,9 @@ class NPUWorker(LocalOrDistributedWorkerBase):
         is_driver_worker: bool = False,
         model_runner_cls: Optional[Type[ModelRunnerBase]] = None,
     ) -> None:
-        # Register ops when worker init.
+        # Register ops and patch when worker init.
         from vllm_ascend import ops  # noqa: F401
+        from vllm_ascend import patch  # noqa: F401
 
         WorkerBase.__init__(self, vllm_config=vllm_config)
         # Try to import mindie_turbo to accelerate vLLM inference.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
In order to adapt the MiniCPM-2B model of the vLLM framework to Ascend hardware, the following two modifications are required: 1. The qkv type conversion in the forward function is deleted to support the rope operator. 2. The fused_moe.fused_moe module is replaced to prevent errors caused by triton not supported，this modification can be deleted if triton is supported

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

