### PR TITLE
Enable label-based image test and use free runner to run lint

### DIFF
--- a/.github/workflows/image_310p_openeuler.yml
+++ b/.github/workflows/image_310p_openeuler.yml
@@ -25,6 +25,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+    types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -43,6 +44,11 @@ on:
       - 'CMakeLists.txt'
       - 'csrc/**'
 
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: vllm-ascend image build
@@ -52,6 +58,7 @@ jobs:
           'ubuntu-latest' ||
           'ubuntu-24.04-arm'
       }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/image_310p_ubuntu.yml
+++ b/.github/workflows/image_310p_ubuntu.yml
@@ -25,6 +25,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+    types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -42,12 +43,18 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
     name: vllm-ascend image build
     runs-on: ubuntu-latest
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/image_a3_openeuler.yml
+++ b/.github/workflows/image_a3_openeuler.yml
@@ -25,6 +25,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+    types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -43,6 +44,11 @@ on:
       - 'CMakeLists.txt'
       - 'csrc/**'
 
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: vllm-ascend image build
@@ -52,6 +58,7 @@ jobs:
           'ubuntu-latest' ||
           'ubuntu-24.04-arm'
       }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/image_a3_ubuntu.yml
+++ b/.github/workflows/image_a3_ubuntu.yml
@@ -25,6 +25,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+    types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -42,12 +43,18 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
     name: vllm-ascend image build
     runs-on: ubuntu-latest
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/image_openeuler.yml
+++ b/.github/workflows/image_openeuler.yml
@@ -24,6 +24,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+    types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -42,6 +43,11 @@ on:
       - 'CMakeLists.txt'
       - 'csrc/**'
 
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: vllm-ascend image build
@@ -51,6 +57,7 @@ jobs:
           'ubuntu-latest' ||
           'ubuntu-24.04-arm'
       }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/image_ubuntu.yml
+++ b/.github/workflows/image_ubuntu.yml
@@ -25,6 +25,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+    types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -42,12 +43,18 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
     name: vllm-ascend image build
     runs-on: ubuntu-latest
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,19 +8,13 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: linux-amd64-cpu-8
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.2.rc1-910b-ubuntu22.04-py3.11
+    runs-on: ubuntu-latest
     steps:
-    - name: Config mirrors
-      run: |
-        sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
-        pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-        pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
-        apt-get update -y
-        apt install git -y
     - name: Checkout vllm-project/vllm-ascend repo
       uses: actions/checkout@v4
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      with:
+        python-version: "3.11"
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
     - name: Checkout vllm-project/vllm repo
@@ -36,9 +30,9 @@ jobs:
     - name: Install vllm-ascend dev
       run: |
         pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
-        git config --global --add safe.directory '*'
-    - name: Run pre-commit check
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       env:
-        SHELLCHECK_OPTS: "--exclude=SC2046,SC2006,SC2086"
-        GOPROXY: "https://goproxy.cn,direct"
-      run: pre-commit run --all-files --hook-stage manual
+        SHELLCHECK_OPTS: "--exclude=SC2046,SC2006,SC2086" # Exclude SC2046, SC2006, SC2086 for actionlint
+      with:
+        extra_args: --all-files --hook-stage manual
+

--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -43,9 +43,8 @@ jobs:
     uses: ./.github/workflows/pre-commit.yml
 
   changes:
-    runs-on: linux-amd64-cpu-0
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.2.rc1-910b-ubuntu22.04-py3.11
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
     outputs:
       e2e_tracker: ${{ steps.filter.outputs.e2e_tracker }}
       ut_tracker: ${{ steps.filter.outputs.ut_tracker }}

--- a/.github/workflows/vllm_ascend_test_full.yaml
+++ b/.github/workflows/vllm_ascend_test_full.yaml
@@ -38,10 +38,8 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: linux-amd64-cpu-0
+    runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.2.rc1-910b-ubuntu22.04-py3.11
     outputs:
       e2e_tracker: ${{ steps.filter.outputs.e2e_tracker }}
       ut_tracker: ${{ steps.filter.outputs.ut_tracker }}


### PR DESCRIPTION
### What this PR does / why we need it?
- Enable label-based image test and use free runner to run lint
- soft revert https://github.com/vllm-project/vllm-ascend/pull/2801/commits/26f388ba0846f29f2dcf50d0163224736d09cfc4

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/404c85ca7290d314bbbf4d130bb55becc437c4c2
