### PR TITLE
[Bugfix] fix fastapi version

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -17,7 +17,7 @@
 # Prerequisites:
 # - Python 3.8+
 # - Install dependencies:
-#     pip install fastapi httpx uvicorn vllm
+#     pip install fastapi<0.124.0 httpx uvicorn vllm
 #
 # Step 1: Start Your Backend Servers
 # ----------------------------------

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -17,7 +17,7 @@
 # Prerequisites:
 # - Python 3.10+
 # - Install dependencies:
-#     pip install fastapi httpx uvicorn vllm
+#     pip install fastapi<0.124.0 httpx uvicorn vllm
 #
 # Step 1: Start Your Backend Servers
 # ----------------------------------

--- a/examples/external_online_dp/dp_load_balance_proxy_server.py
+++ b/examples/external_online_dp/dp_load_balance_proxy_server.py
@@ -17,7 +17,7 @@
 # Prerequisites:
 # - Python 3.10+
 # - Install dependencies:
-#     pip install fastapi httpx uvicorn
+#     pip install fastapi<0.124.0 httpx uvicorn
 #
 # Step 1: Start Your Backend Servers
 # ----------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires = [
     "msgpack",
     "quart",
     "numba",
+    "fastapi<0.124.0",
     "opencv-python-headless<=4.11.0.86", # Required to avoid numpy version conflict with vllm
     "compressed_tensors>=0.11.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ numba
 torch-npu==2.8.0
 
 transformers<=4.57.1
+fastapi<0.124.0


### PR DESCRIPTION
### What this PR does / why we need it?

fix fastapi version == 0.123.10(<0.124.0)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
