### PR TITLE
[Fix] Fix DeepSeek V3.2 "no attr" error

### DIFF
--- a/vllm_ascend/spec_decode/mtp_proposer.py
+++ b/vllm_ascend/spec_decode/mtp_proposer.py
@@ -780,15 +780,16 @@ class MtpProposer(Proposer):
                             hidden_states)
 
                     for layer_name in self.attn_layer_name:
-                        if self.use_async_scheduling and attn_metadata[
-                                layer_name].decode is not None:
-                            actual_size = len(attn_metadata[layer_name].decode.
-                                              actual_seq_lengths_q)
+                        decode_metadata = getattr(attn_metadata[layer_name],
+                                                  "decode", None)
+                        if self.use_async_scheduling and decode_metadata is not None:
+                            actual_size = len(
+                                decode_metadata.actual_seq_lengths_q)
 
-                            attn_metadata[layer_name].decode.seq_lens_list = \
-                                attn_metadata[layer_name].decode.seq_lens_list[:actual_size]
-                            attn_metadata[layer_name].decode.block_table = \
-                                attn_metadata[layer_name].decode.block_table[:actual_size]
+                            decode_metadata.seq_lens_list = \
+                                decode_metadata.seq_lens_list[:actual_size]
+                            decode_metadata.block_table = \
+                                decode_metadata.block_table[:actual_size]
 
                     hidden_states = self.model(input_ids=input_ids,
                                                positions=positions,


### PR DESCRIPTION
### What this PR does / why we need it?
Extracts repeated `attn_metadata[layer_name].decode` access into a single variable to improve code readability and reduce redundancy.

Uses `getattr` with a default value to safely access the decode attribute, making the code more defensive against potential attribute errors.

### Does this PR introduce _any_ user-facing change?
None.

### How was this patch tested?
None.

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
