### PR TITLE
[v0.7.3][Doc] Add accuracy report

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -7,3 +7,4 @@ sphinx-togglebutton
 myst-parser
 msgspec
 sphinx-substitution-extensions
+snowballstemmer<3.0.0

--- a/docs/source/developer_guide/evaluation/accuracy_report/Llama-3.1-8B-Instruct.md
+++ b/docs/source/developer_guide/evaluation/accuracy_report/Llama-3.1-8B-Instruct.md
@@ -1,0 +1,163 @@
+# Llama-3.1-8B-Instruct
+  <div>
+    <strong>vLLM version:</strong> vLLM: v0.7.3, vLLM Ascend: v0.7.3 <br>
+  </div>
+  <div>
+      <strong>Software Environment:</strong> CANN: 8.1.0, PyTorch: 2.5.1, torch-npu: 2.5.1 <br>
+  </div>
+  <div>
+      <strong>Hardware Environment</strong>: Atlas A2 Series <br>
+  </div>
+  <div>
+      <strong>Datasets</strong>: ceval-valid,mmlu,gsm8k <br>
+  </div>
+  <div>
+      <strong>Command</strong>:
+
+  ```bash
+  export MODEL_AEGS='meta-llama/Llama-3.1-8B-Instruct, max_model_len=4096,dtype=auto,tensor_parallel_size=2,gpu_memory_utilization=0.6'
+lm_eval --model vllm --modlel_args $MODEL_ARGS --tasks ceval-valid,gsm8k \
+--apply_chat_template --fewshot_as_multiturn --num_fewshot 5 --batch_size 1
+  ```
+  </div>
+  <div>&nbsp;</div>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc    | ↑ 0.5483 | ± 0.0132 |
+| mmlu                                  | none   | 5      | acc    | ↑ 0.6867 | ± 0.0037 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7286 | ± 0.0122 |
+<details>
+<summary>ceval-valid</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc    | ↑ 0.5483 | ± 0.0132 |
+| - ceval-valid_accountant              | none   | 5      | acc    | ↑ 0.4898 | ± 0.0722 |
+| - ceval-valid_advanced_mathematics    | none   | 5      | acc    | ↑ 0.5263 | ± 0.1177 |
+| - ceval-valid_art_studies             | none   | 5      | acc    | ↑ 0.5455 | ± 0.0880 |
+| - ceval-valid_basic_medicine          | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_business_administration | none   | 5      | acc    | ↑ 0.6061 | ± 0.0864 |
+| - ceval-valid_chinese_language_and_literature | none   | 5      | acc    | ↑ 0.4348 | ± 0.1057 |
+| - ceval-valid_civil_servant           | none   | 5      | acc    | ↑ 0.4894 | ± 0.0737 |
+| - ceval-valid_clinical_medicine       | none   | 5      | acc    | ↑ 0.5455 | ± 0.1087 |
+| - ceval-valid_college_chemistry       | none   | 5      | acc    | ↑ 0.4167 | ± 0.1028 |
+| - ceval-valid_college_economics       | none   | 5      | acc    | ↑ 0.4545 | ± 0.0678 |
+| - ceval-valid_college_physics         | none   | 5      | acc    | ↑ 0.4737 | ± 0.1177 |
+| - ceval-valid_college_programming     | none   | 5      | acc    | ↑ 0.5946 | ± 0.0818 |
+| - ceval-valid_computer_architecture   | none   | 5      | acc    | ↑ 0.5714 | ± 0.1107 |
+| - ceval-valid_computer_network        | none   | 5      | acc    | ↑ 0.7895 | ± 0.0961 |
+| - ceval-valid_discrete_mathematics    | none   | 5      | acc    | ↑ 0.4375 | ± 0.1281 |
+| - ceval-valid_education_science       | none   | 5      | acc    | ↑ 0.7241 | ± 0.0845 |
+| - ceval-valid_electrical_engineer     | none   | 5      | acc    | ↑ 0.4324 | ± 0.0826 |
+| - ceval-valid_environmental_impact_assessment_engineer | none   | 5      | acc    | ↑ 0.5484 | ± 0.0909 |
+| - ceval-valid_fire_engineer           | none   | 5      | acc    | ↑ 0.4839 | ± 0.0912 |
+| - ceval-valid_high_school_biology     | none   | 5      | acc    | ↑ 0.5263 | ± 0.1177 |
+| - ceval-valid_high_school_chemistry   | none   | 5      | acc    | ↑ 0.4737 | ± 0.1177 |
+| - ceval-valid_high_school_chinese     | none   | 5      | acc    | ↑ 0.2105 | ± 0.0961 |
+| - ceval-valid_high_school_geography   | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_high_school_history     | none   | 5      | acc    | ↑ 0.6500 | ± 0.1094 |
+| - ceval-valid_high_school_mathematics | none   | 5      | acc    | ↑ 0.0000 | ± 0.0000 |
+| - ceval-valid_high_school_physics     | none   | 5      | acc    | ↑ 0.3158 | ± 0.1096 |
+| - ceval-valid_high_school_politics    | none   | 5      | acc    | ↑ 0.5789 | ± 0.1164 |
+| - ceval-valid_ideological_and_moral_cultivation | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_law                     | none   | 5      | acc    | ↑ 0.4583 | ± 0.1039 |
+| - ceval-valid_legal_professional      | none   | 5      | acc    | ↑ 0.3913 | ± 0.1041 |
+| - ceval-valid_logic                   | none   | 5      | acc    | ↑ 0.5000 | ± 0.1091 |
+| - ceval-valid_mao_zedong_thought      | none   | 5      | acc    | ↑ 0.5000 | ± 0.1043 |
+| - ceval-valid_marxism                 | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_metrology_engineer      | none   | 5      | acc    | ↑ 0.5833 | ± 0.1028 |
+| - ceval-valid_middle_school_biology   | none   | 5      | acc    | ↑ 0.7143 | ± 0.1010 |
+| - ceval-valid_middle_school_chemistry | none   | 5      | acc    | ↑ 0.8500 | ± 0.0819 |
+| - ceval-valid_middle_school_geography | none   | 5      | acc    | ↑ 0.5833 | ± 0.1486 |
+| - ceval-valid_middle_school_history   | none   | 5      | acc    | ↑ 0.5455 | ± 0.1087 |
+| - ceval-valid_middle_school_mathematics | none   | 5      | acc    | ↑ 0.3684 | ± 0.1137 |
+| - ceval-valid_middle_school_physics   | none   | 5      | acc    | ↑ 0.6316 | ± 0.1137 |
+| - ceval-valid_middle_school_politics  | none   | 5      | acc    | ↑ 0.8095 | ± 0.0878 |
+| - ceval-valid_modern_chinese_history  | none   | 5      | acc    | ↑ 0.5217 | ± 0.1065 |
+| - ceval-valid_operating_system        | none   | 5      | acc    | ↑ 0.6316 | ± 0.1137 |
+| - ceval-valid_physician               | none   | 5      | acc    | ↑ 0.5918 | ± 0.0709 |
+| - ceval-valid_plant_protection        | none   | 5      | acc    | ↑ 0.7727 | ± 0.0914 |
+| - ceval-valid_probability_and_statistics | none   | 5      | acc    | ↑ 0.3889 | ± 0.1182 |
+| - ceval-valid_professional_tour_guide | none   | 5      | acc    | ↑ 0.6207 | ± 0.0917 |
+| - ceval-valid_sports_science          | none   | 5      | acc    | ↑ 0.6316 | ± 0.1137 |
+| - ceval-valid_tax_accountant          | none   | 5      | acc    | ↑ 0.3878 | ± 0.0703 |
+| - ceval-valid_teacher_qualification   | none   | 5      | acc    | ↑ 0.7955 | ± 0.0615 |
+| - ceval-valid_urban_and_rural_planner | none   | 5      | acc    | ↑ 0.5217 | ± 0.0745 |
+| - ceval-valid_veterinary_medicine     | none   | 5      | acc    | ↑ 0.6087 | ± 0.1041 |
+</details>
+<details>
+<summary>mmlu</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmlu                                  | none   | 5      | acc    | ↑ 0.6867 | ± 0.0037 |
+| - humanities                          | none   | 5      | acc    | ↑ 0.6495 | ± 0.0067 |
+| - formal_logic                        | none   | 5      | acc    | ↑ 0.5714 | ± 0.0443 |
+| - high_school_european_history        | none   | 5      | acc    | ↑ 0.7636 | ± 0.0332 |
+| - high_school_us_history              | none   | 5      | acc    | ↑ 0.8186 | ± 0.0270 |
+| - high_school_world_history           | none   | 5      | acc    | ↑ 0.8439 | ± 0.0236 |
+| - international_law                   | none   | 5      | acc    | ↑ 0.8347 | ± 0.0339 |
+| - jurisprudence                       | none   | 5      | acc    | ↑ 0.7778 | ± 0.0402 |
+| - logical_fallacies                   | none   | 5      | acc    | ↑ 0.8098 | ± 0.0308 |
+| - moral_disputes                      | none   | 5      | acc    | ↑ 0.7630 | ± 0.0229 |
+| - moral_scenarios                     | none   | 5      | acc    | ↑ 0.5687 | ± 0.0166 |
+| - philosophy                          | none   | 5      | acc    | ↑ 0.7363 | ± 0.0250 |
+| - prehistory                          | none   | 5      | acc    | ↑ 0.7562 | ± 0.0239 |
+| - professional_law                    | none   | 5      | acc    | ↑ 0.5111 | ± 0.0128 |
+| - world_religions                     | none   | 5      | acc    | ↑ 0.8363 | ± 0.0284 |
+| - other                               | none   | 5      | acc    | ↑ 0.7448 | ± 0.0075 |
+| - business_ethics                     | none   | 5      | acc    | ↑ 0.7200 | ± 0.0451 |
+| - clinical_knowledge                  | none   | 5      | acc    | ↑ 0.7509 | ± 0.0266 |
+| - college_medicine                    | none   | 5      | acc    | ↑ 0.6821 | ± 0.0355 |
+| - global_facts                        | none   | 5      | acc    | ↑ 0.3900 | ± 0.0490 |
+| - human_aging                         | none   | 5      | acc    | ↑ 0.6951 | ± 0.0309 |
+| - management                          | none   | 5      | acc    | ↑ 0.8155 | ± 0.0384 |
+| - marketing                           | none   | 5      | acc    | ↑ 0.8974 | ± 0.0199 |
+| - medical_genetics                    | none   | 5      | acc    | ↑ 0.8200 | ± 0.0386 |
+| - miscellaneous                       | none   | 5      | acc    | ↑ 0.8378 | ± 0.0132 |
+| - nutrition                           | none   | 5      | acc    | ↑ 0.8039 | ± 0.0227 |
+| - professional_accounting             | none   | 5      | acc    | ↑ 0.5532 | ± 0.0297 |
+| - professional_medicine               | none   | 5      | acc    | ↑ 0.7721 | ± 0.0255 |
+| - virology                            | none   | 5      | acc    | ↑ 0.5241 | ± 0.0389 |
+| - social sciences                     | none   | 5      | acc    | ↑ 0.7797 | ± 0.0073 |
+| - econometrics                        | none   | 5      | acc    | ↑ 0.6053 | ± 0.0460 |
+| - high_school_geography               | none   | 5      | acc    | ↑ 0.8485 | ± 0.0255 |
+| - high_school_government_and_politics | none   | 5      | acc    | ↑ 0.9171 | ± 0.0199 |
+| - high_school_macroeconomics          | none   | 5      | acc    | ↑ 0.6923 | ± 0.0234 |
+| - high_school_microeconomics          | none   | 5      | acc    | ↑ 0.7647 | ± 0.0276 |
+| - high_school_psychology              | none   | 5      | acc    | ↑ 0.8697 | ± 0.0144 |
+| - human_sexuality                     | none   | 5      | acc    | ↑ 0.8015 | ± 0.0350 |
+| - professional_psychology             | none   | 5      | acc    | ↑ 0.7271 | ± 0.0180 |
+| - public_relations                    | none   | 5      | acc    | ↑ 0.6818 | ± 0.0446 |
+| - security_studies                    | none   | 5      | acc    | ↑ 0.7224 | ± 0.0287 |
+| - sociology                           | none   | 5      | acc    | ↑ 0.8358 | ± 0.0262 |
+| - us_foreign_policy                   | none   | 5      | acc    | ↑ 0.8900 | ± 0.0314 |
+| - stem                                | none   | 5      | acc    | ↑ 0.5940 | ± 0.0084 |
+| - abstract_algebra                    | none   | 5      | acc    | ↑ 0.3900 | ± 0.0490 |
+| - anatomy                             | none   | 5      | acc    | ↑ 0.6741 | ± 0.0405 |
+| - astronomy                           | none   | 5      | acc    | ↑ 0.7566 | ± 0.0349 |
+| - college_biology                     | none   | 5      | acc    | ↑ 0.8264 | ± 0.0317 |
+| - college_chemistry                   | none   | 5      | acc    | ↑ 0.4700 | ± 0.0502 |
+| - college_computer_science            | none   | 5      | acc    | ↑ 0.5400 | ± 0.0501 |
+| - college_mathematics                 | none   | 5      | acc    | ↑ 0.3900 | ± 0.0490 |
+| - college_physics                     | none   | 5      | acc    | ↑ 0.4314 | ± 0.0493 |
+| - computer_security                   | none   | 5      | acc    | ↑ 0.8000 | ± 0.0402 |
+| - conceptual_physics                  | none   | 5      | acc    | ↑ 0.6170 | ± 0.0318 |
+| - electrical_engineering              | none   | 5      | acc    | ↑ 0.6552 | ± 0.0396 |
+| - elementary_mathematics              | none   | 5      | acc    | ↑ 0.4735 | ± 0.0257 |
+| - high_school_biology                 | none   | 5      | acc    | ↑ 0.8097 | ± 0.0223 |
+| - high_school_chemistry               | none   | 5      | acc    | ↑ 0.6207 | ± 0.0341 |
+| - high_school_computer_science        | none   | 5      | acc    | ↑ 0.7300 | ± 0.0446 |
+| - high_school_mathematics             | none   | 5      | acc    | ↑ 0.4222 | ± 0.0301 |
+| - high_school_physics                 | none   | 5      | acc    | ↑ 0.4636 | ± 0.0407 |
+| - high_school_statistics              | none   | 5      | acc    | ↑ 0.6065 | ± 0.0333 |
+| - machine_learning                    | none   | 5      | acc    | ↑ 0.5446 | ± 0.0473 |
+</details>
+<details>
+<summary>gsm8k</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7286 | ± 0.0122 |
+</details>

