### PR TITLE
[BugFix] Fix dummy_run memory explosion in eager mode

### DIFF
--- a/vllm_ascend/ops/moe/fused_moe_prepare_and_finalize.py
+++ b/vllm_ascend/ops/moe/fused_moe_prepare_and_finalize.py
@@ -186,10 +186,10 @@ class FusedMoEPrepareAndFinalizeWithMC2(FusedMoEPrepareAndFinalize):
                                 self.moe_config.tp_group.device_group)
                 hidden_states = torch.cat(self.split_hidden_states, dim=0)
 
-                # TODO: It is a quick bugfix for the single-operator memory explosion issue
-                # that requires further restructuring. 
-                # If the cache is not cleared after `self.split_hidden_states` is created, 
-                # it can lead to the single-operator memory explosion.
+                # TODO: It is a quick bugfix for the memory explosion issue in eager mode
+                # that requires further restructuring.
+                # If the cache is not cleared after `self.split_hidden_states` is created,
+                # it can lead to the memory explosion in eager mode.
                 del self.split_hidden_states
 
             # Unpad if necessary
@@ -276,10 +276,10 @@ class FusedMoEPrepareAndFinalizeWithAll2All(FusedMoEPrepareAndFinalize):
                                 self.moe_config.tp_group.device_group)
                 hidden_states = torch.cat(self.split_hidden_states, dim=0)
 
-                # TODO: It is a quick bugfix for the single-operator memory explosion issue
-                # that requires further restructuring. 
-                # If the cache is not cleared after `self.split_hidden_states` is created, 
-                # it can lead to the single-operator memory explosion.
+                # TODO: It is a quick bugfix for the memory explosion issue in eager mode
+                # that requires further restructuring.
+                # If the cache is not cleared after `self.split_hidden_states` is created,
+                # it can lead to the memory explosion in eager mode.
                 del self.split_hidden_states
 
             if self.num_tokens < hidden_states.shape[0]:

--- a/vllm_ascend/ops/moe/fused_moe_prepare_and_finalize.py
+++ b/vllm_ascend/ops/moe/fused_moe_prepare_and_finalize.py
@@ -186,8 +186,7 @@ class FusedMoEPrepareAndFinalizeWithMC2(FusedMoEPrepareAndFinalize):
                                 self.moe_config.tp_group.device_group)
                 hidden_states = torch.cat(self.split_hidden_states, dim=0)
 
-                # TODO: It is a quick bugfix for the memory explosion issue in eager mode
-                # that requires further restructuring.
+                # TODO: It is a quick bugfix for the memory explosion issue in eager mode.
                 # If the cache is not cleared after `self.split_hidden_states` is created,
                 # it can lead to the memory explosion in eager mode.
                 del self.split_hidden_states
@@ -276,8 +275,7 @@ class FusedMoEPrepareAndFinalizeWithAll2All(FusedMoEPrepareAndFinalize):
                                 self.moe_config.tp_group.device_group)
                 hidden_states = torch.cat(self.split_hidden_states, dim=0)
 
-                # TODO: It is a quick bugfix for the memory explosion issue in eager mode
-                # that requires further restructuring.
+                # TODO: It is a quick bugfix for the memory explosion issue in eager mode.
                 # If the cache is not cleared after `self.split_hidden_states` is created,
                 # it can lead to the memory explosion in eager mode.
                 del self.split_hidden_states

--- a/vllm_ascend/ops/moe/fused_moe_prepare_and_finalize.py
+++ b/vllm_ascend/ops/moe/fused_moe_prepare_and_finalize.py
@@ -186,6 +186,12 @@ class FusedMoEPrepareAndFinalizeWithMC2(FusedMoEPrepareAndFinalize):
                                 self.moe_config.tp_group.device_group)
                 hidden_states = torch.cat(self.split_hidden_states, dim=0)
 
+                # TODO: It is a quick bugfix for the single-operator memory explosion issue
+                # that requires further restructuring. 
+                # If the cache is not cleared after `self.split_hidden_states` is created, 
+                # it can lead to the single-operator memory explosion.
+                del self.split_hidden_states
+
             # Unpad if necessary
             if self.num_tokens < hidden_states.shape[0]:
                 hidden_states = hidden_states[:self.num_tokens]
@@ -269,6 +275,12 @@ class FusedMoEPrepareAndFinalizeWithAll2All(FusedMoEPrepareAndFinalize):
                 dist.all_gather(list(self.split_hidden_states), hidden_states,
                                 self.moe_config.tp_group.device_group)
                 hidden_states = torch.cat(self.split_hidden_states, dim=0)
+
+                # TODO: It is a quick bugfix for the single-operator memory explosion issue
+                # that requires further restructuring. 
+                # If the cache is not cleared after `self.split_hidden_states` is created, 
+                # it can lead to the single-operator memory explosion.
+                del self.split_hidden_states
 
             if self.num_tokens < hidden_states.shape[0]:
                 hidden_states = hidden_states[:self.num_tokens]


### PR DESCRIPTION
### What this PR does / why we need it?

It is a quick bugfix for the memory explosion issue that requires further refactoring.
The dummy_run in eager mode may lead to OOM and the reason is that `hidden_states` were not released in time. 
The PR temporarily resolves the issue by manually clearing the cache, and further refactoring will be conducted subsequently. 

Before the modification, the dummy_run's memory showed an accumulation issue. 
<img width="1796" height="207" alt="image" src="https://github.com/user-attachments/assets/05e2b04c-2f99-4085-9eda-c78b7d9a57b0" />

After modification, it can be observed that the memory is released promptly. 
<img width="1141" height="251" alt="image" src="https://github.com/user-attachments/assets/5f5ade97-904c-4c9d-a8de-b04869e50e18" />

And it was verified that the model responded normally after a single data input. 


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/b1068903fdca26cf6b4a1a51a32c3365ce3ac636
