### PR TITLE
[Doc] fix docs set rope_theta value is 10e6 in qwen3-235b model

### DIFF
--- a/docs/source/tutorials/Qwen3-235B-A22B.md
+++ b/docs/source/tutorials/Qwen3-235B-A22B.md
@@ -126,7 +126,7 @@ vllm serve vllm-ascend/Qwen3-235B-A22B-w8a8 \
 
 **Notice:**
 - for vllm version below `v0.12.0` use parameter: `--rope_scaling '{"rope_type":"yarn","factor":4,"original_max_position_embeddings":32768}' \`
-- for vllm version `v0.12.0` use parameter: `--hf-overrides '{"rope_parameters": {"rope_type":"yarn","rope_theta":1000,"factor":4,"original_max_position_embeddings":32768}}' \`
+- for vllm version `v0.12.0` use parameter: `--hf-overrides '{"rope_parameters": {"rope_type":"yarn","rope_theta":1000000,"factor":4,"original_max_position_embeddings":32768}}' \`
 
 The parameters are explained as follows:
 - `--data-parallel-size` 1 and `--tensor-parallel-size` 8 are common settings for data parallelism (DP) and tensor parallelism (TP) sizes.


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes https://github.com/vllm-project/vllm-ascend/issues/5201

### Does this PR introduce _any_ user-facing change?
No, doc only

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ad32e3e19ccf0526cb6744a5fed09a138a5fb2f9
