### PR TITLE
[CI/Build] Fix version conflict on transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,6 @@ requires = [
     "quart",
     "numba",
     # Remove after https://github.com/vllm-project/vllm-ascend/issues/1470
-    "transformers<4.53.0",
+    "transformers==4.52.4",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ numba
 torch-npu==2.5.1.post1.dev20250619
 
 # Remove after https://github.com/vllm-project/vllm-ascend/issues/1470
-transformers<4.53.0
+transformers==4.52.4


### PR DESCRIPTION
### What this PR does / why we need it?
Fix version conflict on transformers: `pip._vendor.pkg_resources.ContextualVersionConflict: (transformers 4.53.0 (/usr/local/python3.10.17/lib/python3.10/site-packages), Requirement.parse('transformers<4.53.0'), {'vllm-ascend'})`
Fix https://github.com/vllm-project/vllm-ascend/actions/runs/15933263325/job/44947231642

### Does this PR introduce _any_ user-facing change?
Fix broken build

### How was this patch tested?
CI passed with new existing test.

