### PR TITLE
Supports weight prefetching for qwen235B non-quantized and w8a8 models.

### DIFF
--- a/vllm_ascend/models/qwen3_moe.py
+++ b/vllm_ascend/models/qwen3_moe.py
@@ -47,12 +47,11 @@ from vllm.model_executor.models.utils import (
     make_empty_intermediate_tensors_factory, make_layers, maybe_prefix)
 from vllm.sequence import IntermediateTensors
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ops.fused_moe import AscendFusedMoE
 from vllm_ascend.ops.sequence_parallel import (MetadataForPadding,
                                                init_metadata_for_sp)
-from vllm_ascend.utils import vllm_version_is,npu_prefetch
-from vllm_ascend.ascend_config import get_ascend_config
-
+from vllm_ascend.utils import npu_prefetch, vllm_version_is
 
 
 class CustomSparseMoeBlock(Qwen3MoeSparseMoeBlock):
@@ -205,9 +204,13 @@ class CustomQwen3MoeDecoderLayer(Qwen3MoeDecoderLayer):
         residual: Optional[torch.Tensor],
         _metadata_for_padding: Optional[MetadataForPadding] = None,
     ) -> torch.Tensor:
-        o_proj_size = self.self_attn.o_proj.weight.numel() * self.self_attn.o_proj.weight.element_size()
+        o_proj_size = self.self_attn.o_proj.weight.numel(
+        ) * self.self_attn.o_proj.weight.element_size()
         prefetch_size = 4 * 1024 * 1024 * self.tp_size if 4 * 1024 * 1024 * self.tp_size <= o_proj_size else o_proj_size
-        npu_prefetch(self.self_attn.o_proj.weight, hidden_states, prefetch_size, enabled=self.enable_prefetch)
+        npu_prefetch(self.self_attn.o_proj.weight,
+                     hidden_states,
+                     prefetch_size,
+                     enabled=self.enable_prefetch)
         # To prevent precision issues during the decoder phase when only prefilling enables SP
         if not self.enable_sequence_parallelism:
             self.self_attn.o_proj.reduce_results = True

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -53,7 +53,8 @@ from vllm_ascend.ops.sequence_parallel import MetadataForPadding
 from vllm_ascend.utils import (AscendSocVersion, dispose_tensor,
                                get_all_reduce_merge_state,
                                get_ascend_soc_version,
-                               get_rm_router_logits_state, is_310p,npu_prefetch)
+                               get_rm_router_logits_state, is_310p,
+                               npu_prefetch)
 
 MOE_ALL2ALL_BUFFER: bool = envs_ascend.MOE_ALL2ALL_BUFFER
 
@@ -988,7 +989,8 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         if fused_moe_state == FusedMoEState.MC2:
             ascend_config = get_ascend_config()
-            npu_prefetch(layer.w2_weight, x,
+            npu_prefetch(layer.w2_weight,
+                         x,
                          enabled=ascend_config.torchair_graph_config.enabled)
             return fused_experts_with_mc2(
                 hidden_states=x,

--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -53,7 +53,7 @@ from vllm_ascend.ops.sequence_parallel import MetadataForPadding
 from vllm_ascend.utils import (AscendSocVersion, dispose_tensor,
                                get_all_reduce_merge_state,
                                get_ascend_soc_version,
-                               get_rm_router_logits_state, is_310p)
+                               get_rm_router_logits_state, is_310p,npu_prefetch)
 
 MOE_ALL2ALL_BUFFER: bool = envs_ascend.MOE_ALL2ALL_BUFFER
 
@@ -987,6 +987,9 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         fused_moe_state = get_forward_context().fused_moe_state
 
         if fused_moe_state == FusedMoEState.MC2:
+            ascend_config = get_ascend_config()
+            npu_prefetch(layer.w2_weight, x,
+                         enabled=ascend_config.torchair_graph_config.enabled)
             return fused_experts_with_mc2(
                 hidden_states=x,
                 w1=layer.w13_weight,

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -30,7 +30,8 @@ from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.layers.experts_selector import select_experts
 from vllm_ascend.torchair.utils import npu_stream_switch, npu_wait_tensor
 from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_NZ, AscendSocVersion,
-                               dispose_tensor, get_ascend_soc_version,npu_prefetch)
+                               dispose_tensor, get_ascend_soc_version,
+                               npu_prefetch)
 
 
 def apply_mlp_decode(hidden_states: torch.Tensor,
@@ -947,10 +948,8 @@ class AscendW8A8DynamicFusedMoEMethod:
         elif fused_moe_state == FusedMoEState.MC2:
             ascend_config = get_ascend_config()
             enable_prefetch = ascend_config.torchair_graph_config.enabled
-            npu_prefetch(layer.w13_weight, x,
-                         enabled=enable_prefetch)
-            npu_prefetch(layer.w2_weight, x,
-                         enabled=enable_prefetch)
+            npu_prefetch(layer.w13_weight, x, enabled=enable_prefetch)
+            npu_prefetch(layer.w2_weight, x, enabled=enable_prefetch)
             return fused_experts_with_mc2(
                 hidden_states=x,
                 w1=layer.w13_weight,

--- a/
+++ b/
@@ -1,0 +1,32 @@
+edit bf22490 # 支持qwen235B 非量化及w8a8模型权重预取
+
+# Rebase 5d8ec28..bf22490 onto 5d8ec28 (1 command)
+#
+# Commands:
+# p, pick <commit> = use commit
+# r, reword <commit> = use commit, but edit the commit message
+# e, edit <commit> = use commit, but stop for amending
+# s, squash <commit> = use commit, but meld into previous commit
+# f, fixup [-C | -c] <commit> = like "squash" but keep only the previous
+#                    commit's log message, unless -C is used, in which case
+#                    keep only this commit's message; -c is same as -C but
+#                    opens the editor
+# x, exec <command> = run command (the rest of the line) using shell
+# b, break = stop here (continue rebase later with 'git rebase --continue')
+# d, drop <commit> = remove commit
+# l, label <label> = label current HEAD with a name
+# t, reset <label> = reset HEAD to a label
+# m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
+#         create a merge commit using the original merge commit's
+#         message (or the oneline, if no original merge commit was
+#         specified); use -c <commit> to reword the commit message
+# u, update-ref <ref> = track a placeholder for the <ref> to be updated
+#                       to this position in the new commits. The <ref> is
+#                       updated at the end of the rebase
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# If you remove a line here THAT COMMIT WILL BE LOST.
+#
+# However, if you remove everything, the rebase will be aborted.
+#


### PR DESCRIPTION
### What this PR does / why we need it?
Weight prefetching can reduce the TPOT of the qwen_moe model. In the mixed PD deployment scenario, for non-quantized models (tp4 dp4), the P90 TPOT decreases from 112 ms to 102 ms. In the single decode scenario (tp1 dp16) with Prefill-Decode Disaggregation, the P90 TPOT decreases from 105 ms to 102 ms. For the w8a8 quantized model in the single decode scenario with Prefill-Decode Disaggregation, the P90 TPOT decreases from 109 ms to 102 ms.
### Does this PR introduce _any_ user-facing change?
No. Weight prefetching will be automatically enabled when the user turns on torchair.
### How was this patch tested?
The data was tested on an A3 machine.


- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/6578e873655859462758c5c51e51f876f2aa24a3
