### PR TITLE
[Test] Add some uts(multistream/attention/ops) for vllm ascend

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1,0 +1,666 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import torch
+from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.model_executor.layers.linear import LinearBase
+
+from tests.ut.base import TestBase
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.mla_v1 import (AscendMLABackend,
+                                          AscendMLADecodeMetadata,
+                                          AscendMLAImpl, AscendMLAMetadata,
+                                          AscendMLAMetadataBuilder,
+                                          AscendMLAPrefillMetadata)
+
+
+class TestAscendMLABackend(TestBase):
+
+    def test_get_name(self):
+        self.assertEqual(AscendMLABackend.get_name(), "VLLM_ASCEND_MLA")
+
+    def test_get_metadata_cls(self):
+        self.assertEqual(AscendMLABackend.get_metadata_cls(),
+                         AscendMLAMetadata)
+
+    def test_get_builder_cls(self):
+        self.assertEqual(AscendMLABackend.get_builder_cls(),
+                         AscendMLAMetadataBuilder)
+
+    def test_get_kv_cache_shape(self):
+        result = AscendMLABackend.get_kv_cache_shape(2, 4, 8, 128)
+        self.assertEqual(result, (2, 4, 8, 128))
+
+
+class TestAscendMLAPrefillMetadata(TestBase):
+
+    def test_ascend_mla_prefill_metadata_default(self):
+        attn_mask = torch.tensor([[1, 0], [1, 1]], dtype=torch.bool)
+        query_lens = [1, 2]
+        seq_lens = [2, 2]
+        context_lens = torch.tensor([1, 2])
+        input_positions = torch.tensor([0, 1, 0, 1])
+        query_start_loc = torch.tensor([0, 1, 3])
+        block_table = torch.tensor([[0, 1], [2, 3]])
+        max_query_len = 2
+        max_seq_lens = 2
+
+        metadata = AscendMLAPrefillMetadata(attn_mask=attn_mask,
+                                            query_lens=query_lens,
+                                            seq_lens=seq_lens,
+                                            context_lens=context_lens,
+                                            input_positions=input_positions,
+                                            query_start_loc=query_start_loc,
+                                            block_table=block_table,
+                                            max_query_len=max_query_len,
+                                            max_seq_lens=max_seq_lens)
+        self.assertIs(metadata.attn_mask, attn_mask)
+        self.assertEqual(metadata.query_lens, query_lens)
+        self.assertEqual(metadata.seq_lens, seq_lens)
+        self.assertIs(metadata.context_lens, context_lens)
+        self.assertIs(metadata.input_positions, input_positions)
+        self.assertIs(metadata.query_start_loc, query_start_loc)
+        self.assertIs(metadata.block_table, block_table)
+        self.assertEqual(metadata.max_query_len, max_query_len)
+        self.assertEqual(metadata.max_seq_lens, max_seq_lens)
+        self.assertIsNone(metadata.chunked_context)
+
+    def test_ascend_mla_prefill_metadata_with_chunked_context(self):
+        cu_seq_lens = torch.tensor([0, 2, 4])
+        starts = torch.tensor([0, 2])
+        seq_tot = [2, 2]
+        max_seq_lens = [2, 2]
+        workspace = torch.randn(2, 4)
+        chunk_seq_lens = torch.tensor([2, 2])
+
+        chunked_context = AscendMLAPrefillMetadata.ChunkedContextMetadata(
+            cu_seq_lens=cu_seq_lens,
+            starts=starts,
+            seq_tot=seq_tot,
+            max_seq_lens=max_seq_lens,
+            workspace=workspace,
+            chunk_seq_lens=chunk_seq_lens)
+
+        metadata = AscendMLAPrefillMetadata(
+            attn_mask=torch.tensor([[1, 0], [1, 1]], dtype=torch.bool),
+            query_lens=[1, 2],
+            seq_lens=[2, 2],
+            context_lens=torch.tensor([1, 2]),
+            input_positions=torch.tensor([0, 1, 0, 1]),
+            query_start_loc=torch.tensor([0, 1, 3]),
+            block_table=torch.tensor([[0, 1], [2, 3]]),
+            max_query_len=2,
+            max_seq_lens=2,
+            chunked_context=chunked_context)
+
+        self.assertIsNotNone(metadata.chunked_context)
+        self.assertIs(metadata.chunked_context.cu_seq_lens, cu_seq_lens)
+        self.assertIs(metadata.chunked_context.starts, starts)
+        self.assertEqual(metadata.chunked_context.seq_tot, seq_tot)
+        self.assertEqual(metadata.chunked_context.max_seq_lens, max_seq_lens)
+        self.assertIs(metadata.chunked_context.workspace, workspace)
+        self.assertIs(metadata.chunked_context.chunk_seq_lens, chunk_seq_lens)
+
+
+class TestAscendMLADecodeMetadata(TestBase):
+
+    def test_ascend_mla_decode_metadata_default(self):
+        input_positions = torch.tensor([[1, 2, 3, 4], [1, 2, 3, 4]])
+        block_table = torch.tensor([[0, 3, 2, 1], [0, 2, 1, 3]])
+        seq_lens = torch.tensor([[2], [3]])
+        max_seq_lens = 4
+        seq_lens_list = [2, 3]
+        attn_mask = None
+
+        metadata = AscendMLADecodeMetadata(input_positions, block_table,
+                                           seq_lens, max_seq_lens,
+                                           seq_lens_list, attn_mask)
+
+        self.assertIs(metadata.input_positions, input_positions)
+        self.assertIs(metadata.block_table, block_table)
+        self.assertIs(metadata.seq_lens, seq_lens)
+        self.assertEqual(metadata.max_seq_lens, max_seq_lens)
+        self.assertEqual(metadata.seq_lens_list, seq_lens_list)
+        self.assertIsNone(attn_mask)
+
+
+class TestAscendMLAMetadata(TestBase):
+
+    def test_ascend_mla_metadata_default(self):
+        num_actual_tokens = 100
+        slot_mapping = torch.randn(100, 4, 1024)
+        query_start_loc = torch.tensor([1, 2, 3, 4])
+        seq_lens = [30, 50]
+        block_tables = torch.randint(0, 100, (100, 4))
+
+        num_decodes = 4
+        num_decode_tokens = 8
+        num_prefills = 8
+
+        num_input_tokens = 2
+
+        max_num_tokens_across_dp = 2
+        with_prefill_across_dp = False
+        query_lens = None
+        head_dim = None
+        attn_mask = None
+        attn_state = AscendAttentionState.ChunkedPrefill
+
+        decode = None
+        prefill = None
+
+        metadata = AscendMLAMetadata(
+            num_actual_tokens, slot_mapping, query_start_loc, seq_lens,
+            block_tables, num_decodes, num_decode_tokens, num_prefills,
+            num_input_tokens, max_num_tokens_across_dp, with_prefill_across_dp,
+            query_lens, head_dim, attn_mask, attn_state, decode, prefill)
+
+        self.assertEqual(metadata.num_actual_tokens, num_actual_tokens)
+        self.assertIs(metadata.slot_mapping, slot_mapping)
+        self.assertIs(metadata.query_start_loc, query_start_loc)
+        self.assertEqual(metadata.seq_lens, seq_lens)
+        self.assertIs(metadata.block_tables, block_tables)
+        self.assertEqual(metadata.num_decodes, num_decodes)
+        self.assertEqual(metadata.num_decode_tokens, num_decode_tokens)
+        self.assertEqual(metadata.num_prefills, num_prefills)
+        self.assertEqual(metadata.num_input_tokens, num_input_tokens)
+        self.assertEqual(metadata.max_num_tokens_across_dp,
+                         max_num_tokens_across_dp)
+        self.assertEqual(metadata.with_prefill_across_dp,
+                         with_prefill_across_dp)
+        self.assertEqual(metadata.query_lens, query_lens)
+        self.assertEqual(metadata.head_dim, head_dim)
+        self.assertEqual(metadata.attn_mask, attn_mask)
+        self.assertEqual(metadata.attn_state, attn_state)
+        self.assertEqual(metadata.decode, decode)
+        self.assertEqual(metadata.prefill, prefill)
+
+
+class TestAscendMLAMetadataBuilder(TestBase):
+
+    def test_ascend_mla_metadata_builder_default(self):
+        runner = MagicMock()
+        runner.scheduler_config = MagicMock()
+        runner.model_config = MagicMock()
+        runner.scheduler_config.max_num_seqs = 4
+        runner.model_config.max_model_len = 1024
+        runner.model_config.get_head_size.return_value = 64
+        runner.model_config.dtype = torch.float16
+        runner.chunked_prefill_enabled = False
+        runner.device = "cpu"
+        runner.block_size = 16
+
+        ascend_config = MagicMock()
+        ascend_config.torchair_graph_config = MagicMock()
+        ascend_config.torchair_graph_config.enabled = True
+        with patch("vllm_ascend.attention.mla_v1.get_ascend_config",
+                   return_value=ascend_config):
+            builder = AscendMLAMetadataBuilder(runner)
+
+            self.assertEqual(builder.runner, runner)
+            self.assertEqual(builder.block_size, runner.block_size)
+            self.assertEqual(builder.chunked_prefill_enabled,
+                             runner.chunked_prefill_enabled)
+            self.assertEqual(builder.torchair_graph_enabled, True)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
+    def test_reorder_batch_with_torchair_graph(self, ascend_config):
+        runner = MagicMock()
+        runner.chunked_prefill_enabled = False
+        ascend_config.torchair_graph_config = MagicMock()
+        ascend_config.torchair_graph_config.enabled = True
+
+        builder = AscendMLAMetadataBuilder(runner)
+
+        input_batch = MagicMock()
+        input_batch.req_ids = [0, 1, 2, 3]
+
+        scheduler_output = MagicMock()
+        scheduler_output.num_scheduled_tokens = {0: 2, 1: 1, 2: 3, 3: 1}
+        scheduler_output.scheduled_spec_decode_tokens = {
+            0: [1],
+            1: [],
+            2: [1, 1],
+            3: []
+        }
+
+        input_batch.swap_states = MagicMock()
+
+        modified = builder.reorder_batch(input_batch, scheduler_output)
+
+        self.assertFalse(modified)
+        self.assertEqual(builder._num_decodes, 4)
+        self.assertEqual(builder._num_prefills, 0)
+        self.assertEqual(builder._num_decode_tokens, 7)
+        self.assertEqual(builder._num_prefill_tokens, 0)
+        input_batch.swap_states.assert_not_called()
+
+    def test_reorder_batch_without_torchair_graph(self):
+        ascend_config = MagicMock()
+        runner = MagicMock()
+        runner.chunked_prefill_enabled = False
+        ascend_config.torchair_graph_config = MagicMock()
+        ascend_config.torchair_graph_config.enabled = False
+        with patch("vllm_ascend.attention.mla_v1.get_ascend_config",
+                   return_value=ascend_config):
+            builder = AscendMLAMetadataBuilder(runner)
+
+        input_batch = MagicMock()
+        input_batch.req_ids = [0, 1, 2, 3]
+
+        scheduler_output = MagicMock()
+        scheduler_output.num_scheduled_tokens = {0: 1, 1: 3, 2: 1, 3: 2}
+        scheduler_output.scheduled_spec_decode_tokens = {
+            0: [],
+            1: [1],
+            2: [],
+            3: []
+        }
+
+        input_batch.swap_states = MagicMock()
+
+        modified = builder.reorder_batch(input_batch, scheduler_output)
+
+        self.assertTrue(modified)
+        self.assertEqual(builder._num_decodes, 2)
+        self.assertEqual(builder._num_prefills, 2)
+        self.assertEqual(builder._num_decode_tokens, 2)
+        self.assertEqual(builder._num_prefill_tokens, 5)
+        input_batch.swap_states.assert_called_once_with(1, 2)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
+    def test_get_graph_runner_block_tables_normal(self, mock_ascend_config):
+        ascend_config = MagicMock()
+        mock_ascend_config.return_value = ascend_config
+        ascend_config.torchair_graph_config.enabled = False
+        runner = MagicMock()
+        runner.graph_block_tables = torch.zeros((8, 64), dtype=torch.int32)
+        runner.chunked_prefill_enabled = False
+        builder = AscendMLAMetadataBuilder(runner=runner)
+        block_tables = torch.randint(0, 100, (3, 10), dtype=torch.int32)
+
+        result = builder._get_graph_runner_block_tables(3, block_tables)
+        self.assertEqual(result.shape[0], 3)
+        self.assertEqual(result.shape[1], 64)
+        self.assertTrue(torch.equal(result[:, :10], block_tables))
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
+    def test_get_graph_runner_block_tables_truncated(self, mock_ascend_config):
+        ascend_config = MagicMock()
+        mock_ascend_config.return_value = ascend_config
+        ascend_config.torchair_graph_config.enabled = False
+        runner = MagicMock()
+        runner.graph_block_tables = torch.zeros((8, 4), dtype=torch.int32)
+        runner.chunked_prefill_enabled = False
+        builder = AscendMLAMetadataBuilder(runner=runner)
+        block_tables = torch.randint(0, 100, (3, 10), dtype=torch.int32)
+
+        result = builder._get_graph_runner_block_tables(3, block_tables)
+        self.assertEqual(result.shape[0], 3)
+        self.assertEqual(result.shape[1], 4)
+        self.assertTrue(torch.equal(result, block_tables[:, :4]))
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
+    def test_get_graph_runner_block_tables_from_numpy(self,
+                                                      mock_ascend_config):
+        ascend_config = MagicMock()
+        mock_ascend_config.return_value = ascend_config
+        ascend_config.torchair_graph_config.enabled = False
+        runner = MagicMock()
+        runner.graph_block_tables = np.zeros((8, 64), dtype=np.int32)
+        runner.chunked_prefill_enabled = False
+        builder = AscendMLAMetadataBuilder(runner=runner)
+
+        block_tables = torch.randint(0, 100, (3, 10), dtype=torch.int32)
+
+        result = builder._get_graph_runner_block_tables(3, block_tables)
+
+        self.assertEqual(result.shape[0], 3)
+        self.assertEqual(result.shape[1], 64)
+        self.assertTrue(torch.equal(result[:, :10], block_tables))
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
+    def test_build_dummy(self, mock_ascend_config):
+        ascend_config = MagicMock()
+        mock_ascend_config.return_value = ascend_config
+        ascend_config.torchair_graph_config.enabled = False
+        runner = MagicMock()
+        runner.model_config = MagicMock()
+        runner.device = "cpu"
+        runner.graph_block_tables = torch.zeros((8, 64), dtype=torch.int32)
+        runner.model_config.get_head_size.return_value = 64
+        runner.chunked_prefill_enabled = False
+        runner.attn_mask = torch.zeros((1, 1), dtype=torch.bool)
+        runner.spec_attn_mask = torch.zeros((1, 1), dtype=torch.bool)
+
+        builder = AscendMLAMetadataBuilder(runner=runner,
+                                           metadata_cls=AscendMLAMetadata)
+
+        with patch.object(builder,
+                          "_get_graph_runner_block_tables",
+                          side_effect=lambda x, y: y):
+            metadata = builder.build_dummy(3, 3)
+
+        self.assertIsInstance(metadata, AscendMLAMetadata)
+        self.assertEqual(metadata.num_input_tokens, 3)
+        self.assertEqual(metadata.num_actual_tokens, 3)
+        self.assertEqual(metadata.num_decodes, 1)
+        self.assertEqual(metadata.num_decode_tokens, 1)
+        self.assertEqual(metadata.num_prefills, 0)
+        self.assertEqual(metadata.attn_state, AscendAttentionState.DecodeOnly)
+        self.assertIsNone(metadata.prefill)
+        self.assertIsInstance(metadata.decode, AscendMLADecodeMetadata)
+        self.assertEqual(metadata.block_tables.shape[0], 3)
+        self.assertEqual(metadata.block_tables.shape[1], 64)
+        self.assertEqual(metadata.seq_lens.shape[0], 3)
+        self.assertEqual(metadata.slot_mapping.shape[0], 3)
+        self.assertEqual(metadata.query_start_loc.shape[0], 3)
+
+
+class TestAscendMLAImpl(TestBase):
+
+    @patch('vllm.distributed.parallel_state._TP',
+           new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch("vllm.distributed.get_tensor_model_parallel_world_size",
+           return_value=2)
+    @patch("vllm.config.get_current_vllm_config")
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
+    def setUp(self, ascend_config, vllm_config, mock_get_tp_size, mock_tp):
+        mock_tp.world_size = 2
+        ascend_config.torchair_graph_config.enabled = True
+        ascend_config.torchair_graph_config.enable_kv_nz = False
+        speculative_config = MagicMock()
+        speculative_config.num_speculative_tokens = 4
+        vllm_config.speculative_config = speculative_config
+
+        num_heads = 256
+        head_size = 1024
+        scale = 0.1
+        num_kv_heads = 8
+        kv_cache_dtype = "auto"
+
+        kv_a_layernorm = MagicMock()
+        kv_a_layernorm.weight = torch.randn(96)
+        kv_a_layernorm.variance_epsilon = 1e-6
+        kwargs = {
+            "q_lora_rank": 64,
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "rotary_emb": MagicMock(),
+            "q_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "kv_a_layernorm": kv_a_layernorm,
+        }
+
+        self.impl = AscendMLAImpl(num_heads=num_heads,
+                                  head_size=head_size,
+                                  scale=scale,
+                                  num_kv_heads=num_kv_heads,
+                                  alibi_slopes=None,
+                                  sliding_window=None,
+                                  kv_cache_dtype=kv_cache_dtype,
+                                  blocksparse_params=None,
+                                  logits_soft_cap=None,
+                                  attn_type=None,
+                                  kv_sharing_target_layer_name=None,
+                                  **kwargs)
+
+    def test_init(self):
+        self.assertEqual(self.impl.num_heads, 256)
+        self.assertEqual(self.impl.head_size, 1024)
+        self.assertEqual(self.impl.scale, 0.1)
+        self.assertEqual(self.impl.num_kv_heads, 8)
+        self.assertEqual(self.impl.kv_cache_dtype, "auto")
+        self.assertEqual(self.impl.q_lora_rank, 64)
+        self.assertEqual(self.impl.kv_lora_rank, 32)
+        self.assertEqual(self.impl.qk_nope_head_dim, 64)
+        self.assertEqual(self.impl.qk_rope_head_dim, 32)
+        self.assertEqual(self.impl.qk_head_dim, 96)
+        self.assertEqual(self.impl.v_head_dim, 128)
+        self.assertIsNotNone(self.impl.rotary_emb)
+        self.assertIsNotNone(self.impl.q_proj)
+        self.assertIsNotNone(self.impl.kv_b_proj)
+        self.assertIsNotNone(self.impl.o_proj)
+        self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
+        self.assertIsNotNone(self.impl.kv_a_layernorm)
+        self.assertEqual(self.impl.num_queries_per_kv, 32)
+        self.assertEqual(self.impl.tp_size, 2)
+        self.assertTrue(self.impl.torchair_graph_enabled)
+
+    def test_v_up_proj_and_o_proj(self):
+        batch_size = 4
+        x = torch.randn(batch_size, self.impl.num_heads,
+                        self.impl.kv_lora_rank)
+
+        self.impl.o_proj.return_value = (torch.randn(
+            batch_size, self.impl.num_heads * self.impl.v_head_dim), )
+        if not hasattr(self.impl, 'W_UV') or self.impl.W_UV is None:
+            self.impl.W_UV = torch.randn(self.impl.num_heads,
+                                         self.impl.kv_lora_rank,
+                                         self.impl.v_head_dim)
+        result = self.impl._v_up_proj_and_o_proj(x)
+
+        self.assertEqual(result.shape[0], batch_size)
+        self.assertEqual(result.shape[1],
+                         self.impl.num_heads * self.impl.v_head_dim)
+
+    def test_q_proj_and_k_up_proj(self):
+        batch_size = 4
+        x = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
+        q_proj_output = torch.randn(batch_size, self.impl.num_heads,
+                                    self.impl.qk_head_dim)
+        self.impl.q_proj.return_value = (q_proj_output, )
+        if not hasattr(self.impl, 'W_UK_T') or self.impl.W_UK_T is None:
+            self.impl.W_UK_T = torch.randn(self.impl.num_heads,
+                                           self.impl.qk_nope_head_dim,
+                                           self.impl.kv_lora_rank)
+        result = self.impl._q_proj_and_k_up_proj(x)
+        ql_nope, q_pe = result
+        self.assertEqual(ql_nope.shape[0], batch_size)
+        self.assertEqual(ql_nope.shape[1], self.impl.num_heads)
+        self.assertEqual(ql_nope.shape[2], self.impl.kv_lora_rank)
+        self.assertEqual(q_pe.shape[0], batch_size)
+        self.assertEqual(q_pe.shape[1], self.impl.num_heads)
+        self.assertEqual(q_pe.shape[2], self.impl.qk_rope_head_dim)
+
+    def test_process_weights_after_loading(self):
+        layer = MagicMock(spec=LinearBase)
+        layer.input_size_per_partition = 10
+        quant_method = MagicMock()
+        apply = MagicMock()
+        quant_method.apply = apply
+        layer.quant_method = quant_method
+        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim +
+                                         self.impl.v_head_dim)
+        shape_1 = self.impl.kv_lora_rank
+        layer.weight = torch.randn(shape_0, shape_1)
+        self.impl.kv_b_proj = layer
+        apply.return_value = layer.weight.T
+        self.impl.process_weights_after_loading(torch.bfloat16)
+
+        self.assertEqual(self.impl.W_UK_T.shape[0], self.impl.num_heads)
+        self.assertEqual(self.impl.W_UK_T.shape[1], self.impl.qk_nope_head_dim)
+        self.assertEqual(self.impl.W_UK_T.shape[2], self.impl.kv_lora_rank)
+
+        self.assertEqual(self.impl.W_UV.shape[0], self.impl.num_heads)
+        self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
+        self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
+
+    def test_compute_prefill_context_none(self):
+        batch_size = 4
+        kv_cache = torch.randn(1, 1, 1, 192)
+        query = torch.randn(batch_size, self.impl.num_heads,
+                            self.impl.qk_head_dim)
+        metadata = MagicMock()
+        metadata.prefill = None
+        prefix_out = torch.randn(2, 16, 128)
+        prefix_lse = torch.randn(2, 16, 8)
+        out, lse = self.impl._compute_prefill_context(query, kv_cache, 32,
+                                                      metadata, prefix_out,
+                                                      prefix_lse)
+
+        self.assertTrue(torch.equal(prefix_out, out))
+        self.assertTrue(torch.equal(prefix_lse, lse))
+
+    @patch("torch_npu.atb.npu_paged_cache_load")
+    @patch("torch_npu.atb.npu_ring_mla")
+    def test_compute_prefill_context(self, mock_ring, mock_load):
+        S, N, D, VD = 2, self.impl.num_heads, self.impl.qk_head_dim, self.impl.v_head_dim
+        _, AND = self.impl.qk_rope_head_dim, self.impl.qk_nope_head_dim
+        num_blocks, block_size = 100, 20
+        query = torch.randn(S, N, D)
+        kv_cache = torch.randn(num_blocks, block_size, N, D)
+        prefix_out = torch.randn(S, N, 128)
+        prefix_lse = torch.randn(S, N)
+
+        self.impl.kv_b_proj.return_value = (torch.randn(8, N, VD + AND), )
+
+        chunk_ctx = MagicMock()
+        chunk_ctx.seq_tot = [8]
+        chunk_ctx.chunk_seq_lens = [torch.tensor([8])]
+        chunk_ctx.starts = [torch.tensor([0])]
+
+        prefill_meta = MagicMock()
+        prefill_meta.chunked_context = chunk_ctx
+        prefill_meta.query_lens = [8]
+        prefill_meta.block_table = torch.randint(0, 100, (S, 4))
+
+        meta = MagicMock()
+        meta.prefill = prefill_meta
+
+        out, lse = self.impl._compute_prefill_context(query, kv_cache, 32,
+                                                      meta, prefix_out,
+                                                      prefix_lse)
+
+        mock_load.assert_called_once()
+        mock_ring.assert_called_once()
+
+        self.assertEqual(out.shape, prefix_out.shape)
+        self.assertEqual(lse.shape, prefix_lse.shape)
+
+    @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
+    def test_exec_kv(self, mock_kv_cache):
+        batch_size = 2
+        hidden = torch.randn(batch_size, 128)
+        cos = torch.randn(batch_size, 32)
+        sin = torch.randn(batch_size, 32)
+        kv_cache = (torch.randn(
+            4, 8, self.impl.kv_lora_rank + self.impl.qk_rope_head_dim),
+                    torch.randn(
+                        4, 8,
+                        self.impl.kv_lora_rank + self.impl.qk_rope_head_dim))
+        slots = torch.arange(batch_size, dtype=torch.long)
+
+        proj_out = torch.randn(
+            batch_size, self.impl.num_kv_heads, 1,
+            self.impl.kv_lora_rank + self.impl.qk_rope_head_dim)
+        self.impl.kv_a_proj_with_mqa.return_value = (proj_out, )
+
+        mock_kv_cache.return_value = (torch.randn(batch_size,
+                                                  self.impl.num_kv_heads, 1,
+                                                  self.impl.qk_rope_head_dim),
+                                      torch.randn(batch_size,
+                                                  self.impl.num_kv_heads, 1,
+                                                  self.impl.kv_lora_rank),
+                                      None, None)
+
+        k_pe, k_nope, kv = self.impl.exec_kv(hidden, cos, sin, kv_cache, slots)
+
+        self.impl.kv_a_proj_with_mqa.assert_called_once_with(hidden)
+        mock_kv_cache.assert_called_once()
+        self.assertEqual(k_pe.shape, (batch_size, self.impl.num_kv_heads, 1,
+                                      self.impl.qk_rope_head_dim))
+        self.assertEqual(
+            k_nope.shape,
+            (batch_size, self.impl.num_kv_heads, 1, self.impl.kv_lora_rank))
+        self.assertEqual(kv.shape,
+                         (batch_size, self.impl.num_kv_heads, 1,
+                          self.impl.kv_lora_rank + self.impl.qk_rope_head_dim))
+
+    @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
+    def test_exec_kv_prefill(self, mock_kv):
+        B, N, S, H = 2, self.impl.num_kv_heads, 1, 128
+        hidden_states = torch.randn(B, N, S, H)
+        cos = torch.randn(B, S, 32)
+        sin = torch.randn(B, S, 32)
+        kv_cache = (
+            torch.randn(100, 8,
+                        self.impl.kv_lora_rank + self.impl.qk_rope_head_dim),
+            torch.randn(100, 8,
+                        self.impl.kv_lora_rank + self.impl.qk_rope_head_dim),
+        )
+
+        slots = torch.arange(B * S, dtype=torch.long)
+
+        proj_out = torch.randn(
+            B, N, S, self.impl.kv_lora_rank + self.impl.qk_rope_head_dim)
+        self.impl.kv_a_proj_with_mqa.return_value = (proj_out, )
+
+        mock_kv.return_value = (None, None,
+                                torch.randn(B, self.impl.num_kv_heads, S,
+                                            self.impl.qk_rope_head_dim),
+                                torch.randn(B, self.impl.num_kv_heads, S,
+                                            self.impl.kv_lora_rank))
+
+        k_pe, k_nope = self.impl.exec_kv_prefill(hidden_states, cos, sin,
+                                                 kv_cache, slots)
+
+        self.impl.kv_a_proj_with_mqa.assert_called_once_with(hidden_states)
+        mock_kv.assert_called_once()
+
+        self.assertEqual(
+            k_pe.shape,
+            (B, self.impl.num_kv_heads, S, self.impl.qk_rope_head_dim))
+        self.assertEqual(
+            k_nope.shape,
+            (B, self.impl.num_kv_heads, S, self.impl.kv_lora_rank))
+
+    @patch("torch_npu.npu_interleave_rope")
+    def test_rope_single(self, mock_rope):
+        B, N, D = 2, 16, 1024
+        x = torch.randn(B, N, D)
+        cos = torch.randn(B, N, 1, D)
+        sin = torch.randn(B, N, 1, D)
+        mock_rope.return_value = x.view(B, N, 1, D)
+        result = self.impl.rope_single(x, cos, sin)
+        self.assertEqual(result.shape[0], B)
+        self.assertEqual(result.shape[1], N)
+        self.assertEqual(result.shape[2], D)
+        mock_rope.assert_called_once()
+
+    @patch("vllm_ascend.attention.mla_v1.AscendMLAImpl._v_up_proj_and_o_proj")
+    @patch("torch_npu._npu_paged_attention_mla")
+    def test_forward_decode_without_graph(self, mock_page_attention_mla,
+                                          mock_up_proj):
+        self.impl.running_in_graph = False
+        num_tokens = 100
+        num_blocks = 256
+        block_size = 4
+        q_nope = torch.randn(num_tokens, self.impl.num_heads,
+                             self.impl.qk_nope_head_dim)
+        q_pe = torch.randn(num_tokens, self.impl.num_heads,
+                           self.impl.qk_rope_head_dim)
+        kv_c_and_k_pe_cache = torch.randn(num_blocks, block_size,
+                                          self.impl.num_heads,
+                                          self.impl.kv_lora_rank)
+        metadata = MagicMock()
+        metadata.decode = MagicMock()
+        metadata.decode.block_table = MagicMock()
+        metadata.decode.seq_lens = 10
+        mock_page_attention_mla.return_value = torch.randn(
+            num_tokens, self.impl.num_heads, self.impl.kv_lora_rank)
+        mock_up_proj.return_value = torch.randn(num_tokens,
+                                                self.impl.num_heads,
+                                                self.impl.v_head_dim)
+        result = self.impl._forward_decode(q_nope, q_pe, None, None,
+                                           kv_c_and_k_pe_cache, metadata)
+        self.assertEqual(result.shape[0], num_tokens)
+        self.assertEqual(result.shape[1], self.impl.num_heads)
+        self.assertEqual(result.shape[2], self.impl.v_head_dim)
+        mock_up_proj.assert_called_once()
+        mock_page_attention_mla.assert_called_once()

