### PR TITLE
[1/N][Refactor] Remove the custom split_qkv

### DIFF
--- a/vllm_ascend/models/qwen2_5_vl.py
+++ b/vllm_ascend/models/qwen2_5_vl.py
@@ -76,19 +76,6 @@ class AscendQwen2_5_VisionAttention(Qwen2_5_VisionAttention):
         if self.hidden_size_per_attention_head > MIN_PAD_SIZE and self.hidden_size_per_attention_head < MAX_PAD_SIZE:
             self.hidden_size_per_attention_head = MAX_PAD_SIZE
 
-    def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        # [s, b, 3 * head * head_dim]
-        seq_len, bs, _ = qkv.shape
-
-        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head * head_dim]
-        q, k, v = qkv.chunk(3, dim=2)
-
-        # 3 * [s, b, head * head_dim] -> 3 * [s, b, head, head_dim]
-        new_shape = (seq_len, bs, self.num_attention_heads_per_partition,
-                     self.hidden_size_per_attention_head)
-        q, k, v = (x.view(*new_shape) for x in (q, k, v))
-        return q, k, v
-
     def forward(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
### What this PR does / why we need it?

Due to [vLLM PR #23190](https://github.com/vllm-project/vllm/pull/23190), I think we no longer need to worry about the additional communication overhead caused by TP. Now, we can simply set `--mm-encoder-tp-mode` to enable encoder-side DP. Specifically, in `split_qkv`, `tp_size` will be equal to `1`, so `all_gather_interleave` will not be triggered.

I will complete it tomorrow.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
