### PR TITLE
[CI]Make UT cases in test_comm_ops.py compatible on Ascend NPU

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -131,15 +131,6 @@ class NPUPlatform(Platform):
         return "vllm_ascend.communicator.NPUCommunicator"
 
     @classmethod
-    def set_device(cls, device: torch.device) -> None:
-        """
-        Usage of this function is discouraged in favor of device. In most cases
-        it’s better to use `vllm.current_platform.device_control_env_var` 
-        environmental variable.
-        """
-        return torch.npu.set_device(device)
-
-    @classmethod
     def device_count(cls) -> int:
         """
         Return the number of devices available.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -58,6 +58,7 @@ class NPUPlatform(Platform):
     ray_device_key: str = "NPU"
     device_control_env_var: str = "ASCEND_RT_VISIBLE_DEVICES"
     dispatch_key: str = "PrivateUse1"
+    communicate_backend: str = "hccl"
 
     supported_quantization: list[str] = ["ascend"]
 
@@ -128,3 +129,19 @@ class NPUPlatform(Platform):
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         return "vllm_ascend.communicator.NPUCommunicator"
+
+    @classmethod
+    def set_device(cls, device: torch.device) -> None:
+        """
+        Usage of this function is discouraged in favor of device. In most cases
+        it’s better to use `vllm.current_platform.device_control_env_var` 
+        environmental variable.
+        """
+        return torch.npu.set_device(device)
+
+    @classmethod
+    def device_count(cls) -> int:
+        """
+        Return the number of devices available.
+        """
+        return torch.npu.device_count()


### PR DESCRIPTION
### What this PR does / why we need it?
At present, the test cases in `tests/distributed/test_comm_ops.py` only support CUDA but don't support Ascend NPU. This PR and PR [#14229](https://github.com/vllm-project/vllm/pull/14229) in order to resolve the problem.

### Does this PR introduce _any_ user-facing change?
No，it doesn't.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Run command `pytest tests/distributed/test_comm_ops.py`，and 10 test items passed totally.
