### PR TITLE
[ops]optimize forward native for mrope

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -24,6 +24,7 @@ from vllm.config import CUDAGraphMode
 from vllm.model_executor.layers.rotary_embedding import (
     DeepseekScalingRotaryEmbedding, MRotaryEmbedding, RotaryEmbedding,
     YaRNScalingRotaryEmbedding)
+from vllm.forward_context import get_forward_context
 
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.utils import (AscendDeviceType, enable_custom_op,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces forward_native implementation for multimodal rotary positional embedding (mRoPE) in vllm-ascend, targeting Ascend NPU execution.

The implementation is added to AscendMRotaryEmbedding and provides a functional-equivalent forward path to the original forward() while being explicitly compatible with NPU execution semantics.

### Does this PR introduce _any_ user-facing change?
### Motivation
At present, Qwen3-VL models use the generic forward_native implementation in vllm/vllm/model_executor/layers/rotary_embedding/mrope.py. 
This implementation is backend-agnostic and does not leverage Ascend NPU–specific optimizations, resulting in suboptimal performance when running Qwen3-VL workloads on Ascend.

### How was this patch tested?
Accuracy:
The change has been validated in RL training scenarios using **Qwen3-VL-30B-A3B**
Model convergence and output quality remain consistent with the baseline, with no observed accuracy regression

Performance:
In inference workloads with **Qwen3-VL-30B-A3B,** this native mRoPE implementation delivers 20%+ inference performance improvement compared to the previous path
<img width="1280" height="691" alt="image" src="https://github.com/user-attachments/assets/3c94e22d-108f-4466-bb08-d6393c13e74e" />
<img width="1280" height="341" alt="image" src="https://github.com/user-attachments/assets/36f44166-c80f-4ff2-813a-6e06f4303f77" />

Co-authored-by: alwaysyiyu <alwayszxj@gmail.com>

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
