### PR TITLE
[Feat] Enable EPLB to support MTP layers

### DIFF
--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -28,19 +28,23 @@ from vllm_ascend.eplb.adaptor.abstract_adaptor import EplbAdaptor
 
 class VllmEplbAdaptor(EplbAdaptor):
 
-    def __init__(self, model, **args):
+    def __init__(self, model, mtp_instance=None, num_mtp_layers=0, **args):
         super().__init__(**args)
         self.model = model
         self.rank_id = dist.get_rank()
         self.world_size = dist.get_world_size()
         self.param_dict = dict(self.model.named_parameters())
+        self.mtp_instance = mtp_instance
+        if self.mtp_instance is not None:
+            self.mtp_param_dict = dict(self.mtp_instance.named_parameters())
+        self.num_mtp_layers = num_mtp_layers
         if self.model.config.model_type == "qwen3_moe":
             self.num_dense_layers = 0
             self.global_expert_num = self.model.config.num_experts
         else:
             self.num_dense_layers = self.model.config.first_k_dense_replace
             self.global_expert_num = self.model.config.n_routed_experts
-        self.num_moe_layers = self.model.config.num_hidden_layers - self.num_dense_layers
+        self.num_moe_layers = self.model.config.num_hidden_layers - self.num_dense_layers  # MTP not included
         self.init_redundancy_expert = get_ascend_config(
         ).init_redundancy_expert
 
@@ -54,7 +58,20 @@ class VllmEplbAdaptor(EplbAdaptor):
                 self.model.model.layers[i].mlp.experts.w13_weight_scale_fp32_list
             self.param_dict["model.layers." + str(i) + ".mlp.experts." + "w2_weight_scale_list"] = \
                 self.model.model.layers[i].mlp.experts.w2_weight_scale_list
