### PR TITLE
[Bugfix] Pass vllm_config to kv_connector_no_forward in NPUModelRunner

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1444,7 +1444,8 @@ class NPUModelRunner(GPUModelRunner):
                     )
                     # Return empty ModelRunnerOuptut if there's no work to do.
                     return EMPTY_MODEL_RUNNER_OUTPUT
-                return self.kv_connector_no_forward(scheduler_output)
+                return self.kv_connector_no_forward(scheduler_output,
+                                                    self.vllm_config)
 
             if self.dynamic_eplb:
                 self.eplb_updator.forward_before()


### PR DESCRIPTION
### What this PR does / why we need it?

The newest version crashes in PD separation scenarios because the function is missing the `vllm_config` parameter.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
