### PR TITLE
[4/N][Nightly] nightly cotroller use cpu image

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -69,34 +69,12 @@ jobs:
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}
     container:
-      image: m.daocloud.io/quay.io/ascend/cann:8.3.rc2-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-cpu
       env:
         KUBECONFIG: /tmp/kubeconfig
-        KUBECTL: /root/.cache/.kube/kubectl
         NAMESPACE: vllm-project
         LEADER_POD: vllm-0
-        RESULT_FILE: /root/.cache/tests/ret_${{ inputs.soc_version }}
     steps:
-        - name: Install system denpendencies
-          run: |
-           # configure apt and pip source
-           sed -i 's|ports.ubuntu.com|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list
-           pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
-           pip install jinja2-cli
-
-        - name: Install kubectl
-          run: |
-            # Install kubectl
-            arch=$(uname -m)
-
-            if echo "$arch" | grep -qiE "arm|aarch64"; then
-              echo "Detected ARM architecture: $arch"
-              KUBECTL="$KUBECTL"_arm
-            fi
-            install -o root -g root -m 0755 $KUBECTL /usr/local/bin/kubectl
-
-            # Verify kubectl installation
-            kubectl version --client=true
 
         - name: Decode kubeconfig from secrets
           run: |
@@ -157,10 +135,6 @@ jobs:
             replicas="${{ inputs.replicas }}"
             image="${{ inputs.image }}"
             config_file_path="${{ inputs.config_file_path }}"
-            vllm_version="${{ inputs.vllm_version }}"
-            vllm_ascend_ref="${{ inputs.vllm_ascend_ref }}"
-            vllm_ascend_remote_url="${{ inputs.vllm_ascend_remote_url }}"
-            result_file_path="$RESULT_FILE"
             fail_tag=FAIL_TAG_"${{ inputs.config_file_path }}"
             echo "FAIL_TAG=${fail_tag}" >> $GITHUB_ENV
 
@@ -183,10 +157,6 @@ jobs:
               -D replicas="$replicas" \
               -D image="$image" \
               -D config_file_path="$config_file_path" \
-              -D vllm_version="$vllm_version" \
-              -D vllm_ascend_remote_url="$vllm_ascend_remote_url" \
-              -D vllm_ascend_ref="$vllm_ascend_ref" \
-              -D result_file_path="$result_file_path" \
               -D npu_per_node="$npu_per_node" \
               -D fail_tag="$fail_tag" \
               --outfile lws.yaml

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -22,13 +22,6 @@ spec:
                 value: {{ config_file_path | default("DeepSeek-V3.yaml") }}
               - name: WORKSPACE
                 value: "/vllm-workspace"
-              # Set vLLM version and vLLM-Ascend version here, once there is a new release, update here.
-              - name: VLLM_ASCEND_VERSION
-                value: {{ vllm_ascend_ref | default("main") }}
-              - name: VLLM_ASCEND_REMOTE_URL
-                value: {{ vllm_ascend_remote_url | default("https://github.com/vllm-project/vllm-ascend.git") }}
-              - name: RESULT_FILE_PATH
-                value: {{ result_file_path | default("/root/.cache/tests/ret") }}
               - name: FAIL_TAG
                 value: {{ fail_tag | default("FAIL_TAG") }}
             command:
@@ -81,13 +74,6 @@ spec:
                 value: {{ config_file_path | default("DeepSeek-V3.yaml") }}
               - name: WORKSPACE
                 value: "/vllm-workspace"
-              # Set vLLM version and vLLM-Ascend version here, once there is a new release, update here.
-              - name: VLLM_ASCEND_VERSION
-                value: {{ vllm_ascend_ref | default("main") }}
-              - name: VLLM_ASCEND_REMOTE_URL
-                value: {{ vllm_ascend_remote_url | default("https://github.com/vllm-project/vllm-ascend.git") }}
-              - name: RESULT_FILE_PATH
-                value: {{ result_file_path | default("/root/.cache/tests/ret") }}
               - name: FAIL_TAG
                 value: {{ fail_tag | default("FAIL_TAG") }}
             command:


### PR DESCRIPTION
### What this PR does / why we need it?
Follow up https://github.com/vllm-project/vllm-ascend/pull/5479, This patch use a more lightweight image; remove redundant environment variables
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
