### PR TITLE
[UT] fix skip ut test for test_utils

### DIFF
--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -121,8 +121,7 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/x86_64-linux/devlib
           pytest -sv --cov --cov-report=xml:unittests-coverage.xml tests/ut \
             --ignore tests/ut/torchair/models/test_torchair_deepseek_mtp.py \
-            --ignore tests/ut/torchair/models/test_torchair_deepseek_v2.py \
-            --ignore tests/ut/test_platform.py
+            --ignore tests/ut/torchair/models/test_torchair_deepseek_v2.py
 
       - name: Upload coverage to Codecov
         # only upload coverage when commits merged

--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -122,7 +122,6 @@ jobs:
           pytest -sv --cov --cov-report=xml:unittests-coverage.xml tests/ut \
             --ignore tests/ut/torchair/models/test_torchair_deepseek_mtp.py \
             --ignore tests/ut/torchair/models/test_torchair_deepseek_v2.py \
-            --ignore tests/ut/test_utils.py \
             --ignore tests/ut/test_platform.py
 
       - name: Upload coverage to Codecov

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -359,7 +359,7 @@ class TestNPUPlatform(TestBase):
             if vllm_version_is("0.11.0"):
                 self.assertEqual(
                     vllm_config.compilation_config.level,
-                    CompilationMode.NONE,
+                    CompilationLevel.NO_COMPILATION,
                 )
             else:
                 self.assertEqual(

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -258,10 +258,7 @@ class TestUtils(TestBase):
         model_path = os.path.join(os.path.dirname(__file__), "fake_weight")
         test_model_config = ModelConfig(model=model_path, enforce_eager=True)
         test_parallel_config = ParallelConfig()
-        ascend_config = mock.MagicMock()
-        ascend_config.max_num_batched_tokens = 2048
-        ascend_config.max_model_len = 1024
-        ascend_config.ascend_scheduler_config.enabled = False
+        ascend_config = {"ascend_scheduler_config": {"enabled": False}}
         test_vllm_config = VllmConfig(
             model_config=test_model_config,
             compilation_config=test_compilation_config,


### PR DESCRIPTION
### What this PR does / why we need it?
[UT] fix ut test for test_utils that https://github.com/vllm-project/vllm-ascend/pull/3612 skipped.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
vLLM version: v0.11.0rc3
vLLM main: https://github.com/vllm-project/vllm/commit/17c540a993af88204ad1b78345c8a865cf58ce44

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
