### PR TITLE
[bugfix][mm] change get_num_encoder_tokens to get_num_encoder_embeds in recompute_schedule.py

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -235,10 +235,10 @@ class RecomputeScheduler(Scheduler):
                                 if preempted_encoder_inputs:
                                     # Restore encoder compute budget if the preempted
                                     # request had encoder inputs scheduled in this step.
-                                    num_tokens_to_restore = sum(
-                                        preempted_req.get_num_encoder_tokens(i)
+                                    num_embeds_to_restore = sum(
+                                        preempted_req.get_num_encoder_embeds(i)
                                         for i in preempted_encoder_inputs)
-                                    encoder_compute_budget += num_tokens_to_restore
+                                    encoder_compute_budget += num_embeds_to_restore
                                 req_index -= 1
                         else:
                             preempted_req = self.running.pop()


### PR DESCRIPTION
### What this PR does / why we need it?
adapt to: https://github.com/vllm-project/vllm/pull/30475.

just change get_num_encoder_tokens() to get_num_encoder_embeds() in recompute_schedule.py, which seems that it is currently not in use. The get_num_encoder_tokens() function in VLLM no longer exists.


- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
