### PR TITLE
[bugfix] Fix Qwen3-30B-A3B dp parallel hung issue when running with the dp parallel example

### DIFF
--- a/examples/offline_data_parallel.py
+++ b/examples/offline_data_parallel.py
@@ -247,7 +247,7 @@ if __name__ == "__main__":
         proc.join(timeout=900)
         if proc.exitcode is None:
             print(
-                f"Killing process {proc.pid} that didn't stop within 5 minutes."
+                f"Killing process {proc.pid} that didn't stop within 15 minutes."
             )
             proc.kill()
             exit_code = 1


### PR DESCRIPTION
### What this PR does / why we need it?
Fix Qwen3-30B-A3B dp parallel hung issue when running with the dp parallel example.
For large-parameter models of Qwen3-30B and above, weight loading alone takes 4 to 5 minutes. Therefore, the 5-minute timeout in the current example code implementation is too short, causing some DP instances to be killed prematurely and eventually stuck in the DP synchronization all-reduce operation.

Before this PR:weight loading time snapshot and one dp instance timeout been killed log as following:
<img width="1603" height="581" alt="a7faaeee2f4d671a751b77d61e66887c" src="https://github.com/user-attachments/assets/0ad26fdc-3deb-48b8-ac8a-de1f1c7050dc" />
With this PR code modify, running successful:
<img width="2043" height="883" alt="29abf630f3087482d82e0d3bc95a425f" src="https://github.com/user-attachments/assets/62f9b676-a0d5-435c-b5f6-6cf81a16f3fc" />

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA

vLLM version: v0.11.0rc3
vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.0

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.0
