### PR TITLE
[CI] Fix kubernetes failed to resolve ip by dns name

### DIFF
--- a/tests/e2e/nightly/multi_node/config/utils.py
+++ b/tests/e2e/nightly/multi_node/config/utils.py
@@ -27,7 +27,7 @@ def temp_env(env_dict):
 def dns_resolver(retries: int = 20, base_delay: float = 0.5):
     # We should resolve DNS with retries to avoid transient network issues.
     # When the pod is just started, DNS resolution may fail.
-    def resolve(dns: str) -> str:
+    def resolve(dns: str):
         delay = base_delay
         for attempt in range(retries):
             try:


### PR DESCRIPTION
### What this PR does / why we need it?
While in the scenario where the pod has been started, but the corresponding DNS service is not yet ready. If we immediately resolve the DNS domain name at this time, an error will occur. see https://github.com/vllm-project/vllm-ascend/actions/runs/19436639688/job/55609108796
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
