### PR TITLE
[CI] Enable main based lint check and light ci matrix

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,10 @@ name: pre-commit
 
 on:
     workflow_call:
+      inputs:
+        vllm:
+          required: true
+          type: string
 
 permissions:
   contents: read
@@ -22,6 +26,7 @@ jobs:
       with:
         repository: vllm-project/vllm
         path: ./vllm-empty
+        ref: ${{ inputs.vllm }}
     - name: Install vllm
       working-directory: vllm-empty
       run: |

--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -41,6 +41,8 @@ concurrency:
 jobs:
   lint:
     uses: ./.github/workflows/pre-commit.yml
+    with:
+      vllm: c60e6137f0bf2034853919b3a9d705d7e06b93cf
 
   changes:
     runs-on: ubuntu-latest
@@ -143,7 +145,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.lint.result == 'success' && needs.changes.outputs.e2e_tracker == 'true' && !contains(github.event.pull_request.labels.*.name, 'ready') }}
     uses: ./.github/workflows/_e2e_test.yaml
     with:
-      vllm: v0.10.2
+      vllm: ${{ matrix.vllm_version }}
       runner: linux-aarch64-a2
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.2.rc1-910b-ubuntu22.04-py3.11
       type: light


### PR DESCRIPTION
### What this PR does / why we need it?
Followup on https://github.com/vllm-project/vllm-ascend/pull/3064
1. should limit vllm version to the same hash with mypy
2. fix the vllm version bug for e2e light test.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
CI passed


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/c60e6137f0bf2034853919b3a9d705d7e06b93cf
