### PR TITLE
[EPLB][Bugfix] policy_swift_balancer bugfix and renaming

### DIFF
--- a/docs/source/developer_guide/feature_guide/eplb_swift_balancer.md
+++ b/docs/source/developer_guide/feature_guide/eplb_swift_balancer.md
@@ -25,8 +25,8 @@ vllm_ascend
 │   ├── core
 │   │   ├── policy
 │   │   │   ├── policy_abstract.py
-│   │   │   ├── policy_dynamic_ep.py
-│   │   │   ├── policy_dynamic_ep_v2.py
+│   │   │   ├── policy_default_eplb.py
+│   │   │   ├── policy_swift_balancer.py
 │   │   │   ├── policy_factory.py
 │   │   │   ├── policy_flashlb.py
 │   │   ├── eplb_device_transfer_loader.py
@@ -52,9 +52,9 @@ vllm_ascend
   *Load balancing algorithms with factory pattern instantiation*
     - `policy_abstract.py`  
     Abstract class for load balancing strategy interfaces
-    - `policy_dynamic_ep.py`  
+    - `policy_default_eplb.py`  
     Default implementation of open-source EPLB paper algorithm
-    - `policy_dynamic_ep_v2.py`  
+    - `policy_swift_balancer.py`  
     Enhanced version optimizing expert swaps for low-bandwidth devices (e.g., A2)
     - `policy_flashlb.py`  
     Threshold-based adjustment reducing operational costs through layer-wise fluctuation detection

--- a/tests/ut/eplb/core/policy/test_policy_default_eplb.py
+++ b/tests/ut/eplb/core/policy/test_policy_default_eplb.py
@@ -3,16 +3,16 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from vllm_ascend.eplb.core.policy.policy_dynamic_ep import DynamicEplb
+from vllm_ascend.eplb.core.policy.policy_default_eplb import DefaultEplb
 
 
-class TestDynamicEplb:
+class TestDefaultEplb:
 
     def test_add_redundant_basic(self):
         current_expert_table = np.array([[[0, 1], [1, 0]]])
         expert_workload = np.array([[[2, 3], [4, 1]]])
         num_original_expert = 2
