### PR TITLE
[TEST]Update aisbench params for qwen2.5-vl-7b acc test

### DIFF
--- a/tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
+++ b/tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
@@ -46,6 +46,11 @@ aisbench_cases = [{
     "max_out_len": 2048,
     "batch_size": 128,
     "baseline": 82.05,
+    "temperature": 0,
+    "top_k": -1,
+    "top_p": 1,
+    "seed": "None",
+    "repetition_penalty": 1,
     "threshold": 5
 }, {
     "case_type": "performance",


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates aisbench params for qwen2.5-vl-7b acc test, we need test it daily

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the test

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
