### PR TITLE
[Doc] Fix typo in ASCEND_RT_VISIBLE_DEVICES

### DIFF
--- a/docs/source/tutorials/Qwen2.5-7B.md
+++ b/docs/source/tutorials/Qwen2.5-7B.md
@@ -98,7 +98,7 @@ Qwen2.5-7B-Instruct supports single-node single-card deployment on the 910B4 pla
 
 ```shell
 #!/bin/sh
-export ASCEBD_RT_VISIBLE_DEVICES=0
+export ASCEND_RT_VISIBLE_DEVICES=0
 export MODEL_PATH="Qwen/Qwen2.5-7B-Instruct"
 
 vllm serve ${MODEL_PATH} \


### PR DESCRIPTION
Fixed a typo in the environment variable name. `ASCEBD_RT_VISIBLE_DEVICES` -> `ASCEND_RT_VISIBLE_DEVICES`
Fixes #5580
- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7157596103666ee7ccb7008acee8bff8a8ff1731
