### PR TITLE
[3/N][Nightly] Move ops tests to nightly

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -106,7 +106,7 @@ jobs:
           # We found that if running aclgraph tests in batch, it will cause AclmdlRICaptureBegin error. So we run
           # the test separately.
 
-          pytest -sv --durations=0 tests/e2e/nightly/ops/triton/
+          pytest -sv --durations=0 tests/e2e/nightly/single_node/ops/singlecard_ops/triton/
           pytest -sv --durations=0 tests/e2e/singlecard/test_completion_with_prompt_embeds.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_aclgraph_accuracy.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_async_scheduling.py


### PR DESCRIPTION
### What this PR does / why we need it?
Follow https://github.com/vllm-project/vllm-ascend/pull/5479, since the cases `tests/e2e/nightly/ops/triton/` have to been verified stable enough, we should move it to nightly in principle
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/45c1ca1ca1ee8fa06df263c8715e8a412ff408d4
