### PR TITLE
[CI] Remove transformers installation

### DIFF
--- a/.github/workflows/nightly_benchmarks.yaml
+++ b/.github/workflows/nightly_benchmarks.yaml
@@ -117,7 +117,6 @@ jobs:
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          pip install "transformers<=4.52.4"
           pip install -e .
           pip install -r benchmarks/requirements-bench.txt
 


### PR DESCRIPTION
### What this PR does / why we need it?
Remove transformers installation, The transformers version bug has been fixed by https://github.com/vllm-project/vllm/commit/e936e401debe7fba64d6462666d7dc632bc76357. We can safe to remove the version limit now
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.9.2
- vLLM main: https://github.com/vllm-project/vllm/commit/40d86ee412eeeca93e0c37432db6b96829cb64e2
