### PR TITLE
[CI] Fix broken CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,5 @@ requires = [
     "msgpack",
     "quart",
     "numba",
-    # Remove after https://github.com/vllm-project/vllm-ascend/issues/1470
-    "transformers==4.52.4",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,3 @@ numba
 --pre
 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 torch-npu==2.5.1.post1.dev20250619
-
-# Remove after https://github.com/vllm-project/vllm-ascend/issues/1470
-transformers==4.52.4

--- a/vllm_ascend/ops/common_fused_moe.py
+++ b/vllm_ascend/ops/common_fused_moe.py
@@ -40,23 +40,26 @@ def unquantized_fused_moe_init_func(self, *args, **kwargs):
 
 
 def forward_oot(
-    self,
-    layer: torch.nn.Module,
-    x: torch.Tensor,
-    use_grouped_topk: bool,
-    top_k: int,
-    router_logits: torch.Tensor,
-    renormalize: bool,
-    topk_group: Optional[int] = None,
-    num_expert_group: Optional[int] = None,
-    custom_routing_function: Optional[Callable] = None,
-    scoring_func: str = "softmax",
-    e_score_correction_bias: Optional[torch.Tensor] = None,
-    global_num_experts: Optional[int] = None,
-    expert_map: Optional[torch.Tensor] = None,
-    apply_router_weight_on_input: bool = False,
-    activation: str = "silu",
-) -> torch.Tensor:
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        use_grouped_topk: bool,
+        top_k: int,
+        router_logits: torch.Tensor,
+        renormalize: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        custom_routing_function: Optional[Callable] = None,
+        scoring_func: str = "softmax",
+        e_score_correction_bias: Optional[torch.Tensor] = None,
+        global_num_experts: Optional[int] = None,
+        expert_map: Optional[torch.Tensor] = None,
+        apply_router_weight_on_input: bool = False,
+        activation: str = "silu",
+        enable_eplb: bool = False,
+        expert_load_view: Optional[torch.Tensor] = None,
+        logical_to_physical_map: Optional[torch.Tensor] = None,
+        logical_replica_count: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     if SELECT_GATING_TOPK_SOTFMAX_EXPERTS:
         topk_weights, topk_ids = select_gating_top_k_softmax_experts(

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -355,3 +355,6 @@ class NPUWorker(WorkerBase):
                     torch_profiler_trace_dir))
         else:
             return None
+
+    def get_supported_pooling_tasks(self):
+        return self.model_runner.get_supported_pooling_tasks()


### PR DESCRIPTION
1. vLLM commit https://github.com/vllm-project/vllm/commit/45badd05d04254eb75c48cee7b1d454a80de2165 changed the pooling check logic which  broken vLLM Ascend.
2. vLLM commit https://github.com/vllm-project/vllm/commit/3e04107d97aeb6360fcfb684665b66c94135079b requires higher version of transformers. The transformers version bug has been fixed by https://github.com/vllm-project/vllm/commit/e936e401debe7fba64d6462666d7dc632bc76357. We can safe to remove the version limit now.
3. vLLM commit https://github.com/vllm-project/vllm/commit/217937221b6845913502371aba554a3357fbccfb added a new input `enable_eplb` for FusedMoe Ops

This PR fix the broken CI.


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/6a971ed692974b3d6309d556b15c8cc726b091f9
