### PR TITLE
[bugfix] matmul_allreduce_add_rmsnorm aclnn interface

### DIFF
--- a/csrc/matmul_allreduce_add_rmsnorm/op_host/aclnn_matmul_allreduce_add_rmsnorm.cpp
+++ b/csrc/matmul_allreduce_add_rmsnorm/op_host/aclnn_matmul_allreduce_add_rmsnorm.cpp
@@ -26,6 +26,10 @@ enum NnopbaseHcclServerType {
 };
 extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, NnopbaseHcclServerType sType);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern aclnnStatus aclnnInnerMatmulAllreduceAddRmsnormGetWorkspaceSize(
     const aclTensor *x1,
     const aclTensor *x2,
@@ -47,10 +51,6 @@ extern aclnnStatus aclnnInnerMatmulAllreduceAddRmsnorm(
     uint64_t workspaceSize,
     aclOpExecutor *executor,
     aclrtStream stream);
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 aclnnStatus aclnnMatmulAllreduceAddRmsnormGetWorkspaceSize(
     const aclTensor *x1,


### PR DESCRIPTION
What this PR does / why we need it?
a2 kernel aclnn interface extern "C" fix

Does this PR introduce any user-facing change?
No

How was this patch tested?
vLLM version: v0.12.0
- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
