### PR TITLE
Adjust concurrency group for each npu workflow

### DIFF
--- a/.github/workflows/accuracy_test.yaml
+++ b/.github/workflows/accuracy_test.yaml
@@ -62,8 +62,9 @@ defaults:
   run:
     shell: bash -el {0}
 
+# only cancel in-progress runs of the same workflow
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nightly_benchmarks.yaml
+++ b/.github/workflows/nightly_benchmarks.yaml
@@ -33,9 +33,10 @@ defaults:
   run:
     shell: bash -el {0}
 
+# only 1 job can runs on static-8-01-cards
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: static-8-01-cards
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/.github/workflows/vllm_ascend_test_long_term.yaml
+++ b/.github/workflows/vllm_ascend_test_long_term.yaml
@@ -30,8 +30,9 @@ defaults:
   run:
     shell: bash -el {0}
 
+# only cancel in-progress runs of the same workflow
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -43,15 +44,6 @@ jobs:
       matrix:
         os: [linux-arm64-npu-1, linux-arm64-npu-4]
         vllm_version: [main, v0.9.0]
-    concurrency:
-      group: >
-        ${{
-        matrix.os == 'linux-arm64-npu-4'
-          && github.event.pull_request.number
-          && format('pr-{0}-limit-npu-4-long-term', github.event.pull_request.number)
-        || format('job-{0}-{1}-{2}-long-term', matrix.os, matrix.vllm_version, github.event.pull_request.number)
-        }}
-      cancel-in-progress: false
     name: vLLM Ascend long term test
     runs-on: ${{ matrix.os }}
     container:

--- a/.github/workflows/vllm_ascend_test_pd.yaml
+++ b/.github/workflows/vllm_ascend_test_pd.yaml
@@ -30,9 +30,10 @@ defaults:
   run:
     shell: bash -el {0}
 
+# only 1 job can runs on static-8-01-cards
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: static-8-01-cards
+  cancel-in-progress: false
 
 jobs:
   prefilling-decoding-disaggregation:


### PR DESCRIPTION
### What this PR does / why we need it?
Adjust concurrency group for each npu workflow
- for pd and benchmarks share the static-08-01, so only one job can runs on
- other job one PR/schedule should have only 1 job runs

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed

