### PR TITLE
[Bugfix] Fix accuracy problem caused by mask pollution

### DIFF
--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -572,7 +572,8 @@ class AscendMetadataBuilder(CommonMetadataBuilder[AscendMetadata]):
                 attn_mask = AscendMetadataBuilder._attn_mask_builder.get_attn_mask(  # type: ignore
                     max_seq_len, dtype, device)
                 if attn_mask.numel() > 1 and attn_mask[0][1] > 0:
-                    attn_mask *= -10000
+                    # Do not use in-place multiplication to avoid modifying `attn_mask_cache`!
+                    attn_mask = attn_mask * -10000
                 chunk_mask_list = []
                 for i, seq_len in enumerate(seq_lens):
                     context_len = self.context_lens[i]

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -68,7 +68,8 @@ class AttentionMaskBuilder:
             ) > 1 and self.attn_mask_cache[0][1] > 0:
                 attn_mask = self.get_attn_mask(  # type: ignore
                     max_seq_len, dtype, device)
-                attn_mask *= -10000
+                # Do not use in-place multiplication to avoid modifying `self.attn_mask_cache`!
+                attn_mask = attn_mask * -10000
             else:
                 attn_mask = self.attn_mask_cache
             return torch.index_select(attn_mask, dim=0,


### PR DESCRIPTION
### What this PR does / why we need it?
If a small batch of short requests is sent first, forming a chunk with a length <128, it will corrupt the `attn_mask_cache`, causing subsequent requests that do not form a chunk to have accuracy issues.

The root cause of this problem is the use of in-place multiplication. Modifying it to use out-of-place multiplication will resolve the accuracy problem.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Yes.

- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ad6c2e1a0b56c29065c7d70ff2e736e4f2fb03af

