### PR TITLE
[Feature]Refactor _dummy_run in model_runner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,10 +55,10 @@ repos:
   hooks:
   - id: pymarkdown
     args: [fix]
-# - repo: https://github.com/rhysd/actionlint
-#   rev: v1.7.7
-#   hooks:
-#   - id: actionlint
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.7
+  hooks:
+  - id: actionlint
 - repo: local
   hooks:
   # For local development, you can run mypy using tools/mypy.sh script if needed.


### PR DESCRIPTION
### What this PR does / why we need it?
now _dummy_run in npu_model_runner is different from gpu_model_runner,as some important feature like graph_dispatch and build_atten_metadata,  we do this to be consistent with gpu_model_runner

### Does this PR introduce _any_ user-facing change?
NA

**How was this patch tested?**
vLLM version: v0.12.0
vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
