### PR TITLE
[Bugfix] The server fails to locate the request, leading to the server hanging.

### DIFF
--- a/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
+++ b/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
@@ -284,7 +284,7 @@ class MooncakeStoreConnectorV1Scheduler:
         for finished_req_id in scheduler_output.finished_req_ids:
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)
-            self._unfinished_request_ids.remove(finished_req_id)
+            self._unfinished_request_ids.discard(finished_req_id)
 
         meta = MooncakeConnectorMetadata(self._unfinished_request_ids)
 
@@ -418,7 +418,8 @@ class MooncakeStoreConnectorV1Scheduler:
         """
         if self.kv_role == "kv_consumer":
             return False, None
-        if self._request_trackers[request.request_id].num_saved_tokens <= 0:
+        tracker = self._request_trackers.get(request.request_id)
+        if tracker is not None and tracker.num_saved_tokens <= 0:
             return False, None
         delay_free_blocks = len(block_ids) > 0
         if delay_free_blocks:


### PR DESCRIPTION
### What this PR does / why we need it?
fix bug: In the mooncake pooling scenario, when the client closes the request, the server fails to locate the request, leading to the server hanging.oling scenario, when the client closes the request, the server fails to locate the request, leading to the server hanging.

### How was this patch tested?
Pull up the PD separated pooling service, send requests using aisbench, press CTRL+C twice, and check if the vllm_ascend service exit.

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
