### PR TITLE
Refactoring w4a8 and w8a8 and supporting w4a8 graph mode

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -197,14 +197,15 @@ jobs:
           else
             pytest -sv tests/multicard/test_ilama_lora_tp2.py
             # To avoid oom, we need to run the test in a single process.
+            VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_w4a8_deepseek.py::test_deepseek_W4A8
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_QwQ
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeek
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_topk
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeek_W8A8
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeek_dbo
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeekV3_dbo
-            VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/ --ignore=tests/multicard/test_ilama_lora_tp2.py --ignore=tests/multicard/test_offline_inference_distributed.py
-            VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_w4a8_deepseek.py::test_deepseek_W4A8
+            VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/ --ignore=tests/multicard/test_ilama_lora_tp2.py --ignore=tests/multicard/test_offline_inference_distributed.py --ignore=tests/multicard/test_w4a8_deepseek.py
+
           fi
 
       - name: Run vllm-project/vllm-ascend test on V0 engine

--- a/tests/multicard/test_w4a8_deepseek.py
+++ b/tests/multicard/test_w4a8_deepseek.py
@@ -15,53 +15,47 @@
 # limitations under the License.
 
 import os
+from unittest.mock import patch
 
 import pytest
 
 from tests.conftest import VllmRunner
 
 
-@pytest.mark.skip(reason="Due to OOM,waiting for 1311pr to merge in")
 @pytest.mark.skipif(os.getenv("VLLM_USE_V1") == "0",
                     reason="w4a8_dynamic is not supported on v0")
