### PR TITLE
[Bugfix] fix the assert error in thedeepseek + torchair + MTP scenario

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2410,11 +2410,12 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             # MC2 will consume additional NPU memory.
             # Therefore, we need to run the MC2 path once here to complete its initialization,
             # allowing vLLM to correctly estimate the maximum memory required.
+            num_tokens = min(self.mc2_tokens_capacity,
+                             self.scheduler_config.max_num_batched_tokens)
             if self.max_num_tokens > self.mc2_tokens_capacity and \
                 self._select_moe_comm_method(
-                    self.mc2_tokens_capacity,
-                    with_prefill=True) == MoECommType.MC2:
-                self._dummy_run(self.mc2_tokens_capacity, with_prefill=True)
+                    num_tokens, with_prefill=True) == MoECommType.MC2:
+                self._dummy_run(num_tokens, with_prefill=True)
 
         output = None
         if get_pp_group().is_last_rank:


### PR DESCRIPTION
### What this PR does / why we need it?

On the A2 server, when deploying PD separation using four machines, in the scenario of deepseek+torch+MTP and setting `max_num_batched_tokens`, the service failed to start up and reported an error during `dummy_run`. The reason for the problem is that the `mc2_tokens_capacity` was not checked during `profile_run`.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
