### PR TITLE
Enable eagle spec decode

### DIFF
--- a/tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
@@ -99,7 +99,6 @@ def test_ngram_correctness(
     assert matches > int(0.7 * len(ref_outputs))
 
 
-@pytest.mark.skipif(True, reason="oom in CI, fix me")
 @pytest.mark.parametrize("use_eagle3", [False, True], ids=["eagle", "eagle3"])
 def test_eagle_correctness(
     test_prompts: list[list[dict[str, Any]]],
@@ -121,10 +120,8 @@ def test_eagle_correctness(
     spec_model_name = eagle3_model_name() if use_eagle3 else eagle_model_name()
     with VllmRunner(
             model_name,
-            trust_remote_code=True,
             enable_chunked_prefill=True,
             max_num_seqs=1,
-            max_num_batched_tokens=2048,
             gpu_memory_utilization=0.6,
             speculative_config={
                 "method": "eagle3" if use_eagle3 else "eagle",

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -136,8 +136,6 @@ class EagleProposer(Proposer):
                            hidden_states: torch.Tensor = None,
                            attn_metadata=None,
                            aux_hidden_states: torch.Tensor = None):
-        if self.name == SpecDcodeType.EAGLE:
-            raise NotImplementedError("Eagle Is Not Supported Yet.")
 
         attn_metadata = self._get_eagle_atten_dict(scheduler_output)
         next_token_ids: list[int] = []
@@ -485,9 +483,6 @@ class EagleProposer(Proposer):
         attn_metadata.max_query_len = 1
         attn_metadata.query_start_loc = self.arange[:batch_size + 1]
 
-        if self.vllm_config.speculative_config.num_speculative_tokens > 2:
-            raise ValueError("Speculative tokens > 2 are not supported yet.")
-
         attn_metadata.attn_state = AscendAttentionState.ChunkedPrefill
         for now_speculative in range(
                 self.vllm_config.speculative_config.num_speculative_tokens -
@@ -541,9 +536,8 @@ class EagleProposer(Proposer):
             self.input_ids[:batch_size] = input_ids
             self.positions[:batch_size] = clamped_positions
             self.hidden_states[:batch_size] = hidden_states
-            positions = positions_cpu.to(device)
             attn_mask = self.attn_mask_builder.get_splitfuse_attn_mask(
-                attn_metadata.seq_lens, positions,
+                attn_metadata.seq_lens, positions_cpu,
                 self.vllm_config.model_config.dtype, self.device)
 
             attn_metadata.attn_mask = attn_mask


### PR DESCRIPTION
### What this PR does / why we need it?
Enable eagle spec decode and its UT

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
```
def main():
    
    prompts = [
        "The capital of France is"
    ]
    
    sampling_params = SamplingParams(temperature=0.8)
    
    speculative_config = {
        "method": "eagle",
        "model": "/root/.cache/modelscope/hub/models/vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B",
        "num_speculative_tokens": 3,
        "max_model_len": 128,
    }
    
    llm = LLM(
        model="LLM-Research/Meta-Llama-3.1-8B-Instruct",
        max_num_seqs=1,
        enforce_eager=True,
        gpu_memory_utilization=0.8,
        speculative_config=speculative_config,
        max_model_len=128,
    )
    
    
    outputs = llm.generate(prompts, sampling_params=sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```


