### PR TITLE
Support retrieving NPU IPs for non-consecutive devices.

### DIFF
--- a/vllm_ascend/distributed/llmdatadist_connector.py
+++ b/vllm_ascend/distributed/llmdatadist_connector.py
@@ -50,32 +50,39 @@ HCCN_TOOL_PATH = envs.HCCN_PATH
 
 
 def get_device_ips():
-    world_size = 8
+
     npu_info = subprocess.run(['npu-smi', 'info', '-m'],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               universal_newlines=True)
+
     if npu_info.returncode != 0 or not os.path.exists(HCCN_TOOL_PATH):
-        raise RuntimeError("No npu-smi/hccn_tool tools provided for NPU.")
-    re_result = re.match(r'.*\n\t([0-9]+).*', npu_info.stdout)
-    if re_result is None:
-        raise RuntimeError("Can't find npu start index")
-    npu_start_idx = int(re_result.group(1))
+        raise RuntimeError("npu-smi or hccn_tool is not available. Please check your environment configuration.")
+
+    device_ids = []
+    for line in npu_info.stdout.strip().split('\n'):
+        match = re.match(r'^\s*(\d+)\s+\d+\s+\d+\s+Ascend', line)
+        if match:
+            device_ids.append(int(match.group(1)))
+
+    if not device_ids:
+        raise RuntimeError("Failed to parse any valid device ID from npu-smi output.")
+
     device_ip_list = []
-    for ip_offset in range(world_size):
-        cmd = [
-            HCCN_TOOL_PATH, '-i', f'{npu_start_idx + ip_offset}', '-ip', '-g'
-        ]
+    for device_id in device_ids:
+        cmd = [HCCN_TOOL_PATH, '-i', str(device_id), '-ip', '-g']
         device_ip_info = subprocess.run(cmd,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE,
                                         universal_newlines=True)
-        re_result = re.match(r'ipaddr:(.*)\n', device_ip_info.stdout)
-        if re_result is None:
-            raise RuntimeError("Can't find npu ip")
-        device_ip = re_result.group(1)
+        ip_match = re.search(r'ipaddr:(.*)', device_ip_info.stdout)
+        if not ip_match:
+            raise RuntimeError(f"Failed to retrieve IP address for device {device_id} using hccn_tool.")
+        device_ip = ip_match.group(1).strip()
         device_ip_list.append(device_ip)
+
     return device_ip_list
+
 
 
 class KVTransferEngine:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
This PR optimizes the logic for retrieving NPU device IP addresses:

- Parses valid Ascend device IDs directly from `npu-smi info -m` output;
- Avoids relying on hardcoded `start_index` and `world_size` offset assumptions;
- Supports non-contiguous device IDs;
- Automatically determines the number of active devices to improve compatibility and robustness.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/95bd61ac-1171-41ac-b612-5a44773e9415" />
<img width="705" alt="image" src="https://github.com/user-attachments/assets/5a5e33a4-e987-4880-b8ba-773f8b0c8b57" />
<img width="730" alt="image" src="https://github.com/user-attachments/assets/2088ed5b-dbb8-471d-8754-b3aff001bc34" />
Tested in both 8-card and non-contiguous device ID containers; NPU IDs are returned completely and in order in both cases.

