### PR TITLE
[CI] Remove workflow_dispatch way for image build

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -148,7 +148,6 @@ jobs:
           tags: |
             type=pep440,pattern={{raw}},suffix=${{ env.SUFFIX }}
             type=schedule,pattern=main,suffix=${{ env.SUFFIX }}
-            type=raw,value=${{ inputs.workflow_dispatch_tag }},event=workflow_dispatch,suffix=${{ env.SUFFIX }}
           flavor:
             latest=false
 

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -21,7 +21,7 @@ on:
       tag:
         description: 'Docker tag for build results'
         type: string
-        default: manual
+        default: main
         required: true
 
 jobs:


### PR DESCRIPTION
There is some problem for workflow_dispatch way for image build. Let's remove it first to make CI happy. I'll add it back once it's well tested.

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
