### PR TITLE
[Bugfix] Keep prefill node using prefill code path only in disaggregation mode

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -205,6 +205,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
+        mock_vllm_config.kv_transfer_config = None
         mock_device = 'cpu'
 
         with patch("vllm_ascend.attention.mla_v1.get_ascend_config",

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -276,7 +276,9 @@ class AscendMLAMetadataBuilder:
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         # TODO(xyx): remove the if condition after mla supports torch mode speculative decoding
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = \
-            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+            split_decodes_and_prefills(common_attn_metadata,
+                                       decode_threshold=self.decode_threshold,
+                                       is_kv_producer=self.is_kv_producer)
         assert num_decodes + num_prefills == num_reqs
         assert num_decode_tokens + num_prefill_tokens == num_actual_tokens
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -185,6 +185,8 @@ class AscendMLAMetadataBuilder:
                            self.block_size - 1) // self.block_size
         self.chunked_prefill_enabled = scheduler_config.chunked_prefill_enabled
 
+        self.is_kv_producer = vllm_config.kv_transfer_config is not None and \
+            vllm_config.kv_transfer_config.is_kv_producer
         self.decode_threshold = 1
 
         if self.chunked_prefill_enabled:
@@ -227,7 +229,7 @@ class AscendMLAMetadataBuilder:
 
         for i, req_id in enumerate(input_batch.req_ids):
             num_tokens = scheduler_output.num_scheduled_tokens[req_id]
-            if num_tokens <= self.decode_threshold:
+            if num_tokens <= self.decode_threshold and not self.is_kv_producer:
                 decodes.append(i)
             else:
                 prefills.append(i)


### PR DESCRIPTION
### What this PR does / why we need it?

When running in prefill-decode disaggregation mode, we're not completely confident that the prefill node can handle decode phase requests properly. To ensure reliability, this PR continues to use the prefill code path in the prefill node at all times.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/e9b92dcd89e8d05f162a8fdaa3d5d60012615514
