### PR TITLE
COMM_QUANT_MODE

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -164,6 +164,8 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # are not freed within this timeout, they will be forcibly released.
     "VLLM_ASCEND_KVCACHE_DELAY_FREE_TIMEOUT":
     lambda: int(os.getenv("VLLM_ASCEND_KVCACHE_DELAY_FREE_TIMEOUT", 250)),
+    "VLLM_ASCEND_COMM_QUANT_MODE":
+    lambda: bool(int(os.getenv("VLLM_ASCEND_COMM_QUANT_MODE", '1'))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
### What this PR does / why we need it?
Since the torch_npu.npu_moe_distribute_combine_v2 support quant now, we add env variable "COMM_QUANT_MODE" to control the quant. If COMM_QUANT_MODE=0, quant close, and when COMM_QUANT_MODE=1, quant open.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/72c99f2a75ee082e9755dcddfd5a2289ff4be7d7
