### PR TITLE
[CI][Nightly] Correct the commit hash available for mooncake

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/build_mooncake.sh
+++ b/tests/e2e/nightly/multi_node/scripts/build_mooncake.sh
@@ -10,7 +10,7 @@ RED="\033[0;31m"
 NC="\033[0m" # No Color
 
 branch=${1:-pooling_async_memecpy_v1}
-point=${2:-9d96b2e1dd76cc601d76b1b4c5f6e04605cd81d3}
+point=${2:-8fce1ffab3930fec2a8b8d3be282564dfa1bb186}
 
 repo_url="https://github.com/AscendTransport/Mooncake"
 repo_name="Mooncake"


### PR DESCRIPTION
### What this PR does / why we need it?
Because the previous commit hash was accidentally deleted or overwritten. This patch correct the commit hash available for https://github.com/AscendTransport/Mooncake to make nightly ci happy
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
