### PR TITLE
[v0.9.1][Doc][PD] Restore the default configuration items in examples/disaggregate_prefill_v1/README.md

### DIFF
--- a/examples/disaggregate_prefill_v1/README.md
+++ b/examples/disaggregate_prefill_v1/README.md
@@ -28,7 +28,7 @@ Execution Sequence
 - Start Decode on Node 2 (D2)
 - Start proxy server on Node1
 
-* Run prefill server P1 on first node
+Run prefill server P1 on first node:
 ```shell
 export HCCL_IF_IP=172.19.32.175  # node ip
 export GLOO_SOCKET_IFNAME="eth0"  # network card name
@@ -71,7 +71,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   '{"torchair_graph_config": {"enabled":false}, "ascend_scheduler_config":{"enabled":false}, "chunked_prefill_for_mla":true}' 
 ```
 
-* Run prefill server P2 on second node
+Run prefill server P2 on second node:
 ```shell
 export HCCL_IF_IP=172.19.241.49
 export GLOO_SOCKET_IFNAME="eth0"
@@ -115,7 +115,9 @@ vllm serve /models/deepseek_r1_w8a8 \
   '{"torchair_graph_config": {"enabled":false}, "ascend_scheduler_config":{"enabled":false}, "chunked_prefill_for_mla":true}' 
 ```
 
-* Run decode server d1 on third node
+Run decode server d1 on third node:
+
+* In the D node, the `max-num-batched-tokens` does not need to be set to 36K (since the D node runs a maximum of `max-num-seqs` batches, profile_run only needs to run the number of `max-num-seqs`). So the `max-num-batched-tokens` can be set to `max-num-seqs`, which will reduce the activation memory consumption.
 ```shell
 export HCCL_IF_IP=172.19.123.51
 export GLOO_SOCKET_IFNAME="eth0"
@@ -157,7 +159,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   '{"torchair_graph_config": {"enabled":true},  "ascend_scheduler_config":{"enabled":false}}' 
 ```
 
-* Run decode server d2 on last node
+Run decode server d2 on last node:
 ```shell
 export HCCL_IF_IP=172.19.190.36
 export GLOO_SOCKET_IFNAME="eth0"
@@ -200,13 +202,13 @@ vllm serve /models/deepseek_r1_w8a8 \
   '{"torchair_graph_config": {"enabled":false},  "ascend_scheduler_config":{"enabled":false}}' 
 ```
 
-* Run proxy server on the first node
+Run proxy server on the first node:
 ```shell
 cd /vllm-workspace/vllm-ascend/examples/disaggregate_prefill_v1
 python toy_proxy_server.py --host 172.19.32.175 --port 1025 --prefiller-hosts 172.19.241.49 --prefiller-port 20002 --decoder-hosts 172.19.123.51 --decoder-ports 20002
 ```
 
-* Verification
+Verification
 Check service health using the proxy server endpoint:
 ```shell
 curl http://localhost:1025/v1/completions \
@@ -219,8 +221,8 @@ curl http://localhost:1025/v1/completions \
     }'
 ```
 
-* Performance
-Test performance with vllm benchmark
+Performance
+Test performance with vllm benchmark:
 ```shell
 cd /vllm-workspace/vllm/benchmarks
 python3 benchmark_serving.py \

--- a/examples/disaggregate_prefill_v1/README.md
+++ b/examples/disaggregate_prefill_v1/README.md
@@ -19,7 +19,11 @@ bash gen_ranktable.sh --ips 172.19.32.175 172.19.241.49 172.19.123.51 172.19.190
 ```
 Rank table will generated at `/vllm-workspace/vllm-ascend/examples/disaggregate_prefill_v1/ranktable.json`
 
-## Start disaggregated vLLM-ascend service 
+## Start disaggregated vLLM-ascend service
+For demonstration purposes, we will utilize the quantized version of Deepseek-R1. Recommended Parallelization Strategies:
+- P-node: DP2-TP8-EP16 (Data Parallelism 2, Tensor Parallelism 8, Expert Parallelism 16)
+- D-node: DP4-TP4-EP16 (Data Parallelism 4, Tensor Parallelism 4, Expert Parallelism 16)
+
 Execution Sequence
 - 4 configured node ip are: 172.19.32.175 172.19.241.49 172.19.123.51 172.19.190.36
 - Start Prefill on Node 1 (P1)
