### PR TITLE
[main][bugfix]Fix vLLM startup failure when inferring DeepSeek R1 model in DP scenario

### DIFF
--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1469,6 +1469,8 @@ class AscendFusedMoE(FusedMoE):
                     e_hidden_states, dim=0)
                 final_hidden_states = final_hidden_states[:num_tokens]
                 dispose_tensor(e_hidden_states)
+            else:
+                final_hidden_states = e_hidden_states
         else:
             final_hidden_states = e_hidden_states
 

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1471,6 +1471,7 @@ class AscendFusedMoE(FusedMoE):
                 dispose_tensor(e_hidden_states)
             else:
                 final_hidden_states = e_hidden_states
+                dispose_tensor(e_hidden_states)
         else:
             final_hidden_states = e_hidden_states
 

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1471,7 +1471,6 @@ class AscendFusedMoE(FusedMoE):
                 dispose_tensor(e_hidden_states)
             else:
                 final_hidden_states = e_hidden_states
-                dispose_tensor(e_hidden_states)
         else:
             final_hidden_states = e_hidden_states
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fix vLLM startup failure when inferring DeepSeek R1 model in DP scenario.
When running vLLM inference for the DeepSeek R1 model in DP32+TP1 configuration, the vLLM service fails to start with the following error.
<img width="1786" height="918" alt="21b2011042d4f77f36f5243fa64d9c18" src="https://github.com/user-attachments/assets/df1963fe-587e-43ca-822e-a9094d0034fb" /> 
The root cause is a missing else branch after [this line of code](https://github.com/vllm-project/vllm-ascend/blob/d629f0b2b573c3ba858a09fc93c42f2c2634e043/vllm_ascend/ops/fused_moe.py#L1411). This PR fixes the issue.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed with new added/existing test.


- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5bbaf492a6238ff517249e73151ae9989f7bea9e
