### PR TITLE
[test] add w4a8 accuracy case

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -196,7 +196,7 @@ jobs:
           pytest -sv --durations=0 tests/e2e/multicard/test_offline_inference_distributed.py::test_fc2_for_qwen3_moe
           pytest -sv --durations=0 tests/e2e/multicard/test_offline_inference_distributed.py::test_models_distributed_Qwen_Dense_with_flashcomm_v1
           pytest -sv --durations=0 tests/e2e/multicard/test_offline_inference_distributed.py::test_models_distributed_Qwen_Dense_with_prefetch_mlp_weight
-          pytest -sv --durations=0 tests/e2e/multicard/test_offline_inference_distributed.py::test_models_distributed_DeepSeek_W4A8ACC
+          pytest -sv --durations=0 tests/e2e/multicard/test_offline_inference_distributed.py::test_deepseek_w4a8_accuracy
 
           pytest -sv --durations=0 tests/e2e/multicard/test_prefix_caching.py
           pytest -sv --durations=0 tests/e2e/multicard/test_pipeline_parallel.py

--- a/tests/e2e/multicard/test_offline_inference_distributed.py
+++ b/tests/e2e/multicard/test_offline_inference_distributed.py
@@ -108,7 +108,7 @@ def test_sp_for_qwen3_moe() -> None:
 
 @pytest.mark.parametrize("model", DEEPSEEK_W4A8_MODELS)
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "2048"})
-def test_models_distributed_DeepSeek_W4A8ACC(model):
+def test_deepseek_w4a8_accuracy(model):
     prompts = [
         "Hello, my name is", "The president of the United States is",
         "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs"


### PR DESCRIPTION
### What this PR does / why we need it?

This PR add w4a8  accuracy testcase for e2e test

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

By running the test

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
