### PR TITLE
ut: add ci guard for ut coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,7 @@
 
 coverage:
   status:
-     # Patch coverage is mandatory and must be >= 80%
+    # Patch coverage is mandatory and must be >= 80%
     patch:
       default:
         target: 80%


### PR DESCRIPTION
### What this PR does / why we need it?
add ci guard for ut coverage, if ut coverage of patch pr is below 80%, the ci will failed/

### Does this PR introduce _any_ user-facing change?
not involved

### How was this patch tested?
not involved

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/458e74eb907f96069e6d8a4f3c9f457001fef2ea
