### PR TITLE
[Perf] Add new npu_fused_infer_attention_score op to improve perfomance in splitfuse cases and resolve long-seq mask problems

### DIFF
--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -82,7 +82,7 @@ class AttentionMaskBuilder:
         dtype: torch.dtype = None,
         device: torch.device = None,
     ) -> torch.Tensor:
-        if self.device:
+        if torch.version.cann.startswith("8.3"):
             return self.chunked_prefill_attn_mask
         else:
             if dtype not in [torch.float16, torch.bfloat16]:

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -39,12 +39,13 @@ class AttentionMaskBuilder:
         self,
         max_seq_len: int,
         dtype: torch.dtype,
+        device: torch.device,
     ):
         attn_mask = _generate_attn_mask(max_seq_len, dtype)
 
         self._seq_len_cached = attn_mask.shape[0]
         self.attn_mask_cache = attn_mask
-        self.chunked_prefill_attn_mask = torch.triu(torch.ones(2048, 2048), diagonal=1).to(torch.int8)
+        self.chunked_prefill_attn_mask = torch.triu(torch.ones(2048, 2048), diagonal=1).to(torch.int8).to(device)
 
     @staticmethod
     def get_mask_scale_factor(dtype: torch.dtype = torch.float16):
@@ -67,9 +68,8 @@ class AttentionMaskBuilder:
 
     def get_splitfuse_attn_mask(
         self,
-        device: torch.device,
     ) -> torch.Tensor:
-        return self.chunked_prefill_attn_mask.to(device)
+        return self.chunked_prefill_attn_mask
 
     def _update_attn_cache(self, seqlen: int, dtype: torch.dtype):
         if seqlen > self._seq_len_cached:

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -41,7 +41,7 @@ class AttentionMaskBuilder:
         dtype: torch.dtype,
         device: torch.device = None,
     ):
-        # NOTE: The device argument specifies the target NPU 
+        # NOTE: The device argument specifies the target NPU
         # to be used for the newly added FIA operator.
         # Only pass this parameter when using the new FIA operator.
 
@@ -52,8 +52,9 @@ class AttentionMaskBuilder:
         self.device = device
         if torch.version.cann.startswith("8.3"):
             assigned_mask_dim = 2048
-            self.chunked_prefill_attn_mask = torch.triu(torch.ones(assigned_mask_dim, assigned_mask_dim), diagonal=1
-            ).to(torch.int8).to(device)
+            self.chunked_prefill_attn_mask = torch.triu(
+                torch.ones(assigned_mask_dim, assigned_mask_dim),
+                diagonal=1).to(torch.int8).to(device)
 
     @staticmethod
     def get_mask_scale_factor(dtype: torch.dtype = torch.float16):
@@ -91,14 +92,13 @@ class AttentionMaskBuilder:
             self._update_attn_cache(max_seq_len, dtype)
             # FIXME: Currently the mask value of chunked-prefill situation and Prefill-Only situation
             # is not the same. Fix this in the future when kernel is ready.
-            mask_scale_factor = AttentionMaskBuilder.get_mask_scale_factor(dtype)
+            mask_scale_factor = AttentionMaskBuilder.get_mask_scale_factor(
+                dtype)
             attn_mask = torch.index_select(self.attn_mask_cache,
-                                        dim=0,
-                                        index=position)[:, :max_seq_len]
+                                           dim=0,
+                                           index=position)[:, :max_seq_len]
             attn_mask *= mask_scale_factor
             return attn_mask.contiguous().to(device, non_blocking=True)
-
-
 
     def _update_attn_cache(self, seqlen: int, dtype: torch.dtype):
         if seqlen > self._seq_len_cached:

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -41,14 +41,17 @@ class AttentionMaskBuilder:
         dtype: torch.dtype,
         device: torch.device = None,
     ):
+        # NOTE: The device argument specifies the target NPU 
+        # to be used for the newly added FIA operator.
+        # Only pass this parameter when using the new FIA operator.
+
         attn_mask = _generate_attn_mask(max_seq_len, dtype)
 
         self._seq_len_cached = attn_mask.shape[0]
         self.attn_mask_cache = attn_mask
         self.device = device
         if self.device:
