### PR TITLE
[BugFix][P/D] Modify the recalculation logic to prevent waiting requests from filling up the D node KVCache 

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -565,7 +565,7 @@ async def _handle_completions(api: str, request: Request):
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
                             # if chunk is [done], skip it.
-                            logger.warning(
+                            logger.debug(
                                 f"Skipping chunk: {chunk_str}")
                             yield chunk
                             continue

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -548,7 +548,7 @@ async def _handle_completions(api: str, request: Request):
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
                             # if chunk is [done], skip it.
-                            logger.warning(
+                            logger.debug(
                                 f"Skipping chunk: {chunk_str}")
                             yield chunk
                             continue

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -362,7 +362,7 @@ class RecomputeScheduler(SchedulerInterface):
         skipped_waiting_requests = create_request_queue(self.policy)
 
         # Next, schedule the WAITING requests.
-        if not preempted_reqs:
+        if not preempted_reqs and not recomputed_reqs:
             while self.waiting and token_budget > 0:
                 if len(self.running) == self.max_num_running_reqs:
                     break


### PR DESCRIPTION
### What this PR does / why we need it?
Modify the recalculation logic to prevent waiting requests from filling up the D node KVCache 
### Does this PR introduce _any_ user-facing change?
None
### How was this patch tested?


- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/17c540a993af88204ad1b78345c8a865cf58ce44
