### PR TITLE
[main][bugfix]Fix the issue where quantized model fails to start due to errors in VLLMAscendQuantizer.apply_patch

### DIFF
--- a/vllm_ascend/quantization/quantizer.py
+++ b/vllm_ascend/quantization/quantizer.py
@@ -82,7 +82,7 @@ class VLLMAscendQuantizer:
                     "vllm.model_executor.layers.layernorm.RMSNorm",
                     "forward_oot", [wrapper_rmsnorm_forward_oot])
                 VLLMAscendQuantizer.apply_patch(
-                    "vllm_ascend.worker.model_runner.NPUModelRunnerBase",
+                    "vllm_ascend.worker.model_runner_v1.NPUModelRunner",
                     "load_model", [wrapper_load_model])
                 break
         VLLMAscendQuantizer.patched = True


### PR DESCRIPTION
### What this PR does / why we need it?
In [this line of code](https://github.com/vllm-project/vllm-ascend/blob/ae560f71318a4ce242b087be9c5f8addaefd2c7f/vllm_ascend/quantization/quantizer.py#L85), it imports the vllm_ascend.worker.model_runner module. However, the main branch no longer has vllm_ascend.worker.model_runner, which causes the quantization model to fail during startup. This PR fixes the issue.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed with new added/existing test.


