### PR TITLE
[Kernel]update csrc cmakelist for open-source cann

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -81,7 +81,10 @@ if (BUILD_OPEN_PROJECT)
     target_include_directories(opapi PRIVATE
             $<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/include>
             $<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/include/aclnn>
+            # For CANN 8.3
             $<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/include/aclnn_kernels>
+            # For CANN 8.5 and later
+            $<BUILD_INTERFACE:${ASCEND_CANN_PACKAGE_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc>
     )
     target_compile_options(opapi PRIVATE
             -Werror=format


### PR DESCRIPTION
### What this PR does / why we need it?

Using open-source CANN, installation errors may occur due to changes in the path of the aclnn directory. So we add the header file.

Using open-source CANN, installation errors may occur due to changes in the path of the base/dlog_pub.h for aclnn. 

RFC: https://github.com/vllm-project/vllm-ascend/issues/5494

### Does this PR introduce _any_ user-facing change?
Does not.

### How was this patch tested?


- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5326c89803566a131c928f7fdd2100b75c981a42
