### PR TITLE
Upgrade CANN to 8.2.RC1 (A3)

### DIFF
--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:8.1.rc1-a3-ubuntu22.04-py3.10
+FROM quay.io/ascend/cann:8.2.rc1-a3-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:8.1.rc1-a3-openeuler22.03-py3.10
+FROM quay.io/ascend/cann:8.2.rc1-a3-openeuler22.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1


### PR DESCRIPTION
### What this PR does / why we need it?
Upgrade CANN to 8.2.RC1

### Does this PR introduce _any_ user-facing change?
Yes, A3 image are using 8.2.rc1

### How was this patch tested?
CI passed
- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/de509ae8eb4467bd789234d909e5c725b8fba326
