### PR TITLE
[v0.7.3][Docs] Add install system dependencies in install doc (#438)

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -119,7 +119,14 @@ Once it's done, you can start to set up `vllm` and `vllm-ascend`.
 :selected:
 :sync: pip
 
-You can install `vllm` and `vllm-ascend` from **pre-built wheel** (**Unreleased yet**, please build from source code):
+First install system dependencies:
+
+```bash
+apt update  -y
+apt install -y gcc g++ libnuma-dev
+```
+
+You can install `vllm` and `vllm-ascend` from **pre-built wheel**:
 
 ```{code-block} bash
    :substitutions:


### PR DESCRIPTION
### What this PR does / why we need it?
Backport https://github.com/vllm-project/vllm-ascend/pull/438

Add install system dependencies in install doc

Resolve:
```
$ pip install vllm==v0.7.3
CMake Error at CMakeLists.txt:14 (project):
  No CMAKE_CXX_COMPILER could be found.
  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
// ... ...
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for vllm
Failed to build vllm
ERROR: Failed to build installable wheels for some pyproject.toml based projects (vllm)
```

Closes: https://github.com/vllm-project/vllm-ascend/issues/439 


### Does this PR introduce _any_ user-facing change? 
No

### How was this patch tested?
CI passed
