### PR TITLE
clean up uesless ut test

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -669,12 +669,6 @@ class TestNPUPlatform(TestBase):
     def test_is_pin_memory_available_returns_true(self):
         self.assertTrue(self.platform.is_pin_memory_available())
 
-    def test_supports_v1(self):
-        from vllm.config import ModelConfig
-
-        mock_config = MagicMock(spec=ModelConfig)
-        self.assertTrue(self.platform.supports_v1(mock_config))
-
     def test_get_static_graph_wrapper_cls_returns_correct_value(self):
         self.assertEqual(
             self.platform.get_static_graph_wrapper_cls(),


### PR DESCRIPTION
supports_v1 has been removed already by https://github.com/vllm-project/vllm-ascend/commit/c18ca62a177e77d09df351f2f816df6be5bf8d64
- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
