### PR TITLE
[Doc] Update structured output doc with upstream link

### DIFF
--- a/docs/source/user_guide/feature_guide/structured_output.md
+++ b/docs/source/user_guide/feature_guide/structured_output.md
@@ -14,4 +14,4 @@ In simple terms, structured decoding gives LLMs a "template" to follow. Users pr
 
 Currently, the usage of structured output feature in vllm-ascend is totally the same as that in vllm.
 
-Find more examples and explanations about these usages in [vLLM official document](https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/structured_outputs.py).
+Find more examples and explanations about these usages in [vLLM official document](https://docs.vllm.ai/en/stable/features/structured_outputs/).


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, the usage of structured output feature in vllm-ascend is totally the same as that in vllm.

Thus, IMO, it's better to remove this doc directly to avoid some case that there are some changes in the upstream doc and we don't update our doc in time, which can be misleading to users.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
