### PR TITLE
[BugFix] Add addtional check for mc2 on different hardwares.

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -433,7 +433,11 @@ def _is_default_capture_sizes(vllm_config: VllmConfig) -> bool:
             cudagraph_capture_sizes += list(
                 range(256, max_cudagraph_capture_size + 1, 16))
 
-    if sorted(cudagraph_capture_sizes, reverse=True) == \
+    if vllm_version_is("0.11.0"):
+        target_cudagraph_capture_sizes = sorted(cudagraph_capture_sizes, reverse=True)
+    else:
+        target_cudagraph_capture_sizes = sorted(cudagraph_capture_sizes)
+    if target_cudagraph_capture_sizes == \
             vllm_config.compilation_config.cudagraph_capture_sizes:
         return True
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -664,7 +664,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         # tokens is less than or equal to mc2_tokens_capacity. According to _set_cudagraph_sizes,
         # the max number of tokens in graph is min(max_num_seqs * uniform_decode_query_len, 512).
         if self.compilation_config.cudagraph_capture_sizes:
-            max_num_tokens = self.compilation_config.cudagraph_capture_sizes[0]
+            max_num_tokens = self.compilation_config.max_cudagraph_capture_size
         else:
             # NOTE: To save memory, we cap the max number of tokens to 512.
             max_num_tokens = min(


### PR DESCRIPTION
### What this PR does / why we need it?
This if an extension based on #3411. Hardware-specific restriction for mc2 is added. Besides, I also limit the scenarios where this check take effects to only moe models that might uses mc2.

### Does this PR introduce _any_ user-facing change?
For situations that mc2 is not supported with excessive input tokens, we throws an error earlier in vLLM-Ascend.

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
