### PR TITLE
Support v0.10.1

### DIFF
--- a/tests/ut/core/test_scheduler.py
+++ b/tests/ut/core/test_scheduler.py
@@ -21,7 +21,7 @@ from tests.ut.base import TestBase
 from vllm_ascend.core.scheduler import AscendScheduler
 from vllm_ascend.utils import vllm_version_is
 
-if not vllm_version_is("0.10.1.1"):
+if not (vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1")):
     from vllm.v1.outputs import DraftTokenIds
 else:
     DraftTokenIds = None
@@ -78,7 +78,7 @@ def make_output(scheduler):
     }
     sampled_token_ids = [[1000]] * len(scheduler.running)
     logprobs = None
-    if vllm_version_is("0.10.1.1"):
+    if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
         modelrunner_output = ModelRunnerOutput(
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
@@ -297,7 +297,7 @@ class TestAscendScheduler(TestBase):
             scheduler.running.append(req)
             req.status = RequestStatus.RUNNING
 
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             scheduler_output = SchedulerOutput(
                 scheduled_new_reqs=[],
                 scheduled_cached_reqs=[],
@@ -384,7 +384,7 @@ class TestAscendScheduler(TestBase):
             scheduler.running.append(req)
             req.status = RequestStatus.RUNNING
 
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             scheduler_output = SchedulerOutput(
                 scheduled_new_reqs=[],
                 scheduled_cached_reqs=[],
@@ -468,7 +468,7 @@ class TestAscendScheduler(TestBase):
             scheduler.running.append(req)
             req.status = RequestStatus.RUNNING
 
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             scheduler_output = SchedulerOutput(
                 scheduled_new_reqs=[],
                 scheduled_cached_reqs=[],
@@ -549,7 +549,7 @@ class TestAscendScheduler(TestBase):
         scheduler.requests[requests[0].request_id] = requests[0]
         scheduler.running.append(requests[0])
 
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             scheduler_output = SchedulerOutput(
                 scheduled_new_reqs=[],
                 scheduled_cached_reqs=[],
@@ -645,7 +645,7 @@ class TestAscendScheduler(TestBase):
                 512)
 
             # Model output of the first request.
-            if vllm_version_is("0.10.1.1"):
+            if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
                 model_runner_output = ModelRunnerOutput(
                     req_ids=[requests[0].request_id],
                     req_id_to_index={requests[0].request_id: 0},
@@ -671,7 +671,7 @@ class TestAscendScheduler(TestBase):
             # request is still running.
             scheduler.schedule()
             # Model output of the second request.
-            if vllm_version_is("0.10.1.1"):
+            if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
                 model_runner_output = ModelRunnerOutput(
                     req_ids=[requests[1].request_id],
                     req_id_to_index={requests[1].request_id: 0},
@@ -739,7 +739,7 @@ class TestAscendScheduler(TestBase):
                 req_id = requests[i].request_id
                 self.assertEqual(output.num_scheduled_tokens[req_id], 1)
                 self.assertNotIn(req_id, output.scheduled_spec_decode_tokens)
-            if vllm_version_is("0.10.1.1"):
+            if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
                 model_runner_output = ModelRunnerOutput(
                     req_ids=req_ids,
                     req_id_to_index=req_to_index,
@@ -760,7 +760,7 @@ class TestAscendScheduler(TestBase):
 
             engine_core_outputs = scheduler.update_from_output(
                 output, model_runner_output)
-            if not vllm_version_is("0.10.1.1"):
+            if not (vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1")):
                 scheduler.update_draft_token_ids(draft_token_ids)
 
             for i in range(len(requests)):
@@ -797,7 +797,7 @@ class TestAscendScheduler(TestBase):
                 else:
                     self.assertNotIn(req_id,
                                      output.scheduled_spec_decode_tokens)
-            if vllm_version_is("0.10.1.1"):
+            if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
                 model_runner_output = ModelRunnerOutput(
                     req_ids=req_ids,
                     req_id_to_index=req_to_index,

--- a/tests/ut/kv_connector/utils.py
+++ b/tests/ut/kv_connector/utils.py
@@ -200,7 +200,7 @@ def create_model_runner_output(
     kv_connector_output = KVConnectorOutput(finished_sending=finished_sending,
                                             finished_recving=finished_recving)
     extra_args = {"kv_connector_output": kv_connector_output}
-    if vllm_version_is("0.10.1.1"):
+    if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,

--- a/vllm_ascend/core/scheduler.py
+++ b/vllm_ascend/core/scheduler.py
@@ -33,7 +33,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 
 from vllm_ascend.utils import vllm_version_is
 
-if vllm_version_is("0.10.1.1"):
+if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 else:
     KVCacheBlocks = None
@@ -66,7 +66,7 @@ class AscendScheduler(Scheduler):
         scheduled_running_reqs: list[Request] = []
         preempted_reqs: list[Request] = []
 
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             req_to_new_block_ids: dict[str, list[int]] = {}
         else:
             req_to_new_blocks: dict[str, KVCacheBlocks] = {}
@@ -227,7 +227,7 @@ class AscendScheduler(Scheduler):
 
             if self.lora_config and request.lora_request:
                 scheduled_loras.add(request.lora_request.lora_int_id)
-            if vllm_version_is("0.10.1.1"):
+            if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
                 req_to_new_block_ids[request.request_id] = (
                     self.kv_cache_manager.get_block_ids(request.request_id))
             else:
@@ -320,7 +320,7 @@ class AscendScheduler(Scheduler):
                 # Schedule the request.
                 scheduled_running_reqs.append(request)
                 self.scheduled_req_ids.add(request.request_id)
-                if vllm_version_is("0.10.1.1"):
+                if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
                     req_to_new_block_ids[request.request_id] = (
                         new_blocks.get_block_ids())
                 else:
@@ -362,7 +362,7 @@ class AscendScheduler(Scheduler):
                     any_request, len(self.running)))
 
         # Construct the scheduler output.
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             new_reqs_data = [
                 NewRequestData.from_request(
                     req, req_to_new_block_ids[req.request_id])
@@ -385,7 +385,7 @@ class AscendScheduler(Scheduler):
                 req_to_new_blocks)
         scheduled_cached_reqs = cached_reqs_data
 
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             scheduler_output = SchedulerOutput(
                 scheduled_new_reqs=new_reqs_data,
                 scheduled_cached_reqs=scheduled_cached_reqs,

--- a/vllm_ascend/models/qwen3_moe.py
+++ b/vllm_ascend/models/qwen3_moe.py
@@ -254,7 +254,7 @@ class CustomQwen3MoeModel(Qwen3MoeModel):
         quant_config = vllm_config.quant_config
 
         parallel_config = vllm_config.parallel_config
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             self.num_redundant_experts = parallel_config.num_redundant_experts
         else:
             eplb_config = parallel_config.eplb_config

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -5,7 +5,7 @@ from vllm.v1.sample.sampler import Sampler
 
 from vllm_ascend.utils import is_310p, vllm_version_is
 
-if not vllm_version_is("0.10.1.1"):
+if not (vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1")):
     from vllm.config import LogprobsMode
     DEFAULT_LOGPROBS_MODE = LogprobsMode.RAW_LOGPROBS
 else:
@@ -68,7 +68,7 @@ class AscendTopKTopPSampler(TopKTopPSampler):
     def forward_native(self, logits, generators, k, p):
         """Override pytorch native implementation to torch_npu"""
         logits = self._apply_top_k_top_p(logits, k, p)
-        if not vllm_version_is("0.10.1.1"):
+        if not (vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1")):
 
             logits_to_return = None
             if self.logprobs_mode == LogprobsMode.PROCESSED_LOGITS:
@@ -79,7 +79,7 @@ class AscendTopKTopPSampler(TopKTopPSampler):
 
         probs = logits.softmax(dim=-1, dtype=torch.float32)
         output = None
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             output = random_sample(probs, generators)
         else:
             output = (random_sample(probs, generators), logits_to_return)

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -726,7 +726,7 @@ class InputBatch:
             pooling_params = [
                 self.pooling_params[req_id] for req_id in self.req_ids
             ]
-        if vllm_version_is("0.10.1.1"):
+        if vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1"):
             return PoolingMetadata(
                 prompt_lens=torch.from_numpy(
                     self.num_prompt_tokens[:self.num_reqs]).to(self.device),

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -50,7 +50,7 @@ from vllm_ascend.utils import (init_ascend_soc_version,
                                try_register_lib, vllm_version_is)
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
-if not vllm_version_is("0.10.1.1"):
+if not (vllm_version_is("0.10.1.1") or vllm_version_is("0.10.1")):
     from vllm.v1.outputs import DraftTokenIds
 else:
     DraftTokenIds = None


### PR DESCRIPTION
### What this PR does / why we need it?
This patch also supports v0.10.1

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- CI passed
- test 0.10.1: https://github.com/vllm-project/vllm-ascend/pull/2583
- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/321938e9ac4000e0cb37e328359a7fd3026bc672
