### PR TITLE
[CI] adpat v0.13.0 change

### DIFF
--- a/.github/workflows/labled_doctest.yaml
+++ b/.github/workflows/labled_doctest.yaml
@@ -23,6 +23,7 @@ on:
     branches:
       - 'main'
       - '*-dev'
+      - 'releases/v*'
     paths:
       # If we are changing the doctest we should do a PR test
       - '.github/workflows/labled_doctest.yaml'

--- a/.github/workflows/labled_download_model.yaml
+++ b/.github/workflows/labled_download_model.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/misc/model_list.json'
-      - '.github/workflows/download_model.yaml'
+      - '.github/workflows/labled_download_model.yaml'
     types: [labeled, synchronize]
 
 defaults:

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -21,6 +21,7 @@ on:
     branches:
       - 'main'
       - '*-dev'
+      - 'releases/v*'
     types: [ labeled, synchronize ]
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -22,6 +22,8 @@ on:
     branches:
       - 'main'
       - '*-dev'
+      - 'releases/v*'
+
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
 # It's used to activate ascend-toolkit environment variables.
@@ -70,7 +72,7 @@ jobs:
               - 'packages.txt'
             ut_tracker:
               - 'tests/ut/**'
-              - '.github/workflows/vllm_ascend_test_pr_light.yaml'
+              - '.github/workflows/pr_test_light.yaml'
 
   ut:
     needs: [lint, changes]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Below is maintained branches:
 | v0.7.3-dev | Maintained   | CI commitment for vLLM 0.7.3 version, only bug fix is allowed and no new release tag any more. |
 | v0.9.1-dev | Maintained   | CI commitment for vLLM 0.9.1 version |
 | v0.11.0-dev | Maintained | CI commitment for vLLM 0.11.0 version |
+| releases/v0.13.0 | Maintained | CI commitment for vLLM 0.13.0 version |
 | rfc/feature-name | Maintained | [Feature branches](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html#feature-branches) for collaboration |
 
 Please refer to [Versioning policy](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html) for more details.

--- a/README.zh.md
+++ b/README.zh.md
@@ -79,6 +79,7 @@ vllm-ascend有主干分支和开发分支。
 | v0.7.3-dev | Maintained | 基于vLLM v0.7.3版本CI看护, 只允许Bug修复，不会再发布新版本 |
 | v0.9.1-dev | Maintained | 基于vLLM v0.9.1版本CI看护 |
 | v0.11.0-dev | Maintained | 基于vLLM v0.11.0版本CI看护 |
+| releases/v0.13.0 | Maintained | 基于vLLM v0.13.0版本CI看护 |
 |rfc/feature-name| Maintained | 为协作创建的[特性分支](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html#feature-branches) |
 
 请参阅[版本策略](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html)了解更多详细信息。

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -110,7 +110,8 @@ Usually, each minor version of vLLM (such as 0.7) corresponds to a vLLM Ascend v
 
 | Branch     | State        | Note                                                     |
 | ---------- | ------------ | -------------------------------------------------------- |
-| main       | Maintained   | CI commitment for vLLM main branch and vLLM 0.12.0 tag |
+| main       | Maintained   | CI commitment for vLLM main branch and vLLM 0.13.0 tag |
+| releases/v0.13.0 | Maintained | CI commitment for vLLM 0.13.0 version                |
 | v0.11.0-dev| Maintained   | CI commitment for vLLM 0.11.0 version |
 | v0.9.1-dev | Maintained   | CI commitment for vLLM 0.9.1 version                     |
 | v0.7.3-dev | Maintained   | CI commitment for vLLM 0.7.3 version                     |


### PR DESCRIPTION
Add `releases` match case for CI jobs and update related doc for v0.13.0 branch

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
