### PR TITLE
[Fix] Add warning for incompatible Ray backend with ACL Graph mode

### DIFF
--- a/tests/singlecard/test_aclgraph.py
+++ b/tests/singlecard/test_aclgraph.py
@@ -93,3 +93,16 @@ def test_deepseek_raises_error(monkeypatch: pytest.MonkeyPatch) -> None:
                        max_model_len=1024,
                        enforce_eager=False)
         assert "ACL Graph does not support deepseek" in str(excinfo.value)
+
+
+@pytest.mark.skipif(os.getenv("VLLM_USE_V1") == "0",
+                    reason="aclgraph only support on v1")
+@pytest.mark.parametrize("model", MODELS)
+def test_ray_backend_sets_no_compilation(
+        model: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+        runner = VllmRunner(model,
+                            enforce_eager=False,
+                            distributed_executor_backend="ray")
+        assert runner.model.llm_engine.vllm_config.compilation_config.level == 0

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -157,6 +157,11 @@ class NPUPlatform(Platform):
                 "Torchair compilation enabled on NPU. Setting level to NO_COMPILATION"
             )
             compilation_config.level = CompilationLevel.NO_COMPILATION
+        elif parallel_config.distributed_executor_backend == "ray":
+            logger.warning(
+                "Ray distributed executor backend is not compatible with ACL Graph mode "
+                "right now. Setting level to NO_COMPILATION")
+            compilation_config.level = CompilationLevel.NO_COMPILATION
         else:
             logger.info(
                 "PIECEWISE compilation enabled on NPU. use_inductor not supported - "


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Currently, Ray is not compatible with ACL Graph, so we need to fall back to eager mode when using the Ray backend.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

