### PR TITLE
Remove redundant empty lines in commit msg

### DIFF
--- a/.github/format_pr_body.sh
+++ b/.github/format_pr_body.sh
@@ -30,6 +30,7 @@ VLLM_VERSION=$2
 VLLM_COMMIT=$3
 OLD=/tmp/orig_pr_body.txt
 NEW=/tmp/new_pr_body.txt
+FINAL=/tmp/final_pr_body.txt
 
 gh pr view --json body --template "{{.body}}" "${PR_NUMBER}" > "${OLD}"
 cp "${OLD}" "${NEW}"
@@ -41,16 +42,18 @@ sed -i '/- vLLM .*$/d' "${NEW}"
     echo ""
     echo "- vLLM version: $VLLM_VERSION"
     echo "- vLLM main: $VLLM_COMMIT"
-    echo ""
 } >> "${NEW}"
 
+# Remove redundant empty lines
+uniq "${NEW}" > "${FINAL}"
+
 # Run this only if ${NEW} is different than ${OLD}
-if ! cmp -s "${OLD}" "${NEW}"; then
+if ! cmp -s "${OLD}" "${FINAL}"; then
     echo
     echo "Updating PR body:"
     echo
     cat "${NEW}"
-    gh pr edit --body-file "${NEW}" "${PR_NUMBER}"
+    gh pr edit --body-file "${FINAL}" "${PR_NUMBER}"
 else
     echo "No changes needed"
 fi


### PR DESCRIPTION
### What this PR does / why we need it?
Remove redundant empty lines in commit msg

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
test locally: https://github.com/Yikun/vllm-ascend/pull/48

- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/d0dc4cfca48c2734da18ec42d6bba1346cbfc400

