### PR TITLE
[PD Disagg][CI] Upgrade vllm version to fix ci

### DIFF
--- a/.github/workflows/vllm_ascend_test_pd.yaml
+++ b/.github/workflows/vllm_ascend_test_pd.yaml
@@ -42,9 +42,8 @@ jobs:
     strategy:
       matrix:
         vllm_verison: [
-            # revert me when V1 disaggregation prefill is merged in main
-            # main, 
-            v0.9.1
+            main, 
+            v0.9.2
           ]
     name: vLLM Ascend prefilling decoding disaggregation test
     runs-on: linux-arm64-npu-static-8
@@ -108,4 +107,4 @@ jobs:
 
       - name: Run vllm-project/vllm-ascend PD Disaggregation test
         run: |
-          pytest -sv tests/e2e/pd_disaggreate/test_pd_e2e.py
+          VLLM_USE_V1=0 pytest -sv tests/e2e/pd_disaggreate/test_pd_e2e.py


### PR DESCRIPTION
### What this PR does / why we need it?
Upgrade vllm version to fix ci
FYI, will drop v0 prefill disaggregation after #950 is merged
### Does this PR introduce _any_ user-facing change?
n/a

### How was this patch tested?
CI passed with new existing test.



- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/66f6fbd393721c98440436ab067304ac4331219c