--- a/docs/source/developer_guide/evaluation/accuracy_report/Qwen2.5-7B-Instruct.md
+++ b/docs/source/developer_guide/evaluation/accuracy_report/Qwen2.5-7B-Instruct.md
@@ -1,0 +1,163 @@
+# Qwen2.5-7B-Instruct
+  <div>
+    <strong>vLLM version:</strong> vLLM: v0.7.3, vLLM Ascend: v0.7.3 <br>
+  </div>
+  <div>
+      <strong>Software Environment:</strong> CANN: 8.1.0, PyTorch: 2.5.1, torch-npu: 2.5.1 <br>
+  </div>
+  <div>
+      <strong>Hardware Environment</strong>: Atlas A2 Series <br>
+  </div>
+  <div>
+      <strong>Datasets</strong>: ceval-valid,mmlu,gsm8k <br>
+  </div>
+  <div>
+      <strong>Command</strong>:
+
+  ```bash
+  export MODEL_AEGS='Qwen/Qwen2.5-7B-Instruct, max_model_len=4096,dtype=auto,tensor_parallel_size=2,gpu_memory_utilization=0.6'
+lm_eval --model vllm --modlel_args $MODEL_ARGS --tasks ceval-valid,mmlu,gsm8k \
+--apply_chat_template --fewshot_as_multiturn --num_fewshot 5 --batch_size 1
+  ```
+  </div>
+  <div>&nbsp;</div>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc    | ↑ 0.8009 | ± 0.0105 |
+| mmlu                                  | none   | 5      | acc    | ↑ 0.7358 | ± 0.0036 |
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7286 | ± 0.0122 |
+<details>
+<summary>ceval-valid details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| ceval-valid                           | none   | 5      | acc    | ↑ 0.8009 | ± 0.0105 |
+| - ceval-valid_accountant              | none   | 5      | acc    | ↑ 0.8980 | ± 0.0437 |
+| - ceval-valid_advanced_mathematics    | none   | 5      | acc    | ↑ 0.4211 | ± 0.1164 |
+| - ceval-valid_art_studies             | none   | 5      | acc    | ↑ 0.7576 | ± 0.0758 |
+| - ceval-valid_basic_medicine          | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_business_administration | none   | 5      | acc    | ↑ 0.8485 | ± 0.0634 |
+| - ceval-valid_chinese_language_and_literature | none   | 5      | acc    | ↑ 0.6087 | ± 0.1041 |
+| - ceval-valid_civil_servant           | none   | 5      | acc    | ↑ 0.8298 | ± 0.0554 |
+| - ceval-valid_clinical_medicine       | none   | 5      | acc    | ↑ 0.7273 | ± 0.0972 |
+| - ceval-valid_college_chemistry       | none   | 5      | acc    | ↑ 0.6250 | ± 0.1009 |
+| - ceval-valid_college_economics       | none   | 5      | acc    | ↑ 0.7455 | ± 0.0593 |
+| - ceval-valid_college_physics         | none   | 5      | acc    | ↑ 0.7368 | ± 0.1038 |
+| - ceval-valid_college_programming     | none   | 5      | acc    | ↑ 0.8649 | ± 0.0570 |
+| - ceval-valid_computer_architecture   | none   | 5      | acc    | ↑ 0.7619 | ± 0.0952 |
+| - ceval-valid_computer_network        | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_discrete_mathematics    | none   | 5      | acc    | ↑ 0.2500 | ± 0.1118 |
+| - ceval-valid_education_science       | none   | 5      | acc    | ↑ 0.8621 | ± 0.0652 |
+| - ceval-valid_electrical_engineer     | none   | 5      | acc    | ↑ 0.7027 | ± 0.0762 |
+| - ceval-valid_environmental_impact_assessment_engineer | none   | 5      | acc    | ↑ 0.7097 | ± 0.0829 |
+| - ceval-valid_fire_engineer           | none   | 5      | acc    | ↑ 0.7419 | ± 0.0799 |
+| - ceval-valid_high_school_biology     | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_chemistry   | none   | 5      | acc    | ↑ 0.7368 | ± 0.1038 |
+| - ceval-valid_high_school_chinese     | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_high_school_geography   | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_high_school_history     | none   | 5      | acc    | ↑ 0.9000 | ± 0.0688 |
+| - ceval-valid_high_school_mathematics | none   | 5      | acc    | ↑ 0.5000 | ± 0.1213 |
+| - ceval-valid_high_school_physics     | none   | 5      | acc    | ↑ 0.7368 | ± 0.1038 |
+| - ceval-valid_high_school_politics    | none   | 5      | acc    | ↑ 0.8947 | ± 0.0723 |
+| - ceval-valid_ideological_and_moral_cultivation | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_law                     | none   | 5      | acc    | ↑ 0.6667 | ± 0.0983 |
+| - ceval-valid_legal_professional      | none   | 5      | acc    | ↑ 0.7391 | ± 0.0936 |
+| - ceval-valid_logic                   | none   | 5      | acc    | ↑ 0.6364 | ± 0.1050 |
+| - ceval-valid_mao_zedong_thought      | none   | 5      | acc    | ↑ 0.9583 | ± 0.0417 |
+| - ceval-valid_marxism                 | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_metrology_engineer      | none   | 5      | acc    | ↑ 0.8333 | ± 0.0777 |
+| - ceval-valid_middle_school_biology   | none   | 5      | acc    | ↑ 0.9524 | ± 0.0476 |
+| - ceval-valid_middle_school_chemistry | none   | 5      | acc    | ↑ 0.9500 | ± 0.0500 |
+| - ceval-valid_middle_school_geography | none   | 5      | acc    | ↑ 0.9167 | ± 0.0833 |
+| - ceval-valid_middle_school_history   | none   | 5      | acc    | ↑ 0.9091 | ± 0.0627 |
+| - ceval-valid_middle_school_mathematics | none   | 5      | acc    | ↑ 0.6842 | ± 0.1096 |
+| - ceval-valid_middle_school_physics   | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_middle_school_politics  | none   | 5      | acc    | ↑ 1.0000 | ± 0.0000 |
+| - ceval-valid_modern_chinese_history  | none   | 5      | acc    | ↑ 0.9130 | ± 0.0601 |
+| - ceval-valid_operating_system        | none   | 5      | acc    | ↑ 0.8421 | ± 0.0859 |
+| - ceval-valid_physician               | none   | 5      | acc    | ↑ 0.8163 | ± 0.0559 |
+| - ceval-valid_plant_protection        | none   | 5      | acc    | ↑ 0.8636 | ± 0.0749 |
+| - ceval-valid_probability_and_statistics | none   | 5      | acc    | ↑ 0.5556 | ± 0.1205 |
+| - ceval-valid_professional_tour_guide | none   | 5      | acc    | ↑ 0.8966 | ± 0.0576 |
+| - ceval-valid_sports_science          | none   | 5      | acc    | ↑ 0.9474 | ± 0.0526 |
+| - ceval-valid_tax_accountant          | none   | 5      | acc    | ↑ 0.8571 | ± 0.0505 |
+| - ceval-valid_teacher_qualification   | none   | 5      | acc    | ↑ 0.9091 | ± 0.0438 |
+| - ceval-valid_urban_and_rural_planner | none   | 5      | acc    | ↑ 0.8043 | ± 0.0591 |
+| - ceval-valid_veterinary_medicine     | none   | 5      | acc    | ↑ 0.8261 | ± 0.0808 |
+</details>
+<details>
+<summary>mmlu details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmlu                                  | none   | 5      | acc    | ↑ 0.7358 | ± 0.0036 |
+| - humanities                          | none   | 5      | acc    | ↑ 0.6818 | ± 0.0065 |
+| - formal_logic                        | none   | 5      | acc    | ↑ 0.6032 | ± 0.0438 |
+| - high_school_european_history        | none   | 5      | acc    | ↑ 0.8606 | ± 0.0270 |
+| - high_school_us_history              | none   | 5      | acc    | ↑ 0.8971 | ± 0.0213 |
+| - high_school_world_history           | none   | 5      | acc    | ↑ 0.8861 | ± 0.0207 |
+| - international_law                   | none   | 5      | acc    | ↑ 0.8512 | ± 0.0325 |
+| - jurisprudence                       | none   | 5      | acc    | ↑ 0.7870 | ± 0.0396 |
+| - logical_fallacies                   | none   | 5      | acc    | ↑ 0.8160 | ± 0.0304 |
+| - moral_disputes                      | none   | 5      | acc    | ↑ 0.7861 | ± 0.0221 |
+| - moral_scenarios                     | none   | 5      | acc    | ↑ 0.5899 | ± 0.0164 |
+| - philosophy                          | none   | 5      | acc    | ↑ 0.7717 | ± 0.0238 |
+| - prehistory                          | none   | 5      | acc    | ↑ 0.8549 | ± 0.0196 |
+| - professional_law                    | none   | 5      | acc    | ↑ 0.5287 | ± 0.0127 |
+| - world_religions                     | none   | 5      | acc    | ↑ 0.8655 | ± 0.0262 |
+| - other                               | none   | 5      | acc    | ↑ 0.7686 | ± 0.0073 |
+| - business_ethics                     | none   | 5      | acc    | ↑ 0.8300 | ± 0.0378 |
+| - clinical_knowledge                  | none   | 5      | acc    | ↑ 0.7925 | ± 0.0250 |
+| - college_medicine                    | none   | 5      | acc    | ↑ 0.6879 | ± 0.0353 |
+| - global_facts                        | none   | 5      | acc    | ↑ 0.4900 | ± 0.0502 |
+| - human_aging                         | none   | 5      | acc    | ↑ 0.7444 | ± 0.0293 |
+| - management                          | none   | 5      | acc    | ↑ 0.8641 | ± 0.0339 |
+| - marketing                           | none   | 5      | acc    | ↑ 0.9402 | ± 0.0155 |
+| - medical_genetics                    | none   | 5      | acc    | ↑ 0.7900 | ± 0.0409 |
+| - miscellaneous                       | none   | 5      | acc    | ↑ 0.8506 | ± 0.0127 |
+| - nutrition                           | none   | 5      | acc    | ↑ 0.7941 | ± 0.0232 |
+| - professional_accounting             | none   | 5      | acc    | ↑ 0.5709 | ± 0.0295 |
+| - professional_medicine               | none   | 5      | acc    | ↑ 0.7610 | ± 0.0259 |
+| - virology                            | none   | 5      | acc    | ↑ 0.5783 | ± 0.0384 |
+| - social sciences                     | none   | 5      | acc    | ↑ 0.8310 | ± 0.0067 |
+| - econometrics                        | none   | 5      | acc    | ↑ 0.6140 | ± 0.0458 |
+| - high_school_geography               | none   | 5      | acc    | ↑ 0.8788 | ± 0.0233 |
+| - high_school_government_and_politics | none   | 5      | acc    | ↑ 0.9378 | ± 0.0174 |
+| - high_school_macroeconomics          | none   | 5      | acc    | ↑ 0.8026 | ± 0.0202 |
+| - high_school_microeconomics          | none   | 5      | acc    | ↑ 0.8866 | ± 0.0206 |
+| - high_school_psychology              | none   | 5      | acc    | ↑ 0.8954 | ± 0.0131 |
+| - human_sexuality                     | none   | 5      | acc    | ↑ 0.8015 | ± 0.0350 |
+| - professional_psychology             | none   | 5      | acc    | ↑ 0.7876 | ± 0.0165 |
+| - public_relations                    | none   | 5      | acc    | ↑ 0.7182 | ± 0.0431 |
+| - security_studies                    | none   | 5      | acc    | ↑ 0.7837 | ± 0.0264 |
+| - sociology                           | none   | 5      | acc    | ↑ 0.8756 | ± 0.0233 |
+| - us_foreign_policy                   | none   | 5      | acc    | ↑ 0.8600 | ± 0.0349 |
+| - stem                                | none   | 5      | acc    | ↑ 0.6911 | ± 0.0080 |
+| - abstract_algebra                    | none   | 5      | acc    | ↑ 0.5500 | ± 0.0500 |
+| - anatomy                             | none   | 5      | acc    | ↑ 0.7481 | ± 0.0375 |
+| - astronomy                           | none   | 5      | acc    | ↑ 0.8684 | ± 0.0275 |
+| - college_biology                     | none   | 5      | acc    | ↑ 0.8472 | ± 0.0301 |
+| - college_chemistry                   | none   | 5      | acc    | ↑ 0.5200 | ± 0.0502 |
+| - college_computer_science            | none   | 5      | acc    | ↑ 0.6800 | ± 0.0469 |
+| - college_mathematics                 | none   | 5      | acc    | ↑ 0.5000 | ± 0.0503 |
+| - college_physics                     | none   | 5      | acc    | ↑ 0.5098 | ± 0.0497 |
+| - computer_security                   | none   | 5      | acc    | ↑ 0.7900 | ± 0.0409 |
+| - conceptual_physics                  | none   | 5      | acc    | ↑ 0.7404 | ± 0.0287 |
+| - electrical_engineering              | none   | 5      | acc    | ↑ 0.7172 | ± 0.0375 |
+| - elementary_mathematics              | none   | 5      | acc    | ↑ 0.6614 | ± 0.0244 |
+| - high_school_biology                 | none   | 5      | acc    | ↑ 0.8516 | ± 0.0202 |
+| - high_school_chemistry               | none   | 5      | acc    | ↑ 0.6305 | ± 0.0340 |
+| - high_school_computer_science        | none   | 5      | acc    | ↑ 0.9100 | ± 0.0288 |
+| - high_school_mathematics             | none   | 5      | acc    | ↑ 0.5519 | ± 0.0303 |
+| - high_school_physics                 | none   | 5      | acc    | ↑ 0.6159 | ± 0.0397 |
+| - high_school_statistics              | none   | 5      | acc    | ↑ 0.7037 | ± 0.0311 |
+| - machine_learning                    | none   | 5      | acc    | ↑ 0.5625 | ± 0.0471 |
+</details>
+<details>
+<summary>gsm8k details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| gsm8k                                 | flexible-extract | 5      | exact_match | ↑ 0.7286 | ± 0.0122 |
+</details>

