### PR TITLE
Fix wheel glibc version incompatibility

### DIFF
--- a/.github/Dockerfile.buildwheel
+++ b/.github/Dockerfile.buildwheel
@@ -15,17 +15,16 @@
 # This file is a part of the vllm-ascend project.
 #
 ARG PY_VERSION=3.10
-FROM quay.io/ascend/cann:8.0.0-910b-ubuntu22.04-py${PY_VERSION}
+FROM quay.io/ascend/manylinux:8.0.0-910b-manylinux_2_28-py${PY_VERSION}
 
 ARG COMPILE_CUSTOM_KERNELS=1
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
-RUN apt-get update -y && \
-    apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake libnuma-dev && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/*
+RUN yum update -y && \
+    yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl-devel && \
+    rm -rf /var/cache/yum
 
 WORKDIR /workspace
 
@@ -41,8 +40,6 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     cd vllm-ascend && \
     python3 setup.py bdist_wheel && \
-    ls -l dist && \
-    for f in dist/*.whl; do mv "$f" "$(echo "$f" | sed -e 's/-linux_x86_64\.whl$/-manylinux1_x86_64.whl/' -e 's/-linux_aarch64\.whl$/-manylinux2014_aarch64.whl/')"; done && \
-    ls -l dist
+    ls -l dist 
 
 CMD ["/bin/bash"]

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -82,18 +82,39 @@ jobs:
         wheel:v1 \
         bash -c "cp -r /workspace/vllm-ascend/dist /outpwd"
         ls dist
-      
-    - name: Archive wheel
-      uses: actions/upload-artifact@v4
-      with:
-        name: vllm-ascend-${{ matrix.os }}-py${{ matrix.python-version }}-wheel
-        path: dist/*
 
     - name: Set up Python ${{ matrix.python-version }}
       if: startsWith(github.ref, 'refs/tags/')
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
+      
+    - name: Repair wheels with auditwheel
+      run: |
+        python3 -m pip install auditwheel
+        python3 -m pip install patchelf
+        mkdir -p dist/repaired
+        for whl in dist/*.whl; do
+          auditwheel repair "$whl" -w dist/repaired/
+        done
+        rm -f dist/*.whl
+        mv dist/repaired/*.whl dist/
+        rmdir dist/repaired
+        ls dist
+
+    - name: Verify automatic platform tags
+      run: |
+        cd dist
+        for wheel in *.whl; do
+          echo "验证文件: $wheel"
+          auditwheel show "$wheel"
+        done
+
+    - name: Archive wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: vllm-ascend-${{ matrix.os }}-py${{ matrix.python-version }}-wheel
+        path: dist/*
 
     - name: Release
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -96,10 +96,16 @@ jobs:
         python3 -m pip install patchelf
         mkdir -p dist/repaired
         for whl in dist/*.whl; do
-          auditwheel repair "$whl" -w dist/repaired/
-          --exclude libtorch_cpu.so \
+          auditwheel repair "$whl" -w dist/repaired/ \
+          --exclude libplatform.so \
+          --exclude libregister.so \
           --exclude libtorch.so \
+          --exclude libge_common_base.so \
+          --exclude libtorch_npu.so \
+          --exclude libc10.so \
+          --exclude libc_sec.so \
           --exclude libascendcl.so \
+          --exclude libtorch_cpu.so
         done
         rm -f dist/*.whl
         mv dist/repaired/*.whl dist/

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -99,7 +99,7 @@ jobs:
           auditwheel repair "$whl" -w dist/repaired/ \
           --exclude libplatform.so \
           --exclude libregister.so \
-          --exclude libge_common_base.so \\
+          --exclude libge_common_base.so \
           --exclude libc10.so \
           --exclude libc_sec.so \
           --exclude "libascend*.so" \

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -78,6 +78,7 @@ jobs:
         --build-arg PY_VERSION=${{ matrix.python-version }} \
         -t wheel:v1 .
         docker run --rm \
+        -u $(id -u):$(id -g) \
         -v $(pwd):/outpwd \
         wheel:v1 \
         bash -c "cp -r /workspace/vllm-ascend/dist /outpwd"
@@ -93,13 +94,16 @@ jobs:
       run: |
         python3 -m pip install auditwheel
         python3 -m pip install patchelf
-        sudo mkdir -p dist/repaired
+        mkdir -p dist/repaired
         for whl in dist/*.whl; do
           auditwheel repair "$whl" -w dist/repaired/
+          --exclude libtorch_cpu.so \
+          --exclude libtorch.so \
+          --exclude libascendcl.so \
         done
-        sudo rm -f dist/*.whl
-        sudo mv dist/repaired/*.whl dist/
-        sudo rmdir dist/repaired
+        rm -f dist/*.whl
+        mv dist/repaired/*.whl dist/
+        rmdir dist/repaired
         ls dist
 
     - name: Verify automatic platform tags

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -99,13 +99,11 @@ jobs:
           auditwheel repair "$whl" -w dist/repaired/ \
           --exclude libplatform.so \
           --exclude libregister.so \
-          --exclude libtorch.so \
-          --exclude libge_common_base.so \
-          --exclude libtorch_npu.so \
+          --exclude libge_common_base.so \\
           --exclude libc10.so \
           --exclude libc_sec.so \
-          --exclude libascendcl.so \
-          --exclude libtorch_cpu.so
+          --exclude "libascend*.so" \
+          --exclude "libtorch*.so"
         done
         rm -f dist/*.whl
         mv dist/repaired/*.whl dist/

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         cd dist
         for wheel in *.whl; do
-          echo "验证文件: $wheel"
+          echo "verification file: $wheel"
           auditwheel show "$wheel"
         done
 

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -93,13 +93,13 @@ jobs:
       run: |
         python3 -m pip install auditwheel
         python3 -m pip install patchelf
-        mkdir -p dist/repaired
+        sudo mkdir -p dist/repaired
         for whl in dist/*.whl; do
           auditwheel repair "$whl" -w dist/repaired/
         done
-        rm -f dist/*.whl
-        mv dist/repaired/*.whl dist/
-        rmdir dist/repaired
+        sudo rm -f dist/*.whl
+        sudo mv dist/repaired/*.whl dist/
+        sudo rmdir dist/repaired
         ls dist
 
     - name: Verify automatic platform tags


### PR DESCRIPTION
### What this PR does / why we need it?
- Fixes https://github.com/vllm-project/vllm-ascend/issues/1533

### How was this patch tested?
1. Run the image
```
docker run \
    --name cann_container \
    --device /dev/davinci6 \
    --device /dev/davinci_manager \
    --device /dev/devmm_svm \
    --device /dev/hisi_hdc \
    -v /usr/local/dcmi:/usr/local/dcmi \
    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
    -v /etc/ascend_install.info:/etc/ascend_install.info \
    -it  quay.io/ascend/cann:8.1.rc1-910b-openeuler22.03-py3.11 bash
```

2. Install package
torch=2.5.1
torch-npu=2.5.1.post1.dev20250619 
vllm=0.9.1
vllm-ascend=vllm_ascend-0.1.dev1+g02ac443-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
Artifact download URL: https://github.com/vllm-project/vllm-ascend/actions/runs/16039661265/artifacts/3454481370

3. Test offline script

```
from vllm import LLM, SamplingParams

import os
os.environ["VLLM_USE_V1"] = "1"

prompts = [
    "Hello, my name is",
]

llm = LLM(model="Qwen3/Qwen3-1.7B")

outputs = llm.generate(prompts)

for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

4. Results
![result](https://github.com/user-attachments/assets/20f9d923-00ce-4a2d-8598-9b216045705d)

- vLLM version: v0.9.1
- vLLM main: https://github.com/vllm-project/vllm/commit/b942c094e3ab905aeb16f4136353f378e17159e8
