### PR TITLE
[Platform] format platform to make it more clear

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -62,7 +62,7 @@
 #       inside of the repo, and needs a common interface to destroy them, this patch add the interface of destroy
 #       platform owned `CoordinatorGroup` to make sure all the CoordinateGroup can be properly destroyed
 #    How：
-#       Call platform method `destroy_platform_model_parallel` to destroy all the `CoordinateGroup`
+#       Call `vllm_ascend.distributed.parallel_state method `destroy_platform_model_parallel` to destroy all the `CoordinateGroup`
 #    Related PR (if no, explain why): no related PR, we want add this ability into vllm
 #    Future Plan:
 #       Remove those patch when vllm merged them
@@ -73,7 +73,7 @@
 #       call to the `stateless_init_torch_distributed_process_group`, to enable other platform which may support
 #       stateless process group initialize method
 #    How：
-#       Call platform method `platform_has_backend_register` to judge if there is a stateless process group initialize
+#       rewrite stateless_init_torch_distributed_process_group to judge if there is a stateless process group initialize
 #       method and call platform method `platform_register_backend` to initialize them
 #    Related PR (if no, explain why): no related PR, we want add this ability into vllm
 #    Future Plan:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -226,29 +226,3 @@ class NPUPlatform(Platform):
         model configuration.
         """
         return True
-
-    @classmethod
-    def destroy_platform_model_parallel(cls) -> None:
-        from vllm_ascend.distributed.parallel_state import \
-            destory_ascend_model_parallel
-        destory_ascend_model_parallel()
-
-    @classmethod
-    def platform_has_backend_register(cls) -> bool:
-        return True
-
-    @classmethod
-    def platform_register_backend(cls, pg, prefix_store, group_rank,
-                                  group_size, backend_options,
-                                  timeout) -> None:
-        from torch.distributed import ProcessGroup, is_hccl_available
-        assert is_hccl_available()
-        from torch_npu._C._distributed_c10d import ProcessGroupHCCL
-        backend_options = ProcessGroupHCCL.Options()
-        backend_options._timeout = timeout
-        backend_class = ProcessGroupHCCL(prefix_store, group_rank, group_size,
-                                         backend_options)
-        device = torch.device("npu")
-        backend_class._set_sequence_number_for_group()
-        backend_type = ProcessGroup.BackendType.CUSTOM
-        pg._register_backend(device, backend_type, backend_class)


### PR DESCRIPTION
Platform should only contain the function that based from vllm. This PR move the unrelated function to the right place to make platform more clear.