### PR TITLE
[Nightly] Reinstall vllm-ascend when fetch from remote

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -67,7 +67,9 @@ jobs:
         run: |
           git config --global --add safe.directory "$(pwd)"
           git config --global url."https://gh-proxy.test.osinfra.cn/https://github.com/".insteadOf https://github.com/
+          pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
           git pull origin main
+          pip install -e .
 
       - name: Show vLLM and vLLM-Ascend version
         working-directory: /vllm-workspace

--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -131,7 +131,7 @@ upgrade_vllm_ascend_scr() {
     # This results in the nightly test code not being the latest version.
     cd "$WORKSPACE/vllm-ascend"
     git pull origin main
-    
+    pip install -e .
 }
 
 run_tests_with_log() {


### PR DESCRIPTION
### What this PR does / why we need it?
There exists some scenario that when the remote change the build behavior, we should reinstall it
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