-            #NOTE: New compressed mask needs to be sent to certain device, 
-            # so device needs to be passed here.
+
             assigned_mask_dim = 2048
             self.chunked_prefill_attn_mask = torch.triu(torch.ones(assigned_mask_dim, assigned_mask_dim), diagonal=1
             ).to(torch.int8).to(device)

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -50,8 +50,7 @@ class AttentionMaskBuilder:
         self._seq_len_cached = attn_mask.shape[0]
         self.attn_mask_cache = attn_mask
         self.device = device
-        if self.device:
-
+        if torch.version.cann.startswith("8.3"):
             assigned_mask_dim = 2048
             self.chunked_prefill_attn_mask = torch.triu(torch.ones(assigned_mask_dim, assigned_mask_dim), diagonal=1
             ).to(torch.int8).to(device)

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -39,13 +39,19 @@ class AttentionMaskBuilder:
         self,
         max_seq_len: int,
         dtype: torch.dtype,
-        device: torch.device,
+        device: torch.device = None,
     ):
         attn_mask = _generate_attn_mask(max_seq_len, dtype)
 
         self._seq_len_cached = attn_mask.shape[0]
         self.attn_mask_cache = attn_mask
-        self.chunked_prefill_attn_mask = torch.triu(torch.ones(2048, 2048), diagonal=1).to(torch.int8).to(device)
+        self.device = device
+        if self.device:
+            #NOTE: New compressed mask needs to be sent to certain device, 
+            # so device needs to be passed here.
+            assigned_mask_dim = 2048
+            self.chunked_prefill_attn_mask = torch.triu(torch.ones(assigned_mask_dim, assigned_mask_dim), diagonal=1
+            ).to(torch.int8).to(device)
 
     @staticmethod
     def get_mask_scale_factor(dtype: torch.dtype = torch.float16):
@@ -68,8 +74,29 @@ class AttentionMaskBuilder:
 
     def get_splitfuse_attn_mask(
         self,
+        seq_lens: torch.Tensor = None,
+        position: torch.Tensor = None,
+        dtype: torch.dtype = None,
+        device: torch.device = None,
     ) -> torch.Tensor:
-        return self.chunked_prefill_attn_mask
+        if self.device:
+            return self.chunked_prefill_attn_mask
+        else:
+            if dtype not in [torch.float16, torch.bfloat16]:
+                raise ValueError(
+                    "splitfuse_attn_mask now only supports bf16 and fp16")
+            max_seq_len = max(seq_lens, default=0)
+            self._update_attn_cache(max_seq_len, dtype)
+            # FIXME: Currently the mask value of chunked-prefill situation and Prefill-Only situation
+            # is not the same. Fix this in the future when kernel is ready.
+            mask_scale_factor = AttentionMaskBuilder.get_mask_scale_factor(dtype)
+            attn_mask = torch.index_select(self.attn_mask_cache,
+                                        dim=0,
+                                        index=position)[:, :max_seq_len]
+            attn_mask *= mask_scale_factor
+            return attn_mask.contiguous().to(device, non_blocking=True)
+
+
 
     def _update_attn_cache(self, seqlen: int, dtype: torch.dtype):
         if seqlen > self._seq_len_cached:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -459,7 +459,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         if torch.version.cann.startswith("8.3"):
             # TODO:The npu_fused_infer_attention_score op is planned to
             # be utilized in a wider range in upcoming versions.
-            num_block, block_size, head_num, head_dim = self.key_cache.shape
+            num_block, block_size, _, _ = self.key_cache.shape  # type: ignore
             key = self.key_cache.view(  # type: ignore
                 num_block, block_size, -1)
             value = self.value_cache.view(  # type: ignore

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -568,12 +568,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
                                                    output)
             # Normal V1 situation.
             else:
+                num_tokens = attn_metadata.query_start_loc[-1]
+                query = query[:num_tokens]
                 output = self._forward_v1_style(query, attn_metadata, output)
 
         # to make in-place change to the output tensor
         if hasattr(layer, 'quant_method') and use_kv_cache_int8:
             output = output.view(num_tokens, self.num_heads, self.head_size)
