### PR TITLE
[CI] Skip ops test for e2e

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -108,7 +108,8 @@ jobs:
           # Fix me: OOM error
           #pytest -sv tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
 
-          pytest -sv tests/e2e/singlecard/ops/
+          # TODO: Move ops test to nightly test
+          #pytest -sv tests/e2e/singlecard/ops/
 
   e2e-2-cards:
     name: multicard


### PR DESCRIPTION
### What this PR does / why we need it?
Skip ops test for e2e and will move it to nightly test in the following pr

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