@@ -38,7 +42,7 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
-VLLM_LLMDD_RPC_PORT=5559
+export VLLM_LLMDD_RPC_PORT=5559
 
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
@@ -68,7 +72,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false}, "ascend_scheduler_config":{"enabled":false}, "chunked_prefill_for_mla":true}' 
+  '{"chunked_prefill_for_mla":true}' 
 ```
 
 Run prefill server P2 on second node:
@@ -81,7 +85,7 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
-VLLM_LLMDD_RPC_PORT=5659
+export VLLM_LLMDD_RPC_PORT=5659
 
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
@@ -103,7 +107,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   --enforce-eager \
   --gpu-memory-utilization 0.9  \
   --kv-transfer-config  \
-  '{"kv_connector": "LLMDataDistCMgrConnector", \
+  '{"kv_connector": "LLMDataDistCMgrConnector",
   "kv_buffer_device": "npu",
   "kv_role": "kv_producer",
   "kv_parallel_size": 1,
@@ -112,12 +116,12 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false}, "ascend_scheduler_config":{"enabled":false}, "chunked_prefill_for_mla":true}' 
+  '{"chunked_prefill_for_mla":true}'
 ```
 
 Run decode server d1 on third node:
 
-* In the D node, the `max-num-batched-tokens` does not need to be set to 36K (since the D node runs a maximum of `max-num-seqs` batches, profile_run only needs to run the number of `max-num-seqs`). So the `max-num-batched-tokens` can be set to `max-num-seqs`, which will reduce the activation memory consumption.
+* In the D node, the `max-num-batched-tokens` parameter can be set to a smaller value since the D node processes at most `max-num-seqs` batches concurrently. As the `profile_run` only needs to handle `max-num-seqs` sequences at a time, we can safely set `max-num-batched-tokens` equal to `max-num-seqs`. This optimization will help reduce activation memory consumption.
 ```shell
 export HCCL_IF_IP=172.19.123.51
 export GLOO_SOCKET_IFNAME="eth0"
@@ -127,17 +131,17 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
-VLLM_LLMDD_RPC_PORT=5759
+export VLLM_LLMDD_RPC_PORT=5759
 
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
   --port 20002 \
-  --data-parallel-size 2 \
-  --data-parallel-size-local 1 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
   --api-server-count 2 \
   --data-parallel-address 172.19.123.51 \
   --data-parallel-rpc-port 13356 \
-  --tensor-parallel-size 8 \
+  --tensor-parallel-size 4 \
   --enable-expert-parallel \
   --seed 1024 \
   --served-model-name deepseek \
@@ -156,7 +160,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":true},  "ascend_scheduler_config":{"enabled":false}}' 
+  '{"torchair_graph_config": {"enabled":true}}' 
 ```
 
 Run decode server d2 on last node:
@@ -169,18 +173,18 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
-VLLM_LLMDD_RPC_PORT=5859
+export VLLM_LLMDD_RPC_PORT=5859
 
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
   --port 20002 \
   --headless \
-  --data-parallel-size 2 \
-  --data-parallel-start-rank 1 \
-  --data-parallel-size-local 1 \
+  --data-parallel-size 4 \
+  --data-parallel-start-rank 2 \
+  --data-parallel-size-local 2 \
   --data-parallel-address 172.19.123.51 \
   --data-parallel-rpc-port 13356 \
-  --tensor-parallel-size 8 \
+  --tensor-parallel-size 4 \
   --enable-expert-parallel \
   --seed 1024 \
   --served-model-name deepseek \
@@ -199,7 +203,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false},  "ascend_scheduler_config":{"enabled":false}}' 
+  '{"torchair_graph_config": {"enabled":true}}' 
 ```
 
 Run proxy server on the first node:

--- a/examples/disaggregate_prefill_v1/README.md
+++ b/examples/disaggregate_prefill_v1/README.md
@@ -38,6 +38,8 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
+VLLM_LLMDD_RPC_PORT=5559
+
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
   --port 20002 \
@@ -48,11 +50,11 @@ vllm serve /models/deepseek_r1_w8a8 \
   --data-parallel-rpc-port 13356 \
   --tensor-parallel-size 8 \
   --enable-expert-parallel \
-  --no-enable-prefix-caching \
   --seed 1024 \
   --served-model-name deepseek \
-  --max-model-len 6144  \
-  --max-num-batched-tokens 6144  \
+  --max-model-len 32768  \
+  --max-num-batched-tokens 32768  \
+  --max-num-seqs 256 \
   --trust-remote-code \
   --enforce-eager \
   --gpu-memory-utilization 0.9  \
@@ -66,7 +68,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false, "enable_multistream_shared_expert":false}, "ascend_scheduler_config":{"enabled":true, "enable_chunked_prefill":false}}'
+  '{"torchair_graph_config": {"enabled":false}, "ascend_scheduler_config":{"enabled":false}, "chunked_prefill_for_mla":true}' 
 ```
 
 * Run prefill server P2 on second node
