### PR TITLE
[0.9.1-dev][BUGFIX] BugFix: Prevent prill node crash when proxy server is manually killed

### DIFF
--- a/examples/disaggregate_prefill_v1/README.md
+++ b/examples/disaggregate_prefill_v1/README.md
@@ -205,7 +205,7 @@ vllm serve /models/deepseek_r1_w8a8 \
 Run proxy server on the first node:
 ```shell
 cd /vllm-workspace/vllm-ascend/examples/disaggregate_prefill_v1
-python toy_proxy_server.py --host 172.19.32.175 --port 1025 --prefiller-hosts 172.19.241.49 --prefiller-port 20002 --decoder-hosts 172.19.123.51 --decoder-ports 20002
+python load_balance_proxy_server_example.py --host 172.19.32.175 --port 1025 --prefiller-hosts 172.19.32.175 --prefiller-port 20002 --decoder-hosts 172.19.123.51 --decoder-ports 20002
 ```
 
 Verification

--- a/examples/disaggregate_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregate_prefill_v1/load_balance_proxy_server_example.py
@@ -7,6 +7,7 @@ import asyncio
 import heapq
 import os
 import sys
+import uuid
 from contextlib import asynccontextmanager
 from typing import List
 
@@ -111,7 +112,7 @@ class ProxyState:
     async def next_req_id(self):
         async with self.req_id_lock:
             self.req_id_counter += 1
-            return str(self.req_id_counter)
+            return str(uuid.uuid4())
 
     def select_prefiller(self, token_count):  # Changed to synchronous
         # No lock needed - entire function is atomic

--- a/examples/disaggregate_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregate_prefill_v1/load_balance_proxy_server_example.py
@@ -239,7 +239,9 @@ async def listen_for_disconnect(request: Request) -> None:
         if message["type"] == "http.disconnect":
             break
 
+
 def with_cancellation(handler_func):
+
     @functools.wraps(handler_func)
     async def wrapper(*args, **kwargs):
         request = kwargs["request"]
@@ -250,8 +252,9 @@ def with_cancellation(handler_func):
         for task in pending:
             task.cancel()
         if handler_task in done:
-            return handler_task.result
+            return handler_task.result()
         return None
+    
     return wrapper
 
 
@@ -460,3 +463,4 @@ if __name__ == '__main__':
     global_args = parse_args()
     import uvicorn
     uvicorn.run(app, host=global_args.host, port=global_args.port)
+    


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
Fix the P-node crash issue: request_id reuse caused the engine to crash, leading to the P-node crash. On the other hand, modify the proxy to prevent the D node from triggering the removal of the corresponding request_id from self.waiting when pulling the P node’s kv-cache, since the request_id is not in self.waiting at that moment.
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
By ci
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
