### PR TITLE
[Bugfix]: Correct handling of cos_sin_cache length

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -93,7 +93,9 @@ def native_rope_deepseek_forward(self,
                                  offsets: Optional[torch.Tensor] = None,
                                  max_seq_len: Optional[int] = None):
     if max_seq_len is not None and max_seq_len > self.max_seq_len:
-        _set_cos_sin_cache(self, max_seq_len, query.device, query.dtype)
+        raise ValueError(f"Unable to reach here, max_seq_len {max_seq_len} "
+                         "exceeds the maximum sequence length "
+                         f"{self.max_seq_len} for rotary embedding.")
     if len(key.shape) == 2:
         key = key[:, None, :]
     # Note: we implement the non neox_style method with shuffle the last dim and neox style
@@ -209,7 +211,7 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
 
 
 def _set_cos_sin_cache(self, seq_len, device, dtype):
-    self.max_seq_len_cached = seq_len
+    self.max_seq_len = seq_len * self.scaling_factor
     dim = self.rotary_dim
 
     freq_extra = 1.0 / (self.base**(
@@ -276,7 +278,6 @@ def deepseek_rope_init_func(
     super(DeepseekScalingRotaryEmbedding,
           self).__init__(head_size, rotary_dim, max_position_embeddings, base,
                          is_neox_style, dtype)
-    self.max_seq_len = max_position_embeddings
     _set_cos_sin_cache(self,
                        max_position_embeddings,
                        dtype=dtype,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

This PR addresses the performance issue related to cos/sin cache handling:

1. The cos/sin cache is already initialized with the maximum context length during initialization. However, due to `max_seq_len_cache` being stored as `seq_len`, the condition check was incorrect, leading to unnecessary cache recreation.

2. Since the cos/sin cache is already initialized with maximum context length, it should not trigger recreation during the process.

3. Fixed variable naming: `max_seq_len_cache` was never used and should be `max_seq_len`. This also is the correct variable to check against the maximum context length.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No
### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
CI pass.
