### PR TITLE
[CI] Fix ut ci: no space on the device

### DIFF
--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -150,6 +150,7 @@ class TestAscendRMSNorm(PytestBase):
 
         assert mock_get_forward_context.call_count == 7
         assert mock_forward_context.fusion_linear == "qkv_moe"
+        assert mock_forward_context.layer_idx == 3
 
         x_out, residual_out = layer.forward_oot(x, residual)
 


### PR DESCRIPTION
### What this PR does / why we need it?
The current ut ci is encountering a disk space shortage issue, see https://github.com/vllm-project/vllm-ascend/actions/runs/19884417749/job/56990694594?pr=4168

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with new added/existing test.


- vLLM version: 86e178f7c4d8c3b0eaf3c8e3f810a83f63b90e24
- vLLM main: https://github.com/vllm-project/vllm/commit/86e178f7c4d8c3b0eaf3c8e3f810a83f63b90e24