-        ori_output[:, :, :] = output[:num_tokens, :, :]
+        ori_output[:num_tokens, :, :] = output[:num_tokens, :, :]
         return output.view(num_tokens, self.hidden_size)
 
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -460,6 +460,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_metadata.seq_lens.to(device=query.device)
 
         if self.compressed_mask:
+            # TODO:The npu_fused_infer_attention_score op is planned to
+            # be utilized in a wider range in upcoming versions.
             num_block, block_size, head_num, head_dim = self.key_cache.shape
             key = self.key_cache.view(num_block, block_size, -1)
             value = self.value_cache.view(num_block, block_size, -1)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -464,7 +464,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             query=query,
             key=key,
             value=value,
-            atten_mask=attn_metadata.attn_mask.to(device=query.device),
+            atten_mask=attn_metadata.attn_mask,
             block_table=attn_metadata.block_tables,
             input_layout="TND",
             block_size=block_size,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -460,8 +460,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
             # TODO:The npu_fused_infer_attention_score op is planned to
             # be utilized in a wider range in upcoming versions.
             num_block, block_size, head_num, head_dim = self.key_cache.shape
-            key = self.key_cache.view(num_block, block_size, -1)  # type: ignore
-            value = self.value_cache.view(num_block, block_size, -1)  # type: ignore
+            key = self.key_cache.view(  # type: ignore
+                num_block, block_size, -1)
+            value = self.value_cache.view(  # type: ignore
+                num_block, block_size, -1)
 
             output, _ = torch_npu.npu_fused_infer_attention_score(
                 query=query,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -304,9 +304,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self.key_cache = None
         self.value_cache = None
 
-        pta_version_support_compressed_mask = "2.7.1.dev20250918"
-        self.compressed_mask = verify_torch_npu_version(pta_version_support_compressed_mask, "compressed mask")
-
     def _forward_prefill_no_cache(
         self,
         query: torch.Tensor,
@@ -459,7 +456,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             attn_metadata.seq_lens = \
                 attn_metadata.seq_lens.to(device=query.device)
 
-        if self.compressed_mask:
+        if torch.version.cann.startswith("8.3"):
             # TODO:The npu_fused_infer_attention_score op is planned to
             # be utilized in a wider range in upcoming versions.
             num_block, block_size, head_num, head_dim = self.key_cache.shape

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -37,7 +37,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.attention import vanilla_chunked_prefill
 from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_NZ, aligned_16, is_310p,
-                               nd_to_nz_2d, nd_to_nz_spec, verify_torch_npu_version)
+                               nd_to_nz_2d, nd_to_nz_spec)
 
 
 def wait_for_kv_layer_from_connector(layer_name: str):
@@ -477,20 +477,20 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 num_heads=self.num_heads,
                 scale=self.scale,
                 sparse_mode=3,
