### PR TITLE
[Bugfix] fix cannot import name get_mp_context

### DIFF
--- a/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
+++ b/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
@@ -9,7 +9,7 @@ from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
 from vllm.forward_context import ForwardContext
-from vllm.utils import logger, make_zmq_socket
+from vllm.utils import logger
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.request import Request
@@ -18,6 +18,12 @@ from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm_ascend.distributed.mooncake.config_data import (
     LoadSpec, MooncakeConnectorMetadata, ReqMeta, RequestTracker)
 from vllm_ascend.distributed.mooncake.mooncake_engine import MooncakeEngine
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is("0.11.0"):
+    from vllm.utils import make_zmq_socket
+else:
+    from vllm.utils.network_utils import make_zmq_socket
 
 
 class MooncakeConnectorV1(KVConnectorBase_V1):

--- a/vllm_ascend/patch/platform/patch_multiproc_executor.py
+++ b/vllm_ascend/patch/platform/patch_multiproc_executor.py
@@ -8,7 +8,6 @@ import vllm.v1.executor.multiproc_executor
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
-from vllm.utils import get_mp_context
 from vllm.v1.executor.abstract import FailureCallback
 from vllm.v1.executor.multiproc_executor import (
     MultiprocExecutor, UnreadyWorkerProcHandle, WorkerProc,
@@ -18,10 +17,11 @@ from vllm_ascend.utils import vllm_version_is
 
 if vllm_version_is("0.11.0"):
     from vllm.utils import (get_distributed_init_method, get_loopback_ip,
-                            get_open_port)
+                            get_mp_context, get_open_port)
 else:
     from vllm.utils.network_utils import (get_distributed_init_method,
                                           get_loopback_ip, get_open_port)
+    from vllm.utils.system_utils import get_mp_context
 
 
 class AscendMultiprocExecutor(MultiprocExecutor):


### PR DESCRIPTION
### What this PR does / why we need it?
fix bug: cannot import vllm package
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
