### PR TITLE
[Test] Add acceptance test for eagle/eagle3

### DIFF
--- a/tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode_v1/test_v1_spec_decode.py
@@ -403,16 +403,16 @@ def test_llama_qwen_eagle_acceptance(
     compilation_config = CompilationConfig(cudagraph_capture_sizes=[12])
 
     with VllmRunner(
-        main_model_name,
-        max_model_len=2048,
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-        max_num_seqs=256,
-        distributed_executor_backend="mp",
-        gpu_memory_utilization=0.7,
-        speculative_config=speculative_config,
-        compilation_config=compilation_config,
-        async_scheduling=async_scheduling,
+            main_model_name,
+            max_model_len=2048,
+            disable_log_stats=False,
+            tensor_parallel_size=1,
+            max_num_seqs=256,
+            distributed_executor_backend="mp",
+            gpu_memory_utilization=0.7,
+            speculative_config=speculative_config,
+            compilation_config=compilation_config,
+            async_scheduling=async_scheduling,
     ) as llm:
         _ = llm.generate(prompts, sampling_params)
         metrics = llm.model.get_metrics()


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to add acceptance test for eagle/eagle3 via llama/qwen. We obtained golden baselines by running several times (based on healthy main), which is feasible and convincing.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bc0a5a0c089844b17cb93f3294348f411e523586
