### PR TITLE
[Feature] Enhanced MooncakeConnector to support prefix caching on the decode node

### DIFF
--- a/vllm_ascend/distributed/mooncake_connector.py
+++ b/vllm_ascend/distributed/mooncake_connector.py
@@ -478,11 +478,12 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         # Filter out the remote block ids that correspond to the unhashed local
         # block ids. We assume that the order of remote_block_ids matches the
         # order of local_block_ids.
-        remote_block_ids = []
-        for block_idx, remote_block_id in enumerate(
-                kv_transfer_params["remote_block_ids"]):
-            if local_block_ids[block_idx] in unhashed_block_idxs:
-                remote_block_ids.append(remote_block_id)
+        unhashed_block_idxs_set = set(unhashed_block_idxs)
+        remote_block_ids = [
+            remote_id for remote_id, local_id in zip(
+                kv_transfer_params["remote_block_ids"], local_block_ids)
+            if local_id in unhashed_block_idxs_set
+        ]
 
         self.requests[request_id] = ReqMeta(
             local_block_ids=unhashed_block_idxs,


### PR DESCRIPTION
### What this PR does / why we need it?

Previously, in Mooncake Connector, we assumed that prefix caching was not enabled during decoding, and pulling the cache always started from the first block—which was unnecessary. Enabling prefix caching during decoding helps reduce data transfer. This PR removes that assumption and handles cases where data isn't fully transmitted.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI pass.

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