--- a/tests/ut/core/test_scheduler.py
+++ b/tests/ut/core/test_scheduler.py
@@ -44,12 +44,8 @@ def create_requests(
                                      prompt_logprobs=prompt_logprobs)
     requests = []
     for i in range(num_requests):
-        if mm_positions is not None:
-            mm_position = mm_positions[i]
-            mm_inputs = [MultiModalKwargs({})] * len(mm_position)
-        else:
-            mm_position = None
-            mm_inputs = None
+        mm_position = None
+        mm_inputs = None
         request = Request(
             request_id=f"{i}",
             prompt_token_ids=[i] * num_tokens,

--- a/tests/ut/core/test_scheduler.py
+++ b/tests/ut/core/test_scheduler.py
@@ -1,0 +1,722 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import torch
+from vllm.config import (CacheConfig, KVTransferConfig, ModelConfig,
+                         SchedulerConfig, SpeculativeConfig, VllmConfig)
+from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        KVCacheGroupSpec)
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import Request, RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
+
+from tests.ut.base import TestBase
+from vllm_ascend.core.scheduler import AscendScheduler
+from vllm_ascend.utils import vllm_version_is
+
+EOS_TOKEN_ID = 50256
+MODEL = "Qwen3-0.6B"
+ENABLE_PREFIX_CACHING = None
+PROMPT_LOGPROBS = None
+ENABLE_CHUNKED_PREFILL = False
+MAX_NUM_BATCHED_TOKENS = 10000
+LONG_PREFILL_TOKEN_THRESHOLD = 0
+NUM_SPECULATIVE_TOKENS = None
+MAX_NUM_SEQS = 16
+
+
+def create_requests(
+    num_requests: int,
+    num_tokens: int = 10,
+    mm_positions: Optional[list[PlaceholderRange]] = None,
+    max_tokens: int = 16,
+    stop_token_ids: Optional[list[int]] = None,
+):
+    prompt_logprobs = PROMPT_LOGPROBS
+    sampling_params = SamplingParams(ignore_eos=False,
+                                     max_tokens=max_tokens,
+                                     stop_token_ids=stop_token_ids,
+                                     prompt_logprobs=prompt_logprobs)
+    requests = []
+    for i in range(num_requests):
+        if mm_positions is not None:
+            mm_position = mm_positions[i]
+            mm_inputs = [MultiModalKwargs({})] * len(mm_position)
+        else:
+            mm_position = None
+            mm_inputs = None
+        request = Request(
+            request_id=f"{i}",
+            prompt_token_ids=[i] * num_tokens,
+            sampling_params=sampling_params,
+            multi_modal_inputs=mm_inputs,
+            multi_modal_placeholders=mm_position,
+            multi_modal_hashes=None,
+            eos_token_id=EOS_TOKEN_ID,
+            pooling_params=None,
+        )
+        requests.append(request)
+    return requests
+
+
+def make_output(scheduler):
+    return ModelRunnerOutput(
+        req_ids=[req.request_id for req in scheduler.running],
+        req_id_to_index={
+            req.request_id: i
+            for i, req in enumerate(scheduler.running)
+        },
+        sampled_token_ids=[[1000]] * len(scheduler.running),
+        spec_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[])
+
+
+class TestAscendScheduler(TestBase):
+
+    @patch("vllm.config.ModelConfig.__post_init__", MagicMock())
+    @patch("vllm.config.VllmConfig.__post_init__", MagicMock())
+    @patch('vllm.v1.core.sched.scheduler.compute_encoder_budget')
+    def create_scheduler(self, mock_compute_encoder_budget):
+        mock_compute_encoder_budget.return_value = [10, 20]
+        use_kv_connector = False
+        block_size = 16
+
+        scheduler_config = SchedulerConfig(
+            max_num_seqs=16,
+            max_model_len=MAX_NUM_BATCHED_TOKENS,
+            long_prefill_token_threshold=LONG_PREFILL_TOKEN_THRESHOLD,
+            disable_chunked_mm_input=False,
+            enable_chunked_prefill=ENABLE_CHUNKED_PREFILL,
+            max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+        )
+
+        scheduler_config.max_num_encoder_input_tokens = 10000
+        scheduler_config.encoder_cache_size = 10000
+        scheduler_config.chunked_prefill_enabled = False
+
+        model_config = ModelConfig(
+            model=MODEL,
+            task="auto",
+            tokenizer=MODEL,
+            tokenizer_mode="auto",
+            trust_remote_code=True,
+            dtype="float16",
+            seed=42,
+            max_model_len=MAX_NUM_BATCHED_TOKENS,
+        )
+        model_config.pooler_config = MagicMock()
+        model_config.multimodal_config = MagicMock()
+        # Cache config, optionally force APC
+        kwargs_cache: Dict[str,
+                           Any] = ({} if ENABLE_PREFIX_CACHING is None else {
+                               'enable_prefix_caching':
+                               ENABLE_PREFIX_CACHING
+                           })
+        cache_config = CacheConfig(
+            block_size=block_size,
+            gpu_memory_utilization=0.9,
+            swap_space=0,
+            cache_dtype="auto",
+            **kwargs_cache,
+        )
+
+        kv_transfer_config = KVTransferConfig(
+            kv_connector="SharedStorageConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={"shared_storage_path": "local_storage"},
+        ) if use_kv_connector else None
+
+        speculative_config: Optional[SpeculativeConfig] = None
+        if NUM_SPECULATIVE_TOKENS is not None:
+            speculative_config = SpeculativeConfig(
+                model="ngram", num_speculative_tokens=NUM_SPECULATIVE_TOKENS)
+
+        vllm_config = VllmConfig(
+            scheduler_config=scheduler_config,
+            model_config=model_config,
+            cache_config=cache_config,
+            kv_transfer_config=kv_transfer_config,
+            speculative_config=speculative_config,
+        )
+
+        kv_cache_config = KVCacheConfig(
+            num_blocks=10000,  # A large number of blocks to hold all requests
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(['layer'],
+                                 FullAttentionSpec(block_size, 1, 1,
+                                                   torch.float32, False))
+            ],
+        )
+        cache_config.num_gpu_blocks = 10000
+
+        scheduler = AscendScheduler(
+            vllm_config=vllm_config,
+            kv_cache_config=kv_cache_config,
+            log_stats=True,
+            structured_output_manager=MagicMock(spec=StructuredOutputManager),
+        )
+
+        should_advance = MagicMock()
+        should_advance.return_value = False
+        scheduler.structured_output_manager.should_advance = should_advance
+
+        return scheduler
+
+    def test_add_requests(self):
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=10)
+
+        for i, request in enumerate(requests):
+            scheduler.add_request(request)
+            self.assertIn(request.request_id, scheduler.requests)
+            self.assertEqual(len(scheduler.waiting), i + 1)
+
+    def test_finish_request(self):
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=10)
+        for request in requests:
+            scheduler.add_request(request)
+
+        for i, request in enumerate(requests):
+            scheduler.finish_requests(request.request_id,
+                                      RequestStatus.FINISHED_ABORTED)
+            self.assertNotIn(request.request_id, scheduler.requests)
+            self.assertEqual(len(scheduler.waiting), 9 - i)
+
+    def test_get_num_unfinished_requests(self):
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=10)
+        for request in requests:
+            scheduler.add_request(request)
+
+        for i, request in enumerate(requests):
+            scheduler.finish_requests(request.request_id,
+                                      RequestStatus.FINISHED_STOPPED)
+            self.assertEqual(scheduler.get_num_unfinished_requests(),
+                             len(requests) - i - 1)
+
+    def test_schedule(self):
+        '''Test scheduling. 
+        Two cases: default APC/no prompt logprobs; APC=True + prompt logprobs
+        '''
+        scheduler = self.create_scheduler()
+        scheduler.scheduler_config.chunked_prefill_enabled = False
+        requests = create_requests(num_requests=10)
+        for request in requests:
+            scheduler.add_request(request)
+
+        # Test initial scheduling
+        output = scheduler.schedule()
+        self.assertEqual(len(output.scheduled_new_reqs), len(requests))
+        self.assertEqual(output.scheduled_cached_reqs.num_reqs, 0)
+        self.assertEqual(len(output.finished_req_ids), 0)
+        # Verify all requests are scheduled.
+        for req_id, num_tokens in output.num_scheduled_tokens.items():
+            self.assertEqual(num_tokens,
+                             len(requests[int(req_id)].prompt_token_ids))
+
+        # Verify requests moved from waiting to running
+        self.assertEqual(len(scheduler.waiting), 0)
+        self.assertEqual(len(scheduler.running), len(requests))
+        for i, request in enumerate(requests):
+            self.assertEqual(scheduler.running[i], request)
+
+    def test_schedule_enable_prefix_caching(self):
+        '''Test scheduling.
+        Two cases: default APC/no prompt logprobs; APC=True + prompt logprobs
+        '''
+        global ENABLE_PREFIX_CACHING
+        ENABLE_PREFIX_CACHING = True
+        global PROMPT_LOGPROBS
+        PROMPT_LOGPROBS = 5
+        scheduler = self.create_scheduler()
+        scheduler.scheduler_config.chunked_prefill_enabled = False
+        requests = create_requests(num_requests=10)
+        for request in requests:
+            scheduler.add_request(request)
+
+        # Test initial scheduling
+        output = scheduler.schedule()
+        self.assertEqual(len(output.scheduled_new_reqs), len(requests))
+        self.assertEqual(output.scheduled_cached_reqs.num_reqs, 0)
+        self.assertEqual(len(output.finished_req_ids), 0)
+        # Verify all requests are scheduled.
+        for req_id, num_tokens in output.num_scheduled_tokens.items():
+            self.assertEqual(num_tokens,
+                             len(requests[int(req_id)].prompt_token_ids))
+
+        # Verify requests moved from waiting to running
+        self.assertEqual(len(scheduler.waiting), 0)
+        self.assertEqual(len(scheduler.running), len(requests))
+        for i, request in enumerate(requests):
+            self.assertEqual(scheduler.running[i], request)
+
+    def test_stop_via_update_from_output(self):
+        """Test stopping behavior through update_from_output"""
+        global NUM_SPECULATIVE_TOKENS
+        NUM_SPECULATIVE_TOKENS = 1
+        scheduler = self.create_scheduler()
+
+        # Test case 1: Stop on EOS token
+        requests = create_requests(num_requests=2, max_tokens=10)
+        for req in requests:
+            req.num_computed_tokens = req.num_tokens
+            scheduler.requests[req.request_id] = req
+            scheduler.running.append(req)
+            if not vllm_version_is("0.9.2"):
+                req.status = RequestStatus.RUNNING
+
+        scheduler_output = SchedulerOutput(scheduled_new_reqs=[],
+                                           scheduled_cached_reqs=[],
+                                           num_scheduled_tokens={
+                                               requests[0].request_id: 1,
+                                               requests[1].request_id: 2
+                                           },
+                                           total_num_scheduled_tokens=3,
+                                           scheduled_encoder_inputs={},
+                                           scheduled_spec_decode_tokens={
+                                               requests[0].request_id: [],
+                                               requests[1].request_id: [10]
+                                           },
+                                           num_common_prefix_blocks=0,
+                                           finished_req_ids=set(),
+                                           free_encoder_input_ids=[],
+                                           structured_output_request_ids={},
+                                           grammar_bitmask=None)
+
+        model_output = ModelRunnerOutput(
+            req_ids=[req.request_id for req in requests],
+            req_id_to_index={
+                req.request_id: i
+                for i, req in enumerate(requests)
+            },
+            sampled_token_ids=[[EOS_TOKEN_ID], [10, 11]
+                               ],  # First request hits EOS, second continues
+            spec_token_ids=None,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[])
+
+        scheduler.update_from_output(scheduler_output, model_output)
+
+        # Verify first request stopped, second continues
+        self.assertEqual(len(scheduler.running), 1)
+        self.assertEqual(scheduler.running[0].request_id,
+                         requests[1].request_id)
+        self.assertEqual(requests[0].status, RequestStatus.FINISHED_STOPPED)
+        self.assertIn(requests[0].request_id, scheduler.finished_req_ids)
+        self.assertEqual(list(requests[0].output_token_ids), [EOS_TOKEN_ID])
+        self.assertEqual(list(requests[1].output_token_ids), [10, 11])
+
+        # Test case 2: Stop on custom stop token
+        NUM_SPECULATIVE_TOKENS = 2
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=2,
+                                   max_tokens=10,
+                                   stop_token_ids=[42, 43])
+        for req in requests:
+            req.num_computed_tokens = req.num_tokens
+            scheduler.requests[req.request_id] = req
+            scheduler.running.append(req)
+            if not vllm_version_is("0.9.2"):
+                req.status = RequestStatus.RUNNING
+
+        scheduler_output = SchedulerOutput(scheduled_new_reqs=[],
+                                           scheduled_cached_reqs=[],
+                                           num_scheduled_tokens={
+                                               requests[0].request_id: 3,
+                                               requests[1].request_id: 2
+                                           },
+                                           total_num_scheduled_tokens=5,
+                                           scheduled_encoder_inputs={},
+                                           scheduled_spec_decode_tokens={
+                                               requests[0].request_id:
+                                               [10, 42],
+                                               requests[1].request_id: [13]
+                                           },
+                                           num_common_prefix_blocks=0,
+                                           finished_req_ids=set(),
+                                           free_encoder_input_ids=[],
+                                           structured_output_request_ids={},
+                                           grammar_bitmask=None)
+
+        model_output = ModelRunnerOutput(
+            req_ids=[req.request_id for req in requests],
+            req_id_to_index={
+                req.request_id: i
+                for i, req in enumerate(requests)
+            },
+            sampled_token_ids=[[10, 42, 12],
+                               [13, 14]],  # First request hits stop token
+            spec_token_ids=None,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[])
+
+        scheduler.update_from_output(scheduler_output, model_output)
+
+        # Verify first request stopped on custom token
+        self.assertEqual(len(scheduler.running), 1)
+        self.assertEqual(scheduler.running[0].request_id,
+                         requests[1].request_id)
+        self.assertEqual(requests[0].status, RequestStatus.FINISHED_STOPPED)
+        self.assertEqual(requests[0].stop_reason, 42)
+        self.assertIn(requests[0].request_id, scheduler.finished_req_ids)
+        self.assertEqual(list(requests[0].output_token_ids), [10, 42])
+        self.assertEqual(list(requests[1].output_token_ids), [13, 14])
+
+        # Test case 3: Stop on max tokens
+        NUM_SPECULATIVE_TOKENS = 2
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=2, max_tokens=2)
+        for req in requests:
+            req.num_computed_tokens = req.num_tokens
+            scheduler.requests[req.request_id] = req
+            scheduler.running.append(req)
+            if not vllm_version_is("0.9.2"):
+                req.status = RequestStatus.RUNNING
+
+        scheduler_output = SchedulerOutput(scheduled_new_reqs=[],
+                                           scheduled_cached_reqs=[],
+                                           num_scheduled_tokens={
+                                               requests[0].request_id: 3,
+                                               requests[1].request_id: 1
+                                           },
+                                           total_num_scheduled_tokens=4,
+                                           scheduled_encoder_inputs={},
+                                           scheduled_spec_decode_tokens={
+                                               requests[0].request_id:
+                                               [10, 11],
+                                               requests[1].request_id: []
+                                           },
+                                           num_common_prefix_blocks=0,
+                                           finished_req_ids=set(),
+                                           free_encoder_input_ids=[],
+                                           structured_output_request_ids={},
+                                           grammar_bitmask=None)
+
+        model_output = ModelRunnerOutput(
+            req_ids=[req.request_id for req in requests],
+            req_id_to_index={
+                req.request_id: i
+                for i, req in enumerate(requests)
+            },
+            sampled_token_ids=[[10, 11, 12],
+                               [13]],  # First request exceeds max_tokens
+            spec_token_ids=None,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[])
+
+        scheduler.update_from_output(scheduler_output, model_output)
+
+        # Verify first request stopped due to length
+        self.assertEqual(len(scheduler.running), 1)
+        self.assertEqual(scheduler.running[0].request_id,
+                         requests[1].request_id)
+        self.assertEqual(requests[0].status,
+                         RequestStatus.FINISHED_LENGTH_CAPPED)
+        self.assertIn(requests[0].request_id, scheduler.finished_req_ids)
+        self.assertEqual(list(requests[0].output_token_ids), [10, 11])
+        self.assertEqual(list(requests[1].output_token_ids), [13])
+
+        # Test case 4: Ignore EOS flag
+        scheduler = self.create_scheduler()
+        requests = create_requests(num_requests=1, max_tokens=10)
+        requests[0].sampling_params.ignore_eos = True
+        requests[0].num_computed_tokens = requests[0].num_tokens
+        scheduler.requests[requests[0].request_id] = requests[0]
+        scheduler.running.append(requests[0])
+
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=[],
+            num_scheduled_tokens={requests[0].request_id: 3},
+            total_num_scheduled_tokens=3,
+            scheduled_encoder_inputs={},
+            scheduled_spec_decode_tokens={
+                requests[0].request_id: [EOS_TOKEN_ID, 10]
+            },
+            num_common_prefix_blocks=0,
+            finished_req_ids=set(),
+            free_encoder_input_ids=[],
+            structured_output_request_ids={},
+            grammar_bitmask=None)
+
+        model_output = ModelRunnerOutput(
+            req_ids=[requests[0].request_id],
+            req_id_to_index={requests[0].request_id: 0},
+            sampled_token_ids=[[EOS_TOKEN_ID, 10, 11]],
+            spec_token_ids=None,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[])
+
+        scheduler.update_from_output(scheduler_output, model_output)
+
+        # Verify request continues past EOS
+        self.assertEqual(len(scheduler.running), 1)
+        self.assertFalse(requests[0].is_finished())
+        self.assertEqual(list(requests[0].output_token_ids),
+                         [EOS_TOKEN_ID, 10, 11])
+
+    def test_schedule_concurrent_batches(self):
+        global MAX_NUM_BATCHED_TOKENS
+        global ENABLE_PREFIX_CACHING
+        global ENABLE_CHUNKED_PREFILL
+        global MAX_NUM_SEQS
+        global PROMPT_LOGPROBS
+        ENABLE_PREFIX_CACHING = None
+        MAX_NUM_BATCHED_TOKENS = 1024
+        MAX_NUM_SEQS = 2
+        ENABLE_CHUNKED_PREFILL = True
+        PROMPT_LOGPROBS = None
+
+        enable_prefix_caching_list = [None, True]
+        prompt_logprobs_list = [None, 5]
+
+        for i in range(len(enable_prefix_caching_list)):
+            ENABLE_PREFIX_CACHING = enable_prefix_caching_list[i]
+            PROMPT_LOGPROBS = prompt_logprobs_list[i]
+            scheduler = self.create_scheduler()
+            requests = create_requests(
+                num_requests=2,
+                num_tokens=512,
+            )
+
+            # Schedule the first request.
+            scheduler.add_request(requests[0])
+            scheduler_output0 = scheduler.schedule()
+            self.assertEqual(len(scheduler_output0.scheduled_new_reqs), 1)
+            self.assertEqual(
+                scheduler_output0.num_scheduled_tokens[requests[0].request_id],
+                512)
+
+            # The first request is still running, so only schedule the second request.
+            scheduler.add_request(requests[1])
+            scheduler_output1 = scheduler.schedule()
+            self.assertEqual(len(scheduler_output1.scheduled_new_reqs), 1)
+            self.assertEqual(
+                scheduler_output1.num_scheduled_tokens[requests[1].request_id],
+                512)
+
+            # Model output of the first request.
+            model_runner_output = ModelRunnerOutput(
+                req_ids=[requests[0].request_id],
+                req_id_to_index={requests[0].request_id: 0},
+                sampled_token_ids=[[0]],
+                spec_token_ids=None,
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[])
+
+            scheduler.update_from_output(scheduler_output0,
+                                         model_runner_output)
+
+            # Schedule the next step.
+            # The first request can be scheduled again while the second
+            # request is still running.
+            scheduler.schedule()
+            # Model output of the second request.
+            model_runner_output = ModelRunnerOutput(
+                req_ids=[requests[1].request_id],
+                req_id_to_index={requests[1].request_id: 0},
+                sampled_token_ids=[[0]],
+                spec_token_ids=None,
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[])
+
+            scheduler.update_from_output(scheduler_output1,
+                                         model_runner_output)
+
+    def test_schedule_spec_decoding_stats(self):
+        """Test scheduling behavior with speculative decoding.
+
+        This test verifies that:
+        1. Speculated tokens get scheduled correctly
+        2. Spec decoding stats properly count number of draft and accepted tokens
+        """
+        spec_tokens_list: List[List[List[int]]] = [[[1, 2, 3]], [[1, 2, 3]],
+                                                   [[1, 2], [3]], [[1]], [[]],
+                                                   [[1, 2, 3], [4, 5, 6]]]
+        output_tokens_list: List[List[List[int]]] = [[[1, 2, 3, 4]], [[1, 5]],
+                                                     [[1, 2, 5], [3, 4]],
+                                                     [[1, 2]], [[5]],
+                                                     [[1, 2, 7], [4, 8]]]
+        expected_list: List[Tuple[int, int,
+                                  int, List[int]]] = [(1, 3, 3, [1, 1, 1]),
+                                                      (1, 3, 1, [1, 0, 0]),
+                                                      (2, 3, 3, [2, 1]),
+                                                      (1, 1, 1, [1]),
+                                                      (0, 0, 0, [0]),
+                                                      (2, 6, 3, [2, 1, 0])]
+
+        global NUM_SPECULATIVE_TOKENS
+        for idx in range(len(spec_tokens_list)):
+            spec_tokens = spec_tokens_list[idx]
+            output_tokens = output_tokens_list[idx]
+            expected = expected_list[idx]
+            num_spec_tokens = max(1, max(len(t) for t in spec_tokens))
+            NUM_SPECULATIVE_TOKENS = num_spec_tokens
+            scheduler = self.create_scheduler()
+            requests = create_requests(num_requests=len(spec_tokens),
+                                       num_tokens=1)
+            req_ids = []
+            req_to_index = {}
+            for i, request in enumerate(requests):
+                scheduler.add_request(request)
+                req_ids.append(request.request_id)
+                req_to_index[request.request_id] = i
+
+            # Schedule a decode, which will also draft speculative tokens
+            output = scheduler.schedule()
+            self.assertEqual(len(output.scheduled_new_reqs), len(requests))
+            self.assertEqual(output.total_num_scheduled_tokens, len(requests))
+            for i in range(len(requests)):
+                req_id = requests[i].request_id
+                self.assertEqual(output.num_scheduled_tokens[req_id], 1)
+                self.assertNotIn(req_id, output.scheduled_spec_decode_tokens)
+
+            model_runner_output = ModelRunnerOutput(
+                req_ids=req_ids,
+                req_id_to_index=req_to_index,
+                sampled_token_ids=[[0] for _ in range(len(requests))],
+                spec_token_ids=spec_tokens,
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[])
+
+            engine_core_outputs = scheduler.update_from_output(
+                output, model_runner_output)
+
+            for i in range(len(requests)):
+                running_req = scheduler.running[i]
+                # The prompt token
+                self.assertEqual(running_req.num_computed_tokens, 1)
+                # The prompt token and the sampled token
+                self.assertEqual(running_req.num_tokens, 2)
+                # The prompt token, the sampled token, and the speculated tokens
+                self.assertEqual(running_req.num_tokens_with_spec,
+                                 2 + len(spec_tokens[i]))
+
+            # No draft or accepted tokens counted yet
+            self.assertTrue(
+                not engine_core_outputs
+                or (engine_core_outputs[0].scheduler_stats.spec_decoding_stats
+                    is None))
+
+            # Schedule the speculated tokens for validation
+            output = scheduler.schedule()
+            self.assertEqual(len(output.scheduled_new_reqs), 0)
+            # The sampled token and speculated tokens
+            self.assertEqual(
+                output.total_num_scheduled_tokens,
+                len(requests) + sum(len(ids) for ids in spec_tokens))
+            for i in range(len(requests)):
+                req_id = requests[i].request_id
+                self.assertEqual(output.num_scheduled_tokens[req_id],
+                                 1 + len(spec_tokens[i]))
+                if spec_tokens[i]:
+                    self.assertEqual(
+                        len(output.scheduled_spec_decode_tokens[req_id]),
+                        len(spec_tokens[i]))
+                else:
+                    self.assertNotIn(req_id,
+                                     output.scheduled_spec_decode_tokens)
+
+            model_runner_output = ModelRunnerOutput(
+                req_ids=req_ids,
+                req_id_to_index=req_to_index,
+                sampled_token_ids=output_tokens,
+                spec_token_ids=None,
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[])
+
+            engine_core_outputs = scheduler.update_from_output(
+                output, model_runner_output)
+
+            scheduler_stats = engine_core_outputs[0].scheduler_stats \
+                if engine_core_outputs else None
+            if expected[0] == 0:
+                self.assertIsNone(scheduler_stats.spec_decoding_stats)
+            else:
+                self.assertIsNotNone(scheduler_stats.spec_decoding_stats)
+                stats = scheduler_stats.spec_decoding_stats
+                self.assertEqual(stats.num_drafts, expected[0])
+                self.assertEqual(stats.num_draft_tokens, expected[1])
+                self.assertEqual(stats.num_accepted_tokens, expected[2])
+                self.assertEqual(stats.num_accepted_tokens_per_pos,
+                                 expected[3])
+
+    def assert_scheduler_empty(self, scheduler):
+        """Confirm the scheduler is "empty" - i.e. no leaks."""
+        # Scheduler Metadata.
+        scheduler = self.create_scheduler()
+        self.assertEqual(len(scheduler.requests), 0)
+        self.assertEqual(len(scheduler.waiting), 0)
+        self.assertEqual(len(scheduler.running), 0)
+        self.assertEqual(len(scheduler.finished_req_ids), 0)
+
+        # EncoderCacheManager.
+        self.assertEqual(len(scheduler.encoder_cache_manager.freed), 0)
+        self.assertEqual(len(scheduler.encoder_cache_manager.cached), 0)
+
+        # KVCache Manager.
+        self.assertEqual(
+            len(scheduler.kv_cache_manager.coordinator.single_type_managers[0].
+                req_to_blocks), 0)
+        self.assertEqual(
+            len(scheduler.kv_cache_manager.coordinator.single_type_managers[0].
+                num_cached_block), 0)
+        self.assertEqual(len(scheduler.kv_cache_manager.req_to_block_hashes),
+                         0)
+        self.assertEqual(len(scheduler.kv_cache_manager.req_to_block_hashes),
+                         0)
+        num_free_blocks = (scheduler.kv_cache_manager.block_pool.
+                           free_block_queue.num_free_blocks)
+        self.assertEqual(
+            num_free_blocks,
+            scheduler.kv_cache_manager.block_pool.num_gpu_blocks - 1)
+
+        # NOTE(rob): just the ref count on blocks will be 0. The hash
+        # value, etc will remain since we lazily evict for prefix cache.
+        for block in scheduler.kv_cache_manager.block_pool.blocks:
+            self.assertEqual(block.ref_cnt, 0)
+
+    def test_memory_leak(self):
+        """Test that we do not have a memory leak."""
+        scheduler = self.create_scheduler()
+        NUM_REQUESTS = 5
+        NUM_TOKENS = 10
+        MAX_TOKENS = 10
+        requests = create_requests(num_requests=NUM_REQUESTS,
+                                   num_tokens=NUM_TOKENS,
+                                   max_tokens=MAX_TOKENS)
+
+        # Add each request.
+        for request in requests:
+            scheduler.add_request(request)
+            scheduler_output = scheduler.schedule()
+            model_runner_output = make_output(scheduler)
+            scheduler.update_from_output(scheduler_output, model_runner_output)
+
+        # Iterate until done.
+        while True:
+            scheduler_output = scheduler.schedule()
+            if len(scheduler.running) == 0:
+                break
+            model_runner_output = make_output(scheduler)
+            scheduler.update_from_output(scheduler_output, model_runner_output)
+
+        # Confirm no memory leak.
+        self.assert_scheduler_empty(scheduler)

