### PR TITLE
[CI][v0.7.3] Pin modelscope<1.23.0 match vLLM 0.7.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements-lint.txt
-modelscope
+modelscope<1.23.0
 pytest >= 6.0
 pytest-asyncio


### PR DESCRIPTION
### What this PR does / why we need it?
Pin modelscope<1.23.0 match vLLM 0.7.3

https://github.com/vllm-project/vllm/pull/13807 is not included in v0.7.3, thus we just pin it to branch v0.7.3-dev

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with existing test.

