### PR TITLE
[CI] Skip test_ngram_correctness as the oom issue block CI

### DIFF
--- a/tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
@@ -61,6 +61,7 @@ def eagle3_model_name():
     return "vllm-ascend/EAGLE3-LLaMA3.1-Instruct-8B"
 
 
+@pytest.mark.skip("TODO: Revert me after ngram oom issue on ci is fixed")
 def test_ngram_correctness(
     test_prompts: list[list[dict[str, Any]]],
     sampling_config: SamplingParams,


### PR DESCRIPTION
### What this PR does / why we need it?
Skip test_ngram_correctness as the oom issue block CI
related CI failure: https://github.com/vllm-project/vllm-ascend/actions/runs/19780591780/job/56680823606

### Does this PR introduce _any_ user-facing change?
N/A

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
