### PR TITLE
[0.9.1][bugfix] Remove unnecessary reduce_results access in shared_experts.down_proj

### DIFF
--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1329,11 +1329,6 @@ class AscendFusedMoE(FusedMoE):
         if shared_experts:
             if not self.enable_multistream_moe or fused_moe_state != FusedMoEState.MC2:
                 shared_hidden_states = shared_experts(hidden_states)
-                if (not self.enable_prefill_optimizations
-                        and not shared_experts.down_proj.reduce_results
-                        and shared_experts.down_proj.tp_size > 1):
-                    shared_hidden_states = tensor_model_parallel_all_reduce(
-                        shared_hidden_states)
 
         mc2_mask = forward_context.mc2_mask
         tp_size = get_tensor_model_parallel_world_size()


### PR DESCRIPTION
Remove redundant all-reduce logic in shared_experts.down_proj introduced in earlier PR #1802