### PR TITLE
[Fix] Fix SharedFusedMoE

### DIFF
--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -55,6 +55,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader, maybe_remap_kv_scale_name)
+from vllm.model_executor.models import deepseek_v2
 from vllm.model_executor.models.deepseek_v2 import \
     DeepseekV2ForCausalLM  # noqa: E501
 from vllm.model_executor.models.deepseek_v2 import \
@@ -68,10 +69,13 @@ from vllm.model_executor.models.utils import (
 from vllm.sequence import IntermediateTensors
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ops.common_fused_moe import AscendSharedFusedMoE
 from vllm_ascend.ops.fused_moe import AscendFusedMoE
 from vllm_ascend.quantization.quant_config import AscendLinearMethod
 from vllm_ascend.quantization.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import dispose_tensor
+
+deepseek_v2.SharedFusedMoE = AscendSharedFusedMoE
 
 
 class CustomDeepseekV2SiluAndMul(SiluAndMul):

--- a/vllm_ascend/models/deepseek_v2.py
+++ b/vllm_ascend/models/deepseek_v2.py
@@ -55,7 +55,6 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader, maybe_remap_kv_scale_name)
-from vllm.model_executor.models import deepseek_v2
 from vllm.model_executor.models.deepseek_v2 import \
     DeepseekV2ForCausalLM  # noqa: E501
 from vllm.model_executor.models.deepseek_v2 import \
@@ -69,13 +68,10 @@ from vllm.model_executor.models.utils import (
 from vllm.sequence import IntermediateTensors
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ops.common_fused_moe import AscendSharedFusedMoE
 from vllm_ascend.ops.fused_moe import AscendFusedMoE
 from vllm_ascend.quantization.quant_config import AscendLinearMethod
 from vllm_ascend.quantization.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import dispose_tensor
-
-deepseek_v2.SharedFusedMoE = AscendSharedFusedMoE
 
 
 class CustomDeepseekV2SiluAndMul(SiluAndMul):

--- a/vllm_ascend/patch/platform/patch_common/patch_shared_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_common/patch_shared_fused_moe.py
@@ -1,6 +1,5 @@
-#
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
-# This file is a part of the vllm-ascend project.
+# Copyright 2023 The vLLM team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-import vllm_ascend.patch.platform.patch_common.patch_distributed  # noqa
-import vllm_ascend.patch.platform.patch_common.patch_shared_fused_moe  # noqa
+from vllm.model_executor.models import deepseek_v2, llama4
+
+from vllm_ascend.ops.common_fused_moe import AscendSharedFusedMoE
+
+deepseek_v2.SharedFusedMoE = AscendSharedFusedMoE
+llama4.SharedFusedMoE = AscendSharedFusedMoE


### PR DESCRIPTION
### What this PR does / why we need it?
Really strange that `register_oot` doesn't work with `SharedFusedMoE`, so we have to add this patch, for now.

### Does this PR introduce _any_ user-facing change?
None.

### How was this patch tested?
This PR won't have any effect in DeepSeek since we currently still stick with the old `CustomDeepseekV2`.

- vLLM version: v0.10.1.1
- vLLM main: https://github.com/vllm-project/vllm/commit/0cdd213641d7adcf7ad0e9cf79867344ea1291d9
