### PR TITLE
[P/D]Remove mooncake kvpool unused parameter `local_hostname`

### DIFF
--- a/vllm_ascend/distributed/kvpool/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kvpool/backend/mooncake_backend.py
@@ -76,7 +76,6 @@ class MooncakeBackend(Backend):
 
 @dataclass
 class MooncakeStoreConfig:
-    local_hostname: str
     metadata_server: str
     global_segment_size: Union[int, str]
     local_buffer_size: int
@@ -89,7 +88,6 @@ class MooncakeStoreConfig:
         with open(file_path) as file:
             config = json.load(file)
         return MooncakeStoreConfig(
-            local_hostname=config.get("local_hostname"),
             metadata_server=config.get("metadata_server"),
             global_segment_size=_parse_global_segment_size(
                 config.get("global_segment_size",


### PR DESCRIPTION
### What this PR does / why we need it?
In mooncake kvpool, `local_hostname` is not used. Instead, the local IP is obtained directly via `get_ip()`. Therefore, remove this parameter to avoid confusion.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7157596103666ee7ccb7008acee8bff8a8ff1731
