### PR TITLE
[Bug] Add prefix parameter to parent class initialization

### DIFF
--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -342,7 +342,7 @@ class AscendQwen2VisionTransformer(Qwen2VisionTransformer):
 class AscendQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__(vllm_config=vllm_config)
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
         self.visual = AscendQwen2VisionTransformer(
             self.config.vision_config,
             norm_eps=getattr(self.config, "rms_norm_eps", 1e-6),


### PR DESCRIPTION
Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>

### What this PR does / why we need it?
Add prefix parameter to parent class initialization to avoid parameter naming conflicts

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/32142b3c62277ac7cb941f2036270decb6b514f4
