### PR TITLE
[Core] Restore scheduling logic under default configuration

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -737,7 +737,7 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(VllmConfig)
             self.assertTrue(
                 "PIECEWISE compilation enabled on NPU. use_inductor not supported - "
-                "using only ACL Graph mode" in cm.output[1])
+                "using only ACL Graph mode" in cm.output[0])
             if vllm_version_is("0.11.0"):
                 self.assertEqual(
                     VllmConfig.compilation_config.level,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR reverts the changes introduced in PR #2894  Initially, due to performance issues with the older version of the chunked prefill ops, the default behavior was to use the Ascend scheduler to disable the chunked prefill feature. However, with the improvements in the performance of the new chunked prefill ops, this interception strategy has been removed. This change also aligns with the community's default configuration behavior.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with new added/existing test.

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
