### PR TITLE
Register AscendRowParallelLinear instead of overwrite forward_oot

### DIFF
--- a/tests/ut/patch/worker/patch_common/test_patch_linear.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_linear.py
@@ -1,11 +1,8 @@
-from importlib import reload
 
 import pytest
 import torch
-import vllm
 from pytest_mock import MockerFixture
 
-import vllm_ascend.envs as envs_ascend
 from tests.ut.base import PytestBase
 from vllm_ascend.patch.worker.patch_common import patch_linear
 
@@ -156,12 +153,3 @@ class TestAscendRowParallelLinear(PytestBase):
         )  # noqa
         ret = row_parallel_linear.calc_output(torch.tensor([10.0, 2.0]))
         assert torch.allclose(ret, expected)
-
-    def test_enable_allreduce_matmul(self, mocker: MockerFixture):
-        mocker.patch.object(envs_ascend,
-                            "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE",
-                            new=True)
-        reload(patch_linear)
-        assert envs_ascend.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE
-        assert id(vllm.model_executor.layers.linear.RowParallelLinear) == id(
-            patch_linear.AscendRowParallelLinear)

--- a/vllm_ascend/patch/worker/patch_common/patch_linear.py
+++ b/vllm_ascend/patch/worker/patch_common/patch_linear.py
@@ -19,16 +19,12 @@ from typing import Optional, Union
 
 import torch
 import torch_npu
-import vllm
 from torch.distributed import ProcessGroup
 from torch.nn.parameter import Parameter
 from vllm.distributed import (get_tensor_model_parallel_rank,
                               split_tensor_along_last_dim)
 from vllm.distributed.parallel_state import get_tp_group
-from vllm.logger import logger
 from vllm.model_executor.layers.linear import RowParallelLinear
-
-import vllm_ascend.envs as envs_ascend
 
 _HCOMM_INFO = None
 
@@ -140,8 +136,3 @@ class AscendRowParallelLinear(RowParallelLinear):
         else:
             output = self.quant_method.apply(self, input_parallel, bias=bias_)
         return output
-
-
-if envs_ascend.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE:
-    logger.info("AscendRowParallelLinear: Matmul all-reduce is enabled. ")
-    vllm.model_executor.layers.linear.RowParallelLinear = AscendRowParallelLinear

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -522,6 +522,13 @@ def register_ascend_customop():
     from vllm_ascend.ops.common_fused_moe import AscendFusedMoE
     CustomOp.register_oot(_decorated_op_cls=AscendFusedMoE, name="FusedMoE")
 
+    from vllm_ascend.patch.worker.patch_common.patch_linear import \
+        AscendRowParallelLinear
+
+    if envs_ascend.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE:
+        CustomOp.register_oot(_decorated_op_cls=AscendRowParallelLinear,
+                              name="RowParallelLinear")
+
     # NOTE: Keep this at last to ensure all custom actions are registered
     _ASCEND_CUSTOMOP_IS_REIGISTERED = True
 


### PR DESCRIPTION
### What this PR does / why we need it?
Register AscendRowParallelLinear instead of overwrite forward_oot

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with new added/existing test.
