### PR TITLE
[Bug_fix] fix torchair o_proj forward parameter

### DIFF
--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -297,7 +297,7 @@ class AscendRowParallelLinear(RowParallelLinear):
     def forward(
         self,
         input_,
-        is_prefill: bool = True,
+        **kwargs,
     ) -> Union[torch.Tensor, tuple[torch.Tensor, Optional[Parameter]]]:
         if self.custom_op is not None:
             return self.custom_op.apply(input_)


### PR DESCRIPTION
### What this PR does / why we need it?
In `torchair_mla.py`, the `self.oproj` function includes an additional parameter `is_force_scatter`, while the `AscendRowParallelLinear` function in `linear.py` does not add this parameter.

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
