### PR TITLE
Add workflow to cancel running workflows on PR close

### DIFF
--- a/.github/workflows/cancel_on_pr_close.yaml
+++ b/.github/workflows/cancel_on_pr_close.yaml
@@ -1,0 +1,14 @@
+name: Cancel Running Workflows on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel-running-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflows for this PR
+        uses: peter-evans/workflow-run-cleanup-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/vllm-project/vllm-ascend/actions/runs/20735955959/job/59533181655 is still running after https://github.com/vllm-project/vllm-ascend/pull/5612 is closed. 

And the action will be running for more than 2 hours, which needs to be cleanup.

It seems that the Github Aciton will not cancel it automatically, so I add this to cannel those PR related actions once it is closed.
- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8be6432bdaf6275664d857b1e5e9bf8ed1ce299e
