### PR TITLE
[CI] Fix mypy check in CI

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -103,10 +103,6 @@ jobs:
           pip install yapf==0.32.0
           yapf --diff --recursive .
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
-
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v4
         with:
@@ -125,6 +121,10 @@ jobs:
         run: |
           pip install -r requirements/build.txt --extra-index-url https://download.pytorch.org/whl/cpu
           VLLM_TARGET_DEVICE=empty pip install .
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Mypy Check
         run: |


### PR DESCRIPTION
### What this PR does / why we need it?
Fix mypy check in CI: https://github.com/vllm-project/vllm-ascend/actions/runs/16115919385/job/45469646509?pr=1654

Mypy failed due to the greater numpy version. We need to pin `numpy=1.26.4` in vllm-ascend

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.9.1
- vLLM main: https://github.com/vllm-project/vllm/commit/923147b5e8551887fd64a0fc242c361d5216e1d7
