### PR TITLE
[Image] Refactor image build

### DIFF
--- a/.github/workflows/_pr_image_build.yaml
+++ b/.github/workflows/_pr_image_build.yaml
@@ -6,6 +6,11 @@ on:
         description: 'The tag subfix to use'
         required: true
         type: string
+      should_push:
+        description: 'Whether to push the image'
+        required: false
+        type: boolean
+        default: False
       dockerfile:
         description: 'The Dockerfile to use'
         required: false
@@ -45,7 +50,7 @@ jobs:
         docker-images: false
 
     - name: Publish - Login to Quay Container Registry
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'vllm-project' }}
+      if: ${{ inputs.should_push }}
       uses: docker/login-action@v3
       with:
         registry: quay.io
@@ -68,9 +73,9 @@ jobs:
         context: .
         file: ${{ inputs.dockerfile || 'Dockerfile' }}
         # only trigger when tag, branch/main push
-        push: ${{ github.event_name == 'push' && github.repository_owner == 'vllm-project' }}
+        push: ${{ inputs.should_push }}
         tags: quay.io/ascend/vllm-ascend
-        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.should_push }}
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
         provenance: false
@@ -92,7 +97,7 @@ jobs:
   merge-image:
     runs-on: ubuntu-latest
     needs: build-push-digest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'vllm-project' }}
+    if: ${{ inputs.should_push }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr_tag_image_build_and_push.yaml
+++ b/.github/workflows/pr_tag_image_build_and_push.yaml
@@ -16,8 +16,9 @@ on:
       - 'main'
       - '*-dev'
     paths:
-      - '.github/workflows/image_build_and_push.yml'
+      - '.github/workflows/pr_tag_image_build_and_push.yaml'
       - 'Dockerfile*'
+      - '.github/workflows/_pr_image_build.yml'
       - 'vllm_ascend/**'
       - 'setup.py'
       - 'pyproject.toml'
@@ -25,7 +26,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
-    types: [ labeled ]
+    types: [ labeled, synchronize ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image
     branches:
@@ -79,5 +80,6 @@ jobs:
       dockerfile: ${{ matrix.build_meta.dockerfile }}
       suffix: ${{ matrix.build_meta.suffix }}
       quay_username: ${{ vars.QUAY_USERNAME }}
+      should_push: ${{ github.event_name == 'push' && github.repository_owner == 'vllm-project' }}
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
### What this PR does / why we need it?

In the past time, we used a hybrid architecture cross-compilation approach for image building. This method had a problem: cross-compilation performance was very poor, leading to extremely long build times(abort 4h) and even a probability of failure(see https://github.com/vllm-project/vllm-ascend/actions/runs/20152861650/job/57849208186). Therefore, I recommend using a separate architecture build followed by manifest merging, which significantly reduces image build time(20min).

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
