### PR TITLE
[Bugfix] [EPLB] Reload weights after initiating moe_quant_params

### DIFF
--- a/vllm_ascend/ops/common_fused_moe.py
+++ b/vllm_ascend/ops/common_fused_moe.py
@@ -227,6 +227,7 @@ class AscendFusedMoE(FusedMoE):
         if (self.quant_method.__class__.__name__
                 in ("GPTQMarlinMoEMethod", "CompressedTensorsWNA16MoEMethod")):
             moe_quant_params["intermediate_size_full"] = intermediate_size
+        self.quant_method.create_weights(layer=self, **moe_quant_params)
 
         self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
 


### PR DESCRIPTION
### What this PR does / why we need it?
1. Reload weights after initiating moe_quant_params
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
E2E

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
