### PR TITLE
[bugfix]Prevent overwriting drafters lm-head and embed_tokens

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -119,7 +119,6 @@ class EagleProposer(Proposer):
                 raise AttributeError(
                     "Target model does not have 'embed_tokens' or 'embedding' attribute"
                 )
-            
             # share embed_tokens with the target model if needed
             if not self.model.has_own_embed_tokens:
                 logger.info("Draft model embed_tokens are uninitialized. "


### PR DESCRIPTION
### What this PR does / why we need it?
Some EAGLE3 drafters might have their own lm_head and/or embed_tokens layers. Existing codebase ignores this.By solving this problem, it can greatly improve acceptance rates.   Refer to this pr in vllm: https://github.com/vllm-project/vllm/pull/27737

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
export CUDA_VISIBLE_DEVICES=0
export TP=1
export MODEL_PATH=/model/Llama-3.1-8B-Instruct
export MODEL_NAME=Llama-3.1-8B-Instruct
export PORT=10133
python3 -m vllm.entrypoints.openai.api_server  --host 0.0.0.0 --port ${PORT} --dtype bfloat16  --model ${MODEL_PATH} --served-model-name ${MODEL_NAME} --tensor-parallel-size ${TP} --gpu-memory-utilization 0.85   --max-model-len 32768 --trust-remote-code  --seed 42  --speculative_config '{"method":"eagle3","model":"/model/EAGLE3-LLaMA3.1-Instruct-8B","num_speculative_tokens":5,"draft_tensor_parallel_size":1}'

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83f478bb19489b41e9d208b47b4bb5a95ac171ac
