### PR TITLE
[CI] Unblock 4-cards test

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -240,8 +240,8 @@ jobs:
 
   e2e-4-cards:
     name: multicard-4
-    needs: [e2e, e2e-2-cards]
-    if: ${{ needs.e2e.result == 'success' && needs.e2e-2-cards.result == 'success' && inputs.type == 'full' }}
+    needs: [e2e-2-cards]
+    if: ${{ needs.e2e-2-cards.result == 'success' && inputs.type == 'full' }}
     runs-on: linux-aarch64-a3-4
     container:
       image: m.daocloud.io/quay.io/ascend/cann:8.3.rc2-a3-ubuntu22.04-py3.11


### PR DESCRIPTION
CI cost time:
single: 160min
2-cards: 110min
4-cards: 120min

full cost time:
before this PR: max(160, 110)+120 = 280min
after this PR: min(160, 110)+120 = 230min

Reduce 50min for e2e test.

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
