### PR TITLE
[Doc] Recover installation doc to use pip install

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -136,11 +136,7 @@ Then you can install `vllm` and `vllm-ascend` from **pre-built wheel**:
    :substitutions:
 
 # Install vllm-project/vllm. The newest supported version is |vllm_version|.
-# Because the version |vllm_version| has not been archived in pypi, so you need to install from source.
-git clone --depth 1 --branch |vllm_version| https://github.com/vllm-project/vllm
-cd vllm
-VLLM_TARGET_DEVICE=empty pip install -v -e .
-cd ..
+pip install vllm==|pip_vllm_version|
 
 # Install vllm-project/vllm-ascend from pypi.
 pip install vllm-ascend==|pip_vllm_ascend_version|

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -47,16 +47,8 @@ function install_binary_test() {
     # Setup extra-index-url for x86 & torch_npu dev version
     pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/ https://mirrors.huaweicloud.com/ascend/repos/pypi"
 
-    if [[ "${VLLM_VERSION} " != "v0.11.0rc3" ]]; then
-        # The vLLM version already in pypi, we install from pypi.
-        pip install vllm=="${PIP_VLLM_VERSION}"
-    else
-        # The vLLM version not in pypi, we install from source code with a specific tag.
-        git clone --depth 1 --branch "${VLLM_VERSION}" https://github.com/vllm-project/vllm
-        cd vllm
-        VLLM_TARGET_DEVICE=empty pip install -v -e .
-        cd ..
-    fi
+    # The vLLM version already in pypi, we install from pypi.
+    pip install vllm=="${PIP_VLLM_VERSION}"
 
     pip install vllm-ascend=="${PIP_VLLM_ASCEND_VERSION}"
 


### PR DESCRIPTION
### What this PR does / why we need it?
Use pip installation in installation doc and change related doctest to validate.

### Does this PR introduce _any_ user-facing change?
No, doc only

### How was this patch tested?
Doctest related CI passed
- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
