### PR TITLE
[Bugfix] Add max_num_batched_tokens to InputBatch to make main CI pass

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,8 @@ norecursedirs =
     vllm-empty/tests/neuron
   ; fastsafetensors not support npu now
     vllm-empty/tests/fastsafetensors_loader
+  ; Enable after https://github.com/vllm-project/vllm-ascend/issues/808 resolved
+    vllm-empty/tests/benchmarks
 
 addopts = --ignore=vllm-empty/tests/test_utils.py
           --ignore=vllm-empty/tests/test_config.py

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -200,7 +200,7 @@ class NPUModelRunner:
         if "max_num_batched_tokens" in inspect.signature(
                 InputBatch).parameters:
             input_batch_kwargs[
-                "max_num_batched_tokens"] = self.scheduler_config.max_num_batched_tokens
+                "max_num_batched_tokens"] = self.max_num_tokens
         self.input_batch = InputBatch(**input_batch_kwargs)
 
         self.input_ids = torch.zeros(self.max_num_tokens,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -199,8 +199,7 @@ class NPUModelRunner:
         # For version compatibility and consistency with the latest vllm code
         if "max_num_batched_tokens" in inspect.signature(
                 InputBatch).parameters:
-            input_batch_kwargs[
-                "max_num_batched_tokens"] = self.max_num_tokens
+            input_batch_kwargs["max_num_batched_tokens"] = self.max_num_tokens
         self.input_batch = InputBatch(**input_batch_kwargs)
 
         self.input_ids = torch.zeros(self.max_num_tokens,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -18,6 +18,7 @@
 #
 
 import gc
+import inspect
 import math
 import os
 import time
@@ -187,16 +188,21 @@ class NPUModelRunner:
         # Request states.
         self.requests: Dict[str, CachedRequestState] = {}
         # Persistent batch.
-        self.input_batch = InputBatch(
-            max_num_reqs=self.max_num_reqs,
-            max_num_batched_tokens=self.scheduler_config.
-            max_num_batched_tokens,
-            max_model_len=self.model_config.max_model_len,
-            max_num_blocks_per_req=self.max_num_blocks_per_req,
-            device=self.device,
-            pin_memory=True,
-            vocab_size=self.model_config.get_vocab_size(),
-        )
+        # Persistent batch.
+        input_batch_kwargs = {
+            "max_num_reqs": self.max_num_reqs,
+            "max_model_len": self.model_config.max_model_len,
+            "max_num_blocks_per_req": self.max_num_blocks_per_req,
+            "device": self.device,
+            "pin_memory": True,
+            "vocab_size": self.model_config.get_vocab_size(),
+        }
+        # For version compatibility and consistency with the latest vllm code
+        if "max_num_batched_tokens" in inspect.signature(
+                InputBatch).parameters:
+            input_batch_kwargs[
+                "max_num_batched_tokens"] = self.scheduler_config.max_num_batched_tokens
+        self.input_batch = InputBatch(**input_batch_kwargs)
 
         self.input_ids = torch.zeros(self.max_num_tokens,
                                      dtype=torch.int32,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -188,7 +188,6 @@ class NPUModelRunner:
         # Request states.
         self.requests: Dict[str, CachedRequestState] = {}
         # Persistent batch.
-        # Persistent batch.
         input_batch_kwargs = {
             "max_num_reqs": self.max_num_reqs,
             "max_model_len": self.model_config.max_model_len,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -189,6 +189,7 @@ class NPUModelRunner:
         # Persistent batch.
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
             max_model_len=self.model_config.max_model_len,
             max_num_blocks_per_req=self.max_num_blocks_per_req,
             device=self.device,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -203,7 +203,7 @@ class NPUModelRunner:
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=self.model_config.max_model_len,
                 max_num_blocks_per_req=self.max_num_blocks_per_req,
-                max_num_batched_tokens = self.max_num_tokens,
+                max_num_batched_tokens=self.max_num_tokens,
                 device=self.device,
                 pin_memory=True,
                 vocab_size=self.model_config.get_vocab_size(),

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -189,7 +189,8 @@ class NPUModelRunner:
         # Persistent batch.
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
-            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            max_num_batched_tokens=self.scheduler_config.
+            max_num_batched_tokens,
             max_model_len=self.model_config.max_model_len,
             max_num_blocks_per_req=self.max_num_blocks_per_req,
             device=self.device,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -18,7 +18,6 @@
 #
 
 import gc
-import inspect
 import math
 import os
 import time
@@ -56,6 +55,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm_ascend.attention.attention import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.platform import NPUPlatform
+from vllm_ascend.utils import vllm_version_is
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]
@@ -188,19 +188,26 @@ class NPUModelRunner:
         # Request states.
         self.requests: Dict[str, CachedRequestState] = {}
         # Persistent batch.
-        input_batch_kwargs = {
-            "max_num_reqs": self.max_num_reqs,
-            "max_model_len": self.model_config.max_model_len,
-            "max_num_blocks_per_req": self.max_num_blocks_per_req,
-            "device": self.device,
-            "pin_memory": True,
-            "vocab_size": self.model_config.get_vocab_size(),
-        }
-        # For version compatibility and consistency with the latest vllm code
-        if "max_num_batched_tokens" in inspect.signature(
-                InputBatch).parameters:
-            input_batch_kwargs["max_num_batched_tokens"] = self.max_num_tokens
-        self.input_batch = InputBatch(**input_batch_kwargs)
+        # Remove this after we drop 0.8.5 support
+        if vllm_version_is("0.8.5") or vllm_version_is("0.8.5.post1"):
+            self.input_batch = InputBatch(
+                max_num_reqs=self.max_num_reqs,
+                max_model_len=self.model_config.max_model_len,
+                max_num_blocks_per_req=self.max_num_blocks_per_req,
+                device=self.device,
+                pin_memory=True,
+                vocab_size=self.model_config.get_vocab_size(),
+            )
+        else:
+            self.input_batch = InputBatch(
+                max_num_reqs=self.max_num_reqs,
+                max_model_len=self.model_config.max_model_len,
+                max_num_blocks_per_req=self.max_num_blocks_per_req,
+                max_num_batched_tokens = self.max_num_tokens,
+                device=self.device,
+                pin_memory=True,
+                vocab_size=self.model_config.get_vocab_size(),
+            )
 
         self.input_ids = torch.zeros(self.max_num_tokens,
                                      dtype=torch.int32,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Fix V1 error found by [nightly_ci](https://github.com/vllm-project/vllm-ascend/actions/runs/14950004754/job/41998136610), broken by [[v1] Pass BlockTable and KVCacheSpec to AttentionMetadataBuilders #17483](https://github.com/vllm-project/vllm/pull/17483), make `InputBatch` parameter consistent with vllm.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
CI passed