-                )
+            )
         else:
             torch_npu._npu_paged_attention_splitfuse(
-                        query=query,
-                        key_cache=self.key_cache,
-                        value_cache=self.value_cache,
-                        mask=attn_metadata.attn_mask,
-                        block_table=attn_metadata.block_tables,
-                        seq_len=attn_metadata.query_lens,
-                        context_lens=attn_metadata.seq_lens,
-                        num_kv_heads=self.num_kv_heads,
-                        num_heads=self.num_heads,
-                        scale_value=self.scale,
-                        out=output)
+                query=query,
+                key_cache=self.key_cache,
+                value_cache=self.value_cache,
+                mask=attn_metadata.attn_mask,
+                block_table=attn_metadata.block_tables,
+                seq_len=attn_metadata.query_lens,
+                context_lens=attn_metadata.seq_lens,
+                num_kv_heads=self.num_kv_heads,
+                num_heads=self.num_heads,
+                scale_value=self.scale,
+                out=output)
         return output
 
     def forward(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -460,8 +460,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
             # TODO:The npu_fused_infer_attention_score op is planned to
             # be utilized in a wider range in upcoming versions.
             num_block, block_size, head_num, head_dim = self.key_cache.shape
-            key = self.key_cache.view(num_block, block_size, -1)
-            value = self.value_cache.view(num_block, block_size, -1)
+            key = self.key_cache.view(num_block, block_size, -1)  # type: ignore
+            value = self.value_cache.view(num_block, block_size, -1)  # type: ignore
 
             output, _ = torch_npu.npu_fused_infer_attention_score(
                 query=query,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -586,8 +586,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
                                                    output)
             # Normal V1 situation.
             else:
-                num_tokens = attn_metadata.query_start_loc[-1]
-                query = query[:num_tokens]
+                if torch.version.cann.startswith("8.3"):
+                    # npu_fused_infer_attention_score does not support cases
+                    # where query.shape[0] != attn_metadata.query_start_loc[-1].
+                    # Thus we need unpad it here.
+                    num_tokens = attn_metadata.query_start_loc[-1]
+                    query = query[:num_tokens]
                 output = self._forward_v1_style(query, attn_metadata, output)
 
         # to make in-place change to the output tensor

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -60,7 +60,6 @@ _IS_310P = None
 _SLEEP_MODE_ENABLED = None
 _CURRENT_STREAM = None
 _ASCEND_CUSTOMOP_IS_REIGISTERED = False
-_CURRENT_TORCH_NPU_VERSION = torch_npu.__version__
 
 def is_310p():
     global _IS_310P

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -60,7 +60,7 @@ _IS_310P = None
 _SLEEP_MODE_ENABLED = None
 _CURRENT_STREAM = None
 _ASCEND_CUSTOMOP_IS_REIGISTERED = False
-
+_CURRENT_TORCH_NPU_VERSION = torch_npu.__version__
 
 def is_310p():
     global _IS_310P

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -61,6 +61,7 @@ _SLEEP_MODE_ENABLED = None
 _CURRENT_STREAM = None
 _ASCEND_CUSTOMOP_IS_REIGISTERED = False
 
+
 def is_310p():
     global _IS_310P
     if _IS_310P is None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -303,7 +303,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
 
         if torch.version.cann.startswith("8.3"):
             self.attn_mask_builder = AttentionMaskBuilder(
-                self.scheduler_config.max_num_batched_tokens, self.dtype, self.device)
+                self.scheduler_config.max_num_batched_tokens, self.dtype,
+                self.device)
         else:
             self.attn_mask_builder = AttentionMaskBuilder(
                 self.model_config.max_model_len, self.dtype)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -825,7 +825,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                              attn_state) -> torch.Tensor:
         # Chunk Prefill situation.
         if attn_state == AscendAttentionState.ChunkedPrefill and not self.vllm_config.model_config.use_mla:
-            if selkf.compressed_mas:
+            if self.compressed_mask:
                 return self.attn_mask_builder.get_splitfuse_attn_mask()
             else:
                 return self.attn_mask_builder.get_splitfuse_attn_mask(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -112,7 +112,7 @@ from vllm_ascend.spec_decode.mtp_proposer import MtpProposer
 from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, ACL_FORMAT_FRACTAL_NZ,
                                AscendSocVersion, ProfileExecuteDuration,
                                get_ascend_soc_version, is_310p,
-                               lmhead_tp_enable)
+                               lmhead_tp_enable, verify_torch_npu_version)
 from vllm_ascend.worker.npu_input_batch import CachedRequestState, InputBatch
 
 if TYPE_CHECKING:
@@ -301,8 +301,15 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             use_mla=self.model_config.use_mla,
         )
 
-        self.attn_mask_builder = AttentionMaskBuilder(
-            self.model_config.max_model_len, self.dtype, self.device)
+        pta_version_support_compressed_mask = "2.7.1.dev20250918"
+        self.compressed_mask = verify_torch_npu_version(pta_version_support_compressed_mask, "compressed mask")
+
+        if self.compressed_mask:
+            self.attn_mask_builder = AttentionMaskBuilder(
+                self.scheduler_config.max_num_batched_tokens, self.dtype, self.device)
+        else:
+            self.attn_mask_builder = AttentionMaskBuilder(
+                self.model_config.max_model_len, self.dtype)
 
         # Set up speculative decoding.
         self.spec_attn_mask = None
