### PR TITLE
[Feat] Enable SP across DP for DeepSeekV2 MLA

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -62,6 +62,10 @@ class AscendConfig:
                     "lmhead_tensor_parallel_size is only supported in the pure DP scenario"
                 )
 
+        self.enable_mla_sp = additional_config.get("enable_mla_sp", False)
+        self.o_shard_parallel_size = int(additional_config.get("o_shard_parallel_size", -1))
+        self.enable_o_shard = self.o_shard_parallel_size > 0
+        self.o_shard_full_layers = int(additional_config.get("o_shard_full_layers", 0))
 
 class TorchairGraphConfig:
     """

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -24,6 +24,12 @@ from vllm_ascend.ops.attention import vanilla_chunked_prefill_mla
 from vllm_ascend.utils import npu_prefetch
 from vllm_ascend.worker.npu_input_batch import InputBatch
 
+import torch.distributed as dist
+from vllm.distributed.parallel_state import get_dp_group
+from vllm_ascend.distributed.parallel_state import get_mla_sp_world_group
+from vllm_ascend.mla_sp_context import get_sp_context
+from vllm_ascend.ops.shard import RowShardLinear
+
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -962,6 +968,126 @@ class AscendMLAImpl(MLAAttentionImpl):
                 prefill_q_nope, prefill_q_pe, prefill_k_nope, prefill_k_pe,
                 prefill_value)
         return decode_preprocess_res, prefill_preprocess_res
+    
+    def _forward_prefill_sp(
+        self,
+        hidden_states: torch.Tensor,
+        kv_cache: Tuple[torch.Tensor],
+        attn_metadata: M,
+    ) -> torch.Tensor:
+        sp_context = get_sp_context()
+        assert sp_context is not None
+        npu_prefetch(self.q_a_proj.weight,
+                     hidden_states,
+                     enabled=self.enable_prefetch)
+        # Split inputs from local DP to each device.
+        dp_sp_hidden_states = hidden_states
+        rank_sp_hidden_states = dp_sp_hidden_states[sp_context.my_rank_sp_start_token_within_dp:sp_context.my_rank_sp_end_token_within_dp]
+        sp_tokens = rank_sp_hidden_states.shape[0]
+        if sp_tokens == 0:
+            rank_sp_hidden_states = nn.functional.pad(rank_sp_hidden_states, (0, 0, 0, 1))
+            sp_tokens = 1
+        # MLA prefill:
+        # 1. Perform q_a_proj and q_a_layernorm to obtain q_c
+        # 2. Perform kv_a_proj_with_mqa to obtain kv_no_split
+        # 3. If need_gather_q_kv, perform all_gather.
+        sp_ckq = self.q_a_proj(rank_sp_hidden_states)[0]
+        sp_hidden_states_or_q_c = self.q_a_layernorm(sp_ckq)
+        sp_kv_no_split = self.kv_a_proj_with_mqa(rank_sp_hidden_states)[0]
+        # Rearrange down_proj outputs across DP.
+        sp_output = torch.cat([sp_hidden_states_or_q_c, sp_kv_no_split], dim=1)
+        if sp_tokens < sp_context.num_tokens_per_rank:
+            sp_output = nn.functional.pad(sp_output, (0, 0, 0, sp_context.num_tokens_per_rank - sp_tokens))
+        global_sp_output = get_mla_sp_world_group().all_gather(sp_output, 0)
+        my_dp = sp_context.my_dp
+        dp_output = global_sp_output[sp_context.start_token_of_dp[my_dp]:sp_context.end_token_of_dp[my_dp]]
+        prefill_q_c, prefill_kv_no_split = dp_output.split([self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim], dim=-1)
+
+        if attn_metadata is None:
+            # Dummy run, just construct the attention outputs.
+            output_prefill = torch.empty(
+                [prefill_q_c.shape[0], self.num_heads * self.v_head_dim],
+                dtype=hidden_states.dtype,
+                device=hidden_states.device
+            )
+        else:
+            # Preprocess prefill tokens, write kv cache and get:
+            # prefill_q_nope, prefill_q_pe, prefill_k_nope, prefill_k_pe, prefill_value
+            prefill_q = self.q_proj(prefill_q_c)[0]\
+                .view(-1, self.num_heads, self.qk_head_dim)
+            prefill_q_pe = prefill_q[..., self.qk_nope_head_dim:]
+            prefill_q_nope = prefill_q[..., :self.qk_nope_head_dim]
+            cos = attn_metadata.prefill.cos
+            sin = attn_metadata.prefill.sin
+            prefill_slots = attn_metadata.slot_mapping
+            prefill_q_pe = self.rope_single(prefill_q_pe, cos, sin)
+            prefill_k_pe, prefill_k_c_normed = self.exec_kv_prefill(
+                prefill_kv_no_split, cos, sin, kv_cache, prefill_slots)
+            prefill_k_pe = prefill_k_pe.view(prefill_q_c.shape[0],
+                                                self.num_kv_heads, -1)
+            prefill_k_nope, prefill_value = self.kv_b_proj(
+                prefill_k_c_normed)[0].view(
+                    -1, self.num_heads,
+                    self.qk_nope_head_dim + self.v_head_dim).split(
+                        [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            prefill_k_pe = prefill_k_pe.expand(
+                (*prefill_k_nope.shape[:-1], -1))
+            # Attention outputs.
+            output_prefill = self._forward_prefill(
+                    prefill_q_nope, prefill_q_pe,
+                    prefill_k_nope, prefill_k_pe,
+                    prefill_value, kv_cache, attn_metadata)
+
+        # Rearrange attention outputs across DP to run SP.
+        sp_world_group = get_mla_sp_world_group()
+        tp_size = get_tp_group().world_size
+        my_rank = sp_context.my_rank
+        my_rank_start_token = sp_context.rank_sp_start_token[my_rank]
+        my_rank_end_token = sp_context.rank_sp_end_token[my_rank]
+        num_sp_tokens = max(my_rank_end_token - my_rank_start_token, 0)
+        sp_send = output_prefill
+        if get_dp_group().world_size == 1:
+            padded_len = sp_context.num_tokens_per_rank * sp_world_group.world_size
+            if sp_context.num_global_tokens < padded_len:
+                sp_send = nn.functional.pad(sp_send, (0, 0, 0, padded_len - sp_context.num_global_tokens))
+            sp_output = torch.empty(
+                [sp_context.num_tokens_per_rank * tp_size, self.num_heads * self.v_head_dim],
+                dtype=sp_send.dtype,
+                device=sp_send.device
+            )
+            dist.all_to_all_single(
+                output=sp_output,
+                input=sp_send,
+                group=sp_world_group.device_group,
+            )
+            sp_output = sp_output.reshape(sp_context.num_tokens_per_rank, tp_size * self.num_heads * self.v_head_dim)
+            sp_output = sp_output[:num_sp_tokens]
+        else:
+            sp_output = torch.empty(
+                [num_sp_tokens * tp_size, self.num_heads * self.v_head_dim],
+                dtype=sp_send.dtype,
+                device=sp_send.device
+            )
+            dist.all_to_all_single(
+                output=sp_output,
+                input=sp_send,
+                output_split_sizes=sp_context.output_split_sizes,
+                input_split_sizes=sp_context.input_split_sizes,
+                group=sp_world_group.device_group,
+            )
+            sp_output = sp_output.reshape(num_sp_tokens, tp_size * self.num_heads * self.v_head_dim)
+        sp_tokens = sp_output.shape[0]
+        if sp_tokens == 0:
+            sp_output = nn.functional.pad(sp_output, (0, 0, 0, 1))
+            sp_tokens = 1
+        # O proj
+        o_output = self.o_proj(sp_output)[0]
+        del sp_output
+        if sp_tokens < sp_context.num_tokens_per_rank:
+            o_output = nn.functional.pad(o_output, (0, 0, 0, sp_context.num_tokens_per_rank - sp_tokens))
+        dp_output = get_tp_group().all_gather(o_output, 0)
+        dp_output = dp_output[:sp_context.num_my_dp_sp_tokens]
+        return dp_output
 
     def forward(
         self,
@@ -972,6 +1098,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
+        if get_sp_context() is not None:
+            # SP across DP
+            output[...] = self._forward_prefill_sp(hidden_states, kv_cache, attn_metadata)
+            return output
         if attn_metadata is None:
             # Profiling run.
             return output
@@ -1024,6 +1154,11 @@ class AscendMLAImpl(MLAAttentionImpl):
                     current_ms_metadata.after_comm_event.record()
             else:
                 o_proj_input[num_decode_tokens:] = output_prefill
+
+        # When o_proj sharding is enabled, make sure the second dimension is complete while decoding.
+        if isinstance(self.o_proj, RowShardLinear):
+            o_proj_input = get_tp_group().all_gather(o_proj_input, dim=-1)
+
         # O proj
         current_ms_metadata = get_multistream_comm_context()
         MAX_O_PROJ_PREFETCH_SIZE = 16 * 1024 * 1024

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -91,6 +91,7 @@ def init_ascend_model_parallel(parallel_config: ParallelConfig, ):
                                           backend,
                                           group_name="lmheadtp")
 
+    init_ascend_mla_sp_model_parallel()
 
 def get_mlp_tensor_model_parallel_world_size():
     """Return world size for the tensor model parallel group."""
@@ -101,6 +102,46 @@ def get_mlp_tensor_model_parallel_rank():
     """Return world size for the tensor model parallel group."""
     return get_mlp_tp_group().rank_in_group
 
+# vllm-ascend will maintain its own MLA SP world GroupCoordinator and o_proj sharding GroupCoordinator for
+# customize parallel solution
+_MLA_SP_WORLD: Optional[GroupCoordinator] = None
+_O_SHARD: Optional[GroupCoordinator] = None
+
+def get_mla_sp_world_group() -> GroupCoordinator:
+    assert _MLA_SP_WORLD is not None, ("MLA sequence parallel world group is not initialized")
+    return _MLA_SP_WORLD
+
+def get_o_shard_group() -> GroupCoordinator:
+    assert _O_SHARD is not None, ("o_proj sharding group is not initialized")
+    return _O_SHARD
+
+def init_ascend_mla_sp_model_parallel():
+    from vllm_ascend.ascend_config import get_ascend_config
+    ascend_config = get_ascend_config()
+    world_size = torch.distributed.get_world_size()
+    backend = torch.distributed.get_backend(get_world_group().device_group)
+
+    if ascend_config.enable_mla_sp:
+        assert ascend_config.enable_o_shard, "MLA SP must be enabled with o_proj sharding"
+        global _MLA_SP_WORLD
+        group_ranks = [list(range(torch.distributed.get_world_size()))]
+        _MLA_SP_WORLD = init_model_parallel_group(group_ranks,
+                                                  get_world_group().local_rank,
+                                                  backend,
+                                                  group_name="mla_sp_world")
+
+    if ascend_config.enable_o_shard:
+        o_shard_parallel_size = ascend_config.o_shard_parallel_size
+        assert o_shard_parallel_size >= 2, "o_shard_parallel_size must be >= 2"
+        assert world_size % o_shard_parallel_size == 0, "o_shard_parallel_size must be a divisor of world_size"
+        global _O_SHARD
+        all_ranks = torch.arange(world_size)
+        group_ranks = all_ranks.view(-1, o_shard_parallel_size).unbind(0)
+        group_ranks = [x.tolist() for x in group_ranks]
+        _O_SHARD = init_model_parallel_group(group_ranks,
+                                             get_world_group().local_rank,
+                                             backend,
+                                             group_name="o_shard")
 
 def destroy_ascend_model_parallel():
     global _MC2
@@ -117,3 +158,13 @@ def destroy_ascend_model_parallel():
     if _LMTP:
         _LMTP.destroy()
     _LMTP = None
+
+    global _MLA_SP_WORLD
+    if _MLA_SP_WORLD:
+        _MLA_SP_WORLD.destroy()
+    _MLA_SP_WORLD = None
+
+    global _O_SHARD
+    if _O_SHARD:
+        _O_SHARD.destroy()
+    _O_SHARD = None

--- a/vllm_ascend/mla_sp_context.py
+++ b/vllm_ascend/mla_sp_context.py
@@ -1,0 +1,174 @@
+from typing import Optional, Union
+
+import torch
+from torch import nn
+
+from dataclasses import dataclass
+from vllm.attention import AttentionMetadata
+from vllm.distributed.parallel_state import (get_dp_group, get_tp_group)
+from vllm.forward_context import get_forward_context
+from vllm_ascend.distributed.parallel_state import get_mla_sp_world_group
+
+@dataclass
+class SPContext:
+    num_global_tokens: int
+    num_tokens_per_dp: int
+    num_tokens_per_rank: int
+    start_token_of_dp: list[int]
+    end_token_of_dp: list[int]
+    global_tokens: torch.Tensor
+    dp_sp_start_token: list[int]
+    dp_sp_end_token: list[int]
+    rank_sp_start_token: list[int]
+    rank_sp_end_token: list[int]
+    my_dp: int
+    my_rank: int
+    my_rank_sp_start_token_within_dp: int
+    my_rank_sp_end_token_within_dp: int
+    num_my_dp_sp_tokens: int
+    input_split_sizes: list[int]
+    output_split_sizes: list[int]
+
+_sp_context: Optional[SPContext] = None
+
+def get_sp_context() -> Optional[SPContext]:
+    return _sp_context
+
+def set_sp_context(
+    input_ids: torch.Tensor,
+    attn_metadata: Optional[Union["AttentionMetadata", dict[str, "AttentionMetadata"]]] = None,
+):
+    global _sp_context
+    _sp_context = None
+    sp_enabled = True
+    dp_group = get_dp_group()
+    tp_group = get_tp_group()
+    sp_world_group = get_mla_sp_world_group()
+    assert sp_world_group.world_size > 1
+
+    forward_context = get_forward_context()
+    if forward_context.in_profile_run:
+        return
+
+    num_input_tokens = input_ids.shape[0]
+    max_num_tokens_across_dp = forward_context.max_tokens_across_dp
+
+    if attn_metadata is None:
+        attn_metadata = forward_context.attn_metadata
+    if attn_metadata is not None:
+        if isinstance(attn_metadata, dict):
+            attn_metadata = next(iter(attn_metadata.values()))
+        has_decode = attn_metadata.num_decode_tokens > 0
+        has_prefill = attn_metadata.num_prefills > 0
+        if has_decode or not has_prefill:
+            sp_enabled = False
+    else:
+        assert num_input_tokens == 1, "Length of dummy run must be 1."
+
+    sp_metadata = torch.cat([
+        torch.tensor([sp_enabled, num_input_tokens], device=input_ids.device, dtype=torch.int32),
+        nn.functional.pad(input_ids, (0, max_num_tokens_across_dp - num_input_tokens)),
+    ]).unsqueeze(0)
+    sp_metadata_across_dp = dp_group.all_gather(sp_metadata, 0)
+    for i in range(dp_group.world_size):
+        row = sp_metadata_across_dp[i]
+        sp_enabled = bool(row[0] > 0)
+        if not sp_enabled:
+            return
+
+    num_global_tokens = 0
+    start_token_of_dp = []
+    end_token_of_dp = []
+    for i in range(dp_group.world_size):
+        row = sp_metadata_across_dp[i]
+        num_tokens = int(row[1].item())
+        start_token_of_dp.append(num_global_tokens)
+        num_global_tokens += num_tokens
+        end_token_of_dp.append(num_global_tokens)
+
+    num_tokens_per_rank = calc_div_ceil(num_global_tokens, sp_world_group.world_size)
+    num_tokens_per_dp = num_tokens_per_rank * tp_group.world_size
+    global_tokens = torch.empty(num_global_tokens, dtype=input_ids.dtype, device=input_ids.device)
+    for i in range(dp_group.world_size):
+        row = sp_metadata_across_dp[i]
+        num_tokens = row[1]
+        global_tokens[start_token_of_dp[i]:end_token_of_dp[i]] = row[2:num_tokens+2]
+
+    dp_sp_start_token = []
+    dp_sp_end_token = []
+    rank_sp_start_token = []
+    rank_sp_end_token = []
+    for i in range(dp_group.world_size):
+        start_token = i * num_tokens_per_dp
+        dp_sp_start_token.append(start_token)
+        dp_sp_end_token.append(min(start_token + num_tokens_per_dp, num_global_tokens))
+    for i in range(sp_world_group.world_size):
+        start_token = i * num_tokens_per_rank
+        rank_sp_start_token.append(start_token)
+        rank_sp_end_token.append(min(start_token + num_tokens_per_rank, num_global_tokens))
+
+    my_dp = dp_group.rank_in_group
+    my_rank = sp_world_group.rank_in_group
+    my_rank_sp_start_token_within_dp = tp_group.rank_in_group * num_tokens_per_rank
+    my_rank_sp_end_token_within_dp = min(my_rank_sp_start_token_within_dp + num_tokens_per_rank, max(0, dp_sp_end_token[my_dp] - dp_sp_start_token[my_dp]))
+    num_my_dp_sp_tokens = max(0, dp_sp_end_token[my_dp] - dp_sp_start_token[my_dp])
+
+    tp_size = tp_group.world_size
+    input_split_sizes = []
+    output_split_sizes = []
+    if dp_group.world_size > 1:
+        my_rank_start_token = rank_sp_start_token[my_rank]
+        my_rank_end_token = rank_sp_end_token[my_rank]
+        my_dp_start_token = start_token_of_dp[my_dp]
+        my_dp_end_token = end_token_of_dp[my_dp]
+        for i in range(sp_world_group.world_size):
+            other_rank_start_token = rank_sp_start_token[i]
+            other_rank_end_token = rank_sp_end_token[i]
+            send_start = max(my_dp_start_token, other_rank_start_token)
+            send_end = min(my_dp_end_token, other_rank_end_token)
+            send_len = max(0, send_end - send_start)
+            input_split_sizes.append(send_len)
+
+            other_dp_start_token = start_token_of_dp[i // tp_size]
+            other_dp_end_token = end_token_of_dp[i // tp_size]
+            receive_start = max(other_dp_start_token, my_rank_start_token)
+            receive_end = min(other_dp_end_token, my_rank_end_token)
+            receive_len = max(0, receive_end - receive_start)
+            output_split_sizes.append(receive_len)
+
+    forward_context.with_prefill = True
+    forward_context.max_tokens_across_dp = num_tokens_per_dp
+    forward_context.padded_num_tokens = calc_div_ceil(num_tokens_per_dp, tp_size) * tp_size
+    from vllm_ascend.ascend_forward_context import FusedMoEState
+    if forward_context.fused_moe_state == FusedMoEState.NaiveMulticast:
+        forward_context.fused_moe_state = FusedMoEState.AllGather
+    dp_metadata = forward_context.dp_metadata
+    if dp_metadata is not None:
+        dp_metadata.max_tokens_across_dp_cpu.fill_(num_tokens_per_dp)
+        cu_moe_tokens = 0
+        for i in range(dp_group.world_size):
+            cu_moe_tokens += max(dp_sp_end_token[i] - dp_sp_start_token[i], 1)
+            dp_metadata.cu_tokens_across_dp_cpu[i] = cu_moe_tokens
+
+    _sp_context = SPContext(
+        num_global_tokens=num_global_tokens,
+        num_tokens_per_dp=num_tokens_per_dp,
+        num_tokens_per_rank=num_tokens_per_rank,
+        start_token_of_dp=start_token_of_dp,
+        end_token_of_dp=end_token_of_dp,
+        global_tokens=global_tokens,
+        dp_sp_start_token=dp_sp_start_token,
+        dp_sp_end_token=dp_sp_end_token,
+        rank_sp_start_token=rank_sp_start_token,
+        rank_sp_end_token=rank_sp_end_token,
+        my_dp=my_dp,
+        my_rank=my_rank,
+        my_rank_sp_start_token_within_dp=my_rank_sp_start_token_within_dp,
+        my_rank_sp_end_token_within_dp=my_rank_sp_end_token_within_dp,
+        num_my_dp_sp_tokens=num_my_dp_sp_tokens,
+        input_split_sizes=input_split_sizes,
+        output_split_sizes=output_split_sizes,
+    )
+
+def calc_div_ceil(up: int, down: int) -> int:
+    return (up + down - 1) // down

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -74,6 +74,10 @@ from vllm_ascend.quantization.quant_config import AscendLinearMethod
 from vllm_ascend.quantization.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import dispose_tensor
 
+import torch.distributed as dist
+from vllm_ascend.distributed.parallel_state import get_o_shard_group
+from vllm_ascend.mla_sp_context import (get_sp_context, set_sp_context)
+from vllm_ascend.ops.shard import RowShardLinear
 
 class CustomDeepseekV2SiluAndMul(SiluAndMul):
 
@@ -508,7 +512,13 @@ class CustomDeepseekV2MLAAttention(DeepseekV2MLAAttention):
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.kv_b_proj")
-        if (config.n_routed_experts is not None
+        if ascend_config.enable_o_shard:
+            self.o_proj = RowShardLinear(self.num_heads * self.v_head_dim,
+                                         self.hidden_size,
+                                         bias=False,
+                                         quant_config=quant_config,
+                                         prefix=f"{prefix}.o_proj")
+        elif (config.n_routed_experts is not None
                 and self.debug_layer_idx >= config.first_k_dense_replace
                 and self.debug_layer_idx % config.moe_layer_freq == 0
                 and self.enable_shared_expert_dp):
@@ -732,10 +742,17 @@ class CustomDeepseekV2DecoderLayer(DeepseekV2DecoderLayer):
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)
 
+        sp_context = get_sp_context()
+        if sp_context is not None:
+            sp_tokens = hidden_states.shape[0]
+            if sp_tokens == 0:
+                hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, 1))
         if isinstance(self.mlp, CustomDeepseekV2MoE):
             hidden_states = self.mlp(hidden_states, attn_metadata)
         else:
             hidden_states = self.mlp(hidden_states)
+        if sp_context is not None:
+            hidden_states = hidden_states[:sp_tokens]
 
         if isinstance(
                 self.mlp,
@@ -810,6 +827,55 @@ class CustomDeepseekV2Model(nn.Module):
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))
 
+        ascend_config = get_ascend_config()
+        self.allow_mla_sp = model_config.use_mla\
+                            and hasattr(config, "q_lora_rank")\
+                            and ascend_config.enable_mla_sp\
+                            and ascend_config.enable_o_shard\
+                            and get_pp_group().world_size == 1\
+                            and not ascend_config.enable_shared_expert_dp
+
+    def maybe_initialize_o_shard(self):
+        ascend_config = get_ascend_config()
+        if not ascend_config.enable_o_shard:
+            return
+        full_layers = ascend_config.o_shard_full_layers
+        assert self.start_layer + full_layers < self.end_layer
+        assert full_layers >= 0
+        assert not ascend_config.enable_shared_expert_dp
+        if hasattr(self, 'o_proj_weight_window'):
+            return
+        group_for_shard = get_o_shard_group()
+        world_size = group_for_shard.world_size
+        shard_rank = group_for_shard.rank_in_group
+
+        sample = self.layers[self.start_layer].self_attn.o_proj.weight.data
+        self.o_proj_weight_window = [torch.empty((sample.shape[0] * world_size, sample.shape[1]), dtype=sample.dtype, device=sample.device) for _ in range(full_layers + 1)]
+        full = torch.empty_like(self.o_proj_weight_window[0])
+
+        from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, ACL_FORMAT_FRACTAL_NZ)
+        for i in range(len(self.o_proj_weight_window)):
+            torch_npu.npu_format_cast_(self.o_proj_weight_window[i], ACL_FORMAT_FRACTAL_NZ)
+
+        for i in range(self.start_layer, self.end_layer):
+            o_proj = self.layers[i].self_attn.o_proj
+
+            o_proj.aclnn_input_scale.data = o_proj.aclnn_input_scale.data.repeat(world_size)
+            o_proj.aclnn_input_scale_reciprocal.data = o_proj.aclnn_input_scale_reciprocal.data.repeat(world_size)
+            o_proj.aclnn_input_offset.data = o_proj.aclnn_input_offset.data.repeat(world_size)
+
+            torch_npu.npu_format_cast_(full, ACL_FORMAT_FRACTAL_ND)
+            dist.all_gather_into_tensor(full,
+                                        o_proj.weight.data,
+                                        group=group_for_shard.device_group)
+            torch_npu.npu_format_cast_(full, ACL_FORMAT_FRACTAL_NZ)
+            dispose_tensor(o_proj.weight.data)
+            if i < self.start_layer + full_layers or i % world_size == shard_rank:
+                o_proj.weight.data = full.clone().detach()
+            else:
+                o_proj.weight.data = self.o_proj_weight_window[i % (full_layers + 1)]
+            assert torch_npu.get_npu_format(o_proj.weight.data) == ACL_FORMAT_FRACTAL_NZ
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -822,6 +888,20 @@ class CustomDeepseekV2Model(nn.Module):
         intermediate_tensors: Optional[IntermediateTensors] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
+        ascend_config = get_ascend_config()
+        if ascend_config.enable_o_shard:
+            self.maybe_initialize_o_shard()
+            group_for_shard = get_o_shard_group()
+
+        if self.allow_mla_sp:
+            set_sp_context(input_ids, attn_metadata)
+        sp_context = get_sp_context()
+        if sp_context is not None:
+            assert intermediate_tensors is None
+            assert inputs_embeds is None
+            my_dp = sp_context.my_dp
+            input_ids = sp_context.global_tokens[sp_context.dp_sp_start_token[my_dp]:sp_context.dp_sp_end_token[my_dp]]
+
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -837,6 +917,20 @@ class CustomDeepseekV2Model(nn.Module):
 
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
+
+            if ascend_config.enable_o_shard:
+                o_proj = layer.self_attn.o_proj
+                if i < self.start_layer + ascend_config.o_shard_full_layers:
+                    o_proj.work = None
+                pre_load_layer_idx = i + ascend_config.o_shard_full_layers
+                if pre_load_layer_idx < self.end_layer:
+                    src = group_for_shard.ranks[pre_load_layer_idx % group_for_shard.world_size]
+                    next_o_proj = self.layers[pre_load_layer_idx].self_attn.o_proj
+                    next_o_proj.work = dist.broadcast(next_o_proj.weight.data,
+                                                      src=src,
+                                                      group=group_for_shard.device_group,
+                                                      async_op=True)
+
             hidden_states, residual = layer(
                 positions,
                 hidden_states,
@@ -845,6 +939,46 @@ class CustomDeepseekV2Model(nn.Module):
                           self.start_layer] if kv_caches is not None else None,
                 attn_metadata,
                 replace_allreduce=replace_allreduce)
+
+        if sp_context is not None:
+            dp_group = get_dp_group()
+            sp_send, _ = self.norm(hidden_states, residual)
+            if dp_group.world_size == 1:
+                return sp_send
+            input_split_sizes = []
+            output_split_sizes = []
+            my_dp = sp_context.my_dp
+            my_dp_start_token = sp_context.start_token_of_dp[my_dp]
+            my_dp_end_token = sp_context.end_token_of_dp[my_dp]
+            my_dp_sp_start_token = sp_context.dp_sp_start_token[my_dp]
+            my_dp_sp_end_token = sp_context.dp_sp_end_token[my_dp]
+            for i in range(dp_group.world_size):
+                other_dp_start_token = sp_context.start_token_of_dp[i]
+                other_dp_end_token = sp_context.end_token_of_dp[i]
+                send_start = max(my_dp_sp_start_token, other_dp_start_token)
+                send_end = min(my_dp_sp_end_token, other_dp_end_token)
+                send_len = max(0, send_end - send_start)
+                input_split_sizes.append(send_len)
+
+                other_dp_sp_start_token = sp_context.dp_sp_start_token[i]
+                other_dp_sp_end_token = sp_context.dp_sp_end_token[i]
+                receive_start = max(other_dp_sp_start_token, my_dp_start_token)
+                receive_end = min(other_dp_sp_end_token, my_dp_end_token)
+                receive_len = max(0, receive_end - receive_start)
+                output_split_sizes.append(receive_len)
+            sp_output = torch.empty(
+                [my_dp_end_token - my_dp_start_token, hidden_states.shape[1]],
+                dtype=sp_send.dtype,
+                device=sp_send.device
+            )
+            dist.all_to_all_single(
+                output=sp_output,
+                input=sp_send,
+                output_split_sizes=output_split_sizes,
+                input_split_sizes=input_split_sizes,
+                group=dp_group.device_group,
+            )
+            return sp_output
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({

--- a/vllm_ascend/ops/shard.py
+++ b/vllm_ascend/ops/shard.py
@@ -1,0 +1,134 @@
+from typing import Optional, Union
+
+import torch
+from torch.nn.parameter import Parameter
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.linear import LinearBase
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.distributed import divide
+from vllm_ascend.distributed.parallel_state import get_o_shard_group
+
+@CustomOp.register("row_shard_linear")
+class RowShardLinear(LinearBase):
+    """Linear layer with row shard storage.
+
+    The linear layer is defined as Y = XA + b. A is shard stored along
+    its first dimension as:
+               -   -
+              | A_1 |
+              | .   |
+          A = | .   |
+              | .   |
+              | A_p |
+               -   -
+    Arguments:
+        input_size: first dimension of matrix A.
+        output_size: second dimension of matrix A.
+        bias: If true, add bias.
+        skip_bias_add: This was added to enable performance optimization where
+                       bias can be fused with other element-wise operations.
+                       We skip adding bias but instead return it.
+        params_dtype: Data type for the parameters.
+        quant_config: Quantization configure.
+        prefix: The name of the layer in the state dict, including all parents
+                        (e.g. model.layers.0.self_attn.o_proj)
+        return_bias: If true, return bias together with outputs in forward pass.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        bias: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: Optional[torch.dtype] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+    ):
+        # Divide the weight matrix along the first dimension.
+        self.tp_rank = get_o_shard_group().rank_in_group
+        self.tp_size = get_o_shard_group().world_size
+        self.input_size_per_partition = divide(input_size, self.tp_size)
+        self.output_size_per_partition = output_size
+        self.output_partition_sizes = [output_size]
+
+        super().__init__(input_size,
+                         output_size,
+                         skip_bias_add,
+                         params_dtype,
+                         quant_config,
+                         prefix,
+                         return_bias=return_bias)
+
+        assert self.quant_method is not None
+        self.quant_method.create_weights(
+            layer=self,
+            input_size_per_partition=self.input_size_per_partition,
+            output_partition_sizes=self.output_partition_sizes,
+            input_size=self.input_size,
+            output_size=self.output_size,
+            params_dtype=self.params_dtype,
+            weight_loader=self.weight_loader)
+        if bias:
+            self.bias = Parameter(
+                torch.empty(self.output_size, dtype=params_dtype))
+            set_weight_attrs(self.bias, {
+                "output_dim": 0,
+                "weight_loader": self.weight_loader,
+            })
+        else:
+            self.register_parameter("bias", None)
+
+    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+        group_for_shard = get_o_shard_group()
+        tp_rank = group_for_shard.rank_in_group
+        tp_size = group_for_shard.world_size
+        input_dim = getattr(param, "input_dim", None)
+
+        assert not getattr(param, "use_bitsandbytes_4bit", False)
+        assert not getattr(param, "is_sharded_weight", False)
+        assert not getattr(param, "is_gguf_weight", False)
+        assert not getattr(param, "is_gguf_weight_type", False)
+
+        param_data = param.data
+        if input_dim is not None:
+            shard_size = param_data.shape[input_dim]
+            start_idx = tp_rank * shard_size
+            loaded_weight = loaded_weight.narrow(input_dim, start_idx,
+                                                 shard_size)
+
+        # Special case for loading scales off disk, which often do not
+        # have a shape (such as in the case of AutoFP8).
+        if len(loaded_weight.shape) == 0:
+            loaded_weight = loaded_weight.reshape(1)
+
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+    def forward(
+        self,
+        input,
+        is_prefill=True,
+        is_force_scatter=False
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, Optional[Parameter]]]:
+        # Matrix multiply.
+        assert self.quant_method is not None
+        if self.work is not None:
+            self.work.wait()
+            self.work = None
+        bias_ = None if self.skip_bias_add else self.bias
+        output = self.quant_method.apply(self, input, bias=bias_)
+        output_bias = self.bias if self.skip_bias_add else None
+        if not self.return_bias:
+            return output
+        return output, output_bias
+
+    def extra_repr(self) -> str:
+        s = f"input_features={self.input_size_per_partition}"
+        s += f", output_features={self.output_size}"
+        s += f", bias={self.bias is not None}"
+        s += f", tp_size={self.tp_size}"
+        return s


