### PR TITLE
[Test]Add accuracy test for model Qwen2.5-Omni-7B

### DIFF
--- a/.github/workflows/accuracy_test.yaml
+++ b/.github/workflows/accuracy_test.yaml
@@ -59,6 +59,8 @@ jobs:
             model_name: DeepSeek-V2-Lite
           - runner: a2-4
             model_name: Qwen3-Next-80B-A3B-Instruct
+          - runner: a2-1
+            model_name: Qwen2.5-Omni-7B
       fail-fast: false
     # test will be triggered when tag 'accuracy-test' & 'ready-for-test'
     if:  >-

--- a/tests/e2e/models/configs/Qwen2.5-Omni-7B.yaml
+++ b/tests/e2e/models/configs/Qwen2.5-Omni-7B.yaml
@@ -1,0 +1,11 @@
+model_name: "Qwen/Qwen2.5-Omni-7B"
+runner: "linux-aarch64-a2-1"
+hardware: "Atlas A2 Series"
+model: "vllm-vlm"
+tasks:
+- name: "mmmu_val"
+  metrics:
+  - name: "acc,none"
+    value: 0.52
+max_model_len: 8192
+gpu_memory_utilization: 0.7

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -6,3 +6,4 @@ Qwen2-7B.yaml
 Qwen2-VL-7B-Instruct.yaml
 Qwen2-Audio-7B-Instruct.yaml
 Qwen3-VL-30B-A3B-Instruct.yaml
+Qwen2.5-Omni-7B.yaml


### PR DESCRIPTION
Using non-blocking operations for device-to-host transfers can lead to data corruption in later steps. The CPU tensor is accessed right after the transfer is triggered, but the transfer might not be complete yet. As a result, the data could be wrong. This problem was seen in the A3 environment during `profile_run`.

CI pass.

### What this PR does / why we need it?
Add accuracy test for model Qwen2.5-Omni-7B

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.1
