### PR TITLE
Fix the accuracy arange change in normal scene is more than 7

### DIFF
--- a/tests/e2e/nightly/models/test_qwen3_32b_int8.py
+++ b/tests/e2e/nightly/models/test_qwen3_32b_int8.py
@@ -59,7 +59,7 @@ aisbench_cases = [{
     "max_out_len": 32768,
     "batch_size": 32,
     "baseline": 83.33,
-    "threshold": 7
+    "threshold": 11
 }, {
     "case_type": "performance",
     "dataset_path": "vllm-ascend/GSM8K-in3500-bs400",


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the case where the accuracy range varied by more than 7 in normal scenarios.

Detail error log(2025.12.10):
https://github.com/vllm-project/vllm-ascend/actions/runs/20105949068/job/57689728950

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

I test on local A2 with 2025.12.11 code 5 times, all varied in 7 range, except the above running(73.33) in 2025.12.10, so it seems at low probability vary to 10. Local running results as following:
1st：
dataset          version    metric    mode      vllm-api-general-chat
---------------  ---------  --------  ------  -----------------------
aime2024dataset  -          accuracy  gen                       83.33

2nd：
dataset          version    metric    mode      vllm-api-general-chat
---------------  ---------  --------  ------  -----------------------
aime2024dataset  -          accuracy  gen                       76.67

3rd：
dataset          version    metric    mode      vllm-api-general-chat
---------------  ---------  --------  ------  -----------------------
aime2024dataset  -          accuracy  gen                       90.00

4th：
dataset          version    metric    mode      vllm-api-general-chat
---------------  ---------  --------  ------  -----------------------
aime2024dataset  -          accuracy  gen                       86.67

5th：
dataset          version    metric    mode      vllm-api-general-chat
---------------  ---------  --------  ------  -----------------------
aime2024dataset  -          accuracy  gen                       76.67
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
