### PR TITLE
[Misc] Remove transformers version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ requires = [
     "psutil",
     "setuptools>=64",
     "setuptools-scm>=8",
-    "transformers<=4.57.1",
     "torch-npu==2.8.0",
     "torch==2.8.0",
     "torchvision",

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,3 @@ numba
 #--pre
 #--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 torch-npu==2.8.0
-
-transformers<=4.57.1


### PR DESCRIPTION
### What this PR does / why we need it?
Do not limit transformers version any more, follow what vllm use instead, see https://github.com/vllm-project/vllm/pull/29841
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
