### PR TITLE
[BugFix] Fix aclgraph accu problem in A2.

### DIFF
--- a/vllm_ascend/ops/common_fused_moe.py
+++ b/vllm_ascend/ops/common_fused_moe.py
@@ -26,7 +26,6 @@ from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fused_moe.layer import (
     FusedMoE, UnquantizedFusedMoEMethod, determine_expert_map)
 from vllm.model_executor.layers.shared_fused_moe import SharedFusedMoE
-from vllm.utils import direct_register_custom_op
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import MoECommType
@@ -363,22 +362,6 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             torch.npu.current_stream().wait_stream(self.shared_expert_stream)
         return shared_out, fused_output
 
-
-def _maybe_all_reduce_tensor_model_parallel_impl(
-        final_hidden_states: torch.Tensor) -> torch.Tensor:
-    forward_context = get_forward_context()
-    moe_comm_type = forward_context.moe_comm_type
-    if moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2}:
-        return final_hidden_states
-    else:
-        return tensor_model_parallel_all_reduce(final_hidden_states)
-
-
-direct_register_custom_op(op_name="maybe_all_reduce_tensor_model_parallel",
-                          op_func=_maybe_all_reduce_tensor_model_parallel_impl,
-                          fake_impl=lambda x, label: x,
-                          mutates_args=[],
-                          dispatch_key="PrivateUse1")
 
 UnquantizedFusedMoEMethod.__init__ = unquantized_fused_moe_init_func
 UnquantizedFusedMoEMethod.process_weights_after_loading = process_weights_after_loading


### PR DESCRIPTION
This PR fixes accuracy problem of aclgraph on A2. The problem is introduced by PR #2980, which makes the `all_reduce` of shared_experts exposed to torch dynamo. This PR moves all the codes into forward_impl to shiled from torch dynamo.

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/17b4c6685ce62d5652654784d6771a3d38e4273e
