### PR TITLE
[Doc] Fix DeepSeek-3.2-Exp doc, remove v0.11.0rc0 outdated infos.

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -309,7 +309,10 @@ First, check physical layer connectivity, then verify each node, and finally ver
 Execute the following commands on each node in sequence. The results must all be `success` and the status must be `UP`:
 
 :::::{tab-set}
+:sync-group: multi-node
+
 ::::{tab-item} A2 series
+:sync: A2
 
 ```bash
  # Check the remote switch ports
@@ -328,6 +331,7 @@ Execute the following commands on each node in sequence. The results must all be
 
 ::::
 ::::{tab-item} A3 series
+:sync: A3
 
 ```bash
  # Check the remote switch ports
@@ -350,7 +354,10 @@ Execute the following commands on each node in sequence. The results must all be
 #### Interconnect Verification:
 ##### 1. Get NPU IP Addresses
 :::::{tab-set}
+:sync-group: multi-node
+
 ::::{tab-item} A2 series
+:sync: A2
 
 ```bash
 for i in {0..7}; do hccn_tool -i $i -ip -g | grep ipaddr; done
@@ -358,6 +365,7 @@ for i in {0..7}; do hccn_tool -i $i -ip -g | grep ipaddr; done
 
 ::::
 ::::{tab-item} A3 series
+:sync: A3
 
 ```bash
 for i in {0..15}; do hccn_tool -i $i -ip -g | grep ipaddr; done
@@ -380,7 +388,10 @@ Using vLLM-ascend official container is more efficient to run multi-node environ
 Run the following command to start the container in each node (You should download the weight to /root/.cache in advance):
 
 :::::{tab-set}
+:sync-group: multi-node
+
 ::::{tab-item} A2 series
+:sync: A2
 
 ```{code-block} bash
    :substitutions:
@@ -421,6 +432,7 @@ docker run --rm \
 
 ::::
 ::::{tab-item} A3 series
+:sync: A3
 
 ```{code-block} bash
    :substitutions:

--- a/docs/source/tutorials/DeepSeek-V3.2-Exp.md
+++ b/docs/source/tutorials/DeepSeek-V3.2-Exp.md
@@ -34,7 +34,10 @@ Only AArch64 architecture are supported currently due to extra operator's instal
 :::
 
 :::::{tab-set}
+:sync-group: install
+
 ::::{tab-item} A3 series
+:sync: A3
 
 1. Start the docker image on your node, refer to [using docker](../installation.md#set-up-using-docker).
 
@@ -52,6 +55,7 @@ pip install custom_ops-1.0-cp311-cp311-linux_aarch64.whl
 
 ::::
 ::::{tab-item} A2 series
+:sync: A2
 
 1. Start the docker image on your node, refer to [using docker](../installation.md#set-up-using-docker).
 
@@ -113,7 +117,10 @@ vllm serve vllm-ascend/DeepSeek-V3.2-Exp-W8A8 \
 - `DeepSeek-V3.2-Exp-w8a8`: require 2 Atlas 800 A2 (64G × 8).
 
 :::::{tab-set}
+:sync-group: install
+
 ::::{tab-item} DeepSeek-V3.2-Exp A3 series
+:sync: A3
 
 Run the following scripts on two nodes respectively.
 
@@ -202,6 +209,7 @@ vllm serve /root/.cache/Modelers_Park/DeepSeek-V3.2-Exp \
 
 ::::
 ::::{tab-item} DeepSeek-V3.2-Exp-W8A8 A2 series
+:sync: A2
 
 Run the following scripts on two nodes respectively.
 

--- a/docs/source/tutorials/multi_node_pd_disaggregation_mooncake.md
+++ b/docs/source/tutorials/multi_node_pd_disaggregation_mooncake.md
@@ -96,8 +96,10 @@ We can run the following scripts to launch a server on the prefiller/decoder nod
 ### Layerwise
 
 :::::{tab-set}
+:sync-group: nodes
 
 ::::{tab-item} Prefiller node 1
+:sync: prefill node1
 
 ```shell
 unset ftp_proxy
@@ -153,6 +155,7 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ::::
 
 ::::{tab-item} Prefiller node 2
+:sync: prefill node2
 
 ```shell
 unset ftp_proxy
@@ -208,6 +211,7 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ::::
 
 ::::{tab-item} Decoder node 1 (master Node)
+:sync: decoder node1
 
 ```shell
 unset ftp_proxy
@@ -265,6 +269,7 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ::::
 
 ::::{tab-item} Decoder node 2 (primary node)
+:sync: decoder node2
 
 ```shell
 unset ftp_proxy
@@ -327,8 +332,10 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ### Non-layerwise
 
 :::::{tab-set}
+:sync-group: nodes
 
 ::::{tab-item} Prefiller node 1
+:sync: prefill node1
 
 ```shell
 unset ftp_proxy
@@ -384,6 +391,7 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ::::
 
 ::::{tab-item} Prefiller node 2
+:sync: prefill node2
 
 ```shell
 unset ftp_proxy
@@ -439,6 +447,7 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ::::
 
 ::::{tab-item} Decoder node 1 (master node)
+:sync: decoder node1
 
 ```shell
 unset ftp_proxy
@@ -496,6 +505,7 @@ vllm serve /model/Qwen3-235B-A22B-W8A8 \
 ::::
 
 ::::{tab-item} Decoder node 2 (primary Node)
+:sync: decoder node2
 
 ```shell
 unset ftp_proxy

--- a/docs/source/tutorials/single_npu.md
+++ b/docs/source/tutorials/single_npu.md
@@ -44,7 +44,10 @@ export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256
 Run the following script to execute offline inference on a single NPU:
 
 :::::{tab-set}
+:sync-group: inference
+
 ::::{tab-item} Graph Mode
+:sync: graph mode
 
 ```{code-block} python
    :substitutions:
@@ -71,6 +74,7 @@ for output in outputs:
 ::::
 
 ::::{tab-item} Eager Mode
+:sync: eager mode
 
 ```{code-block} python
    :substitutions:
@@ -110,7 +114,10 @@ Prompt: 'The future of AI is', Generated text: ' following you. As the technolog
 Run docker container to start the vLLM server on a single NPU:
 
 :::::{tab-set}
+:sync-group: inference
+
 ::::{tab-item} Graph Mode
+:sync: graph mode
 
 ```{code-block} bash
    :substitutions:
@@ -139,6 +146,7 @@ vllm serve Qwen/Qwen3-8B --max_model_len 26240
 ::::
 
 ::::{tab-item} Eager Mode
+:sync: eager mode
 
 ```{code-block} bash
    :substitutions:


### PR DESCRIPTION
### What this PR does / why we need it?
Fix DeepSeek-3.2-Exp doc, remove v0.11.0rc0 outdated infos.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