-        result = DynamicEplb.add_redundant(current_expert_table,
+        result = DefaultEplb.add_redundant(current_expert_table,
                                            expert_workload,
                                            num_original_expert)
         expected = np.array([[2 + 1, 3 + 4]])
@@ -20,51 +20,51 @@ class TestDynamicEplb:
 
     def test_get_redundant_num(self):
         counts = np.array([2, 1, 3])
-        assert DynamicEplb.get_redundant_num(3, counts) == 3
+        assert DefaultEplb.get_redundant_num(3, counts) == 3
 
     def test_calculate_max_heat_per_layer(self):
         workload_table = np.array([[[1, 2], [3, 4]], [[2, 2], [1, 1]]])
-        max_heat = DynamicEplb.calculate_max_heat_per_layer(workload_table, 2)
+        max_heat = DefaultEplb.calculate_max_heat_per_layer(workload_table, 2)
         assert max_heat == [7, 4]
 
     def test_constraint_expert_local_exchange(self):
         current = [[[0, 1], [2, 3]]]
         global_dep = [[[1, 0], [3, 2]]]
-        new_dep = DynamicEplb.constraint_expert_local_exchange(
+        new_dep = DefaultEplb.constraint_expert_local_exchange(
             current, global_dep)
         assert new_dep == [[[0, 1], [2, 3]]]
 
     def test_compute_balanced_pack_redundancy_normal(self):
         origin_weights = [(0, 10), (1, 20)]
-        result, boxes = DynamicEplb.compute_balanced_pack_redundancy(
+        result, boxes = DefaultEplb.compute_balanced_pack_redundancy(
             origin_weights, 2, 1)
         assert isinstance(result, list) and len(result) == 2
 
     def test_compute_balanced_pack_redundancy_card0(self):
         origin_weights = [(0, 10)]
         with pytest.raises(RuntimeError):
-            DynamicEplb.compute_balanced_pack_redundancy(origin_weights, 0, 0)
+            DefaultEplb.compute_balanced_pack_redundancy(origin_weights, 0, 0)
 
     def test_compute_balanced_pack_normal(self):
         origin_weights = np.array([(0, 10), (1, 20)], dtype=object)
-        result, boxes = DynamicEplb.compute_balanced_pack(origin_weights, 2)
+        result, boxes = DefaultEplb.compute_balanced_pack(origin_weights, 2)
         assert isinstance(result, list) and len(result) == 2
 
     def test_compute_balanced_pack_card0(self):
         origin_weights = np.array([(0, 10)], dtype=object)
         with pytest.raises(RuntimeError):
-            DynamicEplb.compute_balanced_pack(origin_weights, 0)
+            DefaultEplb.compute_balanced_pack(origin_weights, 0)
 
     def test_original_compute_balanced_pack_redundancy(self):
         origin_weights = [(0, 5), (1, 10)]
-        result, boxes = DynamicEplb.original_compute_balanced_pack_redundancy(
+        result, boxes = DefaultEplb.original_compute_balanced_pack_redundancy(
             origin_weights, 2, 1)
         assert isinstance(result, list) and len(result) == 2
 
     def test_rebalance_experts_normal(self):
         expert_table = np.array([[[0, 1], [1, 0]]])
         workload = np.array([[[2, 3], [4, 1]]])
-        policy = DynamicEplb(config=None)
+        policy = DefaultEplb(config=None)
         change, priority, new_dep = policy.rebalance_experts(
             expert_table, workload)
         assert change in [0, 1]
@@ -73,12 +73,12 @@ class TestDynamicEplb:
         assert np.array(new_dep).shape == expert_table.shape
 
     def test_rebalance_experts_exceptions(self):
-        policy = DynamicEplb(config=None)
+        policy = DefaultEplb(config=None)
 
         # case1: num_original_expert != expert_num
         expert_table = np.array([[[0, 1], [1, 0]]])
         workload = np.array([[[2, 3], [4, 1]]])
-        with patch.object(DynamicEplb,
+        with patch.object(DefaultEplb,
                           'add_redundant',
                           return_value=np.array([[1, 2, 3]])):
             with pytest.raises(ValueError):
@@ -93,6 +93,6 @@ class TestDynamicEplb:
         # case3: num_npus < num_redundancy_expert
         expert_table_small = np.array([[[0, 0]]])  # 1 layer, 1 NPU, 2 experts
         workload_small = np.array([[[1, 1]]])
-        with patch.object(DynamicEplb, 'get_redundant_num', return_value=2):
+        with patch.object(DefaultEplb, 'get_redundant_num', return_value=2):
             with pytest.raises(ValueError):
                 policy.rebalance_experts(expert_table_small, workload_small)

--- a/tests/ut/eplb/core/policy/test_policy_factor.py
+++ b/tests/ut/eplb/core/policy/test_policy_factor.py
@@ -1,8 +1,8 @@
 import pytest
 
 from vllm_ascend.eplb.core.policy.policy_abstract import DynamicConfig
-from vllm_ascend.eplb.core.policy.policy_dynamic_ep import DynamicEplb
-from vllm_ascend.eplb.core.policy.policy_dynamic_ep_v2 import DynamicEplbV2
+from vllm_ascend.eplb.core.policy.policy_default_eplb import DefaultEplb
+from vllm_ascend.eplb.core.policy.policy_swift_balancer import SwiftBalanceEplb
 from vllm_ascend.eplb.core.policy.policy_factory import PolicyFactory
 from vllm_ascend.eplb.core.policy.policy_random import RandomLoadBalance
 
@@ -14,8 +14,8 @@ def dummy_config():
 
 @pytest.mark.parametrize("policy_type, expected_class", [
     (0, RandomLoadBalance),
-    (1, DynamicEplb),
-    (2, DynamicEplbV2),
+    (1, DefaultEplb),
+    (2, SwiftBalanceEplb),
     (999, RandomLoadBalance),
 ])
 def test_generate_policy(policy_type, expected_class, dummy_config):

--- a/vllm_ascend/eplb/core/policy/policy_default_eplb.py
+++ b/vllm_ascend/eplb/core/policy/policy_default_eplb.py
@@ -24,7 +24,7 @@ class DynamicTable:
     placement_table = None
 
 
-class DynamicEplb(EplbPolicy):
+class DefaultEplb(EplbPolicy):
 
     def __init__(self, config: DynamicConfig):
         super().__init__(config)

--- a/vllm_ascend/eplb/core/policy/policy_factory.py
+++ b/vllm_ascend/eplb/core/policy/policy_factory.py
@@ -1,8 +1,8 @@
 # Copyright Huawei Technologies Co., Ltd. 2023-2024. All rights reserved.
 # Todo: Once https://github.com/vllm-project/vllm/pull/24069 is merged in vllm. Remove this factory.
 from .policy_abstract import DynamicConfig, EplbPolicy
-from .policy_dynamic_ep import DynamicEplb
-from .policy_dynamic_ep_v2 import DynamicEplbV2
+from .policy_default_eplb import DefaultEplb
+from .policy_swift_balancer import SwiftBalanceEplb
 from .policy_flashlb import FlashLB, warm_up
 from .policy_random import RandomLoadBalance
 
@@ -20,9 +20,9 @@ class PolicyFactory:
             0:
             RandomLoadBalance,  # RandomLoadBalance: shuffle last physical expert on NPU 1 and 3
             1:
-            DynamicEplb,  # Dynamic EPLB policy: overall expert replacement based on current moe load
+            DefaultEplb,  # Dynamic EPLB policy: overall expert replacement based on current moe load
             2:
-            DynamicEplbV2,  # Dynamic EPLB policy V2:  expert replacement with constrained number of expert shuffle
+            SwiftBalanceEplb,  # Dynamic EPLB policy V2:  expert replacement with constrained number of expert shuffle
             3:
             FlashLB,  # FlashLB EPLB policy: expert replacement based on Joint Optimization, Multi-Shot Enhancement and Incremental Adjustment
         }

--- a/vllm_ascend/eplb/core/policy/policy_swift_balancer.py
+++ b/vllm_ascend/eplb/core/policy/policy_swift_balancer.py
@@ -62,7 +62,7 @@ class DynamicTable:
     placement_table = None
 
 
-class DynamicEplbV2(EplbPolicy):
+class SwiftBalanceEplb(EplbPolicy):
 
     def __init__(self, config: DynamicConfig):
         super().__init__(config)


### PR DESCRIPTION
### What this PR does / why we need it?
1. Rename dynamic_ep to default_eplb.
2. Rename dynamic_ep_v2 to swift_balancer
3. Discard func compose_expert_update_info_bipartite.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
<img width="773" height="146" alt="image" src="https://github.com/user-attachments/assets/1169c7be-c9ec-4720-969f-9f0b158072f9" />


- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bde38c11df0ea066a740efe9b77fff5418be45df
