### PR TITLE
[bugfix] ascend schedule encountered an incorrect req block length in the check_watermark_for_prefill function

### DIFF
--- a/vllm_ascend/core/scheduler.py
+++ b/vllm_ascend/core/scheduler.py
@@ -417,7 +417,7 @@ class AscendScheduler(Scheduler):
                                    self.block_size)
         req_blocks = self.kv_cache_manager.coordinator.get_blocks(
             request.request_id)
-        num_new_blocks = (num_required_blocks - len(req_blocks) -
+        num_new_blocks = (num_required_blocks - len(req_blocks[0]) -
                           len(computed_blocks))
         num_evictable_computed_blocks = sum(1 for blk in computed_blocks
                                             if blk.ref_cnt == 0)


### PR DESCRIPTION
… the check_watermark_for_prefill function

### What this PR does / why we need it?
bugfix for ascend schedule encountered an incorrect req block length in the check_watermark_for_prefill function
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/65197a5fb37ef4d8b93e0b99ecc8b902fe948e97
