### PR TITLE
[Quickfix] Add the missing `apply_router_weight_on_input` in FusedMoE init

### DIFF
--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1258,6 +1258,7 @@ class AscendFusedMoE(FusedMoE):
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
             activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
         )
         AscendFusedMoE.moe_counter += 1
         self.moe_instance_id = AscendFusedMoE.moe_counter


### PR DESCRIPTION
### What this PR does / why we need it?
Add the missing `apply_router_weight_on_input` in FusedMoE init
Quick fix on https://github.com/vllm-project/vllm-ascend/pull/2268#discussion_r2265828849

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with existing test.


- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6807af8f46acd184f99342ff38f2a1359f693b10
