### PR TITLE
Revert "[Eagle] Fix attn_mask index out of range in high concurrency …

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
 from typing import Optional
 
 import numpy as np
@@ -71,7 +72,8 @@ class EagleProposer(Proposer):
                                    1,
                                    device=device,
                                    dtype=torch.int32)
-        attn_mask_len = self.vllm_config.model_config.max_model_len
+        attn_mask_len = min(self.vllm_config.model_config.max_model_len,
+                            int(os.getenv("PAGED_ATTENTION_MASK_LEN", 10000)))
         self.attn_mask_builder = AttentionMaskBuilder(
             attn_mask_len, self.vllm_config.model_config.dtype)
 


### PR DESCRIPTION
…situations (#3187)"

This reverts commit 68c5401ad613d3a946157ba6a7c7c4636b210f02.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.2
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.0
