### PR TITLE
[v0.9.1][Bugfix] Fix guided decoding invalid backend

### DIFF
--- a/tests/singlecard/test_guided_decoding.py
+++ b/tests/singlecard/test_guided_decoding.py
@@ -34,7 +34,7 @@ GuidedDecodingBackendV0 = [
     "lm-format-enforcer",
     "xgrammar",
 ]
-GuidedDecodingBackendV1 = ["xgrammar", "guidance:disable-any-whitespace"]
+GuidedDecodingBackendV1 = ["xgrammar", "guidance"]
 GuidedDecodingBackend = list(
     set(GuidedDecodingBackendV0 + GuidedDecodingBackendV1))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Run:

```bash
pytest -sv tests/singlecard/test_guided_decoding.py
```

Come across an error:

```bash
FAILED tests/singlecard/test_guided_decoding.py::test_guided_json_completion[guidance:disable-any-whitespace] - NotImplementedError: VLLM_USE_V1=1 is not supported with --guided-decoding-backend=guidance:disable-any-whitespace.
FAILED tests/singlecard/test_guided_decoding.py::test_guided_regex[guidance:disable-any-whitespace] - NotImplementedError: VLLM_USE_V1=1 is not supported with --guided-decoding-backend=guidance:disable-any-whitespace.
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Run:

```bash
pytest -sv tests/singlecard/test_guided_decoding.py
```

Output:

```bash
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.10.18, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/sss/github/vllm-v0.9.1/vllm-ascend
configfile: pytest.ini
plugins: anyio-4.10.0, mock-3.14.1
collected 8 items                                                                                                                                                         

tests/singlecard/test_guided_decoding.py ss.ss..s                                                                                                                   [100%]

============================================================================ warnings summary =============================================================================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../miniconda3/envs/vllm-v0.9.1/lib/python3.10/site-packages/torch_npu/dynamo/torchair/__init__.py:8
  /home/sss/miniconda3/envs/vllm-v0.9.1/lib/python3.10/site-packages/torch_npu/dynamo/torchair/__init__.py:8: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 3 passed, 5 skipped, 3 warnings in 193.21s (0:03:13) ===========================================================
```