### PR TITLE
[Nightly] Add DeepSeek-V3.1-w8a8-mtp-QuaRot nightly test.

### DIFF
--- a/.github/workflows/nightly_test_a3.yaml
+++ b/.github/workflows/nightly_test_a3.yaml
@@ -130,6 +130,9 @@ jobs:
           - name: qwen3-235b-w8a8
             os: linux-aarch64-a3-16
             tests: tests/e2e/nightly/models/test_qwen3_235b_w8a8.py
+          - name: deepseek-v3.1-w8a8-mtp-quarot
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/models/test_deepseek_v3_1_w8a8_mtp_quarot.py
           # TODO: Replace deepseek3.2-exp with deepseek3.2 after nightly tests pass
           # - name: deepseek3_2-exp-w8a8
           #   os: linux-aarch64-a3-16

--- a/tests/e2e/nightly/models/test_deepseek_v3_1_w8a8_mtp_quarot.py
+++ b/tests/e2e/nightly/models/test_deepseek_v3_1_w8a8_mtp_quarot.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import json
+from typing import Any
+
+import openai
+import pytest
+from vllm.utils.network_utils import get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+from tools.aisbench import run_aisbench_cases
+
+MODELS = [
+    "Eco-Tech/DeepSeek-V3.1-w8a8-mtp-QuaRot",
+]
+
+prompts = [
+    "San Francisco is a",
+]
+
+api_keyword_args = {
+    "max_tokens": 10,
+}
+
+aisbench_cases = [{
+    "case_type": "accuracy",
+    "dataset_path": "vllm-ascend/gsm8k-lite",
+    "request_conf": "vllm_api_general_chat",
+    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_chat_prompt",
+    "max_out_len": 32768,
+    "batch_size": 32,
+    "baseline": 95,
+    "threshold": 5
+}, {
+    "case_type": "performance",
+    "dataset_path": "vllm-ascend/GSM8K-in3500-bs400",
+    "request_conf": "vllm_api_stream_chat",
+    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_str_perf",
+    "num_prompts": 400,
+    "max_out_len": 1500,
+    "batch_size": 1000,
+    "baseline": 1,
+    "threshold": 0.97
+}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", MODELS)
+async def test_models(model: str) -> None:
+    port = get_open_port()
+    env_dict = {
+        "HCCL_OP_EXPANSION_MODE": "AIV",
+        "VLLM_ASCEND_ENABLE_MLAPO": 1,
+        "VLLM_ASCEND_BALANCE_SCHEDULING": 1,
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True"
+    }
+    speculative_config = {"num_speculative_tokens": 3, "method": "mtp"}
+    compilation_config = {
+        "cudagraph_capture_sizes": [4, 16, 32, 48, 64],
+        "cudagraph_mode": "FULL_DECODE_ONLY"
+    }
+    server_args = [
+        "--quantization", "ascend", "--data-parallel-size", "4",
+        "--tensor-parallel-size", "4", "--enable-expert-parallel", "--port",
+        str(port), "--seed", "1024", "--max-model-len", "36864",
+        "--max-num-batched-tokens", "4096", "--max-num-seqs", "16",
+        "--trust-remote-code", "--gpu-memory-utilization", "0.92",
+        "--async-scheduling", "--no-enable-prefix-caching", "--dtype",
+        "bfloat16", "--speculative-config",
+        json.dumps(speculative_config), "--compilation-config",
+        json.dumps(compilation_config)
+    ]
+    request_keyword_args: dict[str, Any] = {
+        **api_keyword_args,
+    }
+    with RemoteOpenAIServer(model,
+                            server_args,
+                            server_port=port,
+                            env_dict=env_dict,
+                            auto_port=False) as server:
+        client = server.get_async_client()
+        batch = await client.completions.create(
+            model=model,
+            prompt=prompts,
+            **request_keyword_args,
+        )
+        choices: list[openai.types.CompletionChoice] = batch.choices
+        assert choices[0].text, "empty response"
+        print(choices)
+        # aisbench test
+        run_aisbench_cases(model,
+                           port,
+                           aisbench_cases,
+                           server_args=server_args)


### PR DESCRIPTION
### What this PR does / why we need it?
Add DeepSeek-V3.1-w8a8-mtp-QuaRot nightly test.

| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8kdataset | - | accuracy | gen | 96.21 |
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: release/v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/81786c87748b0177111dfdc07af5351d8389baa1
