### PR TITLE
[CI] Remove unsupported python 3.9 format check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,13 +68,6 @@ repos:
   #   language: system
   #   types: [python]
   #   stages: [pre-commit] # Don't run in CI
-  - id: mypy-3.9 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
-    name: Run mypy for Python 3.9
-    entry: tools/mypy.sh 1 "3.9"
-    # Use system python because vllm installation is required
-    language: system
-    types: [python]
-    stages: [manual] # Only run in CI
   - id: mypy-3.10 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
     name: Run mypy for Python 3.10
     entry: tools/mypy.sh 1 "3.10"


### PR DESCRIPTION
### What this PR does / why we need it?
- Fixes the lint test fail for python 3.9, as python 3.9 is not support now.


- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
