### PR TITLE
[CI] Fix no space left in build wheel CI.

### DIFF
--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -57,7 +57,13 @@ jobs:
     - name: Print
       run: |
         lscpu
-        
+
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: true
+        docker-images: false
+
     - name: Build wheel
       run: |
         ls


### PR DESCRIPTION
### What this PR does / why we need it?
[CI] Fix no space left in build wheel CI.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
