### PR TITLE
[Worker] Update memory count method

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
 # This file is a part of the vllm-ascend project.
 # Adapted from vllm-project/vllm/vllm/worker/worker.py
+#              vllm-project/vllm/vllm/utils.py
 # Copyright 2023 The vLLM team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import contextlib
+import time
+from collections.abc import Generator
+from dataclasses import dataclass, field
+
 import torch
 from vllm.logger import logger
 
@@ -58,3 +64,144 @@ def adapt_patch(is_global_patch: bool = False):
         from vllm_ascend.patch import platform  # noqa: F401
     else:
         from vllm_ascend.patch import worker  # noqa: F401
+
+
+@dataclass
+class MemorySnapshot:
+    """Memory snapshot."""
+    torch_peak: int = 0
+    npu_memory: int = 0
+    torch_memory: int = 0
+    non_torch_memory: int = 0
+    timestamp: float = 0.0
+    auto_measure: bool = True
+
+    def __post_init__(self):
+        if self.auto_measure:
+            self.measure()
+
+    def measure(self):
+        # we measure the torch peak memory usage via allocated_bytes,
+        # rather than `torch.npu.memory_reserved()` .
+        # After `torch.npu.reset_peak_memory_stats()`,
+        # `torch.npu.memory_reserved()` will keep growing, and only shrink
+        # when we call `torch.npu.empty_cache()` or OOM happens.
+        self.torch_peak = torch.npu.memory_stats().get(
+            "allocated_bytes.all.peak", 0)
+
+        self.npu_memory = torch.npu.mem_get_info()[1] - torch.npu.mem_get_info(
+        )[0]
+
+        # torch.npu.memory_reserved() is how many bytes
+        # PyTorch gets from npu (by calling npuMalloc, etc.)
+        # this is used to measure the non-torch memory usage
+        self.torch_memory = torch.npu.memory_reserved()
+
+        self.non_torch_memory = self.npu_memory - self.torch_memory
+        self.timestamp = time.time()
+
+    def __sub__(self, other):
+        return MemorySnapshot(
+            torch_peak=self.torch_peak - other.torch_peak,
+            npu_memory=self.npu_memory - other.npu_memory,
+            torch_memory=self.torch_memory - other.torch_memory,
+            non_torch_memory=self.non_torch_memory - other.non_torch_memory,
+            timestamp=self.timestamp - other.timestamp,
+            auto_measure=False,
+        )
+
+
+@dataclass
+class MemoryProfilingResult:
+    """Memory profiling result. All numbers are in bytes.
+    """
+    non_kv_cache_memory: int = 0
+    torch_peak_increase: int = 0
+    non_torch_increase: int = 0
+    weights_memory: float = 0
+    before_create: MemorySnapshot = field(default_factory=MemorySnapshot)
+    before_profile: MemorySnapshot = field(default_factory=MemorySnapshot)
+    after_profile: MemorySnapshot = field(default_factory=MemorySnapshot)
+    profile_time: float = 0.0
+
+
+@contextlib.contextmanager
+def memory_profiling(
+        baseline_snapshot: MemorySnapshot,
+        weights_memory: int) -> Generator[MemoryProfilingResult, None, None]:
+    """Memory profiling context manager.
+    baseline_snapshot: the memory snapshot before the current vLLM instance.
+    weights_memory: memory used by PyTorch when loading the model weights.
+        Note that, before loading the model weights, we also initialize the device
+        and distributed environment, which may consume some memory. This part is not
+        included in the weights_memory because PyTorch does not control it.
+
+    The memory in one GPU can be classified into 3 categories:
+    1. memory used by anything other than the current vLLM instance.
+    2. memory used by torch in the current vLLM instance.
+    3. memory used in the current vLLM instance, but not by torch.
+
+    A quantitive example:
+
+    Before creating the current vLLM instance:
+        category 1: 1 GiB
+        category 2: 0 GiB
+        category 3: 0 GiB
+
+    After creating the current vLLM instance and loading the model,
+    (i.e. before profiling):
+        category 1: 1 GiB
+        category 2: 2 GiB (model weights take 2 GiB)
+        category 3: 0.5 GiB (memory used by NCCL)
+
+    During profiling (peak):
+        category 1: 1 GiB
+        category 2: 4 GiB (peak activation tensors take 2 GiB)
+        category 3: 1 GiB (memory used by NCCL + buffers for some attention backends)
+
+    After profiling:
+        category 1: 1 GiB
+        category 2: 3 GiB (after garbage-collecting activation tensors)
+        category 3: 1 GiB (memory used by NCCL + buffers for some attention backends)
+
+    In this case, non-kv cache takes 5 GiB in total, including:
+    a. 2 GiB used by the model weights (category 2)
+    b. 2 GiB reserved for the peak activation tensors (category 2)
+    c. 1 GiB used by non-torch components (category 3)
+
+    The memory used for loading weights (a.) is directly given from the argument `weights_memory`.
+
+    The increase of `torch.npu.memory_stats()["allocated_bytes.all.peak"]` during profiling gives (b.).
+
+    The increase of `non_torch_memory` from creating the current vLLM instance until after profiling to get (c.).
+    """
+    import gc
+
+    import torch_npu  # noqa: F401
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+    result = MemoryProfilingResult()
+
+    result.before_create = baseline_snapshot
+    # the part of memory used for holding the model weights
+    result.weights_memory = weights_memory
+
+    result.before_profile.measure()
+
+    yield result
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+    result.after_profile.measure()
+
+    diff_profile = result.after_profile - result.before_profile
+    diff_from_create = result.after_profile - result.before_create
+    result.torch_peak_increase = diff_profile.torch_peak
+    result.non_torch_increase = diff_from_create.non_torch_memory
+    result.profile_time = diff_profile.timestamp
+    result.non_kv_cache_memory = result.non_torch_increase \
+                                + result.torch_peak_increase \
+                                + result.weights_memory


### PR DESCRIPTION
### What this PR does / why we need it?
This pr updates the memory count method.
1. Instead of using `torch.npu.mem_get_info()`, we use `torch.npu.memory_stats()`  to profile peak memory usage as https://github.com/vllm-project/vllm/pull/9352 do.
2. Use `memory_profiling` context manager to acctually profile the npu memory when executing `model_runner.profile_run()`, as  
https://github.com/vllm-project/vllm/pull/10511 do.

Fix https://github.com/vllm-project/vllm-ascend/issues/522

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with existing test and the latest mem log is printed

