### PR TITLE
[Nightly] Remove gen_ranktable logic

### DIFF
--- a/tests/e2e/nightly/multi_node/config/models/DeepSeek-R1-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/config/models/DeepSeek-R1-W8A8-EPLB.yaml
@@ -18,8 +18,6 @@ disaggregated_prefill:
   enabled: true
   prefiller_host_index: [0, 1]
   decoder_host_index: [2]
-  ranktable_gen_path: "examples/disaggregated_prefill_v1/gen_ranktable.py"
-  ranktable_path: "/tmp/ranktable.json"
 
 deployment:
   -

--- a/tests/e2e/nightly/multi_node/config/models/DeepSeek-R1-W8A8.yaml
+++ b/tests/e2e/nightly/multi_node/config/models/DeepSeek-R1-W8A8.yaml
@@ -17,8 +17,6 @@ disaggregated_prefill:
   enabled: true
   prefiller_host_index: [0, 1]
   decoder_host_index: [2]
-  ranktable_gen_path: "examples/disaggregated_prefill_v1/gen_ranktable.py"
-  ranktable_path: "/tmp/ranktable.json"
 
 deployment:
   -


### PR DESCRIPTION
### What this PR does / why we need it?
Since the `llmdatadist` has sunset, the logic gen_ranktable should also be removed
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
