### PR TITLE
[Bugfix] update mc2_tokens_capacity for A2

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -590,15 +590,15 @@ class NPUModelRunner(LoRAModelRunnerMixin):
 
     @property
     def mc2_tokens_capacity_hardware(self):
-        soc_version = get_ascend_soc_version()
         # TODO: merge AscendSocVersion A2 and A3 if their MC2 ops have the same max input token limit
-        if soc_version == AscendSocVersion.A2:
-            return 256
-        elif soc_version == AscendSocVersion.A3:
-            return 512
-        else:
-            # for other SOC, like 310p, MC2 is not supported
-            return 0
+        mc2_capacities = {
+            AscendSocVersion.A2: 256,
+            AscendSocVersion.A3: 512,
+        }
+        soc_version = get_ascend_soc_version()
+
+        # The default value of 0 is for other SOCs, like 310p, where MC2 is not supported.
+        return mc2_capacities.get(soc_version, 0)
 
     def _init_mc2_tokens_capacity(self):
         # NOTE: To be clear, we need to make sure that during graph capture, the number of


### PR DESCRIPTION

### What this PR does / why we need it?

The maximum input token limit for MC2 operators on A2 is 256: 
https://www.hiascend.com/document/detail/zh/canncommercial/82RC1/API/aolapi/context/aclnnMoeDistributeDispatchV2.md

This value is currently hardcoded to 512. We need to ensure it is set to 256 when running on A2. This is a temporary workaround until a unified operator limit is implemented.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
