### PR TITLE
Optimize the print info format when deprecated code is used in vllm-ascend

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -46,10 +46,15 @@ else:
 
 _CUSTOM_OP_REGISTERED = False
 
-def config_deprecate_logging():
+
+def config_deprecated_logging():
+    """Configure deprecated logging format, when used deprecated codes
+    in vllm-ascend.
+    """
     import logging
     import warnings
 
+    # Customize warning format to be one line
     def one_line_formatwarning(message, category, filename, lineno, line=None):
         return f"{filename}:{lineno}: {category.__name__}: {message}"
 
@@ -61,6 +66,8 @@ def config_deprecate_logging():
     vllm_logger = logging.getLogger("vllm")
     warnings_logger = logging.getLogger("py.warnings")
 
+    # Propagate vllm logger handlers to warnings logger, to keep the same
+    # format with vllm
     if vllm_logger.handlers:
         warnings_logger.handlers = []
 
@@ -135,7 +142,7 @@ class NPUPlatform(Platform):
         from vllm_ascend.quantization.quant_config import \
             AscendQuantConfig  # noqa: F401
 
-        config_deprecate_logging()
+        config_deprecated_logging()
 
     @classmethod
     def get_device_capability(cls, device_id: int = 0):


### PR DESCRIPTION
### What this PR does / why we need it?
Optimize the warning print information format when detects depredated code is used in vllm-ascend.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Test result as following:
Before:
<img width="2347" height="440" alt="23a8688baa93fd16128d4c2f7d8d0bf7" src="https://github.com/user-attachments/assets/5ac5e80c-362d-4a71-8c84-a2bd7e0f33af" />

After:
<img width="1938" height="262" alt="da783817d42060ff619eb4fd3295be8f" src="https://github.com/user-attachments/assets/12c8eb38-8789-464c-b9bf-99d863e3d24d" />

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
