### PR TITLE
[v0.9.1][Bugfix][PD] fix D crashing if caching is disabled

### DIFF
--- a/vllm_ascend/patch/platform/patch_0_9_1/__init__.py
+++ b/vllm_ascend/patch/platform/patch_0_9_1/__init__.py
@@ -18,4 +18,5 @@
 # patch_utils should be the first import, because it will be used by other
 # patch files.
 import vllm_ascend.patch.worker.patch_common.patch_utils  # noqa isort:skip
+import vllm_ascend.patch.platform.patch_0_9_1.patch_cache_manager  # noqa
 import vllm_ascend.patch.platform.patch_0_9_1.patch_decorator  # noqa

--- a/vllm_ascend/patch/platform/patch_0_9_1/patch_cache_manager.py
+++ b/vllm_ascend/patch/platform/patch_0_9_1/patch_cache_manager.py
@@ -1,0 +1,13 @@
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.request import Request
+
+
+def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+    """Cache the blocks for the request, if enabled."""
+    if self.enable_caching:
+        block_hashes = self.req_to_block_hashes[request.request_id]
+        self.coordinator.cache_blocks(request, block_hashes,
+                                      num_computed_tokens)
+
+
+KVCacheManager.cache_blocks = cache_blocks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

When you launch the decoder with `--no_enable_prefix_caching` on ascend devices and benchmark the system with random inputs, at least 129 tokens each, you see the following message after ~2000 tests.

```
  File "/code/vllm/vllm/v1/core/block_pool.py", line 145, in cache_full_blocks
    assert blk.block_hash is None
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Then the decoder exits and the system freezes.

What's happening is that the caching operation is delayed from immediatly after allocation to after the KVCache transportation
in decoder instances, but currently we always cache blocks after they are received from prefillers even if caching is not enabled at all and these cached blocks never get evicted since caching is disabled.

This PR is aiming at fixing the bug. Since the `main` branch of vllm has already fix it, we backport it to v0.9.1 as a patch.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

No.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Qwen-0.6B 1P1D dp=2 --no_enable_prefix_caching

Qwen-0.6B 1P1D tp=2 --no_enable_prefix_caching
