### PR TITLE
[E2E] Optimize e2e test.

### DIFF
--- a/tests/e2e/singlecard/test_quantization.py
+++ b/tests/e2e/singlecard/test_quantization.py
@@ -26,7 +26,7 @@ def test_quant_W8A8():
         "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs."
     ]
     with VllmRunner(
-            snapshot_download("vllm-ascend/Qwen2.5-0.5B-Instruct-W8A8"),
+            snapshot_download("vllm-ascend/Qwen3-0.6B-W8A8"),
             max_model_len=8192,
             enforce_eager=False,
             gpu_memory_utilization=0.7,


### PR DESCRIPTION
### What this PR does / why we need it?
[E2E] Optimize e2e test.
- Remove the test_basic_camem testcase.
- Change Qwen2.5-0.5B-Instruct-W8A8 to Qwen3-0.6B-W8A8

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
