### PR TITLE
[0.11.0-dev][Bugfix][EPLB] Quick fix for missing log2phy conversion

### DIFF
--- a/vllm_ascend/ops/moe/token_dispatcher.py
+++ b/vllm_ascend/ops/moe/token_dispatcher.py
@@ -178,6 +178,10 @@ class TokenDispatcherWithMC2(MoETokenDispatcher):
                        apply_router_weight_on_input: bool = False,
                        with_quant: bool = False,
                        dynamic_eplb: bool = False):
+        # Apply log2phy if needed
+        if log2phy is not None:
+            topk_ids = log2phy[topk_ids]
+
         self.with_quant = with_quant
         self.expert_map = expert_map
         self.topk_ids = topk_ids


### PR DESCRIPTION
### What this PR does / why we need it?
Quick fix for missing log2phy conversion in MC2 token_dispatcher, which has been already fixed in main branch https://github.com/vllm-project/vllm-ascend/pull/3512.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
e2e & ut