### PR TITLE
[BugFix][main] disable nz only for conv1d

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -416,7 +416,6 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(q_pe.shape[1], self.impl.num_heads)
         self.assertEqual(q_pe.shape[2], self.impl.qk_rope_head_dim)
 
-    @patch('vllm_ascend.utils._ENABLE_NZ', True)
     @patch('torch_npu.npu_format_cast')
     def test_process_weights_after_loading(self, mock_format_cast):
         layer = MagicMock(spec=LinearBase)

--- a/tests/ut/models/test_qwen2_5_vl.py
+++ b/tests/ut/models/test_qwen2_5_vl.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 import torch
 import torch.nn.functional as F
@@ -367,7 +365,6 @@ class TestAscendQwen2_5_VisionTransformer(PytestBase):
         res = attention.pad_qkv_bias(torch.rand((300)))
         assert res.shape[0] == 384
 
-    @patch('vllm_ascend.utils._ENABLE_NZ', True)
     def test_pad_qkv_weight(self, mocker: MockerFixture):
         attention = self.init_vision_transformer(mocker)
         mocker.patch("torch.nn.Module.__setattr__")
@@ -380,7 +377,6 @@ class TestAscendQwen2_5_VisionTransformer(PytestBase):
         res = attention.pad_qkv_weight(torch.rand((300, 300)))
         assert res.shape == (384, 300)
 
-    @patch('vllm_ascend.utils._ENABLE_NZ', True)
     def test_pad_proj_weight(self, mocker: MockerFixture):
         attention = self.init_vision_transformer(mocker)
         mocker.patch("torch.nn.Module.__setattr__")

--- a/tests/ut/quantization/test_w4a8_dynamic.py
+++ b/tests/ut/quantization/test_w4a8_dynamic.py
@@ -260,10 +260,10 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
                 requires_grad=False)
         return layer
 
-    @patch('vllm_ascend.utils._ENABLE_NZ', False)
     @patch('torch_npu.npu_format_cast')
     @patch('torch_npu.npu_quantize')
     @patch('torch.Tensor.npu')
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
     def test_process_weights_after_loading(self, mock_npu, mock_npu_quantize,
                                            mock_npu_format_cast):
         mock_npu.return_value = torch.Tensor()

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -46,18 +46,12 @@ class TestUtils(TestBase):
             self.assertFalse(utils.is_310p())
 
     def test_is_enable_nz(self):
-        # Case when _ENABLE_NZ is already set
-        utils._ENABLE_NZ = True
-        self.assertTrue(utils.is_enable_nz())
-
-        utils._ENABLE_NZ = False
-        self.assertFalse(utils.is_enable_nz())
-
-        # Case when _ENABLE_NZ is None and vllm_config is not provided
-        utils._ENABLE_NZ = None
-        with self.assertRaises(ValueError) as context:
-            utils.is_enable_nz()
-        self.assertIn("vllm_config must be provided", str(context.exception))
+        with mock.patch("vllm_ascend.utils.envs_ascend.VLLM_ASCEND_ENABLE_NZ",
+                        1):
+            self.assertTrue(utils.is_enable_nz())
+        with mock.patch("vllm_ascend.utils.envs_ascend.VLLM_ASCEND_ENABLE_NZ",
+                        0):
+            self.assertFalse(utils.is_enable_nz())
 
     def test_sleep_mode_enabled(self):
         utils._SLEEP_MODE_ENABLED = None

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -281,9 +281,9 @@ class TestNPUWorker(TestBase):
 
             self.assertIn("Sleep mode is not enabled", str(cm.exception))
 
-    @patch('vllm_ascend.utils._ENABLE_NZ', False)
     @patch("vllm_ascend.worker.worker_v1.sleep_mode_enabled")
     @patch("vllm_ascend.worker.worker_v1.CaMemAllocator")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
     def test_wake_up_mode_enabled(self, mock_allocator_class,
                                   mock_sleep_mode_enabled):
         """Test wake_up method when sleep mode is enabled"""

