### PR TITLE
[Nightly] Trigger image build for nightly

### DIFF
--- a/.github/workflows/pr_tag_image_build_and_push.yaml
+++ b/.github/workflows/pr_tag_image_build_and_push.yaml
@@ -26,6 +26,8 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'csrc/**'
+      # We should also trigger image build when nightly test related files are changed to ensure the image is valid for nightly tests
+      - 'tests/e2e/nightly/'
     types: [ labeled ]
   push:
     # Publish image when tagging, the Dockerfile in tag will be build as tag image


### PR DESCRIPTION
### What this PR does / why we need it?
We should also trigger image build when nightly test related files are changed to ensure the image is valid for nightly tests. Please note that this only applies to image with the tag `main*`(which means build triggered by PR).
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7157596103666ee7ccb7008acee8bff8a8ff1731
