### PR TITLE
[Misc] Release origin hidden_states in naive multicast

### DIFF
--- a/vllm_ascend/ops/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe.py
@@ -1231,6 +1231,7 @@ class AscendFusedMoE(FusedMoE):
             self.dp_rank - 1]
         end = cu_tokens_across_dp_cpu[self.dp_rank]
         buffer[start:end, :].copy_(x)
+        dispose_tensor(x)
         for idx in range(self.dp_size):
             start = 0 if idx == 0 else cu_tokens_across_dp_cpu[idx - 1]
             end = cu_tokens_across_dp_cpu[idx]

--- a/vllm_ascend/torchair/ops/torchair_fused_moe.py
+++ b/vllm_ascend/torchair/ops/torchair_fused_moe.py
@@ -1345,6 +1345,7 @@ class TorchairAscendFusedMoE(FusedMoE):
             self.dp_rank - 1]
         end = cu_tokens_across_dp_cpu[self.dp_rank]
         buffer[start:end, :].copy_(x)
+        dispose_tensor(x)
         for idx in range(self.dp_size):
             start = 0 if idx == 0 else cu_tokens_across_dp_cpu[idx - 1]
             end = cu_tokens_across_dp_cpu[idx]


### PR DESCRIPTION
### What this PR does / why we need it?
After copy original hidden states in naive_multicast, we should remove it to reduce activation memory usage.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
vLLM version: v0.10.1.1
vLLM main: https://github.com/vllm-project/vllm/commits/1da94e673c257373280026f75ceb4effac80e892

Set dp=2, tp=8, max-num-seqs = 24 and max-num-batched-tokens=8192. DeepSeek-R1-W8A8 test results are as follows.

**before this PR**
```shell
[kv_cache_utils.py:849] GPU KV cache size: 182,528 tokens
[kv_cache_utils.py:853] Maximum concurrency for 8,192 tokens per request: 22.28x
```

**after this PR**
```shell
[kv_cache_utils.py:849] GPU KV cache size: 184,192 tokens
[kv_cache_utils.py:853] Maximum concurrency for 8,192 tokens per request: 22.48x
```