### PR TITLE
[Perf] Integrate new split_with_sizes_copy op to enhance inference performace

### DIFF
--- a/vllm_ascend/models/qwen3_moe.py
+++ b/vllm_ascend/models/qwen3_moe.py
@@ -50,26 +50,30 @@ from vllm_ascend.ops.fused_moe import AscendFusedMoE
 
 class CustomQwen3MoeAttention(Qwen3MoeAttention):
     def forward(
-        self,
-        hidden_states: torch.Tensor,
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            kv_cache: Optional[torch.Tensor] = None,
+            attn_metadata: Optional[Any] = None,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         sizes = [self.q_size, self.kv_size, self.kv_size]
-        q, k, v = torch.split_with_sizes_copy(qkv, sizes, dim=-1)
 
-        # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim,
-                           self.head_dim)
+        q, k, v = torch.split_with_sizes(qkv, sizes, dim=-1)
+        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
         q_by_head = self.q_norm(q_by_head)
         q = q_by_head.view(q.shape)
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim,
-                           self.head_dim)
+        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
         k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
 
-        attn_output = self.attn(q, k, v)
+        q, k = self.rotary_emb(positions, q, k)
+
+        attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
+
         output, _ = self.o_proj(attn_output)
         return output
+
 
 class CustomSparseMoeBlock(Qwen3MoeSparseMoeBlock):
 


### PR DESCRIPTION
What this PR does / why we need it?
Integrate new split_with_sizes_copy op to improve perfomance in noraml inference cases and resolve long-seq mask problems .

The original op's performance is suboptimal in certain scenarios, necessitating optimization through the new op (npu_fused_infer_attention_score)。
For ultra-long sequences (128k), the original operator will allocate a large attn_mask, which consumes excessive CPU memory. In contrast, the new op supports a fixed-size compressed mask, effectively resolving this issue.
NOTE1: The current PR retains the original logic and uses a version check of the CANN package to determine whether the new op can be enabled. This ensures no impact on existing users. In future versions, this version check and the original logic will be deprecated, and the new op scheduling will be uniformly adopted.
NOTE2: This pr relies on future CANN version, which is not available now.
NOTE3: To enable the new op in chunked prefill, the parameter additional_config should be set like --additional-config '{"ascend_scheduler_config": {"enabled":true,"enable_chunked_prefill":true}}' \ at least.

Does this PR introduce any user-facing change?
No

How was this patch tested?
CI passed

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/f225ea7dd98e9f29752e5c032cd4a8ee1d712f16
