### PR TITLE
Fix accuracy test config --config-list-file

### DIFF
--- a/tests/e2e/singlecard/models/conftest.py
+++ b/tests/e2e/singlecard/models/conftest.py
@@ -62,7 +62,7 @@ def report_output(pytestconfig, config_filename):
         report_path = Path(report_dir) / f"{model_name}.md"
         report_path.parent.mkdir(parents=True, exist_ok=True)
         return report_path
-    
+
     output_path = pytestconfig.getoption("--report_output")
     if output_path:
         output_path = Path(output_path)
@@ -84,6 +84,5 @@ def pytest_generate_tests(metafunc):
             return
         single_config = metafunc.config.getoption("--config")
         config_path = Path(single_config).resolve()
-        
+
         metafunc.parametrize("config_filename", [config_path])
-        


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fix accuracy test related to https://github.com/vllm-project/vllm-ascend/pull/2073, users can now perform accuracy tests on multiple models simultaneously and generate different report files by running:

```bash
cd ~/vllm-ascend
pytest -sv ./tests/e2e/singlecard/models/test_lm_eval_correctness.py \
          --config-list-file ./tests/e2e/singlecard/models/configs/accuracy.txt
```

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
<img width="1648" height="511" alt="image" src="https://github.com/user-attachments/assets/1757e3b8-a6b7-44e5-b701-80940dc756cd" />


- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/61dcc280faf305778c0c44597e823f40063aaed6
