### PR TITLE
[Prefill Optimization] Attention Warmup Support + Better NPU Sort Handling

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -15,7 +15,7 @@ from vllm.model_executor.layers.linear import (LinearBase,
 from vllm.utils import cdiv, round_down
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.attention.attention import _ALLOWED_NUM_QUERIES_PER_KV
+from vllm_ascend.attention.attention import _ALLOWED_NUM_QUERIES_PER_KV, AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.multistream.base import MSAttentionMetadataSplitConfig
 from vllm_ascend.multistream.context import get_multistream_comm_context
@@ -312,6 +312,61 @@ class AscendMLAMetadataBuilder:
                                                           max_blocks]
 
         return graph_block_tables[:num_seqs, :max_blocks]
+
+    def build_dummy_prefill(self, num_reqs: int,
+            num_actual_tokens: int) -> AscendMLAMetadata:
+        device = self.runner.device
+        _, max_blocks = self.runner.graph_block_tables.shape
+        block_table = torch.zeros((num_reqs, max_blocks),
+                                  dtype=torch.int32,
+                                  device=device)
+        block_table = self._get_graph_runner_block_tables(
+            num_reqs, block_table)
+        seq_lens = torch.ones(num_reqs, dtype=torch.int32)
+        input_positions = torch.zeros(num_reqs,
+                                      dtype=torch.int32,
+                                      device=device).long()
+        slot_mapping = torch.full((num_reqs, ),
+                                  PAD_SLOT_ID,
+                                  dtype=torch.int32,
+                                  device=device)
+        query_start_loc = torch.full((num_reqs, ),
+                                     -1,
+                                     dtype=torch.int32,
+                                     device=device)
+
+        query_lens = torch.tensor([1024], dtype=torch.int32)
+        max_query_len = query_lens.max().item()
+
+        mask_builder = AttentionMaskBuilder.initialize_from_len(128, torch.bfloat16)
+        attn_mask = mask_builder.get_attn_mask(num_actual_tokens, torch.bfloat16, 'npu')
+        prefill_metadata = AscendMLAPrefillMetadata(
+            attn_mask=attn_mask,
+            query_lens=query_lens,
+            seq_lens=seq_lens,
+            context_lens=seq_lens,
+            input_positions=input_positions,
+            block_table=block_table,
+            max_query_len=max_query_len,
+            max_seq_lens=num_actual_tokens,
+            query_start_loc=query_start_loc,
+        )
+        return self.metadata_cls(  # type: ignore
+            num_input_tokens=num_actual_tokens,
+            num_actual_tokens=num_actual_tokens,
+            slot_mapping=slot_mapping,
+            head_dim=self.runner.model_config.get_head_size(),
+            num_decodes=0,
+            num_decode_tokens=0,
+            num_prefills=1,
+            attn_mask=attn_mask,
+            attn_state=AscendAttentionState.PrefillNoCache,
+            prefill=prefill_metadata,
+            decode=None,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            block_tables=block_table,
+        )
 
     def build_dummy(self, num_reqs: int,
                     num_actual_tokens: int) -> AscendMLAMetadata:

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -15,7 +15,7 @@ from vllm.model_executor.layers.linear import (LinearBase,
 from vllm.utils import cdiv, round_down
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.attention.attention import _ALLOWED_NUM_QUERIES_PER_KV, AttentionMaskBuilder
+from vllm_ascend.attention.attention import AttentionMaskBuilder, _ALLOWED_NUM_QUERIES_PER_KV
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.multistream.base import MSAttentionMetadataSplitConfig
 from vllm_ascend.multistream.context import get_multistream_comm_context

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -279,7 +279,9 @@ def fused_experts_with_all2all(
                                                scatter_size_list,
                                                gather_size_list)
 
-        sorted_local_expert_idx, sorted_idx = torch.sort(local_expert_idx)
+        # Workaround: Convert to float so that sort runs on AI Core instead of slower AICPU
+        sorted_local_expert_idx, sorted_idx = torch.sort(local_expert_idx.float())
+        sorted_local_expert_idx = sorted_local_expert_idx.to(local_expert_idx.dtype)
 
         expert_tokens = torch_npu.npu_moe_compute_expert_tokens(
             sorted_local_expert_idx, local_num_experts).to(torch.int64)
@@ -315,7 +317,8 @@ def fused_experts_with_all2all(
         group_list_type=group_list_type)
 
     if expert_map is not None:
-        resorted_idx = torch.argsort(sorted_idx)
+        # Workaround: Convert to float so that argsort runs on AI Core instead of slower AICPU
+        resorted_idx = torch.argsort(sorted_idx.float()).to(sorted_idx.dtype)
         hidden_states = hidden_states[resorted_idx]
         hidden_states = ep_group.all_to_all(hidden_states, 0, 0,
                                             gather_size_list,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1858,7 +1858,10 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                     for k, v in self.intermediate_tensors.items()
                 })
 
-            with set_forward_context(None,
+            attn_metadata = self.attn_metadata_builder.build_dummy_prefill(
+                num_reqs=1, num_actual_tokens=input_ids.shape[0])
+
+            with set_forward_context(attn_metadata,
                                      self.vllm_config,
                                      num_tokens=num_tokens):
                 if self.torchair_graph_enabled and not with_prefill:
@@ -1893,7 +1896,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                         input_ids=input_ids,
                         positions=positions,
                         intermediate_tensors=intermediate_tensors,
-                        inputs_embeds=inputs_embeds)
+                        inputs_embeds=inputs_embeds,
+                        attn_metadata=attn_metadata)
                     if self.use_aux_hidden_state_outputs:
                         hidden_states, _ = hidden_states
                     else:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces two improvements to enhance prefill performance on Ascend:

1. **Attention Warmup in Dummy Run:**
   The dummy run used for operator warmup previously skipped the attention layer. This update adds support for running attention during the dummy step, allowing better warmup coverage.

2. **Improved NPU Sort/Argsort Efficiency:**
   On Ascend NPUs, `sort` and `argsort` operations with `int` inputs fall back to a slower AiCPU path. By casting inputs to `float`, performing the sort, and then casting back to `int`, this change avoids the fallback and improves performance.

### Does this PR introduce _any_ user-facing change?

No. This PR only includes internal performance optimizations and does not affect any user-facing APIs or behaviors.
