### PR TITLE
draft of dual stream launch

### DIFF
--- a/vllm_ascend/core/context.py
+++ b/vllm_ascend/core/context.py
@@ -1,0 +1,50 @@
+import threading
+
+import torch
+
+
+class AscendContextManager:
+
+    def __init__(self, vllm_config):
+        self.additional_config = vllm_config.additional_config
+        self.micro_batch_num = self.additional_config.micro_batch_num
+
+        self.device_streams = {
+            "micro_batch_1": torch.npu.Stream(),
+            "micro_batch_2": torch.npu.Stream()
+        }
+        self.device_event = torch.npu.Event()
+        self.host_event = threading.Event()
+
+    def get_stream(self, stream_name):
+        if stream_name in self.device_streams:
+            return self.device_streams[stream_name]
+        else:
+            raise RuntimeError(f"unknow stream name : {stream_name}")
+
+    def record_event(self):
+        current_stream = torch.npu.current_stream()
+        # record the launch task for another stream
+        self.device_event.record(current_stream)
+        # notify another thread for task issue
+        self.host_event.set()
+
+    def wait_event(self):
+        # Should only run after the signal is received from others
+        self.host_event.wait()
+        self.host_event.clear()
+        current_stream = torch.npu.current_stream()
+        current_stream.wait_event(self.device_event)
+
+    def get_stream_context(self, stream_name):
+        return torch.npu.stream(self.get_stream(stream_name))
+
+
+def init_ascend_global_context_manager():
+    global Context
+    Context = AscendContextManager()
+
+
+def get_global_context_manager():
+    global Context
+    return Context


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
The moe layer in sparse model like deepseek tends to bring significant communication overhead over the computation part, the communication result directly comsumed by the routing expert, which makes the computation resources keeped idle in a long time even if the shared expert exeute in parallel. According to the DeepEP indicate in their repo, slice the input into several microbatch and makes the attention computation overlapped with another microbatch's communication part can reduce this overhead significantly, thus bring performance boost. We here purpose a draft on the dual stream launch implementation.

![dual stream](https://github.com/user-attachments/assets/300df01f-8960-4276-8769-d83bf9e2dd0c)


As the figure shows, we slice the input into 2 microbatch in `model_runner`, and maintain a threadpool to launch each stream on different thread. The second stream's execution can only be triggered when first stream have finished its first attention task. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

