### PR TITLE
[Bugfix] [Attention] Remove performance affecting debug variable

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -585,7 +585,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                                  self.head_size,
                                  dtype=query.dtype,
                                  device=query.device)
-        ori_output = output
         if trace_flag:
             torch.ops.vllm.unified_ascend_attention_with_output(
                 query=query,
@@ -668,7 +667,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # to make in-place change to the output tensor
         if hasattr(layer, 'quant_method') and use_kv_cache_int8:
             output = output.view(num_tokens, self.num_heads, self.head_size)
-        ori_output[:num_tokens, :, :] = output[:num_tokens, :, :]
         return output.view(num_tokens, self.hidden_size)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
There is ori_output variable in the forward function of AscendAttentionBackendImpl, which heavily affects the performance (up to 30%) of the attention. This variable is not used anywhere in vllm and vllm-ascend, and looks like just like a debug variable left unnoticed and unremoved.
Profiling with ori_output variable:
<img width="1200" height="669" alt="with_ori_output_v2" src="https://github.com/user-attachments/assets/62c5ba03-6fda-496e-a3d1-72d6b403962a" />

Profiling without ori_output variable:
<img width="973" height="679" alt="without_ori_output_v2" src="https://github.com/user-attachments/assets/5f08e112-63c2-496a-9488-110d350b4fc0" />

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
e2e
models used: Qwen3-14B, Qwen3-30B-A3B, Qwen3-235B-A22B
vLLM version: v0.11.0rc3
- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
