### PR TITLE
[0.9.1][bugfixed] fix the bug when run the inference of quantized ds-w8a8-mtp

### DIFF
--- a/vllm_ascend/quantization/func_wrapper.py
+++ b/vllm_ascend/quantization/func_wrapper.py
@@ -22,6 +22,38 @@ import torch_npu
 from vllm.logger import logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.vocab_parallel_embedding import DEFAULT_VOCAB_PADDING_SIZE
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+
+# func refers to vocabParallelEmbedding.__init__
+def wrapper_vocab_parallel_embedding_init(func):
+
+    def init(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        params_dtype: Optional[torch.dtype] = None,
+        org_num_embeddings: Optional[int] = None,
+        padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        func(
+            self,
+            num_embeddings,
+            embedding_dim,
+            params_dtype,
+            org_num_embeddings,
+            padding_size,
+            quant_config,
+            prefix,
+        )
+        if params_dtype is None:
+            params_dtype = torch.get_default_dtype()
+        self.params_dtype = params_dtype
+
+    return init
 
 
 # func refers to RMSNorm.__init__

--- a/vllm_ascend/quantization/func_wrapper.py
+++ b/vllm_ascend/quantization/func_wrapper.py
@@ -22,8 +22,8 @@ import torch_npu
 from vllm.logger import logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-from vllm.model_executor.layers.vocab_parallel_embedding import DEFAULT_VOCAB_PADDING_SIZE
-from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    DEFAULT_VOCAB_PADDING_SIZE, QuantizationConfig)
 
 
 # func refers to vocabParallelEmbedding.__init__

--- a/vllm_ascend/quantization/quantizer.py
+++ b/vllm_ascend/quantization/quantizer.py
@@ -23,7 +23,8 @@ from typing import Any, Dict, List, Optional
 from vllm.logger import logger
 
 from .func_wrapper import (wrapper_load_model, wrapper_rmsnorm_forward_oot,
-                           wrapper_rmsnorm_init)
+                           wrapper_rmsnorm_init,
+                           wrapper_vocab_parallel_embedding_init)
 from .w4a8_dynamic import (AscendW4A8DynamicFusedMoEMethod,
                            AscendW4A8DynamicLinearMethod)
 from .w8a8 import AscendW8A8LinearMethod
@@ -79,6 +80,9 @@ class VLLMAscendQuantizer:
                 VLLMAscendQuantizer.apply_patch(
                     "vllm_ascend.worker.model_runner.NPUModelRunnerBase",
                     "load_model", [wrapper_load_model])
+                VLLMAscendQuantizer.apply_patch(
+                    "vllm.model_executor.layers.vocab_parallel_embedding.VocabParallelEmbedding",
+                    "__init__", [wrapper_vocab_parallel_embedding_init])
                 break
         VLLMAscendQuantizer.patched = True
         logger.info("Using the vLLM Ascend Quantizer version now!")


### PR DESCRIPTION
1. add wrapper of vocab_parallel_embedding, fixed the bugs when running deepseek-w8a8-mtp

Signed-off-by: curryliu <120010041@link.cuhk.edu.cn>
