### PR TITLE
[CI/Build] add HF_TOKEN for model downloading

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -119,5 +119,7 @@ jobs:
           pytest -sv tests
 
       - name: Run vllm-project/vllm test
+        env:
+          HF_TOKEN: {{ secrets.HF_TOKEN }}
         run: |
           pytest -sv


### PR DESCRIPTION
### What this PR does / why we need it?
Add `HF_TOKEN` for downloading models that requires access rights from huggingface hub. This will fix the CI error in #123 and #76
