### PR TITLE
[bugfix] fix quant method validation bug

### DIFF
--- a/tests/ut/quantization/test_quant_config.py
+++ b/tests/ut/quantization/test_quant_config.py
@@ -66,10 +66,18 @@ class TestAscendQuantConfig(TestBase):
         mock_is_available.return_value = True
         result = AscendQuantConfig.override_quantization_method(None, None)
         self.assertIsNone(result)
+        hf_quant_cfg = {"quant_method": ""}
+        result = AscendQuantConfig.override_quantization_method(
+            hf_quant_cfg, None)
+        self.assertEqual(result, "ascend")
 
         # Test when NPU is not available
         mock_is_available.return_value = False
         result = AscendQuantConfig.override_quantization_method(None, None)
+        self.assertIsNone(result)
+        hf_quant_cfg = {"quant_method": ""}
+        result = AscendQuantConfig.override_quantization_method(
+            hf_quant_cfg, None)
         self.assertIsNone(result)
 
     def test_get_quant_method_for_linear(self):

--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -96,7 +96,7 @@ class AscendQuantConfig(QuantizationConfig):
                                      user_quant) -> Optional[str]:
         if hf_quant_cfg is not None:
             quant_method = hf_quant_cfg.get("quant_method", None)
-            if quant_method is None and torch.npu.is_available():
+            if not quant_method and torch.npu.is_available():
                 return ASCEND_QUANTIZATION_METHOD
         return None
 


### PR DESCRIPTION
### What this PR does / why we need it?
When `hf_quant_cfg` is not None and `hf_quant_cfg.quant_method == ""`, func `override_quantization_method` will return None and raise ValidationError.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
