### PR TITLE
[v0.9.1] fix async pullkv determin

### DIFF
--- a/vllm_ascend/distributed/llmdatadist_c_mgr_connector.py
+++ b/vllm_ascend/distributed/llmdatadist_c_mgr_connector.py
@@ -1,9 +1,9 @@
 import contextlib
 import json
 import math
+import os
 import threading
 import time
-import os
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass

--- a/vllm_ascend/distributed/llmdatadist_c_mgr_connector.py
+++ b/vllm_ascend/distributed/llmdatadist_c_mgr_connector.py
@@ -3,6 +3,7 @@ import json
 import math
 import threading
 import time
+import os
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -334,6 +335,8 @@ class LLMDataDistCMgrConnectorWorker():
         self.init_llm_datadist()
         self.finished_reqs: set[str] = set()
         self.soc_info = NPUSocInfo()
+        # Set hccl deterministic for model execute
+        os.environ["HCCL_DETERMINISTIC"] = "true"
 
     def listen_for_agent_metadata_req(self, event: threading.Event):
         assert self.local_agent_metadata is not None


### PR DESCRIPTION

### What this PR does / why we need it?
Torchair set the `HCCL_DETERMINISTIC` by default, and it will incur error when CacheManagerConnector trying to pullkv in another thread. This PR setting this environment variable ahead of the pullkv process. Makes the pullkv and torchair happy at same time.

## Does this PR introduce _any_ user-facing change?
No change

### How was this patch tested?
ci test