-        # TODO: init self.expert_weight_names depending on different model types, only deepseek v3 w8a8 and qwen3-moe is supported here
+
+        if self.mtp_instance is not None:
+            for i in range(self.num_mtp_layers):
+                layer_idx = self.num_dense_layers + self.num_moe_layers + i
+                                                
+                self.mtp_param_dict["model.layers." + str(layer_idx) + ".mtp_block.mlp.experts." + "w13_weight_list"] = \
+                    self.mtp_instance.model.layers[str(layer_idx)].mtp_block.mlp.experts.w13_weight_list
+                self.mtp_param_dict["model.layers." + str(layer_idx) + ".mtp_block.mlp.experts." + "w2_weight_list"] = \
+                    self.mtp_instance.model.layers[str(layer_idx)].mtp_block.mlp.experts.w2_weight_list
+                self.mtp_param_dict["model.layers." + str(layer_idx) + ".mtp_block.mlp.experts." + "w13_weight_scale_fp32_list"] = \
+                    self.mtp_instance.model.layers[str(layer_idx)].mtp_block.mlp.experts.w13_weight_scale_fp32_list
+                self.mtp_param_dict["model.layers." + str(layer_idx) + ".mtp_block.mlp.experts." + "w2_weight_scale_list"] = \
+                    self.mtp_instance.model.layers[str(layer_idx)].mtp_block.mlp.experts.w2_weight_scale_list
+
         if self.model.quant_config is not None:
             self.expert_weight_names = [
                 "w13_weight_list", "w2_weight_list",
@@ -64,6 +81,20 @@ class VllmEplbAdaptor(EplbAdaptor):
         else:
             self.expert_weight_names = ["w13_weight", "w2_weight"]
 
+        # TODO: init self.expert_weight_names depending on different model types, only deepseek v3 w8a8 and qwen3-moe is supported here
+        if self.mtp_instance is not None:
+            if any("w13_weight_offset" in name
+                   for name, _ in self.mtp_instance.named_parameters()):
+                self.mtp_expert_weight_names = [
+                    "w13_weight_list", "w2_weight_list",
+                    "w13_weight_scale_fp32_list", "w13_weight_offset",
+                    "w2_weight_scale_list", "w2_weight_offset"
+                ]
+            else:
+                self.mtp_expert_weight_names = ["w13_weight", "w2_weight"]
+        else:
+            self.mtp_expert_weight_names = []
+
         self.expert_map_per_layer = dict(
         )  # reference to expert map on device for expert map update
         self.expert_map_per_layer_cpu = dict(
@@ -71,6 +102,12 @@ class VllmEplbAdaptor(EplbAdaptor):
         for layer_idx in range(self.num_moe_layers):
             self.expert_map_per_layer[self.num_dense_layers + layer_idx] = \
                 self.model.get_expert_map(self.num_dense_layers + layer_idx)
+
+        # Currently, MTP only support one layer.
+        if self.mtp_instance is not None:
+            for mtp_layer_idx in range(self.num_mtp_layers):
+                self.expert_map_per_layer[self.num_dense_layers + self.num_moe_layers + mtp_layer_idx] = \
+                    self.mtp_instance.model.get_expert_map(self.num_dense_layers + self.num_moe_layers + mtp_layer_idx)
 
         # TODO: here we set number of buffer tensor equal to number of expert in each laryer, which can be improved
         num_buffer_tensor = torch.where(
@@ -87,6 +124,11 @@ class VllmEplbAdaptor(EplbAdaptor):
         for layer_idx in range(self.num_moe_layers):
             self.log2phy_map_per_layer[self.num_dense_layers + layer_idx] = \
                 self.model.get_log2phy_map(self.num_dense_layers + layer_idx)
+
+        if self.mtp_instance is not None:
+            for mtp_layer_idx in range(self.num_mtp_layers):
+                self.log2phy_map_per_layer[self.num_dense_layers + self.num_moe_layers + mtp_layer_idx] = \
+                    self.mtp_instance.model.get_log2phy_map(self.num_dense_layers + self.num_moe_layers + mtp_layer_idx)
 
         self.all_topk_ids = []
 
@@ -131,12 +173,51 @@ class VllmEplbAdaptor(EplbAdaptor):
                                             name][0].data[local_expert_id])
                 self.expert_param_per_layer[layer_idx].append(per_expert_param)
 
+        if self.mtp_instance is not None:
+            for mtp_layer_id in range(self.num_mtp_layers):
+                layer_idx = self.num_dense_layers + self.num_moe_layers + mtp_layer_id
+                self.expert_param_per_layer[layer_idx] = list()
+                for local_expert_id in range(num_local_expert):
+                    per_expert_param = list()
+                    for name in self.mtp_expert_weight_names:
+                        if name in [
+                                "w13_weight_list", "w2_weight_list",
+                                "w13_weight_scale_fp32_list",
+                                "w2_weight_scale_list"
+                        ]:
+                            per_expert_param.append(
+                                self.mtp_param_dict["model.layers." +
+                                                    str(layer_idx) +
+                                                    ".mtp_block.mlp.experts." +
+                                                    name][local_expert_id])
+                        else:
+                            per_expert_param.append(self.mtp_param_dict[
+                                "model.layers." + str(layer_idx) +
+                                ".mtp_block.mlp.experts." +
+                                name][0].data[local_expert_id])
+                    self.expert_param_per_layer[layer_idx].append(
+                        per_expert_param)
+
     def get_rank_expert_workload(self) -> torch.Tensor:
         self.moe_load = self.model.get_all_moe_loads()
+        if self.mtp_instance is not None:
+            self.moe_load = torch.cat([
+                self.moe_load,
+                self.mtp_instance.model.get_all_moe_loads().to(
+                    device=self.moe_load.device)
+            ],
+                                      dim=0)
         return self.moe_load
 
     def get_init_expert_map(self, num_moe_layers):
         expert_map = self.model.get_all_expert_map(num_moe_layers)
+        if self.mtp_instance is not None:
+            expert_map = torch.cat([
+                expert_map,
+                self.mtp_instance.model.get_all_expert_map().to(
+                    device=expert_map.device)
+            ],
+                                   dim=0)
         if dist.is_initialized():
             world_size = dist.get_world_size()
 
@@ -288,7 +369,9 @@ class VllmEplbAdaptor(EplbAdaptor):
         local_num_experts = self.global_expert_num // self.world_size
 
         expert_map_all = torch.full(
-            (self.num_moe_layers, self.world_size, self.global_expert_num),
+            (self.num_moe_layers if self.mtp_instance is None else
+             (self.num_moe_layers + self.num_mtp_layers), self.world_size,
+             self.global_expert_num),
             -1,
             dtype=torch.int32)
 
@@ -311,6 +394,7 @@ class VllmEplbAdaptor(EplbAdaptor):
 
             local_ids = torch.arange(local_count, dtype=torch.int32)
             expert_map_all[:, r, start:end] = local_ids.unsqueeze(0).expand(
-                self.num_moe_layers, -1)
+                self.num_moe_layers if self.mtp_instance is None else
+                (self.num_moe_layers + self.num_mtp_layers), -1)
 
         return expert_map_all

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -38,9 +38,11 @@ class EplbUpdator:
         self.shared_dict = self.eplb_process.shared_dict
         self.moe_imbalance_dict: dict[int, float] = {}
 
