### PR TITLE
[Store] Add alloc_in_same_node as a configurable parameter

### DIFF
--- a/vllm_ascend/distributed/kvpool/kv_transfer.py
+++ b/vllm_ascend/distributed/kvpool/kv_transfer.py
@@ -116,7 +116,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
         addr_list_tp = addr_list[self.tp_rank % self.put_step::self.put_step]
         size_list_tp = size_list[self.tp_rank % self.put_step::self.put_step]
         if key_list_tp:
-            torch.npu.current_stream().synchronize()
             self.m_store.put(key_list_tp, addr_list_tp, size_list_tp)
         if is_last_chunk:
             self.set_finished_request(req_id)
@@ -196,7 +195,6 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         addr_list_tp = addr_list[self.tp_rank % self.put_step::self.put_step]
         size_list_tp = size_list[self.tp_rank % self.put_step::self.put_step]
         if key_list_tp:
-            torch.npu.current_stream().synchronize()
             self.m_store.put(key_list_tp, addr_list_tp, size_list_tp)
         if req_meta.layer_id == self.final_layer_id and req_meta.is_last_chunk:
             self.set_finished_request(req_meta.req_id)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2334,7 +2334,6 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                     attn_metadata, self.with_prefill, maybe_padded_num_tokens,
                     input_ids, positions, intermediate_tensors, inputs_embeds)
 
-            self.maybe_wait_for_kv_save()
             finished_sending, finished_recving = self.get_finished_kv_transfer(
                 scheduler_output)
 
@@ -2598,7 +2597,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                     # ngram and other speculative decoding methods use the sampled
                     # tokens on the CPU, so they are run after bookkeeping.
                     propose_draft_token_ids(valid_sampled_token_ids)
-
+            self.maybe_wait_for_kv_save()
             if has_kv_transfer_group():
                 get_kv_transfer_group().clear_connector_metadata()
 


### PR DESCRIPTION
### What this PR does / why we need it?
Add alloc_in_same_node as a configurable parameter, `alloc_in_same_node=True` enables the local-preference allocation policy.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
