### PR TITLE
[WIP][Platform] Add support for Ascend 310P

### DIFF
--- a/csrc/kernels/utils.h
+++ b/csrc/kernels/utils.h
@@ -20,9 +20,11 @@ namespace vllm_ascend {
 
 template <typename scalar_t> struct AccType;
 
-template <> struct AccType<bfloat16_t> {
-    using type = float;
-};
+#if (__CCE_AICORE__ >= 220)
+    template <> struct AccType<bfloat16_t> {
+        using type = float;
+    };
+#endif
 
 template <> struct AccType<half> {
     using type = half;

--- a/csrc/kernels/utils.h
+++ b/csrc/kernels/utils.h
@@ -21,31 +21,33 @@ namespace vllm_ascend {
 template <typename scalar_t> struct AccType;
 
 #if (__CCE_AICORE__ >= 220)
-    template <> struct AccType<bfloat16_t> {
-        using type = float;
-    };
+template <> struct AccType<bfloat16_t> {
+  using type = float;
+};
 #endif
 
 template <> struct AccType<half> {
-    using type = half;
+  using type = half;
 };
 
 template <> struct AccType<float> {
-    using type = float;
+  using type = float;
 };
 
 template <> struct AccType<int8_t> {
-    using type = int;
+  using type = int;
 };
 
 template <typename scalar_t>
-__aicore__ inline void local_mem_copy(AscendC::LocalTensor<scalar_t> dst, AscendC::LocalTensor<scalar_t> src, int size)
-{
-    constexpr int loadSize = 256 / sizeof(scalar_t);
-    int loopCnt = size / loadSize;
-    int tailSize = size % loadSize;
-    if (loopCnt)
-        AscendC::Copy(dst, src, loadSize, loopCnt, {1, 1, 8, 8});
-    AscendC::Copy(dst[loopCnt * loadSize], src[loopCnt * loadSize], tailSize, 1, {1, 1, 8, 8});
+__aicore__ inline void local_mem_copy(AscendC::LocalTensor<scalar_t> dst,
+                                      AscendC::LocalTensor<scalar_t> src,
+                                      int size) {
+  constexpr int loadSize = 256 / sizeof(scalar_t);
+  int loopCnt = size / loadSize;
+  int tailSize = size % loadSize;
+  if (loopCnt)
+    AscendC::Copy(dst, src, loadSize, loopCnt, {1, 1, 8, 8});
+  AscendC::Copy(dst[loopCnt * loadSize], src[loopCnt * loadSize], tailSize, 1,
+                {1, 1, 8, 8});
 }
 } // namespace vllm_ascend

--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -37,7 +37,8 @@ from vllm.utils import async_tensor_h2d, make_tensor_with_pad
 
 from vllm_ascend.ops.cache import concat_and_cache_mla
 from vllm_ascend.platform import CUSTOM_OP_ENABLED
-from vllm_ascend.utils import is_310p, nd_to_nz_2d, ACL_FORMAT_FRACTAL_NZ, aligned_16
+from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_NZ, aligned_16, is_310p,
+                               nd_to_nz_2d)
 from vllm_ascend.worker.model_runner import (
     ModelInputForNPUBuilder, ModelInputForNPUWithSamplingMetadata)
 
@@ -170,7 +171,8 @@ class AscendAttentionBackend(AttentionBackend):
         head_size: int,
     ) -> Tuple[int, ...]:
         if is_310p():
-            return (2, num_blocks, num_kv_heads * head_size // 16, block_size, 16)
+            return (2, num_blocks, num_kv_heads * head_size // 16, block_size,
+                    16)
         else:
             return (2, num_blocks, block_size, num_kv_heads, head_size)
 
@@ -658,7 +660,8 @@ class AscendMetadataBuilder(CommonMetadataBuilder[AscendMetadata]):
                     max_prefill_seq_len, dtype, device)
                 if is_310p():
                     mask_nz = nd_to_nz_2d(self.attn_mask)
-                    mask_nz = torch_npu.npu_format_cast(mask_nz.contiguous(), ACL_FORMAT_FRACTAL_NZ)
+                    mask_nz = torch_npu.npu_format_cast(
+                        mask_nz.contiguous(), ACL_FORMAT_FRACTAL_NZ)
                     self.attn_mask = mask_nz
             elif self.num_decode_tokens == 0 and not self.input_builder.chunked_prefill_enabled:
                 # compress mask for prefix cache
@@ -881,8 +884,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                             output = aligned_16(output)
 
                             # do reformat in case of broadcasted tensors
-                            mask = mask.repeat(self.seq_lens_tensor_cpu.size(0), 1, 1, 1)
-                            mask = torch_npu.npu_format_cast(mask.contiguous(), ACL_FORMAT_FRACTAL_NZ)
+                            mask = mask.repeat(
+                                self.seq_lens_tensor_cpu.size(0), 1, 1, 1)
+                            mask = torch_npu.npu_format_cast(
+                                mask.contiguous(), ACL_FORMAT_FRACTAL_NZ)
                         torch_npu._npu_flash_attention(
                             query=query,
                             key=key,
@@ -953,7 +958,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         np.int32))
                 if is_310p():
                     # # seq_lens_tensor needs to be transferred to the device for 310P
