### PR TITLE
[CI] Fix schedule trigger bug

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -134,6 +134,7 @@ jobs:
 
       # only run test on spec decode when the related code changed
       - name: Check for changes in Speculative Decode
+        if: github.event_name != 'schedule'
         id: filter_spec_decode
         uses: dorny/paths-filter@v3
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
This PR aims to fix nightly ci [broken](https://github.com/vllm-project/vllm-ascend/actions/runs/14848150987)
We have a workflow containing multiple triggers:

- push events (to the default branch)
- pull requests (against the default branch)
- scheduled events
Our paths-filter action works great for the first two use-cases, detecting the context and base to compare against. However, it fails for scheduled events giving the error `This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload.`

Any suggestions on how to handle this? There is two  alternative solutions:
1. For a scheduled build there is obviously no "base" to compare against as it's just a specific commit that is used, so we can specific it :
```
- name: Check for changes in Speculative Decode
  id: filter_spec_decode
  uses: dorny/paths-filter@v3
  with:
    base: ${{ steps.prev_commit.outputs.sha }}
    ref: ${{ github.sha }}
    filters: |
      speculative_tests_changed:
        - ".github/workflows/vllm_ascend_test.yaml"
        - "tests/singlecard/spec_decode/**"
        - "tests/multicard/spec_decode_e2e/**"
        - "vllm_ascend/worker/worker.py"
        - "vllm_ascend/worker/model_runner.py"
        - "vllm_ascend/worker/multi_step_runner.py"
        - "vllm_ascend/worker/multi_step_worker.py"
        - "vllm_ascend/worker/draft_model_runner.py"
        - "vllm_ascend/patch/worker/patch_common/patch_metrics.py"
        - "vllm_ascend/patch/worker/patch_common/patch_spec_decode_worker.py"
        - "vllm_ascend/patch/worker/patch_common/patch_multi_step_worker.py"
```
2. For the scheduling trigger event, we choose to skip this filter because we don't need its results:
```
      - name: Check for changes in Speculative Decode
        if: github.event_name != 'schedule'
```
I prefer the latter because it is simpler and easier to maintain, and as this pr do