-    def set_adaptor(self, adaptor):
+    def set_adaptor(self, adaptor, num_mtp_layers):
         self.adaptor = adaptor
-        self.num_moe_layers = self.adaptor.num_moe_layers
+        self.num_moe_layers = (self.adaptor.num_moe_layers
+                               if self.adaptor.mtp_instance is None else
+                               self.adaptor.num_moe_layers + num_mtp_layers)
         self.global_expert_num = self.adaptor.global_expert_num
 
     def init_eplb(self, expert_map_path, process):
@@ -87,6 +89,8 @@ class EplbUpdator:
                     self.expert_map_record_path)
 
             self.adaptor.model.clear_all_moe_loads()
+            if self.adaptor.mtp_instance is not None:
+                self.adaptor.mtp_instance.model.clear_all_moe_loads()
             if not self.gate_eplb:
                 self.cur_iterations = 0
 

--- a/vllm_ascend/eplb/utils.py
+++ b/vllm_ascend/eplb/utils.py
@@ -18,48 +18,78 @@
 import types
 
 import torch
+
 import torch_npu
 
 _MOE_LOAD_ASYNC_STREAM = None
 
+from vllm.model_executor.models.deepseek_mtp import DeepSeekMultiTokenPredictor
+
 
 def get_expert_map(self, layer_id):
-    return self.model.layers[layer_id].mlp.experts.get_map()
+    if not isinstance(self, DeepSeekMultiTokenPredictor):
+        return self.model.layers[layer_id].mlp.experts.get_map()
+    else:
+        return self.layers[str(layer_id)].mtp_block.mlp.experts.get_map()
 
 
 def get_log2phy_map(self, layer_id):
-    return self.model.layers[layer_id].mlp.experts.get_log2phy_map()
+    if not isinstance(self, DeepSeekMultiTokenPredictor):
+        return self.model.layers[layer_id].mlp.experts.get_log2phy_map()
+    else:
+        return self.layers[str(
+            layer_id)].mtp_block.mlp.experts.get_log2phy_map()
 
 
-def get_all_expert_map(self, num_moe_layers):
-    all_loads = []
-    num_dense_layers = self.num_dense_layers if hasattr(
-        self, "num_dense_layers") else 0
-    for layer_id in range(num_moe_layers):
-        load_tensor = self.get_expert_map(
-            layer_id + num_dense_layers)  # (num_experts_per_layer,)
-        all_loads.append(load_tensor)
+def get_all_expert_map(self, num_moe_layers=None):
+    if not isinstance(self, DeepSeekMultiTokenPredictor):
+        all_loads = []
+        num_dense_layers = self.num_dense_layers if hasattr(
+            self, "num_dense_layers") else 0
+        for layer_id in range(num_moe_layers):
+            load_tensor = self.get_expert_map(
+                layer_id + num_dense_layers)  # (num_experts_per_layer,)
+            all_loads.append(load_tensor)
+    else:
+        all_loads = []
+        for layer_id in range(self.mtp_start_layer_idx,
+                              self.mtp_start_layer_idx + self.num_mtp_layers):
+            load_tensor = self.get_expert_map(layer_id)
+            all_loads.append(load_tensor)
 
     return torch.stack(all_loads, dim=0)
 
 
 def get_all_moe_loads(self):
