### PR TITLE
fix bug when rotary_dim is not 128

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -138,8 +138,8 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         forward_context = get_forward_context()
         is_first_layer = forward_context.is_first_layer
         # Generate cos and sin outside layers to avoid repeated calculation.
-        if is_neox_style and \
-            self.head_size == 128:
+        if is_neox_style and self.head_size == 128 and self.cos_sin_cache.shape[
+                -1] == 128:
             if is_first_layer:
                 cos_sin = self.cos_sin_cache.index_select(0, positions)
                 last_dim = cos_sin.size()[-1]


### PR DESCRIPTION
### What this PR does / why we need it?
`torch_npu.npu_apply_rotary_pos_emb` only support  head_size and rotary_dim equal 128. Error occurs when running GLM
like:
```
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596] Traceback (most recent call last):
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/v1/executor/multiproc_executor.py", line 591, in worker_busy_loop
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     output = func(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]              ^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/mnt/deepseek/cloudide/z37xj0b05t1yvqz2/vllm_ascend/worker/worker_v1.py", line 161, in determine_available_memory
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     self.model_runner.profile_run()
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/mnt/deepseek/cloudide/z37xj0b05t1yvqz2/vllm_ascend/worker/model_runner_v1.py", line 2042, in profile_run
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     hidden_states = self._dummy_run(self.max_num_tokens,
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return func(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/mnt/deepseek/cloudide/z37xj0b05t1yvqz2/vllm_ascend/worker/model_runner_v1.py", line 2013, in _dummy_run
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     hidden_states = self._generate_dummy_run_hidden_states(
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/mnt/deepseek/cloudide/z37xj0b05t1yvqz2/vllm_ascend/worker/model_runner_v1.py", line 1863, in _generate_dummy_run_hidden_states
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     hidden_states = self.model(input_ids=input_ids,
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self._call_impl(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return forward_call(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/model_executor/models/glm4_moe.py", line 668, in forward
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     hidden_states = self.model(input_ids, positions, intermediate_tensors,
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/compilation/decorators.py", line 206, in __call__
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self.forward(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/model_executor/models/glm4_moe.py", line 445, in forward
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     hidden_states, residual = layer(positions, hidden_states, residual)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self._call_impl(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return forward_call(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/model_executor/models/glm4_moe.py", line 367, in forward
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     hidden_states = self.self_attn(positions=positions,
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self._call_impl(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return forward_call(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/model_executor/models/glm4_moe.py", line 290, in forward
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     q, k = self.rotary_emb(positions, q, k)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self._call_impl(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return forward_call(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib/python3.11/site-packages/vllm/model_executor/custom_op.py", line 44, in forward
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self._forward_method(*args, **kwargs)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/mnt/deepseek/cloudide/z37xj0b05t1yvqz2/vllm_ascend/ops/rotary_embedding.py", line 153, in forward_oot
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return _rope_forward_oot(self, positions, query, key, is_neox_style,
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/mnt/deepseek/cloudide/z37xj0b05t1yvqz2/vllm_ascend/ops/rotary_embedding.py", line 73, in _rope_forward_oot
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     torch_npu.npu_apply_rotary_pos_emb(query, key, self.cos, self.sin)
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]   File "/usr/local/lib64/python3.11/site-packages/torch/_ops.py", line 1158, in __call__
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]     return self._op(*args, **(kwargs or {}))
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596] RuntimeError: npu_apply_rotary_pos_emb:third_party/op-plugin/op_plugin/ops/opapi/ApplyRotaryPosEmbNpuOpApi.cpp:55 NPU function error: call aclnnApplyRotaryPosEmbV2 failed, error code is 561002
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596] [ERROR] 2025-09-10-10:35:53 (PID:36115, Device:4, RankID:-1) ERR00100 PTA call acl api failed.
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596] E89999: Inner Error!
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596] E89999: [PID: 36115] 2025-09-10-10:35:53.402.643 op[ApplyRotaryPosEmb], all input dim3 must equal[FUNC:CheckParams][FILE:apply_rotary_pos_emb_tiling.cc][LINE:203]
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]         TraceBack (most recent call last):
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]        op[ApplyRotaryPosEmb], CheckParams return failed.[FUNC:DoOpTiling][FILE:apply_rotary_pos_emb_tiling.cc][LINE:510]
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]        ApplyRotaryPosEmb do tiling failed, ret is -1.
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]        Check NnopbaseExecutorDoTiling(executor) failed
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]        Check NnopbaseExecutorTilingAndUpdateBinInfo(executor) failed
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]        Check NnopbaseExecutorMatchCache(executor) failed
^[[1;36m(VllmWorker TP4 pid=36115)^[[0;0m ERROR 09-10 10:35:53 [multiproc_executor.py:596]        Check NnopbaseRunForWorkspace(*executor, workspaceSize) failed
```
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/404c85ca7290d314bbbf4d130bb55becc437c4c2
