### PR TITLE
[BugFix]add all2all when dp_size > 1 && downgrade npu_dequant_swiglu_quant

### DIFF
--- a/vllm_ascend/distributed/communicator.py
+++ b/vllm_ascend/distributed/communicator.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-from typing import Optional
+from typing import Optional, List
 
 import torch
+import torch.distributed as dist
 from torch.distributed import ProcessGroup
 from vllm.distributed.device_communicators.base_device_communicator import \
     DeviceCommunicatorBase
@@ -33,3 +34,58 @@ class NPUCommunicator(DeviceCommunicatorBase):
         # TODO(hz): Refer to CudaCommunicator's implementation to integrate PyHcclCommunicator
         # init device according to rank
         self.device = torch.npu.current_device()
+
+    def all_to_all(self,
+                   input_: torch.Tensor,
+                   scatter_dim: int = 0,
+                   gather_dim: int = -1,
+                   scatter_sizes: List[int] = None,
+                   gather_sizes: List[int] = None) -> torch.Tensor:
+
+        if scatter_dim < 0:
+            scatter_dim += input_.dim()
+        if gather_dim < 0:
+            gather_dim += input_.dim()
+
+        if scatter_sizes is not None and gather_sizes is not None:
+            input_list = [t.contiguous() for t in torch.split(input_, scatter_sizes, scatter_dim)]
+            output_list = []
+            tensor_shape_base = input_list[self.rank].size()
+            for i in range(self.world_size):
+                tensor_shape = list(tensor_shape_base)
+                tensor_shape[gather_dim] = gather_sizes[i]
+                output_list.append(torch.empty(tensor_shape, dtype=input_.dtype, device=input_.device))
+
+        else:
+            input_list = [
+                t.contiguous()
+                for t in torch.tensor_split(input_, self.world_size, scatter_dim)
+            ]
+            output_list = [torch.empty_like(input_list[i]) for i in range(self.world_size)]
+
+        dist.all_to_all(output_list, input_list, group=self.device_group)
+        output_tensor = torch.cat(output_list, dim=gather_dim).contiguous()
+        return output_tensor
+
+    def reduce_scatter(self,
+                       input_: torch.Tensor,
+                       scatter_dim: int = 0) -> torch.Tensor:
+
+        if scatter_dim < 0:
+            scatter_dim += input_.dim()
+        if scatter_dim != 0:
+            input_ = torch.transpose(input_, 0, scatter_dim)
+        dim_size = list(input_.size())
+        dim_size[0] = dim_size[0] // self.world_size
+        output_tensor = torch.empty(dim_size,
+                                    dtype=input_.dtype,
+                                    device=input_.device)
+        dist.reduce_scatter_tensor(output_tensor,
+                                   input_.contiguous(),
+                                   group=self.device_group)
+        if scatter_dim != 0:
+            output_tensor = torch.transpose(output_tensor, 0,
+                                            scatter_dim).contiguous()
+        return output_tensor
+
+

--- a/vllm_ascend/distributed/communicator.py
+++ b/vllm_ascend/distributed/communicator.py
@@ -73,24 +73,3 @@ class NPUCommunicator(DeviceCommunicatorBase):
         dist.all_to_all(output_list, input_list, group=self.device_group)
         output_tensor = torch.cat(output_list, dim=gather_dim).contiguous()
         return output_tensor
-
-    def reduce_scatter(self,
-                       input_: torch.Tensor,
-                       scatter_dim: int = 0) -> torch.Tensor:
-
-        if scatter_dim < 0:
-            scatter_dim += input_.dim()
-        if scatter_dim != 0:
-            input_ = torch.transpose(input_, 0, scatter_dim)
-        dim_size = list(input_.size())
-        dim_size[0] = dim_size[0] // self.world_size
-        output_tensor = torch.empty(dim_size,
-                                    dtype=input_.dtype,
-                                    device=input_.device)
-        dist.reduce_scatter_tensor(output_tensor,
-                                   input_.contiguous(),
-                                   group=self.device_group)
-        if scatter_dim != 0:
-            output_tensor = torch.transpose(output_tensor, 0,
-                                            scatter_dim).contiguous()
-        return output_tensor

--- a/vllm_ascend/distributed/communicator.py
+++ b/vllm_ascend/distributed/communicator.py
@@ -18,7 +18,6 @@ from typing import Optional, List
 
 import torch
 import torch.distributed as dist