-    num_dense_layers = self.num_dense_layers if hasattr(
-        self, "num_dense_layers") else 0
-    all_moe_loads = torch.stack(
-        [self.model.layers[layer_id + num_dense_layers].mlp.experts.moe_load \
-            for layer_id in range(self.num_moe_layers)],
-        dim=0
-    )
+    if not isinstance(self, DeepSeekMultiTokenPredictor):
+        num_dense_layers = self.num_dense_layers if hasattr(
+            self, "num_dense_layers") else 0
+        all_moe_loads = torch.stack(
+            [self.model.layers[layer_id + num_dense_layers].mlp.experts.moe_load \
+                for layer_id in range(self.num_moe_layers)],
+            dim=0
+        )
+    else:
+        all_moe_loads = torch.stack(
+            [self.layers[str(idx)].mtp_block.mlp.experts.moe_load \
+                for idx in range(self.mtp_start_layer_idx,
+                                    self.mtp_start_layer_idx + self.num_mtp_layers)],
+            dim=0
+        )
     return all_moe_loads
 
 
 def clear_all_moe_loads(self):
-    num_dense_layers = self.num_dense_layers if hasattr(
-        self, "num_dense_layers") else 0
-    for layer_id in range(self.num_moe_layers):
-        self.model.layers[layer_id +
-                          num_dense_layers].mlp.experts.clear_moe_load()
+    if not isinstance(self, DeepSeekMultiTokenPredictor):
+        num_dense_layers = self.num_dense_layers if hasattr(
+            self, "num_dense_layers") else 0
+        for layer_id in range(self.num_moe_layers):
+            self.model.layers[layer_id +
+                              num_dense_layers].mlp.experts.clear_moe_load()
+    else:
+        for layer_id in range(self.mtp_start_layer_idx,
+                              self.mtp_start_layer_idx + self.num_mtp_layers):
+            self.layers[str(layer_id)].mtp_block.mlp.experts.clear_moe_load()
 
 
 def model_register(model, model_config):
@@ -69,7 +99,9 @@ def model_register(model, model_config):
     model.get_all_moe_loads = types.MethodType(get_all_moe_loads, model)
     model.clear_all_moe_loads = types.MethodType(clear_all_moe_loads, model)
 
-    config = model_config.hf_config
+    if not isinstance(model, DeepSeekMultiTokenPredictor):
+        config = model_config.hf_config
+
 
     if config.model_type == "qwen3_moe":
         model.num_moe_layers = config.num_hidden_layers
@@ -87,3 +119,4 @@ def moe_load_async_stream() -> torch_npu.npu.Stream:
         # we return the default stream.
         _MOE_LOAD_ASYNC_STREAM = torch_npu.npu.Stream()
     return _MOE_LOAD_ASYNC_STREAM
+

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -61,6 +61,7 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.mamba.abstract import MambaBase
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
 from vllm.model_executor.model_loader import get_model
+from vllm.model_executor.models.deepseek_mtp import DeepSeekMTP
 from vllm.model_executor.models.interfaces import (SupportsMultiModal,
                                                    supports_mrope,
                                                    supports_transcription)
