### PR TITLE
[Bug] use hidden_size_per_attention_head for scale_value

### DIFF
--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -115,7 +115,7 @@ class AscendQwen2_5_VisionAttention(Qwen2_5_VisionAttention):
             key=k,
             value=v,
             seq_len=cu_seqlens,
-            scale_value=self.origin_hidden_size_per_attention_head**-0.5,
+            scale_value=self.hidden_size_per_attention_head**-0.5,
             num_heads=self.num_attention_heads_per_partition,
             num_kv_heads=self.num_attention_heads_per_partition,
             out=context_layer)

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -103,7 +103,7 @@ class AscendQwen2VisionAttention(Qwen2VisionAttention):
             key=k,
             value=v,
             seq_len=self.cu_seqlens,
-            scale_value=self.origin_hidden_size_per_attention_head**-0.5,
+            scale_value=self.hidden_size_per_attention_head**-0.5,
             num_heads=self.num_attention_heads_per_partition,
             num_kv_heads=self.num_attention_heads_per_partition,
             out=context_layer)


### PR DESCRIPTION
Signed-off-by: wuzhongjian <wuzhongjian_yewu@cmss.chinamobile.com>

### What this PR does / why we need it?
```
self.hidden_size_per_attention_head = dist_utils.divide(
            projection_size, num_heads)
self.origin_hidden_size_per_attention_head = self.hidden_size_per_attention_head
if self.hidden_size_per_attention_head > MIN_PAD_SIZE and self.hidden_size_per_attention_head < MAX_PAD_SIZE:
            self.hidden_size_per_attention_head = MAX_PAD_SIZE
```
The intention of this code of `__init__` method is: when the hidden size of each attention head is between 64 and 128, it will be filled to 128 to optimize the computing performance on the Ascend platform.
However, in the `forward` method, when calling `torch_npu._npu_flash_attention_unpad`, `scale_value` uses the original `origin_hidden_size_per_attention_head`. Rather than the `hidden_size_per_attention_head` that might be filled in:
```
scale_value=self.origin_hidden_size_per_attention_head**-0.5,
```
If `hidden_size_per_attention_head` is filled to 128, but `scale_value` still uses the `origin_hidden_size_per_attention_head`(for example, 84), it will lead to an incorrect scaling ratio, thereby affecting the calculation accuracy of the attention weight.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/2671334d45ea96ca57938cc765ba26cdb796d067
