### PR TITLE
[bugfix] Fix the bug of "vllm wrong raised the ERROR : Failed to import vllm_ascend_C:No module named 'vllm_ascend.vllm_ascend_C' #703"

### DIFF
--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -60,7 +60,7 @@ try:
     lib_name = find_loaded_library("vllm_ascend_C")
     camem_available = True
 except ImportError as e:
-    logger.error("Failed to import vllm_ascend_C:%s", e)
+    logger.warning("Failed to import vllm_ascend_C:%s", e)
     init_module = None
     python_create_and_map = None
     python_unmap_and_release = None

--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -60,7 +60,9 @@ try:
     lib_name = find_loaded_library("vllm_ascend_C")
     camem_available = True
 except ImportError as e:
-    logger.warning("Failed to import vllm_ascend_C:%s", e)
+    logger.warning(
+        "Sleep mode disabled: failed to import 'vllm_ascend.vllm_ascend_C': %s", e
+    )
     init_module = None
     python_create_and_map = None
     python_unmap_and_release = None

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,13 +31,9 @@ CUSTOM_OP_ENABLED = False
 try:
     # register custom ops into torch_library here
     import vllm_ascend.vllm_ascend_C  # type: ignore  # noqa: F401
-
-except ImportError:
-    logging.warning(
-        "Warning: Failed to register custom ops, all custom ops will be disabled"
-    )
-else:
     CUSTOM_OP_ENABLED = True
+except ImportError as e:
+    logging.warning("Failed to import vllm_ascend_C:%s", e)
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -33,7 +33,9 @@ try:
     import vllm_ascend.vllm_ascend_C  # type: ignore  # noqa: F401
     CUSTOM_OP_ENABLED = True
 except ImportError as e:
-    logging.warning("Failed to import vllm_ascend_C:%s", e)
+    logging.warning(
+        "Custom operations disabled: failed to import 'vllm_ascend.vllm_ascend_C': %s", e
+    )
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

We fix the bug of https://github.com/vllm-project/vllm-ascend/issues/703, where vllm wrong raised the ERROR : Failed to import vllm_ascend_C:No module named 'vllm_ascend.vllm_ascend_C'. The format for reporting import vllm_ascend_C failure is unified by warning ("Failed to import vllm_ascend_C:%s", e). 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

No. 

