### PR TITLE
[V0 Deprecation] Remove prompt adapter in V1

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,6 @@ norecursedirs =
     vllm-empty/tests/kv_transfer
     vllm-empty/tests/plugins
     vllm-empty/tests/plugins_tests
-    vllm-empty/tests/prompt_adapter
     vllm-empty/tests/compile
     vllm-empty/tests/lora
     vllm-empty/tests/models

--- a/vllm_ascend/worker/draft_model_runner.py
+++ b/vllm_ascend/worker/draft_model_runner.py
@@ -139,7 +139,6 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
             1. Only decodes 
             2. Only flash-attn
             3. No LORA
-            4. No prompt_adapter_config
         """
         if not allow_gpu_advance_step:
             return False
@@ -155,11 +154,7 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
             return False
 
         # TODO: Add support for LORA
-        if self.lora_config:
-            return False
-
-        # TODO: Add soft-tuning prompt adapter support
-        return not self.prompt_adapter_config
+        return not self.lora_config
 
     def set_indices_of_seq_with_bonus_tokens(self,
                                              indices_of_seq_with_bonus_tokens):
@@ -202,9 +197,6 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
             # Sanity
             if self.lora_config is not None:
                 raise ValueError("TP1DraftModelRunner has no support for LORA")
-            if self.prompt_adapter_config is not None:
-                raise ValueError("TP1DraftModelRunner has no support for "
-                                 "prompt_adapter_config")
             if model_input.inputs_embeds is not None:
                 raise ValueError("TP1DraftModelRunner has no support for "
                                  "inputs_embeds")
@@ -218,13 +210,6 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
                 assert model_input.lora_mapping is not None
                 self.set_active_loras(model_input.lora_requests,
                                       model_input.lora_mapping)
-
-            if self.prompt_adapter_config:
-                assert model_input.prompt_adapter_requests is not None
-                assert model_input.prompt_adapter_mapping is not None
-                self.set_active_prompt_adapters(
-                    model_input.prompt_adapter_requests,
-                    model_input.prompt_adapter_mapping)
 
             self.attn_state.begin_forward(model_input)
 

--- a/vllm_ascend/worker/model_runner.py
+++ b/vllm_ascend/worker/model_runner.py
@@ -52,8 +52,6 @@ from vllm.model_executor.models.utils import set_cpu_offload_max_bytes
 from vllm.multimodal import (MULTIMODAL_REGISTRY, BatchedTensorInputs,
                              MultiModalKwargs, MultiModalPlaceholderMap,
                              MultiModalRegistry)
-from vllm.prompt_adapter.layers import PromptAdapterMapping
-from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import IntermediateTensors, SequenceGroupMetadata
 from vllm.utils import (DeviceMemoryProfiler, PyObjectCache, flatten_2d_lists,
@@ -1236,27 +1234,6 @@ class NPUModelRunnerBase(ModelRunnerBase[TModelInputForNPU]):
         if not self.lora_manager:
             raise RuntimeError("LoRA is not enabled.")
         return self.lora_manager.list_adapters()
-
-    def remove_all_prompt_adapters(self):
-        raise RuntimeError("PromptAdapter is not supported on NPU now.")
-
-    def set_active_prompt_adapters(
-            self, prompt_adapter_requests: Set[PromptAdapterRequest],
-            prompt_adapter_mapping: PromptAdapterMapping) -> None:
-        raise RuntimeError("PromptAdapter is not supported on NPU now.")
-
-    def add_prompt_adapter(
-            self, prompt_adapter_request: PromptAdapterRequest) -> bool:
-        raise RuntimeError("PromptAdapter is not supported on NPU now.")
-
-    def remove_prompt_adapter(self, prompt_adapter_id: int) -> bool:
-        raise RuntimeError("PromptAdapter is not supported on NPU now.")
-
-    def pin_prompt_adapter(self, prompt_adapter_id: int) -> bool:
-        raise RuntimeError("PromptAdapter is not supported on NPU now.")
-
-    def list_prompt_adapters(self) -> Set[int]:
-        raise RuntimeError("PromptAdapter is not supported on NPU now.")
 
     @property
     def vocab_size(self) -> int:

--- a/vllm_ascend/worker/multi_step_runner.py
+++ b/vllm_ascend/worker/multi_step_runner.py
@@ -91,9 +91,6 @@ class StatefulModelInputForNPU(StatefulModelInput):
         # assert fmi.lora_mapping is None
         # assert fmi.lora_requests is not None
         # assert len(fmi.lora_requests) == 0
-        # assert fmi.prompt_adapter_mapping is None
-        # assert fmi.prompt_adapter_requests is not None
-        # assert len(fmi.prompt_adapter_requests) == 0
         assert fmi.attn_metadata is not None
         assert fmi.multi_modal_kwargs is not None
         assert len(fmi.multi_modal_kwargs) == 0

--- a/vllm_ascend/worker/pooling_model_runner.py
+++ b/vllm_ascend/worker/pooling_model_runner.py
@@ -116,13 +116,6 @@ class NPUPoolingModelRunner(
             self.set_active_loras(model_input.lora_requests,
                                   model_input.lora_mapping)
 
-        if self.prompt_adapter_config:
-            assert model_input.prompt_adapter_requests is not None
-            assert model_input.prompt_adapter_mapping is not None
-            self.set_active_prompt_adapters(
-                model_input.prompt_adapter_requests,
-                model_input.prompt_adapter_mapping)
-
         assert model_input.attn_metadata is not None
         virtual_engine = model_input.virtual_engine
         model_executable = self.model

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -37,7 +37,6 @@ from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
-from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sequence import (ExecuteModelRequest, IntermediateTensors,
                            SequenceGroupMetadata, SequenceGroupMetadataDelta)
 from vllm.utils import GiB_bytes, bind_kv_cache, get_ip
@@ -502,23 +501,6 @@ class NPUWorker(LocalOrDistributedWorkerBase):
 
     def list_loras(self) -> Set[int]:
         return self.model_runner.list_loras()
-
-    def add_prompt_adapter(
-            self, prompt_adapter_request: PromptAdapterRequest) -> bool:
-        raise NotImplementedError(
-            "Prompt Adapter is not implemented for NPU backend currently.")
-
-    def remove_prompt_adapter(self, prompt_adapter_id: int) -> bool:
-        raise NotImplementedError(
-            "Prompt Adapter is not implemented for NPU backend currently.")
-
-    def pin_prompt_adapter(self, prompt_adapter_id: int) -> bool:
-        raise NotImplementedError(
-            "Prompt Adapter is not implemented for NPU backend currently.")
-
-    def list_prompt_adapters(self) -> Set[int]:
-        raise NotImplementedError(
-            "Prompt Adapter is not implemented for NPU backend currently.")
 
     @property
     def max_model_len(self) -> int:


### PR DESCRIPTION
### What this PR does / why we need it?

Remove V0 prompt adapter, find more details at https://github.com/vllm-project/vllm/pull/20588.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.9.1
- vLLM main: https://github.com/vllm-project/vllm/commit/6db31e7a2735bb8132259bcbc21f046d62974325
