### PR TITLE
[Bugfix] Pad hidden_states to avoid cross-ring AllGatherV

### DIFF
--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -228,12 +228,12 @@ class CustomDeepseekV2MoE(nn.Module):
             shared_output = self.shared_experts(hidden_states)
 
         if self.tp_size > 1:
-            padded_num_tokens = (self.tp_size -
-                                 num_tokens % self.tp_size) % self.tp_size
+            num_padding_tokens = (self.tp_size -
+                                  num_tokens % self.tp_size) % self.tp_size
             # Pad hidden_states to make it divisible by tp_size to avoid cross-ring AllGatherV on 910B2C
-            if padded_num_tokens > 0:
-                hidden_states = nn.functional.pad(hidden_states,
-                                                  (0, 0, 0, padded_num_tokens))
+            if num_padding_tokens > 0:
+                hidden_states = nn.functional.pad(
+                    hidden_states, (0, 0, 0, num_padding_tokens))
             chunk_hidden_states = torch.tensor_split(hidden_states,
                                                      self.tp_size,
                                                      dim=0)
@@ -256,8 +256,8 @@ class CustomDeepseekV2MoE(nn.Module):
             dist.all_gather(list(chunk_hidden_states), router_hidden_states,
                             self.tp_group)
             final_hidden_states = torch.cat(chunk_hidden_states, dim=0)
-            if padded_num_tokens > 0:
-                final_hidden_states = final_hidden_states[:-padded_num_tokens]
+            if num_padding_tokens > 0:
+                final_hidden_states = final_hidden_states[:-num_padding_tokens]
         else:
             final_hidden_states = router_hidden_states
 


### PR DESCRIPTION
### What this PR does / why we need it?

On the 910B2C hardware platform, each machine is equipped with 16 NPU cards. When using Tensor Parallelism (TP)=16, if the num_tokens (input sequence length) is not divisible by tp_size, it triggers cross-ring AllGatherV communication operations, which may result in unexpected errors(see figure below).

![9251917D-B00A-4EAF-A1E4-5B92DA746795](https://github.com/user-attachments/assets/ff55bc55-5046-47b8-82a0-88d0b642af06)


### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

