### PR TITLE
[Bugfix] ngram spec decode attention error and repeat add sampled tok…

### DIFF
--- a/vllm_ascend/spec_decode/ngram_proposer.py
+++ b/vllm_ascend/spec_decode/ngram_proposer.py
@@ -51,13 +51,9 @@ class NgramProposer(VllmNgramProposer, Proposer):
                 draft_token_ids.append([])
                 continue
 
-            # Add sampled_token_ids to token_ids_cpu.
-            start_idx = self.runner.input_batch.num_tokens_no_spec[i]
-            end_idx = start_idx + num_sampled_ids
-            self.runner.input_batch.token_ids_cpu[
-                i, start_idx:end_idx] = sampled_ids
+            num_tokens = self.runner.input_batch.num_tokens_no_spec[i]
             drafter_output = self.propose(
-                self.runner.input_batch.token_ids_cpu[i, :end_idx])
+                self.runner.input_batch.token_ids_cpu[i, :num_tokens])
             if drafter_output is None or len(drafter_output) == 0:
                 draft_token_ids.append([])
             else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1440,6 +1440,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             if self.drafter and (self.drafter.name == SpecDcodeType.EAGLE
                                  or self.drafter.name == SpecDcodeType.EAGLE3):
                 attn_state = AscendAttentionState.ChunkedPrefill
+            elif self.drafter and self.drafter.name == SpecDcodeType.NGRAM:
+                attn_state = AscendAttentionState.DecodeOnly
             else:
                 attn_state = AscendAttentionState.SpecDecoding
         # splitfuse


### PR DESCRIPTION
### What this PR does / why we need it?
- Fixes  ngram spec decode attention error(https://github.com/vllm-project/vllm-ascend/issues/2971) and repeat add sampled token ids

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with new added/existing test.

