### PR TITLE
opti profiler default param

### DIFF
--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -520,7 +520,7 @@ class TestNPUWorker(TestBase):
         # Set enum mocks
         mock_export_type.Text = "Text"
         mock_profiler_level.Level1 = "Level1"
-        mock_aic_metrics.AiCoreNone = "AiCoreNone"
+        mock_aic_metrics.PipeUtilization = "PipeUtilization"
         mock_profiler_activity.CPU = "CPU"
         mock_profiler_activity.NPU = "NPU"
 
@@ -554,7 +554,7 @@ class TestNPUWorker(TestBase):
                 "export_type": "Text",
                 "profiler_level": "Level1",
                 "msprof_tx": False,
-                "aic_metrics": "AiCoreNone",
+                "aic_metrics": "PipeUtilization",
                 "l2_cache": False,
                 "op_attr": False,
                 "data_simplification": False,

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -176,6 +176,20 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB":
     lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
+    # Set torch_npu profiler to profile aicore metrics. There are the following options that can be configured:
+    # 0: torch_npu.profiler.AiCMetrics.AiCoreNone;
+    # 1: torch_npu.profiler.AiCMetrics.PipeUtilization;
+    # 2: torch_npu.profiler.AiCMetrics.ArithmeticUtilization;
+    # 3: torch_npu.profiler.AiCMetrics.Memory;
+    # 4: torch_npu.profiler.AiCMetrics.MemoryL0;
+    # 5: torch_npu.profiler.AiCMetrics.ResourceConflictRatio;
+    # 6: torch_npu.profiler.AiCMetrics.MemoryUB;
+    # 7: torch_npu.profiler.AiCMetrics.L2Cache;
+    # 8: torch_npu.profiler.AiCMetrics.MemoryAccess;
+    # If not set, it will be torch_npu.profiler.AiCMetrics.PipeUtilization by default.
+    # The meanings of various options can refer to: https://www.hiascend.com/document/detail/zh/Pytorch/720/apiref/torchnpuCustomsapi/context/torch_npu-profiler-AiCMetrics.md
+    "VLLM_ASCEND_PROFILER_AIC_METRICS":
+    lambda: int(os.getenv("VLLM_ASCEND_PROFILER_AIC_METRICS", 1)),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -432,11 +432,24 @@ class NPUWorker(WorkerBase):
             logger.info("Profiling enabled. Traces will be saved to: %s",
                         torch_profiler_trace_dir)
 
+            aic_metrics_list = [
+                torch_npu.profiler.AiCMetrics.AiCoreNone,
+                torch_npu.profiler.AiCMetrics.PipeUtilization,
+                torch_npu.profiler.AiCMetrics.ArithmeticUtilization,
+                torch_npu.profiler.AiCMetrics.Memory,
+                torch_npu.profiler.AiCMetrics.MemoryL0,
+                torch_npu.profiler.AiCMetrics.ResourceConflictRatio,
+                torch_npu.profiler.AiCMetrics.MemoryUB,
+                torch_npu.profiler.AiCMetrics.L2Cache,
+                torch_npu.profiler.AiCMetrics.MemoryAccess
+            ]
+
             experimental_config = torch_npu.profiler._ExperimentalConfig(
                 export_type=torch_npu.profiler.ExportType.Text,
                 profiler_level=torch_npu.profiler.ProfilerLevel.Level1,
                 msprof_tx=False,
-                aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+                aic_metrics=aic_metrics_list[
+                    envs_ascend.VLLM_ASCEND_PROFILER_AIC_METRICS],
                 l2_cache=False,
                 op_attr=False,
                 data_simplification=False,


### PR DESCRIPTION
### What this PR does / why we need it?

Set profiler's param `aic_metrics` to `torch_npu.profiler.AiCMetrics.PipeUtilization` by default.

This parameter can obtain more information for op.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.12.0
