### PR TITLE
[Perf] Reduce memory usage by splitting tokens in fused_experts and avoiding unused tensor

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -66,6 +66,8 @@ env_variables: Dict[str, Callable[[], Any]] = {
     lambda: os.getenv("C_COMPILER", None),
     "VLLM_VERSION":
     lambda: os.getenv("VLLM_VERSION", None),
+    "VLLM_FUSED_EXPERTS_SEQ_SPLIT_LENGTH":
+    lambda: int(os.getenv("VLLM_FUSED_EXPERTS_SEQ_SPLIT_LENGTH", "8192")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -219,10 +219,11 @@ class NPUModelRunner:
                 device="cpu",
                 pin_memory=True)
 
-        self.inputs_embeds = torch.zeros(
-            (self.max_num_tokens, self.hidden_size),
-            dtype=self.dtype,
-            device=self.device)
+        if self.is_multimodal_model:
+            self.inputs_embeds = torch.zeros(
+                (self.max_num_tokens, self.hidden_size),
+                dtype=self.dtype,
+                device=self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
         self.arange_np: npt.NDArray[np.int32] = np.arange(max(


### PR DESCRIPTION
### What this PR does / why we need it?
#### splitting tokens in fused_experts
When `--max-model-len`=32768 on `DeepSeek-R1-W8A8`, the `fused_experts` function consumes about 5.75GB of memory. By splitting it into multiple executions, the memory consumption of the `fused_experts` function can be reduced to 1.2GB, thereby increasing the available KVCache.

The disadvantage of this solution is that when the number of prompt tokens sent by the user exceeds VLLM_FUSED_EXPERTS_SEQ_SPLIT_LENGTH, an additional `concat` operator overhead will be added. 

However, considering that the user's request in most scenarios will be less than `8192`, we believe that this overhead is acceptable.

#### avoiding unused tensor
`self.inputs_embeds` in NPUModelRunner V1 will always be generated, but it will only be used in multi-modal situations, so I changed its generation conditions to reduce memory usage.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?


