### PR TITLE
[CI] Bump lm-eval version to v0.4.9.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ openai
 pytest >= 6.0,<9.0.0
 pytest-asyncio
 pytest-mock
-lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d 
+lm-eval==0.4.9.2
 types-jsonschema
 xgrammar
 zmq


### PR DESCRIPTION
### What this PR does / why we need it?
fix https://github.com/vllm-project/vllm-ascend/issues/2865,  lm-eval [got an official update last month](https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.9.2), so let's bump the version.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
