### PR TITLE
[CI] skip xlite-decode-only e2e test

### DIFF
--- a/tests/e2e/singlecard/test_xlite.py
+++ b/tests/e2e/singlecard/test_xlite.py
@@ -35,6 +35,8 @@ MODELS = [
 ]
 
 
+@pytest.mark.skip(
+    reason="TODO: Re-enable xlite_decode_only e2e test when stable.")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [15])
 def test_models_with_xlite_decode_only(


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?
skip xlite-decode-only e2e test
### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/81786c87748b0177111dfdc07af5351d8389baa1
