### PR TITLE
[CI] Nightly image build sync with main image build

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -1,9 +1,14 @@
 name: Nightly Image Build Schedule
 
 on:
-  schedule:
-    # UTC+8: 20pm, 23pm
-    - cron: '0 12,15 * * *'
+  workflow_call:
+    secrets:
+      HW_USERNAME:
+        required: false
+        description: 'Huawei Cloud SWR Username'
+      HW_TOKEN:
+        required: false
+        description: 'Huawei Cloud SWR Token'
 
 # This workflow builds and pushes Docker images for nightly-ci
 # It will be built base on the quay.io/ascend/vllm-ascend:main

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -56,3 +56,13 @@ jobs:
       workflow_dispatch_tag: ${{ inputs.tag }}
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  
+  nightly_image_build:
+    name: Nightly Image Build and Push
+    needs: image_build
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/_nightly_image_build.yaml
+    secrets:
+      HW_USERNAME: ${{ secrets.HW_USERNAME }}
+      HW_TOKEN: ${{ secrets.HW_TOKEN }}


### PR DESCRIPTION
### What this PR does / why we need it?
It is a little strange that nightly image build is unschedule https://github.com/vllm-project/vllm-ascend/actions/workflows/schedule_nightly_image_build.yaml; to avoid it ,we should make it snyc with the main image build
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2f4e6548efec402b913ffddc8726230d9311948d
