### PR TITLE
[Feature] Modify description and api for ascend quantization

### DIFF
--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -138,9 +138,9 @@ class AscendLinearMethod(LinearMethodBase):
         quant_config: The Ascend quantization config.
     """
 
-    def __init__(self, quant_config: AscendQuantConfig) -> None:
+    def __init__(self, quant_config: AscendQuantConfig, prefix: str) -> None:
         self.quantizer = AscendQuantizer.get_quantizer(
-            quant_config.quant_description)
+            quant_config.quant_description, prefix)
         self.quant_method = self.quantizer.build_linear_method()
 
     def create_weights(
@@ -220,9 +220,9 @@ class AscendKVCacheMethod(BaseKVCacheMethod):
         quant_config: The Ascend quantization config.
     """
 
-    def __init__(self, quant_config: AscendQuantConfig) -> None:
+    def __init__(self, quant_config: AscendQuantConfig, prefix: str) -> None:
         self.quantizer = AscendQuantizer.get_quantizer(
-            quant_config.quant_description)
+            quant_config.quant_description, prefix)
         self.quant_method = self.quantizer.build_attention_method()
 
     def create_weights(self, layer: torch.nn.Module) -> None:

--- a/vllm_ascend/quantization/quantizer.py
+++ b/vllm_ascend/quantization/quantizer.py
@@ -25,7 +25,7 @@ class AscendQuantizer:
     """An interface to different quantization implementations for ascend hardwares."""
 
     @classmethod
-    def get_quantizer(cls, quant_config: Dict[str, Any]):
+    def get_quantizer(cls, quant_config: Dict[str, Any], prefix: str):
         # TODO: Need a param to choose quantization algorithms.
         quantization_algorithm = ''
 
@@ -39,7 +39,7 @@ class AscendQuantizer:
             raise NotImplementedError(
                 "There is no available ascend quantizer.")
 
-        return MindIETurboQuantizer.get_quantizer(quant_config)
+        return MindIETurboQuantizer.get_quantizer(quant_config, prefix)
 
     def build_linear_method(self):
         raise NotImplementedError


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
1. It adds more description for classes in quant_config.py
2. It renames AscendQKVQuantAttentionMethod to AscendKVCacheMethod to align with vLLM naming style.
3. It modifies the process when AscendLinearMethod or AscendKVCacheMethod calls create_weights.
-->

### Does this PR introduce _any_ user-facing change?
Yes. When creating weights, now AscendLinearMethod uses get_weight, get_pertensor_param and get_perchannel_param api from linear quant implementation, while AscendKVCacheMethod passes layer into linear quant implementation.

### How was this patch tested?
By performing offline inference:
![image](https://github.com/user-attachments/assets/c0661a08-03eb-4a13-98cc-8d0ff3490c90)


