### PR TITLE
[BugFix] fix greedy temperature in eagle

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -9,7 +9,7 @@ from vllm.v1.sample.rejection_sampler import generate_uniform_probs
 from vllm_ascend.sample.sampler import apply_top_k_top_p
 
 PLACEHOLDER_TOKEN_ID = -1
-GREEDY_TEMPERATURE = -1
+GREEDY_TEMPERATURE = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
 MAX_SPEC_LEN = 32


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Updated the GREEDY_TEMPERATURE value in rejection_sampler.py to 0. 

Commit https://github.com/vllm-project/vllm/commit/a676e668ee10585099816b60a440ec089fd391c4 changed greedy temperature from -1 to 0 in gpu_input_batch.py. So, previously setting this constant to -1 in rejection_sampler.py will compromised the correctness of the is_greedy flag, which will cause a crash if a batch contains a mix of sequences with temperature > 0 and temperature = 0.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
vLLM version: release/v0.13.0
vLLM main: https://github.com/vllm-project/vllm/commit/be2a947521414272fa1ed17fd5345d45ddf10774
