### PR TITLE
[v0.7.3] Bump torch_npu version to dev20250308.3

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -127,9 +127,9 @@ jobs:
         run: |
           mkdir pta
           cd pta
-          wget https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250307.3/pytorch_v2.5.1_py310.tar.gz
+          wget https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250308.3/pytorch_v2.5.1_py310.tar.gz
           tar -xvf pytorch_v2.5.1_py310.tar.gz
-          pip install ./torch_npu-2.5.1.dev20250307-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+          pip install ./torch_npu-2.5.1.dev20250308-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
           cd ..
           rm -rf pta
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By using vLLM Ascend plugin, popular open-source models, including Transformer-l
 - Software:
   * Python >= 3.9
   * CANN >= 8.0.0
-  * PyTorch >= 2.5.1, torch-npu >= 2.5.1.dev20250307
+  * PyTorch >= 2.5.1, torch-npu >= 2.5.1.dev20250308
   * vLLM (the same version as vllm-ascend)
 
 Find more about how to setup your environment step by step in [here](docs/source/installation.md).

--- a/README.zh.md
+++ b/README.zh.md
@@ -36,7 +36,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个让vLLM在Ascend NPU无缝运行的�
 - 软件：
   * Python >= 3.9
   * CANN >= 8.0.RC2
-  * PyTorch >= 2.5.1, torch-npu >= 2.5.1.dev20250307
+  * PyTorch >= 2.5.1, torch-npu >= 2.5.1.dev20250308
   * vLLM (与vllm-ascend版本一致)
 
 在[此处](docs/source/installation.md)，您可以了解如何逐步准备环境。

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -12,7 +12,7 @@ This document describes how to install vllm-ascend manually.
     | Software     | Supported version | Note |
     | ------------ | ----------------- | ---- | 
     | CANN         | >= 8.0.0          | Required for vllm-ascend and torch-npu |
-    | torch-npu    | >= 2.5.1.dev20250307       | Required for vllm-ascend |
+    | torch-npu    | >= 2.5.1.dev20250308       | Required for vllm-ascend |
     | torch        | >= 2.5.1          | Required for torch-npu and vllm |
 
 You have 2 way to install:
@@ -150,15 +150,15 @@ Current version depends on a unreleased `torch-npu`, you need to install manuall
 # 
 # Here we take python 3.10 on aarch64 as an example. Feel free to install the correct version for your environment. See:
 #
-# https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250307.3/pytorch_v2.5.1_py39.tar.gz
-# https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250307.3/pytorch_v2.5.1_py310.tar.gz
-# https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250307.3/pytorch_v2.5.1_py311.tar.gz
+# https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250308.3/pytorch_v2.5.1_py39.tar.gz
+# https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250308.3/pytorch_v2.5.1_py310.tar.gz
+# https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250308.3/pytorch_v2.5.1_py311.tar.gz
 #
 mkdir pta
 cd pta
-wget https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250307.3/pytorch_v2.5.1_py310.tar.gz
+wget https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250308.3/pytorch_v2.5.1_py310.tar.gz
 tar -xvf pytorch_v2.5.1_py310.tar.gz
-pip install ./torch_npu-2.5.1.dev20250307-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+pip install ./torch_npu-2.5.1.dev20250308-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 ```
 ::::
 

--- a/pta_install.sh
+++ b/pta_install.sh
@@ -2,14 +2,14 @@
 set -ex
 mkdir pta
 cd pta || exit
-wget https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250307.3/pytorch_v2.5.1_py310.tar.gz
+wget https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.5.1/20250308.3/pytorch_v2.5.1_py310.tar.gz
 tar -zxvf pytorch_v2.5.1_py310.tar.gz
 
 if [ "$(uname -i)" == "aarch64" ]
 then
-    pip install ./torch_npu-2.5.1.dev20250307-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+    pip install ./torch_npu-2.5.1.dev20250308-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 else
-    pip install ./torch_npu-2.5.1.dev20250307-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl --extra-index https://download.pytorch.org/whl/cpu/
+    pip install ./torch_npu-2.5.1.dev20250308-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl --extra-index https://download.pytorch.org/whl/cpu/
 fi
 
 cd ..


### PR DESCRIPTION
### What this PR does / why we need it?
Backport: https://github.com/vllm-project/vllm-ascend/pull/276

Bump torch_npu version to dev20250308.3 to fix performance regression on multi-stream case: https://github.com/Ascend/pytorch/commit/e04c580d07c0a49a46217656fd84465ca1114d24 .


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
CI passed
