### PR TITLE
Fix the accuracy issues caused by the mrope operator

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -288,7 +288,7 @@ def mrope_forward(
     import torch_npu
     mrope_section = [0, 0, 0] if positions.ndim == 1 else self.mrope_section
 
-    query, key = torch_npu.npu_mrope(positions.contiguous(),
+    query, key = torch_npu.npu_mrope(positions.clone().contiguous(),
                                      query.contiguous(),
                                      key.contiguous(),
                                      self.cos_sin_cache.contiguous(),

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -288,7 +288,7 @@ def mrope_forward(
     import torch_npu
     mrope_section = [0, 0, 0] if positions.ndim == 1 else self.mrope_section
 
-    query, key = torch_npu.npu_mrope(positions,
+    query, key = torch_npu.npu_mrope(positions.contiguous(),
                                      query.contiguous(),
                                      key.contiguous(),
                                      self.cos_sin_cache.contiguous(),

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -288,7 +288,7 @@ def mrope_forward(
     import torch_npu
     mrope_section = [0, 0, 0] if positions.ndim == 1 else self.mrope_section
 
-    query, key = torch_npu.npu_mrope(positions.clone().contiguous(),
+    query, key = torch_npu.npu_mrope(positions.clone().detach().contiguous(),
                                      query.contiguous(),
                                      key.contiguous(),
                                      self.cos_sin_cache.contiguous(),


### PR DESCRIPTION
### What this PR does / why we need it?
Fix precision and inference length issues with MRoPE operator in multi-image long sequences for Qwen2.5-VL-7B

This PR addresses two critical issues observed with the MRoPE operator:
1. Precision degradation in V1 model outputs
2. Inference length limitations (only generating a few characters) when processing multi-image long sequences
![20250813-210227](https://github.com/user-attachments/assets/5cceadb9-eaea-4a53-a300-2ba7a4e6a168)

Root cause analysis revealed that most CANN operators internally perform contiguous() operations to ensure accessing contiguous data during computations. However, the **”positions“** tensor was missing this crucial step, leading to incorrect memory access and corrupted values during operator calculations.

The fix adds a contiguous() operation on the positions tensor at the Python level, ensuring proper memory layout consistency with other tensor operations.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.9.1
- vLLM main: https://github.com/vllm-project/vllm/commit/83fc60bdab2a4187799ece9b8a0f84695858975b

Comparing the accuracy of V0 and V1, the error meets the standard
![20250813-205710](https://github.com/user-attachments/assets/c7aebc61-c9a6-40ec-8c33-01b5539c401d)


