### PR TITLE
[V0.9.1] Revert Flashcomm_v2 and support Flashcomm_v1 in Qwen3

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -205,7 +205,7 @@ jobs:
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeek_w8a8_ep_dbo
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeekV3_dbo
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_QwQ_with_flashcomm_v1
-            VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_Qwen3_with_flashcomm_v2
+            VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/test_offline_inference_distributed.py::test_models_distributed_Qwen3_with_flashcomm_v1
             VLLM_USE_MODELSCOPE=True pytest -sv tests/multicard/ --ignore=tests/multicard/test_ilama_lora_tp2.py --ignore=tests/multicard/test_offline_inference_distributed.py --ignore=tests/multicard/test_w4a8_deepseek.py
           fi
 

--- a/tests/multicard/test_offline_inference_distributed.py
+++ b/tests/multicard/test_offline_inference_distributed.py
@@ -213,8 +213,9 @@ def test_models_distributed_QwQ_with_flashcomm_v1(enforce_eager: bool):
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
 
-@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM": "2"})
-def test_models_distributed_Qwen3_with_flashcomm_v2():
+@pytest.mark.parametrize("enforce_eager", [True, False])
+@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM": "1"})
+def test_models_distributed_Qwen3_with_flashcomm_v1(enforce_eager: bool):
     example_prompts = [
         "Hello, my name is",
     ]
@@ -223,7 +224,7 @@ def test_models_distributed_Qwen3_with_flashcomm_v2():
     with VllmRunner(
             snapshot_download("Qwen/Qwen3-0.6B-Base"),
             max_model_len=8192,
-            enforce_eager=True,
+            enforce_eager=enforce_eager,
             dtype="auto",
             tensor_parallel_size=2,
     ) as vllm_model:

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -148,7 +148,7 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # Batch MC2 in prefill: The number of tokens in each batch
     "VLLM_ASCEND_FUSED_MOE_MC2_CHUNK_SIZE":
     lambda: int(os.getenv("VLLM_ASCEND_FUSED_MOE_MC2_CHUNK_SIZE", "128")),
-    # FlashComm optimization: Enable v1 and v2 by setting this flag to 1 or 2 respectively
+    # FlashComm optimization: Enable v1 by setting this flag to 1 respectively
     "VLLM_ASCEND_ENABLE_FLASHCOMM":
     lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM", '0')),
     # The tolerance of the kv cache size, if the difference between the


### PR DESCRIPTION
### What this PR does / why we need it?
This PR revert [#1726 ](https://github.com/vllm-project/vllm-ascend/pull/1726)，and support flashcomm_v1 in Qwen3.
 
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
CI passed with new added/existing test.

<img width="1459" height="340" alt="image" src="https://github.com/user-attachments/assets/a273cf49-c3d4-42fa-828c-fd9ef6976465" />
