### PR TITLE
[Doc] fix VLLM_USE_V1 value in graph mode docs

### DIFF
--- a/docs/source/user_guide/graph_mode.md
+++ b/docs/source/user_guide/graph_mode.md
@@ -23,7 +23,7 @@ import os
 
 from vllm import LLM
 
-os.environ["VLLM_USE_V1"] = 1
+os.environ["VLLM_USE_V1"] = "1"
 
 model = LLM(model="Qwen/Qwen2-7B-Instruct")
 outputs = model.generate("Hello, how are you?")
@@ -45,7 +45,7 @@ offline example:
 import os
 from vllm import LLM
 
-os.environ["VLLM_USE_V1"] = 1
+os.environ["VLLM_USE_V1"] = "1"
 
 # TorchAirGraph is only work without chunked-prefill now
 model = LLM(model="deepseek-ai/DeepSeek-R1-0528", additional_config={"torchair_graph_config": {"enabled": True},"ascend_scheduler_config": {"enabled": True,}})
@@ -70,7 +70,7 @@ offline example:
 import os
 from vllm import LLM
 
-os.environ["VLLM_USE_V1"] = 1
+os.environ["VLLM_USE_V1"] = "1"
 
 model = LLM(model="someother_model_weight", enforce_eager=True)
 outputs = model.generate("Hello, how are you?")


### PR DESCRIPTION
os.environ["VLLM_USE_V1"] must be assigned with str, not other type.

![image](https://github.com/user-attachments/assets/9d337ae5-00e5-4179-832e-c6c917dd5798)
