### PR TITLE
[v0.11.0-dev][Installation] limit opencv-python-headless version to resolve numpy version conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires = [
     "msgpack",
     "quart",
     "numba",
+    "opencv-python-headless<=4.11.0.86", # Required to avoid numpy version conflict with vllm
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ setuptools-scm>=8
 torch>=2.7.1
 torchvision
 wheel
+opencv-python-headless<=4.11.0.86 # Required to avoid numpy version conflict with vllm
 
 # requirements for disaggregated prefill
 msgpack


### PR DESCRIPTION
### What this PR does / why we need it?
vllm requires opencv-python-headless >= 4.11.0 which requires (numpy<2.3.0,>=2), but vllm-ascend numpy version must be less than 2.0.0, so limit opencv-python-headless less than 4.11.0.86 will fix this conflict.

backport of https://github.com/vllm-project/vllm-ascend/commit/afc58184ec848babe40f89db3537746b9113e099