### PR TITLE
[MISC] Make vllm version configurable

### DIFF
--- a/docs/source/developer_guide/versioning_policy.md
+++ b/docs/source/developer_guide/versioning_policy.md
@@ -20,7 +20,7 @@ For example:
 
 vllm-ascend has main branch and dev branch.
 
-- **main**: main branch，corresponds to the vLLM main branch, and is continuously monitored for quality through Ascend CI.
+- **main**: main branch，corresponds to the vLLM main branch and latest 1 or 2 release version. It is continuously monitored for quality through Ascend CI.
 - **vX.Y.Z-dev**: development branch, created with part of new releases of vLLM. For example, `v0.7.3-dev` is the dev branch for vLLM `v0.7.3` version.
 
 Usually, a commit should be ONLY first merged in the main branch, and then backported to the dev branch to reduce maintenance costs as much as possible.
@@ -45,6 +45,13 @@ Usually, each minor version of vLLM (such as 0.7) will correspond to a vllm-asce
 | main       | Maintained   | CI commitment for vLLM main branch and vLLM 0.8.x branch   |
 | v0.7.3-dev | Maintained   | CI commitment for vLLM 0.7.3 version |
 | v0.7.1-dev | Unmaintained | Replaced by v0.7.3-dev               |
+
+### Backward compatibility
+
+For main branch, vllm-ascend should works with vLLM main branch and latest 1 or 2 release version. So to ensure the backward compatibility, we will do the following:
+- Both main branch and target vLLM release is tested by Ascend E2E CI. For example, currently, vLLM main branch and vLLM 0.8.4 are tested now.
+- For code changes, we will make sure that the changes are compatible with the latest 1 or 2 vLLM release version as well. In this case, vllm-ascend introduced a version check machinism inner the code. It'll check the version of installed vLLM pacakge first to decide which code logic to use. If users hit the `InvalidVersion` error, it sometimes means that they have installed an dev/editable version of vLLM package. In this case, we provide the env variable `VLLM_VERSION` to let users specify the version of vLLM package to use.
+- For documentation changes, we will make sure that the changes are compatible with the latest 1 or 2 vLLM release version as well. Note should be added if there are any breaking changes.
 
 ## Document Branch Policy
 To reduce maintenance costs, **all branch documentation content should remain consistent, and version differences can be controlled via variables in [docs/source/conf.py](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/conf.py)**. While this is not a simple task, it is a principle we should strive to follow.

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -103,3 +103,6 @@ vllm-ascend is tested by functional test, performance test and accuracy test.
 - **Accuracy test**: we're working on adding accuracy test to CI as well.
 
 Finnall, for each release, we'll publish the performance test and accuracy test report in the future.
+
+### 14. How to fix the error "InvalidVersion" when using vllm-ascend?
+It's usually because you have installed an dev/editable version of vLLM package. In this case, we provide the env variable `VLLM_VERSION` to let users specify the version of vLLM package to use. Please set the env variable `VLLM_VERSION` to the version of vLLM package you have installed. The format of `VLLM_VERSION` should be `X.Y.Z`.

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -59,7 +59,9 @@ env_variables: Dict[str, Callable[[], Any]] = {
     "CXX_COMPILER":
     lambda: os.getenv("CXX_COMPILER", None),
     "C_COMPILER":
-    lambda: os.getenv("C_COMPILER", None)
+    lambda: os.getenv("C_COMPILER", None),
+    "VLLM_VERSION":
+    lambda: os.getenv("VLLM_VERSION", None),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -18,7 +18,7 @@
 #
 import torch
 import torch_npu  # noqa: F401
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from vllm.logger import logger
 
 import vllm_ascend.envs as envs
@@ -86,6 +86,17 @@ def adapt_patch(is_global_patch: bool = False):
         from vllm_ascend.patch import worker  # noqa: F401
 
 
-def vllm_version_is(version: str):
-    import vllm
-    return Version(vllm.__version__) == Version(version)
+def vllm_version_is(target_vllm_version: str):
+    if envs.VLLM_VERSION is not None:
+        vllm_version = envs.VLLM_VERSION
+    else:
+        import vllm
+        vllm_version = vllm.__version__
+    try:
+        return Version(vllm_version) == Version(target_vllm_version)
+    except InvalidVersion:
+        raise ValueError(
+            f"Invalid vllm version {vllm_version} found. A dev version of vllm "
+            "is installed probably. Set the environment variable VLLM_VERSION "
+            "to control it by hand. And please make sure the vaule follows the "
+            "format of x.y.z.")


### PR DESCRIPTION
Sometimes, user install a dev/editable version of vllm. In this case, we should make sure vllm-ascend works as well.

This PR add a new env `VLLM_VERSION`. It's used for developers who edit vllm. In this case, developers should set thie env to make sure which vllm version is installed and used.