### PR TITLE
【fix】ops gatingtopk fix nightly ci error

### DIFF
--- a/tests/e2e/nightly/ops/test_fused_moe.py
+++ b/tests/e2e/nightly/ops/test_fused_moe.py
@@ -28,7 +28,8 @@ import torch
 import torch_npu
 from vllm.model_executor.layers.activation import SiluAndMul
 
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
+from vllm_ascend.ops.fused_moe.experts_selector import (
+    check_npu_moe_gating_top_k, select_experts)
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.token_dispatcher import \
     TokenDispatcherWithAllGather
@@ -303,7 +304,10 @@ def test_select_experts(
             e_score_correction_bias=e_score_correction_bias,
         )
 
-        if use_grouped_topk:
+        call_moe_gatingtopk = check_npu_moe_gating_top_k(
+            hidden_states, topk, topk_group, num_expert_group, scoring_func,
+            custom_routing_function)
+        if not call_moe_gatingtopk and use_grouped_topk:
             mock_native_grouped_topk.assert_called_once()
         else:
             mock_native_grouped_topk.assert_not_called()

--- a/tests/ut/quantization/test_w8a8.py
+++ b/tests/ut/quantization/test_w8a8.py
@@ -823,8 +823,7 @@ class TestSelectExperts(TestBase):
                            top_k=self.top_k,
                            use_grouped_topk=False,
                            renormalize=False,
-                           scoring_func="invalid_func",
-                           custom_routing_function=self.mock_custom_routing)
+                           scoring_func="invalid_func")
 
     @patch('torch.topk')
     def test_grouped_topk(self, mock_topk):
@@ -834,15 +833,13 @@ class TestSelectExperts(TestBase):
                                               self.top_k,
                                               dtype=torch.long))
 
-        weights, ids = select_experts(
-            hidden_states=self.hidden_states,
-            router_logits=self.router_logits,
-            top_k=self.top_k,
-            use_grouped_topk=True,
-            renormalize=False,
-            topk_group=4,
-            num_expert_group=2,
-            custom_routing_function=self.mock_custom_routing)
+        weights, ids = select_experts(hidden_states=self.hidden_states,
+                                      router_logits=self.router_logits,
+                                      top_k=self.top_k,
+                                      use_grouped_topk=True,
+                                      renormalize=False,
+                                      topk_group=4,
+                                      num_expert_group=2)
 
         mock_topk.assert_called()
         self.assertEqual(weights.shape, (self.num_tokens, self.top_k))
@@ -864,8 +861,7 @@ class TestSelectExperts(TestBase):
             renormalize=False,
             topk_group=4,
             num_expert_group=2,
-            e_score_correction_bias=e_score_correction_bias,
-            custom_routing_function=self.mock_custom_routing)
+            e_score_correction_bias=e_score_correction_bias)
 
         mock_grouped_topk.assert_called_once()
         self.assertEqual(weights.shape, (self.num_tokens, self.top_k))


### PR DESCRIPTION
### What this PR does / why we need it?

This pr  https://github.com/vllm-project/vllm-ascend/pull/2958 is supporting gatingtopk operator generalization, but caused nightly ci error.
Now we add check logits for ops gatingtopk, and fix nightly ci.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.12.0
