### PR TITLE
[Bugfix] add auto adjust capture in full mode and spec scenario.

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -459,7 +459,13 @@ def update_default_aclgraph_sizes(vllm_config: VllmConfig) -> None:
     Update ACL graph default capture sizes, so that new sizes
     are more friendly to ascend ops && hardware.
     """
-
+    num_spec_tokens = 0
+    if vllm_config.speculative_config:
+        num_spec_tokens = vllm_config.speculative_config.num_speculative_tokens
+    uniform_decode_query_len = 1 + num_spec_tokens
+    vllm_config.compilation_config.adjust_cudagraph_sizes_for_spec_decode(
+        uniform_decode_query_len,
+        vllm_config.parallel_config.tensor_parallel_size)
     if vllm_config.model_config is None or \
         vllm_config.model_config.enforce_eager or \
         not _is_default_capture_sizes(vllm_config):


### PR DESCRIPTION
### What this PR does / why we need it?

In scenarios where full mode and speculative inference are enabled, the capture_sizes does not adjust automatically, resulting in errors during inference. This PR resolves the issue by manually triggering an automatic adjustment during initialization. Further communication with the vLLM team is required regarding this problem.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
