### PR TITLE
add "COMM_QUANT_MODE" env to control quant mode of MoeCombine

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -169,6 +169,8 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # VLLM_ASCEND_EXTERNAL_DP_LB_ENABLED: used for external distributed data parallelism in vllm-ascend, 0.9.1 specific.
     "VLLM_ASCEND_EXTERNAL_DP_LB_ENABLED":
     lambda: bool(int(os.getenv("VLLM_ASCEND_EXTERNAL_DP_LB_ENABLED", '0'))),
+    "COMM_QUANT_MODE":
+    lambda: bool(int(os.getenv("COMM_QUANT_MODE", '1'))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
Since the torch_npu.npu_moe_distribute_combine_v2 support quant now, we add env variable "COMM_QUANT_MODE" to control the quant. If COMM_QUANT_MODE=0, quant close, and when COMM_QUANT_MODE=1, quant open.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
