### PR TITLE
[WIP]Add Func: aclgraph_batch_size auto-adjust to different model

### DIFF
--- a/tests/multicard/test_dynamic_npugraph_batchsize.py
+++ b/tests/multicard/test_dynamic_npugraph_batchsize.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import pytest
+import torch
+from vllm import LLM, SamplingParams
+
+# TODO: revert me when cuda hard code is fixed in 'VllmBackend'
+torch.cuda.CUDAGraph = torch.npu.NPUGraph
+
+MODELS = [
+    "Qwen/Qwen2.5-0.5B-Instruct",
+]
+
+TENSOR_PARALLELS = [2]
+
+prompts = [
+    "Hello, my name is",
+    "The future of AI is",
+]
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("tp_size", TENSOR_PARALLELS)
+@pytest.mark.parametrize("max_tokens", [64])
+@pytest.mark.parametrize("temperature", [0.0])
+@pytest.mark.parametrize("ignore_eos", [True])
+def test_models(model: str, tp_size: int, max_tokens: int, temperature: int,
+                ignore_eos: bool) -> None:
+    # Create an LLM.
+    llm = LLM(
+        model=model,
+        tensor_parallel_size=tp_size,
+    )
+    # Prepare sampling_parames
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        temperature=temperature,
+        ignore_eos=ignore_eos,
+    )
+
+    # Generate texts from the prompts.
+    # The output is a list of RequestOutput objects
+    outputs = llm.generate(prompts, sampling_params)
+    torch.npu.synchronize()
+    # The output length should be equal to prompts length.
+    assert len(outputs) == len(prompts)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
This PR add new function of : aclgraph_batch_size can dynamic adjust to different model; before this PR, the aclgraph_batch_sizes given from vllm to vllm-ascend always too large, and that may result in ERROR while running on different, with the information: "The resources are insufficient".
Now, with this PR, the code can dynamic adjust aclgraph_batch_sizes depend on the model hidden_layer_nums and parallel config, for example:
a. for Qwen2.5-7B, the aclgraph_batch_size length is 33 total;
b. for Qwen2.5-72B, the aclgraph_batch_size length is 11 total;

