### PR TITLE
[refactor](UT,PCP,DCP) refactor pcp&dcp patches in UTs

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import torch
-from vllm.distributed.parallel_state import GroupCoordinator
 
 from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import (AscendAttentionBackend,
@@ -50,30 +49,7 @@ class TestAscendAttentionBackend(TestBase):
 
 class TestAscendAttentionMetadataBuilder(TestBase):
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
-    def setUp(self, mock_get_dcp_size, mock_dcp, mock_get_dcp_group, mock_pcp,
-              mock_get_pcp_group):
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
-
+    def setUp(self):
         self.mock_vllm_config = MagicMock()
         self.mock_vllm_config.speculative_config = None
         self.mock_vllm_config.model_config.max_model_len = 640
@@ -126,30 +102,7 @@ class TestAscendAttentionMetadataBuilder(TestBase):
 
 class TestAscendAttentionBackendImpl(TestBase):
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
-    def setUp(self, mock_get_dcp_size, mock_dcp, mock_get_dcp_group, mock_pcp,
-              mock_get_pcp_group):
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
-
+    def setUp(self):
         self.layer = MagicMock()
         self.layer.layer_name = "test_layer"
         self.layer._k_scale_float = 1.0

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -190,15 +190,7 @@ class TestAscendMLAMetadata(TestBase):
 
 class TestAscendMLAMetadataBuilder(TestBase):
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    def test_ascend_mla_metadata_builder_default(self, mock_dcp,
-                                                 mock_get_dcp_group, mock_pcp,
-                                                 mock_get_pcp_group):
+    def test_ascend_mla_metadata_builder_default(self):
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
@@ -208,22 +200,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = 'cpu'
-
-        mock_dcp.world_size = 2
-        mock_dcp.rank_in_group = 0
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 2
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 2
-        mock_pcp.rank_in_group = 0
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 2
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
 
         mock_vllm_config.speculative_config = None
 
@@ -239,16 +215,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
                 builder.chunked_prefill_enabled,
                 mock_vllm_config.scheduler_config.enable_chunked_prefill)
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    def test_ascend_mla_metadata_builder_spec_decode(self, mock_dcp,
-                                                     mock_get_dcp_group,
-                                                     mock_pcp,
-                                                     mock_get_pcp_group):
+    def test_ascend_mla_metadata_builder_spec_decode(self):
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
@@ -258,20 +225,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = 'cpu'
-
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
 
         mock_spec_config = MagicMock()
         mock_spec_config.num_speculative_tokens = 3
@@ -290,15 +243,8 @@ class TestAscendMLAMetadataBuilder(TestBase):
                 mock_vllm_config.scheduler_config.enable_chunked_prefill)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
     def test_ascend_mla_metadata_builder_build_full_graph(
-            self, mock_dcp, mock_get_dcp_group, mock_pcp, mock_get_pcp_group,
-            mock_get_cos_and_sin_mla):
+            self, mock_get_cos_and_sin_mla):
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
@@ -309,20 +255,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_device = 'cpu'
         torch.Tensor.pin_memory = lambda x: x  # noqa
-
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
 
         mock_spec_config = MagicMock()
         mock_spec_config.num_speculative_tokens = 1
@@ -352,14 +284,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
                          [1, 2, 4, 5, 6, 6, 7, 8])
         self.assertEqual(metadata.decode.block_table.shape[0], 8)
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    def test_reorder_batch(self, mock_dcp, mock_get_dcp_group, mock_pcp,
-                           mock_get_pcp_group):
+    def test_reorder_batch(self):
         ascend_config = MagicMock()
 
         mock_vllm_config = MagicMock()
@@ -369,20 +294,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
         mock_device = 'cpu'
-
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
 
         mock_vllm_config.speculative_config = None
 
