### PR TITLE
[Bugfix]Fix quant_config input parameter bug in qwenvl series

### DIFF
--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -509,7 +509,7 @@ class AscendQwen2_5_VLForConditionalGeneration(
             self.visual = AscendQwen2_5_VisionTransformer(
                 vision_config=config.vision_config,
                 norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-                quant_config=self.quant_config,
+                quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "visual"),
             )
 

--- a/vllm_ascend/models/qwen2_5_vl_without_padding.py
+++ b/vllm_ascend/models/qwen2_5_vl_without_padding.py
@@ -495,7 +495,7 @@ class AscendQwen2_5_VLForConditionalGeneration_Without_Padding(
             self.visual = AscendQwen2_5_VisionTransformer_Without_Padding(
                 vision_config=config.vision_config,
                 norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-                quant_config=self.quant_config,
+                quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "visual"),
             )
 
@@ -574,7 +574,7 @@ class AscendQwen3VLForConditionalGeneration(Qwen3VLForConditionalGeneration):
             self.visual = AscendQwen3_VisionTransformer(
                 config.vision_config,
                 norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-                quant_config=self.quant_config,
+                quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "visual"),
                 use_data_parallel=self.use_data_parallel)
 
@@ -625,7 +625,7 @@ class AscendQwen3VLMoeForConditionalGeneration(
             self.visual = AscendQwen3_VisionTransformer(
                 config.vision_config,
                 norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-                quant_config=self.quant_config,
+                quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "visual"),
                 use_data_parallel=self.use_data_parallel,
             )

--- a/vllm_ascend/models/qwen2_vl.py
+++ b/vllm_ascend/models/qwen2_vl.py
@@ -357,6 +357,6 @@ class AscendQwen2VLForConditionalGeneration(Qwen2VLForConditionalGeneration):
             self.visual = AscendQwen2VisionTransformer(
                 self.config.vision_config,
                 norm_eps=getattr(self.config, "rms_norm_eps", 1e-6),
-                quant_config=self.vllm_config.quant_config,
+                quant_config=vllm_config.quant_config,
                 prefix=maybe_prefix(prefix, "visual"),
             )


### PR DESCRIPTION
### What this PR does / why we need it?
Fix quant_config input parameter bug in qwenvl series. Currently, non-instantiated variables should be passed.
### Does this PR introduce _any_ user-facing change?
None
### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.0
