### PR TITLE
[Do not merge][Main2Main] Upgrade vllm commit to 0115

### DIFF
--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=2c24bc6996cb165fce92f780b388a5e39b3f4060
+          VLLM_COMMIT=46f8a982b191e3a3d3a1eccaf18b184c391ac2ac
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> $GITHUB_ENV
 
       - name: Checkout repository

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [46f8a982b191e3a3d3a1eccaf18b184c391ac2ac, v0.13.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 2c24bc6996cb165fce92f780b388a5e39b3f4060
+      vllm: 46f8a982b191e3a3d3a1eccaf18b184c391ac2ac
   changes:
     runs-on: linux-aarch64-a2-0
     outputs:
@@ -84,7 +84,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [46f8a982b191e3a3d3a1eccaf18b184c391ac2ac, v0.13.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -96,7 +96,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [46f8a982b191e3a3d3a1eccaf18b184c391ac2ac, v0.13.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060]
+        vllm_version: [46f8a982b191e3a3d3a1eccaf18b184c391ac2ac]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -53,7 +53,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0 tag | >= 3.10, < 3.12   | 8.3.RC2 | 2.8.0 / 2.8.0 |
+|     main    | 46f8a982b191e3a3d3a1eccaf18b184c391ac2ac, v0.13.0 tag | >= 3.10, < 3.12   | 8.3.RC2 | 2.8.0 / 2.8.0 |
 
 ## Release cadence
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -10,7 +10,6 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.utils.math_utils import cdiv, round_down
-from vllm.v1.attention.backends.mla.common import MLACommonMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 
 from vllm_ascend import envs
@@ -39,16 +38,19 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, maybe_trans_nz,
                                vllm_version_is, weak_ref_tensors)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
+
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
 # isort: off
 if vllm_version_is('0.13.0'):
-    from vllm.v1.attention.backends.utils import AttentionCGSupport
+    from vllm.v1.attention.backends.mla.common import MLACommonMetadataBuilder  # type: ignore
+    from vllm.v1.attention.backends.utils import AttentionCGSupport  # type: ignore
     from vllm.attention.backends.abstract import (  # type: ignore
         AttentionBackend, MLAAttentionImpl)
     from vllm.attention.backends.utils import PAD_SLOT_ID  # type: ignore
 else:
+    from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
     from vllm.v1.attention.backend import (  # type: ignore
         AttentionBackend, AttentionCGSupport, MLAAttentionImpl)
     from vllm.v1.attention.backends.utils import PAD_SLOT_ID  # type: ignore

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -11,7 +11,6 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.triton_utils import HAS_TRITON
-from vllm.v1.attention.backends.mla.common import MLACommonMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend import envs
@@ -39,10 +38,12 @@ from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 if vllm_version_is('0.13.0'):
-    from vllm.v1.attention.backends.utils import AttentionCGSupport
+    from vllm.v1.attention.backends.mla.common import MLACommonMetadataBuilder  # type: ignore
+    from vllm.v1.attention.backends.utils import AttentionCGSupport  # type: ignore
     from vllm.attention.backends.abstract import (  # type: ignore
         AttentionBackend, MLAAttentionImpl)
 else:
+    from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
     from vllm.v1.attention.backend import (  # type: ignore
         AttentionBackend, AttentionCGSupport, MLAAttentionImpl)
 # isort: on

--- a/vllm_ascend/patch/worker/patch_v2_egale.py
+++ b/vllm_ascend/patch/worker/patch_v2_egale.py
@@ -21,7 +21,7 @@ import torch
 import vllm
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
-from vllm.v1.worker.gpu.sample.metadata import SamplingMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.worker.gpu.spec_decode.eagle import (prepare_eagle_decode,
                                                   prepare_eagle_inputs)
 

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -22,7 +22,6 @@ from typing import Any
 import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
-from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
@@ -31,6 +30,12 @@ from vllm.v1.worker.gpu.cudagraph_utils import \
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 
 from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is('0.13.0'):
+    from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
+else:
+    from vllm.v1.attention.backend import AttentionMetadataBuilder
 
 
 class AclGraphManager(CudaGraphManager):

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -23,13 +23,18 @@ from typing import Any, Tuple
 import numpy as np
 import torch
 from vllm.config import VllmConfig
-from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import EncoderOnlyAttentionSpec, KVCacheConfig
 
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (AscendCommonAttentionMetadata,
                                          AscendPrefillContextParallelMetadata)
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is('0.13.0'):
+    from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
+else:
+    from vllm.v1.attention.backend import AttentionMetadataBuilder
 
 _ATTENTION_MASK_BUILDER = None
 

--- a/vllm_ascend/worker/v2/sample/penalties.py
+++ b/vllm_ascend/worker/v2/sample/penalties.py
@@ -20,7 +20,7 @@
 
 import torch
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.sample.metadata import SamplingMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
 
 
 @triton.jit

--- a/vllm_ascend/worker/v2/sample/sampler.py
+++ b/vllm_ascend/worker/v2/sample/sampler.py
@@ -17,7 +17,7 @@
 
 import torch
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
-from vllm.v1.worker.gpu.sample.metadata import SamplingMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.worker.gpu.sample.min_p import apply_min_p
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 


### PR DESCRIPTION
### What this PR does / why we need it?
1. ✅ Upgrade vllm commit to: **0115 (8471b27df97c3eb79f891802fc0e858f8f7ac6a0)**
- https://github.com/vllm-project/vllm/pull/32245
- https://github.com/vllm-project/vllm/pull/32060

Test result: https://github.com/vllm-project/vllm-ascend/actions/runs/21034239336/job/60490156965?pr=5913

2. Upgrade vllm commit to: **0116 (46f8a982b191e3a3d3a1eccaf18b184c391ac2ac)**

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/11b6af5280d6d6dfb8953af16e67b25f819b3be9
