### PR TITLE
[WIP] Bump numpy version to 2.x

### DIFF
--- a/.github/workflows/vllm_ascend_test_main.yaml
+++ b/.github/workflows/vllm_ascend_test_main.yaml
@@ -77,7 +77,6 @@ jobs:
 
       - name: Install vllm-project/vllm-ascend
         run: |
-          pip uninstall -y numpy
           pip install -r requirements-dev.txt
           pip install -e .
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -78,7 +78,7 @@ python -m venv vllm-ascend-env
 source vllm-ascend-env/bin/activate
 
 # Install required python packages.
-pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple attrs numpy<2.0.0 decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py wheel typing_extensions
+pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple attrs numpy decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py wheel typing_extensions
 
 # Download and install the CANN package.
 wget https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.0.0/Ascend-cann-toolkit_8.0.0_linux-aarch64.run

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy
 pybind11
 setuptools
 setuptools-scm
-numpy==1.26.4
+numpy


### PR DESCRIPTION
### What this PR does / why we need it?
In vLLM, there is no version limit for numpy, we should follow the version policy to reduce maintaince cost and enhance the dev/users experience.

https://github.com/vllm-project/vllm/blob/main/requirements/common.txt#L4


### Does this PR introduce _any_ user-facing change?
Yes, numpy version upgrade

### How was this patch tested?
CI passed

related: https://github.com/vllm-project/vllm-ascend/issues/473
