### PR TITLE
[CI] Cancel whl build when submitting a new commit

### DIFF
--- a/.github/workflows/release_code_and_wheel.yml
+++ b/.github/workflows/release_code_and_wheel.yml
@@ -35,6 +35,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_release_code:
     name: release code


### PR DESCRIPTION
### What this PR does / why we need it?
From a resource-saving perspective, canceling old jobs when submitting new commits can reduce github_hosted in queue
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