@@ -299,6 +300,7 @@ class NPUModelRunner(LoRAModelRunnerMixin, ECConnectorModelRunnerMixin):
                                       'decode_max_num_seqs', 0)
         self.max_num_reqs = max(self.scheduler_config.max_num_seqs,
                                 decode_max_num_seqs)
+        self.mtp_instance = None
         if self.pcp_size > 1:
             self.model_config.max_model_len += 2 * self.pcp_size * self.max_num_reqs
         self.max_num_blocks_per_req = cdiv(self.model_config.max_model_len,
@@ -3147,6 +3149,8 @@ class NPUModelRunner(LoRAModelRunnerMixin, ECConnectorModelRunnerMixin):
                     dummy_compute_logits=dummy_drafter_compute_logits)
             if self.in_profile_run and self.dynamic_eplb:
                 self.model.clear_all_moe_loads()
+                if self.mtp_instance is not None:
+                    self.drafter.model.model.clear_all_moe_loads()
             if not self.in_profile_run and self.dynamic_eplb:
                 self.eplb_updator.take_update_info_from_eplb_process()
                 self.eplb_updator.forward_end()
@@ -3269,9 +3273,16 @@ class NPUModelRunner(LoRAModelRunnerMixin, ECConnectorModelRunnerMixin):
     def eplb_warmup(self):
         if self.dynamic_eplb and not self.is_eplb_warmuped:
             self.is_eplb_warmuped = True
-            self.eplb_adaptor = VllmEplbAdaptor(model=self.model)
+            mtp_instance = self.mtp_instance
+            if mtp_instance is not None:
+                num_mtp_layers = mtp_instance.model.num_mtp_layers
+            else:
+                num_mtp_layers = 0
+            self.eplb_adaptor = VllmEplbAdaptor(model=self.model,
+                                                mtp_instance=mtp_instance,
+                                                num_mtp_layers=num_mtp_layers)
             self.eplb_loader.set_adator(self.eplb_adaptor)
-            self.eplb_updator.set_adaptor(self.eplb_adaptor)
+            self.eplb_updator.set_adaptor(self.eplb_adaptor, num_mtp_layers)
             self.eplb_updator.warm_up_eplb()
 
     def load_model(self) -> None:
@@ -3294,6 +3305,18 @@ class NPUModelRunner(LoRAModelRunnerMixin, ECConnectorModelRunnerMixin):
             if self.drafter:
                 logger.info("Loading drafter model...")
                 self.drafter.load_model(self.model)
+                if self.speculative_config and self.speculative_config.method == 'mtp':
+                    assert isinstance(self.drafter, MtpProposer), \
+                        f"drafter type wrong: {type(self.drafter)}"
+                    assert isinstance(self.drafter.model, (DeepSeekMTP, ACLGraphWrapper)), \
+                        f"drafter type wrong: {type(self.drafter)}, only support DeepSeekMTP or ACLGraphWrapper"
+                    if isinstance(self.drafter.model, DeepSeekMTP):
+                        mtp_instance = self.drafter.model
+                    elif isinstance(self.drafter.model, ACLGraphWrapper):
+                        mtp_instance = self.drafter.model.unwrap()
+                    self.mtp_instance = mtp_instance
+                    model_register(mtp_instance.model, self.vllm_config)
+
                 if self.drafter.name == SpecDcodeType.EAGLE3:
                     self.model.set_aux_hidden_state_layers(
                         self.model.get_eagle3_aux_hidden_state_layers())


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enhances EPLB to support one or multiple MTP layers. Previously, EPLB only supported the main model. Now, it can handle num_speculative_tokens=1 or num_speculative_tokens > 1.
### Does this PR introduce _any_ user-facing change?
No, this PR does not introduce any user-facing changes.
### How was this patch tested?

Co-authored-by:  Skywalker-EP 173723846@qq.com, pop1120138272@icloud.com, dsxsteven@sina.com

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
