### PR TITLE
[Core]Add "int8" kv cache dtype patch for attention quantization

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import vllm_ascend.patch.patch_minicpm  # noqa
 import vllm_ascend.patch.patch_cache_dtype  # noqa
+import vllm_ascend.patch.patch_minicpm  # noqa

--- a/vllm_ascend/patch/patch_cache_dtype.py
+++ b/vllm_ascend/patch/patch_cache_dtype.py
@@ -14,5 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import vllm_ascend.patch.patch_minicpm  # noqa
-import vllm_ascend.patch.patch_cache_dtype  # noqa
+# This file is used to monkey patch int8 cache dtype in vllm to support ascend.
+# Remove this file when vllm support int8 cache dtype.
+
+import torch
+from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE
+
+STR_DTYPE_TO_TORCH_DTYPE['int8'] = torch.int8

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -113,6 +113,10 @@ class NPUPlatform(Platform):
         if cache_config and cache_config.block_size is None:
             # TODO: Set block_size to 128 will lead unexpected accuracy issue in mla case.  Please set block_size to 128 back once the problem is fixed.
             cache_config.block_size = 16
+        if vllm_config.quant_config is not None and \
+            'fa_quant_type' in vllm_config.quant_config.quant_description.keys():
+            # Ascend attention quant uses int8 dtype.
+            cache_config.cache_dtype = 'int8'
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,


### PR DESCRIPTION
1. Ascend attention requires int8 kvcache dtype. It is used in initialization of CacheConfig:
```
if cache_config.cache_dtype == "auto":
    self.dtype = model_config.dtype
else:
    self.dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
```
STR_DTYPE_TO_TORCH_DTYPE is defined in vllm.utils:
```
STR_DTYPE_TO_TORCH_DTYPE = {
    "half": torch.half,
    "bfloat16": torch.bfloat16,
    "float": torch.float,
    "fp8": torch.uint8,
    "fp8_e4m3": torch.uint8,
    "fp8_e5m2": torch.uint8,
}
```
Hence we need to update both cache_dtype and STR_DTYPE_TO_TORCH_DTYPE.