### PR TITLE
[Bugfix] Fix Qwen2.5-Omni-7B accuarcy test

### DIFF
--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -108,13 +108,13 @@ class AscendRMSNorm(RMSNorm):
         residual: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         import torch_npu
-
         if residual is not None:
             residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
             assert x.size(0) == residual.size(0)
+            next_need_quant_fusion_linear = getattr(
+                self, 'next_need_quant_fusion_linear', None)
             x, residual = _addrmsnorm_forward_oot(
-                self, x, residual, self.next_need_quant_fusion_linear,
-                self.bias)
+                self, x, residual, next_need_quant_fusion_linear, self.bias)
             return x, residual
         x, residual = torch_npu.npu_rms_norm(x, self.weight,
                                              self.variance_epsilon)

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -173,7 +173,9 @@ def _maybe_prefetch_mlp_down_proj_impl(x_dependency: torch.Tensor) -> None:
     except AssertionError:
         return
 
-    if not forward_context.prefetch_mlp_enabled:
+    prefetch_mlp_enabled = getattr(forward_context, 'prefetch_mlp_enabled',
+                                   False)
+    if not prefetch_mlp_enabled:
         return
     forward_context.prefetch_mlp_down_proj = True
     model_instance = forward_context.model_instance
@@ -202,7 +204,9 @@ def _maybe_wait_prefetch_done_impl(x: torch.Tensor) -> None:
     except AssertionError:
         return
 
-    if not forward_context.prefetch_mlp_enabled:
+    prefetch_mlp_enabled = getattr(forward_context, 'prefetch_mlp_enabled',
+                                   False)
+    if not prefetch_mlp_enabled:
         return
     if forward_context.prefetch_mlp_gate_up_proj or \
         forward_context.prefetch_mlp_down_proj:


### PR DESCRIPTION
### What this PR does / why we need it?
Fix Qwen2.5-Omni-7B accuarcy test
issue：https://github.com/vllm-project/vllm-ascend/issues/4480
Depends on : https://github.com/vllm-project/vllm-ascend/pull/4534
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
accuracy test:https://github.com/vllm-project/vllm-ascend/actions/runs/19808047476?pr=4556
<img width="1213" height="590" alt="image" src="https://github.com/user-attachments/assets/d0779729-7a14-44fd-8d03-b72097dd3797" />


- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
