### PR TITLE
feat(sfa): Integrate fused mla_preprocess operator

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -409,8 +409,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                                     dtype=torch.int32,
                                     device=self.device)
 
-        if self.vllm_config.model_config.use_mla and \
-            self.compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY:
+        if self.vllm_config.model_config.use_mla:
             rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
             self.cos = torch.ones(self.max_num_reqs *
                                   self.decode_token_per_req,


### PR DESCRIPTION
### What this PR does / why we need it?
Replaces several discrete operations in the SFA forward pass with a single call to the fused `mla_preprocess` custom operator. This operator combines Q/K/V projection, RoPE application, and KV cache updates into one kernel.

A new weight processing method is added to transform and pre-process weights into the specific layout required by the fused operator. This change aims to improve performance by reducing kernel launch overhead.

Additionally, the condition for allocating RoPE caches is relaxed to support MLA in modes other than just full decode.

### Does this PR introduce _any_ user-facing change?
None

### How was this patch tested?
None

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
