### PR TITLE
[0.9.1][bugfix] fix bf16 multistream

### DIFF
--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -139,6 +139,7 @@ def fused_experts_with_mc2(
     moe_all_to_all_group_name: Optional[str] = None,
     shared_experts: Optional[Any] = None,
     is_torchair: bool = False,
+    hidden_states_for_share: Optional[Any] = None,
     mc2_mask: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     quant_mode = 0
@@ -202,8 +203,9 @@ def fused_experts_with_mc2(
 
     if shared_experts is not None:
         with npu_stream_switch("moe_secondary", 0):
-            npu_wait_tensor(hidden_states, topk_weights)
-            shared_gate_up, _ = shared_experts.gate_up_proj(hidden_states)
+            npu_wait_tensor(hidden_states_for_share, topk_weights)
+            shared_gate_up, _ = shared_experts.gate_up_proj(
+                hidden_states_for_share)
             npu_wait_tensor(shared_gate_up, expand_x)
             shared_act = shared_experts.act_fn(shared_gate_up)
 
@@ -279,7 +281,7 @@ def fused_experts_with_mc2(
         **kwargs_mc2
     ) if enable_dispatch_v2 else torch_npu.npu_moe_distribute_combine(
         **kwargs_mc2)
-    
+
     group_list_type = 1
     if shared_experts is None:
         return hidden_states, expert_token_nums, group_list_type
@@ -1011,6 +1013,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         e_score_correction_bias: Optional[torch.Tensor] = None,
         is_prefill: bool = False,
         enable_force_load_balance: bool = False,
+        hidden_states_for_share: Optional[Any] = None,
         shared_experts: Optional[Any] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -1066,6 +1069,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 moe_all_to_all_group_name=self.moe_all_to_all_group_name,
                 shared_experts=shared_experts,
                 is_torchair=self.torchair_graph_enabled,
+                hidden_states_for_share=hidden_states_for_share,
                 mc2_mask=mc2_mask,
             )
         elif fused_moe_state == FusedMoEState.AllGather:
@@ -1308,7 +1312,7 @@ class AscendFusedMoE(FusedMoE):
         forward_context = get_forward_context()
         fused_moe_state = get_forward_context().fused_moe_state
         # For w8a8 dynamic we can do npu_dynamic_quant and gate in parallel.
-        quantized_x_for_share, dynamic_scale_for_share = None, None
+        hidden_states_for_share, dynamic_scale_for_share = None, None
         from vllm_ascend.quantization.w8a8_dynamic import \
             AscendW8A8DynamicFusedMoEMethod
 
@@ -1322,12 +1326,13 @@ class AscendFusedMoE(FusedMoE):
                     router_logits, _ = gate(hidden_states.float())
                 else:
                     router_logits, _ = gate(hidden_states)
+                hidden_states_for_share = hidden_states
                 if hasattr(self.quant_method, "quant_method") and (
                         isinstance(self.quant_method.quant_method,
                                    AscendW8A8DynamicFusedMoEMethod)
                         and fused_moe_state == FusedMoEState.MC2):
                     with npu_stream_switch("moe_secondary", 0):
-                        quantized_x_for_share, dynamic_scale_for_share = (
+                        hidden_states_for_share, dynamic_scale_for_share = (
                             torch_npu.npu_dynamic_quant(hidden_states))
 
         if shared_experts:
@@ -1411,7 +1416,7 @@ class AscendFusedMoE(FusedMoE):
             shared_experts=(shared_experts if self.torchair_graph_enabled
                             and self.enable_multistream_moe and not is_prefill
                             else None),
-            quantized_x_for_share=quantized_x_for_share,
+            hidden_states_for_share=hidden_states_for_share,
             dynamic_scale_for_share=dynamic_scale_for_share,
             mc2_mask=mc2_mask,
             token_dispatcher=self.token_dispatcher,

--- a/vllm_ascend/quantization/w4a8_dynamic.py
+++ b/vllm_ascend/quantization/w4a8_dynamic.py
@@ -233,7 +233,7 @@ class AscendW4A8DynamicFusedMoEMethod:
         log2phy: torch.Tensor = None,
         global_redundant_expert_num: int = 0,
         shared_experts: Optional[Any] = None,
-        quantized_x_for_share: Optional[Any] = None,
+        hidden_states_for_share: Optional[Any] = None,
         dynamic_scale_for_share: Optional[Any] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -273,9 +273,9 @@ class AscendW4A8DynamicFusedMoEMethod:
         shared_gate_up, shared_dequant_scale = None, None
         if shared_experts is not None and fused_moe_state == FusedMoEState.MC2:
             with npu_stream_switch("moe_secondary", 0):
-                npu_wait_tensor(quantized_x_for_share, router_logits)
+                npu_wait_tensor(hidden_states_for_share, router_logits)
                 share_up_out, _ = shared_experts.gate_up_proj(
-                    (quantized_x_for_share, dynamic_scale_for_share))
+                    (hidden_states_for_share, dynamic_scale_for_share))
                 shared_gate_up, shared_dequant_scale = share_up_out[
                     0], share_up_out[1]
 
@@ -306,7 +306,7 @@ class AscendW4A8DynamicFusedMoEMethod:
                 global_redundant_expert_num=global_redundant_expert_num,
                 shared_experts=shared_experts,
                 is_torchair=self.torchair_graph_enabled,
-                quantized_x_for_share=shared_gate_up,
+                hidden_states_for_share=shared_gate_up,
                 dynamic_scale_for_share=shared_dequant_scale,
                 mc2_mask=kwargs.get("mc2_mask", None))
         else:

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -284,7 +284,7 @@ def fused_experts_with_mc2(
     is_torchair: bool = False,
     w1_scale_bias: torch.Tensor = None,
     w2_scale_bias: torch.Tensor = None,
-    quantized_x_for_share: Optional[Any] = None,
+    hidden_states_for_share: Optional[Any] = None,
     dynamic_scale_for_share: Optional[Any] = None,
     mc2_mask: Optional[torch.Tensor] = None,
 ) -> Union[Tuple[torch.Tensor, torch.Tensor, int], Tuple[
@@ -351,9 +351,9 @@ def fused_experts_with_mc2(
 
     if shared_experts is not None:
         with npu_stream_switch("moe_secondary", 0):
-            npu_wait_tensor(quantized_x_for_share, expand_x)
+            npu_wait_tensor(hidden_states_for_share, expand_x)
             shared_act_out = shared_experts.act_fn(
-                (quantized_x_for_share, dynamic_scale_for_share))
+                (hidden_states_for_share, dynamic_scale_for_share))
             shared_act, swiglu_out_scale = shared_act_out[0], shared_act_out[1]
 
     # `expand_x` will be disposed in the `apply_mlp` function
@@ -451,7 +451,7 @@ def fused_prefill_experts_with_mc2(
     is_torchair: bool = False,
     w1_scale_bias: torch.Tensor = None,
     w2_scale_bias: torch.Tensor = None,
-    quantized_x_for_share: Optional[Any] = None,
+    hidden_states_for_share: Optional[Any] = None,
     dynamic_scale_for_share: Optional[Any] = None,
     mc2_mask: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -501,7 +501,7 @@ def fused_prefill_experts_with_mc2(
             is_torchair=is_torchair,
             w1_scale_bias=w1_scale_bias,
             w2_scale_bias=w2_scale_bias,
-            quantized_x_for_share=quantized_x_for_share,
+            hidden_states_for_share=hidden_states_for_share,
             dynamic_scale_for_share=dynamic_scale_for_share,
             mc2_mask=mc2_mask_chunk)
         end_indx += hidden_states_chunk.shape[0]
@@ -1051,7 +1051,7 @@ class AscendW8A8DynamicFusedMoEMethod:
         log2phy: torch.Tensor = None,
         global_redundant_expert_num: int = 0,
         shared_experts: Optional[Any] = None,
-        quantized_x_for_share: Optional[Any] = None,
+        hidden_states_for_share: Optional[Any] = None,
         dynamic_scale_for_share: Optional[Any] = None,
         prefix: str = "",
         running_in_super_kernel: bool = False,
@@ -1094,9 +1094,9 @@ class AscendW8A8DynamicFusedMoEMethod:
                 )
             if shared_experts is not None and fused_moe_state == FusedMoEState.MC2:
                 with npu_stream_switch("moe_secondary", 0):
-                    npu_wait_tensor(quantized_x_for_share, router_logits)
+                    npu_wait_tensor(hidden_states_for_share, router_logits)
                     share_up_out, _ = shared_experts.gate_up_proj(
-                        (quantized_x_for_share, dynamic_scale_for_share))
+                        (hidden_states_for_share, dynamic_scale_for_share))
                     shared_gate_up, shared_dequant_scale = share_up_out[
                         0], share_up_out[1]
 
@@ -1127,7 +1127,7 @@ class AscendW8A8DynamicFusedMoEMethod:
                     global_redundant_expert_num=global_redundant_expert_num,
                     shared_experts=shared_experts,
                     is_torchair=self.torchair_graph_enabled,
-                    quantized_x_for_share=shared_gate_up,
+                    hidden_states_for_share=shared_gate_up,
                     dynamic_scale_for_share=shared_dequant_scale,
                     mc2_mask=kwargs.get("mc2_mask", None))
         elif fused_moe_state == FusedMoEState.MC2_PREFILL:
