### PR TITLE
[EPLB][Nightly][Bugfix] Get expert from moe layer only

### DIFF
--- a/tests/ut/eplb/core/test_eplb_utils.py
+++ b/tests/ut/eplb/core/test_eplb_utils.py
@@ -34,15 +34,14 @@ class TestAscendConfig(unittest.TestCase):
         self.moe_config = moe_config
         self.mock_npu = patch("torch.Tensor.npu",
                               new=lambda self: self).start()
-        self.rank = 1
 
     def test_init_eplb_config_with_eplb(self):
         eplb_config = init_ascend_config(self.vllm_config).eplb_config
-        expert_map, log2phy, redundant_experts = init_eplb_config(
+        _, expert_map, log2phy, redundant_experts = init_eplb_config(
             eplb_config, 0, self.moe_config)
         gt_expert_map = torch.tensor([4, -1, -1, -1, 0, 1, 2, 3])
         gt_log2phy = torch.tensor([9, 1, 2, 3, 5, 6, 7, 8])
-        self.assertTrue(torch.equal(expert_map[self.rank], gt_expert_map))
+        self.assertTrue(torch.equal(expert_map, gt_expert_map))
         self.assertTrue(torch.equal(log2phy, gt_log2phy))
         self.assertEqual(redundant_experts, 2)
 
@@ -51,20 +50,20 @@ class TestAscendConfig(unittest.TestCase):
         self.vllm_config.additional_config["eplb_config"][
             "expert_map_path"] = _TEST_DIR + "/expert_map.json"
         eplb_config = init_ascend_config(self.vllm_config).eplb_config
-        expert_map, log2phy, redundant_experts = init_eplb_config(
+        _, expert_map, log2phy, redundant_experts = init_eplb_config(
             eplb_config, 0, self.moe_config)
         gt_expert_map = torch.tensor([-1, 1, 4, -1, 2, -1, 0, 3])
         gt_log2phy = torch.tensor([2, 6, 9, 3, 7, 4, 5, 8])
-        self.assertTrue(torch.equal(expert_map[self.rank], gt_expert_map))
+        self.assertTrue(torch.equal(expert_map, gt_expert_map))
         self.assertTrue(torch.equal(log2phy, gt_log2phy))
         self.assertEqual(redundant_experts, 2)
 
     def test_init_eplb_config_without_eplb(self):
         self.vllm_config.additional_config = {"refresh": True}
         eplb_config = init_ascend_config(self.vllm_config).eplb_config
-        expert_map, log2phy, redundant_experts = init_eplb_config(
+        _, expert_map, log2phy, redundant_experts = init_eplb_config(
             eplb_config, 0, self.moe_config)
         gt_expert_map = torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3])
         print(expert_map, log2phy, redundant_experts)
-        self.assertTrue(torch.equal(expert_map[self.rank], gt_expert_map))
+        self.assertTrue(torch.equal(expert_map, gt_expert_map))
         self.assertEqual(redundant_experts, 0)

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -188,7 +188,7 @@ class VllmEplbAdaptor(EplbAdaptor):
         all_layer_global_expert_map = []
         for layer_id in range(self.num_moe_layers):
             map_cpu = self.model.model.layers[
-                layer_id].mlp.experts.global_expert_map.cpu()
+                self.num_dense_layers + layer_id].mlp.experts.global_expert_map.cpu()
             all_layer_global_expert_map.append(map_cpu)
             self.expert_map_per_layer_cpu[self.num_dense_layers +
                                           layer_id] = map_cpu[self.rank_id]

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -202,10 +202,8 @@ class AscendFusedMoE(FusedMoE):
 
         # init moe
         eplb_config = ascend_config.eplb_config
-        self.global_expert_map, self.log2phy, self.global_redundant_expert_num = init_eplb_config(
+        self.global_expert_map, self._expert_map, self.log2phy, self.global_redundant_expert_num = init_eplb_config(
             eplb_config, self.moe_instance_id, self.moe_config)
-        if self.global_expert_map is not None:
-            self._expert_map = self.global_expert_map[self.ep_rank].npu()
         self.global_num_experts = num_experts + self.global_redundant_expert_num
         self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy
                                                           is not None)


### PR DESCRIPTION
### What this PR does / why we need it?
1. If the model has dense layers, the current code will attempt to obtain the routing experts of the dense layers, which will cause an error. This should be fixed by modifying the code to skip the dense layers when obtaining the routing experts.
2. The global_expert_map that the function directly outputs a affects the performance of dsv3.2.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

DeepSeek V3.1 conversation is normal.
del":"dsr1","choices":[{"index":0,"message":{"role":"assistant","content":"Of course. Here is a clear and comprehensive explanation of deep learning.\n\n### What is Deep Learning? (In a Nutshell)\n\n**Deep learning is a subset of machine learning that uses artificial neural networks with many layers (\"deep\" networks) to learn and make intelligent decisions from vast amounts of data.**\n\nThink of it as teaching a computer to recognize patterns by example, much like how a human child learns to identify a cat by seeing many pictures of cats.\n\n---\n\n### The Core Idea: Mimicking the Brain (Very Loosely)\n\nAt the heart of deep learning are **Artificial Neural Networks (ANNs)**, which are inspired by the structure of the human brain.\n\n*   **Neurons:** The building blocks are artificial neurons (or nodes), which are simple computational units.\n*   **Layers:** These neurons are arranged in layers:\n    *   **Input Layer:** Receives the raw data (e.g., pixels of an image, words of a sentence).\n    *   **Hidden Layers:** These are the \"deep\" part. A network can have dozens or even hundreds of these layers. Each layer processes the input from the previous layer, extracts increasingly complex features, and passes it on.\n    *   **Output Layer:** Produces the final result (e.g., the label \"cat,\" the translated sentence, a probability score).\n\n\n*A simple visualization of a deep neural network with multiple hidden layers.*\n\n### How Does it Learn?\n\nThe \"learning\" happens through a process","refus

#### aime precision test (dsv3.1)
baseline without eplb
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2024 | 604a78 | accuracy | gen | 66.67 |

eplb
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2024 | 604a78 | accuracy | gen | 70.00 |

dsv3.2 performance
![Snipaste_2026-01-15_15-54-54](https://github.com/user-attachments/assets/1e3efb5e-6351-4dfd-9b0b-6585b2a8a70b)


- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/11b6af5280d6d6dfb8953af16e67b25f819b3be9
