### PR TITLE
Fix: Prevent permanent corruption of target_probs in N-gram sampler

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -479,10 +479,9 @@ def sample_recovered_tokens_pytorch(
             token_idx = start_idx + pos
 
             if IS_NGRAM:
-                draft_token_id = draft_token_ids[token_idx]
-                orig_prob = target_probs[token_idx, draft_token_id].item()
-                target_probs[token_idx, draft_token_id] = 0
                 prob = target_probs[token_idx].clone()
+                draft_token_id = draft_token_ids[token_idx]
+                prob[draft_token_id] = 0.0
             else:
                 draft_p = draft_probs[token_idx].clone()
                 target_p = target_probs[token_idx].clone()
@@ -496,9 +495,6 @@ def sample_recovered_tokens_pytorch(
 
             recovered_id = torch.argmax(prob / q_values).item()
             output_token_ids[token_idx] = recovered_id
-
-            if IS_NGRAM:
-                target_probs[token_idx, draft_token_id] = orig_prob
 
 
 rs.expand_batch_to_tokens = expand_batch_to_tokens


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a critical bug in the `sample_recovered_tokens_pytorch` function that occurs when using N-gram speculative decoding (`IS_NGRAM=True`).

**Bug Description:**

The original implementation was performing an in-place modification on the `target_probs` tensor. Specifically, it set the probability of the `draft_token_id` to zero **before** cloning the probability distribution for the recovery sampling step.

This had the severe side effect of permanently corrupting the `target_probs` tensor for the current sampling operation, as the modification was never reverted. Consequently, any request using N-gram sampling with a non-greedy strategy would produce statistically incorrect results due to sampling from a fundamentally altered distribution.

**The Fix:**

This PR corrects the order of operations. It now **clones the probability distribution from `target_probs` first**, and only then modifies the local clone. This simple change ensures that the original `target_probs` tensor remains unmodified, fixing the bug and restoring the correctness of the rejection sampling algorithm.

### Does this PR introduce _any_ user-facing change?

no user-facing change

### How was this patch tested?

This patch was tested using speculative decoding with an Eagle3 proposer model. The original buggy code consistently resulted in a 0% acceptance rate for proposed tokens. After applying this fix, the acceptance rate returned to a normal, healthy level, confirming that the bug is resolved and the feature now functions correctly.

Co-authored-by: liumail680 <liumai1680@163.com>
Co-authored-by: guanyuzhu <zhuguanyu@huawei.com>

- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/e090b7b45b015e9a4158c6676da802e04f1d88f1