-from torch.distributed import ProcessGroup
 from vllm.distributed.device_communicators.base_device_communicator import \
     DeviceCommunicatorBase
 
@@ -26,9 +25,9 @@ from vllm.distributed.device_communicators.base_device_communicator import \
 class NPUCommunicator(DeviceCommunicatorBase):
 
     def __init__(self,
-                 cpu_group: ProcessGroup,
+                 cpu_group: dist.ProcessGroup,
                  device: Optional[torch.device] = None,
-                 device_group: Optional[ProcessGroup] = None,
+                 device_group: Optional[dist.ProcessGroup] = None,
                  unique_name: str = ""):
         super().__init__(cpu_group, device, device_group, unique_name)
         # TODO(hz): Refer to CudaCommunicator's implementation to integrate PyHcclCommunicator
@@ -39,8 +38,8 @@ class NPUCommunicator(DeviceCommunicatorBase):
                    input_: torch.Tensor,
                    scatter_dim: int = 0,
                    gather_dim: int = -1,
-                   scatter_sizes: List[int] = None,
-                   gather_sizes: List[int] = None) -> torch.Tensor:
+                   scatter_sizes: Optional[List[int]] = None,
+                   gather_sizes: Optional[List[int]] = None) -> torch.Tensor:
 
         if scatter_dim < 0:
             scatter_dim += input_.dim()
@@ -48,20 +47,28 @@ class NPUCommunicator(DeviceCommunicatorBase):
             gather_dim += input_.dim()
 
         if scatter_sizes is not None and gather_sizes is not None:
-            input_list = [t.contiguous() for t in torch.split(input_, scatter_sizes, scatter_dim)]
+            input_list = [
+                t.contiguous()
+                for t in torch.split(input_, scatter_sizes, scatter_dim)
+            ]
             output_list = []
             tensor_shape_base = input_list[self.rank].size()
             for i in range(self.world_size):
                 tensor_shape = list(tensor_shape_base)
                 tensor_shape[gather_dim] = gather_sizes[i]
-                output_list.append(torch.empty(tensor_shape, dtype=input_.dtype, device=input_.device))
+                output_list.append(
+                    torch.empty(tensor_shape,
+                                dtype=input_.dtype,
+                                device=input_.device))
 
         else:
             input_list = [
-                t.contiguous()
-                for t in torch.tensor_split(input_, self.world_size, scatter_dim)
+                t.contiguous() for t in torch.tensor_split(
+                    input_, self.world_size, scatter_dim)
             ]
-            output_list = [torch.empty_like(input_list[i]) for i in range(self.world_size)]
+            output_list = [
+                torch.empty_like(input_list[i]) for i in range(self.world_size)
+            ]
 
         dist.all_to_all(output_list, input_list, group=self.device_group)
         output_tensor = torch.cat(output_list, dim=gather_dim).contiguous()
@@ -87,5 +94,3 @@ class NPUCommunicator(DeviceCommunicatorBase):
             output_tensor = torch.transpose(output_tensor, 0,
                                             scatter_dim).contiguous()
         return output_tensor
-
-

--- a/vllm_ascend/distributed/communicator.py
+++ b/vllm_ascend/distributed/communicator.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 import torch.distributed as dist

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -203,15 +203,11 @@ class CustomDeepseekV2MoE(nn.Module):
             )
         CustomDeepseekV2MoE.top_k = config.num_experts_per_tok
 
-        vllm_config = get_current_vllm_config()
         self.dp_size = get_dp_group().world_size
-        batch_size = vllm_config.scheduler_config.max_num_seqs
         self.enable_mc2 = int(os.environ.get("VLLM_ENABLE_MC2", '0')) == 1
 
-        params_dtype = torch.get_default_dtype()
-        self.final_hidden_states = torch.zeros(
-            [batch_size, config.hidden_size], dtype=params_dtype, device="npu")
         self.tp_group = get_tp_group().device_group
+        self.tp_rank = get_tp_group().rank_in_group
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         attn_metadata = get_forward_context().attn_metadata
@@ -223,19 +219,30 @@ class CustomDeepseekV2MoE(nn.Module):
             is_prefill = attn_metadata.num_prefills > 0
             enable_force_load_balance = False
         num_tokens, hidden_dim = hidden_states.shape
-        hidden_states = hidden_states.view(-1, hidden_dim)
 
