### PR TITLE
[FEATURE][0.9.1] Support mtp > 1

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1008,7 +1008,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BNSD"
 
             if attn_metadata.attn_state == AscendAttentionState.SpecDecoding:
-                assert num_tokens % self.spec_token_num == 0
+                assert num_tokens % (self.spec_token_num + 1) == 0
                 input_layout = "TND"
                 # [bs * q_seq_len, num_heads_per_rank, dim]
                 q_nope = q_nope.view(num_tokens, self.num_heads, -1)

--- a/vllm_ascend/worker/mtp_proposer_v1.py
+++ b/vllm_ascend/worker/mtp_proposer_v1.py
@@ -21,6 +21,7 @@ from vllm_ascend.attention.utils import \
 from vllm_ascend.models.deepseek_mtp import CustomDeepSeekMTP
 from vllm_ascend.utils import ProfileExecuteDuration
 
+PADDING_SLOT_ID = -1
 
 # FIXME(woosuk): The logic here is duplicated with the main sampling code.
 # We should refactor this to reuse the same sampling implementation.
@@ -84,6 +85,13 @@ class MtpProposer:
             device=self.runner.device)
         self.torchair_compiled_model = None  # type: ignore
         self.torchair_compiled_models = {}  # type: ignore
+
+        # We need +1 here because the arange is used to set query_start_loc,
+        # which has one more element than batch_size.
+        self.arange = torch.arange(vllm_config.scheduler_config.max_num_seqs +
+                                   1,
+                                   device=self.runner.device,
+                                   dtype=torch.int32)
 
     @staticmethod
     def prepare_inputs(
@@ -231,44 +239,116 @@ class MtpProposer:
             num_tokens_across_dp = self.runner.num_tokens_across_dp
             with_prefill = self.runner.with_prefill
 
-        with set_ascend_forward_context(
-                attn_metadata,
-                self.vllm_config,
-                num_tokens=num_input_tokens,
-                with_prefill=with_prefill,
-                num_tokens_across_dp=num_tokens_across_dp,
-                in_profile_run=self.runner.in_profile_run,
-                num_actual_tokens=num_tokens):
-            with ProfileExecuteDuration().capture_async('mtp_forward'):
-                model_kwargs = {}
-                model_kwargs["attn_metadata"] = attn_metadata
-                if self.runner.torchair_graph_enabled:
-                    model_kwargs["kv_caches"] = self.runner.kv_caches[-1:]
-                if is_running_torchair:
-                    torchair_compiled_model = self._get_torchair_lazy_compiled_model(
-                        num_input_tokens)
-                    hidden_states = torchair_compiled_model(
-                        input_ids=self.input_ids[:num_input_tokens],
-                        positions=self.positions[:num_input_tokens],
-                        previous_hidden_states=self.
-                        hidden_states[:num_input_tokens],
-                        inputs_embeds=None,
-                        intermediate_tensors=None,
-                        spec_step_idx=0,
-                        **model_kwargs)
-                else:
-                    hidden_states = self.model(
-                        input_ids=self.input_ids[:num_input_tokens],
-                        positions=self.positions[:num_input_tokens],
-                        previous_hidden_states=self.
-                        hidden_states[:num_input_tokens],
-                        kv_caches=self.runner.kv_caches[-1:])
-        sample_hidden_states = hidden_states[last_token_indices]
-        logits = self.model.compute_logits(sample_hidden_states, None)
-        draft_token_ids = logits.argmax(dim=-1)
+        for i in range(self.num_speculative_tokens):
+            with set_ascend_forward_context(
+                    attn_metadata,
+                    self.vllm_config,
+                    num_tokens=num_input_tokens,
+                    with_prefill=with_prefill,
+                    num_tokens_across_dp=num_tokens_across_dp,
+                    in_profile_run=self.runner.in_profile_run,
+                    num_actual_tokens=num_tokens):
+                with ProfileExecuteDuration().capture_async('mtp_forward'):
+                    model_kwargs = {}
+                    model_kwargs["attn_metadata"] = attn_metadata
+                    if self.runner.torchair_graph_enabled:
+                        model_kwargs["kv_caches"] = self.runner.kv_caches[-1:]
+                    if is_running_torchair:
+                        torchair_compiled_model = self._get_torchair_lazy_compiled_model(
+                            num_input_tokens)
+                        hidden_states = torchair_compiled_model(
+                            input_ids=self.input_ids[:num_input_tokens],
+                            positions=self.positions[:num_input_tokens],
+                            previous_hidden_states=self.
+                            hidden_states[:num_input_tokens],
+                            inputs_embeds=None,
+                            intermediate_tensors=None,
+                            spec_step_idx=0,
+                            **model_kwargs)
+                    else:
+                        hidden_states = self.model(
+                            input_ids=self.input_ids[:num_input_tokens],
+                            positions=self.positions[:num_input_tokens],
+                            previous_hidden_states=self.
+                            hidden_states[:num_input_tokens],
+                            kv_caches=self.runner.kv_caches[-1:])
+            sample_hidden_states = hidden_states[last_token_indices]
+            logits = self.model.compute_logits(sample_hidden_states, None)
+            draft_token_ids = logits.argmax(dim=-1)
 
-        # [batch_size, 1]
-        return draft_token_ids.view(-1, 1)
+            if self.num_speculative_tokens == 1 or with_prefill:
+                # [batch_size, 1]
+                return draft_token_ids.view(-1, 1)
+            
+            if i == 0:
+                draft_token_ids_list = [draft_token_ids]
+            else:
+                draft_token_ids_list.append(draft_token_ids)
+            
+            # mtp>1: skip last loop
+            if i == self.num_speculative_tokens - 1:
+                break
+            
+            if i == 0:
+                positions = target_positions[last_token_indices]
+                hidden_states = hidden_states[last_token_indices]
+                slot_mapping = attn_metadata.slot_mapping[last_token_indices]
+                attn_metadata.slot_mapping.fill_(-1)
+                attn_metadata.num_actual_tokens = batch_size
+                attn_metadata.max_query_len = 1
+                attn_metadata.query_start_loc = self.arange[:batch_size + 1]
+                last_token_indices = self.arange[:batch_size]
+                if attn_metadata.num_decode_tokens != 0:
+                    attn_metadata.num_decode_tokens = batch_size
+                if attn_metadata.num_prefill_tokens != 0:
+                    attn_metadata.num_prefill_tokens = batch_size
+                attn_metadata.query_lens = [1] * batch_size
+            
+            input_ids = draft_token_ids_list[-1].int()
+            positions += 1
+
+            # NOTE(woosuk): We should handle the case where the draft model
+            # generates tokens beyond the max model length. Since it is complex
+            # to remove such requests from the batch, we keep them in the batch
+            # but adjust the position ids and slot mappings to avoid the
+            # out-of-range access during the model execution. The draft tokens
+            # generated with this adjustment should be ignored.
+            exceeds_max_model_len = positions >= self.runner.model_config.max_model_len
+            # Mask out the position ids that exceed the max model length.
+            # Otherwise, we may get out-of-range error in RoPE.
+            clamped_positions = torch.where(exceeds_max_model_len, 0,
+                                            positions)
+            # Increment the sequence lengths.
+            attn_metadata.seq_lens[:batch_size] += 1
+            # Mask out the slot mappings that exceed the max model length.
+            # Otherwise, the KV cache will be inadvertently updated with the
+            # padding tokens.
+            slot_mapping += 1
+            slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)
+
+            # copy inputs to buffer for cudagraph
+            self.input_ids[:batch_size] = input_ids
+            self.positions[:batch_size] = clamped_positions
+            self.hidden_states[:batch_size] = hidden_states
+            attn_metadata.slot_mapping[:batch_size] = slot_mapping
+
+            if attn_metadata.prefill is not None:
+                attn_metadata.prefill.seq_lens = attn_metadata.seq_lens
+                attn_metadata.prefill.context_lens = attn_metadata.seq_lens
+                attn_metadata.prefill.input_positions = self.positions[:num_input_tokens]
+                attn_metadata.prefill.max_seq_lens += 1
+                attn_metadata.prefill.max_seq_lens = min(attn_metadata.prefill.max_seq_lens,
+                                            self.runner.model_config.max_model_len)
+            if attn_metadata.decode is not None:
+                attn_metadata.decode.seq_lens = attn_metadata.seq_lens
+                attn_metadata.decode.input_positions = self.positions[:num_input_tokens]
+                attn_metadata.decode.max_seq_lens += 1
+                attn_metadata.decode.max_seq_lens = min(attn_metadata.decode.max_seq_lens,
+                                            self.runner.model_config.max_model_len)
+        
+        # mtp>1: [batch_size, k]
+        draft_token_ids = torch.stack(draft_token_ids_list, dim=1)
+        return draft_token_ids
 
     def load_model(self) -> None:
         loader = get_model_loader(self.vllm_config.load_config)
