### PR TITLE
[Bugfix] Set `ACL_OP_INIT_MODE` env var default to `0`

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -127,7 +127,7 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # We set this var default to `1` in vllm-ascend to avoid segment fault when
     # enable `pin_memory` while creating a tensor using `torch.tensor`.
     "VLLM_ASCEND_ACL_OP_INIT_MODE":
-    lambda: os.getenv("VLLM_ASCEND_ACL_OP_INIT_MODE", '1'),
+    lambda: os.getenv("VLLM_ASCEND_ACL_OP_INIT_MODE", '0'),
     # Some models are optimized by vllm ascend. While in some case, e.g. rlhf
     # training, the optimized model may not be suitable. In this case, set this
     # value to False to disable the optimized model.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Set `ACL_OP_INIT_MODE` env var default to `0`, since vllm-ascend may have problems in some scenarios when setting it to `1`.

Plus, the guide https://github.com/vllm-project/vllm-ascend/issues/734 has also been updated.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

