### PR TITLE
Ears,a efficient adaptive rejection sampling for accelerating speculator

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -132,6 +132,9 @@ env_variables: Dict[str, Callable[[], Any]] = {
     # Whether to anbale balance scheduling
     "VLLM_ASCEND_BALANCE_SCHEDULING":
     lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", '0'))),
+    # EARS tolerance. Enabled if > 0.
+    "VLLM_EARS_TOLERANCE":
+    lambda: float(os.getenv("VLLM_EARS_TOLERANCE", "0.0")),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
### What this PR does / why we need it?
https://github.com/vllm-project/vllm-ascend/issues/5471

### Does this PR introduce _any_ user-facing change?
Added macro definition switch VLLM_EARS_TOLERANCE

### How was this patch tested?
export ASCEND_RT_VISIBLE_DEVICES=14,15
export VLLM_EARS_TOLERANCE=0.3
vllm serve /data2/weights/Qwen_Qwen3-32B \
    -tp 2 \
    --port 9000 \
    --served-model-name Qwen3-32B \
    --speculative-config '{
    "model": "/data2/weights/scd/RedHatAI/Qwen3-32B-speculator.eagle3",
    "num_speculative_tokens": 4,
    "method": "eagle3",
    "draft_tensor_parallel_size": 1
  }'

evalscope perf --url "http://localhost:9001/v1/chat/completions" --parallel 1 --model Qwen3-32B --number 10 --api openai --dataset openqa --temperature 0.9 --stream

<img width="427" height="236" alt="image" src="https://github.com/user-attachments/assets/c3525d3c-5f27-4d82-8939-d9ffb60302e0" />

evalscope eval --model Qwen3-32B --api-url http://localhost:9000/v1 --api-key EMPTY --eval-type openai_api --datasets gsm8k --generation-config '{"temperature": 0.9}'

<img width="426" height="62" alt="image" src="https://github.com/user-attachments/assets/23afaa69-81ff-4c0f-900a-4b03b764325b" />

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7157596103666ee7ccb7008acee8bff8a8ff1731
