### PR TITLE
Set torchvision<0.21.0 to match torch/torch_npu version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,6 @@ requires = [
     "setuptools-scm>=8",
     "torch_npu >= 2.5.1rc1",
     "torch >= 2.5.1",
+    "torchvision<0.21.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ setuptools>=64
 setuptools-scm>=8
 torch_npu >= 2.5.1rc1
 torch >= 2.5.1
+torchvision<0.21.0


### PR DESCRIPTION
### What this PR does / why we need it?
Set torchvision<0.21.0 to match torch/torch_npu version to resolve `RuntimeError: operator torchvision::nms does not exist`.

Closes: https://github.com/vllm-project/vllm-ascend/issues/477

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed

