### PR TITLE
[Build] Make buid_py work in develop installation mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,6 +298,7 @@ class custom_install(install):
 
     def run(self):
         self.run_command("build_ext")
+        self.run_command("build_py")
         install.run(self)
 
 
@@ -354,7 +355,8 @@ def get_requirements() -> List[str]:
 cmdclass = {
     "build_py": custom_build_info,
     "build_ext": cmake_build_ext,
-    "install": custom_install
+    "install": custom_install,
+    "develop": custom_install
 }
 
 setup(


### PR DESCRIPTION
### What this PR does / why we need it?
This pr makes `buid_py` work in develop installation mode, e.g., `python setup.py develop`.

Before this pr, there is no `_build_info.py` generated in `vllm_ascend` when using `python setup.py develop` to install vllm-ascend


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/8d0a01a5f2b53794e4bc6b734d7b63cb8a9b7d7d
