### PR TITLE
[HybridKV] Support KV sharing in mambaspec and fullattnspec

### DIFF
--- a/tests/e2e/multicard/test_qwen3_next.py
+++ b/tests/e2e/multicard/test_qwen3_next.py
@@ -105,4 +105,4 @@ def test_models_distributed_Qwen3_NEXT_MTP_TP4_SIMILARITY():
             print(f"ref_output: {ref_output[1]}")
             print(f"spec_output: {spec_output[1]}")
 
-    assert matches >= int(0.66 * len(ref_outputs))
+    assert matches > int(0.66 * len(ref_outputs))


### PR DESCRIPTION
### What this PR does / why we need it?
Support KV sharing in `MambaSpec` and `FullAttentionSpec`. The cache layout is described in the following image:
<img width="2438" height="532" alt="image" src="https://github.com/user-attachments/assets/5caa1240-b2c1-46fd-9c1b-71d0744882b8" />
After this pr, we could make great use of the HBM, and the `gpu_memory_utilization` could be improved to 0.95. Which unblock the long sequence support of Qwen3-Next

Fixes #3813 #3308 https://github.com/vllm-project/vllm-ascend/issues/3854#issuecomment-3495406510

### How was this patch tested?
Test this pr on gsm8k to make sure the kv sharing doesn't break the accuracy
**Test scripts:**
```bash
VLLM_VERSION=0.11.0 VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_ASCEND_ENABLE_NZ=0 lm_eval \
  --model vllm \
  --model_args pretrained=Qwen/Qwen3-Next-80B-A3B-Instruct,max_model_len=4096,tensor_parallel_size=4 \
  --tasks gsm8k \
  --batch_size 8
```
**Results:**
```bash
# on main

-- ceval

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8514|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8143|±  |0.0107|

# on 0.11.0
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|_  |0.8582|_  |0.0096|
|     |       |strict-match    |     5|exact_match|_  |0.8196|_  |0.0106|
```

There is some bad effect on mtp acceptance rate :-(
```bash
# before this pr:
--------------------------------------------------
total_num_output_tokens: 244639
num_drafts: 138009
num_draft_tokens: 138009
num_accepted_tokens: 105856
mean acceptance length: 1.77
--------------------------------------------------
acceptance at token 0: 0.77

# after this pr:
--------------------------------------------------
total_num_output_tokens: 244426
num_drafts: 151480
num_draft_tokens: 151480
num_accepted_tokens: 92171
mean acceptance length: 1.61
--------------------------------------------------
acceptance at token 0: 0.61
```

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
