### PR TITLE
[P/D] fix mooncake layerwise connector

### DIFF
--- a/vllm_ascend/distributed/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/mooncake_layerwise_connector.py
@@ -1151,7 +1151,8 @@ class MooncakeLayerwiseConnectorWorker:
                       connector_metadata: MooncakeLayerwiseConnectorMetadata,
                       **kwargs) -> None:
         """MooncakeLayerwiseConnector does not save explicitly."""
-        if self.kv_role == 'kv_producer' and connector_metadata.request.keys():
+        if self.kv_role == 'kv_producer' and connector_metadata.requests.keys(
+        ):
             if self.pd_head_ratio != 1:
                 if self.current_layer != 0:
                     self.completion_event.wait()


### PR DESCRIPTION
### What this PR does / why we need it?
fix a typo in mooncake layerwise connector. There is only `requests`, instead of `request` in `connector_metadata`. This pr fixes this typo

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
