### PR TITLE
[Doc] Refactor env vars module and change the way of doc generation

### DIFF
--- a/docs/source/user_guide/env_vars.md
+++ b/docs/source/user_guide/env_vars.md
@@ -1,9 +1,0 @@
-# Environment Variables
-
-vllm-ascend uses the following environment variables to configure the system:
-
-:::{literalinclude} ../../../vllm_ascend/envs.py
-:language: python
-:start-after: begin-env-vars-definition
-:end-before: end-env-vars-definition
-:::

--- a/docs/source/user_guide/environment_variables.md
+++ b/docs/source/user_guide/environment_variables.md
@@ -1,0 +1,28 @@
+# Environment Variables
+
+vllm-ascend uses the following environment variables to configure the system:
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `ASCEND_HOME_PATH` | string | `None` | The home path for CANN toolkit. If not set, the default value is `/usr/local/Ascend/ascend-toolkit/latest`. |
+| `CMAKE_BUILD_TYPE` | string | `None` | The build type of the package. It can be one of the following values: Release, Debug, RelWithDebugInfo. If not set, the default value is Release. |
+| `COMPILE_CUSTOM_KERNELS` | bool | `1` | Whether to compile custom kernels. If not set, the default value is True. If set to False, the custom kernels will not be compiled. Please note that the sleep mode feature will be disabled as well if custom kernels are not compiled. |
+| `CXX_COMPILER` | string | `None` | The CXX compiler used for compiling the package. If not set, the default value is None, which means the system default CXX compiler will be used. |
+| `C_COMPILER` | string | `None` | The C compiler used for compiling the package. If not set, the default value is None, which means the system default C compiler will be used. |
+| `DECODE_DEVICE_ID` | string | `None` | The decode device id for disaggregated prefilling case. |
+| `HCCL_SO_PATH` | string | `None` | The path for HCCL library, it's used by pyhccl communicator backend. If not set, the default value is `libhccl.so`. |
+| `HCCN_PATH` | string | `/usr/local/Ascend/driver/tools/hccn_tool` | The path for HCCN Tool, the tool will be called by disaggregated prefilling case. |
+| `LLMDATADIST_COMM_PORT` | int | `26000` | The port number for llmdatadist communication. If not set, the default value is 26000. |
+| `LLMDATADIST_SYNC_CACHE_WAIT_TIME` | int | `5000` | The wait time for llmdatadist sync cache. If not set, the default value is 5000ms. |
+| `MAX_JOBS` | int | `None` | Max compile thread number for package building. Usually, it is set to the number of CPU cores. If not set, the default value is None, which means all number of CPU cores will be used. |
+| `MOE_ALL2ALL_BUFFER` | bool | `0` | MOE_ALL2ALL_BUFFER: `0`: default, normal init; `1`: enable moe_all2all_buffer. |
+| `PROMPT_DEVICE_ID` | string | `None` | The prefill device id for disaggregated prefilling case. |
+| `SOC_VERSION` | string | `ASCEND910B1` | The version of the Ascend chip. If not set, the default value is ASCEND910B1. It's used for package building. Please make sure that the version is correct. |
+| `USE_OPTIMIZED_MODEL` | bool | `1` | Some models are optimized by vllm ascend. While in some case, e.g. rlhf training, the optimized model may not be suitable. In this case, set this value to False to disable the optimized model. |
+| `VERBOSE` | bool | `0` | If set, vllm-ascend will print verbose logs during compilation. |
+| `VLLM_ASCEND_ENABLE_DBO` | bool | `0` |  |
+| `VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE` | bool | `0` | Whether to enable the topk optimization. It's disabled by default for experimental support We'll make it enabled by default in the future. |
+| `VLLM_ASCEND_MODEL_EXECUTE_TIME_OBSERVE` | bool | `0` | Whether to enable the model execute time observe profile. Disable it when running vllm ascend in production environment. |
+| `VLLM_ASCEND_TRACE_RECOMPILES` | bool | `0` | Whether to enable the trace recompiles from pytorch. |
+| `VLLM_ENABLE_FUSED_EXPERTS_ALLGATHER_EP` | bool | `0` | Whether to enable fused_experts_allgather_ep. `MoeInitRoutingV3` and `GroupedMatmulFinalizeRouting` operators are combined to implement EP. |
+| `VLLM_VERSION` | string | `None` | The version of vllm is installed. This value is used for developers who installed vllm from source locally. In this case, the version of vllm is usually changed. For example, if the version of vllm is `0.9.0`, but when it's installed from source, the version of vllm is usually set to `0.9.1`. In this case, developers need to set this value to `0.9.0` to make sure that the correct package is installed. |

--- a/generate_env_var_doc.py
+++ b/generate_env_var_doc.py
@@ -1,0 +1,20 @@
+import vllm_ascend.envs as envs
+from vllm_ascend.envs import environment_variables
+
+lines = [
+    "# Environment Variables\n",
+    "\n",
+    "vllm-ascend uses the following environment variables to configure the system:\n",
+    "\n",
+    "| Name | Type | Default | Description |\n",
+    "| ---- | ---- | ------- | ----------- |\n",
+]
+
+variable_names = dir(envs)
+for name in variable_names:
+    lines.append(environment_variables[name].doc)
+
+with open("./docs/source/user_guide/environment_variables.md",
+          "w",
+          encoding="utf-8") as file:
+    file.writelines(lines)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Refactor env vars module and change the way of doc generation.

I have encapsulated each env var into a object, and then we can get the doc info from it.

Whenever we update the env vars dict, we just need to run the script directly to generate the latest doc.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

