### PR TITLE
【main】optimization of kimi-k2 in cann8.3

### DIFF
--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -180,7 +180,9 @@ def _select_experts_with_fusion_ops(
     # NOTE: now npu_moe_gating_top_k can only support 'group_count=256' pattern
     global_redundant_expert_num = get_ascend_config().init_redundancy_expert
     is_deepseek_v3_r1 = global_num_experts - global_redundant_expert_num == 256
-    if is_deepseek_v3_r1:
+    is_kimi = global_num_experts - global_redundant_expert_num == 384
+    # NOTE: now npu_moe_gating_top_k can support `group_count=256` pattern, and `group_count=384` pattern in cann8.3
+    if is_deepseek_v3_r1 or (is_kimi and torch.version.cann.startswith("8.3")):
         topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k(
             router_logits,
             k=top_k,  # topk currently 8

--- a/vllm_ascend/torchair/ops/torchair_fused_moe.py
+++ b/vllm_ascend/torchair/ops/torchair_fused_moe.py
@@ -861,8 +861,10 @@ class TorchairAscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         global_redundant_expert_num = get_ascend_config(
         ).init_redundancy_expert
         is_deepseek_v3_r1 = global_num_experts - global_redundant_expert_num == 256
-        # NOTE: now npu_moe_gating_top_k can only support `group_count=256` pattern
-        if is_deepseek_v3_r1:
+        is_kimi = global_num_experts - global_redundant_expert_num == 384
+        # NOTE: now npu_moe_gating_top_k can support `group_count=256` pattern, and `group_count=384` pattern in cann8.3
+        if is_deepseek_v3_r1 or (is_kimi
+                                 and torch.version.cann.startswith("8.3")):
             topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k(
                 router_logits,
                 k=top_k,  # topk currently is 8

--- a/vllm_ascend/torchair/quantization/torchair_w4a8_dynamic.py
+++ b/vllm_ascend/torchair/quantization/torchair_w4a8_dynamic.py
@@ -322,7 +322,9 @@ class TorchairAscendW4A8DynamicFusedMoEMethod:
         assert router_logits.shape[
             1] == global_num_experts - global_redundant_expert_num, "Number of global experts mismatch (excluding redundancy)"
 
-        if global_num_experts == 256:
+        # NOTE: now npu_moe_gating_top_k can support `group_count=256` pattern, and `group_count=384` pattern in cann8.3
+        if global_num_experts == 256 or (global_num_experts == 384 and
+                                         torch.version.cann.startswith("8.3")):
             topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k(
                 router_logits,
                 k=top_k,  # topk currently is 8


### PR DESCRIPTION
### What this PR does / why we need it?
In cann8.3， npu_moe_gating_top_k operator can support expert nums with 384, so kimi can use the operator to get better preformance.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
