### PR TITLE
[Feat]Xlite Qwen3-vl Support

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -49,7 +49,7 @@ The details of each configuration option are as follows:
 **xlite_graph_config**
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `enabled` | bool | `False` | Whether to enable xlite graph mode. Currently only Llama or Qwen dense series models are supported. |
+| `enabled` | bool | `False` | Whether to enable xlite graph mode. Currently only Llama, Qwen dense series models, and Qwen3-vl are supported. |
 | `full_mode` | bool | `False` | Whether to enable xlite for both the prefill and decode stages. By default, xlite is only enabled for the decode stage. |
 
 **weight_prefetch_config**

--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -12,7 +12,7 @@ From v0.9.1rc1 with V1 Engine, vLLM Ascend will run models in graph mode by defa
 
 There are two kinds for graph mode supported by vLLM Ascend:
 - **ACLGraph**: This is the default graph mode supported by vLLM Ascend. In v0.9.1rc1, Qwen and Deepseek series models are well tested.
-- **XliteGraph**: This is the euler xlite graph mode. In v0.11.0, only Llama and Qwen dense serise models are supported.
+- **XliteGraph**: This is the openeuler xlite graph mode. In v0.11.0, only Llama, Qwen dense series models, and Qwen3-vl are supported.
 
 ## Using ACLGraph
 ACLGraph is enabled by default. Take Qwen series models as an example, just set to use V1 Engine is enough.
@@ -36,7 +36,7 @@ vllm serve Qwen/Qwen2-7B-Instruct
 
 ## Using XliteGraph
 
-If you want to run Llama or Qwen dense series models with xlite graph mode, please install xlite, and set xlite_graph_config.
+If you want to run Llama, Qwen dense series models, or Qwen3-vl with xlite graph mode, please install xlite, and set xlite_graph_config.
 
 ```bash
 pip install xlite
@@ -59,7 +59,7 @@ Online example:
 vllm serve path/to/Qwen3-32B --tensor-parallel-size 8 --additional-config='{"xlite_graph_config": {"enabled": true, "full_mode": true}}'
 ```
 
