### PR TITLE
[WIP] feat: add a test case for A3 Non-quantitative (ALL2ALLV + MC2)

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -257,4 +257,4 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_USE_MODELSCOPE: True
         run: |
-          pytest -sv tests/e2e/multicard/test_qwen3_moe.py::test_models_distributed_Qwen3_MOE_TP2_WITH_EP
+          pytest -sv tests/e2e/multicard/test_qwen3_moe.py::test_Qwen3_235b_all2allv_mc2_quant

--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -257,4 +257,5 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_USE_MODELSCOPE: True
         run: |
+          pytest -sv tests/e2e/multicard/test_qwen3_moe.py::test_models_distributed_Qwen3_MOE_TP2_WITH_EP
           pytest -sv tests/e2e/multicard/test_qwen3_moe.py::test_Qwen3_235b_all2allv_mc2_quant

--- a/tests/e2e/multicard/test_qwen3_moe.py
+++ b/tests/e2e/multicard/test_qwen3_moe.py
@@ -103,17 +103,17 @@ def test_models_distributed_Qwen3_MOE_TP2_WITH_ACLGRAPH():
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
 
-def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
+def test_Qwen3_235b_all2allv_mc2_quant():
     """Test Qwen3-235B with all2all sequence and multi-card configuration."""
     # Set environment variables similar to the startup command
