### PR TITLE
[Bugfix] Fix the bug of `torch_npu` that raising segment fault when enable `pin_memory` while creating a tensor

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -49,6 +49,9 @@ else:
     FlexibleArgumentParser = None
 
 os.environ["RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES"] = "1"
+# Fix the bug in torch 2.5.1 that raising segment fault when enable `pin_memory`
+# while creating a tensor using `torch.tensor`.
+os.environ["ACL_OP_INIT_MODE"] = "1"
 
 
 class NPUPlatform(Platform):


### PR DESCRIPTION
…ile creating a tensor using

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Fix the bug in torch 2.5.1 that raising segment fault when enable `pin_memory` while creating a tensor using `torch.tensor`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

