### PR TITLE
[Fixbug] Fix shape not match when sliding_window and dynamic batch_size

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -378,7 +378,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
             # seq_lens_tensor needs to be transferred to the device for 310P.
             attn_metadata.seq_lens = \
                 attn_metadata.seq_lens.to(device=query.device)
-        if self.sliding_window is not None:
+        if self.sliding_window is not None and attn_metadata.seq_lens.shape[
+                0] == query.size(0):
             batch_size = attn_metadata.seq_lens.shape[0]
             block_size = 128
             query = query.view(batch_size, 1, self.num_heads * self.head_size)


### PR DESCRIPTION
### What this PR does / why we need it?
Fix shape not match when test LLM-Research/Phi-4-mini-instruct accuarcy 
command:
```bash
VLLM_USE_MODELSCOPE=True lm_eval --model vllm \
 --model_args pretrained=LLM-Research/Phi-4-mini-instruct,max_model_len=4096,dtype=auto,tensor_parallel_size=1 \
 --tasks gsm8k \
 --apply_chat_template \
 --fewshot_as_multiturn \
 --batch_size auto \
 --num_fewshot 5 \
 --output ./
```
error log:
https://github.com/vllm-project/vllm-ascend/actions/runs/17545954577/job/49829202227?pr=2330
```
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702] EngineCore encountered a fatal error.
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702] Traceback (most recent call last):
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/engine/core.py", line 693, in run_engine_core
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     engine_core.run_busy_loop()
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/engine/core.py", line 720, in run_busy_loop
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     self._process_engine_step()
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/engine/core.py", line 745, in _process_engine_step
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     outputs, model_executed = self.step_fn()
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                               ^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/engine/core.py", line 288, in step
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     model_output = self.execute_model_with_error_logging(
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/engine/core.py", line 274, in execute_model_with_error_logging
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     raise err
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/engine/core.py", line 265, in execute_model_with_error_logging
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return model_fn(scheduler_output)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/v1/executor/abstract.py", line 87, in execute_model
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     output = self.collective_rpc("execute_model",
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     answer = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/utils/__init__.py", line 3007, in run_method
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return func(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/worker_v1.py", line 205, in execute_model
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     output = self.model_runner.execute_model(scheduler_output,
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return func(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 1563, in execute_model
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     hidden_states = self._generate_process_reqs_hidden_states(
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 1179, in _generate_process_reqs_hidden_states
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     hidden_states = self.model(
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                     ^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._call_impl(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return forward_call(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/model_executor/models/llama.py", line 577, in forward
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     model_output = self.model(input_ids, positions, intermediate_tensors,
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/compilation/decorators.py", line 279, in __call__
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     model_output = self.forward(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm-empty/vllm/model_executor/models/llama.py", line 361, in forward
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     def forward(
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._call_impl(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return forward_call(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 838, in _fn
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return fn(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/fx/graph_module.py", line 830, in call_wrapped
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._wrapped_call(self, *args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/fx/graph_module.py", line 406, in __call__
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     raise e
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/fx/graph_module.py", line 393, in __call__
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._call_impl(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return forward_call(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "<eval_with_key>.66", line 208, in forward
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     submod_1 = self.submod_1(getitem, s0, getitem_1, getitem_2, getitem_3);  getitem = getitem_1 = getitem_2 = submod_1 = None
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/fx/graph_module.py", line 830, in call_wrapped
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._wrapped_call(self, *args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/fx/graph_module.py", line 406, in __call__
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     raise e
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/fx/graph_module.py", line 393, in __call__
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._call_impl(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return forward_call(*args, **kwargs)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "<eval_with_key>.2", line 5, in forward
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     unified_ascend_attention_with_output = torch.ops.vllm.unified_ascend_attention_with_output(query = query_2, key = key_2, value = value, output = output_1, layer_name = 'model.layers.0.self_attn.attn');  query_2 = key_2 = value = output_1 = unified_ascend_attention_with_output = None
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/usr/local/python3.11.13/lib/python3.11/site-packages/torch/_ops.py", line 1158, in __call__
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     return self._op(*args, **(kwargs or {}))
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/attention/attention_v1.py", line 579, in unified_ascend_attention_with_output
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     self.impl.forward(self,
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/attention/attention_v1.py", line 554, in forward
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     output = self._forward_decode_only(query, attn_metadata,
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]   File "/__w/vllm-ascend/vllm-ascend/vllm_ascend/attention/attention_v1.py", line 379, in _forward_decode_only
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]     query = query.view(batch_size, 1, self.num_heads * self.head_size)
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_0 pid=3273) ERROR 09-08 09:55:40 [core.py:702] RuntimeError: shape '[255, 1, 3072]' is invalid for input of size 786432
```

### Does this PR introduce _any_ user-facing change?

Users can't set dynamic batch_size or use lm_eval test accuracy when using models(sliding_window)

### How was this patch tested?
accuarcy of LLM-Research/Phi-4-mini-instruct is ok :
```
vllm (pretrained=LLM-Research/Phi-4-mini-instruct,max_model_len=4096,dtype=auto,tensor_parallel_size=1), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8105|±  |0.0108|
|     |       |strict-match    |     5|exact_match|↑  |0.8097|±  |0.0108|
```


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/3c96e7b8a1ffac31b947c753f4fe1d0cd14abf87