-        if (self.tp_size > 1 and self.enable_mc2 and not is_prefill):
-            chunks = torch.chunk(hidden_states,
-                                 get_tp_group().world_size,
-                                 dim=0)
-            hidden_states = chunks[get_tp_group().rank_in_group]
+        if self.tp_size > 1:
+            # pass
+            num_tokens, hidden_size = hidden_states.shape
+            need_padding = num_tokens % 4 == 0
+            if need_padding:
+                target_size = (num_tokens + 3) // 4 * 4
+                new_hidden_states = torch.empty([target_size, hidden_size],
+                                                dtype=hidden_states.dtype,
+                                                device=hidden_states.device)
+                new_hidden_states[:num_tokens] = hidden_states
+                hidden_states = new_hidden_states
+            chunk_hidden_states = torch.tensor_split(hidden_states,
+                                                     self.tp_size,
+                                                     dim=0)
+            local_hidden_states = chunk_hidden_states[self.tp_rank]
+        else:
+            local_hidden_states = hidden_states
 
         # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states)
+        router_logits, _ = self.gate(local_hidden_states)
 
-        final_hidden_states = self.experts(
-            hidden_states=hidden_states,
+        router_hidden_states = self.experts(
+            hidden_states=local_hidden_states,
             router_logits=router_logits,
             is_prefill=is_prefill,
             top_k=CustomDeepseekV2MoE.top_k,
@@ -243,13 +250,12 @@ class CustomDeepseekV2MoE(nn.Module):
         ) * self.routed_scaling_factor
 
         if self.tp_size > 1:
-            if self.enable_mc2 and not is_prefill:
-                dist.all_gather_into_tensor(self.final_hidden_states,
-                                            final_hidden_states, self.tp_group)
-                final_hidden_states = self.final_hidden_states
-            else:
-                final_hidden_states = tensor_model_parallel_all_reduce(
-                    final_hidden_states)
+            dist.all_gather(list(chunk_hidden_states), router_hidden_states,
+                            self.tp_group)
+            final_hidden_states = torch.cat(chunk_hidden_states, dim=0)
+        else:
+            final_hidden_states = router_hidden_states
+
         if self.n_shared_experts is not None:
             shared_output = self.shared_experts(hidden_states)
             final_hidden_states = final_hidden_states + shared_output

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -25,7 +25,6 @@
 # # vllm-project/vllm/vllm/model_executor/models/deepseek_v2.py
 # """Inference-only DeepseekV2/DeepseekV3 model."""
 
-import os
 from typing import Any, Dict, List, Optional, Union
 
 import torch
@@ -213,8 +212,8 @@ class CustomDeepseekV2MoE(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         attn_metadata = get_forward_context().attn_metadata
-        # when profile runs, force experts load balance to avoid high memory
-        # consumption from 1 rank.
+        # when profile runs, force experts to load balanced tokens
+        # to avoid high memory consumption on a single rank.
         # TODO: need a better flag to indicate whether in profile run or not.
         if attn_metadata is None or attn_metadata.slot_mapping[-1] < 0:
             # for profile run

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -207,7 +207,6 @@ class CustomDeepseekV2MoE(nn.Module):
         CustomDeepseekV2MoE.top_k = config.num_experts_per_tok
 
         self.dp_size = get_dp_group().world_size
-        self.enable_mc2 = int(os.environ.get("VLLM_ENABLE_MC2", '0')) == 1
 
         self.tp_group = get_tp_group().device_group
         self.tp_rank = get_tp_group().rank_in_group

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -19,7 +19,6 @@ import os
 from typing import Callable, Optional
 
 import torch
-import torch.distributed as dist
 import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.distributed import tensor_model_parallel_all_reduce
@@ -624,19 +623,9 @@ class AscendFusedMoE(FusedMoE):
         else:
             real_top_k = self.top_k
 
-        if self.dp_size > 1:
-            if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
-                   ) == 1 and not is_prefill:
-                ...
-        else:
-            if int(os.environ.get("USING_LCCL_COM", '0')) == 1:  # type: ignore
-                hidden_states = get_dp_group().all_gather(
-                    hidden_states, 0, False)
-                router_logits = get_dp_group().all_gather(
-                    router_logits, 0, False)
-            else:
-                hidden_states = get_dp_group().all_gather(hidden_states, 0)
-                router_logits = get_dp_group().all_gather(router_logits, 0)
+        if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
+                ) == 1 and not is_prefill:
+            ...
 
         # Matrix multiply.
         final_hidden_states = self.quant_method.apply(
@@ -657,16 +646,9 @@ class AscendFusedMoE(FusedMoE):
             enable_force_load_balance=enable_force_load_balance,
             dp_size=self.dp_size)
 
