### PR TITLE
[main][bugfix] Change seq_lens in dummy attn_metadata to max_query_len

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2665,12 +2665,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
 
             attn_metadata = {}
 
-            # When force_attention == True, the model runs in capturing so we
-            # need seq_lens as max_model_len to get max workspace for attention op.
-            # However, when force_attention == False, the model might be running
-            # normal inference. If dp_size > 1, we only need dummy_run
-            # to execute a short attention with seq_lens as 1.
-            seq_lens = self.model_config.max_model_len if force_attention else 1
+            seq_lens = max_query_len
             self.seq_lens_np[:num_reqs] = seq_lens
             self.seq_lens_np[num_reqs:] = 0
 


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, we set `seq_lens` in dummy attn_metadata to be `max_model_len` to get max workspace for attention during capturing.
However, setting it consistently to be `max_model_len` causing dummy_run to execute a long attention when running actual inference. For example, if there is a single req with `seqs_lens` as [8] but `max_model_len` is 131072, the whole process will be slow down by dummy_run as it execute a fake long-seq attention. Therefore, we instead set it to max_query_len, which is also consistent with vLLM gpu implementation.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
