### PR TITLE
[V0.7.3][LoRA][Qwen3] Make v0.7.3 support Qwen3+LoRA

### DIFF
--- a/vllm_ascend/models/qwen3.py
+++ b/vllm_ascend/models/qwen3.py
@@ -19,7 +19,7 @@
 # Adapted from vllm/model_executor/models/qwen3.py
 # This file is a part of the vllm-ascend project.
 
-from typing import Iterable, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 from torch import nn
@@ -406,8 +406,8 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         "gate_up_proj",
         "down_proj",
     ]
-    embedding_modules = {}  # type: Dict[str, str]
-    embedding_padding_modules = []  # type: List[str]
+    embedding_modules: Dict[str, str] = {}
+    embedding_padding_modules: List[str] = []
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()

--- a/vllm_ascend/models/qwen3.py
+++ b/vllm_ascend/models/qwen3.py
@@ -19,7 +19,7 @@
 # Adapted from vllm/model_executor/models/qwen3.py
 # This file is a part of the vllm-ascend project.
 
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 from torch import nn

--- a/vllm_ascend/models/qwen3.py
+++ b/vllm_ascend/models/qwen3.py
@@ -399,6 +399,16 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         ],
     }
 
+    # LoRA specific attributes
+    supported_lora_modules = [
+        "qkv_proj",
+        "o_proj",
+        "gate_up_proj",
+        "down_proj",
+    ]
+    embedding_modules = {}
+    embedding_padding_modules = []
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config

--- a/vllm_ascend/models/qwen3.py
+++ b/vllm_ascend/models/qwen3.py
@@ -19,7 +19,7 @@
 # Adapted from vllm/model_executor/models/qwen3.py
 # This file is a part of the vllm-ascend project.
 
-from typing import Iterable, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 from torch import nn
@@ -406,8 +406,8 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         "gate_up_proj",
         "down_proj",
     ]
-    embedding_modules = {}
-    embedding_padding_modules = []
+    embedding_modules = {}  # type: Dict[str, str]
+    embedding_padding_modules = []  # type: List[str]
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()


### PR DESCRIPTION
### What this PR does / why we need it?
Because the EOL vLLM-v0.7.3 lacks this PR(https://github.com/vllm-project/vllm/pull/13166), while launching Qwen3+LoRA on vllm-ascend0.7.3, the error **"Qwen3ForCausalLM" object has no attribute "embedding modules**" will be raised.

We modify qwen3.py to support Qwen3+LoRA on vllm-ascend v0.7.3 instead.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