-        if self.dp_size > 1:
-            if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
-                   ) == 1 and not is_prefill:
-                ...
-        else:
-            final_hidden_states = dist._functional_collectives.reduce_scatter_tensor(
-                final_hidden_states,
-                "sum",
-                scatter_dim=0,
-                group=get_dp_group().device_group)
+        if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
+                ) == 1 and not is_prefill:
+            ...
 
         if self.reduce_results and (self.tp_size > 1 or self.ep_size > 1):
             final_hidden_states = tensor_model_parallel_all_reduce(

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -615,6 +615,7 @@ class AscendFusedMoE(FusedMoE):
                 hidden_states: torch.Tensor,
                 router_logits: torch.Tensor,
                 is_prefill: bool,
+                enable_force_load_balance: bool = False,
                 top_k=None):
         assert self.quant_method is not None
 
@@ -628,7 +629,7 @@ class AscendFusedMoE(FusedMoE):
                    ) == 1 and not is_prefill:
                 ...
         else:
-            elif int(os.environ.get("USING_LCCL_COM",
+            if int(os.environ.get("USING_LCCL_COM",
                                     '0')) == 1:  # type: ignore
                 hidden_states = get_dp_group().all_gather(
                     hidden_states, 0, False)
@@ -654,6 +655,7 @@ class AscendFusedMoE(FusedMoE):
             scoring_func=self.scoring_func,
             e_score_correction_bias=self.e_score_correction_bias,
             is_prefill=is_prefill,
+            enable_force_load_balance=enable_force_load_balance,
             dp_size=self.dp_size)
 
         if self.dp_size > 1:

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 # Adapted from vllm/tests/kernels/test_moe.py
 
+import os
 from typing import Callable, Optional
 
 import torch
@@ -627,7 +628,7 @@ class AscendFusedMoE(FusedMoE):
             real_top_k = self.top_k
 
         if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
-                ) == 1 and not is_prefill:
+               ) == 1 and not is_prefill:
             ...
 
         # Matrix multiply.
@@ -650,7 +651,7 @@ class AscendFusedMoE(FusedMoE):
             dp_size=self.dp_size)
 
         if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
-                ) == 1 and not is_prefill:
+               ) == 1 and not is_prefill:
             ...
 
         if self.reduce_results and (self.tp_size > 1 or self.ep_size > 1):

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -15,7 +15,6 @@
 # This file is a part of the vllm-ascend project.
 # Adapted from vllm/tests/kernels/test_moe.py
 
-import os
 from typing import Callable, Optional
 
 import torch

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -629,8 +629,7 @@ class AscendFusedMoE(FusedMoE):
                    ) == 1 and not is_prefill:
                 ...
         else:
-            if int(os.environ.get("USING_LCCL_COM",
-                                    '0')) == 1:  # type: ignore
+            if int(os.environ.get("USING_LCCL_COM", '0')) == 1:  # type: ignore
                 hidden_states = get_dp_group().all_gather(
                     hidden_states, 0, False)
                 router_logits = get_dp_group().all_gather(

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -627,8 +627,7 @@ class AscendFusedMoE(FusedMoE):
         else:
             real_top_k = self.top_k
 
-        if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
-               ) == 1 and not is_prefill:
+        if VLLM_ENABLE_MC2 and not is_prefill:
             ...
 
         # Matrix multiply.
@@ -650,8 +649,7 @@ class AscendFusedMoE(FusedMoE):
             enable_force_load_balance=enable_force_load_balance,
             dp_size=self.dp_size)
 
-        if int(os.environ.get("VLLM_ENABLE_MC2", '0')  # type: ignore
-               ) == 1 and not is_prefill:
+        if VLLM_ENABLE_MC2 and not is_prefill:
             ...
 
         if self.reduce_results and (self.tp_size > 1 or self.ep_size > 1):

--- a/vllm_ascend/patch/platform/patch_common/patch_distributed.py
+++ b/vllm_ascend/patch/platform/patch_common/patch_distributed.py
@@ -16,17 +16,17 @@
 # limitations under the License.
 # Adapted from vllm/model_executor/models/qwen2_vl.py
 # This file is a part of the vllm-ascend project.
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
+import vllm
+import vllm.distributed
 from torch.distributed import ProcessGroup
 from torch.distributed.distributed_c10d import (Backend, PrefixStore,
                                                 _get_default_timeout,
                                                 is_nccl_available)
 from torch.distributed.rendezvous import rendezvous