@@ -411,16 +322,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         self.assertTrue(modified)
         input_batch.swap_states.assert_called_once_with(1, 2)
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    def test_pad_actual_seq_lens_q_mtp_disable_pad(self, mock_dcp,
-                                                   mock_get_dcp_group,
-                                                   mock_pcp,
-                                                   mock_get_pcp_group):
+    def test_pad_actual_seq_lens_q_mtp_disable_pad(self):
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
@@ -431,20 +333,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_device = 'cpu'
         mock_vllm_config.speculative_config = None
-
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
 
         builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
                                            mock_device)
@@ -456,15 +344,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
             num_reqs_pad_size, num_reqs, input_seq_lens)
         self.assertEqual(output_seq_lens, expect_output)
 
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    def test_pad_actual_seq_lens_q_mtp_enable_pad(self, mock_dcp,
-                                                  mock_get_dcp_group, mock_pcp,
-                                                  mock_get_pcp_group):
+    def test_pad_actual_seq_lens_q_mtp_enable_pad(self):
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
@@ -475,20 +355,6 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_device = 'cpu'
         mock_vllm_config.speculative_config = None
-
-        mock_dcp.world_size = 1
-        dcp_group = MagicMock(spec=GroupCoordinator)
-        dcp_group.rank_in_group = 0
-        dcp_group.world_size = 1
-        dcp_group.device_group = MagicMock()
-        mock_get_dcp_group.return_value = dcp_group
-
-        mock_pcp.world_size = 1
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.rank_in_group = 0
-        pcp_group.world_size = 1
-        pcp_group.device_group = MagicMock()
-        mock_get_pcp_group.return_value = pcp_group
 
         common_metadata = MagicMock()
         common_metadata.actual_seq_lengths_q = [2, 4, 6, 8]
@@ -530,22 +396,14 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.kv_cache_spec.num_heads = 32
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
     def test_build_prefix_no_cache_metadata(self, mock_npu_available,
-                                            mock_zeros, mock_dcp_world_size,
-                                            mock_get_pcp_group,
+                                            mock_zeros,
                                             mock_get_cos_and_sin_mla):
         mock_npu_available.return_value = False
-        mock_dcp_world_size.return_value = 1
         torch.Tensor.pin_memory = lambda x: x  # noqa
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.world_size = 1
-        mock_get_pcp_group.return_value = pcp_group
 
         def zeros_override(*args, **kwargs):
             kwargs.pop('pin_memory', None)
@@ -596,22 +454,14 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
     def test_build_chunked_prefix_metadata(self, mock_npu_available,
-                                           mock_zeros, mock_dcp_world_size,
-                                           mock_get_pcp_group,
+                                           mock_zeros,
                                            mock_get_cos_and_sin_mla):
         mock_npu_available.return_value = False
-        mock_dcp_world_size.return_value = 1
         torch.Tensor.pin_memory = lambda x: x  # noqa
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.world_size = 1
-        mock_get_pcp_group.return_value = pcp_group
 
         def zeros_override(*args, **kwargs):
             kwargs.pop('pin_memory', None)
@@ -663,18 +513,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
-    def test_build_decode_only_metadata(self, mock_dcp_world_size,
-                                        mock_get_pcp_group,
-                                        mock_get_cos_and_sin_mla):
-        mock_dcp_world_size.return_value = 1
+    def test_build_decode_only_metadata(self, mock_get_cos_and_sin_mla):
         torch.Tensor.pin_memory = lambda x: x  # noqa
 
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.world_size = 1
-        mock_get_pcp_group.return_value = pcp_group
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=torch.tensor([0, 1, 2, 3]),
             query_start_loc_cpu=torch.tensor([0, 1, 2, 3]),