-You can find more details abort xlite [here](https://gitee.com/openeuler/GVirt/blob/master/xlite/README.md)
+You can find more details abort xlite [here](https://atomgit.com/openeuler/GVirt/blob/master/xlite/README.md)
 
 ## Fallback to the Eager Mode
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -281,7 +281,7 @@ class NPUPlatform(Platform):
             parallel_config.all2all_backend = "flashinfer_all2allv"
             if ascend_config.xlite_graph_config.enabled:
                 logger.info(
-                    "Euler Xlite enabled. See: https://gitee.com/openeuler/GVirt/tree/master/xlite"
+                    "openEuler Xlite enabled. See: https://atomgit.com/openeuler/GVirt/tree/master/xlite"
                 )
                 parallel_config.worker_cls = "vllm_ascend.xlite.xlite_worker.XliteWorker"
             else:


### PR DESCRIPTION
### What this PR does / why we need it?
This patch adds support for the Qwen3-VL model in Xlite. For more details about Xlite, please refer to the following link:https://atomgit.com/openeuler/GVirt/blob/master/xlite/README.md.
The latest performance comparison data between xlite and the default aclgraph mode is as follows:

## Qwen-VL-8B-Instruct TPS 910B3(A2) Online Inference Performance Comparison
- aclgraph: main
- xlite-full: main + xlite-full
- xlite-decode-only: main + xlite-decode-only
- diff1: Performance comparison between xlite-full and aclgraph
- diff2: Performance comparison between xlite-decode-only and aclgraph

| maxconcurrency | item | TTFT(ms) |  | TPOT(ms) |  | QPS (req/s) | OutputSpeed (token/s) |
| --- | --- | --- | --- | --- | --- | --- | --- |
|  |  | Avg | P99 | Avg | P99 |  |  |
| 1 | baseline-aclgraph | 178.27 | 184.16 | 27.75 | 27.82 | 0.06 | 35.69 |
| 1 | xlite-full | 69.06 | 87.87 | 11.44 | 11.54 | 0.16 | 86.61 |
| 1 | xlite-decode-only | 185.13 | 199.94 | 11.47 | 11.53 | 0.15 | 84.84 |
| 1 | diff1 | -61.26% | -52.29% | -58.77% | -58.52% | 166.67% | 142.67% |
| 1 | diff2 | 3.85% | 8.57% | -58.67% | -58.55% | 150.00% | 137.71% |
|  |  |  |  |  |  |  |  |
| 16 | baseline-aclgraph | 357.75 | 1155.70 | 48.24 | 49.32 | 0.62 | 317.20 |
| 16 | xlite-full | 576.74 | 2287.98 | 15.09 | 20.15 | 1.86 | 956.60 |
| 16 | xlite-decode-only | 310.97 | 949.45 | 17.82 | 19.21 | 1.64 | 844.29 |
| 16 | diff1 | 61.21% | 97.97% | -68.72% | -59.14% | 200.00% | 201.58% |
| 16 | diff2 | -13.08% | -17.85% | -63.06% | -61.05% | 164.52% | 166.17% |
|  |  |  |  |  |  |  |  |
| 32 | baseline-aclgraph | 419.91 | 1973.95 | 56.97 | 59.07 | 1.03 | 534.59 |
| 32 | xlite-full | 208.23 | 1410.77 | 18.64 | 19.64 | 3.13 | 1617.74 |
| 32 | xlite-decode-only | 356.80 | 1701.71 | 24.50 | 26.99 | 2.39 | 1234.36 |
| 32 | diff1 | -50.41% | -28.53% | -67.28% | -66.75% | 203.88% | 202.61% |
| 32 | diff2 | -15.03% | -13.79% | -56.99% | -54.31% | 132.04% | 130.90% |
|  |  |  |  |  |  |  |  |
| 48 | baseline-aclgraph | 506.59 | 2951.76 | 66.45 | 69.20 | 1.35 | 692.04 |
| 48 | xlite-full | 830.64 | 5240.03 | 22.33 | 27.76 | 3.80 | 1952.95 |
| 48 | xlite-decode-only | 481.61 | 2603.15 | 31.45 | 34.87 | 2.83 | 1452.36 |
| 48 | diff1 | 63.97% | 77.52% | -66.40% | -59.88% | 181.48% | 182.20% |
| 48 | diff2 | -4.93% | -11.81% | -52.67% | -49.61% | 109.63% | 109.87% |
|  |  |  |  |  |  |  |  |
| 64 | baseline-aclgraph | 565.41 | 3324.24 | 75.87 | 79.60 | 1.57 | 806.16 |
| 64 | xlite-full | 322.10 | 2720.47 | 26.62 | 28.31 | 4.45 | 2280.18 |
| 64 | xlite-decode-only | 828.95 | 3645.51 | 37.66 | 43.38 | 3.12 | 1597.16 |
| 64 | diff1 | -43.03% | -18.16% | -64.91% | -64.43% | 183.44% | 182.84% |
| 64 | diff2 | 46.61% | 9.66% | -50.36% | -45.50% | 98.73% | 98.12% |
|  |  |  |  |  |  |  |  |
| 100 | baseline-aclgraph | 699.57 | 5291.15 | 89.20 | 94.20 | 2.09 | 1073.28 |
| 100 | xlite-full | 469.80 | 5059.35 | 36.42 | 38.74 | 5.09 | 2613.62 |
| 100 | xlite-decode-only | 666.58 | 4567.01 | 54.90 | 61.67 | 3.41 | 1752.78 |
| 100 | diff1 | -32.84% | -4.38% | -59.17% | -58.87% | 143.54% | 143.52% |
| 100 | diff2 | -4.72% | -13.69% | -38.45% | -34.53% | 63.16% | 63.31% |
|  |  |  |  |  |  |  |  |
| 150 | baseline-aclgraph | 886.03 | 7041.38 | 108.72 | 115.38 | 2.57 | 1318.08 |
| 150 | xlite-full | 636.62 | 6715.33 | 49.39 | 53.51 | 5.63 | 2892.58 |
| 150 | xlite-decode-only | 858.40 | 7751.25 | 75.98 | 85.10 | 3.70 | 1900.81 |
| 150 | diff1 | -28.15% | -4.63% | -54.57% | -53.62% | 119.07% | 119.45% |
| 150 | diff2 | -3.12% | 10.08% | -30.11% | -26.24% | 43.97% | 44.21% |
|  |  |  |  |  |  |  |  |
| 200 | baseline-aclgraph | 1118.80 | 10335.10 | 125.67 | 134.94 | 2.98 | 1523.36 |
| 200 | xlite-full | 743.90 | 7800.61 | 61.59 | 67.49 | 6.08 | 3106.19 |
| 200 | xlite-decode-only | 1189.31 | 12558.20 | 93.56 | 105.48 | 4.02 | 2055.62 |
| 200 | diff1 | -33.51% | -24.52% | -50.99% | -49.99% | 104.03% | 103.90% |
| 200 | diff2 | 6.30% | 21.51% | -25.55% | -21.83% | 34.90% | 34.94% |
|  |  |  |  |  |  |  |  |

test config:
```
port=$1
log=$2
export TASK_QUEUE_ENABLE=1
export VLLM_USE_V1=1
export OMP_PROC_BIND=false
export HCCL_OP_EXPANSION_MODE="AIV"
export VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE=1
export VLLM_ASCEND_ENABLE_FLASHCOMM=0
export VLLM_ASCEND_ENABLE_DENSE_OPTIMIZE=1
export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
ip=127.0.0.1
python -m vllm.entrypoints.openai.api_server \
	--model /mnt/nvme1n1/models/Qwen3-VL-8B-Instruct  \
	--tensor-parallel-size 2 \
	--gpu-memory-utilization 0.9 \
	--max-num-batched-tokens 8192 \
	--max-num-seqs=200 \
	--block-size 128 \
	--max-model-len 6656 \
	--trust-remote-code \
	--disable-log-requests \
	--served-model-name qwen3-vl \
	--no-enable-prefix-caching \
	--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
	--async-scheduling \
	--host ${ip} \
	--port ${port} > ${log} 2>&1 &
vllm bench serve --max-concurrency ${concurrency}  --num-prompts ${num_prompts} --host 127.0.0.1 --port 8080 --model qwen --dataset-name random --backend openai-chat --random-input-len 512 --random-output-len 512 --random-range-ratio 0.05  --tokenizer /mnt/nvme0n1/models/Qwen3-32B --endpoint /v1/chat/completions --ignore-eos
```

### Does this PR introduce _any_ user-facing change?
XLite graph mode supports the Qwen3-VL model.

### How was this patch tested?
vLLM version: v0.12.0 

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
