### PR TITLE
[BugFix][WIP] Fix accuray problems with deepseek in situation of ep=1, etp>1

### DIFF
--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -586,22 +586,12 @@ class AscendFusedMoE(FusedMoE):
         self.expert_map = None
         self.activation = activation
 
-        if self.ep_size > 1:
-            # Create a tensor of size num_experts filled with -1
-            self.local_num_experts, self.expert_map = determine_expert_map(
-                self.ep_size,
-                get_ep_group().rank_in_group, self.global_num_experts)
-            self.tp_rank = get_etp_group().rank_in_group
-            self.ep_rank = get_ep_group().rank_in_group
-        else:
-            # Adjust TP size for DP attention
-            # haven't test its functionality yet, may remove in the future
-            self.tp_rank = self.tp_size * self.dp_rank
-            self.ep_rank = 0
-            self.tp_size = self.tp_size * self.dp_size
-            self.ep_size = 1
-            self.local_num_experts = self.global_num_experts
-            self.expert_map = None
+        # Create a tensor of size num_experts filled with -1
+        self.local_num_experts, self.expert_map = determine_expert_map(
+            self.ep_size,
+            get_ep_group().rank_in_group, self.global_num_experts)
+        self.tp_rank = get_etp_group().rank_in_group
+        self.ep_rank = get_ep_group().rank_in_group
 
         if self.scoring_func != "softmax" and not self.use_grouped_topk:
             raise ValueError("Only softmax scoring function is supported for "


### PR DESCRIPTION
This PR tries to fix accuracy problem with deepseek in pure expert-tensor-parallel situation. There are two problems in total:
1. Fix a bug which incorrectly sets the value of tp_rank when ep_size=1. This code was introduced by @ganyi1996ppo, and I'm not very sure if I can directly delete this code without influencing other funcionalities, especially in data-parallel situation. CC @ganyi1996ppo @yiz-liu 
2. Another problem is related with torch_npu.npu_moe_finalize_routing in fused_experts, and I'm working on solving it.