### PR TITLE
[Bugfix] PCP adaptation for VLLM v0.11.2 modifications

### DIFF
--- a/vllm_ascend/distributed/kvpool/pool_scheduler.py
+++ b/vllm_ascend/distributed/kvpool/pool_scheduler.py
@@ -33,8 +33,6 @@ class KVPoolScheduler:
                                 "prefill_context_parallel_size", 1)
         self.dcp_size = getattr(vllm_config.parallel_config,
                                 "decode_context_parallel_size", 1)
-        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
-        self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
 
         self._block_size = vllm_config.cache_config.block_size
         if self.pcp_size > 1:


### PR DESCRIPTION
To adapt to the vLLM v0.11.2 image, the method for obtaining PCP size and DCP size has been modified.
___
- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
