### PR TITLE
[CI]pin vllm commit id

### DIFF
--- a/.github/workflows/format_pr_body.yaml
+++ b/.github/workflows/format_pr_body.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=releases/v0.11.1
+          VLLM_COMMIT=83f478bb19489b41e9d208b47b4bb5a95ac171ac
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> $GITHUB_ENV
 
       - name: Checkout repository

--- a/.github/workflows/vllm_ascend_test.yaml
+++ b/.github/workflows/vllm_ascend_test.yaml
@@ -42,8 +42,7 @@ jobs:
   lint:
     uses: ./.github/workflows/pre-commit.yml
     with:
-      vllm: releases/v0.11.1
-
+      vllm: 83f478bb19489b41e9d208b47b4bb5a95ac171ac
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -83,7 +82,7 @@ jobs:
         VLLM_USE_MODELSCOPE: True
     strategy:
       matrix:
-        vllm_version: [releases/v0.11.1, v0.11.0]
+        vllm_version: [83f478bb19489b41e9d208b47b4bb5a95ac171ac, v0.11.0]
     steps:
       - name: Install packages
         run: |
@@ -140,7 +139,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [releases/v0.11.1, v0.11.0]
+        vllm_version: [83f478bb19489b41e9d208b47b4bb5a95ac171ac, v0.11.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/vllm_ascend_test_full.yaml
+++ b/.github/workflows/vllm_ascend_test_full.yaml
@@ -69,7 +69,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [releases/v0.11.1, v0.11.0]
+        vllm_version: [83f478bb19489b41e9d208b47b4bb5a95ac171ac, v0.11.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' }}
     uses: ./.github/workflows/_e2e_test.yaml


### PR DESCRIPTION
### What this PR does / why we need it?
the code of vllm is updated, pin vllm commit id to recover CI firstly

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/releases/v0.11.1
