### PR TITLE
[Bugfix][Spec Decode][0.9.1] Enable `ACL_OP_INIT_MODE=1` directly only when using V0 spec decode

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -111,15 +111,6 @@ env_variables: Dict[str, Callable[[], Any]] = {
     #   1: enable moe_all2all_buffer.
     "MOE_ALL2ALL_BUFFER":
     lambda: bool(int(os.getenv("MOE_ALL2ALL_BUFFER", '0'))),
-    # VLLM_ASCEND_ACL_OP_INIT_MODE:
-    #   0: default, normal init.
-    #   1: delay init until launch aclops.
-    #   2: forbid aclops init and launch.
-    # Find more details at https://gitee.com/ascend/pytorch/pulls/18094
-    # We set this var default to `1` in vllm-ascend to avoid segment fault when
-    # enable `pin_memory` while creating a tensor using `torch.tensor`.
-    "VLLM_ASCEND_ACL_OP_INIT_MODE":
-    lambda: os.getenv("VLLM_ASCEND_ACL_OP_INIT_MODE", '0'),
     # Some models are optimized by vllm ascend. While in some case, e.g. rlhf
     # training, the optimized model may not be suitable. In this case, set this
     # value to False to disable the optimized model.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -27,7 +27,6 @@ from torch.distributed.distributed_c10d import PrefixStore
 from vllm.logger import logger
 from vllm.platforms import Platform, PlatformEnum
 
-import vllm_ascend.envs as ascend_envs
 from vllm_ascend.ascend_config import check_ascend_config, init_ascend_config
 from vllm_ascend.utils import ASCEND_QUATIZATION_METHOD, update_aclgraph_sizes
 
@@ -38,8 +37,6 @@ else:
     ModelConfig = None
     VllmConfig = None
     FlexibleArgumentParser = None
-
-os.environ["ACL_OP_INIT_MODE"] = ascend_envs.VLLM_ASCEND_ACL_OP_INIT_MODE
 
 
 class NPUPlatform(Platform):
@@ -180,6 +177,7 @@ class NPUPlatform(Platform):
             if envs.VLLM_USE_V1:
                 parallel_config.worker_cls = "vllm_ascend.worker.worker_v1.NPUWorker"
             elif vllm_config.speculative_config:
+                os.environ["ACL_OP_INIT_MODE"] = "1"
                 parallel_config.worker_cls = "vllm.spec_decode.spec_decode_worker.create_spec_worker"
                 parallel_config.sd_worker_cls = "vllm_ascend.worker.worker.NPUWorker"
             elif vllm_config.scheduler_config.is_multi_step:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -177,6 +177,8 @@ class NPUPlatform(Platform):
             if envs.VLLM_USE_V1:
                 parallel_config.worker_cls = "vllm_ascend.worker.worker_v1.NPUWorker"
             elif vllm_config.speculative_config:
+                # NOTE: We set this var to `1` in vllm-ascend to avoid segment
+                # fault when using spec decode with V0 engine.
                 os.environ["ACL_OP_INIT_MODE"] = "1"
                 parallel_config.worker_cls = "vllm.spec_decode.spec_decode_worker.create_spec_worker"
                 parallel_config.sd_worker_cls = "vllm_ascend.worker.worker.NPUWorker"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Enable `ACL_OP_INIT_MODE=1` directly only when using V0 spec decode.

Cherry pick from https://github.com/vllm-project/vllm-ascend/pull/1258.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

