### PR TITLE
[Test][Accuracy] Add accuracy evaluation config for Qwen3-VL-8B-Instruct

### DIFF
--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
@@ -1,0 +1,10 @@
+model_name: "Qwen/Qwen3-VL-8B-Instruct"
+hardware: "Atlas A2 Series"
+model: "vllm-vlm"
+tasks:
+- name: "mmmu_val"
+  metrics:
+  - name: "acc,none"
+    value: 0.55
+max_model_len: 8192
+gpu_memory_utilization: 0.5

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -6,3 +6,4 @@ Qwen2-7B.yaml
 Qwen2-VL-7B-Instruct.yaml
 Qwen2-Audio-7B-Instruct.yaml
 Qwen3-VL-30B-A3B-Instruct.yaml
+Qwen3-VL-8B-Instruct.yaml


### PR DESCRIPTION
### What this PR does / why we need it?

Closes #3508.

To continuously monitor the accuracy of the `Qwen3-VL-8B-Instruct` model, this PR adds the corresponding configuration file to the CI.
The current accuracy is around `0.55`, and `gpu_memory_utilization` is set to 0.5 to prevent OOM issues.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

` pytest -sv ./tests/e2e/models/test_lm_eval_correctness.py --config ./tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml`

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
