### PR TITLE
[Bugfix] fix bug when tp=1

### DIFF
--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -385,7 +385,9 @@ class DenseOptimRowParallelOp(CustomRowParallelOp):
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
 
         if self.tp_size == 1 or not self.reduce_results:
-            output = self.quant_method.apply(self, input_parallel, bias=bias_)
+            output = self.quant_method.apply(self.layer,
+                                             input_parallel,
+                                             bias=bias_)
         else:
             output_parallel = self.quant_method.apply(self.layer,
                                                       input_parallel,


### PR DESCRIPTION
### What this PR does / why we need it?
Addresses a bug in DenseOptimRowParallelOp that occurs when tensor parallelism is not used
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/52d0cb845866869d587fc013a7c59e60a86ebcf2
