### PR TITLE
[performance] Enhance performance after enabling min_p

### DIFF
--- a/vllm_ascend/sample/logits_processor/builtin.py
+++ b/vllm_ascend/sample/logits_processor/builtin.py
@@ -40,8 +40,8 @@ class AscendMinPLogitsProcessor(MinPLogitsProcessor):
         # Convert logits to probability distribution
         probability_values = torch.nn.functional.softmax(logits, dim=-1)
         # Calculate maximum probabilities per sequence
-        max_probabilities = torch.amax(probability_values, 
-                                       dim=-1, 
+        max_probabilities = torch.amax(probability_values,
+                                       dim=-1,
                                        keepdim=True)
         # Adjust min_p
         adjusted_min_p = max_probabilities.mul_(self.min_p)


### PR DESCRIPTION
### What this PR does / why we need it?
When min_p post-processing parameters are enabled, the original vllm implementation introduces the aclnInIndexPutImpl operator, which performs poorly on NPU
<img width="785" height="579" alt="image" src="https://github.com/user-attachments/assets/b48fe5ea-9fd8-4515-af90-ca507c114297" />

<img width="1280" height="640" alt="47179e2ba2f81d84d1b8c93036e0f7a7" src="https://github.com/user-attachments/assets/f1a915f9-eaa6-4592-9b88-8385d977ce0c" />

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
After enabling min_p to collect profiling
<img width="1244" height="606" alt="1764266393633_7D4D93D2-47B9-451a-B225-0FDE8D2EFA9B" src="https://github.com/user-attachments/assets/fc1edafe-1d26-4a63-9fd0-a6711a4085c4" />

The performance has been greatly improved


- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
