### PR TITLE
[Code clean] Remove the unnecessary code

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -20,7 +20,6 @@
 #include <torch_npu/csrc/core/npu/NPUStream.h>
 #include <torch_npu/csrc/framework/OpCommand.h>
 #include <torch_npu/csrc/npu/Module.h>
-#include <pybind11/pybind11.h>
 #include "acl/acl.h"
 #include "ops.h"
 #include "utils.h"
@@ -424,5 +423,3 @@ TORCH_LIBRARY_EXPAND(_C, ops)
         "            int slice_offset, int slice_size) -> Tensor");
     ops.impl("sgmv_expand", torch::kPrivateUse1, &vllm_ascend::sgmv_expand);
 }
-
-REGISTER_EXTENSION(_C)


### PR DESCRIPTION
**Background:**

A dynamic library named vllm_ascend_C.so will be generated when compiling vLLM-Ascend, so when import vllm_ascend.vllm_ascend_C in python, the interperter will search vllm_ascend_C.so and try to find a external symbol named PyInit_vllm_ascend_C which is provided in csrc/camem_allocator.cpp.

**Conclusion:**

The PyInit__C is redundent.

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/717fc00e98c18d183f9141393b4185ddfb6606b3
