### PR TITLE
[ModelRunner][Refactor] Refactor kv cache tensor initialization logic

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2567,12 +2567,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         self.initialize_attn_backend(kv_cache_config)
         self.use_hybrid_blocks = (len(self.attn_groups) > 1)
         self.may_reinitialize_input_batch(kv_cache_config)
-
-        if self.model_config.is_deepseek_mla:
-            kv_caches = self.initialize_kv_cache_tensors_deepseek(
-                kv_cache_config)
-        else:
-            kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
+        kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)
@@ -2583,94 +2578,6 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         aligned_addr = (data_ptr + alignment - 1) // alignment * alignment
         offset = (aligned_addr - data_ptr) // tensor.element_size()
         return tensor[int(offset):]
-
-    def initialize_kv_cache_tensors_deepseek(
-            self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
-        kv_cache_sizes = {}
-        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            assert len(kv_cache_tensor.shared_by) == 1, (
-                "KV cache tensor shared by multiple layers is not supported in "
-                "NPU.")
-            kv_cache_sizes[kv_cache_tensor.shared_by[0]] = kv_cache_tensor.size
-
-        kv_caches: Dict[str, torch.Tensor] = {}
-        for group in self._kv_cache_spec_attn_group_iterator_dispatcher():
-            if vllm_version_is("0.10.2"):
-                kv_cache_spec, group = group
-            else:
-                kv_cache_spec = group.kv_cache_spec
-            attn_backend = group.backend
-            for layer_name in group.layer_names:
-                if layer_name in self.runner_only_attn_layers:
-                    continue
-                tensor_size = kv_cache_sizes[layer_name]
-                num_blocks = tensor_size // kv_cache_spec.page_size_bytes
-                if self.vllm_config.additional_config.get(
-                        "kv_cache_dtype", None) == 'int8':
-                    kv_cache_shape = attn_backend.get_bsh_kv_cache_shape(
-                        num_blocks, kv_cache_spec.block_size,
-                        kv_cache_spec.num_kv_heads, kv_cache_spec.head_size)
-                elif hasattr(attn_backend, "get_supported_block_size"
-                             ) and not self.model_config.is_deepseek_mla:
-                    block_size = attn_backend.get_supported_block_size()[0]
-                    block_size_chunk = kv_cache_spec.block_size // block_size
-                    kv_cache_shape = attn_backend.get_kv_cache_shape(
-                        num_blocks * block_size_chunk, block_size,
-                        kv_cache_spec.num_kv_heads, kv_cache_spec.head_size)
-                else:
-                    kv_cache_shape = self.attn_backend.get_kv_cache_shape(
-                        num_blocks, kv_cache_spec.block_size,
-                        kv_cache_spec.num_kv_heads, kv_cache_spec.head_size)
-                dtype = kv_cache_spec.dtype
-
-                alignment = 2 * 1024 * 1024
-                num_blocks, block_size, num_kv_heads, head_size = kv_cache_shape
-                rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
-                nope_dim = head_size - rope_dim
-                nope_cache_shape = (num_blocks, block_size, num_kv_heads,
-                                    nope_dim)
-                rope_cache_shape = (num_blocks, block_size, num_kv_heads,
-                                    rope_dim)
-                if self.vllm_config.kv_transfer_config is None:
-                    # For no disaggregate pd scenario, allocate kv cache in normal way
-                    rope_cache = torch.zeros(rope_cache_shape,
-                                             dtype=dtype,
-                                             device=self.device)
-                    nope_cache = torch.zeros(nope_cache_shape,
-                                             dtype=dtype,
-                                             device=self.device)
-                    rope_cache = self._convert_torch_format(rope_cache)
-                    nope_cache = self._convert_torch_format(nope_cache)
-                else:
-
-                    # In order to transfer kv cache through the reigster_memory api from llmdatadist, the memory
-                    # address should be aligned by 2M. In most case, torch_npu can allocate 2M aligned memory, but
-                    # we found there are also some exceptions during test, so we manual align those memory here, this part
-                    # of code may consume 2M * 2 * elem_size memory every layer.
-                    nope_allocate_shape = num_blocks * block_size * num_kv_heads * nope_dim
-                    nope_allocate_shape_alignment = nope_allocate_shape + alignment
-                    rope_allocate_shape = num_blocks * block_size * num_kv_heads * rope_dim
-                    rope_allocate_shape_alignment = rope_allocate_shape + alignment
-
-                    nope_cache = torch.zeros(nope_allocate_shape_alignment,
-                                             dtype=dtype,
-                                             device=self.device)
-                    rope_cache = torch.zeros(rope_allocate_shape_alignment,
-                                             dtype=dtype,
-                                             device=self.device)
-                    nope_cache = self._align_memory(
-                        nope_cache,
-                        alignment)[:nope_allocate_shape].view(nope_cache_shape)
-                    rope_cache = self._align_memory(
-                        rope_cache,
-                        alignment)[:rope_allocate_shape].view(rope_cache_shape)
-                kv_caches[layer_name] = (nope_cache, rope_cache)
-
-        bind_kv_cache(kv_caches,
-                      self.compilation_config.static_forward_context,
-                      self.kv_caches)
-
-        return kv_caches
 
     def initialize_kv_cache_tensors(
             self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
@@ -2710,26 +2617,44 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                                 tensor, alignment)[:kv_cache_tensor.size]
                         kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif "self_attn" in layer_name:
+                    # NOTE: We need to init k cache tensor (nope cache tensor in mla) and
+                    # v cache tensor (rope cache tensor in mla) separately to support llmdatadist,
+                    # as it only support the 0-dim of kv_cache is `num_blocks`.
+                    # For deepseek mla, we need to spilt cache tensor accrodding to the nope head dim
+                    # and rope head dim.
+                    if self.model_config.is_deepseek_mla:
+                        head_size = self.model_config.hf_text_config.qk_rope_head_dim + \
+                            self.model_config.hf_text_config.kv_lora_rank
+
+                    k_tensor_split_factor = 2 if not self.model_config.is_deepseek_mla else \
+                        head_size / self.model_config.hf_text_config.kv_lora_rank
+                    v_tensor_split_factor = 2 if not self.model_config.is_deepseek_mla else \
+                        head_size / self.model_config.hf_text_config.qk_rope_head_dim
+                    k_tensor_size = int(kv_cache_tensor.size //
+                                        k_tensor_split_factor)
+                    v_tensor_size = int(kv_cache_tensor.size //
+                                        v_tensor_split_factor)
+
                     if self.vllm_config.kv_transfer_config is None:
-                        k_tensor = torch.zeros(kv_cache_tensor.size // 2,
+                        k_tensor = torch.zeros(k_tensor_size,
                                                dtype=torch.int8,
                                                device=self.device)
-                        v_tensor = torch.zeros(kv_cache_tensor.size // 2,
+                        v_tensor = torch.zeros(v_tensor_size,
                                                dtype=torch.int8,
                                                device=self.device)
                     else:
-                        cache_size = kv_cache_tensor.size // 2
-                        cache_size_aligned = kv_cache_tensor.size // 2 + alignment
-                        k_tensor = torch.zeros(cache_size_aligned,
+                        k_tensor_size_aligned = k_tensor_size + alignment
+                        v_tensor_size_aligned = v_tensor_size + alignment
+                        k_tensor = torch.zeros(k_tensor_size_aligned,
                                                dtype=torch.int8,
                                                device=self.device)
-                        v_tensor = torch.zeros(cache_size_aligned,
+                        v_tensor = torch.zeros(v_tensor_size_aligned,
                                                dtype=torch.int8,
                                                device=self.device)
-                        k_tensor = self._align_memory(k_tensor,
-                                                      alignment)[:cache_size]
-                        v_tensor = self._align_memory(v_tensor,
-                                                      alignment)[:cache_size]
+                        k_tensor = self._align_memory(
+                            k_tensor, alignment)[:k_tensor_size]
+                        v_tensor = self._align_memory(
+                            v_tensor, alignment)[:v_tensor_size]
                     kv_cache_raw_tensors[layer_name] = (k_tensor, v_tensor)
 
         layer_names = set()
@@ -2794,11 +2719,29 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                             kv_cache_spec.num_kv_heads,
                             kv_cache_spec.head_size)
                     dtype = kv_cache_spec.dtype
-                    k_cache = raw_k_tensor.view(dtype).view(kv_cache_shape[1:])
-                    k_cache = self._convert_torch_format(k_cache)
-                    v_cache = raw_v_tensor.view(dtype).view(kv_cache_shape[1:])
-                    v_cache = self._convert_torch_format(v_cache)
-                    kv_caches[layer_name] = (k_cache, v_cache)
+                    if self.model_config.is_deepseek_mla:
+                        num_blocks, block_size, num_kv_heads, head_size = kv_cache_shape
+                        rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
+                        nope_dim = head_size - rope_dim
+                        nope_cache_shape = (num_blocks, block_size,
+                                            num_kv_heads, nope_dim)
+                        rope_cache_shape = (num_blocks, block_size,
+                                            num_kv_heads, rope_dim)
+                        nope_cache = raw_k_tensor.view(dtype).view(
+                            nope_cache_shape)
+                        nope_cache = self._convert_torch_format(nope_cache)
+                        rope_cache = raw_v_tensor.view(dtype).view(
+                            rope_cache_shape)
+                        rope_cache = self._convert_torch_format(rope_cache)
+                        kv_caches[layer_name] = (nope_cache, rope_cache)
+                    else:
+                        k_cache = raw_k_tensor.view(dtype).view(
+                            kv_cache_shape[1:])
+                        k_cache = self._convert_torch_format(k_cache)
+                        v_cache = raw_v_tensor.view(dtype).view(
+                            kv_cache_shape[1:])
+                        v_cache = self._convert_torch_format(v_cache)
+                        kv_caches[layer_name] = (k_cache, v_cache)
                 elif isinstance(kv_cache_spec, MambaSpec):
                     raw_tensor = kv_cache_raw_tensors[layer_name]
                     assert raw_tensor is not None


### PR DESCRIPTION
### What this PR does / why we need it?
Refactor kv cache tensor initialization logic. Unify the kvcache tensor initialization logic of deepseek and normal models

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with existing test.
1. prefill disaggregation scenario
2. deepseek + aclgraph/eager mode
3. qwen3 next