### PR TITLE
[Core]Pass vllm_config into VLLMTurbo when importing mindie_turbo

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -22,7 +22,7 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
-def try_register_lib(lib_name: str, lib_info: str = ""):
+def try_register_lib(lib_name: str, lib_info: str = "") -> bool:
     import importlib
     import importlib.util
     try:
@@ -31,5 +31,6 @@ def try_register_lib(lib_name: str, lib_info: str = ""):
             importlib.import_module(lib_name)
             if lib_info:
                 logger.info(lib_info)
+        return True
     except Exception:
-        pass
+        return False

--- a/vllm_ascend/worker.py
+++ b/vllm_ascend/worker.py
@@ -72,10 +72,13 @@ class NPUWorker(LocalOrDistributedWorkerBase):
 
         WorkerBase.__init__(self, vllm_config=vllm_config)
         # Try to import mindie_turbo to accelerate vLLM inference.
-        try_register_lib(
+        enable_mindie_turbo = try_register_lib(
             "mindie_turbo",
             "MindIE Turbo is installed. vLLM inference will be accelerated with MindIE Turbo."
         )
+        if enable_mindie_turbo:
+            from mindie_turbo import VLLMTurbo
+            vllm_turbo = VLLMTurbo(vllm_config)
         # distribute related config
         self.parallel_config.rank = rank
         self.local_rank = local_rank


### PR DESCRIPTION

### What this PR does / why we need it?

When importing mindie_turbo,  the patches are activated by creating an instance of `VLLMTurbo`. However, there are patches that should be activated on some specific conditions(e.g. quantization). Hence we need pass `vllm_config` into VLLMTurbo to enable conditional patches.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By performing offline inference:
![image](https://github.com/user-attachments/assets/f0ee7d82-6aec-4f2f-8552-bf4e10297051)