--- a/tests/ut/core/test_scheduler.py
+++ b/tests/ut/core/test_scheduler.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import torch
 from vllm.config import (CacheConfig, KVTransferConfig, ModelConfig,
                          SchedulerConfig, SpeculativeConfig, VllmConfig)
-from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
+from vllm.multimodal.inputs import PlaceholderRange
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,

--- a/tests/ut/distributed/device_communicators/test_pyhccl.py
+++ b/tests/ut/distributed/device_communicators/test_pyhccl.py
@@ -9,26 +9,11 @@ from vllm_ascend.distributed.device_communicators.pyhccl import \
 
 
 class MockHcclLib:
-
-    def __init__(self, path):
-        pass
-
-    def hcclGetUniqueId(self):
-        uid = MagicMock()
-        uid.internal = list(range(128))  # 128 字节随意填充
-        return uid
-
-    def hcclCommInitRank(self, rank):
-        return f"fake_comm_{rank}"
-
-    def hcclAllReduce(self, *args, **kw):
-        pass
+    pass
 
 
 class MockUniqueId:
-
-    def __init__(self):
-        self.internal = [0] * 128
+    pass
 
 
 class TestPyHcclCommunicator(TestBase):

--- a/tests/ut/distributed/device_communicators/test_pyhccl.py
+++ b/tests/ut/distributed/device_communicators/test_pyhccl.py
@@ -1,0 +1,99 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from vllm.distributed.utils import StatelessProcessGroup
+
+from tests.ut.base import TestBase
+from vllm_ascend.distributed.device_communicators.pyhccl import \
+    PyHcclCommunicator
+
+
+class MockHcclLib:
+
+    def __init__(self, path):
+        pass
+
+    def hcclGetUniqueId(self):
+        uid = MagicMock()
+        uid.internal = list(range(128))  # 128 字节随意填充
+        return uid
+
+    def hcclCommInitRank(self, rank):
+        return f"fake_comm_{rank}"
+
+    def hcclAllReduce(self, *args, **kw):
+        pass
+
+
+class MockUniqueId:
+
+    def __init__(self):
+        self.internal = [0] * 128
+
+
+class TestPyHcclCommunicator(TestBase):
+
+    @patch.dict(os.environ, {"RANK": "0", "WORLD_SIZE": "1"})
+    def test_world_size_1_return_early(self):
+        comm = PyHcclCommunicator(
+            group=StatelessProcessGroup(0, 1, None, None),
+            device="npu:0",
+        )
+        self.assertTrue(comm.disabled)
+        self.assertFalse(comm.available)
+
+    @patch.dict(os.environ, {"RANK": "0", "WORLD_SIZE": "2"})
+    def test_load_hccl_fail(self):
+        comm = PyHcclCommunicator(group=StatelessProcessGroup(
+            0, 2, None, None),
+                                  device="npu:0",
+                                  library_path="/not/exist/path/libhccl.so")
+        self.assertTrue(comm.disabled)
+
+    @patch(
+        "vllm_ascend.distributed.device_communicators.pyhccl_wrapper.HCCLLibrary",
+        MockHcclLib)
+    @patch(
+        "vllm_ascend.distributed.device_communicators.pyhccl_wrapper.hcclUniqueId",
+        MockUniqueId)
+    @patch("torch.npu.device")
+    @patch("vllm_ascend.utils.current_stream",
+           return_value=MagicMock(npu_stream=5678))
+    def test_stateless_group(self, *_):
+        group = StatelessProcessGroup(rank=3,
+                                      world_size=4,
+                                      store=None,
+                                      socket=None)
+
+        comm = PyHcclCommunicator(group=group, device=3)
+
+        self.assertEqual(comm.rank, 3)
+        self.assertEqual(comm.world_size, 4)
+
+    @patch.dict(os.environ, {"RANK": "1", "WORLD_SIZE": "2"})
+    @patch(
+        "vllm_ascend.distributed.device_communicators.pyhccl_wrapper.HCCLLibrary",
+        MockHcclLib)
+    @patch(
+        "vllm_ascend.distributed.device_communicators.pyhccl_wrapper.hcclUniqueId",
+        MockUniqueId)
+    @patch("torch.distributed.is_initialized", return_value=True)
+    @patch("torch.distributed.get_backend", return_value="nccl")
+    @patch("torch.distributed.get_rank", return_value=1)
+    @patch("torch.distributed.get_world_size", return_value=2)
+    @patch("torch.distributed.get_process_group_ranks", return_value=[0, 1])
+    @patch("torch.distributed.broadcast")
+    @patch("torch.npu.device")
+    @patch("vllm_ascend.utils.current_stream",
+           return_value=MagicMock(npu_stream=1234))
+    def test_multi_gpu_pg_torch(
+        self,
+        *_,
+    ):
+        fake_pg = MagicMock()
+        comm = PyHcclCommunicator(group=fake_pg, device="npu:1")
+
+        self.assertEqual(comm.rank, 1)
+        self.assertEqual(comm.world_size, 2)
+        self.assertFalse(comm.available)
+        self.assertTrue(comm.disabled)

