### PR TITLE
[CI] Fix UT by addressing use_sparse parameter

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -490,7 +490,7 @@ class TestNPUPlatform(TestBase):
             dtype="float16",
             kv_cache_dtype="float16",
             block_size=64,
-            #use_sfa=False,
+            use_sparse=False,
             use_mla=True,
         )
         self.assertEqual(result,
@@ -503,7 +503,7 @@ class TestNPUPlatform(TestBase):
             dtype="float16",
             kv_cache_dtype="float16",
             block_size=64,
-            #use_sfa=False,
+            use_sparse=False,
             use_mla=False,
         )
         self.assertEqual(


### PR DESCRIPTION
Fix broken ut introduced by #5053 

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
