### PR TITLE
[Test] Add accuracy test for Qwen3-VL-30B-A3B-Instruct

### DIFF
--- a/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -1,0 +1,12 @@
+model_name: "Qwen/Qwen3-VL-30B-A3B-Instruct"
+hardware: "Atlas A2 Series"
+model: "vllm-vlm"
+tasks:
+- name: "mmmu_val"
+  metrics:
+  - name: "acc,none"
+    value: 0.58
+max_model_len: 8192
+tensor_parallel_size: 2
+gpu_memory_utilization: 0.7
+enable_expert_parallel: True

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -2,3 +2,4 @@ DeepSeek-V2-Lite.yaml
 Qwen3-8B-Base.yaml
 Qwen2.5-VL-7B-Instruct.yaml
 Qwen3-30B-A3B.yaml
+Qwen3-VL-30B-A3B-Instruct.yaml


### PR DESCRIPTION
### What this PR does / why we need it?

Add accuracy test for Qwen3-VL-30B-A3B-Instruct
This PR depends on https://github.com/vllm-project/vllm-ascend/pull/2330
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
<img width="1487" height="575" alt="image" src="https://github.com/user-attachments/assets/46b81ef6-fa37-4d8a-aac9-fd5c6d3f8e6b" />

https://github.com/vllm-project/vllm-ascend/actions/runs/18400818452/job/52429432021?pr=3362

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