--- a/tests/ut/distributed/device_communicators/test_pyhccl_wrapper.py
+++ b/tests/ut/distributed/device_communicators/test_pyhccl_wrapper.py
@@ -1,0 +1,173 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch.distributed import ReduceOp
+
+from tests.ut.base import TestBase
+from vllm_ascend.distributed.device_communicators.pyhccl_wrapper import (
+    Function, HCCLLibrary, aclrtStream_t, buffer_type, hcclComm_t,
+    hcclDataType_t, hcclDataTypeEnum, hcclRedOp_t, hcclRedOpTypeEnum,
+    hcclResult_t, hcclUniqueId)
+
+
+class TestHcclUniqueId(TestBase):
+
+    def test_construct(self):
+        uid = hcclUniqueId()
+        uid.internal[0] = 12
+        self.assertEqual(len(uid.internal), 4108)
+        self.assertEqual(uid.internal[0], 12)
+
+
+class TestHcclDataTypeEnum(TestBase):
+
+    def test_torch_dtype_mapping(self):
+        expected = {
+            torch.int8: hcclDataTypeEnum.hcclInt8,
+            torch.uint8: hcclDataTypeEnum.hcclUint8,
+            torch.int32: hcclDataTypeEnum.hcclInt32,
+            torch.int64: hcclDataTypeEnum.hcclInt64,
+            torch.float16: hcclDataTypeEnum.hcclFloat16,
+            torch.float32: hcclDataTypeEnum.hcclFloat32,
+            torch.float64: hcclDataTypeEnum.hcclFloat64,
+            torch.bfloat16: hcclDataTypeEnum.hcclBfloat16,
+        }
+
+        for torch_dtype, expected_enum in expected.items():
+            with self.subTest(torch_dtype=torch_dtype):
+                self.assertEqual(hcclDataTypeEnum.from_torch(torch_dtype),
+                                 expected_enum)
+
+    def test_unsupported_dtype_raises(self):
+        with self.assertRaises(ValueError):
+            hcclDataTypeEnum.from_torch(torch.complex64)
+
+
+class TestHcclRedOpTypeEnum(TestBase):
+
+    def test_torch_reduce_op_mapping(self):
+        expected = {
+            ReduceOp.SUM: hcclRedOpTypeEnum.hcclSum,
+            ReduceOp.PRODUCT: hcclRedOpTypeEnum.hcclProd,
+            ReduceOp.MAX: hcclRedOpTypeEnum.hcclMax,
+            ReduceOp.MIN: hcclRedOpTypeEnum.hcclMin,
+        }
+
+        for torch_op, expected_enum in expected.items():
+            with self.subTest(torch_op=torch_op):
+                self.assertEqual(hcclRedOpTypeEnum.from_torch(torch_op),
+                                 expected_enum)
+
+    def test_unsupported_op_raises(self):
+        unsupported_op = "NOT_EXIST"
+        with self.assertRaises(ValueError):
+            hcclRedOpTypeEnum.from_torch(unsupported_op)
+
+
+class TestFunction(TestBase):
+
+    def test_construct_with_valid_args(self):
+        func = Function(name="foo", restype=int, argtypes=[int, str, float])
+        self.assertEqual(func.name, "foo")
+        self.assertIs(func.restype, int)
+        self.assertEqual(func.argtypes, [int, str, float])
+
+
+class TestHCLLLibrary(TestBase):
+
+    def test_init_with_nonexistent_so(self):
+        fake_path = "/definitely/not/exist/libhccl.so"
+        with self.assertRaises(OSError):
+            HCCLLibrary(fake_path)
+
+    def test_hccl_get_error_string(self):
+        lib = MagicMock(sepc=HCCLLibrary)
+        mock_fn = MagicMock()
+        mock_fn.return_value = "HCCL internal error"
+        lib.hcclGetErrorString = mock_fn
+
+        result = hcclResult_t(1)
+        msg = lib.hcclGetErrorString(result)
+        self.assertEqual(msg, "HCCL internal error")
+        mock_fn.assert_called_once()
+
+    def test_hccl_check(self):
+        lib = HCCLLibrary.__new__(HCCLLibrary)
+        mock_fn = MagicMock()
+        mock_fn.return_value = "fake error"
+        lib.hcclGetErrorString = mock_fn
+        result = hcclResult_t(123)
+        with self.assertRaises(RuntimeError) as cm:
+            lib.HCCL_CHECK(result)
+
+        self.assertEqual(str(cm.exception), "HCCL error: fake error")
+
+    @patch.object(HCCLLibrary, "HCCL_CHECK")
+    def test_hccl_get_uniqueId(self, mock_HCCL_CHECK):
+        lib = HCCLLibrary.__new__(HCCLLibrary)
+        lib._funcs = {"HcclGetRootInfo": MagicMock(return_value=0)}
+        unique_id = lib.hcclGetUniqueId()
+        self.assertIsInstance(unique_id, hcclUniqueId)
+        lib._funcs["HcclGetRootInfo"].assert_called_once()
+        mock_HCCL_CHECK.assert_called_once_with(0)
+
+    @patch.object(HCCLLibrary, "HCCL_CHECK")
+    def test_hccl_comm_initRank(self, mock_hccl_check):
+        lib = HCCLLibrary.__new__(HCCLLibrary)
+        lib._funcs = {"HcclCommInitRootInfo": MagicMock(return_value=0)}
+
+        world_size = 4
+        unique_id = hcclUniqueId()
+        rank = 1
+
+        comm = lib.hcclCommInitRank(world_size, unique_id, rank)
+        self.assertIsInstance(comm, hcclComm_t)
+        lib._funcs["HcclCommInitRootInfo"].assert_called_once()
+        mock_hccl_check.assert_called_once_with(0)
+
+    @patch.object(HCCLLibrary, "HCCL_CHECK")
+    def test_hccl_all_reduce(self, mock_hccl_check):
+
+        lib = HCCLLibrary.__new__(HCCLLibrary)
+        lib._funcs = {"HcclAllReduce": MagicMock(return_value=0)}
+        sendbuff = buffer_type()
+        recvbuff = buffer_type()
+        count = 10
+        datatype = hcclDataType_t(1)
+        op = hcclRedOp_t(0)
+        comm = hcclComm_t()
+        stream = aclrtStream_t()
+
+        lib.hcclAllReduce(sendbuff, recvbuff, count, datatype, op, comm,
+                          stream)
+
+        lib._funcs["HcclAllReduce"].assert_called_once_with(
+            sendbuff, recvbuff, count, datatype, op, comm, stream)
+        mock_hccl_check.assert_called_once_with(0)
+
+    @patch.object(HCCLLibrary, "HCCL_CHECK")
+    def test_hccl_broad_cast(self, mock_hccl_check):
+
+        lib = HCCLLibrary.__new__(HCCLLibrary)
+        lib._funcs = {"HcclBroadcast": MagicMock(return_value=0)}
+        buff = buffer_type()
+        count = 10
+        datatype = 1
+        root = 0
+        comm = hcclComm_t()
+        stream = aclrtStream_t()
+
+        lib.hcclBroadcast(buff, count, datatype, root, comm, stream)
+
+        lib._funcs["HcclBroadcast"].assert_called_once_with(
+            buff, count, datatype, root, comm, stream)
+        mock_hccl_check.assert_called_once_with(0)
+
+    @patch.object(HCCLLibrary, "HCCL_CHECK")
+    def test_hcclCommDestroy_success(self, mock_hccl_check):
+        lib = HCCLLibrary.__new__(HCCLLibrary)
+        lib._funcs = {"HcclCommDestroy": MagicMock(return_value=0)}
+        comm = hcclComm_t()
+        lib.hcclCommDestroy(comm)
+        lib._funcs["HcclCommDestroy"].assert_called_once_with(comm)
+        mock_hccl_check.assert_called_once_with(0)