-    monkeypatch.setenv('VLLM_USE_V1', '1')
-    monkeypatch.setenv('VLLM_VERSION', '0.10.1.1')
-    monkeypatch.setenv('VLLM_ASCEND_ENABLE_MOE_ALL2ALL_SEQ', '1')
-    monkeypatch.setenv('TASK_QUEUE_ENABLE', '2')
-    monkeypatch.setenv('PYTORCH_NPU_ALLOC_CONF', 'expandable_segments:True')
-    monkeypatch.setenv('ACL_STREAM_TIMEOUT', '340000')
-    monkeypatch.setenv('HCCL_OP_EXPANSION_MODE', 'AIV')
-    monkeypatch.setenv('HCCL_OP_BASE_FFTS_MODE_ENABLE', 'true')
+    os.environ['VLLM_USE_V1'] = '1'
+    os.environ['VLLM_VERSION'] = '0.10.1.1'
+    os.environ['VLLM_ASCEND_ENABLE_MOE_ALL2ALL_SEQ'] = '1'
+    os.environ['TASK_QUEUE_ENABLE'] = '2'
+    os.environ['PYTORCH_NPU_ALLOC_CONF'] = 'expandable_segments:True'
+    os.environ['ACL_STREAM_TIMEOUT'] = '340000'
+    os.environ['HCCL_OP_EXPANSION_MODE'] = 'AIV'
+    os.environ['HCCL_OP_BASE_FFTS_MODE_ENABLE'] = 'true'
 
     example_prompts = [
         "Hello, my name is",

--- a/tests/e2e/multicard/test_qwen3_moe.py
+++ b/tests/e2e/multicard/test_qwen3_moe.py
@@ -136,7 +136,7 @@ def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
     }
     
     with VllmRunner(
-            snapshot_download("vllm-ascend/Qwen3-235B-A22B-W8A8"),  # Use quantized model path
+            "vllm-ascend/Qwen3-235B-A22B-W8A8",  # Use quantized model path
             tensor_parallel_size=4,
             data_parallel_size=4,
             enable_expert_parallel=True,

--- a/tests/e2e/multicard/test_qwen3_moe.py
+++ b/tests/e2e/multicard/test_qwen3_moe.py
@@ -101,3 +101,53 @@ def test_models_distributed_Qwen3_MOE_TP2_WITH_ACLGRAPH():
             enforce_eager=False,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
+
+def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
+    """Test Qwen3-235B with all2all sequence and multi-card configuration."""
+    # Set environment variables similar to the startup command
+    monkeypatch.setenv('VLLM_USE_V1', '1')
+    monkeypatch.setenv('VLLM_VERSION', '0.10.1.1')
+    monkeypatch.setenv('VLLM_ASCEND_ENABLE_MOE_ALL2ALL_SEQ', '1')
+    monkeypatch.setenv('TASK_QUEUE_ENABLE', '2')
+    monkeypatch.setenv('PYTORCH_NPU_ALLOC_CONF', 'expandable_segments:True')
+    monkeypatch.setenv('ACL_STREAM_TIMEOUT', '340000')
+    monkeypatch.setenv('HCCL_OP_EXPANSION_MODE', 'AIV')
+    monkeypatch.setenv('HCCL_OP_BASE_FFTS_MODE_ENABLE', 'true')
+    
+    example_prompts = [
+        "Hello, my name is",
+        "The capital of France is",
+        "In the field of artificial intelligence,",
+    ]
+    max_tokens = 32
+    
+    # Additional config matching the startup command
+    additional_config = {
+        "torchair_graph_config": {
+            "enabled": True,
+            "use_cached_graph": False,
+            "graph_batch_sizes_init": False,
+            "graph_batch_sizes": [1, 4, 8, 16, 24]
+        },
+        "ascend_scheduler_config": {
+            "enabled": True
+        },
+        "refresh": True
+    }
+    
+    with VllmRunner(
+            snapshot_download("vllm-ascend/Qwen3-235B-A22B-W8A8"),  # Use quantized model path
+            tensor_parallel_size=4,
+            data_parallel_size=4,
+            enable_expert_parallel=True,
+            max_model_len=35840,
+            max_num_seqs=24,
+            max_num_batched_tokens=35840,
+            gpu_memory_utilization=0.95,
+            quantization="ascend",
+            enforce_eager=False,
+            distributed_executor_backend="mp",
+            additional_config=additional_config,
+    ) as vllm_model:
+        vllm_model.generate_greedy(example_prompts, max_tokens)
+    

--- a/tests/e2e/multicard/test_qwen3_moe.py
+++ b/tests/e2e/multicard/test_qwen3_moe.py
@@ -102,6 +102,7 @@ def test_models_distributed_Qwen3_MOE_TP2_WITH_ACLGRAPH():
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
+
 def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
     """Test Qwen3-235B with all2all sequence and multi-card configuration."""
     # Set environment variables similar to the startup command
@@ -113,14 +114,14 @@ def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
     monkeypatch.setenv('ACL_STREAM_TIMEOUT', '340000')
     monkeypatch.setenv('HCCL_OP_EXPANSION_MODE', 'AIV')
     monkeypatch.setenv('HCCL_OP_BASE_FFTS_MODE_ENABLE', 'true')
-    
+
     example_prompts = [
         "Hello, my name is",
         "The capital of France is",
         "In the field of artificial intelligence,",
     ]
     max_tokens = 32
-    
+
     # Additional config matching the startup command
     additional_config = {
         "torchair_graph_config": {
@@ -134,7 +135,7 @@ def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
         },
         "refresh": True
     }
-    
+
     with VllmRunner(
             "vllm-ascend/Qwen3-235B-A22B-W8A8",  # Use quantized model path
             tensor_parallel_size=4,
@@ -150,4 +151,3 @@ def test_Qwen3_235b_all2allv_mc2_quant(monkeypatch):
             additional_config=additional_config,
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
-    


### PR DESCRIPTION
## What this PR does / why we need it?

This PR adds a end-to-end test case for Qwen3-235B MoE (Mixture of Experts) model with multi-card distributed inference configuration. 

## Does this PR introduce any user-facing change?

**No**, this PR does not introduce any user-facing changes. It only adds:
- A new test case in the test suite (test_qwen3_moe.py)
- No API changes, no configuration changes, no behavioral modifications to existing functionality
- The test validates existing features and configurations that are already available to users

## How was this patch tested?

**Test configuration covers**:
- Model: Qwen3-235B-A22B with W8A8 quantization
- Hardware: Multi-card Ascend NPU setup (4 cards TP × 4 cards DP)
- Memory: 95% GPU memory utilization 
- Sequence length: Up to 35,840 tokens
- Batch processing: Support for batch sizes [1, 4, 8, 16, 24]
- Expert parallelism: Enabled for MoE model optimization

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/68dbde5dbb11b9250454d0c9f21a8b3da960b341
