### PR TITLE
clone seq_lens_cpu in attention backend builder

### DIFF
--- a/vllm_ascend/attention/attention_cp.py
+++ b/vllm_ascend/attention/attention_cp.py
@@ -105,7 +105,10 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
 
         block_table = common_attn_metadata.block_table_tensor
         query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        # just clone seq_lens_cpu to avoid data competetion,
+        # it's important for async_scheduling with spec decoding,
+        # or it will make acceptance rate go down.
+        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()
 
         long_seq_metadata = common_attn_metadata.prefill_context_parallel_metadata
         num_actual_tokens_pcp_padded = long_seq_metadata.num_actual_tokens_pcp_padded if long_seq_metadata else None

--- a/vllm_ascend/attention/attention_cp.py
+++ b/vllm_ascend/attention/attention_cp.py
@@ -105,7 +105,7 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
 
         block_table = common_attn_metadata.block_table_tensor
         query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        # just clone seq_lens_cpu to avoid data competetion,
+        # just clone seq_lens_cpu to avoid data competition,
         # it's important for async_scheduling with spec decoding,
         # or it will make acceptance rate go down.
         seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -290,7 +290,10 @@ class AscendAttentionMetadataBuilder:
 
         block_table = common_attn_metadata.block_table_tensor
         query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        # just clone seq_lens_cpu to avoid data competetion,
+        # it's important for async_scheduling with spec decoding,
+        # or it will make acceptance rate go down.
+        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()
 
         long_seq_metadata = common_attn_metadata.prefill_context_parallel_metadata
         num_actual_tokens_pcp_padded = long_seq_metadata.num_actual_tokens_pcp_padded if long_seq_metadata else None

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -290,7 +290,7 @@ class AscendAttentionMetadataBuilder:
 
         block_table = common_attn_metadata.block_table_tensor
         query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        # just clone seq_lens_cpu to avoid data competetion,
+        # just clone seq_lens_cpu to avoid data competition,
         # it's important for async_scheduling with spec decoding,
         # or it will make acceptance rate go down.
         seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()

--- a/vllm_ascend/attention/mla_cp.py
+++ b/vllm_ascend/attention/mla_cp.py
@@ -141,7 +141,11 @@ class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         query_lens = query_seq_lens_cpu[:num_reqs]
-        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        # draft model make `seq_lens_cpu += 1` in propose method,
+        # just clone seq_lens_cpu to avoid data competetion,
+        # it's important for async_scheduling with spec decoding,
+        # or it will make acceptance rate go down.
+        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()
         num_computed_tokens_cpu = (seq_lens - query_lens)
 
         prefill_metadata = None

--- a/vllm_ascend/attention/mla_cp.py
+++ b/vllm_ascend/attention/mla_cp.py
@@ -141,8 +141,7 @@ class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         query_lens = query_seq_lens_cpu[:num_reqs]
-        # draft model make `seq_lens_cpu += 1` in propose method,
-        # just clone seq_lens_cpu to avoid data competetion,
+        # just clone seq_lens_cpu to avoid data competition,
         # it's important for async_scheduling with spec decoding,
         # or it will make acceptance rate go down.
         seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -454,7 +454,10 @@ class AscendMLAMetadataBuilder:
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         query_lens = query_seq_lens_cpu[:num_reqs]
-        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        # just clone seq_lens_cpu to avoid data competetion,
+        # it's important for async_scheduling with spec decoding,
+        # or it will make acceptance rate go down.
+        seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()
         num_computed_tokens_cpu = (seq_lens - query_lens)
 
         prefill_metadata = None

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -454,7 +454,7 @@ class AscendMLAMetadataBuilder:
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         query_lens = query_seq_lens_cpu[:num_reqs]
-        # just clone seq_lens_cpu to avoid data competetion,
+        # just clone seq_lens_cpu to avoid data competition,
         # it's important for async_scheduling with spec decoding,
         # or it will make acceptance rate go down.
         seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs].clone()


### PR DESCRIPTION
### What this PR does / why we need it?
draft model will make `seq_lens_cpu += 1`, which will make acceptance rate go down when enable async scheduling with spec decoding, we just move the clone operation into attention buidler to make sure seq_lens_cpu  in draft model and main model refer to different memory.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