--- a/tests/ut/multistream/test_base.py
+++ b/tests/ut/multistream/test_base.py
@@ -1,0 +1,32 @@
+from tests.ut.base import TestBase
+from vllm_ascend.multistream.base import (MSAttentionMetadataSplitConfig,
+                                          MSEventKey)
+
+
+class Testbase(TestBase):
+
+    def test_ms_event_key(self):
+        self.assertEqual(MSEventKey.ATTN_COM_FINISH.value, 0)
+        self.assertEqual(MSEventKey.ATTN_AR_FINISH.value, 1)
+        self.assertEqual(MSEventKey.FFN_COM_FINISH.value, 2)
+        self.assertEqual(MSEventKey.FFN_AR_FINISH.value, 3)
+        self.assertEqual(MSEventKey.MOE_BEFORE_COMM.value, 4)
+        self.assertEqual(MSEventKey.MOE_AFTER_COMM.value, 5)
+        self.assertEqual(MSEventKey.MOE_SE_COMM_FINISH.value, 6)
+        self.assertEqual(MSEventKey.MOE_SE_COMP_FINISH.value, 7)
+        self.assertEqual(MSEventKey.MOE_GATE_FINISH.value, 8)
+
+    def test_ms_attention_metadata_split_config_default(self):
+        config = MSAttentionMetadataSplitConfig()
+        self.assertEqual(config.num_micro_batches, 2)
+        self.assertEqual(config.min_total_tokens_to_split, 256)
+        self.assertEqual(config.min_prefill_tokens_to_split, 64)
+
+    def test_ms_attention_metadata_split_config_custom(self):
+        config = MSAttentionMetadataSplitConfig(
+            num_micro_batches=4,
+            min_total_tokens_to_split=512,
+            min_prefill_tokens_to_split=128)
+        self.assertEqual(config.num_micro_batches, 4)
+        self.assertEqual(config.min_total_tokens_to_split, 512)
+        self.assertEqual(config.min_prefill_tokens_to_split, 128)

