### PR TITLE
[Doc] Fix cann related urls

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -78,20 +78,19 @@ source vllm-ascend-env/bin/activate
 pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple attrs 'numpy<2.0.0' decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py wheel typing_extensions
 
 # Download and install the CANN package.
-wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C22B800TP052/Ascend-cann-toolkit_8.2.rc1_linux-"$(uname -i)".run
-chmod +x ./Ascend-cann-toolkit_8.2.rc1_linux-"$(uname -i)".run
-./Ascend-cann-toolkit_8.2.rc1_linux-"$(uname -i)".run --full
+wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-toolkit_8.2.RC1_linux-"$(uname -i)".run
+chmod +x ./Ascend-cann-toolkit_8.2.RC1_linux-"$(uname -i)".run
+./Ascend-cann-toolkit_8.2.RC1_linux-"$(uname -i)".run --full
 # https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C22B800TP052/Ascend-cann-kernels-910b_8.2.rc1_linux-aarch64.run
 
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
+wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-kernels-910b_8.2.RC1_linux-"$(uname -i)".run
+chmod +x ./Ascend-cann-kernels-910b_8.2.RC1_linux-"$(uname -i)".run
+./Ascend-cann-kernels-910b_8.2.RC1_linux-"$(uname -i)".run --install
 
-wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C22B800TP052/Ascend-cann-kernels-910b_8.2.rc1_linux-"$(uname -i)".run
-chmod +x ./Ascend-cann-kernels-910b_8.2.rc1_linux-"$(uname -i)".run
-./Ascend-cann-kernels-910b_8.2.rc1_linux-"$(uname -i)".run --install
-
-wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C22B800TP052/Ascend-cann-nnal_8.2.rc1_linux-"$(uname -i)".run
-chmod +x ./Ascend-cann-nnal_8.2.rc1_linux-"$(uname -i)".run
-./Ascend-cann-nnal_8.2.rc1_linux-"$(uname -i)".run --install
+wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-nnal_8.2.RC1_linux-"$(uname -i)".run
+chmod +x ./Ascend-cann-nnal_8.2.RC1_linux-"$(uname -i)".run
+./Ascend-cann-nnal_8.2.RC1_linux-"$(uname -i)".run --install
 
 source /usr/local/Ascend/nnal/atb/set_env.sh
 ```


### PR DESCRIPTION
### What this PR does / why we need it?
Fix cann related urls in installation doc.

### Does this PR introduce _any_ user-facing change?
The users install cann manually could use the correct url after this pr

### How was this patch tested?
N/A

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5bbaf492a6238ff517249e73151ae9989f7bea9e
