### PR TITLE
[Optimize]Change AI Vector core number getting function to glibc ABI free  funcition

### DIFF
--- a/tests/e2e/singlecard/ops/test_vocabparallelembedding.py
+++ b/tests/e2e/singlecard/ops/test_vocabparallelembedding.py
@@ -5,6 +5,9 @@ import torch
 import torch_npu  # noqa: F401
 
 import vllm_ascend.platform  # noqa: F401
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
 
 # Test parameters
 DTYPES = [torch.int32]


### PR DESCRIPTION

### What this PR does / why we need it?
Change AI Vector core number getting function to glibc ABI free  function. After this PR merged in, there should been no glibc ABI problems for bump torch version to 2.7.1.

### Does this PR introduce _any_ user-facing change?
No


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/f59ec35b7f9ff5b1da8aae12e10b83154685c958
