### PR TITLE
[Structured Output][CI] Add test for `outlines` backend for structured output in CI

### DIFF
--- a/tests/e2e/singlecard/test_guided_decoding.py
+++ b/tests/e2e/singlecard/test_guided_decoding.py
@@ -120,6 +120,9 @@ def test_guided_json_completion(guided_decoding_backend: str,
 
 @pytest.mark.parametrize("guided_decoding_backend", GuidedDecodingBackend)
 def test_guided_regex(guided_decoding_backend: str, sample_regex):
+    if guided_decoding_backend == "outlines":
+        pytest.skip("Outlines doesn't support regex-based guided decoding.")
+
     sampling_params = SamplingParams(
         temperature=0.8,
         top_p=0.95,

--- a/tests/e2e/singlecard/test_guided_decoding.py
+++ b/tests/e2e/singlecard/test_guided_decoding.py
@@ -30,7 +30,7 @@ from tests.e2e.conftest import VllmRunner
 os.environ["PYTORCH_NPU_ALLOC_CONF"] = "max_split_size_mb:256"
 MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
 
-GuidedDecodingBackend = ["xgrammar", "guidance"]
+GuidedDecodingBackend = ["xgrammar", "guidance", "outlines"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### What this PR does / why we need it?
Add test for `outlines` backend for structured output in CI.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Tests have all passed with:

```bash
pytest -sv tests/e2e/singlecard/test_guided_decoding.py
```

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/53415653ff24be03e7c90f5b42ef9cb3f72aad71
