### PR TITLE
[CI] Specify the version of xlite

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,5 +21,5 @@ pytest_mock
 msserviceprofiler>=1.2.2
 mindstudio-probe>=8.3.0
 arctic-inference==0.1.1
-xlite
+xlite==0.1.0rc0
 uc-manager


### PR DESCRIPTION
### What this PR does / why we need it?
Pin the xlite version to avoid CI failures during its upgrade.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/7157596103666ee7ccb7008acee8bff8a8ff1731
