### PR TITLE
[0.9.1][bugfix] fix disaggregate prefill hang issue in long output sc…

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1102,7 +1102,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                 self.vllm_config,
                 num_tokens=padded_num_tokens_across_dp,
                 num_tokens_across_dp=num_tokens_across_dp,
-                with_prefill=with_prefill):
+                with_prefill=with_prefill,
+                num_actual_tokens=total_num_scheduled_tokens):
             with ProfileExecuteDuration().capture_async("forward"):
                 self.maybe_setup_kv_connector(scheduler_output)
                 model_kwargs = {}


### PR DESCRIPTION
 fix disaggregate prefill hang issue in long output scenario

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

fix disaggregate prefill hang issue in long output scenario

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
PD disaggregate livecodebench output 32K
http://image.huawei.com/tiny-lts/v1/images/mdstorm/f47ff3da0ab4862750ee0e3c0b8f6a8e_1245x261.png
PD mix vllm benchmark input 3.5K output 1.5K max-concurrency 2048 request-rate 2048
http://image.huawei.com/tiny-lts/v1/images/mdstorm/8537efd60141348c95c7eae3f3f9c417_1229x425.png

