### PR TITLE
[CI] Speed up e2e test

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -239,9 +239,7 @@ jobs:
           pytest -sv --durations=0 tests/e2e/multicard/2-cards/test_single_request_aclgraph.py
 
   e2e-4-cards:
-    name: multicard-4
-    needs: [e2e, e2e-2-cards]
-    if: ${{ needs.e2e.result == 'success' && needs.e2e-2-cards.result == 'success' && inputs.type == 'full' }}
+    needs: e2e
     runs-on: linux-aarch64-a3-4
     container:
       image: m.daocloud.io/quay.io/ascend/cann:8.3.rc2-a3-ubuntu22.04-py3.11


### PR DESCRIPTION
### What this PR does / why we need it?
e2e_2card and e2e_4card run with parallel, which is expected to reduce run e2e time 1h
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
