### PR TITLE
Remove transformer pins for v0.9.1-dev

### DIFF
--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -49,12 +49,6 @@ function install_binary_test() {
     pip install vllm=="$(get_version pip_vllm_version)"
     pip install vllm-ascend=="$(get_version pip_vllm_ascend_version)"
 
-    # TODO(yikun): Remove this when 0.9.1rc2 is released
-    # https://github.com/vllm-project/vllm-ascend/issues/2046
-    if [ "$PIP_VLLM_ASCEND_VERSION" == "0.9.1rc1" ] || [ "$PIP_VLLM_ASCEND_VERSION" == "0.9.0rc2" ] ; then
-        pip install "transformers<4.53.0"
-    fi
-
     pip list | grep vllm
 
     # Verify the installation


### PR DESCRIPTION
### What this PR does / why we need it?
Remove transformer pins for v0.9.1-dev, because we already release the v0.9.1rc2 with right transformer version

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
doctest CI passed
- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7e6544c7978364fcb8178f4ab8b1325e45880aa9