-import vllm
 from vllm.config import ParallelConfig
-import vllm.distributed
 from vllm.distributed.parallel_state import GroupCoordinator
 
 

--- a/vllm_ascend/patch/platform/patch_common/patch_distributed.py
+++ b/vllm_ascend/patch/platform/patch_common/patch_distributed.py
@@ -198,8 +198,8 @@ class GroupCoordinatorPatch(GroupCoordinator):
                    input_: torch.Tensor,
                    scatter_dim: int = 0,
                    gather_dim: int = -1,
-                   scatter_sizes: List[int] = None,
-                   gather_sizes: List[int] = None) -> torch.Tensor:
+                   scatter_sizes: Optional[List[int]] = None,
+                   gather_sizes: Optional[List[int]] = None) -> torch.Tensor:
         if self.world_size == 1:
             return input_
         assert -input_.dim() <= scatter_dim < input_.dim(), (
@@ -208,8 +208,9 @@ class GroupCoordinatorPatch(GroupCoordinator):
         assert -input_.dim() <= gather_dim < input_.dim(), (
             f"Invalid gather dim ({gather_dim}) for input tensor with shape {input_.size()}"
         )
-        return self.device_communicator.all_to_all(input_, scatter_dim, gather_dim,
-                                                   scatter_sizes, gather_sizes)
+        return self.device_communicator.all_to_all(input_, scatter_dim,
+                                                   gather_dim, scatter_sizes,
+                                                   gather_sizes)
 
     def reduce_scatter(self,
                        input_: torch.Tensor,
@@ -222,7 +223,7 @@ class GroupCoordinatorPatch(GroupCoordinator):
         return self.device_communicator.reduce_scatter(input_, scatter_dim)
 
 
-vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch # Note: check the GroupCoordinator with online serving
+vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch  # Note: check the GroupCoordinator with online serving
 vllm.distributed.parallel_state.destroy_model_parallel = ascend_destroy_model_parallel
 ParallelConfig.get_next_dp_init_port = parallel_config_get_dp_port
 ParallelConfig.stateless_init_dp_group = ascend_stateless_init_dp_group

--- a/vllm_ascend/patch/platform/patch_common/patch_distributed.py
+++ b/vllm_ascend/patch/platform/patch_common/patch_distributed.py
@@ -16,16 +16,18 @@
 # limitations under the License.
 # Adapted from vllm/model_executor/models/qwen2_vl.py
 # This file is a part of the vllm-ascend project.
+from typing import Optional, List
 
 import torch
-import vllm
-import vllm.distributed
 from torch.distributed import ProcessGroup
 from torch.distributed.distributed_c10d import (Backend, PrefixStore,
                                                 _get_default_timeout,
                                                 is_nccl_available)
 from torch.distributed.rendezvous import rendezvous
+import vllm
 from vllm.config import ParallelConfig
+import vllm.distributed
+from vllm.distributed.parallel_state import GroupCoordinator
 
 
 def ascend_destroy_model_parallel():
@@ -187,6 +189,40 @@ def ascend_stateless_init_dp_group(self) -> "ProcessGroup":
     return dp_group
 
 
+class GroupCoordinatorPatch(GroupCoordinator):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def all_to_all(self,
+                   input_: torch.Tensor,
+                   scatter_dim: int = 0,
+                   gather_dim: int = -1,
+                   scatter_sizes: List[int] = None,
+                   gather_sizes: List[int] = None) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        assert -input_.dim() <= gather_dim < input_.dim(), (
+            f"Invalid gather dim ({gather_dim}) for input tensor with shape {input_.size()}"
+        )
+        return self.device_communicator.all_to_all(input_, scatter_dim, gather_dim,
+                                                   scatter_sizes, gather_sizes)
+
+    def reduce_scatter(self,
+                       input_: torch.Tensor,
+                       scatter_dim: int = 0) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        return self.device_communicator.reduce_scatter(input_, scatter_dim)
+
+
+vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch # Note: check the GroupCoordinator with online serving
 vllm.distributed.parallel_state.destroy_model_parallel = ascend_destroy_model_parallel
 ParallelConfig.get_next_dp_init_port = parallel_config_get_dp_port
 ParallelConfig.stateless_init_dp_group = ascend_stateless_init_dp_group

--- a/vllm_ascend/patch/worker/patch_common/__init__.py
+++ b/vllm_ascend/patch/worker/patch_common/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import vllm_ascend.patch.worker.patch_common.patch_distributed  # noqa
 import vllm_ascend.patch.worker.patch_common.patch_metrics  # noqa
 import vllm_ascend.patch.worker.patch_common.patch_minicpm  # noqa
 import vllm_ascend.patch.worker.patch_common.patch_multi_step_worker  # noqa

--- a/vllm_ascend/patch/worker/patch_common/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_common/patch_distributed.py
@@ -45,15 +45,5 @@ class GroupCoordinatorPatch(GroupCoordinator):
                                                    gather_dim, scatter_sizes,
                                                    gather_sizes)
 
-    def reduce_scatter(self,
-                       input_: torch.Tensor,
-                       scatter_dim: int = 0) -> torch.Tensor:
-        if self.world_size == 1:
-            return input_
-        assert -input_.dim() <= scatter_dim < input_.dim(), (
-            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
-        )
-        return self.device_communicator.reduce_scatter(input_, scatter_dim)
-
 
 vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch  # Note: check the GroupCoordinator with online serving

--- a/vllm_ascend/patch/worker/patch_common/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_common/patch_distributed.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import List, Optional
+
+import torch
+import vllm
+from vllm.distributed.parallel_state import GroupCoordinator
+
+
+class GroupCoordinatorPatch(GroupCoordinator):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def all_to_all(self,
+                   input_: torch.Tensor,
+                   scatter_dim: int = 0,
+                   gather_dim: int = -1,
+                   scatter_sizes: Optional[List[int]] = None,
+                   gather_sizes: Optional[List[int]] = None) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        assert -input_.dim() <= gather_dim < input_.dim(), (
+            f"Invalid gather dim ({gather_dim}) for input tensor with shape {input_.size()}"
+        )
+        return self.device_communicator.all_to_all(input_, scatter_dim,
+                                                   gather_dim, scatter_sizes,
+                                                   gather_sizes)
+
+    def reduce_scatter(self,
+                       input_: torch.Tensor,
+                       scatter_dim: int = 0) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        return self.device_communicator.reduce_scatter(input_, scatter_dim)
+
+
+vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch  # Note: check the GroupCoordinator with online serving

--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -321,14 +321,11 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         dp_size: int = 1,
         **kwargs,
     ) -> torch.Tensor:
