### PR TITLE
chip type judgement code optimization

### DIFF
--- a/.github/Dockerfile.buildwheel
+++ b/.github/Dockerfile.buildwheel
@@ -18,10 +18,12 @@ ARG PY_VERSION=3.11
 FROM quay.io/ascend/manylinux:8.3.rc1-910b-manylinux_2_28-py${PY_VERSION}
 
 ARG COMPILE_CUSTOM_KERNELS=1
+ARG SOC_VERSION
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 RUN yum update -y && \
     yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl-devel && \
     rm -rf /var/cache/yum

--- a/.github/workflows/image_310p_openeuler.yml
+++ b/.github/workflows/image_310p_openeuler.yml
@@ -132,4 +132,5 @@ jobs:
         file: Dockerfile.310p.openEuler
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          SOC_VERSION=ascend310p1
         provenance: false

--- a/.github/workflows/image_310p_ubuntu.yml
+++ b/.github/workflows/image_310p_ubuntu.yml
@@ -128,4 +128,5 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          SOC_VERSION=ascend310p1
         provenance: false

--- a/.github/workflows/image_a3_openeuler.yml
+++ b/.github/workflows/image_a3_openeuler.yml
@@ -131,5 +131,6 @@ jobs:
         file: Dockerfile.a3.openEuler
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          SOC_VERSION=ascend910_9391
         provenance: false
 

--- a/.github/workflows/image_a3_ubuntu.yml
+++ b/.github/workflows/image_a3_ubuntu.yml
@@ -127,5 +127,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          SOC_VERSION=ascend910_9391
         provenance: false
 

--- a/.github/workflows/image_openeuler.yml
+++ b/.github/workflows/image_openeuler.yml
@@ -131,4 +131,5 @@ jobs:
         file: Dockerfile.openEuler
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          SOC_VERSION=ascend910b1
         provenance: false

--- a/.github/workflows/image_ubuntu.yml
+++ b/.github/workflows/image_ubuntu.yml
@@ -128,4 +128,5 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          SOC_VERSION=ascend910b1
         provenance: false

--- a/.github/workflows/release_code.yml
+++ b/.github/workflows/release_code.yml
@@ -59,6 +59,8 @@ jobs:
           python3 -m pip install twine setuptools_scm
 
       - name: Generate tar.gz
+        env:
+          SOC_VERSION: ascend910b1
         run: |
           python3 setup.py sdist
           ls dist

--- a/.github/workflows/release_whl.yml
+++ b/.github/workflows/release_whl.yml
@@ -69,6 +69,7 @@ jobs:
         ls
         docker build -f ./.github/Dockerfile.buildwheel \
         --build-arg PY_VERSION=${{ matrix.python-version }} \
+        --build-arg SOC_VERSION=ascend910b1 \
         -t wheel:v1 .
         docker run --rm \
         -u $(id -u):$(id -g) \

--- a/.github/workflows/vllm_ascend_test_pr_light.yaml
+++ b/.github/workflows/vllm_ascend_test_pr_light.yaml
@@ -81,6 +81,7 @@ jobs:
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
+        SOC_VERSION: ascend910b1
     strategy:
       matrix:
         vllm_version: [v0.11.2]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,12 @@ FROM quay.io/ascend/cann:8.3.rc1-910b-ubuntu22.04-py3.11
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1
 ARG MOONCAKE_TAG="v0.3.7.post2"
+ARG SOC_VERSION
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 
 WORKDIR /workspace
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -19,10 +19,12 @@ FROM quay.io/ascend/cann:8.3.rc1-310p-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1
+ARG SOC_VERSION
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 
 RUN apt-get update -y && \
     apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake libnuma-dev && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -19,8 +19,10 @@ FROM quay.io/ascend/cann:8.3.rc1-310p-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1
+ARG SOC_VERSION
 
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 
 RUN yum update -y && \
     yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl-devel && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -20,11 +20,13 @@ FROM quay.io/ascend/cann:8.3.rc1-a3-ubuntu22.04-py3.11
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1
 ARG MOONCAKE_TAG=v0.3.7.post2
+ARG SOC_VERSION
 
 COPY . /vllm-workspace/vllm-ascend/
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 
 RUN pip config set global.index-url ${PIP_INDEX_URL}
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -20,8 +20,10 @@ FROM quay.io/ascend/cann:8.3.rc1-a3-openeuler24.03-py3.11
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1
 ARG MOONCAKE_TAG="v0.3.7.post2"
+ARG SOC_VERSION
 
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 
 RUN pip config set global.index-url ${PIP_INDEX_URL}
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -20,8 +20,10 @@ FROM quay.io/ascend/cann:8.3.rc1-910b-openeuler24.03-py3.11
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG COMPILE_CUSTOM_KERNELS=1
 ARG MOONCAKE_TAG="v0.3.7.post2"
+ARG SOC_VERSION
 
 ENV COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS}
+ENV SOC_VERSION=$SOC_VERSION
 
 RUN pip config set global.index-url ${PIP_INDEX_URL}
 


### PR DESCRIPTION
### What this PR does / why we need it?
| | cpu envir | npu envir |
|---|---|---|
| set `SOC_VERSION` | check if `SOC_VERSION` is in dict `soc_to_device`, if not, raise an error that can not support current chip type. | print a warning log when `SOC_VERSION` is not equal to chip type from `npu-smi`, same as left for others. |
| not set `SOC_VERSION` | raise an error that `SOC_VERSION` is necessary when compiling in a cpu envir. | use chip type from `npu-smi` to compile vllm-ascend. |

### Does this PR introduce _any_ user-facing change?

Now we must set env `SOC_VERSION` when compiling in cpu envir. 

### How was this patch tested?


- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
