### PR TITLE
delay the patch to the pre_register_and_update to prevent circule imp…

### DIFF
--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -18,9 +18,6 @@
 
 def register():
     """Register the NPU platform."""
-    # Adapt the global patch here.
-    from vllm_ascend.utils import adapt_patch
-    adapt_patch(is_global_patch=True)
 
     return "vllm_ascend.platform.NPUPlatform"
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -65,6 +65,10 @@ class NPUPlatform(Platform):
     def pre_register_and_update(cls,
                                 parser: Optional[FlexibleArgumentParser] = None
                                 ) -> None:
+        # Adapt the global patch here.
+        from vllm_ascend.utils import adapt_patch
+        adapt_patch(is_global_patch=True)
+
         from vllm_ascend.quantization.quant_config import \
             AscendQuantConfig  # noqa: F401
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

I found the global patch happens at the platform registering phase may encounter the circle import problem if you are trying to patch a module that haven't been intialized by vllm. 

In this PR, I move the patch to the `pre_register_and_update` function to make sure the patch takes effect after all the module in vllm is initialized.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

