### PR TITLE
fix: add missing is_encoder_decoder arg

### DIFF
--- a/tests/ut/core/test_schedule_config.py
+++ b/tests/ut/core/test_schedule_config.py
@@ -27,6 +27,7 @@ class TestAscendSchedulerConfig(TestBase):
             max_model_len=8192,
             is_multimodal_model=False,
             send_delta_data=False,
+            is_encoder_decoder=False,
         )
 
     def test_initialize_from_config_with_default(self):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a `pydantic.ValidationError` in the unit tests caused by recent changes in the upstream vLLM project.

Upstream vLLM PR [#29859](https://github.com/vllm-project/vllm/pull/29859) removed the default value for `is_encoder_decoder` in `SchedulerConfig`, making it a required argument during initialization. As a result, the existing unit test `tests/ut/core/test_schedule_config.py` was failing.

- Explicitly set `is_encoder_decoder=False` when initializing `SchedulerConfig` in `tests/ut/core/test_schedule_config.py` to match the updated upstream class definition.
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.12.0
