### PR TITLE
Async transfer tensor for long sequences

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -378,7 +378,7 @@ class AscendAttentionMetadataBuilder:
                 if self.chunked_prefill_enabled and max_context_len_cpu > 0:
                     local_context_lens_allranks = torch.tensor(
                         num_computed_tokens_of_pcp_dcp
-                    )[num_decodes:num_reqs].to(
+                    )[num_decodes:num_reqs].pin_memory().to(
                         self.device).to(dtype=torch.int32)
                     local_chunked_kv_lens_rank = local_context_lens_allranks[:,
                                                                              self
@@ -405,9 +405,9 @@ class AscendAttentionMetadataBuilder:
                                                     self.dcp_rank] == 0)
                     batch_chunk_seq_mask = torch.repeat_interleave(
                         batch_chunk_seq_mask,
-                        repeats=(query_lens * self.pcp_size).to(self.device))
+                        repeats=(query_lens * self.pcp_size).pin_memory().to(self.device))
                     chunk_seq_mask_filtered_indices = filter_chunked_req_indices(
-                        query_lens, chunked_req_mask).to(self.device)
+                        query_lens, chunked_req_mask).pin_memory().to(self.device)
                     chunked_context_metadata = \
                         AscendMetadataForPrefill.ChunkedContextMetadata(
                             actual_chunk_seq_lengths=torch.cumsum(query_lens * pcp_size, dim=0),

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -568,8 +568,8 @@ class AscendMLAMetadataBuilder:
                     )
                     chunked_context_metadata = \
                     AscendMLAPrefillMetadata.ChunkedContextMetadata(
-                        cu_seq_lens=cu_seq_lens_cpu.to(device, non_blocking=True),
-                        starts=local_chunk_starts.to(device, non_blocking=True),
+                        cu_seq_lens=cu_seq_lens_cpu.pin_memory().to(device, non_blocking=True),
+                        starts=local_chunk_starts.pin_memory().to(device, non_blocking=True),
                         seq_tot=padded_local_chunk_seq_lens.sum(dim=1).tolist(),
                         max_seq_lens=chunk_seq_lens.max(dim=1).values.tolist(),
                         chunk_seq_lens=chunk_seq_lens,
@@ -578,7 +578,7 @@ class AscendMLAMetadataBuilder:
                         padded_chunk_seq_lens_npu=padded_local_chunk_seq_lens.npu(),
                         padded_local_chunk_seq_lens=padded_local_chunk_seq_lens.tolist(),
                         local_context_lens_allranks=local_context_lens_allranks.tolist(),
-                        padded_local_cu_seq_lens=padded_local_cu_chunk_seq_lens_cpu.to(
+                        padded_local_cu_seq_lens=padded_local_cu_chunk_seq_lens_cpu.pin_memory().to(
                             device, non_blocking=True
                         ),
                         cu_seq_lens_lst=cu_seq_lens_cpu.tolist(),
@@ -587,8 +587,8 @@ class AscendMLAMetadataBuilder:
                 else:
                     chunked_context_metadata = \
                         AscendMLAPrefillMetadata.ChunkedContextMetadata(
-                        cu_seq_lens=cu_seq_lens_cpu.to(device, non_blocking=True),
-                        starts=chunk_starts.to(device, non_blocking=True),
+                        cu_seq_lens=cu_seq_lens_cpu.pin_memory().to(device, non_blocking=True),
+                        starts=chunk_starts.pin_memory().to(device, non_blocking=True),
                         seq_tot=chunk_seq_lens.sum(dim=1).tolist(),
                         max_seq_lens=chunk_seq_lens.max(dim=1).values.tolist(),
                         chunk_seq_lens=chunk_seq_lens,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1356,7 +1356,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
 
         cp_kv_recover_idx_for_chunk = torch.from_numpy(
             np.concatenate(
-                self.cp_kv_recover_idx_for_chunk)).to(device=self.device)
+                self.cp_kv_recover_idx_for_chunk)).pin_memory().to(device=self.device)
         cp_kv_recover_idx_for_chunk.copy_(torch.tensor(
             np.array(self.cp_kv_recover_idx_for_chunk).flatten().tolist()),
                                           non_blocking=True)
@@ -2016,7 +2016,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                 cu_num_scheduled_tokens - num_sampled_tokens,
                 num_sampled_tokens)
             logits_indices_pcp += arange
-            logits_indices_pcp = torch.from_numpy(logits_indices_pcp).to(
+            logits_indices_pcp = torch.from_numpy(logits_indices_pcp).pin_memory().to(
                 self.device, non_blocking=True)
 
         # Compute the bonus logits indices.


### PR DESCRIPTION
### What this PR does / why we need it?
To adapt async scheduling of long sequences, tensor transmission from CPU to NPU is changed to async transmission.
The modification is as follows: tensor_cpu.to(device)->tensor_cpu.pin_memory().to(device)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.11.2
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.11.2
