### PR TITLE
[UT]add the UT of pcp and dcp in the attention_cp file 

### DIFF
--- a/tests/ut/attention/test_attention_cp.py
+++ b/tests/ut/attention/test_attention_cp.py
@@ -324,7 +324,7 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(value.shape[2], head_size)
 
 
-class UpdateNpuAttnOutLse(TestBase):
+class TestUpdateNpuAttnOutLse(TestBase):
 
     @patch('vllm.distributed.parallel_state.get_pcp_group')
     @patch('vllm.distributed.parallel_state._PCP',


### PR DESCRIPTION
### What this PR does / why we need it?
add the UT of pcp and dcp in the attention_cp file
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
