### PR TITLE
[Bugfix] fix patch typo

### DIFF
--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,12 +16,11 @@
 
 import os
 
-import vllm_ascend.envs as envs_ascend
 import vllm_ascend.patch.platform.patch_config  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 
-if envs_ascend.DYNAMIC_EPLB not in ("true", "1") or os.getenv(
+if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv(
         "EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa


### PR DESCRIPTION
### What this PR does / why we need it?
Fix a bug caused by this pr: https://github.com/vllm-project/vllm-ascend/pull/4223
The bug makes vllm-ascend/vllm_ascend/patch/platform/patch_multiproc_executor.py patch in a wrong way

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
Tested in a single node. When the environment DYNAMIC_EPLB is set to true, the patch works correctly. When it's set to false, the patch do not patch
- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
