### PR TITLE
[BugFix][Core] Fix a bug running multi-modal with ascend_scheduler

### DIFF
--- a/tests/e2e/singlecard/test_vlm.py
+++ b/tests/e2e/singlecard/test_vlm.py
@@ -55,6 +55,38 @@ def test_multimodal_vl(prompt_template):
             assert output_str, "Generated output should not be empty."
 
 
+def test_multimodal_ascend_scheduler(prompt_template):
+    image = ImageAsset("cherry_blossom") \
+        .pil_image.convert("RGB")
+    img_questions = [
+        "What is the content of this image?",
+        "Describe the content of this image in detail.",
+        "What's in the image?",
+        "Where is this image taken?",
+    ]
+    images = [image] * len(img_questions)
+    prompts = prompt_template(img_questions)
+    with VllmRunner("Qwen/Qwen2.5-VL-3B-Instruct",
+                    max_model_len=4096,
+                    additional_config={
+                        'ascend_scheduler_config': {
+                            'enabled': True,
+                        },
+                    },
+                    mm_processor_kwargs={
+                        "min_pixels": 28 * 28,
+                        "max_pixels": 1280 * 28 * 28,
+                        "fps": 1,
+                    },
+                    enforce_eager=True) as vllm_model:
+        outputs = vllm_model.generate_greedy(prompts=prompts,
+                                             images=images,
+                                             max_tokens=64)
+        assert len(outputs) == len(prompts)
+        for _, output_str in outputs:
+            assert output_str, "Generated output should not be empty."
+
+
 def test_multimodal_audio():
     audio_prompt = "".join([
         f"Audio {idx+1}: <|audio_bos|><|AUDIO|><|audio_eos|>\n"

--- a/vllm_ascend/core/schedule_config.py
+++ b/vllm_ascend/core/schedule_config.py
@@ -26,7 +26,7 @@ MAX_INT = 2147483647
 @dataclass
 class AscendSchedulerConfig(SchedulerConfig):
     enable_chunked_prefill: bool = False
-    max_long_partial_prefills: int = MAX_INT
+    max_long_partial_prefills: int = 1
     long_prefill_token_threshold: int = MAX_INT
     policy: str = "fcfs"
     scheduler_cls: Union[str, Type[object]] = (
@@ -73,9 +73,9 @@ class AscendSchedulerConfig(SchedulerConfig):
                 "max_num_batched_tokens and makes vLLM reject longer "
                 "sequences. Please increase max_num_batched_tokens or "
                 "decrease max_model_len.")
-        # concurrent partial prefills. Default is inf
+        # concurrent partial prefills. Default is 1 meaning not enabled.
         if self.max_long_partial_prefills is None:
-            self.max_long_partial_prefills = MAX_INT
+            self.max_long_partial_prefills = 1
             self.long_prefill_token_threshold = MAX_INT
 
         if self.long_prefill_token_threshold is None or \


### PR DESCRIPTION
This PR fix the bug related with running multi-modal models with AscendScheduler. This bug was introduced by PR #2372 by using the same parameter names as vLLM with different default values. The error is as following:
<details>

```text
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597] WorkerProc failed to start.
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597] Traceback (most recent call last):
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/v1/executor/multiproc_executor.py", line 571, in worker_main
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     worker = WorkerProc(*args, **kwargs)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/v1/executor/multiproc_executor.py", line 437, in __init__
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     self.worker.load_model()
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-ascend-main/vllm_ascend/worker/worker_v1.py", line 307, in load_model
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     self.model_runner.load_model()
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-ascend-main/vllm_ascend/worker/model_runner_v1.py", line 2656, in load_model
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     self.model = get_model(vllm_config=self.vllm_config)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/model_executor/model_loader/__init__.py", line 119, in get_model
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     return loader.load_model(vllm_config=vllm_config,
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/model_executor/model_loader/base_loader.py", line 45, in load_model
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     model = initialize_model(vllm_config=vllm_config,
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/model_executor/model_loader/utils.py", line 63, in initialize_model
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     return model_class(vllm_config=vllm_config, prefix=prefix)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-ascend-main/vllm_ascend/models/qwen2_5_vl.py", line 513, in __init__
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     super().__init__(vllm_config=vllm_config, prefix=prefix)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/model_executor/models/qwen2_5_vl.py", line 1023, in __init__
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     self.language_model = init_vllm_registered_model(
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/model_executor/models/utils.py", line 316, in init_vllm_registered_model
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     vllm_config = vllm_config.with_hf_config(hf_config,
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/mnt/share/whx/repos/vllm-main/vllm/config/__init__.py", line 300, in with_hf_config
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     return replace(self, model_config=model_config)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/usr/local/python3.11.10/lib/python3.11/dataclasses.py", line 1503, in replace
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     return obj.__class__(**changes)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]            ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/pydantic/_internal/_dataclasses.py", line 123, in __init__
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597] pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597] scheduler_config
(EngineCore_DP0 pid=1339259) (Worker_TP2 pid=1339276) ERROR 10-23 15:55:51 [multiproc_executor.py:597]   Value error, max_long_partial_prefills (2147483647) must be greater than or equal to 1 and less than or equal to max_num_partial_prefills (1). [type=value_error, input_value=AscendSchedulerConfig(run..., decode_max_num_seqs=0), input_type=AscendSchedulerConfig]
```

</details>

Currently I fix this bug by changing the default values of these two parameters to align with vLLM.  Please take a look: @Csrayz @frankie-ys @xueliangyang-oeuler @wangxiyuan 


- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/17c540a993af88204ad1b78345c8a865cf58ce44
