### PR TITLE
[v0.7.3]spec decode MultiStepWorker support TP1DraftModelRunner fully

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -17,5 +17,6 @@
 import vllm_ascend.patch.patch_cache_dtype  # noqa
 import vllm_ascend.patch.patch_metrics  # noqa
 import vllm_ascend.patch.patch_minicpm  # noqa
+import vllm_ascend.patch.patch_multi_step_worker  # noqa
 import vllm_ascend.patch.patch_rejection_sampler  # noqa
 import vllm_ascend.patch.patch_spec_decode_worker  # noqa

--- a/vllm_ascend/patch/patch_multi_step_worker.py
+++ b/vllm_ascend/patch/patch_multi_step_worker.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import List, Set, Tuple
+
+import torch
+from vllm.model_executor.layers.sampler import SamplerOutput
+from vllm.sequence import ExecuteModelRequest
+from vllm.spec_decode.multi_step_worker import MultiStepWorker
+
+from vllm_ascend.worker.draft_model_runner import TP1DraftModelRunner
+
+
+def sampler_output(
+    self,
+    execute_model_req: ExecuteModelRequest,
+    sample_len: int,
+    seq_ids_with_bonus_token_in_last_step: Set[int],
+) -> Tuple[List[SamplerOutput], bool]:
+    """Run the model forward pass sample_len times. Returns the list of
+    sampler output, one per model forward pass, along with indicator of
+    whether torch tensor in sampler output need to be transposed in latter
+    sampler_output_to_torch logic.
+
+    For multi step worker, this indicator shall be True.
+    """
+    self._raise_if_unsupported(execute_model_req)
+    # Expand the batch for sequences with a bonus token.
+    # Perform a forward pass on the expanded batch and filter the
+    # response to retain only the original sequences' responses.
+    expanded_request, indices_of_seq_with_bonus_tokens =\
+        self._expand_execute_model_request(
+            execute_model_req, seq_ids_with_bonus_token_in_last_step)
+
+    # Run model sample_len times.
+    model_outputs: List[SamplerOutput] = []
+
+    # TODO: supports_gpu_multi_step is False in ASCEND
+    if isinstance(self.model_runner, TP1DraftModelRunner) and \
+        self.model_runner.supports_gpu_multi_step(expanded_request):
+        # Here we run the draft_model_runner with multi-step prepare
+        # on the GPU directly
+        expanded_request.num_steps = sample_len
+        self.model_runner.set_indices_of_seq_with_bonus_tokens(
+            indices_of_seq_with_bonus_tokens)
+        model_outputs = self.execute_model(execute_model_req=expanded_request)
+    else:
+        # Here we run multi-step directly, with every step prepared
+        # on the CPU.
+        # TODO: Remove this branch once DraftModelRunner supports TP>1
+        # and other restrictions that are part of DraftModelRunner's
+        # supports_gpu_multi_step(..)
+        for _ in range(sample_len):
+            model_output: List[SamplerOutput] = self.worker.execute_model(
+                execute_model_req=expanded_request)
+            assert (len(model_output) == 1
+                    ), "composing multistep workers not supported"
+            model_output = model_output[0]
+
+            self._append_new_tokens(model_output,
+                                    expanded_request.seq_group_metadata_list,
+                                    indices_of_seq_with_bonus_tokens)
+            model_outputs.append(model_output)
+
+    # move indices to device to avoid stream sync
+    indices_of_seq_with_bonus_tokens = torch.tensor(
+        indices_of_seq_with_bonus_tokens, device=self.device)
+    filtered_model_outputs = self._filter_model_output(
+        model_outputs, indices_of_seq_with_bonus_tokens)
+    return filtered_model_outputs, True
+
+
+MultiStepWorker.sampler_output = torch.inference_mode()(sampler_output)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
spec decode MultiStepWorker support TP1DraftModelRunner fully, support run the draft_model_runner with multi-step prepare on the NPU directly and support draft_model_runner use MLA.

1. before this pr, `MultiStepWorker` would not step into the branch using NPU prepare, but only into the branch using CPU prepare (`line 52` of `vllm_ascend/patch/patch_multi_step_worker.py`).  Although this has `no effect` on the `correct operation` of speculative decoding and the performance of the two branches is basically the same as of the current version, I support entering this branch in this PR. In general, there are two main changes in `patch_multi_step_worker.py`: first, the `is_cuda_like()` check is removed and the `TP1DraftModelRunner` rewritten in vllm_ascend is used; second, the `supports_gpu_multi_step()` function is made to return true on NPU devices when outer Multi_step_worker could work correct.

3. before this pr, `TP1DraftModelRunner`  only supports Attention on NPU, but not MLA. The relevant adaptation is in `vllm_ascend/worker/draft_model_runner.py`. Although I don’t know why the `input_positions` of `model_input.attn_metadata` in vllm-ascend needs to be added in `execute_model`, it is done in `model_runner.py`, so I also made corresponding changes. Otherwise, when atten_backend is MLA, it will prompt that input_positions cannot be found.

4. I commented out two lines in `draft_model_runner.py` in `line118` to support the scenario of K>1. 
  ```
  # lora_mapping=model_input.lora_mapping,
  # lora_requests=model_input.lora_requests,
  ```
  I added comments. In the future, when vllm-ascend supports lora feature, the changes here can be restored.

### Does this PR introduce _any_ user-facing change?
This PR has no effect on users.

### How was this patch tested?
have tested

