### PR TITLE
[CI] fix the vllm run-npu-test.sh break: cannot import _Backend from vllm.platforms

### DIFF
--- a/vllm_ascend/patch/worker/patch_common/patch_attention_selector.py
+++ b/vllm_ascend/patch/worker/patch_common/patch_attention_selector.py
@@ -24,7 +24,15 @@ import vllm.envs as envs
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.attention.selector import (backend_name_to_enum,
                                      get_global_forced_attn_backend)
-from vllm.platforms import _Backend, current_platform
+from vllm.platforms import current_platform
+
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is("0.11.0"):
+    from vllm.platforms import _Backend
+else:
+    from vllm.attention.backends.registry import _Backend
+
 from vllm.utils import resolve_obj_by_qualname
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
 Adapt to vllm changes: ["Move Backend enum into registry #25893" ](https://github.com/vllm-project/vllm/pull/25893)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
