### PR TITLE
[EPLB]: Correct local expert number calculation with redundant experts

### DIFF
--- a/vllm_ascend/ops/expert_load_balancer.py
+++ b/vllm_ascend/ops/expert_load_balancer.py
@@ -85,7 +85,10 @@ class ExpertLoadBalancer(object):
         layer_expert_map = expert_placement_map[layer_id]
         rank_expert_map = layer_expert_map[rank_id].to(
             torch.npu.current_device())
-        rank_local_expert_num = torch.sum(torch.ne(rank_expert_map, -1)).item()
+
+        # valid num in expert_map may not equal to
+        # rank_local_expert_num when num_redundant_experts > 0
+        rank_local_expert_num = len(self.expert_map_tensor[layer_id, rank_id])
         return rank_local_expert_num, rank_expert_map
 
     def get_rank_log2phy_map(self, layer_id, rank_id):

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1092,8 +1092,11 @@ class AscendFusedMoE(FusedMoE):
 
         assert self.quant_method is not None
 
-        local_num_experts = torch.sum(self.expert_map != -1) \
-            if self.expert_map is not None else num_experts
+        if self.log2phy is not None:
+            local_num_experts = self.local_num_experts
+        else:
+            local_num_experts = torch.sum(self.expert_map != -1) \
+                if self.expert_map is not None else num_experts
 
         moe_quant_params = {
             "num_experts": local_num_experts,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

- Fixed issue: [#122](https://github.com/vllm-project/vllm-ascend/issues/1222)  , support for expert mapping with redundant experts


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Test passed when passed a expert_map with redundant_experts == 16:

```bash
export VLLM_ENABLE_MC2=1
export VLLM_USE_V1=1
export TASK_QUEUE_ENABLE=1

source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

export ASCEND_LAUNCH_BLOCKING=0
export VLLM_VERSION=0.9.0
MODEL_PATH=DeepSeek-R1-W8A8-VLLM
python -m vllm.entrypoints.openai.api_server --model=$MODEL_PATH \
    --load-format=prefetch_auto \
    --quantization ascend \
    --served-model-name auto \
    --trust-remote-code \
    --distributed-executor-backend=mp \
    --port 8006 \
    -tp=8 \
    -dp=2 \
    --enable-expert-parallel \
    --max-num-seqs 24 \
    --max-model-len 2048 \
    --max-num-batched-tokens 2048 \
    --block-size 128 \
    --no-enable-prefix-caching \
    --additional-config '{"torchair_graph_config":{"enabled":true,"use_cached_graph":true,"graph_batch_sizes":[24]},"ascend_scheduler_config":{"enabled":true}, "expert_tensor_parallel_size":1, "expert_map_path": "delta_gsm8k_temp0.0_16_16.json"}' \
    --gpu-memory-utilization 0.90
``` 

