### PR TITLE
e2e test, use GE graph mode for torchair

### DIFF
--- a/tests/e2e/multicard/test_torchair_ge_graph_mode.py
+++ b/tests/e2e/multicard/test_torchair_ge_graph_mode.py
@@ -24,7 +24,6 @@ from typing import Dict
 
 import pytest
 
-
 from tests.e2e.conftest import VllmRunner
 
 os.environ["PYTORCH_NPU_ALLOC_CONF"] = "max_split_size_mb:256"


### PR DESCRIPTION
### What this PR does / why we need it?
There is currently a lack of test cases for TorchAir in the GE graph mode. We have supplemented a test case for this scenario, using a lightweight network (Qwen3-30B) for testing.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
