### PR TITLE
[v0.9.1-dev]dynamic eplb metrics

### DIFF
--- a/vllm_ascend/eplb/eplb_loggers.py
+++ b/vllm_ascend/eplb/eplb_loggers.py
@@ -1,0 +1,179 @@
+import time
+import json
+import threading
+from typing import Optional
+
+import torch
+import torch_npu
+import prometheus_client
+import numpy as np
+
+from vllm.logger import logger
+from vllm.distributed.parallel_state import get_ep_group
+from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
+
+RECORDING_TIME = 10
+
+
+class EplbStatLogger:
+    _instance = None
+    _gauge_cls = prometheus_client.Gauge
+    _counter_cls = prometheus_client.Counter
+
+    def __init__(self, adaptor: VllmEplbAdaptor, expert_map_path: Optional[str]):
+        self.rank = get_ep_group().rank
+        self.layers_num = adaptor.num_moe_layers
+        self.global_expert_num = adaptor.global_expert_num
+        self.ep_size = get_ep_group().world_size
+
+        if expert_map_path is None:
+            # self.phy2log_map = torch.arange(self.global_expert_num).repeat(self.layers_num, 1)
+            self.phy2log_map = [[i for i in range(self.global_expert_num)] for _ in range(self.layers_num)]
+        else:
+            self.phy2log_map = self._expert_file_to_list(expert_map_path)
+            self.global_expert_num = len(self.phy2log_map[0])
+
+        self.local_expert_num = self.global_expert_num // self.ep_size
+
+        labelnames_phy_load = ["rank", "layer", "phy_expert_id"]
+        labelnames_phy2log = ["rank", "layer", "phy_expert_id", "log_expert_id"]
+
+        self.phy_expert = self._counter_cls(
+            name="vllm:phy_expert_heat",
+            documentation="Heat of each physical expert per rank",
+            labelnames=labelnames_phy_load)
+
+        self.phy2log = self._gauge_cls(
+            name="vllm:phy2log",
+            documentation="physical expert to logical expert per rank",
+            labelnames=labelnames_phy2log)
+
+        self.do_record_loop = threading.Thread(target=self.record_loop)
+        self.moe_load = None
+
+        self.update_load = False
+        self.update_map = False
+
+        # only init in rank0
+        self.all_phy2log = []
+        if self.rank == 0:
+            for layer_id in range(self.layers_num):
+                for phy_expert_id in range(self.global_expert_num):
+                    self.phy_expert.labels(rank=phy_expert_id // self.local_expert_num,
+                                           layer=layer_id,
+                                           phy_expert_id=phy_expert_id % self.local_expert_num)
+
+            for layer_id in range(len(self.phy2log_map)):
+                local_phy2log = []
+                for phy_expert_id, log_expert_id in enumerate(self.phy2log_map[layer_id]):
+                    a = self.phy2log.labels(rank=phy_expert_id // self.local_expert_num,
+                                            layer=layer_id,
+                                            phy_expert_id=phy_expert_id % self.local_expert_num,
+                                            log_expert_id=log_expert_id)
+                    a.set(1)
+                    local_phy2log.append(a)
+                self.all_phy2log.append(local_phy2log)
+
+            self.moe_load = torch.zeros((self.layers_num, self.ep_size, self.local_expert_num))
+
+            self.lock = threading.Lock()
+            self.start_loop()
+
+    @staticmethod
+    def get_instance():
+        if EplbStatLogger._instance is None:
+            raise ValueError(
+                "ExpertLoadBalancer instance has not been initialized.")
+        return EplbStatLogger
+
+    @staticmethod
+    def init_instance(adaptor: VllmEplbAdaptor, expert_map_path: Optional[str]):
+        """Initialize the singleton instance of ExpertLoadBalancer."""
+        EplbStatLogger._instance = EplbStatLogger(
+            adaptor, expert_map_path)
+        return EplbStatLogger._instance
+
+    def record(self, moe_load, phy2log_map):
+        if self.rank != 0:
+            return
+        try:
+            with self.lock:
+                if moe_load is not None:
+                    torch.add(self.moe_load, moe_load, out=self.moe_load)
+                    self.update_load = True
+
+                if phy2log_map is not None:
+                    self.phy2log_map = phy2log_map
+                    self.update_map = True
+        except Exception as e:
+            logger.debug(f"Record moe_load or phy2log error, error result:{e}")
+
+    def record_loop(self):
+        while True:
+            try:
+                if self.update_load:
+                    with self.lock:
+                        self.update_load = False
+                        moe_load = self.moe_load.tolist()
+                        self.moe_load.zero_()
+                    moe_load = np.array(moe_load)
+                    res = np.zeros_like(moe_load)
+                    res[..., 0] = moe_load[..., 0]
+                    res[..., 1:] = moe_load[..., 1:] - moe_load[..., :-1]
+                    res = res.reshape(self.layers_num, -1)
+                    self.record_expert_load(res)
+
+                if self.update_map:
+                    with self.lock:
+                        self.update_map = False
+                        phy2log_map = self.phy2log_map
+                    phy2log_map = np.array(phy2log_map).reshape(self.layers_num, -1)
+                    self.record_phy2log(phy2log_map)
+            except Exception as e:
+                logger.debug(f"Record moe_load or phy2log prometheus error, error result:{e}")
+            time.sleep(RECORDING_TIME)
+
+    def start_loop(self):
+        self.do_record_loop.start()
+
+    def record_phy2log(self, phy2log_map: list[list[int]]):
+        for layer_id in range(len(phy2log_map)):
+            for phy_expert_id, log_expert_id in enumerate(phy2log_map[layer_id]):
+                self.all_phy2log[layer_id][phy_expert_id].set(0)
+
+                a = self.phy2log.labels(
+                    rank=phy_expert_id // self.local_expert_num,
+                    layer=layer_id,
+                    phy_expert_id=phy_expert_id % self.local_expert_num,
+                    log_expert_id=log_expert_id
+                )
+                a.set(1)
+                self.all_phy2log[layer_id][phy_expert_id] = a
+
+    def record_expert_load(self, moe_load: list[list[int]]):
+        for layer_id in range(len(moe_load)):
+            for phy_expert_id, load in enumerate(moe_load[layer_id]):
+                self.phy_expert.labels(
+                    rank=phy_expert_id // self.local_expert_num,
+                    layer=layer_id,
+                    phy_expert_id=phy_expert_id % self.local_expert_num,
+                ).inc(load)
+
+    def _expert_file_to_list(self, expert_map_path: str):
+        with open(expert_map_path, "r") as f:
+            data = json.load(f)
+
+        phy2log_data = []
+        for layer in data["layer_list"]:
+            device_data = []
+            for device in layer["device_list"]:
+                device_data += device["device_expert"]
+            phy2log_data.append(device_data)
+        return phy2log_data
+
+    def clear(self):
+        for layer_id in range(self.layers_num):
+            for phy_expert_id in range(self.global_expert_num):
+                self.phy_expert.labels(rank=phy_expert_id // self.local_expert_num,
+                                       layer=layer_id,
+                                       phy_expert_id=phy_expert_id % self.local_expert_num).reset()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

In the dynamic EPLB, expert heat is written to the metrics interface, allowing for observation of expert heat.
Metrics are written to the physical expert heat and the physical expert to logical expert mapping table. Because redundant experts prevent the logical expert from accurately observing the heat on each card, physical expert heat is recorded. The physical expert to logical expert mapping is also recorded to map heat back to the logical expert.
Physical expert heat is recorded using layer, phy_expert_id, and rank, representing the MoE layer, physical expert ID, and card, respectively. The physical expert to logical expert mapping table uses layer, log_expert_id, phy_expert_id, and rank, representing the MoE layer, logical expert ID, physical expert ID, and card, respectively. The mapping table uses a binding relationship: the log_expert_id indicator is 1 when the phy_expert_id is bound to it, and 0 otherwise.

After the test, the impact on the overall tpot is less than 1%.


- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
version vllm-ascend v0.9.1 dev
export DYNAMIC_EXPERT_LOAD_METRICS=1

<img width="1208" height="76" alt="image" src="https://github.com/user-attachments/assets/85cc1ce0-bc3d-498d-9dce-7883f94a1d63" />
<img width="1390" height="44" alt="image" src="https://github.com/user-attachments/assets/1364ff87-7e92-47fb-b727-6df0b9d54232" />

