### PR TITLE
[Misc] Fix enable_sequence_parallelism in PassConfig

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -752,9 +752,10 @@ def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
         if vllm_config is None:
             from vllm.config import get_current_vllm_config
             vllm_config = get_current_vllm_config()
+        vllm_enable_sp = vllm_config.compilation_config.pass_config.enable_sequence_parallelism if vllm_version_is(
+            "0.12.0") else vllm_config.compilation_config.pass_config.enable_sp
         _ENABLE_SP = (
-            vllm_config.compilation_config.pass_config.enable_sp
-            or envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
+            vllm_enable_sp or envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
             # Flash comm 1 should be enabled by env VLLM_ASCEND_ENABLE_FLASHCOMM1
             # We retain the env VLLM_ASCEND_ENABLE_FLASHCOMM here for backward compatibility.
             or bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM", '0'))))


### PR DESCRIPTION
### What this PR does / why we need it?
Fix enable_sequence_parallelism in PassConfig
after https://github.com/vllm-project/vllm/pull/29646, `PassConfig.enable_sequence_parallelism` is renamed to `PassConfig.enable_sp`, but it dosen't be included in vLLM v0.12.0, we need to make compatibility for it

### How was this patch tested?
CI passed with existing test.
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
