### PR TITLE
[Fix] Fixes issues in MTP with async scheduling and ACL graph

### DIFF
--- a/vllm_ascend/spec_decode/mtp_proposer.py
+++ b/vllm_ascend/spec_decode/mtp_proposer.py
@@ -807,7 +807,7 @@ class MtpProposer(Proposer):
                         self.use_async_scheduling and attn_metadata[layer_name].decode is not None:
                         for layer_name in self.attn_layer_name:
                             actual_size = len(attn_metadata[layer_name].decode.
-                                            actual_seq_lengths_q)
+                                              actual_seq_lengths_q)
 
                             attn_metadata[layer_name].decode.seq_lens_list = \
                                 attn_metadata[layer_name].decode.seq_lens_list[:actual_size]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1019,7 +1019,7 @@ class NPUModelRunner(GPUModelRunner):
             # TODO: We should make this official ASAP. Also note that if we pad here,
             # the builders won’t need to add any extra padding.
             if self.compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL and \
-                uniform_decode and num_input_tokens <= self.aclgraph_batch_sizes[-1]:
+                uniform_decode and num_input_tokens <= self.cudagraph_batch_sizes[-1]:
                 num_reqs_padded = num_input_tokens // self.uniform_decode_query_len
                 pad_size = num_reqs_padded - num_reqs
                 if pad_size > 0:


### PR DESCRIPTION
### What this PR does / why we need it?
Corrects attention metadata size for MTP when both asynchronous scheduling and full ACL graph mode are enabled. This prevents potential size mismatches during execution.

Additionally, improves the robustness of calculating token sample indices by explicitly aligning tensor shapes.

Finally, prevents padding when the number of input tokens exceeds the maximum ACL graph batch size to avoid out-of-bounds errors.

### Does this PR introduce _any_ user-facing change?
None.

### How was this patch tested?
Need to add corresponding test case ASAP.
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
