### PR TITLE
[TEST]Add performance baseline for some nightly cases

### DIFF
--- a/tests/e2e/nightly/models/test_deepseek_r1_0528_w8a8.py
+++ b/tests/e2e/nightly/models/test_deepseek_r1_0528_w8a8.py
@@ -113,6 +113,8 @@ async def test_models(model: str, mode: str) -> None:
         print(choices)
         if mode in ["single"]:
             return
+        if mode == "aclgraph":
+            aisbench_cases[1]["baseline"] = 478.7924
         # aisbench test
         run_aisbench_cases(model,
                            port,

--- a/tests/e2e/nightly/models/test_qwen2_5_vl_32b.py
+++ b/tests/e2e/nightly/models/test_qwen2_5_vl_32b.py
@@ -64,7 +64,7 @@ aisbench_cases = [{
     "top_p": 1,
     "repetition_penalty": 1,
     "request_rate": 0,
-    "baseline": 1,
+    "baseline": 1454.8686,
     "threshold": 0.97
 }]
 

--- a/tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
+++ b/tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
@@ -56,7 +56,7 @@ aisbench_cases = [{
     "max_out_len": 256,
     "batch_size": 128,
     "request_rate": 0,
-    "baseline": 1,
+    "baseline": 2884.2267,
     "threshold": 0.97
 }]
 

--- a/tests/e2e/nightly/models/test_qwen3_30b_w8a8.py
+++ b/tests/e2e/nightly/models/test_qwen3_30b_w8a8.py
@@ -46,7 +46,7 @@ aisbench_cases = [{
     "max_out_len": 1500,
     "batch_size": 45,
     "request_rate": 0,
-    "baseline": 1,
+    "baseline": 771.0623,
     "threshold": 0.97
 }]
 

--- a/tests/e2e/nightly/models/test_qwen3_32b_int8.py
+++ b/tests/e2e/nightly/models/test_qwen3_32b_int8.py
@@ -48,8 +48,13 @@ batch_size_dict = {
     "linux-aarch64-a2-4": 72,
     "linux-aarch64-a3-4": 76,
 }
+perf_baseline_dict = {
+    "linux-aarch64-a2-4": 1163.6003,
+    "linux-aarch64-a3-4": 1267.4346,
+}
 VLLM_CI_RUNNER = os.getenv("VLLM_CI_RUNNER", "linux-aarch64-a2-4")
 performance_batch_size = batch_size_dict.get(VLLM_CI_RUNNER, 1)
+perf_baseline = perf_baseline_dict.get(VLLM_CI_RUNNER, 1)
 
 aisbench_cases = [{
     "case_type": "accuracy",
@@ -68,7 +73,7 @@ aisbench_cases = [{
     "num_prompts": 4 * performance_batch_size,
     "max_out_len": 1500,
     "batch_size": performance_batch_size,
-    "baseline": 1,
+    "baseline": perf_baseline,
     "threshold": 0.97
 }]
 


### PR DESCRIPTION
This PR adds performance baseline for some cases, we need to verify the performance
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
by running the test

- vLLM version: v0.12.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