@@ -818,7 +825,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                              attn_state) -> torch.Tensor:
         # Chunk Prefill situation.
         if attn_state == AscendAttentionState.ChunkedPrefill and not self.vllm_config.model_config.use_mla:
-            return self.attn_mask_builder.get_splitfuse_attn_mask()
+            if selkf.compressed_mas:
+                return self.attn_mask_builder.get_splitfuse_attn_mask()
+            else:
+                return self.attn_mask_builder.get_splitfuse_attn_mask(
+                    seq_lens, position, self.dtype, self.device)
         # Prefill without cache situation.
         elif attn_state == AscendAttentionState.PrefillNoCache:
             max_seq_len = max(seq_lens, default=0)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -302,7 +302,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         )
 
         self.attn_mask_builder = AttentionMaskBuilder(
-            self.model_config.max_model_len, self.dtype)
+            self.model_config.max_model_len, self.dtype, self.device)
 
         # Set up speculative decoding.
         self.spec_attn_mask = None
@@ -818,8 +818,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                              attn_state) -> torch.Tensor:
         # Chunk Prefill situation.
         if attn_state == AscendAttentionState.ChunkedPrefill and not self.vllm_config.model_config.use_mla:
-            return self.attn_mask_builder.get_splitfuse_attn_mask(
-                self.device)
+            return self.attn_mask_builder.get_splitfuse_attn_mask()
         # Prefill without cache situation.
         elif attn_state == AscendAttentionState.PrefillNoCache:
             max_seq_len = max(seq_lens, default=0)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -818,8 +818,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                              attn_state) -> torch.Tensor:
         # Chunk Prefill situation.
         if attn_state == AscendAttentionState.ChunkedPrefill and not self.vllm_config.model_config.use_mla:
-            return self.attn_mask_builder.get_splitfuse_attn_mask(
-                seq_lens, position, self.dtype, self.device)
+            return torch.triu(torch.ones(2048, 2048), diagonal=1).to(torch.int8)
         # Prefill without cache situation.
         elif attn_state == AscendAttentionState.PrefillNoCache:
             max_seq_len = max(seq_lens, default=0)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -818,7 +818,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                              attn_state) -> torch.Tensor:
         # Chunk Prefill situation.
         if attn_state == AscendAttentionState.ChunkedPrefill and not self.vllm_config.model_config.use_mla:
-            return torch.triu(torch.ones(2048, 2048), diagonal=1).to(torch.int8)
+            return self.attn_mask_builder.get_splitfuse_attn_mask(
+                self.device)
         # Prefill without cache situation.
         elif attn_state == AscendAttentionState.PrefillNoCache:
             max_seq_len = max(seq_lens, default=0)


### PR DESCRIPTION
### What this PR does / why we need it?
Add new npu_fused_infer_attention_score op to improve perfomance in splitfuse cases and resolve long-seq mask problems .

1. The original op's performance is suboptimal in certain scenarios, necessitating optimization through the _new op_ (npu_fused_infer_attention_score)。
2. For ultra-long sequences (128k), the original operator will allocate a large attn_mask, which consumes excessive CPU memory. In contrast, the _new op_ supports a fixed-size compressed mask, effectively resolving this issue.

NOTE1: The current PR retains the original logic and uses a version check of the CANN package to determine whether the _new op_ can be enabled. This ensures no impact on existing users. In future versions, this version check and the original logic will be deprecated, and the _new op_ scheduling will be uniformly adopted.
NOTE2: This pr relies on future CANN version, which is not available now.
NOTE3: To enable the new op in chunked prefill, the parameter additional_config should be set like `--additional-config '{"ascend_scheduler_config": {"enabled":true,"enable_chunked_prefill":true}}' \` at least.

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
CI passed




- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/6c5f82e5aa87cd73ce03ce10fc44138f75ee1aea