--- a/docs/source/developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct.md
+++ b/docs/source/developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct.md
@@ -1,0 +1,70 @@
+# Qwen2.5-VL-7B-Instruct
+  <div>
+    <strong>vLLM version:</strong> vLLM: v0.7.3, vLLM Ascend: v0.7.3 <br>
+  </div>
+  <div>
+      <strong>Software Environment:</strong> CANN: 8.1.0, PyTorch: 2.5.1, torch-npu: 2.5.1 <br>
+  </div>
+  <div>
+      <strong>Hardware Environment</strong>: Atlas A2 Series <br>
+  </div>
+  <div>
+      <strong>Datasets</strong>: mmmu_val <br>
+  </div>
+  <div>
+      <strong>Command</strong>:
+
+  ```bash
+  export MODEL_AEGS='Qwen/Qwen2.5-VL-7B-Instruct, max_model_len=8192,dtype=auto,tensor_parallel_size=2,max_images=2'
+lm_eval --model vllm-vlm --modlel_args $MODEL_ARGS --tasks mmmu_val \
+--apply_chat_template --fewshot_as_multiturn  --batch_size 1
+  ```
+  </div>
+  <div>&nbsp;</div>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmmu_val                              | none   | 0      | acc    | ↑ 0.5122 | ± 0.0162 |
+<details>
+<summary>mmmu_val details</summary>
+
+| Task                  | Filter | n-shot | Metric   | Value   | Stderr |
+|-----------------------|-------:|-------:|----------|--------:|-------:|
+| mmmu_val                              | none   | 0      | acc    | ↑ 0.5122 | ± 0.0162 |
+| - Art and Design                      | none   | 0      | acc    | ↑ 0.6667 | ± 0.0424 |
+| - Art                                 | none   | 0      | acc    | ↑ 0.6667 | ± 0.0875 |
+| - Art Theory                          | none   | 0      | acc    | ↑ 0.8333 | ± 0.0692 |
+| - Design                              | none   | 0      | acc    | ↑ 0.6667 | ± 0.0875 |
+| - Music                               | none   | 0      | acc    | ↑ 0.5000 | ± 0.0928 |
+| - Business                            | none   | 0      | acc    | ↑ 0.4133 | ± 0.0404 |
+| - Accounting                          | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Economics                           | none   | 0      | acc    | ↑ 0.5333 | ± 0.0926 |
+| - Finance                             | none   | 0      | acc    | ↑ 0.3333 | ± 0.0875 |
+| - Manage                              | none   | 0      | acc    | ↑ 0.3333 | ± 0.0875 |
+| - Marketing                           | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Health and Medicine                 | none   | 0      | acc    | ↑ 0.5867 | ± 0.0406 |
+| - Basic Medical Science               | none   | 0      | acc    | ↑ 0.6000 | ± 0.0910 |
+| - Clinical Medicine                   | none   | 0      | acc    | ↑ 0.6333 | ± 0.0895 |
+| - Diagnostics and Laboratory Medicine | none   | 0      | acc    | ↑ 0.4667 | ± 0.0926 |
+| - Pharmacy                            | none   | 0      | acc    | ↑ 0.6000 | ± 0.0910 |
+| - Public Health                       | none   | 0      | acc    | ↑ 0.6333 | ± 0.0895 |
+| - Humanities and Social Science       | none   | 0      | acc    | ↑ 0.7000 | ± 0.0413 |
+| - History                             | none   | 0      | acc    | ↑ 0.7000 | ± 0.0851 |
+| - Literature                          | none   | 0      | acc    | ↑ 0.8333 | ± 0.0692 |
+| - Psychology                          | none   | 0      | acc    | ↑ 0.7333 | ± 0.0821 |
+| - Sociology                           | none   | 0      | acc    | ↑ 0.5333 | ± 0.0926 |
+| - Science                             | none   | 0      | acc    | ↑ 0.4200 | ± 0.0409 |
+| - Biology                             | none   | 0      | acc    | ↑ 0.4000 | ± 0.0910 |
+| - Chemistry                           | none   | 0      | acc    | ↑ 0.3667 | ± 0.0895 |
+| - Geography                           | none   | 0      | acc    | ↑ 0.4667 | ± 0.0926 |
+| - Math                                | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Physics                             | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Tech and Engineering                | none   | 0      | acc    | ↑ 0.4000 | ± 0.0337 |
+| - Agriculture                         | none   | 0      | acc    | ↑ 0.5333 | ± 0.0926 |
+| - Architecture and Engineering        | none   | 0      | acc    | ↑ 0.4333 | ± 0.0920 |
+| - Computer Science                    | none   | 0      | acc    | ↑ 0.4000 | ± 0.0910 |
+| - Electronics                         | none   | 0      | acc    | ↑ 0.2667 | ± 0.0821 |
+| - Energy and Power                    | none   | 0      | acc    | ↑ 0.2667 | ± 0.0821 |
+| - Materials                           | none   | 0      | acc    | ↑ 0.4000 | ± 0.0910 |
+| - Mechanical Engineering              | none   | 0      | acc    | ↑ 0.5000 | ± 0.0928 |
+</details>

