### PR TITLE
[0.11.0][Bug Fix] Fixes ngram spec decode bug introduced by vllm

### DIFF
--- a/vllm_ascend/spec_decode/ngram_proposer.py
+++ b/vllm_ascend/spec_decode/ngram_proposer.py
@@ -39,30 +39,33 @@ class NgramProposer(VllmNgramProposer, Proposer):
                            hidden_states=None,
                            attn_metadata=None,
                            aux_hidden_states=None) -> list[list[int]]:
-        # TODO(woosuk): Optimize.
-        draft_token_ids: list[list[int]] = []
+        valid_ngram_requests = []
         for i, sampled_ids in enumerate(valid_sampled_token_ids):
             num_sampled_ids = len(sampled_ids)
             if not num_sampled_ids:
-                # Skip speculative decoding.
-                draft_token_ids.append([])
                 continue
 
-            # Skip requests that require top-p, top-k, etc.
             req_id = self.runner.input_batch.req_ids[i]
             if req_id in self.runner.input_batch.spec_decode_unsupported_reqs:
-                draft_token_ids.append([])
                 continue
 
-            # Add sampled_token_ids to token_ids_cpu.
+            num_tokens = self.runner.input_batch.num_tokens_no_spec[i]
+            if num_tokens >= self.runner.input_batch.max_model_len:
+                # Skip requests that have already reached the max model length.
+                continue
+
             start_idx = self.runner.input_batch.num_tokens_no_spec[i]
             end_idx = start_idx + num_sampled_ids
             self.runner.input_batch.token_ids_cpu[
                 i, start_idx:end_idx] = sampled_ids
-            drafter_output = self.propose(
-                self.runner.input_batch.token_ids_cpu[i, :end_idx])
-            if drafter_output is None or len(drafter_output) == 0:
-                draft_token_ids.append([])
-            else:
-                draft_token_ids.append(drafter_output.tolist())
+
+            valid_ngram_requests.append(i)
+
+        draft_token_ids = self.batch_propose(
+            len(valid_sampled_token_ids),
+            valid_ngram_requests,
+            self.runner.input_batch.num_tokens_no_spec,
+            self.runner.input_batch.token_ids_cpu,
+        )
+
         return draft_token_ids


### PR DESCRIPTION
### What this PR does / why we need it?
[Bug Fix] Fixes ngram spec decode bug introduced by vllm https://github.com/vllm-project/vllm/pull/24986

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
```
def main():
    prompts = [
        "The future of AI is",
    ]

    # Create a sampling params object.
    sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
    # Create an LLM.
    llm = LLM(
            model="LLM-Research/Meta-Llama-3.1-8B-Instruct",
            tensor_parallel_size=1,
            speculative_config={
                "method": "ngram",
                "num_speculative_tokens": 5, # 每次最多推测 5 个 token
                "prompt_lookup_max": 4, # 最多使用 4 个 n-gram 进行匹配
            },
            enforce_eager=True,
        )

    # Generate texts from the prompts.
    outputs = llm.generate(prompts, sampling_params)
    print(f"Outputs: {outputs}")
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/c9461e05a4ed3557cfbf4b15ded1e26761cc39ca
