### PR TITLE
Set numpy < 2.0.0 to resolve numpy VersionConflict

### DIFF
--- a/.github/workflows/vllm_ascend_test_main.yaml
+++ b/.github/workflows/vllm_ascend_test_main.yaml
@@ -77,7 +77,6 @@ jobs:
 
       - name: Install vllm-project/vllm-ascend
         run: |
-          pip uninstall -y numpy
           pip install -r requirements-dev.txt
           pip install -e .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [build-system]
 # Should be mirrored in requirements.txt
 requires = [
-    "setuptools>=64",
-    "setuptools-scm>=8",
     "cmake>=3.26",
-    "pybind11",
     "decorator",
+    "numpy<2.0.0",
+    "pybind11",
     "pyyaml",
     "scipy",
+    "setuptools>=64",
+    "setuptools-scm>=8",
     "torch_npu >= 2.5.1rc1",
-    "torch >= 2.5.1"
+    "torch >= 2.5.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+# Should be mirrored in pyporject.toml
+cmake>=3.26
 decorator
+numpy<2.0.0
+pybind11
 pyyaml
 scipy
-pybind11
-setuptools
-setuptools-scm
-numpy==1.26.4
+setuptools>=64
+setuptools-scm>=8
+torch_npu >= 2.5.1rc1
+torch >= 2.5.1


### PR DESCRIPTION
### What this PR does / why we need it?
vLLM bumps numpy version to 2.x: https://github.com/vllm-project/vllm/commit/8427f70493ed67bf26cb9e7fa98ac202b991c37d , this will cause a `pip._vendor.pkg_resources.ContextualVersionConflict: (numpy 2.2.4 (/usr/local/python3.10/lib/python3.10/site-packages), Requirement.parse('numpy==1.26.4'), {'vllm-ascend'})` failure when vllm ascend install. This PR resolved the issue by:
- Set numpy < 2.0.0 to resolve numpy VersionConflict
- Sync requirements and toml 
- Reorder


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed

Closes: https://github.com/vllm-project/vllm-ascend/issues/473
