### PR TITLE
[Perf] Update causal conv1d fn for better perf

### DIFF
--- a/vllm_ascend/ops/triton/mamba/casual_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/casual_conv1d.py
@@ -50,8 +50,7 @@ def causal_conv1d_fn_native(
     out = out[..., :seqlen]
     if return_final_states:
         final_states = F.pad(x, (width - 1 - x.shape[-1], 0)).to(
-            dtype_in
-        )  # (batch, dim, width - 1)
+            dtype_in)  # (batch, dim, width - 1)
         if final_states_out is not None:
             final_states_out.copy_(final_states)
         else:
@@ -115,13 +114,9 @@ def causal_conv1d_fn(
             activation=activation,
             return_final_states=True,
             final_states_out=conv_states[cache_indices[0]].unsqueeze(0),
-            initial_states=(
-                conv_states[cache_indices[0]].unsqueeze(0)
-                if has_initial_state[0]
-                else None
-            ),
-        )
-    )
+            initial_states=(conv_states[cache_indices[0]].unsqueeze(0)
+                if has_initial_state[0] else None),
+        ))
 
     out_ref.append(torch.cat([t[0] for t in out_ref_b], dim=-1))
     out_ref_tensor = torch.cat(out_ref, dim=0)


### PR DESCRIPTION
### What this PR does / why we need it?
Update the causal_conv1d_fn for better perf. For details, get seqlens from input x.shape rather than query_start_loc to remove tolist operation for less duration time.

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