@@ -1146,7 +1146,7 @@ class AscendW8A8DynamicFusedMoEMethod:
                 global_redundant_expert_num=global_redundant_expert_num,
                 shared_experts=shared_experts,
                 is_torchair=self.torchair_graph_enabled,
-                quantized_x_for_share=shared_gate_up,
+                hidden_states_for_share=shared_gate_up,
                 dynamic_scale_for_share=shared_dequant_scale,
                 mc2_mask=kwargs.get("mc2_mask", None))
         elif fused_moe_state == FusedMoEState.AllGather:

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -596,7 +596,6 @@ def fused_experts_with_all2all(hidden_states: torch.Tensor,
             sorted_local_expert_idx, local_num_experts).to(torch.int64)
 
         hidden_states = hidden_states[sorted_idx]
-        group_list_type = 0
     else:
         row_idx_len = num_tokens * top_k
         row_idx = torch.arange(0,
@@ -613,7 +612,7 @@ def fused_experts_with_all2all(hidden_states: torch.Tensor,
         expert_tokens = torch_npu.npu_moe_compute_expert_tokens(
             expanded_expert_idx, num_experts)
         expert_tokens = expert_tokens.to(torch.int64)
-        group_list_type = 0
+    group_list_type = 0
 
     # `hidden_states` will be disposed in the `apply_mlp` function
     hidden_states = apply_mlp(
@@ -767,7 +766,7 @@ def fused_experts_with_all2all_v2(
         export_for_source_row=None,
         drop_pad_mode=2)
 
-    return final_hidden_states
+    return final_hidden_states, tokens_per_local_expert.to(torch.int64), 1
 
 
 def fused_experts(hidden_states: torch.Tensor,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the shape conflicts between shared & routed experts for deepseek model when tp > 1 and multistream_moe enabled. It also fixes the interface conflicts for deepseek (BF16) introduced by https://github.com/vllm-project/vllm-ascend/pull/1391.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
It was tested with single-node online serving with DP2TP8EP16 and 8-node disaggregated prefill scenarios with DP2TP8EP16 for P and DP64EP64 for D.
