### PR TITLE
Use ci_vllm_version when recording vLLM commit

### DIFF
--- a/.github/format_pr_body.sh
+++ b/.github/format_pr_body.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
-#
+# Adapted from vllm/.github/scripts/cleanup_pr_body.sh
 
 #!/bin/bash
 
@@ -34,11 +34,15 @@ NEW=/tmp/new_pr_body.txt
 gh pr view --json body --template "{{.body}}" "${PR_NUMBER}" > "${OLD}"
 cp "${OLD}" "${NEW}"
 
-# Remove "FIX #xxxx (*link existing issues this PR will resolve*)"
+# Remove notes in pr description and add vLLM version and commit
 sed -i '/<!--/,/-->/d' "${NEW}"
 sed -i '/- vLLM .*$/d' "${NEW}"
-echo "- vLLM version: $VLLM_VERSION" >> "${NEW}"
-echo "- vLLM main: $VLLM_COMMIT" >> "${NEW}"
+{
+    echo ""
+    echo "- vLLM version: $VLLM_VERSION"
+    echo "- vLLM main: $VLLM_COMMIT"
+    echo ""
+} >> "${NEW}"
 
 # Run this only if ${NEW} is different than ${OLD}
 if ! cmp -s "${OLD}" "${NEW}"; then

--- a/.github/workflows/format_pr_body.yaml
+++ b/.github/workflows/format_pr_body.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Get vLLM release version
         run: |
-          VLLM_VERSION=$(python3 docs/source/conf.py | jq .vllm_version | tr -d '"')
+          VLLM_VERSION=$(python3 docs/source/conf.py | jq .ci_vllm_version | tr -d '"')
           echo "VLLM_VERSION=$VLLM_VERSION" >> $GITHUB_ENV
 
       - name: Update PR description

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,6 +76,8 @@ myst_substitutions = {
     'pip_vllm_version': "0.9.1",
     # CANN image tag
     'cann_image_tag': "8.1.rc1-910b-ubuntu22.04-py3.10",
+    # vllm version in ci
+    'ci_vllm_version': 'v0.9.2',
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
### What this PR does / why we need it?
Use ci_vllm_version when recording vllm commit

Followup on https://github.com/vllm-project/vllm-ascend/pull/1623

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Test mannually.
$ python3 docs/source/conf.py | jq .ci_vllm_version | tr -d '"'
v0.9.2
- Test on my local repo: https://github.com/Yikun/vllm-ascend/pull/35

- vLLM version: v0.9.1
- vLLM main: https://github.com/vllm-project/vllm/commit/49e8c7ea256bd48a36391b5bc72212af39278b67
