### PR TITLE
disable quantization in mindie_turbo

### DIFF
--- a/vllm_ascend/quantization/quantizer.py
+++ b/vllm_ascend/quantization/quantizer.py
@@ -48,14 +48,8 @@ class AscendQuantizer:
         if quantization_algorithm in CUSTOMIZED_QUANTIZER_TYPE:
             return
 
-        try:
-            module = importlib.import_module("mindie_turbo")
-            MindIETurboQuantizer = module.MindIETurboQuantizer
-            return MindIETurboQuantizer.get_quantizer(quant_config, prefix,
-                                                      packed_modules_mapping)
-        except ImportError:
-            return VLLMAscendQuantizer.get_quantizer(quant_config, prefix,
-                                                     packed_modules_mapping)
+        return VLLMAscendQuantizer.get_quantizer(quant_config, prefix,
+                                                 packed_modules_mapping)
 
     def build_linear_method(self):
         raise NotImplementedError


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
since the interface in vllm-ascend has changed so quickly, the quantization function in mindie_turbo is no longer needed, so it needs to be discarded.
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
through ci
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

