### PR TITLE
[Perf] Reduce memory usage by splitting tokens in fused_experts

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -33,7 +33,7 @@ The following table lists the additional configuration options available in vLLM
 | `expert_map_path`             | str  | `None` | When using expert load balancing for the MOE model, an expert map path needs to be passed in. |
 | `chunked_prefill_for_mla`     | bool | `False` | Whether to enable the fused operator-like chunked_prefill. |
 | `kv_cache_dtype`     | str | `None` | When using the kv cache quantization method, kv cache dtype needs to be set, currently only int8 is supported. |
-| `fused_moe_max_chunk_size`    | int | 8192 | The maximum token chunk size for the fused MoE operation. Input exceeding this size is split into multiple chunks for processing. |
+| `fused_moe_max_chunk_size`    | int | `max_num_batched_tokens * data_parallel_size` | The maximum token chunk size for the fused MoE operation. Input exceeding this size is split into multiple chunks for processing. |
 
 The details of each config option are as follows:
 

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -33,6 +33,7 @@ The following table lists the additional configuration options available in vLLM
 | `expert_map_path`             | str  | `None` | When using expert load balancing for the MOE model, an expert map path needs to be passed in. |
 | `chunked_prefill_for_mla`     | bool | `False` | Whether to enable the fused operator-like chunked_prefill. |
 | `kv_cache_dtype`     | str | `None` | When using the kv cache quantization method, kv cache dtype needs to be set, currently only int8 is supported. |
+| `fused_moe_max_chunk_size`    | int | 8192 | The maximum token chunk size for the fused MoE operation. Input exceeding this size is split into multiple chunks for processing. |
 
 The details of each config option are as follows:
 
@@ -76,6 +77,7 @@ An example of additional configuration is as follows:
         "enable_chunked_prefill": True,
     },
     "expert_tensor_parallel_size": 1,
+    "fused_moe_max_chunk_size": 8192,
     "refresh": False,
 }
 ```

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -50,6 +50,11 @@ class AscendConfig:
         self.expert_map_path = additional_config.get("expert_map_path", None)
         self.chunked_prefill_for_mla = additional_config.get(
             "chunked_prefill_for_mla", False)
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        dp_size = vllm_config.parallel_config.data_parallel_size
+        self.fused_moe_max_chunk_size = int(
+            additional_config.get("fused_moe_max_chunk_size",
+                                  max_num_tokens * dp_size))
 
 
 class TorchairGraphConfig:


### PR DESCRIPTION
### What this PR does / why we need it?
Reduce activation memory usage during the prefill phase in MOE for long-context scenarios.

### Does this PR introduce _any_ user-facing change?
Yes. If the user wants to use this feature, they need to manually set the fused_moe_max_chunk_size field in the additional-config dictionary.

### How was this patch tested?
Yes.




- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/be1e128dfb5b50c586eae1d4ee4d6f24f6076dd8

