### PR TITLE
[main] [bugfix] Fix misjudging quantized/unquantized scenarios

### DIFF
--- a/tests/ut/ops/test_token_dispatcher.py
+++ b/tests/ut/ops/test_token_dispatcher.py
@@ -263,7 +263,6 @@ class TestTokenDispatcherWithAllGather(TestBase):
             "max_num_tokens": 100,
             "ep_size": 2,
             "num_experts": 128,
-            "with_quant": True,
         }
         self.dispatcher_quant = TokenDispatcherWithAllGather(**kwargs)
 
@@ -460,8 +459,7 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
     def test_token_dispatch_with_quant(self):
         self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2,
                                                       num_experts=4,
-                                                      num_local_experts=2,
-                                                      with_quant=True)
+                                                      num_local_experts=2)
 
         hidden_states = torch.randn(8, 16)
         topk_weights = torch.rand(8, 4)
@@ -476,7 +474,8 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
                                                 topk_weights=topk_weights,
                                                 topk_ids=topk_ids,
                                                 row_idx=self.row_idx,
-                                                expert_map=expert_map)
+                                                expert_map=expert_map,
+                                                with_quant=True)
 
         self.assertIsNotNone(result["hidden_states"])
         self.assertIsNotNone(result["group_list"])
@@ -486,8 +485,7 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
     def test_token_dispatch_with_quant_no_active_tokens(self):
         self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2,
                                                       num_experts=4,
-                                                      num_local_experts=2,
-                                                      with_quant=True)
+                                                      num_local_experts=2)
 
         self.mock_repeat_interleave.return_value = torch.tensor(
             [], dtype=torch.long)
@@ -505,7 +503,8 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
                                                 topk_weights=topk_weights,
                                                 topk_ids=topk_ids,
                                                 row_idx=self.row_idx,
-                                                expert_map=expert_map)
+                                                expert_map=expert_map,
+                                                with_quant=True)
 
         self.assertIsNotNone(result["hidden_states"])
         self.assertIsNotNone(result["group_list"])

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -99,8 +99,6 @@ def set_ascend_forward_context(
         forward_context.fused_moe_state = fused_moe_state
         forward_context.in_profile_run = in_profile_run
 
-        with_quant = vllm_config.quant_config is not None
-        forward_context.with_quant = with_quant
         from vllm_ascend.ops.moe_dispatcher.token_dispatcher import \
             get_token_dispatcher
         dispatcher_name = get_dispatcher_name(ep_size, with_prefill)

--- a/vllm_ascend/quantization/w4a8_dynamic.py
+++ b/vllm_ascend/quantization/w4a8_dynamic.py
@@ -308,7 +308,8 @@ class AscendW4A8DynamicFusedMoEMethod:
             shared_experts=shared_experts,
             shared_gate_up=shared_gate_up,
             shared_dequant_scale=shared_dequant_scale,
-            mc2_mask=kwargs.get("mc2_mask", None))
+            mc2_mask=kwargs.get("mc2_mask", None),
+            with_quant=True)
 
     def process_scale(self, weight: torch.Tensor, scale, per_group_scale):
         group_num, k, n = weight.shape

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -406,7 +406,8 @@ class AscendW8A8DynamicFusedMoEMethod:
             shared_experts=shared_experts,
             shared_gate_up=shared_gate_up,
             shared_dequant_scale=shared_dequant_scale,
-            mc2_mask=kwargs.get("mc2_mask", None))
+            mc2_mask=kwargs.get("mc2_mask", None),
+            with_quant=True)
 
     def process_weights_after_loading(self, layer):
         if self.transpose_weight:


### PR DESCRIPTION
### What this PR does / why we need it?
In a mixed-precision scenario, quant_config is not None, but MoE needs to perform unquantized computation; however, quantized computation is currently being used. Therefore, we put the with_quant logic into forward, avoid misjudging in mix-precision scenarios.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
e2e & ut

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/98ac0cb32d9462e50bd998f9f2eb6e4c09232c95
