### PR TITLE
[Bugfix][SHM] Use writer lock by default and remove redundant env

### DIFF
--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -17,12 +17,14 @@
 import os
 
 import vllm_ascend.patch.platform.patch_config  # noqa
-import vllm_ascend.patch.platform.patch_core  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
-import vllm_ascend.patch.platform.patch_message_queue  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false") == "true" or os.getenv(
         "EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
+
+if os.getenv("SHM_BARRIER", "true") == "true":
+    import vllm_ascend.patch.platform.patch_core  # noqa
+    import vllm_ascend.patch.platform.patch_message_queue  # noqa

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import os
+
 from vllm.triton_utils import HAS_TRITON
 
 if HAS_TRITON:
@@ -30,3 +32,6 @@ import vllm_ascend.patch.worker.patch_multimodal_merge  # noqa
 import vllm_ascend.patch.worker.patch_minicpm  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
 import vllm_ascend.patch.worker.patch_attention_layer  # noqa
+
+if os.getenv("SHM_BARRIER", "true") == "true":
+    import vllm_ascend.patch.platform.patch_message_queue  # noqa


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
This PR aims to remove env introduced by #3988 and use lock by default. As described in https://github.com/vllm-project/vllm/issues/27858, we have tested the writer lock method in various scenarios and the performance is almost unaffected. Therefore, we believe that it would be safe to enable the lock by default and remove the redundant env `SHM_BARRIER` now.

After discussion, we decide to preserve env and set it as true by default.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
`SHM_BARRIER` is set as true by default.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
by ci
