### PR TITLE
fix kv nz accuracy bug

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -785,7 +785,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
         kv_no_split = kv_no_split.view(
             B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
-        cache_mode = "PA_BLK_NZ" if self.enable_kv_nz else "PA"
+        cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
         _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
             self.kv_a_layernorm.weight,

--- a/vllm_ascend/torchair/torchair_mla.py
+++ b/vllm_ascend/torchair/torchair_mla.py
@@ -961,7 +961,7 @@ class AscendMLATorchairImpl(MLAAttentionImpl):
         kv = self.kv_a_proj_with_mqa(hidden_states)[0]
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
         kv = kv.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
-        cache_mode = "PA_BLK_NZ" if self.enable_kv_nz else "PA"
+        cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
         _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv,
             self.kv_a_layernorm.weight,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
when `enable_kv_nz` is true, output of Deepseek R1 is invalid.
```
{"id":"chatcmpl-f01fa84f397b417abf6d3c5243787d38","object":"chat.completion","created":1758106562,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"<think>0I0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0O0","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":7,"total_tokens":107,"completion_tokens":100,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}
```
The reason is that the decode stage incorrectly usage of `torch_npu.npu_kv_rmsnorm_rope_cache`. After fix:
```
{"id":"chatcmpl-4a9e79534b2b4945a9496621d1dc53f6","object":"chat.completion","created":1758108051,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"<think>\nOkay, the user sent \"Hello, my name is\" and then the conversation ends. They might have intended to complete the sentence but didn't. I should prompt them to provide their name so I can address them properly. Maybe respond with a friendly greeting and ask for their name. Let me make sure to keep it welcoming and open. Something like, \"Hello! It's nice to meet you. Could you please tell me your name?\" That should encourage them to share their name without","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":7,"total_tokens":107,"completion_tokens":100,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}
```

run server:
```
nohup python -m vllm.entrypoints.openai.api_server --model=DeepSeek-R1-W8A8-VLLM \
    --quantization ascend \
    --served-model-name auto \
    --trust-remote-code \
    --distributed-executor-backend=mp \
    --port 8009 \
    -tp=8 \
    -dp=2 \
    --max-num-seqs 24 \
    --max-model-len 32768 \
    --max-num-batched-tokens 8192 \
    --additional-config '{"torchair_graph_config":{"enabled":true,"use_cached_graph":true,"graph_batch_sizes":[24], "enable_kv_nz": true},"expert_tensor_parallel_size":16}' \
    --block-size 128 \
    --gpu-memory-utilization 0.96 &> run.log &
disown
```

curl:
```
curl --location 'http://127.0.0.1:8009/v1/chat/completions' --header 'Content-Type: application/json' --data '{
        "top_p": 1,
        "ignore_eos": false,
        "stream": false,
        "max_tokens": 100,
        "stop": "None",
        "top_k": -1,
        "temperature": 0.6,
        "messages": [
            {
                "role": "system",
                "content": "Hello, my name is"
            }
        ]
    }'
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No
### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

