### PR TITLE
[bugfix] Fix nightly clang installation following previous attempt 

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -78,8 +78,7 @@ jobs:
         - name: Decode kubeconfig from secrets
           run: |
             # Decode and save kubeconfig
-            # echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $KUBECONFIG
-            cp /root/.cache/.kube/kubeconfig.yaml $KUBECONFIG
+            echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $KUBECONFIG
 
         - name: Checkout code
           uses: actions/checkout@v6

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -129,7 +129,6 @@ jobs:
           apt-get update && apt-get -y install clang-15
           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
-          clang -v
           BISHENG_NAME="Ascend-BiSheng-toolkit_aarch64_20260105.run"
           BISHENG_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/${BISHENG_NAME}"
           wget -O "${BISHENG_NAME}" "${BISHENG_URL}" && chmod a+x "${BISHENG_NAME}" && "./${BISHENG_NAME}" --install && rm "${BISHENG_NAME}"

--- a/.github/workflows/nightly_test_a3.yaml
+++ b/.github/workflows/nightly_test_a3.yaml
@@ -28,7 +28,7 @@ on:
   pull_request: 
     branches:
       - 'main'
-    # types: [ labeled ]
+    types: [ labeled ]
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -53,39 +53,39 @@ jobs:
           - name: multi-node-deepseek-pd
             config_file_path: DeepSeek-V3.yaml
             size: 2
-          # - name: multi-node-qwen3-dp
-          #   config_file_path: Qwen3-235B-A22B.yaml
-          #   size: 2
-          # # - name: multi-node-dpsk-4node-pd
-          # #   config_file_path: DeepSeek-R1-W8A8.yaml
-          # #   size: 4
-          # - name: multi-node-qwenw8a8-2node
-          #   config_file_path: Qwen3-235B-W8A8.yaml
-          #   size: 2
-          # # - name: multi-node-deepseek-r1-w8a8-eplb
-          # #   config_file_path: DeepSeek-R1-W8A8-EPLB.yaml
-          # #   size: 4
-          # - name: multi-node-qwenw8a8-2node-eplb
-          #   config_file_path: Qwen3-235B-W8A8-EPLB.yaml
-          #   size: 2
-          # - name: multi-node-dpsk3.2-2node
-          #   config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
-          #   size: 2
-          # - name: multi-node-deepseek-r1-w8a8-longseq
-          #   config_file_path: DeepSeek-R1-W8A8-longseq.yaml
-          #   size: 2
-          # - name: multi-node-qwenw8a8-2node-longseq
-          #   config_file_path: Qwen3-235B-W8A8-longseq.yaml
-          #   size: 2
-          # - name: multi-node-qwen-disagg-pd
-          #   config_file_path: Qwen3-235B-disagg-pd.yaml
-          #   size: 2
-          # - name: multi-node-qwen-vl-disagg-pd
-          #   config_file_path: Qwen3-VL-235B-disagg-pd.yaml
-          #   size: 2
-          # - name: multi-node-kimi-k2-instruct-w8a8
-          #   config_file_path: Kimi-K2-Instruct-W8A8.yaml
-          #   size: 2
+          - name: multi-node-qwen3-dp
+            config_file_path: Qwen3-235B-A22B.yaml
+            size: 2
+          # - name: multi-node-dpsk-4node-pd
+          #   config_file_path: DeepSeek-R1-W8A8.yaml
+          #   size: 4
+          - name: multi-node-qwenw8a8-2node
+            config_file_path: Qwen3-235B-W8A8.yaml
+            size: 2
+          # - name: multi-node-deepseek-r1-w8a8-eplb
+          #   config_file_path: DeepSeek-R1-W8A8-EPLB.yaml
+          #   size: 4
+          - name: multi-node-qwenw8a8-2node-eplb
+            config_file_path: Qwen3-235B-W8A8-EPLB.yaml
+            size: 2
+          - name: multi-node-dpsk3.2-2node
+            config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+            size: 2
+          - name: multi-node-deepseek-r1-w8a8-longseq
+            config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+            size: 2
+          - name: multi-node-qwenw8a8-2node-longseq
+            config_file_path: Qwen3-235B-W8A8-longseq.yaml
+            size: 2
+          - name: multi-node-qwen-disagg-pd
+            config_file_path: Qwen3-235B-disagg-pd.yaml
+            size: 2
+          - name: multi-node-qwen-vl-disagg-pd
+            config_file_path: Qwen3-VL-235B-disagg-pd.yaml
+            size: 2
+          - name: multi-node-kimi-k2-instruct-w8a8
+            config_file_path: Kimi-K2-Instruct-W8A8.yaml
+            size: 2
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a3
@@ -99,57 +99,57 @@ jobs:
   
   single-node-tests:
     name: single-node
