### PR TITLE
[CI] Fix changes CI

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -49,24 +49,25 @@ jobs:
       e2e_tracker: ${{ steps.filter.outputs.e2e_tracker }}
       ut_tracker: ${{ steps.filter.outputs.ut_tracker }}
     steps:
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          e2e_tracker:
-            - '.github/workflows/vllm_ascend_test.yaml'
-            - 'vllm_ascend/**'
-            - 'csrc/**'
-            - 'cmake/**'
-            - 'tests/e2e/**'
-            - 'CMakeLists.txt'
-            - 'setup.py'
-            - 'requirements.txt'
-            - 'requirements-dev.txt'
-            - 'requirements-lint.txt'
-            - 'packages.txt'
-          ut_tracker:
-            - 'tests/ut/**'
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            e2e_tracker:
+              - '.github/workflows/vllm_ascend_test.yaml'
+              - 'vllm_ascend/**'
+              - 'csrc/**'
+              - 'cmake/**'
+              - 'tests/e2e/**'
+              - 'CMakeLists.txt'
+              - 'setup.py'
+              - 'requirements.txt'
+              - 'requirements-dev.txt'
+              - 'requirements-lint.txt'
+              - 'packages.txt'
+            ut_tracker:
+              - 'tests/ut/**'
   ut:
     needs: [lint, changes]
     name: unit test


### PR DESCRIPTION
Add `checkout` action before `dorny/paths-filter` to make it works with `push` case.
This is a known issue that `dorny/paths-filter` works without `checkout` in `pull_request` case but failed in `push` case. More detail is here:
https://github.com/dorny/paths-filter/issues/60#issuecomment-1464281021

The push CI works after this PR. The test result is here:
https://github.com/wangxiyuan/vllm-ascend/actions/runs/16285606468/job/45983607539
- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/d4d309409f2396e68e4b5a67ede194913502388b

