### PR TITLE
[Doc] Upgrade docker run command

### DIFF
--- a/docs/source/developer_guide/contribution/testing.md
+++ b/docs/source/developer_guide/contribution/testing.md
@@ -66,6 +66,7 @@ export DEVICE=/dev/davinci0
 export IMAGE=quay.io/ascend/vllm-ascend:main
 docker run --rm \
     --name vllm-ascend \
+    --shm-size=1g \
     --device $DEVICE \
     --device /dev/davinci_manager \
     --device /dev/devmm_svm \
@@ -101,6 +102,7 @@ pip install -r requirements-dev.txt
 export IMAGE=quay.io/ascend/vllm-ascend:main
 docker run --rm \
     --name vllm-ascend \
+    --shm-size=1g \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \

--- a/docs/source/developer_guide/evaluation/using_evalscope.md
+++ b/docs/source/developer_guide/evaluation/using_evalscope.md
@@ -13,6 +13,7 @@ export DEVICE=/dev/davinci7
 # Update the vllm-ascend image
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
+--shm-size=1g \
 --name vllm-ascend \
 --device $DEVICE \
 --device /dev/davinci_manager \

--- a/docs/source/developer_guide/evaluation/using_lm_eval.md
+++ b/docs/source/developer_guide/evaluation/using_lm_eval.md
@@ -13,6 +13,7 @@ export DEVICE=/dev/davinci7
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \
@@ -141,6 +142,7 @@ export DEVICE=/dev/davinci7
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/developer_guide/evaluation/using_opencompass.md
+++ b/docs/source/developer_guide/evaluation/using_opencompass.md
@@ -13,6 +13,7 @@ export DEVICE=/dev/davinci7
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/developer_guide/performance/optimization_and_tuning.md
+++ b/docs/source/developer_guide/performance/optimization_and_tuning.md
@@ -14,6 +14,7 @@ export DEVICE=/dev/davinci0
 export IMAGE=m.daocloud.io/quay.io/ascend/cann:|cann_image_tag|
 docker run --rm \
 --name performance-test \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/developer_guide/performance/performance_benchmark.md
+++ b/docs/source/developer_guide/performance/performance_benchmark.md
@@ -12,6 +12,7 @@ export DEVICE=/dev/davinci7
 export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -53,6 +53,7 @@ export DEVICE=/dev/davinci7
 export IMAGE=quay.io/ascend/cann:|cann_image_tag|
 docker run --rm \
     --name vllm-ascend-env \
+    --shm-size=1g \
     --device $DEVICE \
     --device /dev/davinci_manager \
     --device /dev/devmm_svm \
@@ -207,6 +208,7 @@ export DEVICE=/dev/davinci7
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
     --name vllm-ascend-env \
+    --shm-size=1g \
     --device $DEVICE \
     --device /dev/davinci_manager \
     --device /dev/devmm_svm \

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -23,6 +23,7 @@ export DEVICE=/dev/davinci0
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \
@@ -52,6 +53,7 @@ export DEVICE=/dev/davinci0
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-openeuler
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device $DEVICE \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/tutorials/multi-node_dsv3.2.md
+++ b/docs/source/tutorials/multi-node_dsv3.2.md
@@ -105,6 +105,7 @@ export NAME=vllm-ascend
 docker run --rm \
 --name $NAME \
 --net=host \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \
@@ -145,6 +146,7 @@ export NAME=vllm-ascend
 docker run --rm \
 --name $NAME \
 --net=host \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_node.md
+++ b/docs/source/tutorials/multi_node.md
@@ -70,6 +70,7 @@ export NAME=vllm-ascend
 docker run --rm \
 --name $NAME \
 --net=host \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_node_kimi.md
+++ b/docs/source/tutorials/multi_node_kimi.md
@@ -18,6 +18,7 @@ export NAME=vllm-ascend
 docker run --rm \
 --name $NAME \
 --net=host \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_node_qwen3vl.md
+++ b/docs/source/tutorials/multi_node_qwen3vl.md
@@ -18,6 +18,7 @@ export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
 --net=host \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_node_ray.md
+++ b/docs/source/tutorials/multi_node_ray.md
@@ -65,6 +65,7 @@ export NAME=vllm-ascend
 docker run --rm \
 --name $NAME \
 --net=host \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_npu.md
+++ b/docs/source/tutorials/multi_npu.md
@@ -10,6 +10,7 @@ Run docker container:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_npu_moge.md
+++ b/docs/source/tutorials/multi_npu_moge.md
@@ -10,6 +10,7 @@ Run container:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_npu_quantization.md
+++ b/docs/source/tutorials/multi_npu_quantization.md
@@ -11,6 +11,7 @@ w8a8 quantization feature is supported by v0.8.4rc2 or higher
 export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_npu_qwen3_moe.md
+++ b/docs/source/tutorials/multi_npu_qwen3_moe.md
@@ -10,6 +10,7 @@ Run docker container:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/multi_npu_qwen3_next.md
+++ b/docs/source/tutorials/multi_npu_qwen3_next.md
@@ -13,6 +13,7 @@ Run docker container:
 # Update the vllm-ascend image
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
+--shm-size=1g \
 --name vllm-ascend-qwen3 \
 --device /dev/davinci0 \
 --device /dev/davinci1 \

--- a/docs/source/tutorials/single_node_300i.md
+++ b/docs/source/tutorials/single_node_300i.md
@@ -17,6 +17,7 @@ Run docker container:
 export IMAGE=quay.io/ascend/vllm-ascend:v0.10.0rc1-310p
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci1 \
 --device /dev/davinci2 \

--- a/docs/source/tutorials/single_npu.md
+++ b/docs/source/tutorials/single_npu.md
@@ -12,6 +12,7 @@ Run docker container:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \
@@ -117,6 +118,7 @@ Run docker container to start the vLLM server on a single NPU:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \
@@ -143,6 +145,7 @@ vllm serve Qwen/Qwen3-8B --max_model_len 26240
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/tutorials/single_npu_audio.md
+++ b/docs/source/tutorials/single_npu_audio.md
@@ -12,6 +12,7 @@ Run docker container:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/tutorials/single_npu_multimodal.md
+++ b/docs/source/tutorials/single_npu_multimodal.md
@@ -12,6 +12,7 @@ Run docker container:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \
@@ -128,6 +129,7 @@ Run docker container to start the vLLM server on a single NPU:
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/tutorials/single_npu_qwen3_embedding.md
+++ b/docs/source/tutorials/single_npu_qwen3_embedding.md
@@ -12,6 +12,7 @@ Take Qwen3-Embedding-8B model as an example, first run the docker container with
 export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \

--- a/docs/source/tutorials/single_npu_qwen3_quantization.md
+++ b/docs/source/tutorials/single_npu_qwen3_quantization.md
@@ -11,6 +11,7 @@ w4a8 quantization feature is supported by v0.9.1rc2 or higher
 export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 docker run --rm \
 --name vllm-ascend \
+--shm-size=1g \
 --device /dev/davinci0 \
 --device /dev/davinci_manager \
 --device /dev/devmm_svm \


### PR DESCRIPTION
### What this PR does / why we need it?
Update the docker run command, specifically: add --shm-size=1g
### Does this PR introduce _any_ user-facing change?
users/developers using docker to pull vllm-ascend, the shared memory of the container  will be increased from the default 64MB to 1G

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
