### PR TITLE
[0.9.1][CI] Pin vllm version to v0.9.1 to make mypy check passed

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -48,6 +48,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
+        vllm_version: [v0.9.1]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
@@ -86,6 +87,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: vllm-project/vllm
+          ref: ${{ matrix.vllm_version }}
           path: vllm-empty
 
       - name: Actionlint Check


### PR DESCRIPTION
### What this PR does / why we need it?
Pin vllm version to v0.9.1 to make mypy check passed

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Lint ci passed

