### PR TITLE
[TEST]Update mm param --mm-processor-cache-gb

### DIFF
--- a/tests/e2e/nightly/models/test_qwen2_5_vl_32b.py
+++ b/tests/e2e/nightly/models/test_qwen2_5_vl_32b.py
@@ -80,7 +80,7 @@ async def test_models(model: str, tp_size: int) -> None:
         "HCCL_OP_EXPANSION_MODE": "AIV"
     }
     server_args = [
-        "--no-enable-prefix-caching", "--disable-mm-preprocessor-cache",
+        "--no-enable-prefix-caching", "--mm-processor-cache-gb", "0",
         "--tensor-parallel-size",
         str(tp_size), "--port",
         str(port), "--max-model-len", "30000", "--max-num-batched-tokens",

--- a/tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
+++ b/tests/e2e/nightly/models/test_qwen2_5_vl_7b.py
@@ -72,7 +72,7 @@ async def test_models(model: str, tp_size: int) -> None:
         "HCCL_OP_EXPANSION_MODE": "AIV"
     }
     server_args = [
-        "--no-enable-prefix-caching", "--disable-mm-preprocessor-cache",
+        "--no-enable-prefix-caching", "--mm-processor-cache-gb", "0",
         "--tensor-parallel-size",
         str(tp_size), "--port",
         str(port), "--max-model-len", "30000", "--max-num-batched-tokens",


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the mm param --mm-processor-cache-gb, we need it to run the case

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
by running the test

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
