### PR TITLE
[Installation] limit opencv-python-headless version to resolve numpy version conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ requires = [
     "msgpack",
     "quart",
     "numba",
+    "opencv-python-headless<=4.11.0.86", # Required to avoid numpy version conflict with vllm
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ torch>=2.7.1
 torchvision
 wheel
 pandas-stubs
+opencv-python-headless<=4.11.0.86 # Required to avoid numpy version conflict with vllm
 
 # requirements for disaggregated prefill
 msgpack


### PR DESCRIPTION
### What this PR does / why we need it?

vllm requires opencv-python-headless >= 4.11.0 which requires (numpy<2.3.0,>=2), but vllm-ascend numpy version must be less than 2.0.0, so limit opencv-python-headless less than 4.11.0.86 will fix this conflict.

### Does this PR introduce _any_ user-facing change?
No 

### How was this patch tested?

tested by CI 

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
