### PR TITLE
[bugFix] Correct the vllm interface e2e test Base container image name

### DIFF
--- a/tests/e2e/vllm_interface/vllm_test.cfg
+++ b/tests/e2e/vllm_interface/vllm_test.cfg
@@ -1,2 +1,2 @@
 # Base docker image used to build the vllm-ascend e2e test image, which is built in the vLLM repository
-BASE_IMAGE_NAME="quay.io/ascend/cann:8.3.rc1.alpha002-910b-ubuntu22.04-py3.11"
+BASE_IMAGE_NAME="quay.io/ascend/cann:8.2.rc1-910b-ubuntu22.04-py3.11"


### PR DESCRIPTION
### What this PR does / why we need it?
Correct the vllm interface e2e test Base container image name

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Tests in vllm ci pipeline
- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/52d0cb845866869d587fc013a7c59e60a86ebcf2
