### PR TITLE
[Main][Feat]Set the Profiler parameters through environment variables consistent with vLLM

### DIFF
--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -452,11 +452,13 @@ class TestNPUWorker(TestBase):
         mock_logger,
         mock_envs_vllm,
     ):
-        """Test _init_profiler method - profiler enabled case"""
+        """Test _init_profiler method - profiler enabled case with stack and memory profiling enabled"""
         from vllm_ascend.worker.worker_v1 import NPUWorker
 
         # Set environment variables to enable profiler
         mock_envs_vllm.VLLM_TORCH_PROFILER_DIR = "/path/to/traces"
+        mock_envs_vllm.VLLM_TORCH_PROFILER_WITH_STACK = True
+        mock_envs_vllm.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY = True
 
         # Set enum mocks
         mock_export_type.Text = "Text"
@@ -516,13 +518,83 @@ class TestNPUWorker(TestBase):
             # Verify profiler parameters
             expected_activities = ["CPU", "NPU"]
             self.assertEqual(profile_kwargs["activities"], expected_activities)
-            self.assertFalse(profile_kwargs["with_stack"])
-            self.assertFalse(profile_kwargs["profile_memory"])
+            self.assertTrue(profile_kwargs["with_stack"])
+            self.assertTrue(profile_kwargs["profile_memory"])
             self.assertFalse(profile_kwargs["with_modules"])
             self.assertEqual(profile_kwargs["experimental_config"],
                              mock_experimental_config_instance)
             self.assertEqual(profile_kwargs["on_trace_ready"],
                              mock_trace_handler_instance)
+
+            # Verify return value
+            self.assertEqual(result, mock_profiler_instance)
+
+    @patch("vllm_ascend.worker.worker_v1.envs_vllm")
+    @patch("vllm_ascend.worker.worker_v1.logger")
+    @patch("torch_npu.profiler._ExperimentalConfig")
+    @patch("torch_npu.profiler.profile")
+    @patch("torch_npu.profiler.tensorboard_trace_handler")
+    @patch("torch_npu.profiler.ExportType")
+    @patch("torch_npu.profiler.ProfilerLevel")
+    @patch("torch_npu.profiler.AiCMetrics")
+    @patch("torch_npu.profiler.ProfilerActivity")
+    def test_init_profiler_enabled_without_stack_and_memory(self,
+        mock_profiler_activity,
+        mock_aic_metrics,
+        mock_profiler_level,
+        mock_export_type,
+        mock_trace_handler,
+        mock_profile,
+        mock_experimental_config,
+        mock_logger,
+        mock_envs_vllm,
+    ):
+        """Test _init_profiler method - profiler enabled case with stack and memory profiling disabled"""
+        from vllm_ascend.worker.worker_v1 import NPUWorker
+
+        # Set environment variables to enable profiler but disable stack and memory profiling
+        mock_envs_vllm.VLLM_TORCH_PROFILER_DIR = "/path/to/traces"
+        mock_envs_vllm.VLLM_TORCH_PROFILER_WITH_STACK = False
+        mock_envs_vllm.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY = False
+
+        # Set enum mocks
+        mock_export_type.Text = "Text"
+        mock_profiler_level.Level1 = "Level1"
+        mock_aic_metrics.AiCoreNone = "AiCoreNone"
+        mock_profiler_activity.CPU = "CPU"
+        mock_profiler_activity.NPU = "NPU"
+
+        # Set mock return values
+        mock_experimental_config_instance = MagicMock()
+        mock_experimental_config.return_value = mock_experimental_config_instance
+        mock_trace_handler_instance = MagicMock()
+        mock_trace_handler.return_value = mock_trace_handler_instance
+        mock_profiler_instance = MagicMock()
+        mock_profile.return_value = mock_profiler_instance
+
+        # Create worker mock
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+
+            # Test _init_profiler
+            result = worker._init_profiler()
+
+            # Verify log output
+            mock_logger.info.assert_called_once_with(
+                "Profiling enabled. Traces will be saved to: %s",
+                "/path/to/traces")
+
+            # Verify profiler creation
+            mock_profile.assert_called_once()
+            profile_call = mock_profile.call_args
+            profile_kwargs = profile_call.kwargs
+
+            # Verify profiler parameters
+            expected_activities = ["CPU", "NPU"]
+            self.assertEqual(profile_kwargs["activities"], expected_activities)
+            self.assertFalse(profile_kwargs["with_stack"])
+            self.assertFalse(profile_kwargs["profile_memory"])
+            self.assertFalse(profile_kwargs["with_modules"])
 
             # Verify return value
             self.assertEqual(result, mock_profiler_instance)

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -538,7 +538,8 @@ class TestNPUWorker(TestBase):
     @patch("torch_npu.profiler.ProfilerLevel")
     @patch("torch_npu.profiler.AiCMetrics")
     @patch("torch_npu.profiler.ProfilerActivity")
-    def test_init_profiler_enabled_without_stack_and_memory(self,
+    def test_init_profiler_enabled_without_stack_and_memory(
+        self,
         mock_profiler_activity,
         mock_aic_metrics,
         mock_profiler_level,

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -334,8 +334,8 @@ class NPUWorker(WorkerBase):
                     torch_npu.profiler.ProfilerActivity.CPU,
                     torch_npu.profiler.ProfilerActivity.NPU,
                 ],
-                with_stack=False,
-                profile_memory=False,
+                with_stack=envs_vllm.VLLM_TORCH_PROFILER_WITH_STACK,
+                profile_memory=envs_vllm.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY,
                 with_modules=False,
                 experimental_config=experimental_config,
                 on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, when performing profiling in vLLM-Ascend, if you need to obtain the Python call stack, you have to manually modify the code. The code location is: [worker_v1.py#L337](https://github.com/vllm-project/vllm-ascend/blob/6c973361fc2eba5d3faa9b6b496b4b9fec4dc784/vllm_ascend/worker/worker_v1.py#L337) where you set with_stack to true.
Now, in vLLM, you can set whether to obtain the Python call stack through an environment variable. The relevant PR is: [#21803](https://github.com/vllm-project/vllm/pull/21803) and the documentation is: [profiling](https://docs.vllm.ai/en/latest/contributing/profiling.html?h=vllm_torch_profiler_with_stack#profile-with-pytorch-profiler)
This PR sets the profiler initialization parameters by using the same environment variable as vLLM, eliminating the need for manual code modification.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed with new added/existing test.


- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c5d004aaaf3b2106d33974c673bec0568c18f762
