### PR TITLE
Add vLLM 0.11.0 release hourly job

### DIFF
--- a/.github/workflows/vllm_ascend_test_full_vllm_0.11.0.yaml
+++ b/.github/workflows/vllm_ascend_test_full_vllm_0.11.0.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+name: 'ascend test / vllm 0.11.0'
+
+on:
+  # Run 1-card and 2-cards e2e tests per 2h
+  schedule:
+    - cron: '0 */2 * * *'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      # If we are changing the doctest we should do a PR test
+      - 'vllm_ascend_test_full_vllm_0.11.0.yaml'
+  workflow_dispatch:
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+# only cancel in-progress runs of the same workflow
+# and ignore the lint / 1 card / 4 cards test type
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-test:
+    uses: ./.github/workflows/_e2e_test.yaml
+    with:
+      vllm: releases/v0.11.0
+      runner: linux-aarch64-a2
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.2.rc1-910b-ubuntu22.04-py3.11
+      type: full


### PR DESCRIPTION
### What this PR does / why we need it?
Add vLLM 0.11.0 release hourly job to monitor release branch changes

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.0
