### PR TITLE
[Bugfix] Fix no attribute 'cos_cached'  situation when running Moonlight-16B-A3B-Instruct

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -238,8 +238,8 @@ class AscendMLAMetadataBuilder:
                 device=device,
             )
         self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
-        self.cos_cache = None
-        self.sin_cache = None
+        self.cos_cache: torch.Tensor = None
+        self.sin_cache: torch.Tensor = None
 
         self.chunk_seq_lens: torch.Tensor = None
         self.cu_seq_lens_cpu: torch.Tensor = None
@@ -415,7 +415,9 @@ class AscendMLAMetadataBuilder:
                 self.cos_cache = self.cos_cache.reshape(-1, last_dim)
                 self.sin_cache = self.sin_cache.reshape(-1, last_dim)
             else:
-                raise ValueError("Rotary embedding cache not found")
+                raise ValueError(
+                    f"Rotary embedding cache not found in {type(start_rotary_emb)}"
+                )
         if self.cos_cache.dtype != self.model_config.dtype:  # type: ignore
             self.cos_cache = self.cos_cache.to(  # type: ignore
                 self.model_config.dtype)  # type: ignore


### PR DESCRIPTION
Fix no attribute 'cos_cached' situation when running Moonlight-16B-A3B-Instruct

### What this PR does / why we need it?

In scenarios where models like Moonlight (using MLA but without `rope_scaling` in `config.json`) invoke `AscendRotaryEmbedding`, `cos_cached` and `sin_cached` should be got from `AscendRotaryEmbedding.cos_sin_cache`

fix  #5385 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/81786c87748b0177111dfdc07af5351d8389baa1
