### PR TITLE
[CI] Enable 2 jobs for nightly test

### DIFF
--- a/.github/workflows/vllm_ascend_test_nightly_a3.yaml
+++ b/.github/workflows/vllm_ascend_test_nightly_a3.yaml
@@ -62,6 +62,12 @@ jobs:
           - name: qwen2-5-vl-7b
             os: linux-aarch64-a3-4
             tests: tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
+          - name: qwen2-5-vl-32b
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/models/test_qwen2_5_vl_32b.py
+          - name: qwen3-32b-int8-prefix-cache
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/features/test_prefix_cache_qwen3_32b_int8.py
           - name: deepseek-r1-0528-w8a8
             os: linux-aarch64-a3-16
             tests: tests/e2e/nightly/models/test_deepseek_r1_0528_w8a8.py


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds 2 jobs to a3 nightly test, which contains 4 test cases, we need test them nightly

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
by running the test

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
