### PR TITLE
Fix attn_group initialization timing

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3097,7 +3097,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         block_sizes = [
             kv_cache_group.kv_cache_spec.block_size
             for kv_cache_group in kv_cache_config.kv_cache_groups
-            if not isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec)
+            if not isinstance(kv_cache_group.kv_cache_spec,
+                              EncoderOnlyAttentionSpec)
         ]
 
         # Generate kernel_block_sizes that matches each block_size
@@ -3108,7 +3109,8 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         for kv_cache_group_id, kv_cache_group in enumerate(
                 kv_cache_config.kv_cache_groups):
 
-            if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
+            if isinstance(kv_cache_group.kv_cache_spec,
+                          EncoderOnlyAttentionSpec):
                 continue
 
             if isinstance(kv_cache_group.kv_cache_spec, AttentionSpec):


### PR DESCRIPTION
### What this PR does / why we need it?
Fix attn_group initialization timing so that fix qwen3-next model
https://github.com/vllm-project/vllm-ascend/actions/runs/18524192520/job/52791059946?pr=3477
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
vLLM version: v0.11.0

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
