### PR TITLE
Docs: Remove deprecated --task parameter for embedding models

### DIFF
--- a/docs/source/tutorials/Qwen3_embedding.md
+++ b/docs/source/tutorials/Qwen3_embedding.md
@@ -30,7 +30,7 @@ Using the Qwen3-Embedding-8B model as an example, first run the docker container
 ### Online Inference
 
 ```bash
-vllm serve Qwen/Qwen3-Embedding-8B --host 127.0.0.1 --port 8888
+vllm serve Qwen/Qwen3-Embedding-8B --runner pooling --host 127.0.0.1 --port 8888
 ```
 
 Once your server is started, you can query the model with input prompts.


### PR DESCRIPTION
Fixes #3376

- Remove --task embed from vllm serve command in Qwen3_embedding.md
- Remove task='embed' parameter from LLM constructor in Python example

The --task parameter has been deprecated in recent vLLM versions 
in favor of automatic model type detection.
- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
