### PR TITLE
Fix e2e data parallel test: add resource release code

### DIFF
--- a/tests/e2e/multicard/test_data_parallel.py
+++ b/tests/e2e/multicard/test_data_parallel.py
@@ -30,7 +30,6 @@ import pytest
 MODELS = ["Qwen/Qwen2.5-0.5B-Instruct"]
 
 
-@pytest.mark.skipif(True, reason="TODO: fix dp timeout error in ci")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})


### PR DESCRIPTION
### What this PR does / why we need it?
Fix e2e data parallel test: add resource release code and give more time to engine to pause their processing loops before exiting.

### Does this PR introduce _any_ user-facing change?
No


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/5895afd78047614a037cac1fc4634825c749fd59