--- a/tests/ut/multistream/test_metadata.py
+++ b/tests/ut/multistream/test_metadata.py
@@ -1,0 +1,246 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.multistream.base import MSEventKey
+from vllm_ascend.multistream.metadata import (MultiStreamConfig,
+                                              MultiStreamMetadata,
+                                              MultiStreamStepMetadata,
+                                              split_micro_batches_tensors)
+
+
+class TestMetaData(TestBase):
+
+    def setUp(self):
+        self.test_tensors_list = [torch.randn(100, 1024) for i in range(3)]
+        self.test_tensors = torch.randn(100, 1024)
+        self.test_tensors_dict = {
+            'query': torch.randn(100, 1024),
+            'key': torch.randn(100, 1024),
+            'value': torch.randn(100, 1024)
+        }
+        self.split_index = 50
+
+        mock_stream = MagicMock(spec=torch.npu.Stream)
+        event_keys = [MagicMock(spec=MSEventKey)]
+        multistream_config = MagicMock(spec=MultiStreamConfig)
+
+        self.metadata = MultiStreamMetadata(
+            calculate_stream=mock_stream,
+            communicate_stream=mock_stream,
+            start_layer=1,
+            end_layer=3,
+            event_keys=event_keys,
+            multistream_config=multistream_config)
+
+    def test_split_micro_batches_tensors(self):
+        test_tensors_list_res = split_micro_batches_tensors(
+            self.test_tensors_list, self.split_index)
+        test_tensors_res = split_micro_batches_tensors(self.test_tensors,
+                                                       self.split_index)
+        keys = ['query', 'key', 'value']
+        test_tensors_dict_res = split_micro_batches_tensors(
+            self.test_tensors_dict, self.split_index, keys)
+        for i in range(3):
+            self.assertEqual(len(test_tensors_list_res[i][0]),
+                             self.split_index)
+
+            self.assertEqual(
+                len(test_tensors_list_res[i][0]) +
+                len(test_tensors_list_res[i][1]), 100)
+
+        self.assertEqual(len(test_tensors_res[0]), self.split_index)
+        self.assertEqual(
+            len(test_tensors_res[0]) + len(test_tensors_res[1]), 100)
+
+        for key in keys:
+            self.assertEqual(len(test_tensors_dict_res[0][key]),
+                             self.split_index)
+            self.assertEqual(
+                len(test_tensors_dict_res[0][key]) +
+                len(test_tensors_dict_res[1][key]), 100)
+
+    def test_default_init_multistream_step_metadata(self):
+        metadata = MultiStreamStepMetadata()
+        self.assertIsNone(metadata.comm_stream)
+        self.assertIsNone(metadata.before_comm_event)
+        self.assertIsNone(metadata.after_comm_event)
+
+    def test_custom_init_multistream_step_metadata(self):
+        mockStream = MagicMock(spec=torch.npu.Stream)
+        mockEvent1 = MagicMock(spec=torch.npu.Event)
+        mockEvent2 = MagicMock(spec=torch.npu.Event)
+
+        metadata = MultiStreamStepMetadata(mockStream, mockEvent1, mockEvent2)
+        self.assertEqual(metadata.comm_stream, mockStream)
+        self.assertEqual(metadata.before_comm_event, mockEvent1)
+        self.assertEqual(metadata.after_comm_event, mockEvent2)
+
+    def test_default_init_multistream_config(self):
+        config = MultiStreamConfig()
+        self.assertEqual(config.min_total_tokens_to_split, 256)
+        self.assertEqual(config.min_prefill_tokens_to_split, 64)
+        self.assertEqual(config.num_micro_batches, 2)
+        self.assertEqual(config.imbalance_ratio, 0.1)
+
+    def test_custom_init_multistream_config(self):
+        config = MultiStreamConfig(512, 128, 1, 0.2)
+        self.assertEqual(config.min_total_tokens_to_split, 512)
+        self.assertEqual(config.min_prefill_tokens_to_split, 128)
+        self.assertEqual(config.num_micro_batches, 1)
+        self.assertEqual(config.imbalance_ratio, 0.2)
+
+    def test_init_multistream_metadata(self):
+        mock_stream = MagicMock(spec=torch.npu.Stream)
+
+        event_keys = [MagicMock()]
+        multistream_config = MagicMock(spec=MultiStreamConfig)
+
+        metadata = MultiStreamMetadata(calculate_stream=mock_stream,
+                                       communicate_stream=mock_stream,
+                                       start_layer=1,
+                                       end_layer=3,
+                                       event_keys=event_keys,
+                                       multistream_config=multistream_config)
+
+        self.assertEqual(metadata.calculate_stream, mock_stream)
+        self.assertEqual(metadata.communicate_stream, mock_stream)
+        self.assertEqual(metadata.start_layer, 1)
+        self.assertEqual(metadata.end_layer, 3)
+        self.assertEqual(metadata.ms_config, multistream_config)
+        self.assertTrue(metadata.causal_lm)
+
+    def test_build_events(self):
+        mock_stream = MagicMock(spec=torch.npu.Stream)
+        mock_event = MagicMock(spec=torch.npu.Event)
+        with patch('torch.npu.Event', return_value=mock_event):
+            event_keys = [MagicMock(spec=MSEventKey)]
+            multistream_config = MultiStreamConfig(
+                num_micro_batches=2,
+                min_total_tokens_to_split=256,
+                min_prefill_tokens_to_split=64)
+
+            metadata = MultiStreamMetadata(
+                calculate_stream=mock_stream,
+                communicate_stream=mock_stream,
+                start_layer=1,
+                end_layer=3,
+                event_keys=event_keys,
+                multistream_config=multistream_config)
+
+            expected_events = {
+                0: {
+                    0: {
+                        event_keys[0]: mock_event
+                    },
+                    1: {
+                        event_keys[0]: mock_event
+                    }
+                },
+                1: {
+                    0: {
+                        event_keys[0]: mock_event
+                    },
+                    1: {
+                        event_keys[0]: mock_event
+                    }
+                },
+                2: {
+                    0: {
+                        event_keys[0]: mock_event
+                    },
+                    1: {
+                        event_keys[0]: mock_event
+                    }
+                }
+            }
+            self.assertEqual(metadata.ms_events, expected_events)
+
+    def test_build_ms_split_config(self):
+        mock_stream = MagicMock(spec=torch.npu.Stream)
+        event_keys = [MagicMock(spec=MSEventKey)]
+        multistream_config = MagicMock(spec=MultiStreamConfig)
+        multistream_config.num_micro_batches = 2
+        multistream_config.min_total_tokens_to_split = 256
+        multistream_config.min_prefill_tokens_to_split = 64
+
+        metadata = MultiStreamMetadata(calculate_stream=mock_stream,
+                                       communicate_stream=mock_stream,
+                                       start_layer=1,
+                                       end_layer=3,
+                                       event_keys=event_keys,
+                                       multistream_config=multistream_config)
+
+        self.assertIsNotNone(metadata.ms_split_config)
+        self.assertEqual(metadata.ms_split_config.num_micro_batches,
+                         multistream_config.num_micro_batches)
+        self.assertEqual(metadata.ms_split_config.min_total_tokens_to_split,
+                         multistream_config.min_total_tokens_to_split)
+        self.assertEqual(metadata.ms_split_config.min_prefill_tokens_to_split,
+                         multistream_config.min_prefill_tokens_to_split)
+
+    def test_try_wait_event(self):
+        mock_stream = MagicMock(spec=torch.npu.Stream)
+        mock_event = MagicMock(spec=torch.npu.Event)
+        event_keys = [MagicMock(spec=MSEventKey)]
+        multistream_config = MagicMock(spec=MultiStreamConfig)
+        with patch('torch.npu.Event', return_value=mock_event):
+            metadata = MultiStreamMetadata(
+                calculate_stream=mock_stream,
+                communicate_stream=mock_stream,
+                start_layer=1,
+                end_layer=3,
+                event_keys=event_keys,
+                multistream_config=multistream_config)
+
+            metadata.try_wait_event(layer_index=1,
+                                    micro_batch_index=0,
+                                    event_key=event_keys[0])
+            mock_event.wait.assert_called_once()
+
+    def test_try_record_event(self):
+        mock_stream = MagicMock(spec=torch.npu.Stream)
+        mock_event = MagicMock(spec=torch.npu.Event)
+        event_keys = [MagicMock(spec=MSEventKey)]
+        multistream_config = MagicMock(spec=MultiStreamConfig)
+        with patch('torch.npu.Event', return_value=mock_event):
+            metadata = MultiStreamMetadata(
+                calculate_stream=mock_stream,
+                communicate_stream=mock_stream,
+                start_layer=1,
+                end_layer=3,
+                event_keys=event_keys,
+                multistream_config=multistream_config)
+
+            metadata.try_record_event(layer_index=1,
+                                      micro_batch_index=0,
+                                      event_key=event_keys[0])
+            mock_event.record.assert_called_once()
+
+    def test_merge_batches_none_input(self):
+        input_tensors = None
+        result = self.metadata.merge_micro_batches(input_tensors)
+        self.assertIsNone(result)
+
+    def test_merge_batches_single_tensor_input(self):
+        input_tensors = [torch.tensor([1, 2, 3])]
+        result = self.metadata.merge_micro_batches(input_tensors)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(torch.equal(result[0], torch.tensor([1, 2, 3])))
+
+    def test_merge_batches_list_of_tensors_input(self):
+        input_tensors = [torch.tensor([1, 2]), torch.tensor([3, 4])]
+        result = self.metadata.merge_micro_batches(input_tensors)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result, input_tensors)
+
+    def test_merge_batches_nested_list_input(self):
+        input_tensors = [[torch.tensor([1, 2]),
+                          torch.tensor([3, 4])],
+                         [torch.tensor([5, 6]),
+                          torch.tensor([7, 8])]]
+        result = self.metadata.merge_micro_batches(input_tensors)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(torch.equal(result[0], torch.tensor([1, 2, 3, 4])))
+        self.assertTrue(torch.equal(result[1], torch.tensor([5, 6, 7, 8])))

