### PR TITLE
[BugFix][P/D] Fix pre-create link parameter error

### DIFF
--- a/vllm_ascend/distributed/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/mooncake_layerwise_connector.py
@@ -1149,7 +1149,7 @@ class MooncakeLayerwiseConnectorWorker:
             session_id = f"{req_meta_update.remote_host}:{agent_meta.te_rpc_port}"
             ret = self.engine.batch_transfer_sync_write(
                 session_id, [self.kv_caches_base_addr[0]],
-                [agent_meta.kv_caches_base_addr[0]], 128)
+                [agent_meta.kv_caches_base_addr[0]], [128])
             if ret < 0:
                 logger.error(
                     f"Mooncake transfer failed to create link to device {session_id}"


### PR DESCRIPTION
### What this PR does / why we need it?
Fix pre-create link parameter error, `batch_transfer_sync_write` requires list.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By CI.

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
