### PR TITLE
[0.7.3] optimize qwen2_vl and qwen2_5_vl

### DIFF
--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -4,7 +4,7 @@ from vllm import ModelRegistry
 def register_model():
     ModelRegistry.register_model(
         "Qwen2VLForConditionalGeneration",
-        "vllm_ascend.models.qwen2_vl:CustomQwen2VLForConditionalGeneration")
+        "vllm_ascend.models.qwen2_vl:AscendQwen2VLForConditionalGeneration")
 
     ModelRegistry.register_model(
         "Qwen2_5_VLForConditionalGeneration",

--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -66,6 +66,7 @@ class AscendQwen2_5_VisionAttention(Qwen2_5_VisionAttention):
         self.embed_dim = embed_dim
         self.hidden_size_per_attention_head = dist_utils.divide(
             projection_size, num_heads)
+        self.origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head
         if self.hidden_size_per_attention_head > MIN_PAD_SIZE and self.hidden_size_per_attention_head < MAX_PAD_SIZE:
             self.hidden_size_per_attention_head = MAX_PAD_SIZE
 
@@ -95,13 +96,13 @@ class AscendQwen2_5_VisionAttention(Qwen2_5_VisionAttention):
 
         context_layer = torch.torch.empty_like(q)
 
-        # operator requires pta version >= 2.5.1
+        # operator requires pta version >= 2.5.1.dev20250226
         torch_npu._npu_flash_attention_unpad(
             query=q,
             key=k,
             value=v,
             seq_len=cu_seqlens,
-            scale_value=self.hidden_size_per_attention_head**-0.5,
+            scale_value=self.origin_hidden_size_per_attention_head**-0.5,
             num_heads=self.num_attention_heads_per_partition,
             num_kv_heads=self.num_attention_heads_per_partition,
             out=context_layer)
@@ -164,6 +165,7 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
         super().__init__(vision_config, norm_eps, quant_config, prefix)
         norm_layer = partial(RMSNorm, eps=norm_eps)
         self.interleaved = interleaved
+        self.enable_pad = False
         self.patch_embed = AscendQwen2_5_VisionPatchEmbed(
             patch_size=vision_config.patch_size,
             temporal_patch_size=vision_config.temporal_patch_size,
@@ -187,6 +189,7 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
             self.hidden_size, self.num_heads)
 
         if self.hidden_size_per_attention_head > MIN_PAD_SIZE and self.hidden_size_per_attention_head < MAX_PAD_SIZE:
+            self.enable_pad = True
             self.origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head
             self.half_origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head // 2
             self.half_pad_hidden_size_per_attention_head = (
@@ -196,10 +199,11 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
     def cal_cos_sin(self, rotary_pos_emb):
         cos = rotary_pos_emb.cos()  # [seqlen, rotary_dim / 2]
         sin = rotary_pos_emb.sin()
-        cos = torch.nn.functional.pad(
-            cos, (0, self.half_pad_hidden_size_per_attention_head))
-        sin = torch.nn.functional.pad(
-            sin, (0, self.half_pad_hidden_size_per_attention_head))
+        if self.enable_pad == True:
+            cos = torch.nn.functional.pad(
+                cos, (0, self.half_pad_hidden_size_per_attention_head))
+            sin = torch.nn.functional.pad(
+                sin, (0, self.half_pad_hidden_size_per_attention_head))
 
         if not self.interleaved:
             cos_new = torch.cat((cos, cos), dim=-1)
@@ -285,11 +289,11 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
                 weight_loader = getattr(param, "weight_loader",
                                         default_weight_loader)
                 weight_loader(param, loaded_weight)
-                if ("attn.proj.weight" in name):
+                if ("attn.proj.weight" in name) and self.enable_pad == True:
                     param.data = self.pad_proj_weight(param.data)
-                if ("attn.qkv.weight" in name):
+                if ("attn.qkv.weight" in name) and self.enable_pad == True:
                     param.data = self.pad_qkv_weight(param.data)
-                if ("attn.qkv.bias" in name):
+                if ("attn.qkv.bias" in name) and self.enable_pad == True:
                     param.data = self.pad_qkv_bias(param.data)
             loaded_params.add(name)
         return loaded_params

--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -199,7 +199,7 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
     def cal_cos_sin(self, rotary_pos_emb):
         cos = rotary_pos_emb.cos()  # [seqlen, rotary_dim / 2]
         sin = rotary_pos_emb.sin()
-        if self.enable_pad == True:
+        if self.enable_pad:
             cos = torch.nn.functional.pad(
                 cos, (0, self.half_pad_hidden_size_per_attention_head))
             sin = torch.nn.functional.pad(
@@ -289,11 +289,11 @@ class AscendQwen2_5_VisionTransformer(Qwen2_5_VisionTransformer):
                 weight_loader = getattr(param, "weight_loader",
                                         default_weight_loader)
                 weight_loader(param, loaded_weight)
-                if ("attn.proj.weight" in name) and self.enable_pad == True:
+                if ("attn.proj.weight" in name) and self.enable_pad:
                     param.data = self.pad_proj_weight(param.data)
-                if ("attn.qkv.weight" in name) and self.enable_pad == True:
+                if ("attn.qkv.weight" in name) and self.enable_pad:
                     param.data = self.pad_qkv_weight(param.data)
-                if ("attn.qkv.bias" in name) and self.enable_pad == True:
+                if ("attn.qkv.bias" in name) and self.enable_pad:
                     param.data = self.pad_qkv_bias(param.data)
             loaded_params.add(name)
         return loaded_params

--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -42,8 +42,8 @@ from vllm.model_executor.models.qwen2_5_vl import (
 from vllm.model_executor.models.utils import maybe_prefix
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
-MIN_PAD_SIZE = 64
-MAX_PAD_SIZE = 128
+MIN_PAD_SIZE = 64  # min_size to pad weight
+MAX_PAD_SIZE = 128  # max_size to pad weight
 
 
 class AscendQwen2_5_VisionAttention(Qwen2_5_VisionAttention):
@@ -96,7 +96,7 @@ class AscendQwen2_5_VisionAttention(Qwen2_5_VisionAttention):
 
         context_layer = torch.torch.empty_like(q)
 
-        # operator requires pta version >= 2.5.1.dev20250226
+        # operator requires pta version >= 2.5.1
         torch_npu._npu_flash_attention_unpad(
             query=q,
             key=k,

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -1,9 +1,7 @@
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
-# Adapted from vllm/model_executor/models/qwen2_vl.py
 # Copyright 2023 The vLLM team.
 #
-# This file is a part of the vllm-ascend project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +14,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Adapted from vllm/model_executor/models/qwen2_vl.py
+# This file is a part of the vllm-ascend project.
 
+from collections.abc import Iterable
 from functools import partial
-from typing import Callable, Optional, Type
+from typing import Callable, Optional, Set, Type, Tuple
 
 import torch
 import torch.nn as nn
@@ -27,18 +28,23 @@ from einops import rearrange
 from transformers.models.qwen2_vl.configuration_qwen2_vl import \
     Qwen2VLVisionConfig
 from vllm.config import VllmConfig
+from vllm.distributed import utils as dist_utils
 from vllm.model_executor.layers.activation import QuickGELU
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.qwen2_vl import (
     Qwen2VisionAttention, Qwen2VisionBlock, Qwen2VisionPatchEmbed,
     Qwen2VisionTransformer, Qwen2VLDummyInputsBuilder,
     Qwen2VLForConditionalGeneration, Qwen2VLMultiModalProcessor,
-    Qwen2VLProcessingInfo, apply_rotary_pos_emb_vision)
+    Qwen2VLProcessingInfo)
 from vllm.model_executor.models.utils import maybe_prefix
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
+MIN_PAD_SIZE = 64
+MAX_PAD_SIZE = 128
 
-class CustomQwen2VisionAttention(Qwen2VisionAttention):
+
+class AscendQwen2VisionAttention(Qwen2VisionAttention):
 
     def __init__(
         self,
@@ -56,12 +62,16 @@ class CustomQwen2VisionAttention(Qwen2VisionAttention):
             prefix,
         )
         self.cu_seqlens = None
+        self.origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head
+        if self.hidden_size_per_attention_head > MIN_PAD_SIZE and self.hidden_size_per_attention_head < MAX_PAD_SIZE:
+            self.hidden_size_per_attention_head = MAX_PAD_SIZE
 
     def forward(
         self,
         x: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        rotary_pos_emb: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
     ) -> torch.Tensor:
 
         self.cu_seqlens = cu_seqlens
@@ -76,9 +86,8 @@ class CustomQwen2VisionAttention(Qwen2VisionAttention):
         q, k, v = [
             rearrange(x, "s b ... -> b s ...").contiguous() for x in (q, k, v)
         ]
-        if rotary_pos_emb is not None:
-            q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
-            k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
+        q = torch_npu.npu_rotary_mul(q, cos, sin)
+        k = torch_npu.npu_rotary_mul(k, cos, sin)
         q, k, v = [
             rearrange(x, "b s h d -> (b s) h d").contiguous()
             for x in (q, k, v)
@@ -86,13 +95,13 @@ class CustomQwen2VisionAttention(Qwen2VisionAttention):
 
         context_layer = torch.torch.empty_like(q)
 
-        # operator requires pta version >= 2.5.1
+        # operator requires pta version >= 2.5.1.dev20250226
         torch_npu._npu_flash_attention_unpad(
             query=q,
             key=k,
             value=v,
             seq_len=self.cu_seqlens,
-            scale_value=self.hidden_size_per_attention_head**-0.5,
+            scale_value=self.origin_hidden_size_per_attention_head**-0.5,
             num_heads=self.num_attention_heads_per_partition,
             num_kv_heads=self.num_attention_heads_per_partition,
             out=context_layer)
@@ -104,7 +113,7 @@ class CustomQwen2VisionAttention(Qwen2VisionAttention):
         return output
 
 
-class CustomQwen2VisionBlock(Qwen2VisionBlock):
+class AscendQwen2VisionBlock(Qwen2VisionBlock):
 
     def __init__(
         self,
@@ -118,14 +127,30 @@ class CustomQwen2VisionBlock(Qwen2VisionBlock):
     ) -> None:
         super().__init__(dim, num_heads, mlp_ratio, act_layer, norm_layer,
                          quant_config, prefix)
-        self.attn = CustomQwen2VisionAttention(embed_dim=dim,
+        self.attn = AscendQwen2VisionAttention(embed_dim=dim,
                                                num_heads=num_heads,
                                                projection_size=dim,
                                                quant_config=quant_config,
                                                prefix=f"{prefix}.attn")
 
+    def forward(
+            self,
+            x: torch.Tensor,
+            cu_seqlens: torch.Tensor,
+            cos: torch.Tensor,
+            sin: torch.Tensor,
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x),
+            cu_seqlens=cu_seqlens,
+            cos=cos,
+            sin=sin,
+        )
 
-class CustomQwen2VisionPatchEmbed(Qwen2VisionPatchEmbed):
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class AscendQwen2VisionPatchEmbed(Qwen2VisionPatchEmbed):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = x.matmul(
@@ -133,7 +158,7 @@ class CustomQwen2VisionPatchEmbed(Qwen2VisionPatchEmbed):
         return x
 
 
-class CustomQwen2VisionTransformer(Qwen2VisionTransformer):
+class AscendQwen2VisionTransformer(Qwen2VisionTransformer):
 
     def __init__(
         self,
@@ -141,10 +166,14 @@ class CustomQwen2VisionTransformer(Qwen2VisionTransformer):
         norm_eps: float = 1e-6,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        interleaved=False,
     ) -> None:
         super().__init__(vision_config, norm_eps, quant_config, prefix)
 
-        self.patch_embed = CustomQwen2VisionPatchEmbed(
+        self.interleaved = interleaved
+        self.enable_pad = False
+        self.depth = vision_config.depth
+        self.patch_embed = AscendQwen2VisionPatchEmbed(
             patch_size=vision_config.patch_size,
             temporal_patch_size=vision_config.temporal_patch_size,
             in_channels=vision_config.in_channels,
@@ -152,7 +181,7 @@ class CustomQwen2VisionTransformer(Qwen2VisionTransformer):
         )
 
         self.blocks = nn.ModuleList([
-            CustomQwen2VisionBlock(dim=self.embed_dim,
+            AscendQwen2VisionBlock(dim=self.embed_dim,
                                    num_heads=self.num_heads,
                                    mlp_ratio=vision_config.mlp_ratio,
                                    norm_layer=partial(nn.LayerNorm,
@@ -162,26 +191,142 @@ class CustomQwen2VisionTransformer(Qwen2VisionTransformer):
             for layer_idx in range(vision_config.depth)
         ])
 
+        self.hidden_size = vision_config.embed_dim
+        self.num_heads = vision_config.num_heads
+        self.hidden_size_per_attention_head = dist_utils.divide(
+            self.hidden_size, self.num_heads)
+
+        if self.hidden_size_per_attention_head > MIN_PAD_SIZE and self.hidden_size_per_attention_head < MAX_PAD_SIZE:
+            self.enable_pad = True
+            self.origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head
+            self.half_origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head // 2
+            self.half_pad_hidden_size_per_attention_head = (
+                MAX_PAD_SIZE - self.hidden_size_per_attention_head) // 2
+            self.hidden_size_per_attention_head = MAX_PAD_SIZE
+
+    def cal_cos_sin(self, rotary_pos_emb):
+        cos = rotary_pos_emb.cos()  # [seqlen, rotary_dim / 2]
+        sin = rotary_pos_emb.sin()
+        if self.enable_pad == True:
+            cos = torch.nn.functional.pad(
+                cos, (0, self.half_pad_hidden_size_per_attention_head))
+            sin = torch.nn.functional.pad(
+                sin, (0, self.half_pad_hidden_size_per_attention_head))
+
+        if not self.interleaved:
+            cos_new = torch.cat((cos, cos), dim=-1)
+            sin_new = torch.cat((sin, sin), dim=-1)
+        else:
+            cos_new = rearrange(torch.stack((cos, cos), dim=-1),
+                                "... d two -> ...(d two)",
+                                two=2)
+            sin_new = rearrange(torch.stack((sin, sin), dim=-1),
+                                "... d two -> ...(d two)",
+                                two=2)
+        cos_new = cos_new.reshape(1, -1, 1,
+                                  self.hidden_size_per_attention_head)
+        sin_new = sin_new.reshape(1, -1, 1,
+                                  self.hidden_size_per_attention_head)
+        return cos_new, sin_new
+
+    def pad_qkv_bias(self, bias):
+        first_half = bias.reshape(
+            -1, 3, self.origin_hidden_size_per_attention_head
+        )[:, :, :self.half_origin_hidden_size_per_attention_head]
+        second_half = bias.reshape(
+            -1, 3, self.origin_hidden_size_per_attention_head
+        )[:, :, self.half_origin_hidden_size_per_attention_head:]
+        first_half_padded = torch.nn.functional.pad(
+            first_half, (0, self.half_pad_hidden_size_per_attention_head))
+        second_half_padded = torch.nn.functional.pad(
+            second_half, (0, self.half_pad_hidden_size_per_attention_head))
+        bias_padded = torch.cat([first_half_padded, second_half_padded], dim=2)
+        bias_final = bias_padded.reshape(-1)
+        return bias_final
+
+    def pad_qkv_weight(self, data):
+        qkv_weight_first_half = data.reshape(
+            -1, 3, self.origin_hidden_size_per_attention_head, self.hidden_size
+        )[:, :, :self.half_origin_hidden_size_per_attention_head, :]
+        qkv_weight_second_half = data.reshape(
+            -1, 3, self.origin_hidden_size_per_attention_head, self.hidden_size
+        )[:, :, self.half_origin_hidden_size_per_attention_head:, :]
+
+        qkv_weight_first_half_padded = torch.nn.functional.pad(
+            qkv_weight_first_half,
+            (0, 0, 0, self.half_pad_hidden_size_per_attention_head))
+        qkv_weight_second_half_padded = torch.nn.functional.pad(
+            qkv_weight_second_half,
+            (0, 0, 0, self.half_pad_hidden_size_per_attention_head))
+        qkv_weight_padded = torch.cat(
+            [qkv_weight_first_half_padded, qkv_weight_second_half_padded],
+            dim=2)
+        qkv_weight_final = qkv_weight_padded.reshape(-1, self.hidden_size)
+        return qkv_weight_final
+
+    def pad_proj_weight(self, data):
+        out_weight = torch.nn.functional.pad(
+            data.reshape(self.hidden_size, -1,
+                         self.half_origin_hidden_size_per_attention_head),
+            (0, self.half_pad_hidden_size_per_attention_head, 0, 0)).reshape(
+                self.hidden_size, -1)
+        return out_weight
+
+    def load_weights(self, weights: Iterable[Tuple[str,
+                                                   torch.Tensor]]) -> Set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: Set[str] = set()
+
+        for name, loaded_weight in weights:
+            for (param_name, weight_name, shard_id) in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight)
+                if ("attn.proj.weight" in name) and self.enable_pad == True:
+                    param.data = self.pad_proj_weight(param.data)
+                if ("attn.qkv.weight" in name) and self.enable_pad == True:
+                    param.data = self.pad_qkv_weight(param.data)
+                if ("attn.qkv.bias" in name) and self.enable_pad == True:
+                    param.data = self.pad_qkv_bias(param.data)
+            loaded_params.add(name)
+        return loaded_params
+
     def forward(
         self,
         x: torch.Tensor,
         grid_thw: torch.Tensor,
     ) -> torch.Tensor:
+        # compute cu_seqlens and avoid cumsum to fit operator unpadFA
+        cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2],
+                                             grid_thw[:,
+                                                      0]).cpu().to(torch.int32)
+
         # patchify
         x = x.to(device=self.device, dtype=self.dtype)
         x = self.patch_embed(x)
 
         # compute position embedding
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
-
-        # compute cu_seqlens and avoid cumsum to fit operator unpadFA
-        cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2],
-                                             grid_thw[:,
-                                                      0]).cpu().to(torch.int32)
+        cos, sin = self.cal_cos_sin(rotary_pos_emb)
 
         x = x.unsqueeze(1)
         for blk in self.blocks:
-            x = blk(x, cu_seqlens=cu_seqlens, rotary_pos_emb=rotary_pos_emb)
+            x = blk(x, cu_seqlens=cu_seqlens, cos=cos, sin=sin)
 
         # adapter
         x = self.merger(x)
@@ -191,11 +336,11 @@ class CustomQwen2VisionTransformer(Qwen2VisionTransformer):
 @MULTIMODAL_REGISTRY.register_processor(Qwen2VLMultiModalProcessor,
                                         info=Qwen2VLProcessingInfo,
                                         dummy_inputs=Qwen2VLDummyInputsBuilder)
-class CustomQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
+class AscendQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config)
-        self.visual = CustomQwen2VisionTransformer(
+        self.visual = AscendQwen2VisionTransformer(
             self.config.vision_config,
             norm_eps=getattr(self.config, "rms_norm_eps", 1e-6),
             quant_config=self._maybe_ignore_quant_config(

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -143,11 +143,15 @@ class AscendQwen2VisionBlock(Qwen2VisionBlock):
         sin: torch.Tensor,
     ) -> torch.Tensor:
         x = x + self.attn(
-            self.norm1(x), cu_seqlens=cu_seqlens, cos=cos, sin=sin,
+            self.norm1(x),
+            cu_seqlens=cu_seqlens,
+            cos=cos,
+            sin=sin,
         )
 
         x = x + self.mlp(self.norm2(x))
         return x
+
 
 class AscendQwen2VisionPatchEmbed(Qwen2VisionPatchEmbed):
 

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -136,11 +136,11 @@ class AscendQwen2VisionBlock(Qwen2VisionBlock):
                                                prefix=f"{prefix}.attn")
 
     def forward(
-            self,
-            x: torch.Tensor,
-            cu_seqlens: torch.Tensor,
-            cos: torch.Tensor,
-            sin: torch.Tensor,
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
     ) -> torch.Tensor:
         x = x + self.attn(
             self.norm1(x),

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -143,10 +143,7 @@ class AscendQwen2VisionBlock(Qwen2VisionBlock):
         sin: torch.Tensor,
     ) -> torch.Tensor:
         x = x + self.attn(
-            self.norm1(x),
-            cu_seqlens=cu_seqlens,
-            cos=cos,
-            sin=sin,
+            self.norm1(x), cu_seqlens=cu_seqlens, cos=cos, sin=sin,
         )
 
         x = x + self.mlp(self.norm2(x))

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -40,8 +40,8 @@ from vllm.model_executor.models.qwen2_vl import (
 from vllm.model_executor.models.utils import maybe_prefix
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
-MIN_PAD_SIZE = 64
-MAX_PAD_SIZE = 128
+MIN_PAD_SIZE = 64  # min_size to pad weight
+MAX_PAD_SIZE = 128  # max_size to pad weight
 
 
 class AscendQwen2VisionAttention(Qwen2VisionAttention):
@@ -97,7 +97,7 @@ class AscendQwen2VisionAttention(Qwen2VisionAttention):
 
         context_layer = torch.torch.empty_like(q)
 
-        # operator requires pta version >= 2.5.1.dev20250226
+        # operator requires pta version >= 2.5.1
         torch_npu._npu_flash_attention_unpad(
             query=q,
             key=k,

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -19,7 +19,7 @@
 
 from collections.abc import Iterable
 from functools import partial
-from typing import Callable, Optional, Set, Type, Tuple
+from typing import Callable, Optional, Set, Tuple, Type
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
Optimize qwen2_vl and qwen2_5_vl.
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
Testing this PR on 1080p picture with tp=1, bs=1 on Qwen2-VL and Qwen2.5-VL, every fa op's during time lasting from 11ms to 9ms, got roughly 22% perf boost. 
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

