### PR TITLE
[bugfix] Improve log level and info for custom ops build

### DIFF
--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -60,7 +60,7 @@ try:
     lib_name = find_loaded_library("vllm_ascend_C")
     camem_available = True
 except ImportError as e:
-    logger.error("Failed to import vllm_ascend_C:%s", e)
+    logger.warning("Failed to import vllm_ascend_C:%s. Sleep mode will be disabled. ", e)
     init_module = None
     python_create_and_map = None
     python_unmap_and_release = None

--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -60,7 +60,8 @@ try:
     lib_name = find_loaded_library("vllm_ascend_C")
     camem_available = True
 except ImportError as e:
-    logger.warning("Failed to import vllm_ascend_C:%s. Sleep mode will be disabled. ", e)
+    logger.warning(
+        "Failed to import vllm_ascend_C:%s. Sleep mode will be disabled. ", e)
     init_module = None
     python_create_and_map = None
     python_unmap_and_release = None

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,13 +31,11 @@ CUSTOM_OP_ENABLED = False
 try:
     # register custom ops into torch_library here
     import vllm_ascend.vllm_ascend_C  # type: ignore  # noqa: F401
-
-except ImportError:
-    logging.warning(
-        "Warning: Failed to register custom ops, all custom ops will be disabled"
-    )
-else:
     CUSTOM_OP_ENABLED = True
+except ImportError as e:
+    logging.warning(
+        "Failed to import 'vllm_ascend.vllm_ascend_C': %s. All custom ops will be disabled. ", e
+    )
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -34,8 +34,8 @@ try:
     CUSTOM_OP_ENABLED = True
 except ImportError as e:
     logging.warning(
-        "Failed to import 'vllm_ascend.vllm_ascend_C': %s. All custom ops will be disabled. ", e
-    )
+        "Failed to import 'vllm_ascend.vllm_ascend_C': %s. All custom ops will be disabled. ",
+        e)
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the bug of #703, where vllm wrong raised the ERROR : Failed to import vllm_ascend_C:No module named 'vllm_ascend.vllm_ascend_C'. The format for reporting import vllm_ascend_C failure is unified by warning ("Failed to import vllm_ascend_C:%s", e).

### Does this PR introduce _any_ user-facing change?
No

