### PR TITLE
[0.9.1] [P/D] [bugfix] pd proxy enhance usability

### DIFF
--- a/examples/disaggregate_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregate_prefill_v1/load_balance_proxy_server_example.py
@@ -184,15 +184,31 @@ def parse_args():
                         type=str,
                         nargs="+",
                         default=["localhost"])
+    parser.add_argument("--prefiller-hosts-num",
+                        type=int,
+                        nargs="+",
+                        default=None)
     parser.add_argument("--prefiller-ports",
                         type=int,
                         nargs="+",
                         default=[8001])
+    parser.add_argument("--prefiller-ports-inc",
+                        type=int,
+                        nargs="+",
+                        default=None)
     parser.add_argument("--decoder-hosts",
                         type=str,
                         nargs="+",
                         default=["localhost"])
+    parser.add_argument("--decoder-hosts-num",
+                        type=int,
+                        nargs="+",
+                        default=None)
     parser.add_argument("--decoder-ports", type=int, nargs="+", default=[8002])
+    parser.add_argument("--decoder-ports-inc",
+                        type=int,
+                        nargs="+",
+                        default=None)
     parser.add_argument("--max-retries",
                         type=int,
                         default=3,
@@ -209,6 +225,49 @@ def parse_args():
     if len(args.decoder_hosts) != len(args.decoder_ports):
         raise ValueError(
             "Number of decoder hosts must match number of decoder ports")
+    if args.prefiller_hosts_num is not None and (len(args.prefiller_hosts_num)
+                                                 != len(args.prefiller_hosts)):
+        raise ValueError(
+            "Number of prefiller hosts num must match number of prefiller hosts"
+        )
+    if args.prefiller_ports_inc is not None and (len(args.prefiller_ports_inc)
+                                                 != len(args.prefiller_ports)):
+        raise ValueError(
+            "Number of prefiller ports inc must match number of prefiller ports"
+        )
+    if args.decoder_hosts_num is not None and (len(args.decoder_hosts_num) !=
+                                               len(args.decoder_hosts)):
+        raise ValueError(
+            "Number of decoder hosts num must match number of decoder hosts")
+    if args.decoder_ports_inc is not None and (len(args.decoder_ports_inc) !=
+                                               len(args.decoder_ports)):
+        raise ValueError(
+            "Number of decoder ports inc must match number of decoder ports")
+
+    if args.prefiller_hosts_num is not None:
+        args.prefiller_hosts = [
+            host for host, num in zip(args.prefiller_hosts,
+                                      args.prefiller_hosts_num)
+            for _ in range(num)
+        ]
+    if args.prefiller_ports_inc is not None:
+        args.prefiller_ports = [(int(port) + i) for port, inc in zip(
+            args.prefiller_ports, args.prefiller_ports_inc)
+                                for i in range(inc)]
+
+    if args.decoder_hosts_num is not None:
+        args.decoder_hosts = [
+            host
+            for host, num in zip(args.decoder_hosts, args.decoder_hosts_num)
+            for _ in range(num)
+        ]
+    if args.decoder_ports_inc is not None:
+        args.decoder_ports = [
+            (int(port) + i)
+            for port, inc in zip(args.decoder_ports, args.decoder_ports_inc)
+            for i in range(inc)
+        ]
+
     args.prefiller_instances = list(
         zip(args.prefiller_hosts, args.prefiller_ports))
     args.decoder_instances = list(zip(args.decoder_hosts, args.decoder_ports))


### PR DESCRIPTION
### What this PR does / why we need it?
pd proxy enhance usability，add prefiller-hosts-num、prefiller-ports-inc、decoder-hosts-num、decoder-ports-inc paramter in pd proxy

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
python load_balance_proxy_server_example.py \
  --port 8000 \
  --host 0.0.0.0 \
  --prefiller-hosts \
    141.61.39.101 \
    141.61.39.109 \
    141.61.39.121 \
    141.61.39.125 \
  --prefiller-hosts-num \
    2 2 2 2 \
  --prefiller-ports \
    9000 9000 9000 9000 \
  --prefiller-ports-inc \
    2 2 2 2\
  --decoder-hosts \
    141.61.39.129 \
    141.61.39.133 \
    141.61.39.137 \
    141.61.39.141 \
  --decoder-hosts-num \
    16 16 16 16 \
  --decoder-ports  \
    9000 9000 9000 9000 \
  --decoder-ports-inc \
    16 16 16 16 \

Parameter | meaning
--port | Proxy service IP
--host | Proxy service Host
--prefiller-hosts | Hosts of prefiller nodes
--prefiller-hosts-num | Number of repetitions for prefiller node hosts
--prefiller-ports | Ports of prefiller nodes
--prefiller-ports-inc | Number of increments for prefiller node ports
--decoder-hosts | Hosts of decoder nodes
--decoder-hosts-num | Number of repetitions for decoder node hosts
--decoder-ports | Ports of decoder nodes
--decoder-ports-inc | Number of increments for decoder node ports
