### PR TITLE
[BugFix] Fix a problem of failing to utilize custom kv cache dtype.

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -169,6 +169,11 @@ class NPUPlatform(Platform):
                     "it has been disabled automatically.")
                 vllm_config.additional_config["enable_graph_mode"] = False
 
+            kv_cache_dtype = vllm_config.additional_config.get(
+                "kv_cache_dtype", None)
+            if kv_cache_dtype is not None:
+                vllm_config.cache_config.cache_dtype = kv_cache_dtype
+
         parallel_config = vllm_config.parallel_config
         if parallel_config and parallel_config.worker_cls == "auto":
             if envs.VLLM_USE_V1:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1286,7 +1286,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                     block_size=block_size,
                     num_kv_heads=attn_module.num_kv_heads,
                     head_size=attn_module.head_size,
-                    dtype=attn_module.dtype,
+                    dtype=self.kv_cache_dtype,
                     use_mla=use_mla)
             elif attn_module.attn_type in (AttentionType.ENCODER,
                                            AttentionType.ENCODER_ONLY):


### PR DESCRIPTION
This PR fixes bugs in FA3 quantization situation.
There are three problems in total:
1. Not use self.kv_cache_dtype to initialize kv_cache_spec in model_runner_v1.py, fixed.
2. In v0 situation, if we pass "kv_cache_dtype" to initialize vllm, program will collapse due to a validation in vllm's config.py (https://github.com/vllm-project/vllm/blob/c1e4a4052d65d72d45e39db1edb6b7deb4ffd426/vllm/config.py#L1496)
3. In v1 situation, currenly "kv_cache_dtype" can't be passed as described in [issue 17355](https://github.com/vllm-project/vllm/issues/17355) 
To solve problem 2 and 3, we currently pass kv_cache_dtype through additional_config and set the cache dtype of cache_config in platform's `check_and_update_config`

