### PR TITLE
[BUGFIX] Mtp torchair pd fix

### DIFF
--- a/vllm_ascend/torchair/torchair_model_runner.py
+++ b/vllm_ascend/torchair/torchair_model_runner.py
@@ -84,7 +84,7 @@ class NPUTorchairModelRunner(NPUModelRunner):
 
     def _may_pad_kv_consumer_num_seq(self):
         # pd disaggregation scenario need redundant_batch_sizes to avoid each batch's seq_len exceed 16 tokens
-        # self.max_num_reqs here is greather than the actual maximum request number
+        # self.max_num_reqs here is greater than the actual maximum request number
         if self.is_kv_consumer:
             FIA_SEQ_LEN_LIMIT = 16
             new_max_num_reqs = self.max_num_reqs + math.ceil(
@@ -104,7 +104,7 @@ class NPUTorchairModelRunner(NPUModelRunner):
         tp_size = self.parallel_config.tensor_parallel_size
         # Use integer arithmetic for ceiling division.
         num_tokens_per_tp_rank = (max_num_tokens + tp_size - 1) // tp_size
-        # maintain the same calculation logic as the funciton _align_graph_size_divisible_by_tp_size()
+        # maintain the same calculation logic as the function _align_graph_size_divisible_by_tp_size()
         self.mc2_tokens_capacity = num_tokens_per_tp_rank * tp_size
 
     def _sync_metadata_across_dp(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -524,7 +524,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
     def _may_pad_kv_consumer_num_seq(self):
         # For Full Graph + MTP in a PD (Prefill/Decode) disaggregation scenario,
         # we may want to pad self.max_num_seqs in kv_consumer nodes to avoid
-        # exceeding a sequence length limit (16 tokens) in npu_fused_infer_attention_score opertion
+        # exceeding a sequence length limit (16 tokens) in npu_fused_infer_attention_score operation
         pass
 
     def _init_mc2_tokens_capacity(self):


### PR DESCRIPTION
### What this PR does / why we need it?

In memory of https://github.com/vllm-project/vllm-ascend/pull/2610 and #3449 Fix Mtp torchair pd bug.

In the pd Disaggregation scenario, the first token of the inference after the d node receives the kv follows the eager mode.

Fixes:
Running with MTP torchair graph mode with Prefilling Decoding Disaggregation , if all requests processed by the D node are requests just transmitted from the P node, it will break the torchair graph.

Reason: During PD Disaggregation , the P node only transmits the KV cache and prompt to the D node, not the actual tokens inferred (neither the main model tokens nor the MTP tokens are transmitted). Therefore, the D node will treat this request as one without MTP tokens for inference (seq_len=1).
The community does not have graph mode issues because the community's attention has a seq_len=1 for each batch during the decode phase.
We have issues because the graph mode pads according to processing 2 tokens per request. When there are some seq_len=1 and some seq_len=2, padding is done at the end. If all requests received by the D node are seq_len=1, padding cannot be performed normally according to the attention's fia operator constraints.

Solution:

The kv consumer uses extra torchair graph padding to avoid breaking FIA graph constrains (The one this PR implemented).

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
