### PR TITLE
【Refactor】Normalize the enabling logic for sp/fc2

### DIFF
--- a/vllm_ascend/models/layers/mla.py
+++ b/vllm_ascend/models/layers/mla.py
@@ -151,7 +151,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             hidden_states: torch.Tensor,
             kv_cache: Optional[torch.Tensor] = None,
             attn_metadata: Optional[AttentionMetadata] = None) -> torch.Tensor:
-        need_gather_q_kv = get_forward_context().sp_enabled
+        need_gather_q_kv = get_forward_context().is_any_flashcomm_enabled
         output_shape = hidden_states.shape
         # FIXME: This does not seem right, should make sure the buffer is fixed
         output = torch.empty(output_shape,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -332,7 +332,7 @@ class AscendFusedMoE(FusedMoE):
         hidden_states, router_logits, mc2_mask, context_metadata = forward_context.moe_comm_method.prepare(
             hidden_states=hidden_states,
             router_logits=router_logits,
-            replace_allreduce=forward_context.sp_enabled,
+            replace_allreduce=forward_context.is_any_flashcomm_enabled,
             enable_shared_expert_dp=self.enable_shared_expert_dp)
 
         # Matrix multiply.

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -381,13 +381,13 @@ class SequenceRowParallelOp(CustomRowParallelOp):
         assert self.quant_method is not None
         try:
             forward_context = get_forward_context()
-            sp_enabled = forward_context.sp_enabled
+            is_any_flashcomm_enabled = forward_context.is_any_flashcomm_enabled
         except AssertionError:
-            sp_enabled = False
+            is_any_flashcomm_enabled = False
 
         x = input_parallel
 
-        if not sp_enabled:
+        if not is_any_flashcomm_enabled:
             output_parallel = self.layer.quant_method.apply(self.layer,
                                                             x,
                                                             bias=bias_)

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -29,8 +29,7 @@ def _maybe_all_gather_and_maybe_unpad_impl(
     except AssertionError:
         return x
 
-    sp_enabled = forward_context.sp_enabled
-    if sp_enabled and label:
+    if forward_context.is_any_flashcomm_enabled and label:
         dp_metadata = forward_context.dp_metadata
         if dp_metadata is None or not is_ep_comm:
             x = tensor_model_parallel_all_gather(x, 0)
@@ -65,7 +64,7 @@ def _maybe_pad_and_reduce_impl(x: torch.Tensor,
     except AssertionError:
         return tensor_model_parallel_all_reduce(x)
 
-    if not forward_context.sp_enabled:
+    if not forward_context.is_any_flashcomm_enabled:
         return tensor_model_parallel_all_reduce(x)
 
     dp_metadata = forward_context.dp_metadata
@@ -124,7 +123,7 @@ def _maybe_all_gather_and_maybe_unpad_fake(
         label: bool,
         is_ep_comm: bool = False) -> torch.Tensor:
 
-    if get_forward_context().sp_enabled and label:
+    if get_forward_context().is_any_flashcomm_enabled and label:
         return torch.empty(
             (x.shape[0] * get_tensor_model_parallel_world_size(),
              *x.shape[1:]),
@@ -136,7 +135,7 @@ def _maybe_all_gather_and_maybe_unpad_fake(
 
 def _maybe_pad_and_reduce_fake(x: torch.Tensor,
                                is_ep_comm: bool = False) -> torch.Tensor:
-    if get_forward_context().sp_enabled:
+    if get_forward_context().is_any_flashcomm_enabled:
         return torch.empty(
             (x.shape[0] // get_tensor_model_parallel_world_size(),
              *x.shape[1:]),
@@ -234,7 +233,7 @@ def _maybe_all_reduce_tensor_model_parallel_impl(
     forward_context = get_forward_context()
     moe_comm_type = forward_context.moe_comm_type
     if moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2
-                         } or forward_context.sp_enabled:
+                         } or forward_context.is_any_flashcomm_enabled:
         return final_hidden_states
     else:
         return tensor_model_parallel_all_reduce(final_hidden_states)
@@ -256,7 +255,7 @@ def _matmul_and_reduce_impl_fake(input_parallel: torch.Tensor,
     forward_context = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
     num_tokens = input_parallel.size(0)
-    if forward_context.sp_enabled:
+    if forward_context.is_any_flashcomm_enabled:
         num_tokens = num_tokens // self.tp_size
     output = torch.empty(size=(num_tokens, self.output_size_per_partition),
                          device=input_parallel.device,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1779,7 +1779,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                     update_attn_params(self.update_stream, forward_context,
                                        maybe_padded_num_tokens)
 
-        if get_forward_context().sp_enabled:
+        if get_forward_context().is_any_flashcomm_enabled:
             hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
             pad_size = get_forward_context().pad_size
             if pad_size > 0:


### PR DESCRIPTION
Signed-off-by: Levi-JQ <yujinqi2@huawei.com>

### What this PR does / why we need it?
The community already has the SP/FlashComm1T feature, and we will subsequently add the FlashComm2 feature. Therefore, we have refactored the enabling method for the SP feature to align it with the enabling approach for FC2.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
