### PR TITLE
[Platform][Bugfix] Add platform interface to check `max_model_len`

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -43,6 +43,8 @@ else:
     VllmConfig = None
     FlexibleArgumentParser = None
 
+ASCEND_MAX_MODEL_LEN = 65535
+
 
 class NPUPlatform(Platform):
 
@@ -476,13 +478,14 @@ class NPUPlatform(Platform):
         """
         Check max_model_len for the current platform.
         """
-        if max_model_len > 65536:
+        if max_model_len > ASCEND_MAX_MODEL_LEN:
             logger.warning(
                 "max_model_len is not specified and the default value"
                 "derived from the model config is %d, which is too large"
                 "and will make the engine stuck in initializing distributed"
-                "communication. Set max_model_len to 65536.",
+                "communication. Set max_model_len to %d.",
                 max_model_len,
+                ASCEND_MAX_MODEL_LEN,
             )
-            max_model_len = 65535
+            max_model_len = ASCEND_MAX_MODEL_LEN
         return max_model_len


### PR DESCRIPTION
### What this PR does / why we need it?
When we launch vllm without specifying `--max-model-len`, it will use the default value derived from the model config, e.g., `max_position_embeddings`.

```bash
vllm serve /root/.cache/modelscope/hub/models/Qwen/Qwen3-VL-30B-A3B-Instruct \
--tensor-parallel-size 4 \
--enable-expert-parallel \
--enforce-eager
```

With regard to `Qwen3-VL-30B-A3B`, its default `max_model_len` is `262144`, which is too large and will make the engine stuck in initializing distributed communication.

```bash
...
Using max model len 262144
...
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 0 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 1 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 1, EP rank 1
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 3 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 3, EP rank 3
INFO 10-25 02:18:40 [parallel_state.py:1208] rank 2 in world size 4 is assigned as DP rank 0, PP rank 0, TP rank 2, EP rank 2
# Get stuck in here
```

Thus, we need to set a limited default value when `--max-model-len` is not specified. After testing, I find that the engine will get stuck when `max_model_len` > **65536** on Ascend A2 devices. Thus, we set it to **65536** when the default value is too large.

> [!NOTE]
> Find more details at https://github.com/vllm-project/vllm/pull/27556 and https://github.com/vllm-project/vllm-ascend/issues/3543.
> Part of https://github.com/vllm-project/vllm-ascend/issues/3508.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
