### PR TITLE
Ensure that the qwen3-vl model uses the mrope operator(fix issue#5670)

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -533,7 +533,7 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor,
     ):
-        if self.mrope_section != [16, 24, 24] or \
+        if (self.mrope_section != [16, 24, 24] and self.mrope_section != [24, 20, 20]) or \
             get_ascend_device_type() == AscendDeviceType.A5:
             return super().forward_oot(positions, query, key)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Resolve iusse #5670 , currently the mrope operator only supports the mrope section of qwen2.5-vl, but the shape of qwen3-vl is different, and the inability to use the mrope operator will result in rollback. Therefore, add the shape of qwen3-vl so that the qwen3-vl model can also use the mrope operator
- Fixes #5670  
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
#### code
Collect profiling for testing using the offline inference script test_outline.py
```
from transformers import AutoProcessor
from vllm import LLM, SamplingParams
from qwen_vl_utils import process_vision_info
import os
from torch_npu.profiler.profiler import analyse
MODEL_PATH = "Qwen3-VL-8B-Instruct"

#profiling_path="./vllm_ascend_profile_outline"
#os.environ["VLLM_TORCH_PROFILER_DIR"]=profiling_path
os.environ["HCCL_BUFFSIZE"]='1024'
os.environ["VLLM_USE_V1"]='1'
os.environ["OMP_NUM_THREADS"]='10'
os.environ["CPU_AFFINITY_CONF"]='1'
os.environ["TASK_QUEUE_ENABLE"]='1'

os.environ["VLL_ASCEND_ENABLE_TOPK_OPTIMIZE"]='1'
os.environ["MIES_USE_MB_SWAPPER"]='1'

llm = LLM(
    model=MODEL_PATH,
    max_model_len=16384,
    limit_mm_per_prompt={"image": 10},
    compilation_config ={"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[1, 2, 4, 8, 16, 24]},
    enable_prefix_caching=False,
    mm_processor_cache_gb = 0,
)

sampling_params = SamplingParams(
    max_tokens=10
)

image_messages = [
    {"role": "system", "content": "You are a helpful assistant."},
    {
        "role": "user",
        "content": [
            {
                "type": "image",
                "image": "https://modelscope.oss-cn-beijing.aliyuncs.com/resource/qwen.png",
                "min_pixels": 224 * 224,
                "max_pixels": 1280 * 28 * 28,
            },
            {"type": "text", "text": "Please provide a detailed description of this image"},
        ],
    },
]

messages = image_messages

processor = AutoProcessor.from_pretrained(MODEL_PATH)
prompt = processor.apply_chat_template(
    messages,
    tokenize=False,
    add_generation_prompt=True,
)

image_inputs, _, _ = process_vision_info(messages, return_video_kwargs=True)

mm_data = {}
if image_inputs is not None:
    mm_data["image"] = image_inputs
llm_inputs = {
    "prompt": prompt,
    "multi_modal_data": mm_data,
}
llm.start_profile()
outputs = llm.generate([llm_inputs], sampling_params=sampling_params)
llm.stop_profile()
generated_text = outputs[0].outputs[0].text
print(generated_text)
#analyse(profiler_path=profiling_path)
```
#### profiling test

<img width="2581" height="392" alt="image" src="https://github.com/user-attachments/assets/c5c98cbb-7a91-4308-80ae-48bd376e3de8" />



- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
