### PR TITLE
fix transformer version to 4.57.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ numba
 #--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 torch-npu==2.8.0
 
-transformers==4.57.3
+transformers>=4.57.3
 fastapi<0.124.0


### PR DESCRIPTION
### What this PR does / why we need it?
In certain scenarios (such as smoke testing), the source code is used to update the vllm-ascend version for running updated models (such as Qwen3-VL). However, vllm and vllm-ascend themselves have no restrictions on the transformer version, and the transformer will not be updated, resulting in errors when launching the model.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
