### PR TITLE
[CI] Make e2e test to be preemptible and simple

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -118,8 +118,7 @@ jobs:
     needs: [lint]
     if: ${{ needs.lint.result == 'success' }}
     strategy:
-      # TODO(yikun): 1 ---> 2
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         os: [linux-arm64-npu-1]
         vllm_version: [main, v0.9.1]
@@ -176,6 +175,9 @@ jobs:
           VLLM_USE_MODELSCOPE: True
         run: |
           pytest -sv tests/singlecard/test_offline_inference.py
+          # TODO: switch hf to modelscope
+          VLLM_USE_MODELSCOPE=False HF_ENDPOINT=https://hf-mirror.com \
+            pytest -sv tests/singlecard/test_ilama_lora.py
           # TODO(sss): guided decoding doesn't work, fix it later
           # pytest -sv tests/singlecard/test_guided_decoding.py
           # test_ascend_config.py should be ran separately because it will regenerate the global config many times.
@@ -183,6 +185,7 @@ jobs:
           pytest -sv tests/singlecard/test_camem.py
           pytest -sv tests/singlecard/ \
           --ignore=tests/singlecard/test_offline_inference.py \
+          --ignore=tests/singlecard/test_ilama_lora.py \
           --ignore=tests/singlecard/test_guided_decoding.py \
           --ignore=tests/singlecard/test_ascend_config.py \
           --ignore=tests/singlecard/test_camem.py
@@ -193,8 +196,10 @@ jobs:
           VLLM_USE_V1: 0
           VLLM_USE_MODELSCOPE: True
         run: |
-          pytest -sv tests/singlecard/test_ilama_lora.py
           pytest -sv tests/singlecard/test_offline_inference.py
+          # TODO: switch hf to modelscope
+          VLLM_USE_MODELSCOPE=False HF_ENDPOINT=https://hf-mirror.com \
+            pytest -sv tests/singlecard/test_ilama_lora.py
           # guided decoding doesn't work, fix it later
           # pytest -sv tests/singlecard/test_guided_decoding.py
           pytest -sv tests/singlecard/test_camem.py
@@ -203,6 +208,7 @@ jobs:
           pytest -sv tests/singlecard/test_prompt_embedding.py
           pytest -sv tests/singlecard/ \
             --ignore=tests/singlecard/test_offline_inference.py \
+            --ignore=tests/singlecard/test_ilama_lora.py \
             --ignore=tests/singlecard/test_guided_decoding.py \
             --ignore=tests/singlecard/test_camem.py \
             --ignore=tests/singlecard/test_ascend_config.py \
@@ -271,7 +277,9 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_USE_MODELSCOPE: True
         run: |
-          pytest -sv tests/multicard/test_ilama_lora_tp2.py
+          # TODO: switch hf to modelscope
+          VLLM_USE_MODELSCOPE=False HF_ENDPOINT=https://hf-mirror.com \
+            pytest -sv tests/multicard/test_ilama_lora_tp2.py
           # Fixme: run VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py will raise error.
           # To avoid oom, we need to run the test in a single process.
           pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_QwQ
@@ -286,7 +294,9 @@ jobs:
           VLLM_USE_V1: 0
           VLLM_USE_MODELSCOPE: True
         run: |
-          pytest -sv tests/multicard/test_ilama_lora_tp2.py
+          # TODO: switch hf to modelscope
+          VLLM_USE_MODELSCOPE=False HF_ENDPOINT=https://hf-mirror.com \
+            pytest -sv tests/multicard/test_ilama_lora_tp2.py
           # Fixme: run VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py will raise error.
           # To avoid oom, we need to run the test in a single process.
           pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_QwQ

--- a/tests/singlecard/test_ilama_lora.py
+++ b/tests/singlecard/test_ilama_lora.py
@@ -5,7 +5,7 @@ from vllm.lora.request import LoRARequest
 
 from tests.conftest import VllmRunner
 
-MODEL_PATH = "vllm-ascend/ilama-3.2-1B"
+MODEL_PATH = "ArthurZ/ilama-3.2-1B"
 
 PROMPT_TEMPLATE = """I want you to act as a SQL terminal in front of an example database, you need only to return the sql command to me.Below is an instruction that describes a task, Write a response that appropriately completes the request.\n"\n##Instruction:\nconcert_singer contains tables such as stadium, singer, concert, singer_in_concert. Table stadium has columns such as Stadium_ID, Location, Name, Capacity, Highest, Lowest, Average. Stadium_ID is the primary key.\nTable singer has columns such as Singer_ID, Name, Country, Song_Name, Song_release_year, Age, Is_male. Singer_ID is the primary key.\nTable concert has columns such as concert_ID, concert_Name, Theme, Stadium_ID, Year. concert_ID is the primary key.\nTable singer_in_concert has columns such as concert_ID, Singer_ID. concert_ID is the primary key.\nThe Stadium_ID of concert is the foreign key of Stadium_ID of stadium.\nThe Singer_ID of singer_in_concert is the foreign key of Singer_ID of singer.\nThe concert_ID of singer_in_concert is the foreign key of concert_ID of concert.\n\n###Input:\n{query}\n\n###Response:"""  # noqa: E501
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR make e2e test to be simple, even bring some repeat code between single card and multicard, but we will not struggle with across max-parallel, matrix and concurrency: 
1. This PR make e2e test to be preemptible and simple:
- lint ---> e2e (2 parallel) ---> e2e multi-card (1 parallel)
- Anytime you push another PR will cancel previous job, whatever the job is lint / e2e / multi-cards
2. Use Modelscope rather than hf-mirror
3. Resolve some error like `Canceling since a higher priority waiting request for pr-XXXX-limit-npu-4 exists`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
- lint ---> e2e (2 parallel) ---> e2e multi-card (1 parallel)
- e2e test will canceled by update patch
