### PR TITLE
[Bugfix][P/D] TP size larger than KV cache head causes accuracy issues

### DIFF
--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -18,6 +18,7 @@ multi-node_dsv3.2.md
 multi_node
 multi_node_kimi
 multi_node_qwen3vl
-multi_node_pd_disaggregation
+multi_node_pd_disaggregation_llmdatadist
+multi_node_pd_disaggregation_mooncake
 multi_node_ray
 :::

--- a/docs/source/tutorials/multi_node_pd_disaggregation_llmdatadist.md
+++ b/docs/source/tutorials/multi_node_pd_disaggregation_llmdatadist.md
@@ -1,4 +1,4 @@
-# Prefill-Decode Disaggregation Verification (Qwen)
+# Prefill-Decode Disaggregation Llmdatadist Verification (Qwen)
 
 ## Getting Start
 

--- a/tests/ut/distributed/test_parallel_state.py
+++ b/tests/ut/distributed/test_parallel_state.py
@@ -32,8 +32,13 @@ def test_init_ascend_model_parallel(mock_distributed, parallel_config):
     mock_ascend_config.lmhead_tensor_parallel_size = 2
     mock_ascend_config.oproj_tensor_parallel_size = 2
     mock_ascend_config.pd_tp_ratio = 2
+    mock_ascend_config.num_head_replica = 0
+    mock_ascend_config.pd_head_ratio = 2
+    mock_vllm_config = MagicMock()
+    mock_vllm_config.kv_transfer_config.is_kv_producer = True
     with patch('vllm_ascend.distributed.parallel_state.model_parallel_initialized', return_value=False), \
          patch('vllm_ascend.distributed.parallel_state.init_model_parallel_group'), \
+         patch('vllm_ascend.distributed.parallel_state.get_current_vllm_config', return_value=mock_vllm_config), \
          patch('vllm_ascend.distributed.parallel_state.get_ascend_config', return_value=mock_ascend_config):
         init_ascend_model_parallel(parallel_config)
 

