### PR TITLE
[Bugfix] Fix memory-leak caused by dist._functional_collectives.reduce_scatter_tensor

### DIFF
--- a/examples/offline_inference_npu_v1.py
+++ b/examples/offline_inference_npu_v1.py
@@ -24,7 +24,6 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 from vllm import LLM, SamplingParams
 
-
 if __name__ == "__main__":
     prompts = [
         "Hello, my name is",

--- a/vllm_ascend/distributed/communication_op.py
+++ b/vllm_ascend/distributed/communication_op.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import torch
+from vllm.distributed.parallel_state import get_dp_group
+
+
+def data_parallel_reduce_scatter(input_: torch.Tensor,
+                                 dim: int = -1) -> torch.Tensor:
+    """Reduce-Scatter the input tensor across data parallel group."""
+    return get_dp_group().reduce_scatter(input_, dim)


### PR DESCRIPTION
### What this PR does / why we need it?
In some cases, `dist._functional_collectives.reduce_scatter_tensor` can cause its input tensor not to be released immediately after the current layer ends. Instead, it will only be released when the GPU memory usage of the current process reaches a certain threshold (approximately every 15 layers each time).

**Before Fix**

<img width="1441" alt="截屏2025-06-24 01 26 13" src="https://github.com/user-attachments/assets/72d5dbb3-c8c8-4778-bf64-8db7bab8aff0" />

**After Fix**
<img width="1475" alt="截屏2025-06-24 01 23 43" src="https://github.com/user-attachments/assets/6c69cfcd-a469-4ee5-b8c6-210aeb3a5bdf" />

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.9.1
- vLLM main: https://github.com/vllm-project/vllm/commit/9ff2af6d2ba1757c6e59fe803225a73e61fe526f
