### PR TITLE
[main][bugfix] Add 'layer_type' param to get_pergroup_param() for compatibility

### DIFF
--- a/vllm_ascend/quantization/w4a4_flatquant_dynamic.py
+++ b/vllm_ascend/quantization/w4a4_flatquant_dynamic.py
@@ -130,8 +130,11 @@ class AscendW4A4FlatQuantDynamicLinearMethod:
                                                    dtype=torch.float32)
         return params_dict
 
-    def get_pergroup_param(self, input_size: int, output_size: int,
-                           params_dtype: torch.dtype) -> Dict[str, Any]:
+    def get_pergroup_param(self,
+                           input_size: int,
+                           output_size: int,
+                           params_dtype: torch.dtype,
+                           layer_type: Optional[str] = None) -> Dict[str, Any]:
         return {}
 
     @staticmethod


### PR DESCRIPTION
Resolves a `TypeError: got an unexpected keyword argument 'layer_type'`.

A recent change (PR #3311) started passing the `layer_type` argument when calling `get_pergroup_param()`. This specific implementation does not use this parameter, causing the error.

This patch adds `layer_type=None` to the method signature to maintain API compatibility and ignore the unused argument.
- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
