### PR TITLE
[Fix] fix llava-1.5-7b-hf & Qwen2-Audio-7B-Instruct accuracy test

### DIFF
--- a/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
@@ -9,3 +9,4 @@ tasks:
     value: 0.45
 num_fewshot: 5
 gpu_memory_utilization: 0.8
+enforce_eager: True

--- a/tests/e2e/models/configs/llava-1.5-7b-hf.yaml
+++ b/tests/e2e/models/configs/llava-1.5-7b-hf.yaml
@@ -9,3 +9,4 @@ tasks:
 trust_remote_code: True
 gpu_memory_utilization: 0.8
 dtype: "bfloat16"
+enforce_eager: True


### PR DESCRIPTION
### What this PR does / why we need it?
 llava-1.5-7b-hf & Qwen2-Audio-7B-Instruct accuracy test by eager mode due to https://github.com/vllm-project/vllm-ascend/issues/4107

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
 llava-1.5-7b-hf & Qwen2-Audio-7B-Instruct accuracy test ok by eager mode :
<img width="2155" height="446" alt="image" src="https://github.com/user-attachments/assets/ad1109f3-a8e5-4037-ac1e-24f4e2c3f3df" />
<img width="2287" height="502" alt="image" src="https://github.com/user-attachments/assets/be4c2d49-aab3-43f0-80fd-c5d113ddeb39" />


- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
