### PR TITLE
[Perf][CustomOP] Recover performance through override init

### DIFF
--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -21,6 +21,9 @@ from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul
 
 class AscendQuickGELU(QuickGELU):
 
+    def __init__(self):
+        super().__init__()
+
     def forward_oot(self, x: torch.tensor) -> torch.Tensor:
         import torch_npu
 
@@ -29,6 +32,9 @@ class AscendQuickGELU(QuickGELU):
 
 
 class AscendSiluAndMul(SiluAndMul):
+
+    def __init__(self):
+        super().__init__()
 
     def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
         import torch_npu

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -60,6 +60,16 @@ class AddRMSNormW8A8Quant(RMSNorm):
 
 class AscendRMSNorm(RMSNorm):
 
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        var_hidden_size: Optional[int] = None,
+        has_weight: bool = True,
+        dtype: Optional[torch.dtype] = None,
+    ) -> None:
+        super().__init__(hidden_size, eps, var_hidden_size, has_weight, dtype)
+
     def forward_oot(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
### What this PR does / why we need it?
```python
CustomOP.__new__() --> nn.Module.__new__() --> AscendQuickGELU.__init__() --> QuickGELU.__init__()
```

### Does this PR introduce _any_ user-facing change?


### How was this patch tested?
