### PR TITLE
[Bugfix] Disable check vllm init temporary

### DIFF
--- a/tools/check_python_src_init.py
+++ b/tools/check_python_src_init.py
@@ -20,7 +20,8 @@ import os
 import sys
 
 VLLM_ASCEND_SRC = "vllm_ascend"
-VLLM_SRC = "vllm-empty/vllm"
+# TODO: Re-enable this after upstream fixed
+# VLLM_SRC = "vllm-empty/vllm"
 
 
 def check_init_file_in_package(directory):
@@ -56,7 +57,7 @@ def find_missing_init_dirs(src_dir):
 def main():
     all_missing = set()
 
-    for src in [VLLM_ASCEND_SRC, VLLM_SRC]:
+    for src in [VLLM_ASCEND_SRC]:
         missing = find_missing_init_dirs(src)
         all_missing.update(missing)
 


### PR DESCRIPTION
### What this PR does / why we need it?
For the vllm src https://github.com/vllm-project/vllm/tree/main/vllm/attention/layers do not have `__init__.py`, which will break the python src init check, so we skip it for now
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6b47ef24de3d3b4f551aca0bc21b9f16f3d21b6a
