### PR TITLE
[Doc] update vllm version in ci

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ myst_substitutions = {
     # CANN image tag
     'cann_image_tag': "8.2.rc1-910b-ubuntu22.04-py3.11",
     # vllm version in ci
-    'ci_vllm_version': 'v0.10.0',
+    'ci_vllm_version': 'v0.10.1.1',
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
### What this PR does / why we need it?
update vllm version in ci

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/170e8ea9ea95294d1bdc4af4bea73741ea759e22
