### PR TITLE
[CI] Fix mypy CI

### DIFF
--- a/.github/workflows/vllm_ascend_test_main.yaml
+++ b/.github/workflows/vllm_ascend_test_main.yaml
@@ -63,10 +63,6 @@ jobs:
         run: |
           apt-get -y install `cat packages.txt`
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements-dev.txt
-
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v4
         with:
@@ -80,6 +76,8 @@ jobs:
 
       - name: Install vllm-project/vllm-ascend
         run: |
+          pip uninstall -y numpy
+          pip install -r requirements-dev.txt
           pip install -e .
 
       - name: Install pta

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -9,7 +9,7 @@ clang-format==18.1.5
 sphinx-lint==1.0.0
 
 # type checking
-mypy==1.11.1
+mypy==1.15.0
 types-PyYAML
 types-requests
 types-setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 scipy
 setuptools
 setuptools-scm
+numpy==1.26.4

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -21,6 +21,7 @@ import gc
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import numpy as np
+import numpy.typing as npt
 import torch
 import torch.distributed
 import torch.nn as nn
@@ -171,10 +172,9 @@ class NPUModelRunner:
             device=self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
-        self.arange_np = np.arange(max(self.max_num_reqs + 1,
-                                       self.max_model_len,
-                                       self.max_num_tokens),
-                                   dtype=np.int32)
+        self.arange_np: npt.NDArray[np.int32] = np.arange(max(
+            self.max_num_reqs + 1, self.max_model_len, self.max_num_tokens),
+                                                          dtype=np.int32)
         # NOTE(woosuk): These tensors are "stateless", i.e., they are literally
         # a faster version of creating a new tensor every time. Thus, we should
         # not make any assumptions about the values in these tensors.


### PR DESCRIPTION
### What this PR does / why we need it?
Fix CI by updating mypy and pining numpy version

_the modification of model_runner_v1 is just to make CI happy_

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed

