### PR TITLE
[CI] Upload plog to github artifact

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -132,6 +132,7 @@ jobs:
         with:
           name: plogs
           path: plogs.tar.gz
+          retention-days: 3
 
 
   e2e-2-cards:
@@ -242,3 +243,4 @@ jobs:
         with:
           name: plogs
           path: plogs.tar.gz
+          retention-days: 3


### PR DESCRIPTION
### What this PR does / why we need it?
This patch upload the plog to GitHub artifacts if it exists, this will help developers view the plog to locate more detailed errors.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
