### PR TITLE
[Ops] replace _update_out_and_lse with _npu_attn_out_lse_update

### DIFF
--- a/tests/ut/attention/test_attention_cp.py
+++ b/tests/ut/attention/test_attention_cp.py
@@ -137,8 +137,10 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(output.shape[2], 128)
 
     @patch('torch.ops.npu.npu_fused_infer_attention_score')
+    @patch('torch_npu.npu_attention_update')
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
-    def test_compute_prefill_context(self, mock_npu_attention):
+    def test_compute_prefill_context(self, mock_npu_attention_update,
+                                     mock_npu_attention):
 
         block_num = 100
         block_size = 128
@@ -181,7 +183,9 @@ class TestAscendAttentionCPImpl(TestBase):
                                                       head_size), torch.randn(
                                                           batch_size,
                                                           num_heads, 1)
-
+        mock_npu_attention_update.return_value = torch.randn(
+            batch_size, self.impl.num_heads,
+            head_size), torch.randn(batch_size, self.impl.num_heads, 1)
         context_output = self.impl._compute_prefill_context(
             query, kv_cache, attn_metadata)
         local_context_output = torch.cat(context_output,
@@ -406,11 +410,9 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.assertEqual(attn_lse.shape, (96, 8, 1))
 
     @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch(
-        'vllm_ascend.attention.context_parallel.attention_cp.AscendAttentionCPImpl._update_out_and_lse'
-    )
+    @patch('torch_npu.npu_attention_update')
     def test_attention_with_nomask_and_mask_chunk(
-            self, mock_update_out_and_lse,
+            self, mock_npu_attention_update,
             mock_npu_fused_infer_attention_score):
         # Mock input data
         q = torch.randn(self.q_total_tokens, self.impl.num_heads,
@@ -432,7 +434,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
             self.q_total_tokens, self.impl.num_heads,
             self.impl.head_size), torch.randn(self.q_total_tokens,
                                               self.impl.num_heads, 1)
-        mock_update_out_and_lse.return_value = torch.randn(
+        mock_npu_attention_update.return_value = torch.randn(
             self.q_total_tokens, self.impl.num_heads,
             self.impl.head_size), torch.randn(self.q_total_tokens,
                                               self.impl.num_heads, 1)
@@ -481,8 +483,12 @@ class TestUpdateNpuAttnOutLse(TestBase):
             self.q_total_tokens, self.impl.num_heads,
             self.impl.head_size), torch.randn(self.q_total_tokens,
                                               self.impl.num_heads, 1)
-        mock_npu_attn_out_lse_update.return_value = torch.randn(
-            self.q_total_tokens, self.impl.num_heads, self.impl.head_size)
+        mock_npu_attn_out_lse_update.return_value = (torch.randn(
+            self.q_total_tokens, self.impl.num_heads, self.impl.head_size),
+                                                     torch.randn(
+                                                         self.q_total_tokens,
+                                                         self.impl.num_heads,
+                                                         1))
 
         # Call the method under test
         output, attn_lse = self.impl._attention_with_nomask_and_mask(
@@ -500,7 +506,6 @@ class TestUpdateNpuAttnOutLse(TestBase):
         mock_npu_attn_out_lse_update.assert_called_once()
         self.assertEqual(mock_npu_fused_infer_attention_score.call_count, 2)
         self.assertIsNotNone(output)
-        self.assertEqual(attn_lse, None)
 
     @patch(
         'vllm_ascend.attention.context_parallel.attention_cp.AscendAttentionCPImpl._npu_attn_out_lse_update'
@@ -550,14 +555,14 @@ class TestUpdateNpuAttnOutLse(TestBase):
         attn_out_nomask = torch.randn(8, 128, 128)
 
         # Mock output
-        mock_npu_attention_update.return_value = (torch.randn(8 * 128,
-                                                              128), None)
+        mock_npu_attention_update.return_value = (torch.randn(8 * 128, 128),
+                                                  torch.randn(8 * 128, 1))
 
         # Call the method under test
-        output = self.impl._npu_attn_out_lse_update(attn_lse_mask,
-                                                    attn_lse_nomask,
-                                                    attn_out_mask,
-                                                    attn_out_nomask)
+        output, _ = self.impl._npu_attn_out_lse_update(attn_lse_mask,
+                                                       attn_lse_nomask,
+                                                       attn_out_mask,
+                                                       attn_out_nomask)
 
         # Assert the method call
         self.assertIsInstance(output, torch.Tensor)
@@ -565,28 +570,11 @@ class TestUpdateNpuAttnOutLse(TestBase):
 
         mock_npu_attention_update.assert_called_once()
 
-    def test_update_out_and_lse(self):
-        # Mock input data
-        out_list = torch.randn(3, 2, 4,
-                               8)  # [N, batch_size, num_heads, head_size]
-        lse_list = torch.randn(3, 2, 4, 1)  # [N, batch_size, num_heads, 1]
-
-        # Call the method under test
-        out_final, lse_final = self.impl._update_out_and_lse(
-            out_list, lse_list)
-
-        # Assert the method call
-        self.assertEqual(out_final.shape,
-                         (2, 4, 8))  # [batch_size, num_heads, head_size]
-        self.assertEqual(lse_final.shape,
-                         (2, 4, 1))  # [batch_size, num_heads, 1]
-
-        self.assertIsInstance(out_final, torch.Tensor)
-        self.assertIsInstance(lse_final, torch.Tensor)
-
+    @patch('torch_npu.npu_attention_update')
     @patch_distributed_groups(dcp_size=2, pcp_size=3)
     def test_update_chunk_attn_out_lse_dcp2_pcp3(self, mock_all_to_all_single,
-                                                 mock_dcp, mock_pcp):
+                                                 mock_dcp, mock_pcp,
+                                                 mock_npu_attention_update):
         # Mock input data
         prefix_chunk_output = torch.randn(2, 4, 8)
         prefix_chunk_lse = torch.randn(2, 4, 1)
@@ -601,6 +589,8 @@ class TestUpdateNpuAttnOutLse(TestBase):
             chunk_data)
         global_context_output = global_context_output.permute([2, 0, 1
                                                                ]).contiguous()
+        mock_npu_attention_update.return_value = (torch.randn(2, 2, 8),
+                                                  torch.randn(2, 2, 1))
         output, lse = self.impl._update_global_context_output(
             global_context_output)
 
@@ -613,9 +603,11 @@ class TestUpdateNpuAttnOutLse(TestBase):
         mock_all_to_all_single.assert_called_once()
         mock_pcp.all_gather.assert_called_once()
 
+    @patch('torch_npu.npu_attention_update')
     @patch_distributed_groups(dcp_size=2)
     def test_update_chunk_attn_out_lse_dcp2_pcp1(self, mock_all_to_all_single,
-                                                 mock_dcp, mock_pcp):
+                                                 mock_dcp, mock_pcp,
+                                                 mock_npu_attention_update):
         # Mock input data
         prefix_chunk_output = torch.randn(2, 4, 8)
         prefix_chunk_lse = torch.randn(2, 4, 1)
