### PR TITLE
[CI] Uninstall triton in dockerfile (#298)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.7.3
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /workspace/vllm
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install /workspace/vllm/
+# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
+RUN python3 -m pip uninstall -y triton
 
 # Install vllm-ascend
 RUN python3 -m pip install /workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/


### PR DESCRIPTION
### What this PR does / why we need it?

The triton doesn't work with ascend. We should make sure it's uninstalled in dockerfile

Backport: https://github.com/vllm-project/vllm-ascend/pull/298
Closes: https://github.com/vllm-project/vllm-ascend/issues/291

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
CI passed