--- a/tests/ut/multistream/test_ms_split.py
+++ b/tests/ut/multistream/test_ms_split.py
@@ -1,0 +1,147 @@
+from unittest.mock import MagicMock
+
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.multistream.base import MSAttentionMetadataSplitConfig
+from vllm_ascend.multistream.ms_split import (compute_split_seq_index,
+                                              model_input_split_v1_mla_attn,
+                                              split_attn_int_type,
+                                              split_attn_tensor_type)
+
+
+class TestMsSplit(TestBase):
+
+    def test_decode_only(self):
+        result = compute_split_seq_index(
+            query_lens=None,
+            attn_state=AscendAttentionState.DecodeOnly,
+            num_tokens=10)
+        self.assertEqual(result, [5, 5])
+
+    def test_perfect_balance(self):
+        query_lens = [2, 3, 5]
+        result = compute_split_seq_index(
+            query_lens=query_lens,
+            attn_state=AscendAttentionState.PrefillNoCache,
+            num_tokens=10)
+        self.assertEqual(result, [5, 2])
+
+    def test_imbalance(self):
+        query_lens = [1, 2, 3, 4]
+        result = compute_split_seq_index(
+            query_lens=query_lens,
+            attn_state=AscendAttentionState.PrefillNoCache,
+            num_tokens=10)
+        self.assertEqual(result, [0, 0])
+
+    def test_query_lens_none(self):
+        with self.assertRaises(AssertionError):
+            compute_split_seq_index(
+                query_lens=None,
+                attn_state=AscendAttentionState.PrefillNoCache,
+                num_tokens=10)
+
+    def test_empty_query_lens(self):
+        query_lens: list[int] = []
+        result = compute_split_seq_index(
+            query_lens=query_lens,
+            attn_state=AscendAttentionState.PrefillNoCache,
+            num_tokens=10)
+        self.assertEqual(result, [0, 0])
+
+    def test_single_query_len(self):
+        query_lens = [10]
+        result = compute_split_seq_index(
+            query_lens=query_lens,
+            attn_state=AscendAttentionState.PrefillNoCache,
+            num_tokens=10)
+        self.assertEqual(result, [0, 0])
+
+    def test_split_attn_tensor_type_middle(self):
+        input_tensor = torch.tensor([1, 2, 3, 4, 5])
+        index = 3
+        expected_result = [torch.tensor([1, 2, 3]), torch.tensor([4, 5])]
+        result = split_attn_tensor_type(input_tensor, index)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(torch.equal(result[0], expected_result[0]))
+        self.assertTrue(torch.equal(result[1], expected_result[1]))
+
+    def test_split_attn_tensor_type_start(self):
+        input_tensor = torch.tensor([1, 2, 3, 4, 5])
+        index = 0
+        expected_result = [torch.tensor([]), torch.tensor([1, 2, 3, 4, 5])]
+        result = split_attn_tensor_type(input_tensor, index)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(torch.equal(result[0], expected_result[0]))
+        self.assertTrue(torch.equal(result[1], expected_result[1]))
+
+    def test_split_attn_tensor_type_end(self):
+        input_tensor = torch.tensor([1, 2, 3, 4, 5])
+        index = 5
+        expected_result = [torch.tensor([1, 2, 3, 4, 5]), torch.tensor([])]
+        result = split_attn_tensor_type(input_tensor, index)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(torch.equal(result[0], expected_result[0]))
+        self.assertTrue(torch.equal(result[1], expected_result[1]))
+
+    def test_split_attn_tensor_type_empty_tensor(self):
+        input_tensor = torch.tensor([])
+        index = 0
+        expected_result = [torch.tensor([]), torch.tensor([])]
+        result = split_attn_tensor_type(input_tensor, index)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(torch.equal(result[0], expected_result[0]))
+        self.assertTrue(torch.equal(result[1], expected_result[1]))
+
+    def test_split_attn_int_type_index_greater_than_var(self):
+        var = 5
+        index = 10
+        expected_result = [5, 0]
+        result = split_attn_int_type(var, index)
+        self.assertEqual(result, expected_result)
+
+    def test_split_attn_int_type_index_equal_to_var(self):
+        var = 5
+        index = 5
+        expected_result = [5, 0]
+        result = split_attn_int_type(var, index)
+        self.assertEqual(result, expected_result)
+
+    def test_split_attn_int_type_index_less_than_var(self):
+        var = 10
+        index = 5
+        expected_result = [5, 5]
+        result = split_attn_int_type(var, index)
+        self.assertEqual(result, expected_result)
+
+    def test_split_attn_int_type_index_zero(self):
+        var = 10
+        index = 0
+        expected_result = [0, 10]
+        result = split_attn_int_type(var, index)
+        self.assertEqual(result, expected_result)
+
+    def test_split_attn_int_type_var_zero(self):
+        var = 0
+        index = 5
+        expected_result = [0, 0]
+        result = split_attn_int_type(var, index)
+        self.assertEqual(result, expected_result)
+
+    def test_split_attn_int_type_both_zero(self):
+        var = 0
+        index = 0
+        expected_result = [0, 0]
+        result = split_attn_int_type(var, index)
+        self.assertEqual(result, expected_result)
+
+    def test_split_v1_mla_attn_input_none(self):
+        attn_metadata = None
+        ascendMLAPrefillMetadata = MagicMock()
+        ms_split_config = MSAttentionMetadataSplitConfig(num_micro_batches=1)
+        result = model_input_split_v1_mla_attn(attn_metadata,
+                                               ascendMLAPrefillMetadata,
+                                               ms_split_config)
+        self.assertEqual(result, [None])

