### PR TITLE
[Doc][fix] Fix the title of the document for the layer_sharding feature

### DIFF
--- a/docs/source/user_guide/feature_guide/layer_sharding.md
+++ b/docs/source/user_guide/feature_guide/layer_sharding.md
@@ -1,4 +1,4 @@
-# Layer Sharding Guide
+# Layer Sharding Linear Guide
 
 ## Overview
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the title of the document for the layer_sharding feature
<img width="1666" height="776" alt="image" src="https://github.com/user-attachments/assets/23a4e851-0042-4602-9be6-372e2629000d" />

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