@@ -631,6 +623,8 @@ class TestUpdateNpuAttnOutLse(TestBase):
             chunk_data)
         global_context_output = global_context_output.permute([2, 0, 1
                                                                ]).contiguous()
+        mock_npu_attention_update.return_value = (torch.randn(2, 2, 8),
+                                                  torch.randn(2, 2, 1))
         output, lse = self.impl._update_global_context_output(
             global_context_output)
 
@@ -643,9 +637,11 @@ class TestUpdateNpuAttnOutLse(TestBase):
         mock_all_to_all_single.assert_called_once()
         mock_pcp.all_gather.assert_not_called()
 
+    @patch('torch_npu.npu_attention_update')
     @patch_distributed_groups(pcp_size=2)
     def test_update_chunk_attn_out_lse_dcp1_pcp2(self, mock_all_to_all_single,
-                                                 mock_dcp, mock_pcp):
+                                                 mock_dcp, mock_pcp,
+                                                 mock_npu_attention_update):
         # Mock input data
         prefix_chunk_output = torch.randn(2, 4, 8)
         prefix_chunk_lse = torch.randn(2, 4, 1)
@@ -661,6 +657,9 @@ class TestUpdateNpuAttnOutLse(TestBase):
             chunk_data)
         global_context_output = global_context_output.permute([2, 0, 1
                                                                ]).contiguous()
+        mock_npu_attention_update.return_value = torch.randn(2, 4,
+                                                             8), torch.randn(
+                                                                 2, 4, 1)
         output, lse = self.impl._update_global_context_output(
             global_context_output)
 

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -337,17 +337,8 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         output = attn_out_mask
         attn_lse = attn_lse_mask
         if k_nomask is not None:
