### PR TITLE
enable vl e2e ut

### DIFF
--- a/tests/e2e/singlecard/test_vlm.py
+++ b/tests/e2e/singlecard/test_vlm.py
@@ -32,7 +32,6 @@ from tests.e2e.conftest import VllmRunner
 os.environ["PYTORCH_NPU_ALLOC_CONF"] = "max_split_size_mb:256"
 
 
-@pytest.mark.skip(reason="fix me")
 def test_multimodal_vl(prompt_template):
     image = ImageAsset("cherry_blossom") \
         .pil_image.convert("RGB")

--- a/tests/e2e/singlecard/test_vlm.py
+++ b/tests/e2e/singlecard/test_vlm.py
@@ -51,9 +51,6 @@ def test_multimodal_vl(prompt_template):
                         "fps": 1,
                     },
                     enforce_eager=True) as vllm_model:
-        vllm_model.generate_greedy(prompts=prompts,
-                                   images=images,
-                                   max_tokens=64)
         outputs = vllm_model.generate_greedy(prompts=prompts,
                                              images=images,
                                              max_tokens=64)


### PR DESCRIPTION
### What this PR does / why we need it?
This pr enable vl e2e ut, intercept vl related issues, like https://github.com/vllm-project/vllm-ascend/actions/runs/17661718634/job/50196111314

Needs https://github.com/vllm-project/vllm-ascend/pull/2883 first.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with new added/existing test.


- vLLM version: main
- vLLM main: https://github.com/vllm-project/vllm/commit/fdb09c77d6f92fab0ebced332aa79fda86eaf1fc
