### PR TITLE
[P/D] NIXL Connector for v1 distributed

### DIFF
--- a/tools/install_nixl.sh
+++ b/tools/install_nixl.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Usage: ./install_nixl.sh [--force]
+
+FORCE=false
+if [ "$1" == "--force" ]; then
+    FORCE=true
+fi
+
+SUDO=false
+if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    SUDO=true
+fi
+
+# A function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+if command_exists apt; then
+    if $SUDO; then
+        sudo apt install -y build-essential cmake pkg-config
+    else
+        apt install -y build-essential cmake pkg-config
+    fi
+elif command_exists dnf; then
+    if $SUDO; then
+        sudo dnf install -y gcc-c++ cmake pkg-config
+    else
+        dnf install -y gcc-c++ cmake pkg-config
+    fi
+else
+    echo "No apt or dnf package manager detected"
+    exit 1
+fi
+
+ARCH=$(uname -m)
+
+ROOT_DIR="/usr/local"
+mkdir -p "$ROOT_DIR"
+UCX_HOME="$ROOT_DIR/ucx"
+NIXL_HOME="$ROOT_DIR/nixl"
+
+export PATH="$UCX_HOME/bin:$NIXL_HOME/bin:$PATH"
+export LD_LIBRARY_PATH="$UCX_HOME/lib:$NIXL_HOME/lib/$ARCH-linux-gnu:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$UCX_HOME/lib/pkgconfig"
+
+TEMP_DIR="nixl_installer"
+mkdir -p "$TEMP_DIR"
+cd "$TEMP_DIR"
+
+pip install meson ninja pybind11
+
+if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
+    echo "Installing UCX"
+    wget https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz
+    tar xzf ucx-1.18.0.tar.gz; rm ucx-1.18.0.tar.gz
+    cd ucx-1.18.0
+    
+    ./configure  --prefix=$UCX_HOME                \
+                --enable-shared                    \
+                --disable-static                   \
+                --disable-doxygen-doc              \
+                --enable-optimizations             \
+                --enable-cma                       \
+                --enable-devel-headers             \
+                --with-dm                          \
+                --with-verbs                       \
+                --enable-mt
+    make -j
+    make -j install-strip
+    
+    if $SUDO; then
+        echo "Running ldconfig with sudo"
+        sudo ldconfig
+    else
+        echo "Skipping ldconfig - sudo not available"
+        echo "Please run 'sudo ldconfig' manually if needed"
+    fi
+
+    cd ..
+else
+    echo "Found existing UCX. Skipping UCX installation"  
+fi
+
+if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
+    echo "Installing NIXL"
+    wget https://github.com/ai-dynamo/nixl/archive/refs/tags/0.4.1.tar.gz
+    tar xzf 0.4.1.tar.gz; rm 0.4.1.tar.gz
+    cd nixl-0.4.1
+    meson setup build --prefix=$NIXL_HOME -Ducx_path=$UCX_HOME -Ddisable_gds_backend=true
+    cd build
+    ninja
+    ninja install
+    cd ..
+    pip install .
+    cd ..
+else
+    echo "Found existing NIXL. Skipping NIXL installation"  
+fi

--- a/vllm_ascend/distributed/__init__.py
+++ b/vllm_ascend/distributed/__init__.py
@@ -22,3 +22,9 @@ KVConnectorFactory.register_connector(
     "LLMDataDistCMgrConnector",
     "vllm_ascend.distributed.llmdatadist_c_mgr_connector",
     "LLMDataDistCMgrConnector")
+
+
+KVConnectorFactory.register_connector(
+    "NixlNpuConnector",
+    "vllm_ascend.distributed.nixl_npu_connector",
+    "NixlNpuConnector")

