### PR TITLE
[DO NOT MERGE][Model][Patch] Support for Deepseek-OCR

### DIFF
--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -20,6 +20,8 @@ from vllm.triton_utils import HAS_TRITON
 if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
 
+import vllm_ascend.patch.worker.patch_deepseek_ocr  # noqa
+
 # isort: off
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa

--- a/vllm_ascend/patch/worker/patch_deepseek_ocr.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_ocr.py
@@ -1,0 +1,151 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Patch for DeepseekMoE to use NPU-optimized operations.
+
+This patch replaces DeepseekMoE.forward with an NPU-optimized version that uses
+torch_npu.npu_moe_gating_top_k_softmax for better performance on Ascend NPUs.
+"""
+
+import torch
+import torch_npu
+import vllm.model_executor.models.deepseek
+from vllm.distributed import tensor_model_parallel_all_reduce
+
+
+def ascend_deepseek_moe_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    """
+    NPU-optimized forward pass for DeepSeek MoE.
+
+    This replaces the default MoE forward to use torch_npu.npu_moe_gating_top_k_softmax
+    for better performance on Ascend NPUs.
+
+    Args:
+        self: DeepseekMoE instance
+        hidden_states: Input tensor [num_tokens, hidden_dim]
+
+    Returns:
+        Output tensor [num_tokens, hidden_dim]
+    """
+    num_tokens, hidden_dim = hidden_states.shape
+    hidden_states = hidden_states.view(-1, hidden_dim)
+
+    # Compute shared experts output if available
+    if self.config.n_shared_experts is not None:
+        shared_output = self.shared_experts(hidden_states)
+
+    # Compute router logits: (num_tokens, n_experts)
+    router_logits, _ = self.gate(hidden_states)
+
+    # Use NPU-optimized top-k gating with softmax
+    topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k_softmax(
+        router_logits, finished=None, k=self.top_k
+    )
+
+    # Renormalize topk weights if configured
+    if self.config.norm_topk_prob:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    # Run MoE inference: route tokens to experts
+    final_hidden_states = ascend_deepseek_moe_infer(
+        self, hidden_states, topk_ids, topk_weights
+    )
+
+    # Add shared experts output if available
+    if self.config.n_shared_experts is not None:
+        final_hidden_states = final_hidden_states + shared_output
+
+    # All-reduce across tensor parallel ranks
+    final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
+
+    return final_hidden_states.view(num_tokens, hidden_dim)
+
+
+def ascend_deepseek_moe_infer(
+    self,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weight: torch.Tensor,
+) -> torch.Tensor:
+    """
+    NPU-optimized MoE inference using expert routing.
+
+    This implementation routes tokens to experts efficiently by:
+    1. Counting tokens per expert
+    2. Sorting tokens by expert ID
+    3. Processing all tokens for each expert in a batch
+    4. Scattering results back to original positions
+    5. Applying router weights
+
+    Args:
+        self: DeepseekMoE instance
+        x: Input tensor [num_tokens, hidden_dim]
+        topk_ids: Expert IDs for each token [num_tokens, top_k]
+        topk_weight: Router weights [num_tokens, top_k]
+
+    Returns:
+        Weighted expert outputs [num_tokens, hidden_dim]
+    """
+    # Count how many tokens go to each expert
+    # cnts: [num_tokens, num_experts] with 1s at selected expert positions
+    cnts = topk_ids.new_zeros((topk_ids.shape[0], len(self.experts)))
+    cnts.scatter_(1, topk_ids, 1)
+    tokens_per_expert = cnts.sum(dim=0)  # [num_experts]
+
+    # Sort all (token, expert) pairs by expert ID for efficient batching
+    # idxs: indices that would sort the flattened topk_ids
+    idxs = topk_ids.to(torch.float32).view(-1).argsort()
+
+    # Gather tokens in sorted order by expert
+    # Each token appears top_k times (once for each selected expert)
+    sorted_tokens = x[idxs // topk_ids.shape[1]]
+    tokens_per_expert = tokens_per_expert.cpu().numpy()
+
+    # Process tokens through each expert
+    outputs = []
+    start_idx = 0
+    for i, num_tokens in enumerate(tokens_per_expert):
+        end_idx = start_idx + num_tokens
+        if num_tokens == 0:
+            continue
+
+        expert = self.experts[i]
+        tokens_for_this_expert = sorted_tokens[start_idx:end_idx]
+        expert_out = expert(tokens_for_this_expert)
+        outputs.append(expert_out)
+        start_idx = end_idx
+
+    # Concatenate all expert outputs
+    outs = torch.cat(outputs, dim=0) if len(outputs) else sorted_tokens.new_empty(0)
+
+    # Scatter outputs back to original positions
+    new_x = torch.empty_like(outs)
+    new_x[idxs] = outs
+
+    # Reshape to [num_tokens, top_k, hidden_dim] and apply router weights
+    final_out = (
+        new_x.view(*topk_ids.shape, -1)
+        .type(topk_weight.dtype)
+        .mul_(topk_weight.unsqueeze(dim=-1))
+        .sum(dim=1)
+        .type(new_x.dtype)
+    )
+    return final_out
+
+
+# Patch DeepseekMoE class with NPU-optimized forward method
+vllm.model_executor.models.deepseek.DeepseekMoE.forward = ascend_deepseek_moe_forward


### PR DESCRIPTION
### What this PR does / why we need it?

This PR is a temporary adaptation for DeepSeek-OCR, implemented using a patch-based approach.
In vllm-ascend, it’s preferable to customize operators (ops) rather than defining custom models.
In addition, the adaptation of this operator refers to the code previously open-sourced by Zhixin Ma in the Modelers community.

### Does this PR introduce _any_ user-facing change?

None.

### How was this patch tested?

```
vllm serve deepseek-ai/DeepSeek-OCR   --trust-remote-code   --limit-mm-per-prompt '{"image": 1}'   --enforce-eager   --max-num-seqs 1
```

```
curl -X POST http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "/shared/cache/modelscope/hub/models/deepseek-ai/DeepSeek-OCR/",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "image_url",
            "image_url": {
              "url": "data:image/png;base64,'$(base64 -w 0 text_pic.png)'"
            }
          },
          {
            "type": "text",
            "text": "Convert the document to markdown."
          }
        ]
      }
    ],
    "temperature": 0.0,
    "max_tokens": 512,
    "extra_body": {
      "ngram_size": 30,
      "window_size": 90,
      "whitelist_token_ids": [128821, 128822]
    }
  }'
```

## How to install the latest version?

```
export IMAGE=quay.io/ascend/vllm-ascend:main
docker run --rm \
    --name vllm-ascend-env \
    --shm-size=1g \
    --net=host \
    --device /dev/davinci0 \
    --device /dev/davinci_manager \
    --device /dev/devmm_svm \
    --device /dev/hisi_hdc \
    -v /usr/local/dcmi:/usr/local/dcmi \
    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
    -v /etc/ascend_install.info:/etc/ascend_install.info \
    -v /root/.cache:/root/.cache \
    -it $IMAGE bash
```

Or

```
git clone https://github.com/vllm-project/vllm
git checkout 83f478
VLLM_TARGET_DEVICE=empty pip install -v -e .
cd ..
git clone https://github.com/vllm-project/vllm-ascend
pip install -v -e .
```

## Known issues

If the following issue happen, you can set `export VLLM_ASCEND_ENABLE_NZ=0` to fix it.

```
(EngineCore DPO pid=6321) File "/vLLmspace/vLLm/vLLm/model_executor/model_Loader/base_Loader.py", Line 56, in load model
(EngineCore DPO pid=6321) process weights after loading(model, model config, target device)
(EngineCore DPO pid=6321) File "/vLlmspace/vLlm/vllm/model executor/model loader/utils.py”, line 107, in process weights after loading
(EngineCore DPO pid=6321) quant method.process weights after loading(module)
(EngineCore_DPO pid=6321) File "/VLlmspace/vllm-ascend/vilm ascend/ops/Linear.py”, Line 50, in process weights after_loading
(EngineCore DPO pid=6321) Layer.weight.data = torch npu.npu format cast(
(EngineCore DPO pid=6321) AAAAAAAAAAAAAAAAAAAAAAAAAA
(EngineCore DPO pid-6321) File "/usr/local/python3.11.13/1ib/python3.11/site-packages/torch/ ops.py", Line 1158, in call
(EngineCore DPO pid=6321) return self, op( args, **(kwargs or f}))
(EngineCore DPO pid-6321) annnnanhhnnnnnnnnnnnnAnnAAAAAAAAA
(EngineCore DPB pid=6321) RuntimeError: NPU out of memory. Tried to allocate 282.00 MiB (NPU 0: 60.97 GiB total capacity; 59.56 GiB alread
y allocated; 59.56 GiB current active; 16.49 MiB free; 60.34 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max split size mb to avoid fragmentation.
```
- vLLM version: v0.11.0rc3
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