### PR DESCRIPTION
### What this PR does / why we need it?
The DeepSeekV2 MLA computation is facing two problems under multi-way DP configuration:
- Incoming requests often have varying input sequence lengths, leading to the unbalance among each DP.
- When there aren't many requests, some DP shards will just do dummy run and become useless.

This PR introduces a staged hybrid parallelism strategy optimized for MLA computation during the prefill phase:
<div align="center">

![pic](https://github.com/user-attachments/assets/8de03232-191c-4ba2-9619-fa2c7b2d8aa6)

Picture from https://arxiv.org/pdf/2506.12708 Fig. 16
</div>

- Stage 1: All the input tokens among all DP shards will be evenly rearranged to each rank. (SP)
- Stage 2: For each DP, All-Gather to get its own tokens and apply TP to run attention. After solving the KV Cache problem, this stage will be further optimized such that each DP is able to handle all the global tokens instead.
- Stage 3: All-to-All to run SP for `o_proj`. Here the weight of `o_proj` matrix will be completed. To save the memory, this PR introduces a shard approach. The weights of `o_proj` are kept at different ranks, and broadcast asynchronously to get the complete matrix in `FRACTAL_NZ` format for current layer during the computation.

### Does this PR introduce _any_ user-facing change?
This PR introduces three new configs in `additional_config`:
| Name | Effect | Required | Type | Constraints |
|---------|---------|---------|---------|---------|
| `enable_mla_sp` | Whether to enable SP for DeepSeekV2 MLA. | No | bool | Must be enabled with `o_proj` shard feature. It is temporary disabled when some other features are enabled. |
| `o_shard_parallel_size` | How to divide the rows of the `o_proj` matrix evenly across ranks for shard. | No | int | It should be at least 2 and should be a divisor of `world_size`. When it is missing, the shard feature is disabled. |
| `o_shard_full_layers` | The first complete `o_shard_full_layers` layers will be kept among all ranks without shard. When computing the `k`-th layer, the `o_proj` weight of the `k + o_shard_full_layers`-th layer will be broadcast asynchronously. | No | int | Default value is `0`. |

Example:
`--additional-config '{"enable_mla_sp": true, "o_shard_parallel_size": 8, "o_shard_full_layers": 5}'`

### How was this patch tested?
vLLM main: https://github.com/vllm-project/vllm/commit/a4454e9401c9c76150dc3a4d23d10377926b2fb6

- For DP 4 TP 4 configuration, start script:
```
export VLLM_USE_V1=1
export TASK_QUEUE_ENABLE=1

python -m vllm.entrypoints.openai.api_server --model=DeepSeek-R1-W8A8-VLLM \
 --served-model-name auto \
 --load-format=auto \
 --trust-remote-code \
 --enforce_eager \
 --distributed-executor-backend=mp \
 -tp=4 \
 -dp=4 \
 --quantization ascend \
 --additional-config '{"chunked_prefill_for_mla": true, "enable_mla_sp": true, "o_shard_parallel_size": 8, "o_shard_full_layers": 5}' \
 --port 8006 \
 --max-num-seqs 24 \
 --max-model-len 8192 \
 --max-num-batched-tokens 8192 \
 --block-size 128 \
 --gpu-memory-utilization 0.96 \
 --no-enable-prefix-caching
```
| max-concurrency | #requests | input tokens distribution | SP Throughput | Baseline Throughput |
|---------|---------|---------|---------|---------|
| 1 | 200 | Fixed 4096 | **0.77** | 0.64 |
| 96 | 400 | Fixed 4096 | **1.87** | 1.30 |
| 96 | 400 | Randomly from [1 .. 4096] | **3.67** | 2.44 |

- For DP 1 TP 16 configuration, the `max-model-len` and `max-num-batched-tokens` are `32768`.

| max-concurrency | #requests | input tokens distribution | SP Throughput | Baseline Throughput |
|---------|---------|---------|---------|---------|
| 1 | 200 | Fixed 4096 | 1.35 | **1.52** |
| 24 | 200 | Fixed 4096 | **2.29** | 2.21 |

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c07a73317d202c2dad67f12893fcddb6d3664950