--- a/vllm_ascend/distributed/nixl_npu_connector.py
+++ b/vllm_ascend/distributed/nixl_npu_connector.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any, Tuple
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+    NixlConnector
+)
+
+
+class NixlNpuConnector(NixlConnector):
+    
+    ############################################################
+    # Worker Side Methods
+    ############################################################
+    def register_kv_caches(
+            self,
+            kv_caches: dict[
+                str,  # type: ignore[override]
+                Tuple[torch.Tensor]]):
+        converted_kv_caches: dict[str, torch.Tensor] = {
+            key: tensor_tuple[0] for key, tensor_tuple in kv_caches.items()
+        }
+        assert self.connector_worker is not None
+        self.connector_worker.register_kv_caches(converted_kv_caches)
+    
+


### PR DESCRIPTION
### What this PR does / why we need it?

This PR is a benchmark example of using NIXL TransferEngine to implement disaggregate prefill. After compiling and installing NIXL, the vLLM V1 engine can use NIXL for KV Cache transmission between Ascend NPUs.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

docker image: quay.io/ascend/vllm-ascend:v0.9.2rc1
NIXL version: v0.5.0

### NIXL

See detail [NIXL](https://github.com/ai-dynamo/nixl)

### Prerequisites for NIXL source build

Run the tools/install_nixl.sh script for automatic installation, or refer to the following steps for manual installation.

#### Ubuntu
```bash
apt install -y build-essential cmake pkg-config
pip3 install meson ninja pybind11
```

#### UCX
```bash
wget https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz
tar xzf ucx-1.18.0.tar.gz
cd ucx-1.18.0
# Remove the cuda and gdrcopy parameters
./configure  --prefix=/opt/ucx       \
    --enable-shared                    \
    --disable-static                   \
    --disable-doxygen-doc              \
    --enable-optimizations             \
    --enable-cma                       \
    --enable-devel-headers             \
    --with-verbs                       \
    --with-dm                          \
    --enable-mt
make -j
make -j install-strip
ldconfig

# ucx env
export PATH=$PATH:/opt/ucx/bin
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ucx/lib
export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/ucx/lib/pkgconfig
```

### NIXL Build & install

```bash
git clone https://github.com/ai-dynamo/nixl.git
cd nixl
meson setup build \
    -Ducx_path=/opt/ucx \
    -Dinstall_headers=true \
    -Ddisable_gds_backend=true
cd build
ninja
ninja install
cd ..
pip3 install .

# If you need to compile the nixl wheel package (optional)
pip3 install build
python3 -m build --wheel
```

###  Test & benchmark 
```bash
# File path : vllm-ascend/examples/disaggregated_prefill/
bash test_nixl_connector.sh
```

### Example

The register_kv_caches interface of vLLM-Ascend is inconsistent with the upstream vLLM. A new NixlNpuConnector is added to override the register_kv_caches method.

#### disagg prefill
```bash
  ASCEND_RT_VISIBLE_DEVICES=0 python3 \
    -m vllm.entrypoints.openai.api_server \
    --model deepseek-ai/DeepSeek-R1-Distill-Qwen-7B \
    --port 30100 \
    --gpu-memory-utilization 0.9 \
    --kv-transfer-config \
    '{"kv_connector":"NixlNpuConnector","kv_role":"kv_producer","kv_rank":0,"kv_parallel_size":1,"kv_buffer_size":5e9}' 
```

#### decode
```bash
  ASCEND_RT_VISIBLE_DEVICES=1 python3 \
    -m vllm.entrypoints.openai.api_server \
    --model deepseek-ai/DeepSeek-R1-Distill-Qwen-7B \
    --port 30200 \
    --gpu-memory-utilization 0.9 \
    --kv-transfer-config \
    '{"kv_connector":"NixlNpuConnector","kv_role":"kv_consumer","kv_rank":1,"kv_parallel_size":1,"kv_buffer_size":5e9}' 
```
#### proxy server
```bash
python3 toy_proxy_server.py --host 0.0.0.0 --port 30000 \
    --prefiller-hosts localhost --prefiller-port 30100 \
    --decoder-hosts localhost --decoder-ports 30200
```


- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/5bbaf492a6238ff517249e73151ae9989f7bea9e