-def test_deepseek_W4A8(monkeypatch: pytest.MonkeyPatch):
-    with monkeypatch.context() as m:
-        m.setenv("VLLM_USE_V1", "1")
-
-        prompts = [
-            "Hello, my name is",
-            "The president of the United States is",
-            "The capital of France is",
-            "The future of AI is",
-        ]
-        dtype = "bfloat16"
-        max_tokens = 5
-        with VllmRunner(
-                "vllm-ascend/DeepSeek-R1-w4a8-pruning",
-                dtype=dtype,
-                tensor_parallel_size=2,
-                enforce_eager=True,
-                quantization="ascend",
-                enable_expert_parallel=True,
-                additional_config={
-                    "torchair_graph_config": {
-                        "enabled": False,
-                    },
-                    "ascend_scheduler_config": {
-                        "enabled": True,
-                    }
+@patch.dict(os.environ, {"VLLM_USE_V1": "1", "VLLM_ASCEND_MLA_PA": "1"})
+def test_deepseek_W4A8():
+    prompts = [
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    dtype = "bfloat16"
+    max_tokens = 5
+    with VllmRunner(
+            "vllm-ascend/DeepSeek-R1-w4a8-pruning",
+            dtype=dtype,
+            tensor_parallel_size=2,
+            quantization="ascend",
+            enforce_eager=True,
+            enable_expert_parallel=True,
+            additional_config={
+                "torchair_graph_config": {
+                    "enabled": False,
                 },
-        ) as vllm_model:
-            # use greedy sampler to make sure the generated results are fix
-            vllm_output = vllm_model.generate_greedy(prompts, max_tokens)
+                "ascend_scheduler_config": {
+                    "enabled": True,
+                }
+            },
+    ) as vllm_model:
+        # use greedy sampler to make sure the generated results are fix
+        vllm_output = vllm_model.generate_greedy(prompts, max_tokens)
 
-        golden_results = [
-            'Hello, my name is逸研究发现IPPudsimentary',
-            'The president of the United States is逸 Ban Corporealistically',
-            'The capital of France is逸 Ban Corporealistically',
-            'The future of AI is逸 Ban Corporealistically',
-        ]
-        assert len(golden_results) == len(vllm_output)
-        for i in range(len(vllm_output)):
-            assert golden_results[i] == vllm_output[i][1]
-            print(f"Generated text: {vllm_output[i][1]!r}")
+    golden_results = [
+        'The capital of France is逸 Ban Corporealistically',
+        'The future of AI is逸 Ban Corporealistically',
+    ]
+    assert len(golden_results) == len(vllm_output)
+    for i in range(len(vllm_output)):
+        assert golden_results[i] == vllm_output[i][1]
+        print(f"Generated text: {vllm_output[i][1]!r}")

--- a/tests/multicard/test_w4a8_deepseek.py
+++ b/tests/multicard/test_w4a8_deepseek.py
@@ -37,7 +37,7 @@ def test_deepseek_W4A8(model: str):
     dtype = "bfloat16"
     max_tokens = 5
     with VllmRunner(
-            model=snapshot_download(model),
+            model_name=snapshot_download(model),
             dtype=dtype,
             tensor_parallel_size=2,
             quantization="ascend",

--- a/tests/multicard/test_w4a8_deepseek.py
+++ b/tests/multicard/test_w4a8_deepseek.py
@@ -15,51 +15,53 @@
 # limitations under the License.
 
 import os
-from unittest.mock import patch
 
 import pytest
-from modelscope import snapshot_download  # type: ignore
 
 from tests.conftest import VllmRunner
 
-MODELS = ["vllm-ascend/DeepSeek-R1-w4a8-pruning"]
 
-
+@pytest.mark.skip(reason="Due to OOM,waiting for 1311pr to merge in")
 @pytest.mark.skipif(os.getenv("VLLM_USE_V1") == "0",
                     reason="w4a8_dynamic is not supported on v0")
-@pytest.mark.parametrize("model", MODELS)
-@patch.dict(os.environ, {"VLLM_USE_V1": "1", "VLLM_ASCEND_MLA_PA": "1"})
-def test_deepseek_W4A8(model: str):
-    prompts = [
-        "The capital of France is",
-        "The future of AI is",
-    ]
-    dtype = "bfloat16"
-    max_tokens = 5
-    with VllmRunner(
-            model_name=snapshot_download(model),
-            dtype=dtype,
-            tensor_parallel_size=2,
-            quantization="ascend",
-            enforce_eager=True,
-            enable_expert_parallel=True,
-            additional_config={
-                "torchair_graph_config": {
-                    "enabled": False,
-                },
-                "ascend_scheduler_config": {
-                    "enabled": True,
-                }
-            },
-    ) as vllm_model:
-        # use greedy sampler to make sure the generated results are fix
-        vllm_output = vllm_model.generate_greedy(prompts, max_tokens)
+def test_deepseek_W4A8(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
 
-    golden_results = [
-        'The capital of France is逸 Ban Corporealistically',
-        'The future of AI is逸 Ban Corporealistically',
-    ]
-    assert len(golden_results) == len(vllm_output)
-    for i in range(len(vllm_output)):
-        assert golden_results[i] == vllm_output[i][1]
-        print(f"Generated text: {vllm_output[i][1]!r}")
+        prompts = [
+            "Hello, my name is",
+            "The president of the United States is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        dtype = "bfloat16"
+        max_tokens = 5
+        with VllmRunner(
+                "vllm-ascend/DeepSeek-R1-w4a8-pruning",
+                dtype=dtype,
+                tensor_parallel_size=2,
+                enforce_eager=True,
+                quantization="ascend",
+                enable_expert_parallel=True,
+                additional_config={
+                    "torchair_graph_config": {
+                        "enabled": False,
+                    },
+                    "ascend_scheduler_config": {
+                        "enabled": True,
+                    }
+                },
+        ) as vllm_model:
+            # use greedy sampler to make sure the generated results are fix
+            vllm_output = vllm_model.generate_greedy(prompts, max_tokens)
+
+        golden_results = [
+            'Hello, my name is逸研究发现IPPudsimentary',
+            'The president of the United States is逸 Ban Corporealistically',
+            'The capital of France is逸 Ban Corporealistically',
+            'The future of AI is逸 Ban Corporealistically',
+        ]
+        assert len(golden_results) == len(vllm_output)
+        for i in range(len(vllm_output)):
+            assert golden_results[i] == vllm_output[i][1]
+            print(f"Generated text: {vllm_output[i][1]!r}")

--- a/tests/multicard/test_w4a8_deepseek.py
+++ b/tests/multicard/test_w4a8_deepseek.py
@@ -18,14 +18,18 @@ import os
 from unittest.mock import patch
 
 import pytest
+from modelscope import snapshot_download  # type: ignore
 
 from tests.conftest import VllmRunner
+
+MODELS = ["vllm-ascend/DeepSeek-R1-w4a8-pruning"]
 
 
 @pytest.mark.skipif(os.getenv("VLLM_USE_V1") == "0",
                     reason="w4a8_dynamic is not supported on v0")
+@pytest.mark.parametrize("model", MODELS)
 @patch.dict(os.environ, {"VLLM_USE_V1": "1", "VLLM_ASCEND_MLA_PA": "1"})
-def test_deepseek_W4A8():
+def test_deepseek_W4A8(model: str):
     prompts = [
         "The capital of France is",
         "The future of AI is",
@@ -33,7 +37,7 @@ def test_deepseek_W4A8():
     dtype = "bfloat16"
     max_tokens = 5
     with VllmRunner(
-            "vllm-ascend/DeepSeek-R1-w4a8-pruning",
+            model=snapshot_download(model),
             dtype=dtype,
             tensor_parallel_size=2,
             quantization="ascend",

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -40,7 +40,6 @@ def apply_mlp(hidden_states: torch.Tensor,
               group_list: torch.Tensor,
               dynamic_scale: torch.Tensor = None,
               group_list_type: int = 1,
-              is_mc2: bool = False,
               w1_scale_bias: torch.Tensor = None,
               w2_scale_bias: torch.Tensor = None) -> torch.Tensor:
     """
@@ -80,12 +79,13 @@ def apply_mlp(hidden_states: torch.Tensor,
     _output_dtype = w2_scale.dtype
 
     if w1_scale_bias is not None:
-        group_list_type = 1
-        if not is_mc2:
+        if group_list_type == 0:
             group_list = torch.cat(
                 [group_list[:1], torch.diff(group_list, dim=0)])
+            group_list_type = 1
         bias1 = [w1_scale_bias]
         bias2 = [w2_scale_bias]
+        # TODO w4a8 scene: dynamic acquisition of dtype in the future
         _output_dtype = torch.bfloat16
 
     # gmm1: gate_up_proj
@@ -206,7 +206,6 @@ def fused_experts_with_mc2(
                               w2_scale,
                               expert_token_nums,
                               dynamic_scale=dynamic_scale,
-                              is_mc2=True,
                               w1_scale_bias=w1_scale_bias,
                               w2_scale_bias=w2_scale_bias)
 

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -39,7 +39,10 @@ def apply_mlp(hidden_states: torch.Tensor,
               w2_scale: torch.Tensor,
               group_list: torch.Tensor,
               dynamic_scale: torch.Tensor = None,
-              group_list_type: int = 1) -> torch.Tensor:
+              group_list_type: int = 1,
+              is_mc2: bool = False,
+              w1_scale_bias: torch.Tensor = None,
+              w2_scale_bias: torch.Tensor = None) -> torch.Tensor:
     """
     apply MLP: gate_up_proj -> swiglu -> down_proj
 
@@ -73,17 +76,30 @@ def apply_mlp(hidden_states: torch.Tensor,
     else:
         pertoken_scale = dynamic_scale
 
+    bias1, bias2 = None, None
+    _output_dtype = w2_scale.dtype
+
+    if w1_scale_bias is not None:
+        group_list_type = 1
+        if not is_mc2:
+            group_list = torch.cat(
+                [group_list[:1], torch.diff(group_list, dim=0)])
+        bias1 = [w1_scale_bias]
+        bias2 = [w2_scale_bias]
+        _output_dtype = torch.bfloat16
+
     # gmm1: gate_up_proj
     hidden_states = torch_npu.npu_grouped_matmul(
         x=[hidden_states],
         weight=[w1],
         scale=[w1_scale],
+        bias=bias1,
         per_token_scale=[pertoken_scale],
         split_item=2,
         group_list_type=group_list_type,
         group_type=0,
         group_list=group_list,
-        output_dtype=w2_scale.dtype)[0]
+        output_dtype=_output_dtype)[0]
 
     # act_fn: swiglu
     hidden_states = torch_npu.npu_swiglu(hidden_states)
@@ -95,12 +111,13 @@ def apply_mlp(hidden_states: torch.Tensor,
         x=[hidden_states],
         weight=[w2],
         scale=[w2_scale],
+        bias=bias2,
         per_token_scale=[swiglu_out_scale],
         split_item=2,
         group_list_type=group_list_type,
         group_type=0,
         group_list=group_list,
-        output_dtype=w2_scale.dtype)[0]
+        output_dtype=_output_dtype)[0]
 
     return hidden_states
 
@@ -120,6 +137,8 @@ def fused_experts_with_mc2(
     global_redundant_expert_num: int = 0,
     shared_experts: Optional[Any] = None,
     is_torchair: bool = False,
+    w1_scale_bias: torch.Tensor = None,
+    w2_scale_bias: torch.Tensor = None
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     if log2phy:
         topk_ids = log2phy[topk_ids]
@@ -186,7 +205,10 @@ def fused_experts_with_mc2(
                               w2,
                               w2_scale,
                               expert_token_nums,
-                              dynamic_scale=dynamic_scale)
+                              dynamic_scale=dynamic_scale,
+                              is_mc2=True,
+                              w1_scale_bias=w1_scale_bias,
+                              w2_scale_bias=w2_scale_bias)
 
     # moeCombine
     kwargs_mc2 = {
@@ -230,20 +252,20 @@ def fused_experts_with_mc2(
 
 # currently expert parallelism implemented with all2all
 # is under-optimized.
-def fused_experts_with_all2all(
-    hidden_states: torch.Tensor,
-    w1: torch.Tensor,
-    w1_scale: torch.Tensor,
-    w2: torch.Tensor,
-    w2_scale: torch.Tensor,
-    topk_weights: torch.Tensor,
-    topk_ids: torch.Tensor,
-    top_k: int,
-    expert_map: torch.Tensor = None,
-    ep_group: GroupCoordinator = None,
-    log2phy: torch.Tensor = None,
-    global_redundant_expert_num: int = 0,
-):
+def fused_experts_with_all2all(hidden_states: torch.Tensor,
+                               w1: torch.Tensor,
+                               w1_scale: torch.Tensor,
+                               w2: torch.Tensor,
+                               w2_scale: torch.Tensor,
+                               topk_weights: torch.Tensor,
+                               topk_ids: torch.Tensor,
+                               top_k: int,
+                               expert_map: torch.Tensor = None,
+                               ep_group: GroupCoordinator = None,
+                               log2phy: torch.Tensor = None,
+                               global_redundant_expert_num: int = 0,
+                               w1_scale_bias: torch.Tensor = None,
+                               w2_scale_bias: torch.Tensor = None):
     if log2phy:
         topk_ids = log2phy[topk_ids]
     original_shape = hidden_states.shape
@@ -322,7 +344,9 @@ def fused_experts_with_all2all(
         w2,
         w2_scale,
         expert_tokens,  #16
-        group_list_type=group_list_type)
+        group_list_type=group_list_type,
+        w1_scale_bias=w1_scale_bias,
+        w2_scale_bias=w2_scale_bias)
 
     if expert_map is not None:
         resorted_idx = torch.argsort(sorted_idx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
1.Refactoring w4a8_dynamic and w8a8_dynamic
2.support w4a8 graph mode
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
#### 1.How to get weights using Modelslim

##### Installation steps

Use the branch master, the commit id is: 298e175d69b3b855111a1e09bbe2fcd12fdb4e24
git clone https://gitee.com/ascend/msit.git
cd msit/msmodelslim
bash install.sh

##### The required transformers environment

pip install transformers==4.48.2

##### Generate w4a8 weights

cd /example/DeepSeek
Command reference: msmodelslim/example/DeepSeek/README.md  Execute the  [pre-check](https://gitee.com/ascend/msit/blob/master/msmodelslim/example/DeepSeek/README.md#运行前必检) and [DeepSeek-R1 w4a8 mix quantization](https://gitee.com/ascend/msit/blob/master/msmodelslim/example/DeepSeek/README.md#deepseek-r1-w4a8-混合量化前三层-mlpw8a8-dynamic-量化mla共享专家w8a8量化路由专家w4a8-dynamic量化) chapter
Reference command：python3 quant_deepseek_w4a8.py --model_path {Original weight path} --save_path {Generate weight path} --mindie_format

##### Adapt to vllm-ascend

Since mindie_format generates mindie format, some adaptation modifications are needed for vllm-ascend to use it:
`quant_model_description_w8a8_dynamic.json` rename to `quant_model_description.json`, and add `"group_size": 256`
Modification in `config.json`：`"model_type":deepseekv2` is changed to `"model_type":deepseek_v3` ; `quantization_config` is removed;

#### 2.How to run w4a8
##### a.How to run eager mode
export VLLM_USE_V1=1  # v1

TP + EP：
python -m vllm.entrypoints.openai.api_server --model=$1 --trust-remote-code -tp $2 --enable_expert_parallel --quantization ascend --port $3 --max-model-len $4 --max-num-seqs $5 --enforce-eager
eg: python -m vllm.entrypoints.openai.api_server --model=/weightpath/w4a8_4_layer --trust-remote-code -tp 4 --enable_expert_parallel --quantization ascend --port 8002 --max-model-len 2048 --max-num-seqs 128 --enforce-eager
DP+TP+EP:
python -m vllm.entrypoints.openai.api_server --model=$1 --trust-remote-code -tp $2 -dp $3 --enable_expert_parallel --quantization ascend --port $4 --max-model-len $5 --max-num-seqs $6 --enforce-eager
eg: python -m vllm.entrypoints.openai.api_server --model=/weightpath/w4a8_4_layer --trust-remote-code -tp 2 -dp2 --enable_expert_parallel --quantization ascend --port 8002 --max-model-len 2048 --max-num-seqs 128 --enforce-eager

##### b.How to run graph mode
export VLLM_USE_V1=1  # v1
export HCCL_BUFFSIZE=1024

#If you use graph mode, tp<=4
DP+TP+EP:
python -m vllm.entrypoints.openai.api_server --model=$1 --trust-remote-code -tp $2 -dp $3 --enable_expert_parallel --quantization ascend --port $4 --max-model-len $5 --additional_config='{"ascend_scheduler_config":{"enabled":true},"torchair_graph_config":{"enabled":true}}'
eg: python -m vllm.entrypoints.openai.api_server --model=/weight/dsr1_w4a8_vllm --trust-remote-code -tp 4 -dp 4 --enable_expert_parallel --quantization ascend --port 8002 --max-model-len 5120 --additional_config='{"ascend_scheduler_config":{"enabled":true},"torchair_graph_config":{"enabled":true}}'