### PR TITLE
[Docker] Fix openEuler image suffix

### DIFF
--- a/.github/workflows/image_openeuler.yml
+++ b/.github/workflows/image_openeuler.yml
@@ -62,7 +62,7 @@ jobs:
         tags: |
           type=ref,event=branch,suffix=-openeuler
           type=ref,event=pr,suffix=-openeuler
-          type=pep440,pattern={{raw}}-openeuler
+          type=pep440,pattern={{raw}},suffix=-openeuler
 
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -88,8 +88,6 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         # only trigger when tag, branch/main push
         push: ${{ github.event_name == 'push' && github.repository_owner == 'vllm-project' }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/image_ubuntu.yml
+++ b/.github/workflows/image_ubuntu.yml
@@ -88,8 +88,6 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         # only trigger when tag, branch/main push
         push: ${{ github.event_name == 'push' && github.repository_owner == 'vllm-project' }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### What this PR does / why we need it?
There was a bug when we release v0.8.4rc1 (openEuler image tag was wrong set to 0.8.4rc1), according doc of docker-meta-action, it should be append suffix:
```
tags: |
  type=pep440,enable=true,priority=900,prefix=,suffix=,pattern=,value=
```

This patch just fix openEuler image suffix to make pep440 tag rule work.

This patch also remove the cache step because the cache step bring more than 10mins export, but reduce less time in next trigger.

### Does this PR introduce _any_ user-facing change?
Yes, docker image tag set to right

### How was this patch tested?
I test with in my fork repo by setting default branch:
- release a tag: v0.7.88rc1 (pep440 tag)
- The log show `--label org.opencontainers.image.version=v0.7.88rc1-openeuler` is right rule

https://github.com/Yikun/vllm-ascend/actions/runs/14560411481/job/40842950165#step:9:205

Related: https://github.com/vllm-project/vllm-ascend/pull/489
