### PR TITLE
[Bugfix] Make pd more generalization

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -94,16 +94,18 @@ class AscendConfig:
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
                 try:
-                    # only support Qwen model now
-                    # TODO: use a more robust method to get kv_head_num
-                    num_kv_head = vllm_config.model_config.hf_config.num_key_value_heads
+                    num_kv_head = vllm_config.model_config.hf_text_config.num_key_value_heads
                     self.num_head_replica = prefill_tp_size // num_kv_head if prefill_tp_size >= num_kv_head else 1
                     prefill_tp_size = min(prefill_tp_size, num_kv_head)
                     decode_tp_size = min(decode_tp_size, num_kv_head)
                     self.pd_head_ratio = prefill_tp_size // decode_tp_size
                 except Exception:
-                    raise AssertionError(
-                        "Can not get num_key_value_heads from model_config")
+                    raise ValueError(
+                        "The text_config extracted from the model config does not have "
+                        "`num_key_value_heads` attribute. This indicates a mismatch "
+                        "between the model config and vLLM's expectations. Please "
+                        "ensure that the model config is compatible with vLLM."
+                    )
 
             if self.pd_tp_ratio == 0:
                 raise AssertionError(

--- a/vllm_ascend/distributed/mooncake_connector.py
+++ b/vllm_ascend/distributed/mooncake_connector.py
@@ -345,7 +345,7 @@ class KVCacheRecvingThread(threading.Thread):
         self.vllm_config = vllm_config
         self.model_config = self.vllm_config.model_config
         self.block_size = self.vllm_config.cache_config.block_size
-        self.num_layers = self.model_config.hf_config.num_hidden_layers
+        self.num_layers = self.model_config.hf_text_config.num_hidden_layers
         self.pp_layer_indices = {
             rank:
             get_prefill_pp_indices(self.num_layers, rank,


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, in pd disaggregated scenario, when the prefiller's `tp_size` > decoder's `tp_size`, we need to get `num_key_value_heads` from model_config, but for different models, the `config.json` are different(eg: for multi-modal models, there exist a `text_config` section), we cannot directly obtain this field through hf_config. Instead, we need to use special preprocessing in transformers to perform different processing on different models to obtain a unified configuration.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7157596103666ee7ccb7008acee8bff8a8ff1731
