### PR TITLE
[CI] check for runtime errors in qwen3-next-w8a8 under eager mode.

### DIFF
--- a/tests/e2e/nightly/single_node/models/test_qwen3_next_w8a8.py
+++ b/tests/e2e/nightly/single_node/models/test_qwen3_next_w8a8.py
@@ -77,8 +77,7 @@ async def test_models(model: str) -> None:
         "--trust-remote-code",
         "--gpu-memory-utilization",
         "0.65",
-        "--compilation-config",
-        '{"cudagraph_capture_sizes": [32], "cudagraph_mode":"FULL_DECODE_ONLY"}',
+        "--enforce-eager",
     ]
     request_keyword_args: dict[str, Any] = {
         **api_keyword_args,


### PR DESCRIPTION
### What this PR does / why we need it?
check for runtime errors in qwen3-next-w8a8 under eager mode.
### Does this PR introduce _any_ user-facing change?
N/A
### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
