### PR TITLE
[CI] add lint block before running e2e

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -130,9 +130,9 @@ jobs:
           verbose: true
 
   e2e:
-    needs: [changes]
+    needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.e2e_tracker == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && needs.lint.result == 'success' && needs.changes.outputs.e2e_tracker == 'true' }}
     strategy:
       max-parallel: 2
       matrix:


### PR DESCRIPTION
### What this PR does / why we need it?
add lint block before running e2e. follow up https://github.com/vllm-project/vllm-ascend/pull/2445

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
N/A
