### PR TITLE
local_buffer_size support for units: GB, MB, KB, B

### DIFF
--- a/vllm_ascend/distributed/kvpool/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kvpool/backend/mooncake_backend.py
@@ -94,7 +94,7 @@ class MooncakeStoreConfig:
             global_segment_size=_parse_global_segment_size(
                 config.get("global_segment_size",
                            DEFAULT_GLOBAL_SEGMENT_SIZE)),
-            local_buffer_size=(config.get("local_buffer_size",
+            local_buffer_size=_parse_global_segment_size(config.get("local_buffer_size",
                                           DEFAULT_LOCAL_BUFFER_SIZE)),
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),


### PR DESCRIPTION
### What this PR does / why we need it?
Improve usability，local_buffer_size support for units: GB, MB, KB, B, For example, "20 GB"

### Does this PR introduce _any_ user-facing change?
local_buffer_size support for units: GB, MB, KB, B

### How was this patch tested?
Mooncake configures local_buffer_size as GB, MB, KB, B

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
