### PR TITLE
Add OOT platform E2E test case to be run in the vllm buildkite pipeline

### DIFF
--- a/tests/e2e/vllm_interface/singlecard/test_sampler.py
+++ b/tests/e2e/vllm_interface/singlecard/test_sampler.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+# Adapted from vllm/tests/entrypoints/llm/test_guided_generate.py
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from vllm import SamplingParams
+
+from tests.e2e.conftest import VllmRunner
+
+
+def test_models_topk() -> None:
+    example_prompts = [
+        "The capital of France is",
+    ]
+    sampling_params = SamplingParams(max_tokens=10,
+                                     temperature=0.0,
+                                     top_k=10,
+                                     top_p=0.9)
+
+    with VllmRunner("Qwen/Qwen3-0.6B",
+                    max_model_len=4096,
+                    gpu_memory_utilization=0.7) as runner:
+        runner.generate(example_prompts, sampling_params)

--- a/tests/e2e/vllm_interface/vllm_test.cfg
+++ b/tests/e2e/vllm_interface/vllm_test.cfg
@@ -1,0 +1,2 @@
+# Base docker image used to build the vllm-ascend e2e test image, which is built in the vLLM repository
+BASE_IMAGE_NAME="quay.io/ascend/cann:8.3.rc1.alpha002-910b-ubuntu22.04-py3.11"


### PR DESCRIPTION
### What this PR does / why we need it?
Add OOT platform E2E test case to be run in the vllm buildkite pipeline. 
Note: added test case is not run in vllm-ascend CI.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA

Test result:
1.Test case: has run successfully in local host:
<img width="1399" height="611" alt="f013110e-6a76-45aa-a7eb-38d9faa1b8fc" src="https://github.com/user-attachments/assets/3f9b2728-b4f6-4005-986f-a9bf2944d48c" />
<img width="2012" height="226" alt="946cb5f4-d339-4f46-a6b5-fadb138670c8" src="https://github.com/user-attachments/assets/0999a827-3724-4225-9937-2e9d1cbaebfc" />

2.Added oot_test.cfg can been successfully get and parsed:
<img width="889" height="70" alt="9cdce3f4-1d83-46d3-ba48-d2113c7376c3" src="https://github.com/user-attachments/assets/7596c4cd-c1cb-460e-b7dc-9312f8e84f2a" />
```
# Base ubuntu image with CANN and python installed
TEST_RUN_CONFIG_URL="https://raw.githubusercontent.com/leo-pony/vllm-ascend/refs/heads/main/tests/e2e/oot_interface/oot_test.cfg"
TEST_RUN_CONFIG_FILE="oot_test.cfg"

# This function checks for and installs 'curl' on Ubuntu if it's not found.
install_curl() {
  if ! command -v curl &> /dev/null; then
    sudo yum update
    if sudo yum install -y curl; then
      echo "'curl' was installed successfully."
    else
      echo "Error: Failed to install 'curl'. Please check your network connection and package repositories."
      return 1
    fi
  fi
  return 0
}

# Downloads test run configuration file from a remote URL.
# Loads the configuration into the current script environment.
get_config() {
  # Call the helper function to ensure curl is installed.
  install_curl
  if [ $? -ne 0 ]; then
    return 1
  fi
  
  # Use curl to download the configuration file and check if the download was successful.
  if curl -s -o "$TEST_RUN_CONFIG_FILE" "$TEST_RUN_CONFIG_URL"; then
    echo "Configuration file downloaded successfully."
    source "$TEST_RUN_CONFIG_FILE"
    return 0
  else
    echo "Error: Failed to download configuration from $TEST_RUN_CONFIG_URL."
    return 1
  fi
}

# get test running configuration.
get_config
# Check if the function call was successful. If not, exit the script.
if [ $? -ne 0 ]; then
  exit 1
fi
echo "Base docker image name of test case: $BASE_IMAGE_NAME"

```

3.Format test passed:
<img width="742" height="380" alt="97d6dc0d-382b-47fc-bf32-94a6d8267d81" src="https://github.com/user-attachments/assets/3c4af284-0079-43f7-bece-bc03f7056c95" />


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/f225ea7dd98e9f29752e5c032cd4a8ee1d712f16
