### PR TITLE
[0.9.1] cancel the verification between deepseek_mtp and non-ascend scheduler in disaggregated_prefill deployment

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -203,13 +203,22 @@ def check_ascend_config(vllm_config, enforce_eager):
                 "Ascend scheduler is only supported for V1 Engine.")
     # for v1 engine
     else:
-        # TODO(yexiong): remove this verification after mtp model supports original vllm scheduler
+        # TODO(yexiong): Currently deepseek_mtp can be enabled with original vllm
+        # scheduler only in disaggregated prefill scenarios. Otherwise, it should
+        # be enabled with only ascend scheduler. This block will be removed once
+        # mtp is completely compatible with all scenarios.
         if (not ascend_config.ascend_scheduler_config.enabled
                 and vllm_config.speculative_config
                 and vllm_config.speculative_config.method == 'deepseek_mtp'):
-            raise NotImplementedError(
-                "Currently deepseek MTP model is only supported for ascend scheduler."
-            )
+            if vllm_config.kv_transfer_config is None:
+                raise NotImplementedError(
+                    "Using deepseek_mtp without the ascend scheduler is only supported for disaggregated prefill deployments now."
+                )
+            else:
+                logger.warning(
+                    "Deepseek MTP model is enabled without ascend scheduler. Combination of deepseek MTP and original vllm "
+                    "scheduler is an experimental setting in disaggregated prefill scenarios and will be completely released soon."
+                )
         # for eager mode
         if enforce_eager:
             # torchair_graph cannot be enabled with eager mode.


### PR DESCRIPTION
### What this PR does / why we need it?
Currently deepseek_mtp can be enabled with original vllm scheduler only in disaggregated prefill scenarios (experimental). This pr change the verification logic to allow users to enable deepseek_mtp without ascend scheduler in disaggregated prefill deployments.

### Does this PR introduce _any_ user-facing change?
Users can enable deepseek_mtp model without ascend scheduler in disaggregated_prefill deployments.

### How was this patch tested?
CI and e2e vllm serving passed.

