### PR TITLE
[Doc][Example][Bugfix] Elements in local_device_ids should be casted …

### DIFF
--- a/examples/disaggregated_prefill_v1/gen_ranktable.py
+++ b/examples/disaggregated_prefill_v1/gen_ranktable.py
@@ -63,8 +63,11 @@ chips_per_card = get_cmd_stdout("npu-smi info -l | grep \"Chip Count\"").split(
 chips_per_card = int(chips_per_card)
 
 if args.local_device_ids:
-    local_device_ids = args.local_device_ids.split(',')
-    local_device_ids = [int(id_str) for id_str in local_device_ids]
+    try:
+        local_device_ids = [int(id_str) for id_str in args.local_device_ids.split(',')]
+    except ValueError:
+        print(f"Error: --local-device-ids must be a comma-separated list of integers. Received: '{args.local_device_ids}'")
+        exit(1)
 else:
     local_device_ids = []
     for card_id in range(num_cards):

--- a/examples/disaggregated_prefill_v1/gen_ranktable.py
+++ b/examples/disaggregated_prefill_v1/gen_ranktable.py
@@ -64,6 +64,7 @@ chips_per_card = int(chips_per_card)
 
 if args.local_device_ids:
     local_device_ids = args.local_device_ids.split(',')
+    local_device_ids = [int(id_str) for id_str in local_device_ids]
 else:
     local_device_ids = []
     for card_id in range(num_cards):


### PR DESCRIPTION
### What this PR does / why we need it?
It's a tiny bugfix in the `gen_ranktable.py` script. The script is an util to help setup an example case. It is used to prepare a ranktable before disaggregated prefill deployment. 

Elements in `local_device_ids` list should be casted to `int` type before referred for a MOD math operation.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No.


- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
