### PR TITLE
[Fix] Removes explicit ATB extension registration

### DIFF
--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -22,7 +22,6 @@ from typing import Optional
 import torch
 import torch.nn as nn
 import torch_npu
-from torch_npu.op_plugin.atb._atb_ops import _register_atb_extensions
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
@@ -63,7 +62,6 @@ class NPUWorker(WorkerBase):
         # Register ops when worker init.
         from vllm_ascend import ops
         ops.register_dummy_fusion_op()
-        _register_atb_extensions()
         # init ascend config
         init_ascend_config(vllm_config)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Since the ATB extension registration has now been fixed in torch_npu, we have removed the invocation of this private method.

This is the `main` version of #1921 .

### Does this PR introduce _any_ user-facing change?
None.

### How was this patch tested?
No need for further testing.

- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/8d0a01a5f2b53794e4bc6b734d7b63cb8a9b7d7d
