### PR TITLE
[BugFix] Fix Qwen3-Next because of TP Attn + EP MoE modified

### DIFF
--- a/vllm_ascend/models/qwen3_next.py
+++ b/vllm_ascend/models/qwen3_next.py
@@ -51,13 +51,10 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.transformers_utils.configs import Qwen3NextConfig
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
-from vllm.model_executor.models.qwen3_next import Qwen3NextAttention  # isort: skip
-from vllm.model_executor.models.qwen3_next import Qwen3NextDecoderLayer  # isort: skip
-from vllm.model_executor.models.qwen3_next import Qwen3NextForCausalLM  # isort: skip
-from vllm.model_executor.models.qwen3_next import Qwen3NextGatedDeltaNet  # isort: skip
-from vllm.model_executor.models.qwen3_next import Qwen3NextModel  # isort: skip
-from vllm.model_executor.models.qwen3_next import Qwen3NextSparseMoeBlock  # isort: skip
-from vllm.model_executor.models.qwen3_next import fused_gdn_gating  # isort: skip
+from vllm.model_executor.models.qwen3_next import (  # isort: skip
+    Qwen3NextAttention, Qwen3NextDecoderLayer, Qwen3NextForCausalLM,
+    Qwen3NextGatedDeltaNet, Qwen3NextModel, Qwen3NextSparseMoeBlock,
+    fused_gdn_gating)
 
 
 class CustomQwen3NextGatedDeltaNet(Qwen3NextGatedDeltaNet, MambaBase):
@@ -434,7 +431,11 @@ class CustomQwen3NextDecoderLayer(Qwen3NextDecoderLayer):
         prefix: str = "",
     ) -> None:
         nn.Module.__init__(self)
-        self.config = config
+        config = vllm_config.model_config.hf_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        speculative_config = vllm_config.speculative_config
 
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
@@ -520,7 +521,7 @@ class CustomQwen3NextModel(Qwen3NextModel):
 
         def get_layer(prefix: str):
             return CustomQwen3NextDecoderLayer(
-                config,
+                vllm_config,
                 layer_type=config.layer_types[extract_layer_index(prefix)],
                 prefix=prefix,
             )


### PR DESCRIPTION
 The upstream changes to the `TP Attn + EP MoE` module caused the qwen3-next inference to fail, so this issue was fixed, caused by https://github.com/vllm-project/vllm/pull/24982.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
```
def main():
    prompts = [
        "窗前明月光，",
        "The president of the United States is Mr.",
        "The capital of France is",
        "The future of AI is",
        "感时花溅泪，",
        "家书抵万金啥意思？",
        "plz tell me a story: ",
    ]

    # Create a sampling params object.
    sampling_params = SamplingParams(max_tokens=100, temperature=0.6, top_k=40, top_p=0.95)
    # Create an LLM.
    llm = LLM(
        model="Qwen/Qwen3-Next-80B-A3B-Instruct",
              tensor_parallel_size=4,
              enforce_eager=True,
              trust_remote_code=True,
              max_model_len=256,
              gpu_memory_utilization=0.7,
              block_size=64
              )

    # Generate texts from the prompts.
    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```


- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.0
