### PR TITLE
Docs: Remove deprecated --task parameter for embedding models

### DIFF
--- a/docs/source/tutorials/Qwen3_embedding.md
+++ b/docs/source/tutorials/Qwen3_embedding.md
@@ -30,7 +30,7 @@ Using the Qwen3-Embedding-8B model as an example, first run the docker container
 ### Online Inference
 
 ```bash
-vllm serve Qwen/Qwen3-Embedding-8B --task embed --host 127.0.0.1 --port 8888
+vllm serve Qwen/Qwen3-Embedding-8B --host 127.0.0.1 --port 8888
 ```
 
 Once your server is started, you can query the model with input prompts.
@@ -71,7 +71,6 @@ if __name__=="__main__":
     input_texts = queries + documents
 
     model = LLM(model="Qwen/Qwen3-Embedding-8B",
-                task="embed",
                 distributed_executor_backend="mp")
 
     outputs = model.embed(input_texts)


### PR DESCRIPTION
Fixes #3376

- Remove --task embed from vllm serve command in Qwen3_embedding.md
- Remove task='embed' parameter from LLM constructor in Python example

The --task parameter has been deprecated in recent vLLM versions in favor of automatic model type detection.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
