### PR TITLE
Remove cancel for main to main check

### DIFF
--- a/.github/workflows/vllm_ascend_test_full_vllm_main.yaml
+++ b/.github/workflows/vllm_ascend_test_full_vllm_main.yaml
@@ -17,7 +17,7 @@
 name: 'ascend test / vllm main'
 
 on:
-  # Run 1-card and 2-cards e2e tests per 2h
+  # Run full e2e tests per 2h
   schedule:
     - cron: '0 */2 * * *'
   workflow_dispatch:
@@ -28,12 +28,6 @@ on:
 defaults:
   run:
     shell: bash -el {0}
-
-# only cancel in-progress runs of the same workflow
-# and ignore the lint / 1 card / 4 cards test type
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   e2e-test:


### PR DESCRIPTION
### What this PR does / why we need it?
Remove cancel for main to main check. Another choice we set timeout to 4h but I think 2h to get results is more important.

Related:
https://github.com/vllm-project/vllm-ascend/actions/workflows/vllm_ascend_test_full_vllm_main.yaml

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Can be merged directly if lint passed
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.12.0
