### PR TITLE
[Bugfix] fix delay free prefill req

### DIFF
--- a/vllm_ascend/distributed/mooncake_connector.py
+++ b/vllm_ascend/distributed/mooncake_connector.py
@@ -1140,7 +1140,7 @@ class MooncakeConnectorWorker:
                 if self.tp_rank in self._prefill_get_remote_tp_rank(req_id):
                     self.kv_send_thread.add_delayed_request(
                         req_id, delay_start_time)
-    
+
     def _prefill_get_remote_tp_rank(self, req_id: str) -> List[int]:
         return sum(self._get_remote_tp_ranks_for_req(req_id), [])
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fix following two bugs:
- function `_get_remote_tp_ranks_for_req` returns a List[List[int]], but in `start_load_kv` use `if self.tp_rank in self._prefill_get_remote_tp_rank(req_id)` to decide whether add_delayed_request, it will nerver enter the branch, we need to flatten List[List[int]]
- when qwen-235B using TP=4 DP=4, `_get_remote_tp_ranks_for_req` returns a List[Array(int)], we forgot to cast nparray to list in this case, it will cause an error. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