-        return self.quant_method.apply(layer, x, router_logits, top_k,
-                                       renormalize, use_grouped_topk,
-                                       global_num_experts, expert_map,
-                                       topk_group, num_expert_group,
-                                       custom_routing_function, scoring_func,
-                                       e_score_correction_bias, is_prefill,
-                                       enable_force_load_balance,
-                                       dp_size)
+        return self.quant_method.apply(
+            layer, x, router_logits, top_k, renormalize, use_grouped_topk,
+            global_num_experts, expert_map, topk_group, num_expert_group,
+            custom_routing_function, scoring_func, e_score_correction_bias,
+            is_prefill, enable_force_load_balance, dp_size)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if hasattr(self.quant_method, "process_weights_after_loading"):

--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -317,7 +317,8 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         scoring_func: str = "softmax",
         e_score_correction_bias: Optional[torch.Tensor] = None,
         is_prefill: bool = True,
-        dp_size: int = 1
+        enable_force_load_balance: bool = False,
+        dp_size: int = 1,
         **kwargs,
     ) -> torch.Tensor:
         return self.quant_method.apply(layer, x, router_logits, top_k,
@@ -326,6 +327,7 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
                                        topk_group, num_expert_group,
                                        custom_routing_function, scoring_func,
                                        e_score_correction_bias, is_prefill,
+                                       enable_force_load_balance,
                                        dp_size)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -317,6 +317,7 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         scoring_func: str = "softmax",
         e_score_correction_bias: Optional[torch.Tensor] = None,
         is_prefill: bool = True,
