### PR TITLE
V1 parallel fix: bug fix to enable DP in V1

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -62,6 +62,8 @@ env_variables: Dict[str, Callable[[], Any]] = {
     lambda: os.getenv("C_COMPILER", None),
     "VLLM_VERSION":
     lambda: os.getenv("VLLM_VERSION", None),
+    "VLLM_ENABLE_MC2":
+    lambda: os.getenv("VLLM_ENABLE_MC2", "0"),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -238,7 +238,6 @@ class CustomDeepseekV2MoE(nn.Module):
 
 =======
         if attn_metadata is None:
-            # profile / dummy run
             is_prefill = True
         else:
             is_prefill = True if attn_metadata.num_prefills > 0 else False

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -215,14 +215,6 @@ class CustomDeepseekV2MoE(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         attn_metadata = get_forward_context().attn_metadata
-<<<<<<< HEAD
-        if attn_metadata is None:
-            # for profile run
-            is_prefill = True
-        else:
-            is_prefill = attn_metadata.num_prefills > 0
-=======
->>>>>>> a0abdeb (fix dp _dummy_run() bug)
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
@@ -234,15 +226,8 @@ class CustomDeepseekV2MoE(nn.Module):
 
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-<<<<<<< HEAD
-
-=======
-        if attn_metadata is None:
-            is_prefill = True
-        else:
-            is_prefill = True if attn_metadata.num_prefills > 0 else False
-        # is_prefill = attn_metadata.num_prefills > 0
->>>>>>> a0abdeb (fix dp _dummy_run() bug)
+        is_prefill = True if attn_metadata is None \ 
+                        or attn_metadata.num_prefills > 0 else False
         final_hidden_states = self.experts(
             hidden_states=hidden_states,
             router_logits=router_logits,

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -215,11 +215,14 @@ class CustomDeepseekV2MoE(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         attn_metadata = get_forward_context().attn_metadata
+<<<<<<< HEAD
         if attn_metadata is None:
             # for profile run
             is_prefill = True
         else:
             is_prefill = attn_metadata.num_prefills > 0
+=======
+>>>>>>> a0abdeb (fix dp _dummy_run() bug)
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
@@ -231,7 +234,16 @@ class CustomDeepseekV2MoE(nn.Module):
 
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
+<<<<<<< HEAD
 
+=======
+        if attn_metadata is None:
+            # profile / dummy run
+            is_prefill = True
+        else:
+            is_prefill = True if attn_metadata.num_prefills > 0 else False
+        # is_prefill = attn_metadata.num_prefills > 0
+>>>>>>> a0abdeb (fix dp _dummy_run() bug)
         final_hidden_states = self.experts(
             hidden_states=hidden_states,
             router_logits=router_logits,

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.quantization.base_config import \
     QuantizeMethodBase
 
 from vllm_ascend.distributed.parallel_state import get_ep_group, get_etp_group
+import vllm_ascend.envs as envs
 
 
 def fused_experts_with_mc2(
@@ -426,7 +427,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         self.global_batch_size = vllm_config.scheduler_config.max_num_seqs
         self.local_batch_size = self.global_batch_size // self.ep_size
 
-        if os.environ.get("VLLM_ENABLE_MC2") == "1":
+        if envs.VLLM_ENABLE_MC2 == "1":
             # all to all comm is only enabled in MC2 mode
             try:
                 device_group = ep_group.device_group

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -273,3 +273,6 @@ class NPUWorker(WorkerBase):
                     torch_profiler_trace_dir))
         else:
             return None
+
+    def execute_dummy_batch(self) -> None:
+        self.model_runner._dummy_run(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

This PR fixed 2 bugs that disable Data Parallel on V1.

[BUG 1] All-to-all communication is only used in MC2 mode, which is still not fully supported. Before the backend supports the communication, we closed all-to-all function while not using MC2.

[BUG 2] When DP ranks have different max_tokens params, the rank finishes forwarding first must wait for others before termination due to all-reduce. Otherwise there will show communication error. This should be supported by execute_dummy_batch() to run a dummy forward. However, the dummy MoE will return immediately before all-reduce. We need to let dummy run the all_reduce func.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

Yes, as a bug-fix PR, it introduces a new method and several branches.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
 This patch can be tested with:
```
# torch version: 2.5.1+cpu
# torch_npu version: 2.5.1
export VLLM_ENABLE_MC2=0
export VLLM_USE_V1=1
export TASK_QUEUE_ENABLE=2
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export VLLM_ENABLE_GRAPH_MODE=0
export USING_LCCL_COM=0
export VLLM_WORKER_MULTIPROC_METHOD=spawn

# recommended test model: DeepSeek-V2-Lite
python examples/offline_inference/data_parallel.py  --model=<your-model> --dp-size=2 --tp-size=8
```

Co-authored-by: HanlinDu ftdl21@pku.edu.cn
Co-authored-by: ZhengWG zwg0606@gmail.com
Co-authored-by: realliujiaxu realliujiaxu@163.com