### PR TITLE
[Nightly] Upgrade single node test to latest main

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -62,6 +62,13 @@ jobs:
           npu-smi info
           cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
 
+      - name: Sync from vllm-Ascend main branch
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          git config --global --add safe.directory "$(pwd)"
+          git config --global url."https://gh-proxy.test.osinfra.cn/https://github.com/".insteadOf https://github.com/
+          git pull origin main
+
       - name: Show vLLM and vLLM-Ascend version
         working-directory: /vllm-workspace
         run: |


### PR DESCRIPTION
### What this PR does / why we need it?
Sync source code from vllm-ascend on nightly tests
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