-                    self.seq_lens_tensor_cpu = self.seq_lens_tensor_cpu.to(device=self.key_cache.device)
+                    self.seq_lens_tensor_cpu = self.seq_lens_tensor_cpu.to(
+                        device=self.key_cache.device)
                 block_tables = attn_metadata.decode_metadata.block_tables
                 torch_npu._npu_paged_attention(
                     query=query,

--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -37,6 +37,7 @@ from vllm.utils import async_tensor_h2d, make_tensor_with_pad
 
 from vllm_ascend.ops.cache import concat_and_cache_mla
 from vllm_ascend.platform import CUSTOM_OP_ENABLED
+from vllm_ascend.utils import is_310p, nd_to_nz_2d, ACL_FORMAT_FRACTAL_NZ, aligned_16
 from vllm_ascend.worker.model_runner import (
     ModelInputForNPUBuilder, ModelInputForNPUWithSamplingMetadata)
 
@@ -168,7 +169,10 @@ class AscendAttentionBackend(AttentionBackend):
         num_kv_heads: int,
         head_size: int,
     ) -> Tuple[int, ...]:
-        return (2, num_blocks, block_size, num_kv_heads, head_size)
+        if is_310p():
+            return (2, num_blocks, num_kv_heads * head_size // 16, block_size, 16)
+        else:
+            return (2, num_blocks, block_size, num_kv_heads, head_size)
 
     @staticmethod
     def swap_blocks(
@@ -652,6 +656,10 @@ class AscendMetadataBuilder(CommonMetadataBuilder[AscendMetadata]):
                 # normal mask
                 self.attn_mask = AscendMetadataBuilder._attn_mask_builder.get_attn_mask(  # type: ignore
                     max_prefill_seq_len, dtype, device)
+                if is_310p():
+                    mask_nz = nd_to_nz_2d(self.attn_mask)
+                    mask_nz = torch_npu.npu_format_cast(mask_nz.contiguous(), ACL_FORMAT_FRACTAL_NZ)
+                    self.attn_mask = mask_nz
             elif self.num_decode_tokens == 0 and not self.input_builder.chunked_prefill_enabled:
                 # compress mask for prefix cache
                 self.compress_mask = AscendMetadataBuilder._attn_mask_builder.get_attn_mask(  # type: ignore
@@ -865,6 +873,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         self.seq_lens_tensor_cpu = torch.from_numpy(
                             np.array(attn_metadata.prefill_metadata.seq_lens).
                             astype(np.int32))
+                        if is_310p():
+                            # align q k v output tensors
+                            query = aligned_16(query)
+                            key = aligned_16(key)
+                            value = aligned_16(value)
+                            output = aligned_16(output)
+
+                            # do reformat in case of broadcasted tensors
+                            mask = mask.repeat(self.seq_lens_tensor_cpu.size(0), 1, 1, 1)
+                            mask = torch_npu.npu_format_cast(mask.contiguous(), ACL_FORMAT_FRACTAL_NZ)
                         torch_npu._npu_flash_attention(
                             query=query,
                             key=key,
@@ -875,6 +893,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                             num_heads=self.num_heads,
                             num_kv_heads=self.num_kv_heads,
                             out=output)
+                        output = output[:num_tokens, :, :]
                 # Prefix cache only and cache hit
                 elif attn_metadata.num_decode_tokens == 0 and not attn_metadata.chunked_prefill_enabled:
                     assert kv_cache is not None
@@ -932,6 +951,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.seq_lens_tensor_cpu = torch.from_numpy(
                     np.array(attn_metadata.decode_metadata.seq_lens).astype(
                         np.int32))
+                if is_310p():
+                    # # seq_lens_tensor needs to be transferred to the device for 310P
+                    self.seq_lens_tensor_cpu = self.seq_lens_tensor_cpu.to(device=self.key_cache.device)
                 block_tables = attn_metadata.decode_metadata.block_tables
                 torch_npu._npu_paged_attention(
                     query=query,

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 from vllm.model_executor.layers.layernorm import RMSNorm
+
 from vllm_ascend.utils import is_310p
 
 
@@ -34,10 +35,11 @@ def forward_oot(
             orig_dtype = residual.dtype
             x = x + residual.to(x.dtype)
             residual = x.to(orig_dtype)
-            x, _ = torch_npu.npu_rms_norm(x, self.weight, self.variance_epsilon)
+            x, _ = torch_npu.npu_rms_norm(x, self.weight,
+                                          self.variance_epsilon)
         else:
-            x, _, residual = torch_npu.npu_add_rms_norm(x, residual, self.weight,
-                                                    self.variance_epsilon)
+            x, _, residual = torch_npu.npu_add_rms_norm(
+                x, residual, self.weight, self.variance_epsilon)
         return x, residual
 
     x, residual = torch_npu.npu_rms_norm(x, self.weight, self.variance_epsilon)

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm_ascend.utils import is_310p
 
 
 def forward_oot(
@@ -29,7 +30,13 @@ def forward_oot(
     import torch_npu
 
     if residual is not None:
-        x, _, residual = torch_npu.npu_add_rms_norm(x, residual, self.weight,
+        if is_310p():
+            orig_dtype = residual.dtype
+            x = x + residual.to(x.dtype)
+            residual = x.to(orig_dtype)
+            x, _ = torch_npu.npu_rms_norm(x, self.weight, self.variance_epsilon)
+        else:
+            x, _, residual = torch_npu.npu_add_rms_norm(x, residual, self.weight,
                                                     self.variance_epsilon)
         return x, residual
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -24,9 +24,10 @@ import vllm.envs as envs
 from vllm.logger import logger
 from vllm.platforms import Platform, PlatformEnum
 from vllm.utils import supports_dynamo
-from vllm_ascend.utils import is_310p, communication_adaptation_310p
 
-from vllm_ascend.utils import ASCEND_QUATIZATION_METHOD, update_aclgraph_sizes
+from vllm_ascend.utils import (ASCEND_QUATIZATION_METHOD,
+                               communication_adaptation_310p, is_310p,
+                               update_aclgraph_sizes)
 
 CUSTOM_OP_ENABLED = False
 try:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -24,6 +24,7 @@ import vllm.envs as envs
 from vllm.logger import logger
 from vllm.platforms import Platform, PlatformEnum
 from vllm.utils import supports_dynamo
+from vllm_ascend.utils import is_310p, communication_adaptation_310p
 
 from vllm_ascend.utils import ASCEND_QUATIZATION_METHOD, update_aclgraph_sizes
 
@@ -84,6 +85,10 @@ class NPUPlatform(Platform):
 
         from vllm_ascend.quantization.quant_config import \
             AscendQuantConfig  # noqa: F401
+
+        if is_310p():
+            logger.info("patch torch communication while using Ascend 310P")
+            communication_adaptation_310p()
 
     @classmethod
     def get_device_capability(cls, device_id: int = 0):

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -21,7 +21,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
-import torch_npu
+import torch_npu  # noqa: F401
 from packaging.version import InvalidVersion, Version
 from vllm.logger import logger
 
@@ -47,6 +47,7 @@ SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
 
 ACL_FORMAT_FRACTAL_ND = 2
 ACL_FORMAT_FRACTAL_NZ = 29
+
 
 def is_310p():
     global SOC_VERSION
@@ -95,8 +96,8 @@ def nd_to_nz_2d(in_tensor: torch.Tensor) -> torch.Tensor:
     pad_dims[1] = _round_up(in_tensor.size(1), 16) - in_tensor.size(1)
 
     return _custom_transpose(
-        _custom_reshape(_custom_pad(in_tensor, pad_dims), aux_dims), 1, 2
-    ).contiguous()
+        _custom_reshape(_custom_pad(in_tensor, pad_dims), aux_dims), 1,
+        2).contiguous()
 
 
 def aligned_16(tensor: torch.Tensor):
@@ -113,7 +114,10 @@ def aligned_16(tensor: torch.Tensor):
         return tensor
 
     # Create a new tensor with shape (n_aligned, H, W) and fill it with zeros
-    new_tensor = torch.zeros(n_aligned, *tensor.shape[1:], dtype=tensor.dtype, device=tensor.device)
+    new_tensor = torch.zeros(n_aligned,
+                             *tensor.shape[1:],
+                             dtype=tensor.dtype,
+                             device=tensor.device)
 
     # Copy the original tensor to the first N positions of the new tensor
     new_tensor[:n] = tensor
@@ -166,20 +170,19 @@ def communication_adaptation_310p():
         return all_reduce
 
     torch.distributed.all_reduce = all_reduce_wrapper_310p(
-        torch.distributed.all_reduce
-    )
+        torch.distributed.all_reduce)
     torch.distributed.distributed_c10d.all_reduce = all_reduce_wrapper_310p(
-        torch.distributed.distributed_c10d.all_reduce
-    )
+        torch.distributed.distributed_c10d.all_reduce)
 
     def reduce_scatter_310p(output_tensor, input_tensor, group=None):
         rank = torch.distributed.get_rank(group)
         world_size = torch.distributed.get_world_size(group)
-        torch.distributed.all_reduce(
-            input_tensor, torch.distributed.ReduceOp.SUM, group, async_op=False
-        )
+        torch.distributed.all_reduce(input_tensor,
+                                     torch.distributed.ReduceOp.SUM,
+                                     group,
+                                     async_op=False)
         interval = input_tensor.shape[0] // world_size
-        output_tensor[:] = input_tensor[rank * interval : (rank + 1) * interval]
+        output_tensor[:] = input_tensor[rank * interval:(rank + 1) * interval]
 
     torch.distributed._reduce_scatter_base = reduce_scatter_310p
     torch.distributed.distributed_c10d._reduce_scatter_base = reduce_scatter_310p

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -21,6 +21,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
+import torch_npu
 from packaging.version import InvalidVersion, Version
 from vllm.logger import logger
 
@@ -39,6 +40,149 @@ else:
 MAX_CAPTURE_SIZE = 1920
 
 ASCEND_QUATIZATION_METHOD = "ascend"
+
+# 310P3 202, 910B4 224
+SOC_VERSION = None
+SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
+
+ACL_FORMAT_FRACTAL_ND = 2
+ACL_FORMAT_FRACTAL_NZ = 29
+
+def is_310p():
+    global SOC_VERSION
+    if SOC_VERSION is None:
+        SOC_VERSION = torch.npu.get_device_name(0)
+    return SOC_VERSION in SOC_VERSION_INFERENCE_SERIES
+
+
+class NullHandle:
+
+    def __init__(self):
+        pass
+
+    def wait(self):
+        pass
+
+
+def _round_up(x: int, align: int):
+    if align == 0:
+        return -1
+    return (x + align - 1) // align * align
+
+
+def _custom_pad(x, pad_dims):
+    return torch.nn.functional.pad(x, pad_dims)
+
+
+def _custom_reshape(x, target_shape):
+    return x.reshape(target_shape)
+
+
+def _custom_transpose(x, dim1, dim2):
+    return x.transpose(dim1, dim2)
+
+
+def nd_to_nz_2d(in_tensor: torch.Tensor) -> torch.Tensor:
+    aux_dims = [0, 0, 0, 0]
+    aux_dims[0] = 1
+    aux_dims[1] = _round_up(in_tensor.size(0), 16)
+
+    pad_dims = [0, 0, 0, 0]
+    pad_dims[3] = _round_up(in_tensor.size(0), 16) - in_tensor.size(0)
+
+    aux_dims[2] = _round_up(in_tensor.size(1), 16) // 16
+    aux_dims[3] = 16
+    pad_dims[1] = _round_up(in_tensor.size(1), 16) - in_tensor.size(1)
+
+    return _custom_transpose(
+        _custom_reshape(_custom_pad(in_tensor, pad_dims), aux_dims), 1, 2
+    ).contiguous()
+
+
+def aligned_16(tensor: torch.Tensor):
+    """Aligned tensor for 310P"""
+
+    # Get the size of the current 0th dimension
+    n = tensor.size(0)
+
+    # Calculate the aligned size
+    n_aligned = ((n + 15) // 16) * 16
+
+    # If already aligned, return the original tensor
+    if n == n_aligned:
+        return tensor
+
+    # Create a new tensor with shape (n_aligned, H, W) and fill it with zeros
+    new_tensor = torch.zeros(n_aligned, *tensor.shape[1:], dtype=tensor.dtype, device=tensor.device)
+
+    # Copy the original tensor to the first N positions of the new tensor
+    new_tensor[:n] = tensor
+
+    return new_tensor
+
+
+def communication_adaptation_310p():
+
+    def broadcast310p(tensor, src, group=None, async_op=False):
+        rank = torch.distributed.get_rank(group)
+        world_size = torch.distributed.get_world_size(group)
+        tensor_list = [torch.empty_like(tensor) for _ in range(world_size)]
+        tensor_list[rank] = tensor
+        torch.distributed.all_gather(tensor_list, tensor, group=group)
+        tensor[...] = tensor_list[src]
+        if async_op:
+            return NullHandle()
+        else:
+            return None
+
+    torch.distributed.broadcast = broadcast310p
+    torch.distributed.distributed_c10d.broadcast = broadcast310p
+
+    def all_reduce_wrapper_310p(fn):
+
+        def all_reduce(
+            tensor,
+            op=torch.distributed.ReduceOp.SUM,
+            group=None,
+            async_op=False,
+        ):
+            if tensor.dtype != torch.int64:
+                return fn(tensor, op, group, async_op)
+            rank = torch.distributed.get_rank(group)
+            world_size = torch.distributed.get_world_size(group)
+            tensor_list = [torch.empty_like(tensor) for _ in range(world_size)]
+            tensor_list[rank] = tensor
+            torch.distributed.all_gather(tensor_list, tensor, group=group)
+            if op == torch.distributed.ReduceOp.SUM:
+                return torch.stack(tensor_list).sum(0)
+            elif op == torch.distributed.ReduceOp.MAX:
+                return torch.tensor(
+                    torch.stack(tensor_list).cpu().numpy().max(0),
+                    device=tensor.device,
+                )
+            else:
+                raise RuntimeError(f"not implement op {op}")
+
+        return all_reduce
+
+    torch.distributed.all_reduce = all_reduce_wrapper_310p(
+        torch.distributed.all_reduce
+    )
+    torch.distributed.distributed_c10d.all_reduce = all_reduce_wrapper_310p(
+        torch.distributed.distributed_c10d.all_reduce
+    )
+
+    def reduce_scatter_310p(output_tensor, input_tensor, group=None):
+        rank = torch.distributed.get_rank(group)
+        world_size = torch.distributed.get_world_size(group)
+        torch.distributed.all_reduce(
+            input_tensor, torch.distributed.ReduceOp.SUM, group, async_op=False
+        )
+        interval = input_tensor.shape[0] // world_size
+        output_tensor[:] = input_tensor[rank * interval : (rank + 1) * interval]
+
+    torch.distributed._reduce_scatter_base = reduce_scatter_310p
+    torch.distributed.distributed_c10d._reduce_scatter_base = reduce_scatter_310p
 
 
 def try_register_lib(lib_name: str, lib_info: str = ""):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -50,7 +50,8 @@ from vllm.worker.worker_base import (LocalOrDistributedWorkerBase, WorkerBase,
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.platform import NPUPlatform
-from vllm_ascend.utils import try_register_lib, ACL_FORMAT_FRACTAL_NZ, is_310p, ACL_FORMAT_FRACTAL_ND
+from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, ACL_FORMAT_FRACTAL_NZ,
+                               is_310p, try_register_lib)
 from vllm_ascend.worker.model_runner import NPUModelRunner
 from vllm_ascend.worker.pooling_model_runner import NPUPoolingModelRunner
 
@@ -338,18 +339,22 @@ class NPUWorker(LocalOrDistributedWorkerBase):
             for _ in range(self.parallel_config.pipeline_parallel_size)
         ]
         import torch_npu
-        acl_format = ACL_FORMAT_FRACTAL_NZ if is_310p() else ACL_FORMAT_FRACTAL_ND
+        acl_format = ACL_FORMAT_FRACTAL_NZ if is_310p(
+        ) else ACL_FORMAT_FRACTAL_ND
         for ve in range(self.parallel_config.pipeline_parallel_size):
             num_layers = len(self.cache_engine[ve].gpu_cache)
             for i in range(num_layers):
                 if torch.is_tensor(self.cache_engine[ve].gpu_cache[i]):
-                    self.cache_engine[ve].gpu_cache[i] = torch_npu.npu_format_cast(
-                        self.cache_engine[ve].gpu_cache[i], acl_format)
+                    self.cache_engine[ve].gpu_cache[
+                        i] = torch_npu.npu_format_cast(
+                            self.cache_engine[ve].gpu_cache[i], acl_format)
                 else:
-                    self.cache_engine[ve].gpu_cache[i][0] = torch_npu.npu_format_cast(
-                        self.cache_engine[ve].gpu_cache[i][0], acl_format)
-                    self.cache_engine[ve].gpu_cache[i][1] = torch_npu.npu_format_cast(
-                        self.cache_engine[ve].gpu_cache[i][1], acl_format)
+                    self.cache_engine[ve].gpu_cache[i][
+                        0] = torch_npu.npu_format_cast(
+                            self.cache_engine[ve].gpu_cache[i][0], acl_format)
+                    self.cache_engine[ve].gpu_cache[i][
+                        1] = torch_npu.npu_format_cast(
+                            self.cache_engine[ve].gpu_cache[i][1], acl_format)
         self.gpu_cache = [
             self.cache_engine[ve].gpu_cache
             for ve in range(self.parallel_config.pipeline_parallel_size)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -50,7 +50,7 @@ from vllm.worker.worker_base import (LocalOrDistributedWorkerBase, WorkerBase,
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.platform import NPUPlatform
-from vllm_ascend.utils import try_register_lib
+from vllm_ascend.utils import try_register_lib, ACL_FORMAT_FRACTAL_NZ, is_310p, ACL_FORMAT_FRACTAL_ND
 from vllm_ascend.worker.model_runner import NPUModelRunner
 from vllm_ascend.worker.pooling_model_runner import NPUPoolingModelRunner
 
@@ -338,17 +338,18 @@ class NPUWorker(LocalOrDistributedWorkerBase):
             for _ in range(self.parallel_config.pipeline_parallel_size)
         ]
         import torch_npu
+        acl_format = ACL_FORMAT_FRACTAL_NZ if is_310p() else ACL_FORMAT_FRACTAL_ND
         for ve in range(self.parallel_config.pipeline_parallel_size):
             num_layers = len(self.cache_engine[ve].gpu_cache)
             for i in range(num_layers):
                 if torch.is_tensor(self.cache_engine[ve].gpu_cache[i]):
-                    torch_npu.npu_format_cast(
-                        self.cache_engine[ve].gpu_cache[i], 2)
+                    self.cache_engine[ve].gpu_cache[i] = torch_npu.npu_format_cast(
+                        self.cache_engine[ve].gpu_cache[i], acl_format)
                 else:
-                    torch_npu.npu_format_cast(
-                        self.cache_engine[ve].gpu_cache[i][0], 2)
-                    torch_npu.npu_format_cast(
-                        self.cache_engine[ve].gpu_cache[i][1], 2)
+                    self.cache_engine[ve].gpu_cache[i][0] = torch_npu.npu_format_cast(
+                        self.cache_engine[ve].gpu_cache[i][0], acl_format)
+                    self.cache_engine[ve].gpu_cache[i][1] = torch_npu.npu_format_cast(
+                        self.cache_engine[ve].gpu_cache[i][1], acl_format)
         self.gpu_cache = [
             self.cache_engine[ve].gpu_cache
             for ve in range(self.parallel_config.pipeline_parallel_size)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

- This PR introduces changes to adapt the `pos_encoding_kernels.cpp`, `utils.h`, `attention.py`, `layernorm.py`, `platform.py`, and `utils.py` files to support Ascend 310P devices. 
- Specifically, it adjusts the `loadSize` constant based on the Ascend AI Core version and adds conditional compilation directives for `bfloat16_t` support. 
- It also includes modifications to handle specific behaviors required for the Ascend 310P, such as tensor alignment and format casting.
- The purpose of these changes is to ensure compatibility and optimal performance on Ascend 310P devices.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

- Yes, this PR introduces changes that affect the behavior of the library when running on Ascend 310P devices. 
- Users of Ascend 310P will see improved performance and compatibility due to the added support and optimizations.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

The patch has been tested locally on Ascend 310P hardware to ensure that the changes do not break existing functionality and that the new features work as intended.

#### ENV information

```shell
npu-smi info
+--------------------------------------------------------------------------------------------------------+
| npu-smi 24.1.0.1                                 Version: 24.1.0.1                                     |
+-------------------------------+-----------------+------------------------------------------------------+
| NPU     Name                  | Health          | Power(W)     Temp(C)           Hugepages-Usage(page) |
| Chip    Device                | Bus-Id          | AICore(%)    Memory-Usage(MB)                        |
+===============================+=================+======================================================+
| 1536    310P3                 | OK              | NA           65                0     / 0             |
| 0       0                     | 0000:06:00.0    | 0            1524 / 44280                            |
+-------------------------------+-----------------+------------------------------------------------------+
| 1536    310P3                 | OK              | NA           64                17452 / 17452         |
| 1       1                     | 0000:06:00.0    | 0            36314/ 43693                            |
+===============================+=================+======================================================+
| 1792    310P3                 | OK              | NA           72                17636 / 17636         |
| 0       2                     | 0000:07:00.0    | 95           36982/ 44280                            |
+-------------------------------+-----------------+------------------------------------------------------+
| 1792    310P3                 | OK              | NA           68                0     / 0             |
| 1       3                     | 0000:07:00.0    | 0            1216 / 43693                            |
+===============================+=================+======================================================+
| 2048    310P3                 | OK              | NA           60                0     / 0             |
| 0       4                     | 0000:08:00.0    | 0            1411 / 44280                            |
+-------------------------------+-----------------+------------------------------------------------------+
| 2048    310P3                 | OK              | NA           57                0     / 0             |
| 1       5                     | 0000:08:00.0    | 0            1494 / 43693                            |
+===============================+=================+======================================================+
| 2304    310P3                 | OK              | NA           53                18200 / 18200         |
| 0       6                     | 0000:09:00.0    | 0            37812/ 44280                            |
+-------------------------------+-----------------+------------------------------------------------------+
| 2304    310P3                 | OK              | NA           49                18194 / 18194         |
| 1       7                     | 0000:09:00.0    | 0            37958/ 43693                            |
+===============================+=================+======================================================+
```
CANN, NNAL version: 8.1.RC1
> [!IMPORTANT]  
> Because the current PTA 2.5.1 version cannot pass parameters in the NZ format as required when calling NNAL operators on 310P, we used a temporary debugging version provided by the PTA team for testing.

#### Code example

```python
from vllm import LLM, SamplingParams
prompts = ["水的沸点是100摄氏度吗？请回答是或者否。", "若腋下体温为38摄氏度，请问这人是否发烧？请回答是或者否。",
           "水的沸点是100摄氏度吗？请回答是或者否。", "若腋下体温为38摄氏度，请问这人是否发烧？请回答是或者否。"]

# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.0, top_p=0.95, max_tokens=10)
# Create an LLM.
llm = LLM(
    model="Qwen/Qwen2.5-7B-Instruct",
    max_model_len=4096,
    max_num_seqs=4,
    dtype="float16",
    disable_custom_all_reduce=True,
    trust_remote_code=True,
    tensor_parallel_size=2,
    compilation_config={"custom_ops":['none', "+rms_norm", "+rotary_embedding"]},
)

# Generate texts from the prompts.
outputs = llm.generate(prompts, sampling_params)
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

```


<!--
- CI tests have been run with the new and existing test cases, and they passed successfully.
- Additionally, manual testing was performed to verify the behavior of the modified functions and classes.
-->
