### PR TITLE
[Fix] Enable npu_mrope by environment variables

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -133,6 +133,12 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # value to False to disable the optimized model.
     "USE_OPTIMIZED_MODEL":
     lambda: bool(int(os.getenv('USE_OPTIMIZED_MODEL', '1'))),
+    # VLLM_ASCEND_ENABLE_NPU_MROPE:
+    #   0: using npu_rotary_embedding.
+    #   1: using npu_mrope.
+    # Just a temporary plan，will be removed after npu_mrope supports aclgraph mode.
+    "VLLM_ASCEND_ENABLE_NPU_MROPE":
+    lambda: bool(int(os.getenv('VLLM_ASCEND_ENABLE_NPU_MROPE', '0'))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
npu_rotary_embedding will trigger gatherv3's error, enable npu_mrope to solve this issue.
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
`export VLLM_ASCEND_ENABLE_NPU_MROPE=1` to enable npu_mrope
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
math500 tested in deepseek 671b
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

