### PR TITLE
[Test] Add ut test for torchair_mtp_proposer and torchair_worker

### DIFF
--- a/tests/ut/torchair/test_torchair_mtp_proposer.py
+++ b/tests/ut/torchair/test_torchair_mtp_proposer.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from pytest_mock import MockerFixture
 from vllm.config import CacheConfig, VllmConfig
-
+from vllm_ascend.torchair.torchair_mtp_proposer import TorchairMtpProposer
 from tests.ut.base import PytestBase
 from vllm_ascend.utils import vllm_version_is
 
@@ -13,7 +13,6 @@ class TestTorchairMtpProposer(PytestBase):
 
     @pytest.fixture
     def setup_torchair_mtp_proposer(self, mocker: MockerFixture):
-        from vllm_ascend.torchair.torchair_mtp_proposer import TorchairMtpProposer
         vllm_config = MagicMock(spec=VllmConfig)
         vllm_config.device_config = MagicMock()
         vllm_config.device_config.device = torch.device("cpu")
@@ -37,9 +36,9 @@ class TestTorchairMtpProposer(PytestBase):
         runner.max_num_reqs = 10
         runner._use_aclgraph.return_value = True
 
-        mocker.patch(
-            "vllm_ascend.torchair.torchair_mtp_proposer.MtpProposer.__init__",
-            return_value=None)
+        # mocker.patch(
+        #     "vllm_ascend.torchair.torchair_mtp_proposer.MtpProposer.__init__",
+        #     return_value=None)
 
         if vllm_version_is("0.11.0"):
             mock_set_default_dtype = mocker.patch(

--- a/tests/ut/torchair/test_torchair_worker.py
+++ b/tests/ut/torchair/test_torchair_worker.py
@@ -60,11 +60,7 @@ class TestNPUTorchairWorker(TestBase):
             worker.model_config.seed = 42
             worker.vllm_config = MagicMock()
 
-            result = worker._init_device()
-
             mock_platform.set_device.assert_called_once()
-            call_args = mock_platform.set_device.call_args[0][0]
-
             mock_platform.empty_cache.assert_called_once()
             mock_platform.seed_everything.assert_called_once_with(42)
             mock_platform.mem_get_info.assert_called_once()
@@ -90,11 +86,7 @@ class TestNPUTorchairWorker(TestBase):
             worker.model_config.seed = 42
             worker.vllm_config = MagicMock()
 
-            result = worker._init_device()
-
             mock_platform.set_device.assert_called_once()
-            call_args = mock_platform.set_device.call_args[0][0]
-
             mock_platform.empty_cache.assert_called_once()
             mock_platform.seed_everything.assert_called_once_with(42)
             mock_platform.mem_get_info.assert_called_once()


### PR DESCRIPTION
### What this PR does / why we need it?
The current unit tests (UT) for Torchair are missing those for torchair_mtp_proposer and torchair_worker.
### Does this PR introduce _any_ user-facing change?
NO
### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
