### PR TITLE
[CI] Disable per-PR triggering for A3

### DIFF
--- a/.github/workflows/vllm_ascend_dist.yaml
+++ b/.github/workflows/vllm_ascend_dist.yaml
@@ -18,13 +18,10 @@
 name: 'e2e test / a3-test'
 
 on:
-  push:
-    branches:
-      - 'main'
+  workflow_call:
+
   pull_request:
-    branches:
-      - 'main'
-      - '*-dev'
+    types: [ labeled ]
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -40,33 +37,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      e2e_tracker: ${{ steps.filter.outputs.e2e_tracker }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            e2e_tracker:
-              - '.github/workflows/vllm_ascend_dist.yaml'
-              - 'vllm_ascend/**'
-              - 'csrc/**'
-              - 'cmake/**'
-              - 'tests/e2e/**'
-              - 'CMakeLists.txt'
-              - 'setup.py'
-              - 'requirements.txt'
-              - 'requirements-dev.txt'
-              - 'requirements-lint.txt'
-              - 'packages.txt'
-
   e2e:
-    needs: [changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.e2e_tracker == 'true'}}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dist-test') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [linux-aarch64-a3-8]


### PR DESCRIPTION
### What this PR does / why we need it?
Disable per-PR triggering for A3 for now, we trigger the dist test in the label `dist-test` rather than
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/136d853e65a91a21b08227217b51daaba2d5cc71
