### PR TITLE
Pin transformers<4.53.0 and fix EPLB interface to make CI passed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,7 @@ requires = [
     "msgpack",
     "quart",
     "numba",
+    # Remove after https://github.com/vllm-project/vllm-ascend/issues/1470
+    "transformers<4.53.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ numba
 --pre
 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 torch-npu==2.5.1.post1.dev20250619
+
+# Remove after https://github.com/vllm-project/vllm-ascend/issues/1470
+transformers<4.53.0

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -866,6 +866,9 @@ class CustomDeepseekV2ForCausalLM(DeepseekV2ForCausalLM):
         self.sampler = get_sampler()
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)
+        # TODO(yikun): a placeholder to make CI passed
+        # support EPLB (vllm#18343) in future
+        self.num_redundant_experts = 0
 
     def forward(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?
- Fix vLLM EPLB break https://github.com/vllm-project/vllm/commit/e9fd658a736a4d30f7a367c317506c87ad7f5359
- Fix transformers>=4.53.0 image processor break: https://github.com/vllm-project/vllm-ascend/issues/1470

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

CI passed
