### PR TITLE
replace npu_incre_flash_attention with npu_fused_infer_attention_score

### DIFF
--- a/vllm_ascend/torchair/torchair_attention.py
+++ b/vllm_ascend/torchair/torchair_attention.py
@@ -431,17 +431,24 @@ class AscendAttentionTorchairBackendImpl(AttentionImpl):
             block_size = key_cache.shape[1]
             query = query.view(num_tokens, 1,
                                self.num_heads * self.head_size).contiguous()
-            output = torch_npu.npu_incre_flash_attention(
-                query,
-                key_cache,
-                value_cache,
-                num_key_value_heads=self.num_kv_heads,
+            output, _ = torch_npu.npu_fused_infer_attention_score(
+                query=query,
+                key=key_cache,
+                value=value_cache,
+                query_rope=None,
+                key_rope=None,
                 num_heads=self.num_heads,
-                actual_seq_lengths=seq_lens,
-                scale_value=self.scale,
-                block_table=block_table,
+                num_key_value_heads=self.num_kv_heads,
                 input_layout='BSH',
-                block_size=block_size)
+                atten_mask=attn_metadata.attn_mask,
+                sparse_mode=0,
+                scale=self.scale,
+                antiquant_mode=0,
+                antiquant_scale=None,
+                block_table=block_table,
+                block_size=block_size,
+                actual_seq_lengths_kv=seq_lens,
+            )
         else:
             raise NotImplementedError(
                 "Torchair graph mode with non-MLA attention backend is still experimental."


### PR DESCRIPTION
### What this PR does / why we need it?
The npu_incre_flash_attention  interface is no longer maintained and is replaced by npu_fused_infer_attention_score
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/e93f4cc9e37484009f74e15d3111a1f335c532a5
