### PR TITLE
[BugFix]GPQA Accuracy Issue Bugfix

### DIFF
--- a/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
+++ b/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
@@ -163,8 +163,8 @@ class MooncakeStoreConnectorV1Scheduler:
         self.client = MooncakeLookupClient(vllm_config)
         self.use_layerwise = use_layerwise
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
-        self.consumer_is_to_load = extra_config.get("consumer_is_to_load", False)
+        self.consumer_is_to_load = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "consumer_is_to_load", False)
         # request_id -> (vllm cached tokes, mooncake cached tokens)
         self.load_specs: dict[str, LoadSpec] = {}
         self._block_size = vllm_config.cache_config.block_size


### PR DESCRIPTION
### What this PR does / why we need it?
The GPQA dataset accuracy in the PD separation scenario of testing is 33.2, which does not meet the paper's requirement of 70. Resolve this accuracy issue.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
qpqa has accuracy issues, but modifying the code can ensure the accuracy meets the standard

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
