### PR TITLE
[CI] Exclude broken nodes in nightly test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       args: [
         --toml, pyproject.toml,
         '--skip', 'csrc/**,tests/prompts/**,./benchmarks/sonnet.txt,*tests/lora/data/**,build/**,./vllm_ascend.egg-info/**,.github/**,typos.toml',
-        '-L', 'CANN,cann,NNAL,nnal,ASCEND,ascend,EnQue,CopyIn,ArchType,AND,ND'
+        '-L', 'CANN,cann,NNAL,nnal,ASCEND,ascend,EnQue,CopyIn,ArchType,AND,ND,NotIn'
       ]
       additional_dependencies:
         - tomli

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -13,6 +13,15 @@ spec:
         labels:
           role: leader
       spec:
+        affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution: 
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                      - 172.22.5.7
         containers:
           - name: vllm-leader
             imagePullPolicy: Always
@@ -72,6 +81,15 @@ spec:
             path: /usr/local/Ascend/driver/tools
     workerTemplate:
       spec:
+        affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution: 
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                      - 172.22.5.7
         containers:
           - name: vllm-worker
             imagePullPolicy: Always


### PR DESCRIPTION
### What this PR does / why we need it?
Exclude broken nodes in nightly test
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bc0a5a0c089844b17cb93f3294348f411e523586
