### PR TITLE
Docs: Add A3 Docker image guidance for Atlas A3 machines

### DIFF
--- a/docs/source/tutorials/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/Qwen3-30B-A3B.md
@@ -7,7 +7,10 @@ Run docker container:
 ```{code-block} bash
    :substitutions:
 # Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# For Atlas A2 machines:
+# export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# For Atlas A3 machines:
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 docker run --rm \
 --name vllm-ascend \
 --shm-size=1g \

--- a/docs/source/tutorials/Qwen3-Dense.md
+++ b/docs/source/tutorials/Qwen3-Dense.md
@@ -61,7 +61,10 @@ docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 # Update --device according to your device (Atlas A2: /dev/davinci[0-7] Atlas A3:/dev/davinci[0-15]).
 # Update the vllm-ascend image according to your environment.
 # Note you should download the weight to /root/.cache in advance.
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# For Atlas A2 machines:
+# export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# For Atlas A3 machines:
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 docker run --rm \
     --name vllm-ascend-env \
     --shm-size=1g \

--- a/docs/source/tutorials/Qwen3-Next.md
+++ b/docs/source/tutorials/Qwen3-Next.md
@@ -27,7 +27,10 @@ If the machine environment is an Atlas 800I A3(64G*16), the deployment approach 
 ```{code-block} bash
    :substitutions:
 # Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# For Atlas A2 machines:
+# export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# For Atlas A3 machines:
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
 docker run --rm \
 --shm-size=1g \
 --name vllm-ascend-qwen3 \


### PR DESCRIPTION
Fixes #3386

- Update Qwen3-30B-A3B.md to use A3-specific image tag
- Update Qwen3-Dense.md to provide both A2 and A3 image options
- Update Qwen3-Next.md to use A3-specific image for Atlas A3 environments

Previously, documentation only mentioned A2 images (vllm-ascend:version) but Atlas A3 machines require A3-specific images (vllm-ascend:version-a3). This change ensures users select the correct image for their hardware.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
