### PR TITLE
[CI/UT] Ignore vllm/tests/test_vllm_port.py

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -61,6 +61,8 @@ addopts = --ignore=vllm-empty/tests/test_utils.py
           --ignore=vllm-empty/tests/detokenizer/test_stop_reason.py
         ;   oom on llama-2-7b-hf
           --ignore=vllm-empty/tests/detokenizer/test_stop_strings.py
+        ; no need to run on vllm-ascend
+          --ignore=vllm-empty/tests/test_vllm_port.py
 
 testpaths =
     vllm-empty/tests


### PR DESCRIPTION
Ignore `vllm/tests/test_vllm_port.py` in ut as no related to vllm-ascend, and it is breaking CI
