### PR TITLE
[Test] Add accuarcy tset for Qwen2-Audio-7B-Instruct

### DIFF
--- a/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
@@ -1,0 +1,11 @@
+model_name: "Qwen/Qwen2-Audio-7B-Instruct"
+runner: "linux-aarch64-a2-1"
+hardware: "Atlas A2 Series"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.44
+  - name: "exact_match,flexible-extract"
+    value: 0.45
+num_fewshot: 5

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -2,3 +2,4 @@ DeepSeek-V2-Lite.yaml
 Qwen3-8B-Base.yaml
 Qwen2.5-VL-7B-Instruct.yaml
 Qwen3-30B-A3B.yaml
+Qwen2-Audio-7B-Instruct.yaml


### PR DESCRIPTION
### What this PR does / why we need it?
Add accuarcy tset for Qwen2-Audio-7B-Instruct
This PR depends on https://github.com/vllm-project/vllm-ascend/pull/2330

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/b1068903fdca26cf6b4a1a51a32c3365ce3ac636
