### PR TITLE
[TEST] Speed up DS V2 accuracy test and turn up accuracy baseline

### DIFF
--- a/tests/e2e/models/configs/DeepSeek-V2-Lite.yaml
+++ b/tests/e2e/models/configs/DeepSeek-V2-Lite.yaml
@@ -3,11 +3,11 @@ tasks:
 - name: "gsm8k"
   metrics:
   - name: "exact_match,strict-match"
-    value: 0.375
+    value: 0.385
   - name: "exact_match,flexible-extract"
-    value: 0.375
+    value: 0.385
 tensor_parallel_size: 2
-batch_size: 8
+batch_size: 32
 gpu_memory_utilization: 0.7
 apply_chat_template: False
 fewshot_as_multiturn: False


### PR DESCRIPTION
### What this PR does / why we need it?
1. update expected accuracy for DeepSeek-V2-Lite
2. add batch size 

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/838d7116ba59db528647b29f0d000742f4af9d4b
