### PR TITLE
[bugfix] mlapo adaptation

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1177,14 +1177,12 @@ class AscendMLAImpl(MLAAttentionImpl):
 
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         decode_q_nope = torch.empty(
-            (hidden_states.shape[0], self.W_UK_T.shape[0],
-             decode_k_nope.shape[-1]),
+            (bsz, self.W_UK_T.shape[0], decode_k_nope.shape[-1]),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
         decode_q_pe = torch.empty(
-            (hidden_states.shape[0], self.W_UK_T.shape[0],
-             decode_k_pe.shape[-1]),
+            (bsz, self.W_UK_T.shape[0], decode_k_pe.shape[-1]),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )


### PR DESCRIPTION
### What this PR does / why we need it?

This pull request fixes a potential bug in the `mlapo` adaptation within the `_mla_decode_preprocess` method. The change ensures that tensors for query projection are allocated with the correct size by using `bsz` (the number of decode tokens) directly, instead of relying on `hidden_states.shape[0]`. This improves the code's robustness and prevents potential runtime errors that could arise from using a padded tensor's shape. The fix is correct and enhances the reliability of the attention mechanism.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?


- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.0
