### PR TITLE
[0.11.0][Bugfix] Remove the ZMQ communication setup on the D node

### DIFF
--- a/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
+++ b/vllm_ascend/distributed/mooncake/mooncake_store_connector_v1.py
@@ -208,7 +208,8 @@ class MooncakeStoreConnectorV1Scheduler:
         else:
             token_ids = torch.tensor(request.prompt_token_ids)
 
-        num_external_hit_tokens = self.client.lookup(token_ids)  # type: ignore[union-attr]
+        num_external_hit_tokens = self.client.lookup(  # type: ignore[union-attr]
+            token_ids)
 
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1


### PR DESCRIPTION
In the PD separation scenario, the D node does not need to perform get operations, and therefore does not need to create ZeroMQ (ZMQ) communication.