### PR TITLE
[Bugfix] Update lm_eval version to remove deprecated param

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ openai
 pytest >= 6.0
 pytest-asyncio
 pytest-mock
-lm-eval==0.4.8
+lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d 
 types-jsonschema
 xgrammar
 zmq


### PR DESCRIPTION
### What this PR does / why we need it?
update lm_eval to fix #2865, notice that the latest lm_eval [release](https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.9.1) haven't include this commit, so let's first pin it to the commit before the next release

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed

Closes: https://github.com/vllm-project/vllm-ascend/issues/2865

- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/d13360183a429562ff7d62235534ef37e712409c
