### PR TITLE
[KVCache][Bugfix] Fix kv cache initialization error of attention layer

### DIFF
--- a/vllm_ascend/models/deepseek_mtp.py
+++ b/vllm_ascend/models/deepseek_mtp.py
@@ -166,7 +166,7 @@ class CustomDeepSeekMultiTokenPredictor(DeepSeekMultiTokenPredictor):
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
-        sampling_metadata,  # type: ignore
+        sampling_metadata=None,  # type: ignore
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
         current_step_idx = (spec_step_idx % self.num_mtp_layers)

--- a/vllm_ascend/models/qwen3_next.py
+++ b/vllm_ascend/models/qwen3_next.py
@@ -1080,7 +1080,7 @@ class Qwen3NextForCausalLM(nn.Module, HasInnerState, SupportsLoRA, SupportsPP,
     def compute_logits(
             self,
             hidden_states: torch.Tensor,
-            sampling_metadata,  # type: ignore
+            sampling_metadata=None,  # type: ignore
     ) -> Optional[torch.Tensor]:
         return self.logits_processor(self.lm_head, hidden_states,
                                      sampling_metadata)

--- a/vllm_ascend/torchair/models/qwen2.py
+++ b/vllm_ascend/torchair/models/qwen2.py
@@ -344,7 +344,7 @@ class CustomQwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
     def compute_logits(
             self,
             hidden_states: torch.Tensor,
-            sampling_metadata,  # type: ignore
+            sampling_metadata=None,  # type: ignore
     ) -> Optional[torch.Tensor]:
         logits = self.logits_processor(self.lm_head, hidden_states,
                                        sampling_metadata)

--- a/vllm_ascend/torchair/models/torchair_deepseek_mtp.py
+++ b/vllm_ascend/torchair/models/torchair_deepseek_mtp.py
@@ -170,7 +170,7 @@ class TorchairDeepSeekMultiTokenPredictor(DeepSeekMultiTokenPredictor):
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
-        sampling_metadata,  # type: ignore
+        sampling_metadata=None,  # type: ignore
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
         current_step_idx = (spec_step_idx % self.num_mtp_layers)

--- a/vllm_ascend/torchair/models/torchair_pangu_moe.py
+++ b/vllm_ascend/torchair/models/torchair_pangu_moe.py
@@ -936,7 +936,7 @@ class PanguProMoEForCausalLM(nn.Module, SupportsPP):
     def compute_logits(
             self,
             hidden_states: torch.Tensor,
-            sampling_metadata,  # type: ignore
+            sampling_metadata=None,  # type: ignore
     ) -> Optional[torch.Tensor]:
         logits = self.logits_processor(self.lm_head, hidden_states,
                                        sampling_metadata)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2779,8 +2779,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                 if "linear_attn" in layer_name:
                     # for mamba linear attention
                     for layer_name_inner in kv_cache_tensor.shared_by:
-                        if "self_attn" in layer_name_inner or layer_name_inner in kv_cache_raw_tensors.keys(
-                        ):
+                        if ("attn" in layer_name_inner and "linear_attn" not in layer_name_inner) or \
+                            layer_name_inner in kv_cache_raw_tensors.keys():
                             continue
                         if self.vllm_config.kv_transfer_config is None:
                             tensor = torch.zeros(kv_cache_tensor.size,


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes #3096 
1. Fix kv cache initialization error of attention layer. There are some models with layer name like `attn.attn`, instead of `self_attn`, but the initialization of kv cache tensors only check for `self_attn` and `attn.attn`, which leding to the error `AssertionError: Some layers are not correctly initialized`
2. Set the default value of input arg `sampling_metadata` in `compute_logits` for the modeling files in vllm-ascend. Thus fixing the error `Qwen3NextForCausalLM.compute_logits() missing 1 required positional argument: 'sampling_metadata'`

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
test locally with internlm


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/5aeb9254521023f97aca292b3478aa7ff485ffb2
