### PR TITLE
[Fix]  fix Qwen2-Audio-7B-Instruct accuracy test

### DIFF
--- a/.github/workflows/vllm_ascend_test_nightly_a2.yaml
+++ b/.github/workflows/vllm_ascend_test_nightly_a2.yaml
@@ -108,8 +108,7 @@ jobs:
             model_list:
               - Qwen3-8B
               - Qwen2.5-VL-7B-Instruct
-              # TODO: This model has a bug that needs to be fixed and readded
-              # - Qwen2-Audio-7B-Instruct
+              - Qwen2-Audio-7B-Instruct
               - Qwen3-8B-W8A8
               - Qwen3-VL-8B-Instruct
               - Qwen2.5-Omni-7B

--- a/.github/workflows/vllm_ascend_test_report.yaml
+++ b/.github/workflows/vllm_ascend_test_report.yaml
@@ -64,8 +64,7 @@ jobs:
             model_list:
               - Qwen3-8B
               - Qwen2.5-VL-7B-Instruct
-              # TODO: This model has a bug that needs to be fixed and readded
-              # - Qwen2-Audio-7B-Instruct
+              - Qwen2-Audio-7B-Instruct
           - runner: linux-aarch64-a2-2
             model_list:
               - Qwen3-30B-A3B

--- a/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
@@ -8,3 +8,4 @@ tasks:
   - name: "exact_match,flexible-extract"
     value: 0.45
 num_fewshot: 5
+gpu_memory_utilization: 0.8


### PR DESCRIPTION
### What this PR does / why we need it?

fix Qwen2-Audio-7B-Instruct accuracy test

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
