### PR TITLE
[Test] Add acceptance test for deepseek mtp

### DIFF
--- a/tests/e2e/nightly/features/test_mtpx_deepseek_r1_0528_w8a8.py
+++ b/tests/e2e/nightly/features/test_mtpx_deepseek_r1_0528_w8a8.py
@@ -149,7 +149,8 @@ async def test_models(model: str, mode: str) -> None:
             metrics_text = (await client.get(server.url_for("metrics"))).text
 
     num_drafts, num_accepted_tokens_per_pos = analysis_metrics(
-        metrics_text, speculative_config["num_speculative_tokens"],
+        metrics_text,
+        2 if mode == "mtp2" else 3,
     )
 
     acceptance_per_pos = [


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to add acceptance test for deepseek mtp together with tests/e2e/nightly/features/test_mtpx_deepseek_r1_0528_w8a8.py. We obtained golden baselines based on commit id https://github.com/vllm-project/vllm-ascend/commit/e54630e01cd4d022b1b0e3e7a217ea5494c72711, which is feasible and convincing.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci
- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bc0a5a0c089844b17cb93f3294348f411e523586
