### PR TITLE
[v0.9.1] Switch Infra to linux-aarch64-a2 and python to 3.11

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,10 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
-    - linux-arm64-npu-1
-    - linux-arm64-npu-2
-    - linux-arm64-npu-4
+    - linux-aarch64-a2-0
+    - linux-aarch64-a2-1
+    - linux-aarch64-a2-2
+    - linux-aarch64-a2-4
+    - linux-aarch64-a2-8
     - linux-arm64-npu-static-8
     - ubuntu-24.04-arm

--- a/.github/workflows/accuracy_test.yaml
+++ b/.github/workflows/accuracy_test.yaml
@@ -79,8 +79,8 @@ jobs:
       }}
     runs-on: >-
       ${{
-          (matrix.model_name == 'Qwen/Qwen2.5-VL-7B-Instruct' && 'linux-arm64-npu-4') ||
-          'linux-arm64-npu-2'
+          (matrix.model_name == 'Qwen/Qwen2.5-VL-7B-Instruct' && 'linux-aarch64-a2-4') ||
+          'linux-aarch64-a2-2'
       }}
     strategy:
       matrix:

--- a/.github/workflows/vllm_ascend_doctest.yaml
+++ b/.github/workflows/vllm_ascend_doctest.yaml
@@ -43,7 +43,7 @@ jobs:
       # Each version should be tested
       fail-fast: false
       matrix:
-        vllm_verison: [main, v0.7.3-dev, main-openeuler, v0.7.3-dev-openeuler]
+        vllm_verison: [v0.9.1-dev, v0.9.1-dev-openeuler]
     name: vLLM Ascend test
     runs-on: linux-aarch64-a2-1
     container:

--- a/.github/workflows/vllm_ascend_doctest.yaml
+++ b/.github/workflows/vllm_ascend_doctest.yaml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         vllm_verison: [main, v0.7.3-dev, main-openeuler, v0.7.3-dev-openeuler]
     name: vLLM Ascend test
-    runs-on: linux-arm64-npu-1
+    runs-on: linux-aarch64-a2-1
     container:
       image: m.daocloud.io/quay.io/ascend/vllm-ascend:${{ matrix.vllm_verison }}
     steps:

--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -114,12 +114,12 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        os: [linux-arm64-npu-1, linux-arm64-npu-4]
+        os: [linux-aarch64-a2-1, linux-aarch64-a2-4]
         vllm_version: [v0.9.1]
     concurrency:
       group: >
         ${{
-        matrix.os == 'linux-arm64-npu-4'
+        matrix.os == 'linux-aarch64-a2-4'
           && github.event.pull_request.number
           && format('pr-{0}-limit-npu-4', github.event.pull_request.number)
         || format('job-{0}-{1}-{2}', matrix.os, matrix.vllm_version, github.event.pull_request.number)
@@ -177,7 +177,7 @@ jobs:
           VLLM_USE_V1: 1
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         run: |
-          if [[ "${{ matrix.os }}" == "linux-arm64-npu-1" ]]; then
+          if [[ "${{ matrix.os }}" == "linux-aarch64-a2-1" ]]; then
             VLLM_USE_MODELSCOPE=True pytest -sv tests/singlecard/test_offline_inference.py
             pytest -sv tests/singlecard/test_guided_decoding.py
             # test_ascend_config.py should be ran separately because it will regenerate the global config many times.
@@ -213,7 +213,7 @@ jobs:
         env:
           VLLM_USE_V1: 0
         run: |
-          if [[ "${{ matrix.os }}" == "linux-arm64-npu-1" ]]; then
+          if [[ "${{ matrix.os }}" == "linux-aarch64-a2-1" ]]; then
             VLLM_USE_MODELSCOPE=True  pytest -sv tests/singlecard/test_offline_inference.py
             pytest -sv tests/singlecard/test_guided_decoding.py
             pytest -sv tests/singlecard/test_camem.py

--- a/.github/workflows/vllm_ascend_test_long_term.yaml
+++ b/.github/workflows/vllm_ascend_test_long_term.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        os: [linux-arm64-npu-1, linux-arm64-npu-4]
+        os: [linux-aarch64-a2-1, linux-aarch64-a2-4]
         vllm_version: [v0.9.1]
     name: vLLM Ascend long term test
     runs-on: ${{ matrix.os }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run vllm-project/vllm-ascend long term test
         run: |
-          if [[ "${{ matrix.os }}" == "linux-arm64-npu-1" ]]; then
+          if [[ "${{ matrix.os }}" == "llinux-aarch64-a2-1" ]]; then
             # v0 spec decode test
             # VLLM_USE_MODELSCOPE=True pytest -sv tests/long_term/spec_decode_v0/e2e/test_mtp_correctness.py  # it needs a clean process
             # pytest -sv tests/long_term/spec_decode_v0 --ignore=tests/long_term/spec_decode_v0/e2e/test_mtp_correctness.py


### PR DESCRIPTION
### What this PR does / why we need it?
Switch Infra to linux-aarch64-a2 and python to 3.11

Soft backport: https://github.com/vllm-project/vllm-ascend/pull/2065
Soft backport: https://github.com/vllm-project/vllm-ascend/pull/2072

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
search all: `linux-arm64-npu` and `3.10`