### PR TITLE
[Bugfix] Fix duplicated KV cache allocation in qwen3-Next

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2874,7 +2874,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                 layer_name = kv_cache_tensor.shared_by[idx]
                 if "linear_attn" in layer_name:
                     # for mamba linear attention
-                   kv_cache_raw_tensors[layer_name] = tensor
+                    kv_cache_raw_tensors[layer_name] = tensor
                 elif "attn" in layer_name:
                     # for other attentions, e.g., self_attn, sliding window attn
                     kv_cache_raw_tensors[layer_name] = (k_tensor, v_tensor)


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the bug described in https://github.com/vllm-project/vllm-ascend/issues/3368: Duplicated Allocation of Shared Hybrid Cache in Qwen3-Next

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
The model qwen3-next has been tested.

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
