### PR TITLE
[FixCI] Enable chunked prefill for auto-prefix-caching test

### DIFF
--- a/tests/e2e/multicard/test_prefix_caching.py
+++ b/tests/e2e/multicard/test_prefix_caching.py
@@ -58,7 +58,6 @@ INPUT_PROMPTS = [
 ]
 
 
-@pytest.mark.skip(reason="Fix me, the accuracy is not correct")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [50])
 def test_prefix_cache_with_v1_scheduler(model: str, max_tokens: int) -> None:
@@ -66,6 +65,7 @@ def test_prefix_cache_with_v1_scheduler(model: str, max_tokens: int) -> None:
                     enforce_eager=False,
                     max_model_len=2048,
                     tensor_parallel_size=2,
+                    enable_chunked_prefill=True,
                     gpu_memory_utilization=0.7) as vllm_model:
         prefix_cache_output = vllm_model.generate_greedy(
             INPUT_PROMPTS, max_tokens)
@@ -75,6 +75,7 @@ def test_prefix_cache_with_v1_scheduler(model: str, max_tokens: int) -> None:
                     enforce_eager=False,
                     max_model_len=2048,
                     tensor_parallel_size=2,
+                    enable_chunked_prefill=True,
                     gpu_memory_utilization=0.7) as vllm_model:
         vllm_output = vllm_model.generate_greedy(INPUT_PROMPTS, max_tokens)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Enable chunked prefill for auto-prefix-caching test.

After upgrading the vLLM version to v0.11.2 in #4400, the accuracy on auto-prefix-caching + non-chunked-prefill is broken. Due to chunked prefill is enabled by default, we change the apc test case firstly to recover CI.

After https://github.com/vllm-project/vllm/pull/28833, non-Pooling models won't be able to disable chunked prefill any more. 
Maybe we should fix the chunked prefill configuration issue in https://github.com/vllm-project/vllm-ascend/pull/4498 together
### How was this patch tested?
CI passed with existing test.

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
