### PR TITLE
Use small num_tokens to dummy_run for decode

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -66,6 +66,8 @@ env_variables: Dict[str, Callable[[], Any]] = {
     lambda: os.getenv("C_COMPILER", None),
     "VLLM_VERSION":
     lambda: os.getenv("VLLM_VERSION", None),
+    "MODEL_INSTANCE_ROLE":
+    lambda: os.getenv("MODEL_INSTANCE_ROLE", None),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
In PD seperate case, for decode role, warmup should not use the max_num_tokens, it could be smaller to get the correct GPU memory useage, and save more memory for kvcache. 

### How was this patch tested?
In decode node
export MODEL_INSTANCE_ROLE="decode"

run 1p1d case to test
