### PR TITLE
[CI] Skip some failed ops tests

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -148,5 +148,10 @@ jobs:
         run: |
           # ignore test_dispatch_ffn_combine until the test is fixed
           pytest -sv ${{ inputs.tests }} \
-          --ignore=tests/e2e/nightly/ops/test_dispatch_ffn_combine.py 
+          --ignore=tests/e2e/nightly/ops/test_dispatch_ffn_combine.py \
+          --ignore=tests/e2e/nightly/ops/test_fused_moe.py \
+          --ignore=tests/e2e/nightly/ops/test_rotary_embedding.py \
+          --ignore=tests/e2e/nightly/ops/test_matmul_allreduce_add_rmsnorm.py
+
+
 


### PR DESCRIPTION
### What this PR does / why we need it?
Skip some failed ops tests
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5fbfa8d9ef15948599631baeb91e8220b2ee9bcc
