### PR TITLE
[Bugfix] Fix header include issue in rope

### DIFF
--- a/csrc/kernels/pos_encoding_kernels.cpp
+++ b/csrc/kernels/pos_encoding_kernels.cpp
@@ -15,11 +15,6 @@
  */
 
 #include "kernel_operator.h"
-#include "kernel_tpipe_impl.h"
-#include "kernel_tensor_impl.h"
-#include "kernel_type.h"
-#include "kernel_operator_intf.h"
-#include "inner_interface/inner_kernel_operator_intf.h"
 #include <stdio.h>
 #include "types.h"
 #include "utils.h"


### PR DESCRIPTION
### What this PR does / why we need it?
vLLM-Ascend's rope implementaion include several header file that are not supposed to be included by outside users. Current implementation may break when canntoolkits update, this PR remove those not compatible file includes to guarantee the safety of upgrading cann toolkits.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested by rope unittest

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/3e6dd400160525b71b19e3f94b0066b1bea7bb97
