### PR TITLE
[CI] Increase HCCL_BUFFSIZE in CI

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -190,6 +190,7 @@ jobs:
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_USE_MODELSCOPE: True
+          HCCL_BUFFSIZE: 500
         run: |
           pytest -sv tests/e2e/singlecard/test_offline_inference.py
           # pytest -sv tests/e2e/singlecard/test_ilama_lora.py
@@ -272,6 +273,7 @@ jobs:
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_USE_MODELSCOPE: True
+          HCCL_BUFFSIZE: 500
         run: |
           # pytest -sv tests/e2e/multicard/test_ilama_lora_tp2.py
           # Fixme: run VLLM_USE_MODELSCOPE=True pytest -sv tests/e2e/multicard/test_offline_inference_distributed.py will raise error.


### PR DESCRIPTION
### What this PR does / why we need it?
Sometime test cases will fail due to insufficient memory in the hccl communication domain， see [workflow](https://github.com/vllm-project/vllm-ascend/actions/runs/17288023516/job/49075212029?pr=1376)
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/006477e60b49babfca96352c7c648f10fff4a053
