### PR TITLE
[usability]Modify the default value of the protocol to ascend

### DIFF
--- a/vllm_ascend/distributed/kvpool/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kvpool/backend/mooncake_backend.py
@@ -96,7 +96,7 @@ class MooncakeStoreConfig:
                            DEFAULT_GLOBAL_SEGMENT_SIZE)),
             local_buffer_size=_parse_global_segment_size(
                 config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)),
-            protocol=config.get("protocol", "tcp"),
+            protocol=config.get("protocol", "ascend"),
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"))
 


### PR DESCRIPTION
### What this PR does / why we need it?
The recommended configuration in the document kv_pool.md is ascend. Modify the default value of the protocol to ascend，Improve usability

#### 1.Configure mooncake.json

The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path where mooncake.json is located.

```
{
    "local_hostname": "xx.xx.xx.xx",
    "metadata_server": "P2PHANDSHAKE",
    "protocol": "ascend",
    "device_name": "",
    "alloc_in_same_node": true,
    "master_server_address": "xx.xx.xx.xx:50088",
    "global_segment_size": "1GB" (1024MB/1048576KB/1073741824B/1073741824)
}
```

**local_hostname**: Configured as the IP address of the current master node.  
**metadata_server**: Configured as **P2PHANDSHAKE**.  
**protocol:** Configured for Ascend to use Mooncake's HCCL communication.  
**device_name**: ""  
**alloc_in_same_node**: Indicator for preferring local buffer allocation strategy.  
**master_server_address**: Configured with the IP and port of the master service.  
**global_segment_size**: Expands the kvcache size registered by the PD node to the master.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Mooncake does not set up a protocol to launch the pooled VLLM service; test whether the pooling function is working.

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