@@ -79,6 +81,8 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
+VLLM_LLMDD_RPC_PORT=5659
+
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
   --port 20002 \
@@ -90,11 +94,11 @@ vllm serve /models/deepseek_r1_w8a8 \
   --data-parallel-rpc-port 13356 \
   --tensor-parallel-size 8 \
   --enable-expert-parallel \
-  --no-enable-prefix-caching \
   --seed 1024 \
   --served-model-name deepseek \
-  --max-model-len 6144  \
-  --max-num-batched-tokens 6144  \
+  --max-model-len 32768  \
+  --max-num-batched-tokens 32768  \
+  --max-num-seqs 256 \
   --trust-remote-code \
   --enforce-eager \
   --gpu-memory-utilization 0.9  \
@@ -108,7 +112,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false, "enable_multistream_shared_expert":false},  "ascend_scheduler_config":{"enabled":true, "enable_chunked_prefill":false}}' 
+  '{"torchair_graph_config": {"enabled":false}, "ascend_scheduler_config":{"enabled":false}, "chunked_prefill_for_mla":true}' 
 ```
 
 * Run decode server d1 on third node
@@ -121,6 +125,8 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
+VLLM_LLMDD_RPC_PORT=5759
+
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
   --port 20002 \
@@ -131,13 +137,12 @@ vllm serve /models/deepseek_r1_w8a8 \
   --data-parallel-rpc-port 13356 \
   --tensor-parallel-size 8 \
   --enable-expert-parallel \
-  --no-enable-prefix-caching \
   --seed 1024 \
   --served-model-name deepseek \
-  --max-model-len 6144  \
-  --max-num-batched-tokens 6144  \
+  --max-model-len 32768  \
+  --max-num-batched-tokens 256  \
+  --max-num-seqs 256 \
   --trust-remote-code \
-  --enforce-eager \
   --gpu-memory-utilization 0.9  \
   --kv-transfer-config  \
   '{"kv_connector": "LLMDataDistCMgrConnector",
@@ -149,7 +154,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false, "enable_multistream_shared_expert":false},  "ascend_scheduler_config":{"enabled":true, "enable_chunked_prefill":false}}'
+  '{"torchair_graph_config": {"enabled":true},  "ascend_scheduler_config":{"enabled":false}}' 
 ```
 
 * Run decode server d2 on last node
@@ -162,6 +167,8 @@ export DISAGGREGATED_PREFILL_RANK_TABLE_PATH=/vllm-workspace/vllm-ascend/example
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=100
 export VLLM_USE_V1=1
+VLLM_LLMDD_RPC_PORT=5859
+
 vllm serve /models/deepseek_r1_w8a8 \
   --host 0.0.0.0 \
   --port 20002 \
@@ -173,13 +180,12 @@ vllm serve /models/deepseek_r1_w8a8 \
   --data-parallel-rpc-port 13356 \
   --tensor-parallel-size 8 \
   --enable-expert-parallel \
-  --no-enable-prefix-caching \
   --seed 1024 \
   --served-model-name deepseek \
-  --max-model-len 6144  \
-  --max-num-batched-tokens 6144  \
+  --max-model-len 32768  \
+  --max-num-batched-tokens 256  \
+  --max-num-seqs 256 \
   --trust-remote-code \
-  --enforce-eager \
   --gpu-memory-utilization 0.9  \
   --kv-transfer-config  \
   '{"kv_connector": "LLMDataDistCMgrConnector",
@@ -191,7 +197,7 @@ vllm serve /models/deepseek_r1_w8a8 \
   "kv_connector_module_path": "vllm_ascend.distributed.llmdatadist_c_mgr_connector"
   }'  \
   --additional-config \
-  '{"torchair_graph_config": {"enabled":false, "enable_multistream_shared_expert":false},  "ascend_scheduler_config":{"enabled":true, "enable_chunked_prefill":false}}' 
+  '{"torchair_graph_config": {"enabled":false},  "ascend_scheduler_config":{"enabled":false}}' 
 ```
 
 * Run proxy server on the first node


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
- In the D node, the `max-num-batched-tokens` parameter can be set to a smaller value since the D node processes at most `max-num-seqs` batches concurrently. As the `profile_run` only needs to handle `max-num-seqs` sequences at a time, we can safely set `max-num-batched-tokens` equal to `max-num-seqs`. This optimization will help reduce activation memory consumption.
- Restore the default configuration items for PD separation. 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

