### PR TITLE
Quick Fix: Enforce eager mode in the V1 engine ahead of the upcoming CANN and torch_npu releases

### DIFF
--- a/tests/multicard/test_offline_inference_distributed.py
+++ b/tests/multicard/test_offline_inference_distributed.py
@@ -47,7 +47,6 @@ def test_models_distributed(model: str,
             dtype=dtype,
             tensor_parallel_size=4,
             distributed_executor_backend=distributed_executor_backend,
-            enforce_eager=True,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 

--- a/tests/ops/test_fused_moe.py
+++ b/tests/ops/test_fused_moe.py
@@ -22,7 +22,6 @@ Run `pytest tests/ops/test_fused_moe.py`.
 
 import pytest
 import torch
-from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.activation import SiluAndMul
 
 from vllm_ascend.ops.fused_moe import fused_experts
@@ -68,36 +67,31 @@ def test_fused_experts(
     dtype: torch.dtype,
     device: str,
 ):
-    vllm_config = VllmConfig()
-    with set_current_vllm_config(vllm_config):
-        a = torch.randn((m, k), device=device, dtype=dtype) / 10
-        w1 = torch.randn((e, 2 * n, k), device=device, dtype=dtype) / 10
-        w2 = torch.randn((e, k, n), device=device, dtype=dtype) / 10
+    a = torch.randn((m, k), device=device, dtype=dtype) / 10
+    w1 = torch.randn((e, 2 * n, k), device=device, dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device=device, dtype=dtype) / 10
 
-        score = torch.randn((m, e), device=device, dtype=dtype)
+    score = torch.randn((m, e), device=device, dtype=dtype)
 
-        if ep_size > 1:
-            local_e = e // ep_size
-            e_ids = torch.randint(0,
-                                  e, (local_e, ),
-                                  device=device,
-                                  dtype=torch.int32)
-            e_map = torch.full((e, ), -1, device=device, dtype=torch.int32)
-            e_map[e_ids] = torch.arange(local_e,
-                                        device=device,
-                                        dtype=torch.int32)
-            w1 = w1[e_ids]
-            w2 = w2[e_ids]
-        else:
-            e_map = None
+    if ep_size > 1:
+        local_e = e // ep_size
+        e_ids = torch.randint(0,
+                              e, (local_e, ),
+                              device=device,
+                              dtype=torch.int32)
+        e_map = torch.full((e, ), -1, device=device, dtype=torch.int32)
+        e_map[e_ids] = torch.arange(local_e, device=device, dtype=torch.int32)
+        w1 = w1[e_ids]
+        w2 = w2[e_ids]
+    else:
+        e_map = None
 
-        score = torch.softmax(score, dim=-1, dtype=dtype)
-        topk_weights, topk_ids = torch.topk(score, topk)
-        topk_ids = topk_ids.to(torch.int32)
+    score = torch.softmax(score, dim=-1, dtype=dtype)
+    topk_weights, topk_ids = torch.topk(score, topk)
+    topk_ids = topk_ids.to(torch.int32)
 
-        output = fused_experts(a, w1, w2, topk_weights, topk_ids, topk, e_map)
-        torch_output = torch_moe(a, w1, w2, topk_weights, topk_ids, topk,
-                                 e_map)
-        # TODO: The native params are: atol=2e-2, rtol=0, maybe related to the nan problem
-        torch.testing.assert_close(output, torch_output, atol=4e-2, rtol=1)
+    output = fused_experts(a, w1, w2, topk_weights, topk_ids, topk, e_map)
+    torch_output = torch_moe(a, w1, w2, topk_weights, topk_ids, topk, e_map)
+    # TODO: The native params are: atol=2e-2, rtol=0, maybe related to the nan problem
+    torch.testing.assert_close(output, torch_output, atol=4e-2, rtol=1)
     torch.npu.empty_cache()

--- a/tests/singlecard/test_offline_inference.py
+++ b/tests/singlecard/test_offline_inference.py
@@ -50,7 +50,7 @@ def test_models(model: str, dtype: str, max_tokens: int) -> None:
     with VllmRunner(model,
                     max_model_len=8192,
                     dtype=dtype,
-                    enforce_eager=True,
+                    enforce_eager=False,
                     gpu_memory_utilization=0.7) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Enforce eager mode in the V1 engine ahead of the upcoming CANN and torch_npu releases.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
After this change, users will no longer need to manually set enforce_eager=True.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Test it with regular offline inference examples.
