### PR TITLE
[Bugfix] Add try for `_build_info` importing

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -67,8 +67,12 @@ _CURRENT_STREAM = None
 def is_310p():
     global _IS_310P
     if _IS_310P is None:
-        from vllm_ascend import _build_info  # type: ignore
-        _IS_310P = _build_info.__soc_version__.lower().startswith("ascend310p")
+        try:
+            from vllm_ascend import _build_info  # type: ignore
+            _IS_310P = _build_info.__soc_version__.lower().startswith(
+                "ascend310p")
+        except ImportError as e:
+            pass
     return _IS_310P
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

When I lauch vllm-ascend, I get this error:

```bash
Traceback (most recent call last):
  File "/home/sss/github/vllm-ascend/examples/offline_inference_npu_v1.py", line 38, in <module>
    llm = LLM(model="/shared/cache/modelscope/hub/models/Qwen/Qwen2.5-7B-Instruct",
  File "/home/sss/github/vllm/vllm/entrypoints/llm.py", line 263, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
  File "/home/sss/github/vllm/vllm/v1/engine/llm_engine.py", line 142, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
  File "/home/sss/github/vllm/vllm/engine/arg_utils.py", line 1050, in create_engine_config
    current_platform.pre_register_and_update()
  File "/home/sss/github/vllm-ascend/vllm_ascend/platform.py", line 64, in pre_register_and_update
    adapt_patch(is_global_patch=True)
  File "/home/sss/github/vllm-ascend/vllm_ascend/utils.py", line 252, in adapt_patch
    from vllm_ascend.patch import platform  # noqa: F401
  File "/home/sss/github/vllm-ascend/vllm_ascend/patch/platform/__init__.py", line 24, in <module>
    from vllm_ascend.patch.platform import patch_common  # noqa: F401
  File "/home/sss/github/vllm-ascend/vllm_ascend/patch/platform/patch_common/__init__.py", line 18, in <module>
    import vllm_ascend.patch.platform.patch_common.patch_distributed  # noqa
  File "/home/sss/github/vllm-ascend/vllm_ascend/patch/platform/patch_common/patch_distributed.py", line 149, in <module>
    if is_310p():
  File "/home/sss/github/vllm-ascend/vllm_ascend/utils.py", line 70, in is_310p
    from vllm_ascend import _build_info  # type: ignore
ImportError: cannot import name '_build_info' from 'vllm_ascend' (/home/sss/github/vllm-ascend/vllm_ascend/__init__.py)
[ERROR] 2025-07-01-01:36:04 (PID:12161, Device:-1, RankID:-1) ERR99999 UNKNOWN applicaiton exception
```

Thus, it's necessary to add a `try ... except ...` guard for the `_build_info` importing.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
no.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

```bash
python examples/offline_inference_npu_v1.py
```

logs:

```bash
Prompt: 'Hello, my name is', Generated text: ' Dr. David M. Kline, and I am a board-certified orthopedic surgeon. I am a member of the American Academy of Orthopedic Surgeons, the American Association of Hip and Knee Surgeons, and the American Association of Arthroscopy and Sports Medicine. I am also a member of the American College of Surgeons.\nI am a native of the San Francisco Bay Area and received my undergraduate degree from the University of California, Berkeley. I received my medical degree from the'
Prompt: 'The president of the United States is', Generated text: ' the head of state and head of government of the United States. The president directs the executive branch of the federal government and is the commander-in-chief of the United States Armed Forces. The president is further empowered to appoint federal judges, including members of the Supreme Court, subject to Senate approval. The president is also responsible for the enforcement of federal law and may grant federal pardons and reprieves. The president is further empowered to make treaties, subject to Senate ratification, and to receive foreign ambassadors'
Prompt: 'The capital of France is', Generated text: " Paris. Which of the following statements is true?\nA. Paris is the capital of France.\nB. Paris is not the capital of France.\nC. Paris is the capital of Germany.\nD. Paris is the capital of Italy.\nTo determine which statement is true, let's analyze each option step by step:\n\nA. Paris is the capital of France.\n- This statement is true. Paris is indeed the capital of France.\n\nB. Paris is not the capital of France.\n- This statement is"
Prompt: 'The future of AI is', Generated text: ' here. It’s not just a buzzword or a concept anymore. It’s a reality that’s transforming the way we live, work, and interact with technology. From self-driving cars to virtual assistants, AI is becoming an integral part of our daily lives. But what exactly is AI, and how is it changing the world? In this article, we’ll explore the basics of AI, its applications, and its impact on society.\nWhat is AI?\nArtificial Intelligence (AI) is a branch'
```

