### PR TITLE
[bugfix]Return the Transformer version from 4.57.2 to 4.57.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     "pandas-stubs",
     "setuptools>=64",
     "setuptools-scm>=8",
+    "transformers<=4.57.1",
     "torch-npu==2.7.1",
     "torch==2.7.1",
     "torchvision",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ numba
 #--pre
 #--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 torch-npu==2.7.1
+
+transformers<=4.57.1


### PR DESCRIPTION
### What this PR does / why we need it?
This PR pins the transformers dependency to 4.57.1.

Reason: CI tests (specifically test_completion_with_prompt_embeds.py) are failing with an AttributeError: 'dict' object has no attribute 'model_type' when using newer versions of transformers.

The issue stems from a bug in tokenization_utils_base.py where the code attempts to access the model_type field of a configuration dictionary (_config) using dot notation (_config.model_type) instead of dictionary key lookup (_config["model_type"] or _config.get("model_type")). This occurs in the logic block checking for transformers_version <= 4.57.2.

Pinning the version to 4.57.1 bypasses this buggy code path and restores CI stability.

Error Traceback:
``` shell
/usr/local/python3.11.13/lib/python3.11/site-packages/transformers/tokenization_utils_base.py:2419: 
if _is_local and _config.model_type not in [
E   AttributeError: 'dict' object has no attribute 'model_type'
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2918c1b49c88c29783c86f78d2c4221cb9622379
