### PR TITLE
[Followup] remove v prefix in pip_vllm_version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ myst_substitutions = {
     # the newest release version of vllm-ascend and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
     'pip_vllm_ascend_version': "0.7.3rc1",
-    'pip_vllm_version': "v0.7.3",
+    'pip_vllm_version': "0.7.3",
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
### What this PR does / why we need it?
remove v prefix in pip_vllm_version, followup on #203

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
```
$ grep "|pip_vllm_version|" -r ./docs/source
./docs/source/installation.md:pip install vllm==|pip_vllm_version|
```
preview
<img width="796" alt="image" src="https://github.com/user-attachments/assets/516cef2e-9037-473a-8f04-baaaa260c1e3" />

