### PR TITLE
Remove the shape judgment logic for self.mrope_section and force the use of the torch_npu.nup_mrope operator.

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -405,8 +405,8 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor,
     ):
-        if self.mrope_section != [16, 24, 24]:
-            return super().forward_oot(positions, query, key)
+        # if self.mrope_section != [16, 24, 24]:
+        #     return super().forward_oot(positions, query, key)
 
         import torch_npu
         mrope_section = [0, 0, 0


### PR DESCRIPTION
…use of the torch_npu.nup_mrope operator.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
