### PR TITLE
[0.13.0][cherry-pick][bugfix]Synchronize memcache adaptation on A2

### DIFF
--- a/vllm_ascend/distributed/kvpool/pool_scheduler.py
+++ b/vllm_ascend/distributed/kvpool/pool_scheduler.py
@@ -82,7 +82,10 @@ class KVPoolScheduler:
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 
-        need_to_allocate = num_external_hit_tokens - num_computed_tokens
+        if num_external_hit_tokens < num_computed_tokens:
+            need_to_allocate = 0
+        else:
+            need_to_allocate = num_external_hit_tokens - num_computed_tokens
 
         logger.info(
             "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",

--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -87,7 +87,7 @@ class KVPoolWorker:
             self.put_step = 1
 
         self.metadata = KeyMetadata(
-            model_config.model.split('/')[-1],
+            model_config.model.rstrip('/').split('/')[-1],
             self.head_or_tp_rank,
             self.pcp_rank,
             self.dcp_rank,


### PR DESCRIPTION
### What this PR does / why we need it?
When running memcache in the A2 environment, the logic for registering memory needs to be added. Additionally, there is a link establishment conflict between memcache and HCCS during initialization in A2, so the link should be established in advance.

pick-from: #5601
