### PR TITLE
[main][bugfix] Address abnormal VRAM increase in quantized models with floating-point MTP

### DIFF
--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -412,6 +412,8 @@ def fused_experts_with_all2all(
     num_experts = w1.shape[0]
 
     if expert_map is not None:
+        assert ep_group is not None, "ep_group must be provided when expert_map is not None"
+
         global_num_experts = len(expert_map) + global_redundant_expert_num
         if hasattr(torch_npu, "npu_moe_init_routing_quant"):
             quantized_tokens, expanded_row_idx, global_expert_tokens, _, token_scales = torch_npu.npu_moe_init_routing_quant(
@@ -431,7 +433,9 @@ def fused_experts_with_all2all(
 
         gather_sizes = global_expert_tokens.new_empty(
             global_expert_tokens.shape[0])
-        dist.all_to_all_single(gather_sizes, global_expert_tokens)
+        dist.all_to_all_single(gather_sizes,
+                               global_expert_tokens,
+                               group=ep_group.device_group)
 
         token_counts_combined = torch.stack(
             [gather_sizes, global_expert_tokens], dim=0)
@@ -447,10 +451,16 @@ def fused_experts_with_all2all(
         gather_size_list = token_counts_combined_cpu[1]
         scatter_size_list = token_counts_combined_cpu[0]
 
-        dist.all_to_all_single(gathered_tokens, quantized_tokens,
-                               scatter_size_list, gather_size_list)
-        dist.all_to_all_single(dynamic_scale, token_scales, scatter_size_list,
-                               gather_size_list)
+        dist.all_to_all_single(gathered_tokens,
+                               quantized_tokens,
+                               scatter_size_list,
+                               gather_size_list,
+                               group=ep_group.device_group)
+        dist.all_to_all_single(dynamic_scale,
+                               token_scales,
+                               scatter_size_list,
+                               gather_size_list,
+                               group=ep_group.device_group)
 
         hidden_states, dynamic_scale, inverse_indices, expert_tokens = torch_npu.npu_moe_re_routing(
             gathered_tokens,
@@ -492,8 +502,11 @@ def fused_experts_with_all2all(
             index=inverse_indices.to(torch.float32).argsort().to(torch.int32))
 
         hidden_states = reordered_outputs.new_empty(*quantized_tokens.shape)
-        dist.all_to_all_single(hidden_states, reordered_outputs,
-                               gather_size_list, scatter_size_list)
+        dist.all_to_all_single(hidden_states,
+                               reordered_outputs,
+                               gather_size_list,
+                               scatter_size_list,
+                               group=ep_group.device_group)
 
         final_hidden_states = torch_npu.npu_moe_finalize_routing(
             hidden_states,

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -412,8 +412,8 @@ def fused_experts_with_all2all(
     num_experts = w1.shape[0]
 
     if expert_map is not None:
-        assert ep_group is not None, "ep_group must be provided when expert_map is not None"
-
+        if ep_group is None:
+            raise ValueError("ep_group must be provided when expert_map is not None")
         global_num_experts = len(expert_map) + global_redundant_expert_num
         if hasattr(torch_npu, "npu_moe_init_routing_quant"):
             quantized_tokens, expanded_row_idx, global_expert_tokens, _, token_scales = torch_npu.npu_moe_init_routing_quant(

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -413,7 +413,8 @@ def fused_experts_with_all2all(
 
     if expert_map is not None:
         if ep_group is None:
-            raise ValueError("ep_group must be provided when expert_map is not None")
+            raise ValueError(
+                "ep_group must be provided when expert_map is not None")
         global_num_experts = len(expert_map) + global_redundant_expert_num
         if hasattr(torch_npu, "npu_moe_init_routing_quant"):
             quantized_tokens, expanded_row_idx, global_expert_tokens, _, token_scales = torch_npu.npu_moe_init_routing_quant(


### PR DESCRIPTION
### **Problem & Cause**

VRAM usage increased abnormally during mixed-precision inference with quantized models and floating-point MTP. This was caused by `dist.all_to_all_single` creating extra HCCL communicators, which produced unnecessary buffers that consumed more memory.

### **Solution**

This commit adds a communicator parameter to `dist.all_to_all_single`. By passing the existing communicator from the `vllm-ascend` framework, we ensure all communication operations use a unified domain, preventing the creation of extra buffers and solving the VRAM issue.

### **Collaborators**

@kunpengW-code 
cc  @Yikun @wangxiyuan 

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/91e382c935c2905c29f3ca22c658e03e8f02deaa
