### PR TITLE
Revert "[Bugfix] support mtp kv transfer and pp partition by hand in kv transfer (#4892)"

### DIFF
--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -242,8 +242,7 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
             block_len=[1024, 2048],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
-            kv_caches=self.kv_caches,
-            prefill_pp_layer_partition=None)
+            kv_caches=self.kv_caches)
 
     def test_add_request(self):
         test_req = {
@@ -296,8 +295,7 @@ class TestSocketManagement(unittest.TestCase):
             block_len=[1024, 2048],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
-            kv_caches=self.kv_caches,
-            prefill_pp_layer_partition=None)
+            kv_caches=self.kv_caches)
         self.thread.remote_sockets = defaultdict(deque)
         self.thread.remote_poller = MagicMock()
 
@@ -354,8 +352,7 @@ class TestCoreFunctionality(unittest.TestCase):
             block_len=[1024, 2048],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
-            kv_caches=self.kv_caches,
-            prefill_pp_layer_partition=None)
+            kv_caches=self.kv_caches)
         self.thread.request_queue = self.mock_queue
         self.test_req = {
             "request_id": "req1",
@@ -437,8 +434,7 @@ class TestMetadataHandling(unittest.TestCase):
             block_len=[1024, 2048],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
-            kv_caches=self.kv_caches,
-            prefill_pp_layer_partition=None)
+            kv_caches=self.kv_caches)
         self.test_metadata = MooncakeAgentMetadata(
             engine_id="remote_engine",
             te_rpc_port=9090,
@@ -502,8 +498,7 @@ class TestMainThreadLoop(unittest.TestCase):
             block_len=[1024, 2048],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
-            kv_caches=self.kv_caches,
-            prefill_pp_layer_partition=None)
+            kv_caches=self.kv_caches)
         self.thread.request_queue = queue.Queue()
 
     @patch.object(KVCacheRecvingThread, '_handle_request')
@@ -540,7 +535,6 @@ class MockVllmConfig:
         self.parallel_config = MagicMock()
         self.cache_config = MagicMock()
         self.kv_transfer_config = MagicMock()
-        self.speculative_config = MagicMock()
         self.model_config.use_mla = True
         self.parallel_config.tensor_parallel_size = 2
         self.parallel_config.data_parallel_rank = 0


### PR DESCRIPTION
This reverts commit 332b547728c24a900a40c47a4eba6f5048117efc.

This break deepseek3.2 in PD case.


- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
