### PR TITLE
[Doc] modify the version compatibility between vllm and vllm-ascend

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Below is maintained branches:
 
 | Branch     | Status       | Note                                 |
 |------------|--------------|--------------------------------------|
-| main       | Maintained   | CI commitment for vLLM main branch and vLLM 0.10.x branch   |
+| main       | Maintained   | CI commitment for vLLM main branch and vLLM v0.10.2 tag   |
 | v0.7.1-dev | Unmaintained | Only doc fixed is allowed |
 | v0.7.3-dev | Maintained   | CI commitment for vLLM 0.7.3 version, only bug fix is allowed and no new release tag any more. |
 | v0.9.1-dev | Maintained   | CI commitment for vLLM 0.9.1 version |


### PR DESCRIPTION
### What this PR does / why we need it?
modify the version compatibility between vllm and vllm-ascend, the main branch of vllm-ascend corresponds to the v0.10.2 tag of vllm.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/f225ea7dd98e9f29752e5c032cd4a8ee1d712f16
