### PR TITLE
[CI] Delete deepseek3.2-exp nightly test

### DIFF
--- a/.github/workflows/nightly_test_a3.yaml
+++ b/.github/workflows/nightly_test_a3.yaml
@@ -61,9 +61,10 @@ jobs:
           - name: multi-node-qwenw8a8-2node
             config_file_path: Qwen3-235B-W8A8.yaml
             size: 2
-          - name: multi-node-dpsk3.2-exp-2node
-            config_file_path: DeepSeek-V3_2-Exp-bf16.yaml
-            size: 2
+          # TODO: Replace deepseek3.2-exp with deepseek3.2 after nightly tests pass
+          # - name: multi-node-dpsk3.2-exp-2node
+          #   config_file_path: DeepSeek-V3_2-Exp-bf16.yaml
+          #   size: 2
           - name: multi-node-deepseek-r1-w8a8-eplb
             config_file_path: DeepSeek-R1-W8A8-EPLB.yaml
             size: 4
@@ -128,9 +129,10 @@ jobs:
           - name: qwen3-235b-w8a8
             os: linux-aarch64-a3-16
             tests: tests/e2e/nightly/models/test_qwen3_235b_w8a8.py
-          - name: deepseek3_2-exp-w8a8
-            os: linux-aarch64-a3-16
-            tests: tests/e2e/nightly/models/test_deepseek_v3_2_exp_w8a8.py
+          # TODO: Replace deepseek3.2-exp with deepseek3.2 after nightly tests pass
+          # - name: deepseek3_2-exp-w8a8
+          #   os: linux-aarch64-a3-16
+          #   tests: tests/e2e/nightly/models/test_deepseek_v3_2_exp_w8a8.py
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       vllm: v0.12.0


### PR DESCRIPTION
### What this PR does / why we need it?

Delete deepseek3.2-exp nightly test firstly for replacing deepseek3.2-exp with deepseek3.2 after nightly tests pass.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