-            if attn_metadata.prefill is not None and attn_metadata.prefill.chunked_context is None:
-                output = self._npu_attn_out_lse_update(attn_lse_mask,
-                                                       attn_lse_nomask,
-                                                       attn_out_mask,
-                                                       attn_out_nomask)
-                attn_lse = None
-            else:
-                output, attn_lse = self._update_out_and_lse(
-                    torch.stack([attn_out_nomask, attn_out_mask], dim=0),
-                    torch.stack([attn_lse_nomask, attn_lse_mask], dim=0))
-
+            output, attn_lse = self._npu_attn_out_lse_update(
+                attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask)
         return output, attn_lse
 
     def _npu_attn_out_lse_update(self, attn_lse_mask, attn_lse_nomask,
@@ -363,13 +354,14 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         attn_out_nomask = attn_out_nomask.to(torch.float32)
         attn_lse_mask = attn_lse_mask.to(torch.float32)
         attn_lse_nomask = attn_lse_nomask.to(torch.float32)
-        attn_output = [attn_out_nomask, attn_out_mask]
-        attn_lse = [attn_lse_nomask, attn_lse_mask]
-        update_type = 0
-        output, _ = torch_npu.npu_attention_update(attn_lse, attn_output,
-                                                   update_type)
-        output = output.view(T, N, D)
-        return output
+        attn_output_list = [attn_out_nomask, attn_out_mask]
+        attn_lse_list = [attn_lse_nomask, attn_lse_mask]
+        update_type = 1
+        attn_output, attn_lse = torch_npu.npu_attention_update(
+            attn_lse_list, attn_output_list, update_type)
+        attn_output = attn_output.view(T, N, D)
+        attn_lse = attn_lse.view(T, N, 1)
+        return attn_output, attn_lse
 
     def _forward_prefill_cp(self, query: torch.Tensor, key: torch.Tensor,
                             value: torch.Tensor,
@@ -551,21 +543,6 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
             attn_out, attn_lse, attn_metadata.decode_meta.batch_seq_mask)
         attn_out = _npu_attention_update(self.head_size, attn_out_lse)
         return attn_out
-
-    def _update_out_and_lse(self, out_list: torch.Tensor,
-                            lse_list: torch.Tensor) -> torch.Tensor:
-        """LSE_final = log(sum(exp(LSE_i))), O_final = sum(exp(LSE_i - LSE_final) * O_i)
-        Args:
-            out_list: shape = [N, batch_size, num_heads, head_size]
-            lse_list: shape = [N, batch_size, num_heads, 1]
-        Returns:
-            out_final: shape = [batch_size, num_heads, head_size]
-            lse_final: shape = [batch_size, num_heads, 1]
-        """
-        lse_final = torch.logsumexp(lse_list, dim=0, keepdim=False)
-        out_final = torch.sum(torch.exp(lse_list - lse_final) * out_list,
-                              dim=0)
-        return out_final, lse_final
 
     def _update_chunk_attn_out_lse_with_current_attn_out_lse(
             self, current_attn_output_prefill, current_attn_lse_prefill,
@@ -782,8 +759,9 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         # Split out lse
         attn_out_allgather, attn_lse_allgather = torch.split(
             x, [D, 1], dim=-1)  # [N, S, H, D], [N, S, H, 1]
-        context_output, context_lse = self._update_out_and_lse(
-            attn_out_allgather, attn_lse_allgather)
+        context_output, context_lse = self._npu_attn_out_lse_update(
+            attn_lse_allgather[1], attn_lse_allgather[0],
+            attn_out_allgather[1], attn_out_allgather[0])
         return context_output, context_lse
 
     def forward_impl(


### PR DESCRIPTION
### What this PR does / why we need it?
Replace "_update_out_and_lse" function implemented with "torch.logsumexp" by "_npu_attn_out_lse_update" implemented with "torch_npu.npu_attention_update" to improve the efficiency

### Does this PR introduce _any_ user-facing change?
Nope

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
- CANN version: CANN 8.5.0.B073, https://cmc-szv.clouddragon.huawei.com/cmcversion/index/releaseView?deltaId=13564349490332928&isSelect=Software
- PTA version: 7.3.T999-20251223-07, https://cmc-szv.clouddragon.huawei.com/cmcversion/index/findSnapshotComponentVersion?deltaId=13874688357908992

