### PR TITLE
[UT] fix skipped test_utils ut test.

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -128,7 +128,6 @@ jobs:
           --ignore=tests/ut/kv_connector/test_remote_decode_lifecycle.py \
           --ignore=tests/ut/kv_connector/test_remote_prefill_lifecycle.py \
           --ignore=tests/ut/torchair/models/test_torchair_deepseek_v2.py \
-          --ignore=tests/ut/torchair/test_utils.py
 
       - name: Upload coverage to Codecov
         # only upload coverage when commits merged

--- a/tests/ut/torchair/test_utils.py
+++ b/tests/ut/torchair/test_utils.py
@@ -64,7 +64,7 @@ class TestTorchairUtils(TestBase):
         mock_model_registry.return_value = mock_registry
         utils.register_torchair_model()
 
-        self.assertEqual(mock_model_registry.register_model.call_count, 6)
+        self.assertEqual(mock_model_registry.register_model.call_count, 7)
         call_args_list = mock_model_registry.register_model.call_args_list
 
         expected_registrations = [
@@ -75,6 +75,9 @@ class TestTorchairUtils(TestBase):
              "vllm_ascend.torchair.models.torchair_deepseek_v2:TorchairDeepseekV2ForCausalLM"
              ),
             ("DeepseekV3ForCausalLM",
+             "vllm_ascend.torchair.models.torchair_deepseek_v3:TorchairDeepseekV3ForCausalLM"
+             ),
+            ("DeepseekV32ForCausalLM",
              "vllm_ascend.torchair.models.torchair_deepseek_v3:TorchairDeepseekV3ForCausalLM"
              ),
             ("Qwen2ForCausalLM",


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes: fix the test in `tests/ut/torchair/test_utils.py` and enable the UT test in CI.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
vLLM version: v0.11.0rc3
vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
