### PR TITLE
[Bugfix] Fix mm_merge

### DIFF
--- a/vllm_ascend/patch/worker/patch_multimodal_merge.py
+++ b/vllm_ascend/patch/worker/patch_multimodal_merge.py
@@ -37,8 +37,9 @@ def _merge_multimodal_embeddings(
         This updates ``inputs_embeds`` in place.
     """
     flattened = _flatten_embeddings(multimodal_embeddings)
+    input_dtype = inputs_embeds.dtype
     try:
-        inputs_embeds[is_multimodal] = flattened
+        inputs_embeds[is_multimodal] = flattened.to(dtype=input_dtype)
     except RuntimeError as e:
         num_expected_tokens = is_multimodal.sum().item()
         assert isinstance(num_expected_tokens, int)


### PR DESCRIPTION
### What this PR does / why we need it?
We should transfer the mm_embed to the dtype of input_embed before performing the in-place assignment
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