+        dp_size: int = 1
         **kwargs,
     ) -> torch.Tensor:
         return self.quant_method.apply(layer, x, router_logits, top_k,
@@ -324,7 +325,8 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
                                        global_num_experts, expert_map,
                                        topk_group, num_expert_group,
                                        custom_routing_function, scoring_func,
-                                       e_score_correction_bias, is_prefill)
+                                       e_score_correction_bias, is_prefill,
+                                       dp_size)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if hasattr(self.quant_method, "process_weights_after_loading"):

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -69,24 +69,17 @@ def apply_mlp(hidden_states_wrapper: List[torch.Tensor],
     hidden_states = torch_npu.npu_grouped_matmul(
         x=[hidden_states],
         weight=[w1],
-        split_item=3,
+        scale=[w1_scale],
+        per_token_scale=[pertoken_scale],
+        split_item=2,
         group_list_type=group_list_type,
         group_type=0,
         group_list=group_list,
-        output_dtype=torch.int32)[0]
+        output_dtype=w2_scale.dtype)[0]
 
     # act_fn: swiglu
-    hidden_states, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
-        x=hidden_states,
-        weight_scale=w1_scale,
-        activation_scale=pertoken_scale,
-        bias=None,
-        quant_scale=None,
-        quant_offset=None,
-        group_index=group_list,
-        activate_left=True,
-        quant_mode=1,
-    )
+    hidden_states = torch_npu.npu_swiglu(hidden_states)
+    hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
 
     # gmm2: down_proj
     hidden_states = torch_npu.npu_grouped_matmul(
@@ -648,7 +641,7 @@ class AscendW8A8DynamicFusedMoEMethod:
             layer.w2_weight.data = layer.w2_weight.data.transpose(
                 1, 2).contiguous()
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.view(
-            layer.w13_weight_scale.data.shape[0], -1).to(torch.float32)
+            layer.w13_weight_scale.data.shape[0], -1)
         layer.w13_weight_offset.data = layer.w13_weight_offset.data.view(
             layer.w13_weight_offset.data.shape[0], -1)
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.view(

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -565,6 +565,7 @@ class AscendW8A8DynamicFusedMoEMethod:
         scoring_func: str = "softmax",
         e_score_correction_bias: Optional[torch.Tensor] = None,
         is_prefill: bool = True,
+        enable_force_load_balance: bool = True,
         dp_size: int = 1,
         **kwargs,
     ) -> torch.Tensor:
@@ -599,6 +600,9 @@ class AscendW8A8DynamicFusedMoEMethod:
                 scoring_func=scoring_func,
                 e_score_correction_bias=e_score_correction_bias,
             )
+        
+        if enable_force_load_balance:
+            topk_ids = torch.randint_like(topk_ids, 0, global_num_experts)
 
         if os.environ.get("VLLM_ENABLE_MC2", '0') == "1" and not is_prefill:
             return fused_experts_with_mc2(

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -19,9 +19,10 @@ import os
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
-import torch_npu
 import torch.distributed as dist
+import torch_npu
 from vllm.distributed import GroupCoordinator
+
 from vllm_ascend.distributed.parallel_state import get_ep_group
 from vllm_ascend.ops.fused_moe import select_experts
 

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -24,7 +24,10 @@ import torch_npu
 from vllm.distributed import GroupCoordinator
 
 from vllm_ascend.distributed.parallel_state import get_ep_group
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ops.fused_moe import select_experts
+
+VLLM_ENABLE_MC2: bool = envs_ascend.VLLM_ENABLE_MC2
 
 
 def apply_mlp(hidden_states_wrapper: List[torch.Tensor],
@@ -616,7 +619,7 @@ class AscendW8A8DynamicFusedMoEMethod:
         if enable_force_load_balance:
             topk_ids = torch.randint_like(topk_ids, 0, global_num_experts)
 
-        if os.environ.get("VLLM_ENABLE_MC2", '0') == "1" and not is_prefill:
+        if VLLM_ENABLE_MC2 and not is_prefill:
             return fused_experts_with_mc2(
                 hidden_states=x,
                 w1=layer.w13_weight,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
1. This PR introduces native `all_to_all` communication operator to fix `allgather` bugs when dp_size > 1. Besides, it adds a naive implementation of force-load-balance when doing profile runs.
2. The operator `npu_dequant_swiglu_quant` only supports input hidden_states with dtype `torch.int32`. This tensor occupies space of  `global_bs * seq_len * topk * hidden_size`, which might be very large as `ep_size` grows. Therefore we need to disable this operator and use original `swiglu` && `quantize`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By performing offline inference:
![image](https://github.com/user-attachments/assets/e003d5dc-0753-41ae-9303-e87f73ac6828)