-    # if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-    # needs: multi-node-tests
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    needs: multi-node-tests
     strategy:
       fail-fast: false
       matrix:
         test_config:
-          # - name: qwen3-32b-in8-a3
-          #   os: linux-aarch64-a3-4
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen3_32b_int8.py
-          # - name: qwen3-32b-int8-a3-feature-stack3
-          #   os: linux-aarch64-a3-4
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen3_32b_int8_a3_feature_stack3.py
-          # - name: qwen3-235b-a22b-w8a8-eplb
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen3_235b_a22b_w8a8_eplb.py
-          # - name: deepseek-r1-w8a8-eplb
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_deepseek_r1_0528_w8a8_eplb.py
-          # - name: deepseek-r1-w8a8-mtpx
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_mtpx_deepseek_r1_0528_w8a8.py
-          # - name: qwen2-5-vl-7b
-          #   os: linux-aarch64-a3-4
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen2_5_vl_7b.py
-          # - name: qwen2-5-vl-32b
-          #   os: linux-aarch64-a3-4
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen2_5_vl_32b.py
-          # - name: qwen3-32b-int8-prefix-cache
-          #   os: linux-aarch64-a3-4
-          #   tests: tests/e2e/nightly/single_node/models/test_prefix_cache_qwen3_32b_int8.py
-          # - name: deepseek-r1-0528-w8a8
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_deepseek_r1_0528_w8a8.py
-          # - name: deepseek-r1-0528-w8a8-prefix-cache
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_prefix_cache_deepseek_r1_0528_w8a8.py
-          # - name: qwq-32b-a3
-          #   os: linux-aarch64-a3-4
-          #   tests: tests/e2e/nightly/single_node/models/test_qwq_32b.py
-          # - name: qwen3-30b-w8a8
-          #   os: linux-aarch64-a3-2
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen3_30b_w8a8.py
-          # - name: qwen3-235b-w8a8
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_qwen3_235b_w8a8.py
+          - name: qwen3-32b-in8-a3
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/single_node/models/test_qwen3_32b_int8.py
+          - name: qwen3-32b-int8-a3-feature-stack3
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/single_node/models/test_qwen3_32b_int8_a3_feature_stack3.py
+          - name: qwen3-235b-a22b-w8a8-eplb
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_qwen3_235b_a22b_w8a8_eplb.py
+          - name: deepseek-r1-w8a8-eplb
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_deepseek_r1_0528_w8a8_eplb.py
+          - name: deepseek-r1-w8a8-mtpx
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_mtpx_deepseek_r1_0528_w8a8.py
+          - name: qwen2-5-vl-7b
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/single_node/models/test_qwen2_5_vl_7b.py
+          - name: qwen2-5-vl-32b
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/single_node/models/test_qwen2_5_vl_32b.py
+          - name: qwen3-32b-int8-prefix-cache
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/single_node/models/test_prefix_cache_qwen3_32b_int8.py
+          - name: deepseek-r1-0528-w8a8
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_deepseek_r1_0528_w8a8.py
+          - name: deepseek-r1-0528-w8a8-prefix-cache
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_prefix_cache_deepseek_r1_0528_w8a8.py
+          - name: qwq-32b-a3
+            os: linux-aarch64-a3-4
+            tests: tests/e2e/nightly/single_node/models/test_qwq_32b.py
+          - name: qwen3-30b-w8a8
+            os: linux-aarch64-a3-2
+            tests: tests/e2e/nightly/single_node/models/test_qwen3_30b_w8a8.py
+          - name: qwen3-235b-w8a8
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_qwen3_235b_w8a8.py
           - name: qwen3-next-w8a8
             os: linux-aarch64-a3-4
             tests: tests/e2e/nightly/single_node/models/test_qwen3_next_w8a8.py
-          # - name: kimi-k2-thinking
-          #   os: linux-aarch64-a3-16
-          #   tests: tests/e2e/nightly/single_node/models/test_kimi_k2_thinking.py
+          - name: kimi-k2-thinking
+            os: linux-aarch64-a3-16
+            tests: tests/e2e/nightly/single_node/models/test_kimi_k2_thinking.py
           # TODO: Replace deepseek3.2-exp with deepseek3.2 after nightly tests pass
           # - name: deepseek3_2-exp-w8a8
           #   os: linux-aarch64-a3-16


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the issue where the previous PR https://github.com/vllm-project/vllm-ascend/pull/5733 failed to install Clang in nightly environment.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/bde38c11df0ea066a740efe9b77fff5418be45df
