### PR TITLE
Use small num_tokens to dummy_run for decode

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -66,6 +66,8 @@ env_variables: Dict[str, Callable[[], Any]] = {
     lambda: os.getenv("C_COMPILER", None),
     "VLLM_VERSION":
     lambda: os.getenv("VLLM_VERSION", None),
+    "MODEL_INSTANCE_ROLE":
+    lambda: os.getenv("MODEL_INSTANCE_ROLE", None),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -55,6 +55,7 @@ from vllm_ascend.attention.attention import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.utils import vllm_version_is
+import vllm_ascend.envs as envs
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
In PD seperate case, for decode role, warmup should not use the max_num_tokens, it could be smaller to get the correct GPU memory useage, and save more memory for kvcache.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
In decode node
export MODEL_INSTANCE_ROLE="decode"

run 1p1d case to test

