### PR TITLE
[V1] Revert the default value of enable_chunked_prefill in additional…

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -204,9 +204,6 @@ class NPUPlatform(Platform):
                     "ascend_scheduler_config", None) is not None:
                 additional_scheduler_config = additional_config.get(
                     "ascend_scheduler_config")
-                if vllm_config.scheduler_config.enable_chunked_prefill:
-                    additional_scheduler_config[
-                        "enable_chunked_prefill"] = True
                 from vllm_ascend.core.schedule_config import \
                     AscendSchedulerConfig
                 ascend_scheduler_config = AscendSchedulerConfig.initialize_from_config(


### PR DESCRIPTION
…_scheduler_config

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
Revert the default value of enable_chunked_prefill to 'False' in additional_scheduler_config. In engine v1, enable_chunked_prefill is forcibly set to True in VllmConfig, which causes it to be perceived as True in check_and_update_config(). As a result, when the v0 scheduler is enabled, the chunked prefill feature remains active, leading to the failure of the v0 scheduler and causing it to fall back to the native v1 scheduling logic.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with new added/existing test.

