### PR TITLE
[MM][Bugfix] Add MoE verification for multi-modal models

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -680,7 +680,7 @@ def is_moe_model(vllm_config: VllmConfig):
     return _IS_MOE_MODEL
 
 
-def _is_contain_expert(config: dict | str):
+def _is_contain_expert(config: Any):
     if isinstance(config, dict):
         for k, v in config.items():
             if "expert" in str(k):


### PR DESCRIPTION
### What this PR does / why we need it?

Fix https://github.com/vllm-project/vllm-ascend/issues/3891.

The empty of `moe_comm_method` in the above issue is due to the wrong check for MoE models. To be specific, the method `is_moe_model` only checks whether a text-only model is a MoE model, without considering multi-modal models, e.g., `VL` and `Omni`.

Config of text-only models looks like:

- https://huggingface.co/Qwen/Qwen3-30B-A3B/blob/main/config.json

We can verify MoE models by checking if there is a key named `num_experts`. 

This is different from `VL` or `Omni` models, whose config files look like:

- https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct/blob/main/config.json
- https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct/blob/main/config.json

We can verify MoE models by checking if there is a key named `num_experts` in `text_config` dict.

Part of https://github.com/vllm-project/vllm-ascend/issues/3508.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

---

**Update: 2025/11/03**

Check the config dict recursively to find if it has a key contains "expert", without checking the model architecture.

It is worth noting that, we can't verify a model by if it contains `FusedMoE` module because `is_moe_model` is called somewhere before the model loading, e.g., it's called when updating the ACLGraph config in platform initialization.
- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