@@ -718,18 +559,10 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
-    def test_build_for_graph_capture_decode_only(self, mock_dcp_world_size,
-                                                 mock_get_pcp_group,
+    def test_build_for_graph_capture_decode_only(self,
                                                  mock_get_cos_and_sin_mla):
-        mock_dcp_world_size.return_value = 1
         torch.Tensor.pin_memory = lambda x: x  # noqa
 
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.world_size = 1
-        mock_get_pcp_group.return_value = pcp_group
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=torch.tensor([0, 1, 2, 3]),
             query_start_loc_cpu=torch.tensor([0, 1, 2, 3]),
@@ -774,17 +607,8 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    @patch("vllm.distributed.get_decode_context_model_parallel_world_size",
-           return_value=1)
-    def test_build_for_graph_capture_prefill(self, mock_dcp_world_size,
-                                             mock_get_pcp_group,
-                                             mock_get_cos_and_sin_mla):
-        mock_dcp_world_size.return_value = 1
+    def test_build_for_graph_capture_prefill(self, mock_get_cos_and_sin_mla):
         torch.Tensor.pin_memory = lambda x: x  # noqa
-        pcp_group = MagicMock(spec=GroupCoordinator)
-        pcp_group.world_size = 1
-        mock_get_pcp_group.return_value = pcp_group
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=torch.tensor([0, 3, 7]),
             query_start_loc_cpu=torch.tensor([0, 3, 7]),
@@ -820,23 +644,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
 
 class TestAscendMLAImpl(TestBase):
 
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
     @patch('vllm.distributed.parallel_state._TP',
            new_callable=lambda: MagicMock(spec=GroupCoordinator))
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    def setUp(self, get_current_vllm_config, mock_tp, mock_dcp, mock_pcp):
+    def setUp(self, get_current_vllm_config, mock_tp):
         mock_tp.world_size = 2
         mock_tp.rank_in_group = MagicMock()
         mock_tp.device_group = MagicMock()
-        mock_dcp.world_size = 1
-        mock_dcp.rank_in_group = MagicMock()
-        mock_dcp.device_group = MagicMock()
-        mock_pcp.world_size = 1
-        mock_pcp.rank_in_group = MagicMock()
-        mock_pcp.device_group = MagicMock()
         vllm_config = MagicMock()
         speculative_config = MagicMock()
         model_config = MagicMock()

--- a/tests/ut/attention/utils.py
+++ b/tests/ut/attention/utils.py
@@ -1,0 +1,64 @@
+from functools import wraps
+from unittest.mock import MagicMock, patch
+
+from vllm.distributed.parallel_state import all_gather_fake
+
+
+def patch_distributed_groups(dcp_size=1,
+                             dcp_rank=0,
+                             pcp_size=1,
+                             pcp_rank=0,
+                             needs_mocks=True):
+    """
+    Decorator to patch common distributed group mocks with configuration
+    
+    Args:
+        dcp_size: DCP world size (default: 1)
+        dcp_rank: DCP rank (default: 0)
+        pcp_size: PCP world size (default: 1)
+        pcp_rank: PCP rank (default: 0)
+        needs_mocks: Whether to pass mock objects as the first arguments 
+             after 'self' to the decorated function. 
+             If True, the decorated function receives: 
+                 func(self, mock_all_to_all_single, mock_dcp, mock_pcp, *args, **kwargs)
+             If False, mocks are not passed and function receives: 
+                 func(self, *args, **kwargs)
+             (default: True)
+    """
+
+    def decorator(func):
+
+        @wraps(func)
+        @patch('torch.distributed.all_to_all_single')
+        @patch('vllm.distributed.parallel_state._PCP')
+        @patch('vllm.distributed.parallel_state._DCP')
+        def wrapper(self, mock_dcp, mock_pcp, mock_all_to_all_single, *args,
+                    **kwargs):
+            mock_dcp.rank_in_group = dcp_rank
+            mock_dcp.world_size = dcp_size
+            mock_dcp.device_group = MagicMock()
+
+            mock_dcp.all_gather = MagicMock()
+            mock_dcp.all_gather.side_effect = lambda input_, dim: all_gather_fake(
+                input_, dim, mock_dcp.world_size, "mock_dcp_group")
+
+            mock_pcp.rank_in_group = pcp_rank
+            mock_pcp.world_size = pcp_size
+            mock_pcp.device_group = MagicMock()
+
+            mock_pcp.all_gather = MagicMock()
+            mock_pcp.all_gather.side_effect = lambda input_, dim: all_gather_fake(
+                input_, dim, mock_pcp.world_size, "mock_pcp_group")
+
+            mock_all_to_all_single.side_effect = lambda output, input, *a, **kw: output.copy_(
+                input)
+
+            if needs_mocks:
+                return func(self, mock_all_to_all_single, mock_dcp, mock_pcp,
+                            *args, **kwargs)
+            else:
+                return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, patch
 
 import msgspec
 import zmq
-from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.utils.network_utils import make_zmq_path
 
 fake_engine = types.ModuleType("mooncake.engine")
@@ -23,6 +22,7 @@ _mock_ascend_config = MagicMock(enable_kv_nz=False)
 _mock_pp_group = MagicMock(rank_in_group=0, world_size=1)
 _mock_tp_group = MagicMock(rank_in_group=0, world_size=4)
 _mock_pcp_group = MagicMock(rank_in_group=0, world_size=1)
+_mock_dcp_group = MagicMock(rank_in_group=0, world_size=1)
 patch('vllm_ascend.distributed.mooncake_connector.get_pp_group',
       return_value=_mock_pp_group).start()
 patch('vllm_ascend.distributed.mooncake_connector.get_tp_group',
@@ -35,6 +35,7 @@ patch(
     return_value=0).start()
 patch('vllm_ascend.distributed.mooncake_connector.get_pcp_group',
       return_value=_mock_pcp_group).start()
+patch('vllm.distributed.parallel_state._DCP', _mock_dcp_group).start()
 
 from vllm_ascend.distributed.mooncake_connector import (  # noqa: E402
     KVCacheRecvingThread, KVCacheSendingThread, KVCacheTaskTracker,
@@ -1092,17 +1093,6 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.mock_transfer_engine.get_rpc_port.return_value = 9090
         self.mock_transfer_engine.initialize.return_value = 0
         self.mock_transfer_engine.register_memory.return_value = 0
-        self.mock_dcp_group = MagicMock(spec=GroupCoordinator)
-        self.mock_dcp_group.rank_in_group = 0
-        self.mock_dcp_group.world_size = 1
-        self.mock_dcp_group.device_group = MagicMock()
-        self.mock_dcp = MagicMock()
-        self.mock_dcp.world_size = 1
-
-        self.mock_pcp_group = MagicMock(spec=GroupCoordinator)
-        self.mock_pcp_group.rank_in_group = 0
-        self.mock_pcp_group.world_size = 1
-        self.mock_pcp_group.device_group = MagicMock()
 
         self.patches = [
             patch('torch.Tensor.size', return_value=(10, 16, 8, 16)),
@@ -1137,13 +1127,6 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                   MagicMock()),
             patch('vllm_ascend.distributed.mooncake_connector.threading.Event',
                   MagicMock()),
-            patch('vllm.distributed.parallel_state.get_dcp_group',
-                  return_value=self.mock_dcp_group),
-            patch('vllm.distributed.parallel_state._DCP',
-                  return_value=self.mock_dcp),
-            patch(
-                'vllm_ascend.distributed.mooncake_connector.get_decode_context_model_parallel_world_size',
-                return_value=1),
             patch(
                 'vllm_ascend.distributed.mooncake_connector.get_ascend_config',
                 return_value=MagicMock()),


### PR DESCRIPTION
### What this PR does / why we need it?
Refactor PCP & DCP patches in UTs: Merge and reuse communication groups and communication function patches to reduce code duplication.
### Does this PR introduce _any_ user-facing change?
No
- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/45c1ca1ca1ee8fa06df263c8715e8a412ff408d4