@@ -325,41 +405,44 @@ class MtpProposer:
         input_ids = self.input_ids[:num_tokens]
         positions = self.positions[:num_tokens]
         previous_hidden_states = self.hidden_states[:num_tokens]
-        with set_ascend_forward_context(
-                attn_metadata,
-                self.vllm_config,
-                num_tokens=num_tokens,
-                with_prefill=with_prefill,
-                num_tokens_across_dp=num_tokens_across_dp,
-                in_profile_run=self.runner.in_profile_run,
-                num_actual_tokens=0):
-            if is_running_torchair:
-                assert attn_metadata is not None
-                torch._dynamo.mark_static(input_ids)
-                torch._dynamo.mark_static(positions)
-                torch._dynamo.mark_static(previous_hidden_states)
-                torch._dynamo.mark_static(attn_metadata.decode.block_table)
-                torch._dynamo.mark_static(attn_metadata.decode.input_positions)
-                torch._dynamo.mark_static(attn_metadata.decode.sin)
-                torch._dynamo.mark_static(attn_metadata.decode.cos)
-                torch._dynamo.mark_static(get_forward_context().mc2_mask)
-                torch._dynamo.mark_static(attn_metadata.slot_mapping)
-                torch._dynamo.mark_static(attn_metadata.decode.attn_mask)
-                torchair_compiled_model = self._get_torchair_lazy_compiled_model(
-                    num_tokens)
-                torchair_compiled_model(
-                    input_ids=input_ids,
-                    positions=positions,
-                    previous_hidden_states=previous_hidden_states,
-                    inputs_embeds=None,
-                    intermediate_tensors=None,
-                    attn_metadata=attn_metadata,
-                    kv_caches=self.runner.kv_caches[-1:],
-                    spec_step_idx=0)
-            else:
-                self.model(input_ids=input_ids,
-                           positions=positions,
-                           previous_hidden_states=previous_hidden_states)
+        for _ in range(self.num_speculative_tokens):
+            with set_ascend_forward_context(
+                    attn_metadata,
+                    self.vllm_config,
+                    num_tokens=num_tokens,
+                    with_prefill=with_prefill,
+                    num_tokens_across_dp=num_tokens_across_dp,
+                    in_profile_run=self.runner.in_profile_run,
+                    num_actual_tokens=0):
+                if is_running_torchair:
+                    assert attn_metadata is not None
+                    torch._dynamo.mark_static(input_ids)
+                    torch._dynamo.mark_static(positions)
+                    torch._dynamo.mark_static(previous_hidden_states)
+                    torch._dynamo.mark_static(attn_metadata.decode.block_table)
+                    torch._dynamo.mark_static(attn_metadata.decode.input_positions)
+                    torch._dynamo.mark_static(attn_metadata.decode.sin)
+                    torch._dynamo.mark_static(attn_metadata.decode.cos)
+                    torch._dynamo.mark_static(get_forward_context().mc2_mask)
+                    torch._dynamo.mark_static(attn_metadata.slot_mapping)
+                    torch._dynamo.mark_static(attn_metadata.decode.attn_mask)
+                    torchair_compiled_model = self._get_torchair_lazy_compiled_model(
+                        num_tokens)
+                    torchair_compiled_model(
+                        input_ids=input_ids,
+                        positions=positions,
+                        previous_hidden_states=previous_hidden_states,
+                        inputs_embeds=None,
+                        intermediate_tensors=None,
+                        attn_metadata=attn_metadata,
+                        kv_caches=self.runner.kv_caches[-1:],
+                        spec_step_idx=0)
+                else:
+                    self.model(input_ids=input_ids,
+                            positions=positions,
+                            previous_hidden_states=previous_hidden_states)
+            if with_prefill:
+                break
 
     def _get_torchair_lazy_compiled_model(self, batch_size: int):
         if batch_size < 0 or batch_size > self.runner.torchair_graph_batch_sizes[


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Support mtp > 1 with：

- [ ] torchair
- [ ] single dp
- [ ] multi dp

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

`
export HCCL_IF_IP=xxx # node ip
export HCCL_BUFFSIZE=1024
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export HCCL_DETERMINISTIC=True

export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
export MINDIE_LOG_TO_STDOUT="benchmark:1; client:1"

export VLLM_USE_V1=1
export VLLM_ENABLE_MC2=1
export VLLM_VERSION=0.9.2

LOG_FILE="./mtp_tp16/mtp_log_$(date +%Y%m%d_%H%M).log"

python -m vllm.entrypoints.openai.api_server
--model="/home/data/DeepSeek-R1_w8a8/"
--trust-remote-code
--max-model-len 40000
--no-enable-prefix-caching
--tensor-parallel-size 16
--data_parallel_size 1
--enable_expert_parallel
--served-model-name deepseekr1
--quantization ascend
--max-num-seqs 16
--max-num-batched-tokens 6000
--speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}'
--host 0.0.0.0
--port 1234
--additional-config '{"ascend_scheduler_config":{"enabled":true}, "torchair_graph_config":{"enabled":true,"graph_batch_sizes":[16]}}'
--gpu_memory_utilization 0.9 > $LOG_FILE 2>&1
`
