### PR TITLE
[Doc]Modify errors in the tutorial document(qwen2-audio-7b)

### DIFF
--- a/docs/source/tutorials/single_npu_qwen2_audio.md
+++ b/docs/source/tutorials/single_npu_qwen2_audio.md
@@ -53,7 +53,7 @@ Run the following script to execute offline inference on a single NPU:
 ```python
 from vllm import LLM, SamplingParams
 from vllm.assets.audio import AudioAsset
-from vllm.utils import FlexibleArgumentParser
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 # If network issues prevent AudioAsset from fetching remote audio files, retry or check your network.
 audio_assets = [AudioAsset("mary_had_lamb"), AudioAsset("winning_call")]
@@ -177,8 +177,8 @@ docker run --rm \
 -e PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256 \
 -it $IMAGE \
 vllm serve Qwen/Qwen2-Audio-7B-Instruct \
---max_model_len 16384 \
---max-num-batched-tokens 16384 \
+--max_model_len 8192 \
+--max-num-batched-tokens 8192 \
 --limit-mm-per-prompt '{"audio":2}' \
 --chat-template /path/to/your/vllm-ascend/examples/chat_templates/template_qwen2_audio.jinja
 ```
@@ -201,7 +201,7 @@ Once your server is started, you can query the model with input prompts:
 curl -X POST http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "/root/.cache/modelscope/models/Qwen/Qwen2-Audio-7B-Instruct",
+        "model": "Qwen/Qwen2-Audio-7B-Instruct",
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": [


### PR DESCRIPTION
### What this PR does / why we need it?
Modify errors in the tutorial document(qwen2-audio-7b)
- Fixes Deprecated Import: Updates the import of FlexibleArgumentParser from **vllm.utils** to **vllm.utils.argparse_utils** to address a deprecation warning and prevent future ImportError.

Related errors：
``` bash
ImportError: cannot import name 'FlexibleArgumentParser' from 'vllm.utils' (/vllm-workspace/vllm/vllm/utils/__init__.py)
```


- Corrects Max Sequence Length: Changes the --max_model_len from **16384** to the model-supported **8192**. This resolves the ValueError caused by exceeding the model's physical context window (max_position_embeddings).

Related errors：
``` bash
Value error, User-specified max_model_len (16384) is greater than the derived max_model_len 
(max_position_embeddings=8192 or model_max_length=None in model's config.json). To allow overriding this maximum, set 
the env var VLLM_ALLOW_LONG_MAX_MODEL_LEN=1. VLLM_ALLOW_LONG_MAX_MODEL_LEN must be used with extreme 
caution. If the model uses relative position encoding (RoPE), positions exceeding derived_max_model_len lead to nan. If the 
model uses absolute position encoding, positions exceeding derived_max_model_len will cause a CUDA array out-of-bounds 
error. [type=value_error, input_value=ArgsKwargs((), {'model': ...rocessor_plugin': None}), input_type=ArgsKwargs]
```
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
