### PR TITLE
[CI] Use offline mode for modelscope

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -25,6 +25,7 @@ jobs:
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
+        TRANSFORMERS_OFFLINE: 1
     steps:
       - name: Check npu and CANN info
         run: |
@@ -118,6 +119,7 @@ jobs:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
         HCCL_BUFFSIZE: 1024
+        TRANSFORMERS_OFFLINE: 1
     steps:
       - name: Check npu and CANN info
         run: |
@@ -214,6 +216,7 @@ jobs:
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
+        TRANSFORMERS_OFFLINE: 1
     steps:
       - name: Check npu and CANN info
         run: |


### PR DESCRIPTION
### What this PR does / why we need it?
Set the global env `TRANSFORMERS_OFFLINE: 1`, which will avoid downloading the file and return the path to the
local cached file if it exists when using modelscope's `snapshot_download` api

### Does this PR introduce _any_ user-facing change?
**Note**: for the developers: If you try to download files in the CI system for some new test cases, the default env `TRANSFORMERS_OFFLINE: 1` means  only the cached files will be accessed. If no cache file is detected, an error is raised This is useful in case your network is slow and you don’t care about having the latest version of a file. So, if you want to get some files from network, please set the env: `HF_HUB_OFFLINE` or `TRANSFORMERS_OFFLINE` as false to get the access of network

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
