### PR TITLE
[Test] Temporarily skips Qwen3-30B-A3B-W8A8 data parallel test case

### DIFF
--- a/tests/e2e/multicard/test_data_parallel.py
+++ b/tests/e2e/multicard/test_data_parallel.py
@@ -28,7 +28,10 @@ from unittest.mock import patch
 import pytest
 
 MODELS = [
-    "Qwen/Qwen3-0.6B", "Qwen/Qwen3-30B-A3B", "vllm-ascend/Qwen3-30B-A3B-W8A8"
+    "Qwen/Qwen3-0.6B",
+    "Qwen/Qwen3-30B-A3B",
+    # FIXME(Potabk): Skip this case for now
+    # "vllm-ascend/Qwen3-30B-A3B-W8A8"
 ]
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
This case is breaking CI, please see https://github.com/vllm-project/vllm-ascend/actions/runs/20084930558/job/57620266368?pr=4854

### Does this PR introduce _any_ user-facing change?
None.

### How was this patch tested?
None.
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
