### PR TITLE
[Bugfix] Fix precision issues in moe_mlp (vllm-ascend main)

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -46,7 +46,7 @@ def cumsum_group_list(group_list: torch.Tensor,
         return group_list.cumsum(dim=0)
     if src_list_type == 0 and dst_list_type == 1:
         group_diff = torch.diff(group_list)
-        new_group = torch.cat([group_diff[0].unsqueeze(0), group_diff], dim=0)
+        new_group = torch.cat([group_list[0].unsqueeze(0), group_diff], dim=0)
         return new_group
     if src_list_type == 2 and dst_list_type == 0:
         experts = pad(group_list[:, 0], (1, 0))


### PR DESCRIPTION
### What this PR does / why we need it?
Use group_list[0] to replace group_diff[0] in  function "cumsum_group_list" (moe_mlp.py). 
The purpose is to modify it to the correct logic of converting cumsum to count.

### Does this PR introduce _any_ user-facing change?
No
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