--- a/vllm_ascend/models/qwen3_next.py
+++ b/vllm_ascend/models/qwen3_next.py
@@ -119,6 +119,7 @@ class CustomQwen3NextGatedDeltaNet(Qwen3NextGatedDeltaNet, MambaBase):
             output_size=self.conv_dim,
             bias=False,
             prefix=f"{prefix}.conv1d",
+            use_nz=False,
         )
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -59,7 +59,6 @@ _MIN_DP_BUFFER_SIZE = 50
 _IS_MOE_MODEL = None
 _ENABLE_SP = None
 _HAS_LAYER_IDX = None
-_ENABLE_NZ = None
 _SUBSCRIBED_COMPUTE_STREAMS = set()
 _GRAPH_PRINT_STREAM = None
 _GRAPH_PRINT_STREAM_LOCK = Lock()
@@ -129,14 +128,8 @@ def is_310p():
     return _IS_310P
 
 
-def is_enable_nz(vllm_config: Optional[VllmConfig] = None) -> bool:
-    global _ENABLE_NZ
-    if _ENABLE_NZ is None:
-        if not vllm_config:
-            raise ValueError(
-                "vllm_config must be provided when _ENABLE_NZ is None")
-        _ENABLE_NZ = envs_ascend.VLLM_ASCEND_ENABLE_NZ and vllm_config.model_config.hf_config.model_type != "qwen3_next"
-    return _ENABLE_NZ
+def is_enable_nz() -> bool:
+    return envs_ascend.VLLM_ASCEND_ENABLE_NZ
 
 
 def sleep_mode_enabled():

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -87,7 +87,6 @@ class NPUWorker(WorkerBase):
         # register patch for vllm
         from vllm_ascend.utils import adapt_patch
         adapt_patch()
-        is_enable_nz(vllm_config)
         # Register ops when worker init.
         from vllm_ascend import ops
         ops.register_dummy_fusion_op()


### PR DESCRIPTION
### What this PR does / why we need it?

Changes conv1d npu format to fix a precision problem, descripted by https://github.com/vllm-project/vllm-ascend/issues/4266.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

The environment is same with this issue, https://github.com/vllm-project/vllm-ascend/issues/4266.

Run below codes:

```python
if __name__ == '__main__':
    prompts = [
        "Who are you?",
    ]

    sampling_params = SamplingParams(temperature=0.0, top_p=0.95, top_k=40, max_tokens=128)
    llm = LLM(model="/home/model/Qwen3-Next-80B-A3B-Instruct",
              tensor_parallel_size=4,
              enforce_eager=True,
              distributed_executor_backend="mp",
              gpu_memory_utilization=0.7,
              max_model_len=4096)

    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(output.outputs[0].token_ids)
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

Results:

```text
[358, 1079, 1207, 16948, 11, 264, 3460, 12934, 4128, 1614, 28135, 7881, 553, 279, 50391, 38072, 11607, 1212, 54364, 5737, 13, 358, 1079, 6188, 311, 4226, 4755, 11, 1855, 1467, 1741, 438, 7343, 11, 3946, 9293, 11, 14298, 11, 19502, 11, 323, 803, 11, 438, 1632, 438, 2736, 19819, 32711, 11, 15473, 11, 323, 1008, 9079, 13, 1416, 498, 614, 894, 4755, 476, 1184, 12994, 11, 2666, 1910, 311, 1077, 752, 1414, 29094, 0, 151645]
Prompt: 'Who are you?', Generated text: ' I am Qwen, a large-scale language model independently developed by the Tongyi Lab under Alibaba Group. I am designed to answer questions, create text such as stories, official documents, emails, scripts, and more, as well as perform logical reasoning, programming, and other tasks. If you have any questions or need assistance, feel free to let me know anytime!'
```

It is meaningful now.

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
