### PR TITLE
[CI] Fix nightly CI for A2 series

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -197,8 +197,6 @@ jobs:
           run: |
             POD_PREFIX="${POD_PREFIX:-vllm-0}"
             SIZE="${{ inputs.size }}"
-            SLEEP_FOLLOWER=2
-            SLEEP_LEADER=2
             TIMEOUT=1200  # default timeout 20 minutes
 
             echo "Waiting for Pods in namespace [$NAMESPACE] to become Running and Ready (timeout ${TIMEOUT}s)..."


### PR DESCRIPTION
### What this PR does / why we need it?
For multi-node CI system, we need to ensure that cluster resources meet the expected specifications before conducting multi-node interoperability tests. Otherwise, unexpected errors may occur (for example, we might mistakenly assume all nodes are ready and perform a global cluster IP acquisition, which would cause an exception to be thrown in Python because some nodes might not actually be ready at that point). Therefore, we need to wait at the workflow level until all resources meet the expected specifications.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
