### PR TITLE
[CI] Add workflow to cancel running workflows on PR close

### DIFF
--- a/.github/workflows/pr_close_cancel_job.yaml
+++ b/.github/workflows/pr_close_cancel_job.yaml
@@ -1,0 +1,46 @@
+name: Cancel runs on PR close
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.payload.pull_request.head.ref;
+
+            const statuses = ["in_progress", "queued", "waiting", "pending", "requested"];
+            for (const status of statuses) {
+              let page = 1;
+              while (true) {
+                const resp = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner, repo, branch, status, per_page: 100, page
+                });
+
+                const runs = resp.data.workflow_runs;
+                if (!runs.length) break;
+
+                for (const run of runs) {
+                  if (run.id === context.runId) continue; // don't cancel this workflow
+                  try {
+                    await github.rest.actions.cancelWorkflowRun({ owner, repo, run_id: run.id });
+                    core.info(`Cancel requested: ${run.html_url}`);
+                  } catch (e) {
+                    // common reasons: already completed (409) or insufficient permissions (403)
+                    core.warning(`Failed to cancel ${run.html_url}: ${e.message}`);
+                  }
+                }
+
+                if (runs.length < 100) break;
+                page++;
+              }
+            }


### PR DESCRIPTION
Example: https://github.com/vllm-project/vllm-ascend/actions/runs/20735955959/job/59533181655 is still running after https://github.com/vllm-project/vllm-ascend/pull/5612 is closed.

And the action will be running for more than 2 hours, which needs to be cleanup.

It seems that the Github Aciton will not cancel it automatically, so I add this to cannel those PR related actions once it is closed.

Tested in https://github.com/pacoxu/pacoxu/actions/runs/20743173119.
- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
