### PR TITLE
[main] Optimize rope in Qwen3

### DIFF
--- a/vllm_ascend/models/qwen3.py
+++ b/vllm_ascend/models/qwen3.py
@@ -4,15 +4,18 @@ from typing import Optional, Union
 import torch
 from torch import nn
 from transformers import Qwen3Config
+from vllm.attention import AttentionType
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.interfaces import SupportsLoRA, SupportsPP
 from vllm.model_executor.models.qwen2 import Qwen2Model
-from vllm.model_executor.models.qwen3 import Qwen3DecoderLayer
+from vllm.model_executor.models.qwen3 import Qwen3Attention, Qwen3MLP
 from vllm.model_executor.models.utils import (AutoWeightsLoader,
                                               PPMissingLayer, maybe_prefix)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
@@ -21,7 +24,43 @@ from vllm.sequence import IntermediateTensors
 from vllm_ascend.ops.layernorm import AddRMSNormW8A8Quant
 
 
-class CustomQwen3DecoderLayer(Qwen3DecoderLayer):
+class CustomQwen3Attention(Qwen3Attention):
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        # Add qk-norm
+        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim,
+                           self.head_dim)
+        q_by_head = self.q_norm(q_by_head)
+        q = q_by_head.view(q.shape)
+        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim,
+                           self.head_dim)
+        k_by_head = self.k_norm(k_by_head)
+        k = k_by_head.view(k.shape)
+        if type(self.rotary_emb) is RotaryEmbedding:
+            # We optimized RotaryEmbedding by moving index_select of cos & sin outside.
+            # if cos & sin are provided, set is_cos_sin_cached to True to skip index_select.
+            q, k = self.rotary_emb(positions,
+                                   q,
+                                   k,
+                                   cos=cos,
+                                   sin=sin,
+                                   is_cos_sin_cached=True)
+        else:
+            q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class CustomQwen3DecoderLayer(nn.Module):
 
     def __init__(
         self,
@@ -30,31 +69,99 @@ class CustomQwen3DecoderLayer(Qwen3DecoderLayer):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
-        super().__init__(config=config,
-                         cache_config=cache_config,
-                         quant_config=quant_config,
-                         prefix=prefix)
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        # Requires transformers > 4.32.0
+        rope_theta = getattr(config, "rope_theta", 1000000)
+        rope_scaling = getattr(config, "rope_scaling", None)
+
+        # By default, Qwen3 uses causal attention as it is a decoder-only model.
+        # You can override the HF config with `is_causal=False` to enable
+        # bidirectional attention, which is used in some embedding models
+        # (e.g. Alibaba-NLP/gte-Qwen3-7B-instruct)
+        if getattr(config, "is_causal", True):
+            attn_type = AttentionType.DECODER
+        else:
+            attn_type = AttentionType.ENCODER_ONLY
+
+        self.self_attn = CustomQwen3Attention(
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            max_position=config.max_position_embeddings,
+            num_kv_heads=config.num_key_value_heads,
+            rope_theta=rope_theta,
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, 'attention_bias', False),
+            head_dim=getattr(config, 'head_dim', None),
+            cache_config=cache_config,
+            quant_config=quant_config,
+            rope_scaling=rope_scaling,
+            prefix=f"{prefix}.self_attn",
+            attn_type=attn_type,
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
         if quant_config is None:
-            return
+            self.input_layernorm = RMSNorm(config.hidden_size,
+                                           eps=config.rms_norm_eps)
+            self.post_attention_layernorm = RMSNorm(config.hidden_size,
+                                                    eps=config.rms_norm_eps)
+        else:
+            from vllm_ascend.quantization.quant_config import AscendQuantConfig
+            from vllm_ascend.quantization.w8a8 import AscendW8A8LinearMethod
 
-        from vllm_ascend.quantization.quant_config import AscendQuantConfig
-        from vllm_ascend.quantization.w8a8 import AscendW8A8LinearMethod
+            assert isinstance(quant_config, AscendQuantConfig), \
+                "Expected quant_config to be an instance of AscendQuantConfig"
 
-        assert isinstance(quant_config, AscendQuantConfig), \
-            "Expected quant_config to be an instance of AscendQuantConfig"
+            if isinstance(self.self_attn.qkv_proj.quant_method.quant_method,
+                          AscendW8A8LinearMethod):
+                self.input_layernorm = AddRMSNormW8A8Quant(
+                    config.hidden_size,
+                    layer=self.self_attn.qkv_proj,
+                    eps=config.rms_norm_eps)
+            else:
+                self.input_layernorm = RMSNorm(config.hidden_size,
+                                               eps=config.rms_norm_eps)
+            if isinstance(self.mlp.gate_up_proj.quant_method.quant_method,
+                          AscendW8A8LinearMethod):
+                self.post_attention_layernorm = AddRMSNormW8A8Quant(
+                    config.hidden_size,
+                    layer=self.mlp.gate_up_proj,
+                    eps=config.rms_norm_eps)
+            else:
+                self.post_attention_layernorm = RMSNorm(
+                    config.hidden_size, eps=config.rms_norm_eps)
 
-        if isinstance(self.self_attn.qkv_proj.quant_method.quant_method,
-                      AscendW8A8LinearMethod):
-            self.input_layernorm = AddRMSNormW8A8Quant(
-                config.hidden_size,
-                layer=self.self_attn.qkv_proj,
-                eps=config.rms_norm_eps)
-        if isinstance(self.mlp.gate_up_proj.quant_method.quant_method,
-                      AscendW8A8LinearMethod):
-            self.post_attention_layernorm = AddRMSNormW8A8Quant(
-                config.hidden_size,
-                layer=self.mlp.gate_up_proj,
-                eps=config.rms_norm_eps)
+    def forward(
+        self,
+        positions: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Self Attention
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(
+                hidden_states, residual)
+        hidden_states = self.self_attn(
+            positions=positions,
+            cos=cos,
+            sin=sin,
+            hidden_states=hidden_states,
+        )
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
 
 
 ALL_DECODER_LAYER_TYPES = {
@@ -77,6 +184,57 @@ class CustomQwen3Model(Qwen2Model):
         super().__init__(vllm_config=vllm_config,
                          prefix=prefix,
                          decoder_layer_type=CustomQwen3DecoderLayer)
+        self.cos_sin_cache = None
+        first_existing_layer = self.layers[self.start_layer]
+        if type(first_existing_layer.self_attn.rotary_emb) is RotaryEmbedding:
+            self.cos_sin_cache = first_existing_layer.self_attn.rotary_emb.cos_sin_cache
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.get_input_embeddings(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        # Generate cos and sin outside layers to avoid repeated calculation.
+        cos, sin = None, None
+        if self.cos_sin_cache is not None:
+            cos_sin = self.cos_sin_cache.index_select(0, positions)
+            last_dim = cos_sin.size()[-1]
+            cos, sin = cos_sin.reshape(-1, 2,
+                                       last_dim // 2).repeat(1, 1,
+                                                             2).chunk(2,
+                                                                      dim=-2)
+            # BSNH
+            cos, sin = cos.view(1, -1, 1, last_dim).contiguous(), sin.view(
+                1, -1, 1, last_dim).contiguous()
+
+        for layer in self.layers[self.start_layer:self.end_layer]:
+            hidden_states, residual = layer(
+                positions,
+                cos,
+                sin,
+                hidden_states,
+                residual,
+            )
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({
+                "hidden_states": hidden_states,
+                "residual": residual
+            })
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
 
 
 class CustomQwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -32,13 +32,15 @@ def custom_rotary_embedding_enabled(query, neox_style, head_size):
 
 
 def rope_forward_oot(
-    self,
-    positions: torch.Tensor,
-    query: torch.Tensor,
-    key: torch.Tensor,
-    offsets: Optional[torch.Tensor] = None,
-    is_neox_style_override: Optional[bool] = None
-) -> Tuple[torch.Tensor, torch.Tensor]:
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        offsets: Optional[torch.Tensor] = None,
+        cos: torch.Tensor = None,
+        sin: torch.Tensor = None,
+        is_neox_style_override: Optional[bool] = None,
+        is_cos_sin_cached: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
     if get_ascend_config().torchair_graph_config.enabled:
         return self.forward_native(
             positions,
@@ -72,17 +74,25 @@ def rope_forward_oot(
         raise NotImplementedError(
             "Batched rotary embedding is currently not supported on NPU.")
     else:
-        # TODO: Remove the contiguous in the future.
-        query = query.contiguous().view(query.shape[0], -1)
-        key = key.contiguous().view(key.shape[0], -1)
-        torch_npu._npu_rotary_embedding(
-            positions,
-            query,
-            key,
-            self.head_size,
-            self.cos_sin_cache,
-            neox_style,
-        )
+        if is_cos_sin_cached and neox_style and self.head_size == self.rotary_dim and self.head_size == 128:
+            # If cos and sin are generated outside, use npu_apply_rotary_pos_emb to avoid redundant calculation.
+            # This method requires head_size and rotary_dim equal 128 and neox_style is True
+            query = query.contiguous().view(1, query.shape[0], -1,
+                                            self.head_size)
+            key = key.contiguous().view(1, key.shape[0], -1, self.head_size)
+            torch_npu.npu_apply_rotary_pos_emb(query, key, cos, sin)
+        else:
+            # TODO: Remove the contiguous in the future.
+            query = query.contiguous().view(query.shape[0], -1)
+            key = key.contiguous().view(key.shape[0], -1)
+            torch_npu._npu_rotary_embedding(
+                positions,
+                query,
+                key,
+                self.head_size,
+                self.cos_sin_cache,
+                neox_style,
+            )
     return query.view(query_shape), key.view(key_shape)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
Optimize rope by extracting index_select from layers into model, which can reduce (layer_num -1) * 2 Gather ops in each prefill/decode stage. Simultaneously, The original operator is replaced with the more efficient operator.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with new added/existing test.


- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ebf7605b0dd58ff5d572d1918e52ca732025eee0
