### PR TITLE
[Perf] Remove unnecessary dispose_tensor

### DIFF
--- a/vllm_ascend/models/deepseek_dbo.py
+++ b/vllm_ascend/models/deepseek_dbo.py
@@ -76,7 +76,6 @@ from vllm_ascend.multistream.metadata import (MultiStreamConfig,
                                               MultiStreamStepMetadata,
                                               make_multistream_metadata_ds)
 from vllm_ascend.ops.fused_moe import AscendFusedMoE
-from vllm_ascend.utils import dispose_tensor
 
 VLLM_ASCEND_ENABLE_DBO: bool = envs_ascend.VLLM_ASCEND_ENABLE_DBO
 
@@ -487,13 +486,8 @@ class CustomDeepseekDBODecoderLayer(DeepseekV2DecoderLayer):
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
-            previous_hidden_states, previous_residual = hidden_states, residual
             hidden_states, residual = self.input_layernorm(
                 hidden_states, residual)
-            # Dispose hidden_states and residual from the previous layer
-            # to save npu memory because they're no longer used.
-            dispose_tensor(previous_hidden_states)
-            dispose_tensor(previous_residual)
 
         hidden_states = self.self_attn(
             positions=positions,

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -73,7 +73,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ops.fused_moe import AscendFusedMoE
 from vllm_ascend.quantization.quant_config import AscendLinearMethod
 from vllm_ascend.quantization.w8a8_dynamic import AscendW8A8DynamicLinearMethod
-from vllm_ascend.utils import dispose_tensor, npu_prefetch
+from vllm_ascend.utils import npu_prefetch
 
 
 class CustomDeepseekV2SiluAndMul(SiluAndMul):
@@ -726,13 +726,8 @@ class CustomDeepseekV2DecoderLayer(DeepseekV2DecoderLayer):
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
-            previous_hidden_states, previous_residual = hidden_states, residual
             hidden_states, residual = self.input_layernorm(
                 hidden_states, residual)
-            # Dispose hidden_states and residual from the previous layer
-            # to save npu memory because they're no longer used.
-            dispose_tensor(previous_hidden_states)
-            dispose_tensor(previous_residual)
         if mla_moe_communication and self.layer_idx > self.first_k_dense_replace:
             hidden_states = tensor_model_parallel_all_gather(hidden_states,
                                                              dim=0)

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -63,12 +63,8 @@ def apply_mlp_decode(hidden_states: torch.Tensor,
     """
 
     if dynamic_scale is None:
-        unquantized_hidden_states = hidden_states
         hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(
             hidden_states)
-        # Dispose the original unquantized hidden states
-        # to save npu memory because they're no longer used.
-        dispose_tensor(unquantized_hidden_states)
     else:
         pertoken_scale = dynamic_scale
 
@@ -288,7 +284,6 @@ def fused_experts_with_mc2(
                 (shared_gate_up, shared_dequant_scale))
             shared_act, swiglu_out_scale = shared_act_out[0], shared_act_out[1]
 
-    # `expand_x` will be disposed in the `apply_mlp` function
     if w1_scale_bias is None:
         down_out_list = apply_mlp_decode(expand_x,
                                          w1,

--- a/vllm_ascend/torchair/models/torchair_deepseek_v2.py
+++ b/vllm_ascend/torchair/models/torchair_deepseek_v2.py
@@ -73,7 +73,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.quantization.quant_config import AscendLinearMethod
 from vllm_ascend.quantization.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.torchair.ops.torchair_fused_moe import TorchairAscendFusedMoE
-from vllm_ascend.utils import dispose_tensor, npu_prefetch
+from vllm_ascend.utils import npu_prefetch
 
 
 class TorchairDeepseekV2SiluAndMul(SiluAndMul):
@@ -726,13 +726,8 @@ class TorchairDeepseekV2DecoderLayer(DeepseekV2DecoderLayer):
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
-            previous_hidden_states, previous_residual = hidden_states, residual
             hidden_states, residual = self.input_layernorm(
                 hidden_states, residual)
-            # Dispose hidden_states and residual from the previous layer
-            # to save npu memory because they're no longer used.
-            dispose_tensor(previous_hidden_states)
-            dispose_tensor(previous_residual)
         if mla_moe_communication and self.layer_idx > self.first_k_dense_replace:
             hidden_states = tensor_model_parallel_all_gather(hidden_states,
                                                              dim=0)


### PR DESCRIPTION
### What this PR does / why we need it?
In #966, I added the `dispose_tensor` function to reduce NPU memory spikes, but it has a slight impact on performance. So I only used it in the MOE w8a8_dynamic part. However, over the past few months, this function has been overused. So this PR gets rid of the unnecessary uses.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing test cases.

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d0a4a3f645dd57364a0562e01ee8a04e4afa63ba