--- a/tests/ut/ops/test_cache.py
+++ b/tests/ut/ops/test_cache.py
@@ -1,0 +1,32 @@
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.ops.cache import concat_and_cache_mla
+
+
+class TestCache(TestBase):
+
+    def setUp(self):
+        self.num_tokens = 4
+        self.num_kv_head = 1
+        self.nope = 3
+        self.rope = 4
+        self.num_blocks = 2
+        self.block_size = 2
+        self.kv_c_normed = torch.randn(self.num_tokens, self.nope)
+        self.k_pe = torch.randn(self.num_tokens, self.num_kv_head, self.rope)
+        self.kv_cache = torch.zeros(self.num_blocks, self.block_size,
+                                    self.num_kv_head, self.nope + self.rope)
+        self.slot_mapping = torch.tensor([0, 1, 2, 3])
+
+    def test_concat_and_cache_mla(self):
+        concat_and_cache_mla(self.kv_c_normed, self.k_pe, self.kv_cache,
+                             self.slot_mapping)
+        kv_cache_reshaped = self.kv_cache.view(
+            self.num_blocks * self.block_size, self.num_kv_head, -1)
+        expected = torch.cat([self.kv_c_normed.unsqueeze(1), self.k_pe],
+                             dim=-1).squeeze(1)
+        for i in range(self.num_tokens):
+            idx = self.slot_mapping[i].item()
+            self.assertTrue(torch.allclose(kv_cache_reshaped[idx],
+                                           expected[i]))


### PR DESCRIPTION
### What this PR does / why we need it?
Add some uts for vllm ascend
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/8d0a01a5f2b53794e4bc6b734d7b63cb8a9b7d7d
