### PR TITLE
[CI] Re-enable `vllm-empty/tests/benchmarks`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,8 +39,6 @@ norecursedirs =
     vllm-empty/tests/neuron
   ; fastsafetensors not support npu now
     vllm-empty/tests/fastsafetensors_loader
-  ; Enable after https://github.com/vllm-project/vllm-ascend/issues/808 resolved
-    vllm-empty/tests/benchmarks
 
 addopts = --ignore=vllm-empty/tests/test_utils.py
           --ignore=vllm-empty/tests/test_config.py


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
For the [#17962](https://github.com/vllm-project/vllm/pull/17962?notification_referrer_id=NT_kwDOCexQHLUxNjM0MTM3OTEwNDoxNjY0ODE5NDg#event-17608938997) has merged, vllm openapi server can now launch normally on python==3.10, we re-enable the related tests
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
CI passed