--- a/docs/source/developer_guide/evaluation/accuracy_report/index.md
+++ b/docs/source/developer_guide/evaluation/accuracy_report/index.md
@@ -1,0 +1,9 @@
+# Accuracy Report
+
+:::{toctree}
+:caption: Accuracy Report
+:maxdepth: 1
+Llama-3.1-8B-Instruct
+Qwen2.5-7B-Instruct
+Qwen2.5-VL-7B-Instruct
+:::

--- a/docs/source/developer_guide/evaluation/index.md
+++ b/docs/source/developer_guide/evaluation/index.md
@@ -2,7 +2,8 @@
 
 :::{toctree}
 :caption: Accuracy
-:maxdepth: 1
+:maxdepth: 2
 using_opencompass
 using_lm_eval
+accuracy_report/index
 :::


### PR DESCRIPTION
### What this PR does / why we need it?
Add accuracy report for v0.7.3 release
Models and datasets for accuracy test：
    
|                 Model              |              datasets              |
|---------------------------- | --------------------------- | 
| Qwen2.5-7B-Instruct        |  ceval-val, gsm8k, mmlu  |
| Llama-3.1-8B-Instruct      |  ceval-val, gsm8k, mmlu  |
| Qwen2.5-VL-7B-Instruct  |           mmmu_val             |


### Does this PR introduce _any_ user-facing change?
This PR will display the accuracy test report of the v0.7.3 version in docs/source/developer_guide/accuracy_report。
Qwen2.5-7B-Instruct.md
Llama-3.1-8B-Instruct.md
Qwen2.5-VL-7B-Instruct .md


