### PR TITLE
[0.9.1][PromptLogprobs][V1] Support prompt logprobs to fix ceval accuracy in V1

### DIFF
--- a/tests/singlecard/test_offline_inference.py
+++ b/tests/singlecard/test_offline_inference.py
@@ -131,3 +131,21 @@ def test_models_topk() -> None:
                     enforce_eager=True,
                     gpu_memory_utilization=0.7) as vllm_model:
         vllm_model.generate(example_prompts, sampling_params)
+
+
+def test_models_prompt_logprobs() -> None:
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    with VllmRunner("Qwen/Qwen3-0.6B-Base",
+                    max_model_len=8192,
+                    dtype="float16",
+                    enforce_eager=True,
+                    gpu_memory_utilization=0.7) as vllm_model:
+        vllm_model.generate_greedy_logprobs(example_prompts,
+                                            max_tokens=50,
+                                            num_logprobs=1)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1516,7 +1516,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                 sampled_token_ids=valid_sampled_token_ids,
                 spec_token_ids=spec_token_ids,
                 logprobs=logprobs_lists,
-                prompt_logprobs_dict={},
+                prompt_logprobs_dict=prompt_logprobs_dict,
                 finished_sending=finished_sending,
                 finished_recving=finished_recving,
             )


### PR DESCRIPTION
### What this PR does / why we need it?
Support prompt logprobs to fix ceval accuracy in V1

### Does this PR introduce _any_ user-facing change?
1. Users could set `prompt_logprobs` in `SamplingParams` after this pr
2. Users could use lm_eval to evaluate the accuracy

### How was this patch tested?
CI passed with new added test.
