### PR TITLE
[CI] fix wheel build fail: "liberror_manager.so" could not be localed

### DIFF
--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -103,7 +103,8 @@ jobs:
           --exclude libc10.so \
           --exclude libc_sec.so \
           --exclude "libascend*.so" \
-          --exclude "libtorch*.so"
+          --exclude "libtorch*.so" \
+          --exclude "liberror_manager.so"
         done
         rm -f dist/*.whl
         mv dist/repaired/*.whl dist/


### PR DESCRIPTION
### What this PR does / why we need it?
- Fixes # fix wheel build fail: "liberror_manager.so" could not be localed, fixing issue imformation:



