### PR TITLE
[TEST]Add MALPO for aclgraph in nightly test

### DIFF
--- a/tests/e2e/nightly/models/test_deepseek_r1_0528_w8a8.py
+++ b/tests/e2e/nightly/models/test_deepseek_r1_0528_w8a8.py
@@ -32,6 +32,7 @@ MODES = [
     "torchair",
     "single",
     "aclgraph",
+    "aclgraph_mlapo",
     "no_chunkprefill",
 ]
 
@@ -107,6 +108,8 @@ async def test_models(model: str, mode: str) -> None:
         server_args.append("--enforce-eager")
         additional_config["torchair_graph_config"] = {"enabled": False}
     if mode == "aclgraph":
+        additional_config["torchair_graph_config"] = {"enabled": False}
+    if mode == "aclgraph_mlapo":
         env_dict["VLLM_ASCEND_ENABLE_MLAPO"] = "1"
         additional_config["torchair_graph_config"] = {"enabled": False}
     if mode == "no_chunkprefill":


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds MALPO for deepseek aclgraph, we need to test it nightly
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
By running the test

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
