### PR TITLE
【Main】kv_pool_register_buffer

### DIFF
--- a/vllm_ascend/distributed/mooncake/mooncake_engine.py
+++ b/vllm_ascend/distributed/mooncake/mooncake_engine.py
@@ -167,7 +167,7 @@ class MooncakeEngine:
         except Exception as e:
             raise RuntimeError(
                 f"Mooncake memory registration failed. Error is: {e}")
-                
+
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         self.current_layer = 0
         self.layerwise_retrievers = []

--- a/vllm_ascend/distributed/mooncake/mooncake_store.py
+++ b/vllm_ascend/distributed/mooncake/mooncake_store.py
@@ -73,7 +73,7 @@ class Mooncakestore():
 
     def batch_exists(self, keys: list[str]) -> list[bool]:
         return self.store.batch_is_exist(keys)
-    
+
     def register_buffer(self, ptr, length):
         return self.store.register_buffer(ptr, length)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Mooncake Store with ascend direct transport (ADXL) backend requires us to register the KV caches in Mooncake Store Connector. When we are using Mooncake Store together with Mooncake P2P Connector, which also register KV Cache so Mooncake Store doesn't have to, with vLLM's Multi-Connecor we are fine. However, for non-PD Disaggregate scenario, we need to do so  explicitly.  

### Does this PR introduce _any_ user-facing change?
A new kv_connector_extra_config: "register_buffer" is added, which is set to False by default. Need to be set to True for non-PD Disaggregate scenario.

### How was this patch tested?
vLLM version: v0.11.0rc3
vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
