### PR TITLE
[Build] Speedup image build

### DIFF
--- a/.github/workflows/image_openeuler.yml
+++ b/.github/workflows/image_openeuler.yml
@@ -1,4 +1,4 @@
-name: 'image'
+name: 'image / openEuler'
 # This is a docker build check and publish job:
 # 1. PR Triggered docker image build check
 #   - is for image build check
@@ -33,9 +33,13 @@ on:
 
 jobs:
   build:
-    name: vllm-ascend openEuler image
-    runs-on: ubuntu-latest
-
+    name: vllm-ascend image build
+    runs-on: >-
+      ${{
+          github.event_name == 'push' && github.repository_owner == 'vllm-project' &&
+          'ubuntu-latest' ||
+          'ubuntu-24.04-arm'
+      }}
     steps:
     - uses: actions/checkout@v4
 
@@ -87,7 +91,12 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: >-
+          ${{
+              github.event_name == 'push' && github.repository_owner == 'vllm-project' &&
+              'linux/amd64,linux/arm64' ||
+              'linux/arm64'
+          }}
         # use the current repo path as the build context, ensure .git is contained
         context: .
         # only trigger when tag, branch/main push

--- a/.github/workflows/image_ubuntu.yml
+++ b/.github/workflows/image_ubuntu.yml
@@ -1,4 +1,4 @@
-name: 'image'
+name: 'image / Ubuntu'
 # This is a docker build check and publish job:
 # 1. PR Triggered docker image build check
 #   - is for image build check
@@ -33,7 +33,7 @@ on:
 jobs:
 
   build:
-    name: vllm-ascend Ubuntu image
+    name: vllm-ascend image build
     runs-on: ubuntu-latest
 
     steps:
@@ -87,7 +87,12 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: >-
+          ${{
+              github.event_name == 'push' && github.repository_owner == 'vllm-project' &&
+              'linux/amd64,linux/arm64' ||
+              'linux/amd64'
+          }}
         # use the current repo path as the build context, ensure .git is contained
         context: .
         # only trigger when tag, branch/main push


### PR DESCRIPTION
### What this PR does / why we need it?
1. Rename workflow name to show OS info
2. Speedup image build:
- PR: only arm64 build on openEuler arm64, only amd64 build on Ubuntu amd64
- Push/Tag: still keep origin logic use qemu on amd64

This PR actually drop the e2e image build per PR but I think it's fine consider it's stable enough, if we still meet some problem we can revert this PR

43-44mins ---> about 8-10 mins

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
