### PR TITLE
Fix for tp execute model output

### DIFF
--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -19,6 +19,7 @@
 
 from typing import Optional
 
+import copy
 import torch
 import torch.nn as nn
 import torch_npu
@@ -27,7 +28,8 @@ from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
-from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized
+from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
+                                        has_kv_transfer_group)
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
@@ -35,7 +37,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, GiB_bytes
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
-from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
 
 from vllm_ascend.ascend_config import init_ascend_config
@@ -204,9 +206,21 @@ class NPUWorker(WorkerBase):
             assert isinstance(output, IntermediateTensors)
             get_pp_group().send_tensor_dict(output.tensors,
                                             all_gather_group=get_tp_group())
-            return None
+            if not has_kv_transfer_group():
+                return None
+            # In case of PP with kv transfer, we need to pass through the
+            # finished_sending and finished_recving buffers.
+            new_output = EMPTY_MODEL_RUNNER_OUTPUT
+            if (output.finished_sending or output.finished_recving
+                    or output.finished_loading_dict):
+                new_output = copy.copy(new_output)
+                new_output.finished_sending = output.finished_sending
+                new_output.finished_recving = output.finished_recving
+                new_output.finished_loading_dict = output.finished_loading_dict
+            output = new_output
+
         assert isinstance(output, ModelRunnerOutput)
-        return output if self.is_driver_worker else None
+        return output
 
     def load_model(self) -> None:
         if self.vllm_config.model_config.enable_sleep_mode:


### PR DESCRIPTION
### What this PR does / why we need it?
- Fix for model running in tensor parallelism: without this modification, with vllm tag v0.10.0 and current vllm_ascend main branch, models can return None, which is then accessed in "update_finished_set(output.finished_sending". This causes an exception.

- Fixes: Ported code from gpu_worker in vllm, which checks for kv_transfer_group.

### Does this PR introduce _any_ user-facing change?
No function signature modified. The execute_model function has a modified behavior to check for finished transfers of KV.

### How was this patch tested?