--- a/tests/ut/kv_connector/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_layerwise_connector.py
@@ -78,7 +78,8 @@ class TestKVCacheSendingLayerThreadBasic(unittest.TestCase):
     def setUp(self):
         self.p1 = patch(
             'vllm_ascend.distributed.mooncake_layerwise_connector.get_ascend_config',
-            new=MagicMock(return_value=SimpleNamespace(pd_tp_ratio=1)))
+            new=MagicMock(return_value=SimpleNamespace(
+                pd_tp_ratio=1, num_head_replica=0, pd_head_ratio=1)))
         self.p2 = patch(
             'vllm_ascend.distributed.mooncake_layerwise_connector.get_current_vllm_config',
             new=MagicMock(return_value=SimpleNamespace(
@@ -242,7 +243,8 @@ class TestSendingLayerThread(unittest.TestCase):
     def setUp(self):
         self.p1 = patch(
             'vllm_ascend.distributed.mooncake_layerwise_connector.get_ascend_config',
-            new=MagicMock(return_value=SimpleNamespace(pd_tp_ratio=1)))
+            new=MagicMock(return_value=SimpleNamespace(
+                pd_tp_ratio=1, num_head_replica=0, pd_head_ratio=1)))
         self.p2 = patch(
             'vllm_ascend.distributed.mooncake_layerwise_connector.get_current_vllm_config',
             new=MagicMock(return_value=SimpleNamespace(
@@ -900,7 +902,9 @@ class TestMooncakeLayerwiseConnectorWorker(unittest.TestCase):
                        {'vllm_ascend.envs': self.envs_ascend_mock}),
             patch(
                 'vllm_ascend.distributed.mooncake_layerwise_connector.get_ascend_config',
-                return_value=SimpleNamespace(pd_tp_ratio=1),
+                return_value=SimpleNamespace(pd_tp_ratio=1,
+                                             num_head_replica=0,
+                                             pd_head_ratio=1),
             ),
             patch(
                 'vllm_ascend.distributed.mooncake_layerwise_connector.get_current_vllm_config',

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -118,9 +118,10 @@ class AscendConfig:
                     prefill_tp_size = min(prefill_tp_size, num_kv_head)
                     decode_tp_size = min(decode_tp_size, num_kv_head)
                     self.pd_head_ratio = prefill_tp_size // decode_tp_size
-                except Exception as e:
-                    raise AssertionError(f"Can not get num_key_value_heads from model_config")
-            
+                except Exception:
+                    raise AssertionError(
+                        "Can not get num_key_value_heads from model_config")
+
             if self.pd_tp_ratio == 0:
                 raise AssertionError(
                     "Only support P node tp size lagger then D node tp size")

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -69,31 +69,36 @@ def init_ascend_model_parallel(parallel_config: ParallelConfig, ):
         "distributed prefill tensor parallel group is already initialized")
     prefill_tensor_model_parallel_size = pd_tp_ratio
     # divide alltoall groups
-    if pd_head_ratio > 1 and get_current_vllm_config().kv_transfer_config.is_kv_producer:
+    if pd_head_ratio > 1 and get_current_vllm_config(
+    ).kv_transfer_config.is_kv_producer:
         num_head_replica = get_ascend_config().num_head_replica
         remote_tp_size = parallel_config.tensor_parallel_size // pd_tp_ratio
         if num_head_replica <= 1:
-            group_ranks = all_ranks.view(-1,
-                                        prefill_tensor_model_parallel_size).unbind(0)
+            group_ranks = all_ranks.view(
+                -1, prefill_tensor_model_parallel_size).unbind(0)
         else:
-            group_ranks = all_ranks.clone().view(parallel_config.data_parallel_size,
-                                        -1,
-                                        num_head_replica) # [DP_size, num_head, num_head_replica]
+            group_ranks = all_ranks.clone().view(
+                parallel_config.data_parallel_size, -1,
+                num_head_replica)  # [DP_size, num_head, num_head_replica]
             group_ranks = group_ranks.permute(0, 2, 1)
-            group_ranks = group_ranks.reshape(-1, group_ranks.size(-1)) # [DP_size * num_head_replica, num_head]
+            group_ranks = group_ranks.reshape(
+                -1,
+                group_ranks.size(-1))  # [DP_size * num_head_replica, num_head]
             alltoall_group_size = group_ranks.size(-1) // remote_tp_size
-            group_ranks = group_ranks.unsqueeze(-1).view(parallel_config.data_parallel_size,
-                                                        num_head_replica,
-                                                        -1,
-                                                        alltoall_group_size) # [DP_size, num_head_replica, num_alltoall_group, alltoall_group_size]
+            group_ranks = group_ranks.unsqueeze(-1).view(
+                parallel_config.data_parallel_size, num_head_replica, -1,
+                alltoall_group_size
+            )  # [DP_size, num_head_replica, num_alltoall_group, alltoall_group_size]
             group_ranks = group_ranks.view(-1, alltoall_group_size).unbind(0)
         group_ranks = [x.tolist() for x in group_ranks]
         local_rank = get_world_group().local_rank
-        num = next((i for i, ranks in enumerate(group_ranks) if local_rank in ranks), None)
+        num = next(
+            (i for i, ranks in enumerate(group_ranks) if local_rank in ranks),
+            None)
         _P_TP = init_model_parallel_group(group_ranks,
-                                        get_world_group().local_rank,
-                                        backend,
-                                        group_name=f"p_tp_{num}")
+                                          get_world_group().local_rank,
+                                          backend,
+                                          group_name=f"p_tp_{num}")
 
     global _MC2
     group_ranks = all_ranks.unbind(0)


### PR DESCRIPTION
### What this PR does / why we need it?
Resolve the issue where, in the case of unequal TP (Tensor Parallelism), the TP size  is larger than the number of model attention kvcache heads, causing the KV cache to generate duplicates, which leads to transmission errors in the original code.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
By ci
- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
