### PR TITLE
[ModelRunnerV1] Adapt kv_cache quant in v1.

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -877,7 +877,7 @@ class NPUModelRunner:
                     block_size=block_size,
                     num_kv_heads=attn_module.num_kv_heads,
                     head_size=attn_module.head_size,
-                    dtype=attn_module.dtype)
+                    dtype=self.kv_cache_dtype)
             elif attn_module.attn_type in (AttentionType.ENCODER,
                                            AttentionType.ENCODER_ONLY):
                 # encoder-only attention does not need KV cache.


### PR DESCRIPTION
set self.kv_cache_dtype to kv_cache_spec in model_runner_v1 in order to support kv_cache quant in v1