### PR TITLE
[Feat] Eagle adapt vllm's speculative_config.enforce_eager

### DIFF
--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -31,6 +31,7 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 4096
         self.vllm_config.compilation_config.mode = CompilationMode.VLLM_COMPILE
         self.vllm_config.model_config.enforce_eager = False
+        self.vllm_config.speculative_config.enforce_eager = False
 
         proposer = EagleProposer(vllm_config=self.vllm_config,
                                  device=self.device,


### PR DESCRIPTION
### What this PR does / why we need it?
There is a new command "enforce_eager" in vllm's SpeculativeConfig. When it open, spec model should only run in eager mode and no impact the main model. This PR will let the eagle in vllm-ascend can use this command.
You can see this command in vllm/vllm/config/speculative.py

### Does this PR introduce _any_ user-facing change?
If you want to make eagle model always run in eager mode, you should add the '"enforce_eager": true' command when you set the speculative_config in your start sever command.
For example:
"""
vllm server /weights/Qwen3 \
    --speculative-config '{"enforce_eager": true, "method": "eagle3", "model": "/weights/Eagle-Qwen3", "num_speculative_tpkens": 1}'
"""

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
