### PR TITLE
Increase doctest timeout to 300s and time print

### DIFF
--- a/tests/e2e/common.sh
+++ b/tests/e2e/common.sh
@@ -14,7 +14,7 @@ _err() { _red "Error: $*" && exit 1; }
 
 CURL_TIMEOUT=1
 CURL_COOLDOWN=5
-CURL_MAX_TRIES=180
+CURL_MAX_TRIES=300
 
 function wait_url_ready() {
   local serve_name="$1"

--- a/tests/e2e/doctests/001-quickstart-test.sh
+++ b/tests/e2e/doctests/001-quickstart-test.sh
@@ -57,8 +57,8 @@ function quickstart_online_test() {
 }
 
 _info "====> Start simple_test"
-simple_test
+time simple_test
 _info "====> Start quickstart_offline_test"
-quickstart_offline_test
+time quickstart_offline_test
 _info "====> Start quickstart_online_test"
-quickstart_online_test
+time quickstart_online_test

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -59,4 +59,4 @@ function install_binary_test() {
 }
 
 _info "====> Start install_binary_test"
-install_binary_test
+time install_binary_test

--- a/tests/e2e/run_doctests.sh
+++ b/tests/e2e/run_doctests.sh
@@ -22,7 +22,6 @@ set -eo errexit
 . $(dirname "$0")/common.sh
 
 export VLLM_USE_MODELSCOPE=true
-export VLLM_LOGGING_LEVEL=ERROR
 
 _info "====> Start Quickstart test"
 . "${SCRIPT_DIR}/doctests/001-quickstart-test.sh"


### PR DESCRIPTION
### What this PR does / why we need it?
Increase doctest timeout to 300s and time print, according to time print in https://github.com/vllm-project/vllm-ascend/pull/3045 , most of time consumed in `Graph capturing`, so I think it's fine to increase doctest timeout

This PR also add time log for each task.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Run `/vllm-workspace/vllm-ascend/tests/e2e/run_doctests.sh`
- CI passed

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/a684c0124cb8ac04984b6fd621d99e1463016eac

Closes: https://github.com/vllm-project/vllm-ascend/issues/3045