### PR TITLE
[Feature] add all_to_all and reduce_scatter

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import vllm_ascend.patch.patch_communicator  # noqa

--- a/vllm_ascend/patch/patch_communicator.py
+++ b/vllm_ascend/patch/patch_communicator.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+import vllm
+from vllm.distributed.parallel_state import GroupCoordinator
+
+
+class GroupCoordinatorPatch(GroupCoordinator):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def all_to_all(self,
+                   input_: torch.Tensor,
+                   scatter_dim: int = 0,
+                   gather_dim: int = -1) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        assert -input_.dim() <= gather_dim < input_.dim(), (
+            f"Invalid gather dim ({gather_dim}) for input tensor with shape {input_.size()}"
+        )
+        return self.device_communicator.all_to_all(input_, scatter_dim,
+                                                   gather_dim)
+
+    def reduce_scatter(self,
+                       input_: torch.Tensor,
+                       scatter_dim: int = 0) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        return self.device_communicator.reduce_scatter(input_, scatter_dim)
+
+
+vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -66,6 +66,7 @@ class NPUWorker(LocalOrDistributedWorkerBase):
                  is_driver_worker: bool = False):
         # Register ops when worker init.
         from vllm_ascend import ops  # noqa: F401
+        from vllm_ascend import patch  # noqa: F401
 
         WorkerBase.__init__(self, vllm_config=vllm_config)
         # Try to import mindie_turbo to accelerate vLLM inference.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Support all_to_all and reduce_scatter fuctions for GroupCoordinator and Communicator.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

No.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT code will be provided below.

```
"""Test the communication operators.

Run `pytest tests/distributed/test_comm_ops.py`.
"""
import os

import pytest
import ray
import torch
import torch_npu
from torch_npu.contrib import transfer_to_npu

from vllm.distributed import (broadcast_tensor_dict, get_pp_group,
                              tensor_model_parallel_all_gather,
                              tensor_model_parallel_all_reduce,
                              tensor_model_parallel_all_to_all,
                              tensor_model_parallel_reduce_scatter)

from ..utils import init_test_distributed_environment, multi_process_parallel


@ray.remote(num_gpus=1, max_calls=1)
def all_to_all_test_worker(tp_size: int, pp_size: int, rank: int,
                           distributed_init_port: str):
    # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
    # so that each worker can see all the GPUs
    # they will be able to set the device to the correct GPU
    import vllm_ascend.patch.patch_communicator
    os.environ.pop("ASCEND_RT_VISIBLE_DEVICES", None)
    device = torch.device(f"npu:{rank}")
    torch.npu.set_device(device)
    init_test_distributed_environment(tp_size, pp_size, rank,
                                      distributed_init_port)
    num_dimensions = 4
    tensor_size = list(range(2, num_dimensions * tp_size + 1, tp_size))
    total_size = 1
    for s in tensor_size:
        total_size *= s
    for scatter_dimension in range(num_dimensions):
        for gather_dimension in range(num_dimensions):
            all_tensors = [
                torch.arange(total_size, dtype=torch.float32,
                            device="npu").reshape(tensor_size) * (r + 1) for r in range(tp_size)
            ]
            t = all_tensors[rank % tp_size]
            predicted = tensor_model_parallel_all_to_all(t, scatter_dimension, gather_dimension)
            expected = tensor_model_parallel_all_to_all(predicted, gather_dimension, scatter_dimension)
            torch.testing.assert_close(t, expected)


@ray.remote(num_gpus=1, max_calls=1)
def reduce_scatter_test_worker(tp_size: int, pp_size: int, rank: int,
                           distributed_init_port: str):
    # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
    # so that each worker can see all the GPUs
    # they will be able to set the device to the correct GPU
    import vllm_ascend.patch.patch_communicator
    os.environ.pop("ASCEND_RT_VISIBLE_DEVICES", None)
    device = torch.device(f"npu:{rank}")
    torch.npu.set_device(device)
    init_test_distributed_environment(tp_size, pp_size, rank,
                                      distributed_init_port)
    num_dimensions = 3
    tensor_size = list(range(2, num_dimensions * tp_size + 1, tp_size))
    total_size = 1
    for s in tensor_size:
        total_size *= s
    for scatter_dimension in range(num_dimensions):
        all_tensors = [
            torch.arange(total_size, dtype=torch.float32,
                        device="npu").reshape(tensor_size) * (r + 1) for r in range(tp_size)
        ]

        sum_tensor = torch.sum(torch.stack(all_tensors, dim=0), dim=0)
        expected_tensors = torch.tensor_split(sum_tensor, tp_size, scatter_dimension)
        t = all_tensors[rank % tp_size]
        expected = expected_tensors[rank % tp_size]
        t = tensor_model_parallel_reduce_scatter(t, scatter_dimension)
        torch.testing.assert_close(t, expected)


@pytest.mark.skipif(torch.npu.device_count() < 2,
                    reason="Need at least 2 GPUs to run the test.")
@pytest.mark.parametrize("tp_size", [2])
@pytest.mark.parametrize("test_target", [
    all_to_all_test_worker,
    reduce_scatter_test_worker
])
def test_multi_process_tensor_parallel(tp_size, test_target):
    multi_process_parallel(tp_size, 1, test_target)
```