### PR TITLE
[Bugfix]Fix eplb enable when using mtp float weights.

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -184,8 +184,8 @@ class AscendFusedMoE(FusedMoE):
         # init moe.
         self.local_num_experts, self.expert_map, _ = determine_expert_map(
             self.ep_size, self.ep_rank, self.global_num_experts)
-        #Todo init_eplb_enable is a flag to judge whether enable eplb in drafter or not enable,
-        # this flag will be remove when eplb supporting mtp and fload weights.
+        # TODO: Temporary flag to indicate if static EPLB is enabled. This is a
+        # workaround to bypass a quantization check that fails with float weights.
         init_eplb_enable = False
         # static eplb initializing with expert_map_path
         if self.expert_map_path and os.path.exists(


### PR DESCRIPTION
### What this PR does / why we need it?
Fix eplb enable when using mtp float weights. It will be remove when eplb supporting mtp and float weights.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
Deepseek-V3 + MTP + EPLB in A3.
![Uploading image.png…]()


- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
