### PR TITLE
[CI]Run qwen3 moe e2e test in aclgraph mode

### DIFF
--- a/tests/e2e/multicard/test_qwen3_moe.py
+++ b/tests/e2e/multicard/test_qwen3_moe.py
@@ -35,6 +35,7 @@ def test_models_distributed_Qwen3_MOE_TP2():
             dtype=dtype,
             tensor_parallel_size=2,
             distributed_executor_backend="mp",
+            enforce_eager=False,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
@@ -51,5 +52,6 @@ def test_models_distributed_Qwen3_MOE_TP2_WITH_EP():
             tensor_parallel_size=2,
             enable_expert_parallel=True,
             distributed_executor_backend="mp",
+            enforce_eager=False,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)


### PR DESCRIPTION
VllmRunner start with eager mode by default. This PR enable graph mode test for qwen3 moe
- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/c494f96fbcf5e9f19f59e3dea6c2780aeb6c567f
