### PR TITLE
[WIP][2/N][Feat] Attention and MoE weight prefetch in Qwen3MoE models

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -11,6 +11,7 @@ from vllm.forward_context import (BatchDescriptor, get_forward_context,
                                   set_forward_context)
 
 import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ops.weight_prefetch import WeightPrefetchMethod
 from vllm_ascend.utils import enable_sp
 
 
@@ -65,7 +66,8 @@ def set_ascend_forward_context(
         aclgraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         batch_descriptor: Optional[BatchDescriptor] = None,
         prefetch_stream: torch.npu.Stream = None,
-        model_instance: torch.nn.Module = None):
+        model_instance: torch.nn.Module = None,
+        weight_prefetch_method: Optional[WeightPrefetchMethod] = None):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
     We add some additional param into forward_context.
@@ -127,6 +129,7 @@ def set_ascend_forward_context(
             hasattr(model_instance.model, "start_layer"):
             forward_context.layer_idx = model_instance.model.start_layer
 
+        # TODO(rjg-lyh): refactor mlp weight prefetch method
         # set for mlp weight prefetch
         prefetch_mlp_enabled = envs_ascend.VLLM_ASCEND_ENABLE_DENSE_OPTIMIZE and \
             envs_ascend.VLLM_ASCEND_ENABLE_PREFETCH_MLP and \
@@ -138,7 +141,10 @@ def set_ascend_forward_context(
             forward_context.prefetch_mlp_gate_up_proj = False
             forward_context.prefetch_mlp_down_proj = False
         forward_context.prefetch_mlp_enabled = prefetch_mlp_enabled
-
+        # TODO(yuzhup): add moe weight prefetch method
+        forward_context.model_instance = model_instance
+        forward_context.weight_prefetch_method = weight_prefetch_method
+        weight_prefetch_method.update_forward_param(num_tokens)
         # TODO(rjg-lyh): The current implementation is somewhat brute force and not elegant.
         # It will be improved later by implementing operator fusion through the FX graph.
         #

--- a/vllm_ascend/ops/moe/experts_selector.py
+++ b/vllm_ascend/ops/moe/experts_selector.py
@@ -18,6 +18,7 @@ from typing import Callable, Optional
 
 import torch
 import torch_npu
+from vllm.forward_context import get_forward_context
 
 
 def return_row_idx(hidden_states, top_k):
@@ -65,7 +66,10 @@ def select_experts(hidden_states: torch.Tensor,
         topk_weights: router weights of shape (num_tokens, top_k).
         topk_ids: selected expert IDs of shape (num_tokens, top_k).
     """
-
+    # prefetch w1_w3_proj.weight preprocess
+    weight_prefetch_method = get_forward_context().weight_prefetch_method
+    if weight_prefetch_method:
+        weight_prefetch_method.maybe_prefetch_moe_weight_preprocess("gate_up")
     topk_weights, topk_ids, row_idx = _select_experts_with_fusion_ops(
         hidden_states=hidden_states,
         router_logits=router_logits,

--- a/vllm_ascend/ops/moe/moe_mlp.py
+++ b/vllm_ascend/ops/moe/moe_mlp.py
@@ -77,6 +77,9 @@ def quant_apply_mlp(hidden_states: torch.Tensor,
     bias1, bias2 = None, None
     _output_dtype = w2_scale.dtype
 
+    weight_prefetch_method = get_forward_context().weight_prefetch_method
+    if weight_prefetch_method:
+        weight_prefetch_method.maybe_prefetch_moe_weight_postprocess()
     is_mc2 = get_forward_context().moe_comm_type == MoECommType.MC2
     if w1_scale_bias is None and is_mc2:
         if fusion:

--- a/vllm_ascend/ops/weight_prefetch.py
+++ b/vllm_ascend/ops/weight_prefetch.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass, field
+
+import torch
+import torch_npu
+
+from vllm.forward_context import get_forward_context
+from vllm_ascend.ascend_config import WeightPrefetchConfig
+from vllm_ascend.utils import current_stream, prefetch_stream, npu_stream_switch
+
+SUPPORTED_MODULES = ["attn", "mlp", "moe"]
+MOE_PREFETCH_TOKEN_THRESHOLD = 96
+
+
+@dataclass
+class ModuleWeightPrefetchConfig:
+    module_name: str
+    enable: bool = False
+    prefetch_ratio: dict = field(default_factory=dict)
+    is_active_this_forward: bool = False
+
+    def __post_init__(self) -> None:
+        self.prefetch_ratio = {
+            prefix: ratio
+            for prefix, ratio in self.prefetch_ratio.items()
+            if 0 <= ratio <= 1
+        }
+
+        assert self.module_name in SUPPORTED_MODULES, (
+            f"Invalid module name {self.module_name}, should be one of {SUPPORTED_MODULES}")
+
+        if self.module_name in SUPPORTED_MODULES:
+            self.enable = self.enable and any(self.prefetch_ratio.values()) > 0
+
+
+class WeightPrefetchMethod:
+    """
+    Unified weight prefetch method.
+    """
+
+    def __init__(self, weight_prefetch_config: WeightPrefetchConfig) -> None:
+        self.calculation_stream = current_stream()
+        self.prefetch_stream = prefetch_stream()
+
+        self.attn = ModuleWeightPrefetchConfig(
+            module_name="attn",
+            enable=weight_prefetch_config.enabled,
+            prefetch_ratio=weight_prefetch_config.prefetch_ratio.get("attn", {}),
+        )
+        self.moe = ModuleWeightPrefetchConfig(
+            module_name="moe",
+            enable=weight_prefetch_config.enabled,
+            prefetch_ratio=weight_prefetch_config.prefetch_ratio.get("moe", {}),
+        )
+
+    def maybe_prefetch_attn_weight_preprocess(self,
+                                              prefix: str,
+                                              weight: torch.Tensor,
+                                              start_flag: torch.Tensor) -> None:
+        if not self.attn.enable:
+            return
+
+        weight_size = weight.data.element_size() * weight.data.numel() * self.attn.prefetch_ratio.get(prefix, 0)
+
+        self.calculation_stream = torch_npu.npu.current_stream()
+        self.weight_prefetch_impl(weight=weight,
+                                  start_flag=start_flag,
+                                  max_weight_size=int(weight_size))
+
+    def maybe_prefetch_attn_weight_postprocess(self) -> None:
+        if self.attn.enable and self.prefetch_stream is not None:
+            self.calculation_stream.wait_stream(self.prefetch_stream)
+
+    def update_forward_param(self, num_tokens: int):
+        if self.moe.enable:
+            self.moe.is_active_this_forward = num_tokens >= MOE_PREFETCH_TOKEN_THRESHOLD
+
+    def maybe_prefetch_moe_weight_preprocess(self, prefix):
+        if not self.moe.is_active_this_forward:
+            return
+        forward_context = get_forward_context()
+        weight = forward_context.model_instance.model.layers[forward_context.layer_idx].mlp.experts.w13_weight
+        weight_size = weight.data.element_size() * weight.data.numel() * self.moe.prefetch_ratio.get(prefix, 0)
+        self.calculation_stream = torch_npu.npu.current_stream()
+        self.weight_prefetch_impl(weight=weight,
+                                  start_flag=None,
+                                  max_weight_size=int(weight_size))
+        forward_context.layer_idx += 1
+
+    def maybe_prefetch_moe_weight_postprocess(self):
+        if self.moe.is_active_this_forward and self.prefetch_stream is not None:
+            self.calculation_stream.wait_stream(self.prefetch_stream)
+
+    def weight_prefetch_impl(self,
+                             weight: torch.Tensor,
+                             start_flag: torch.Tensor,
+                             max_weight_size: int) -> None:
+        self.prefetch_stream.wait_stream(self.calculation_stream)
+        with npu_stream_switch(self.prefetch_stream):
+            torch.ops.vllm.maybe_npu_prefetch(inputs=weight,
+                                              dependency=start_flag,
+                                              max_size=max_weight_size)
+


### PR DESCRIPTION
### What this PR does / why we need it?

- Refacotr and integrate a unified `WeightPrefetchMethod`
- Integrate `gate_up_proj.weight` in quantized Attention modules
- Prefetching these weights ahead of matmul-like operators imporves performance by reducing L2 cache transfer latency

### Does this PR introduce _any_ user-facing change?

Add a new config in `--additional-config` for configuration:
```json
{
    "weight_prefetch_config": {
        "enabled": True,
        "prefetch_ratio": {
            "moe": {
                "gate_up": 0.8
            },
        },
    },
}
```
This feature is enabled by default, and can be disabled through this configuration

### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/17b4c6685ce62d5652654784d6771a3d38e4273e