### PR TITLE
[nightly] Remove node tolerations for hk cluster

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/lws-a2.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws-a2.yaml.jinja2
@@ -13,12 +13,6 @@ spec:
         labels:
           role: leader
       spec:
-        schedulerName: volcano
-        tolerations:
-          - key: "instance"
-            operator: "Equal"
-            value: "vllm"
-            effect: "NoSchedule"
         containers:
           - name: vllm-leader
             imagePullPolicy: Always
@@ -71,12 +65,6 @@ spec:
             path: /usr/local/Ascend/driver/tools
     workerTemplate:
       spec:
-        schedulerName: volcano
-        tolerations:
-          - key: "instance"
-            operator: "Equal"
-            value: "vllm"
-            effect: "NoSchedule"
         containers:
           - name: vllm-worker
             imagePullPolicy: Always


### PR DESCRIPTION
### What this PR does / why we need it?
Since we have upgrade all the nodes' `cann` HDK version to `25.3rc1`, we should not limit nightly schedule to the specific nodes
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bde38c11df0ea066a740efe9b77fff5418be45df
