### PR TITLE
[Doc] Add layer_sharding additional config for DeepSeek-V3.2-W8A8

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -78,8 +78,7 @@ jobs:
         - name: Decode kubeconfig from secrets
           run: |
             # Decode and save kubeconfig
-            # echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $KUBECONFIG
-            cp /root/.cache/.kube/kubeconfig.yaml $KUBECONFIG
+            echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > $KUBECONFIG
 
         - name: Checkout code
           uses: actions/checkout@v6

--- a/.github/workflows/nightly_test_a3.yaml
+++ b/.github/workflows/nightly_test_a3.yaml
@@ -28,11 +28,7 @@ on:
   pull_request: 
     branches:
       - 'main'
-    # types: [ labeled ]
-  push:
-    branches:
-      - 'main'
-
+    types: [ labeled ]
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -48,48 +44,48 @@ concurrency:
 jobs:
   multi-node-tests:
     name: multi-node
-    # if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
         test_config:
-          # - name: multi-node-deepseek-pd
-          #   config_file_path: DeepSeek-V3.yaml
-          #   size: 2
-          # - name: multi-node-qwen3-dp
-          #   config_file_path: Qwen3-235B-A22B.yaml
-          #   size: 2
+          - name: multi-node-deepseek-pd
+            config_file_path: DeepSeek-V3.yaml
+            size: 2
+          - name: multi-node-qwen3-dp
+            config_file_path: Qwen3-235B-A22B.yaml
+            size: 2
           # - name: multi-node-dpsk-4node-pd
           #   config_file_path: DeepSeek-R1-W8A8.yaml
           #   size: 4
-          # - name: multi-node-qwenw8a8-2node
-          #   config_file_path: Qwen3-235B-W8A8.yaml
-          #   size: 2
+          - name: multi-node-qwenw8a8-2node
+            config_file_path: Qwen3-235B-W8A8.yaml
+            size: 2
           # - name: multi-node-deepseek-r1-w8a8-eplb
           #   config_file_path: DeepSeek-R1-W8A8-EPLB.yaml
           #   size: 4
-          # - name: multi-node-qwenw8a8-2node-eplb
-          #   config_file_path: Qwen3-235B-W8A8-EPLB.yaml
-          #   size: 2
+          - name: multi-node-qwenw8a8-2node-eplb
+            config_file_path: Qwen3-235B-W8A8-EPLB.yaml
+            size: 2
           - name: multi-node-dpsk3.2-2node
             config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
             size: 2
-          # - name: multi-node-deepseek-r1-w8a8-longseq
-          #   config_file_path: DeepSeek-R1-W8A8-longseq.yaml
-          #   size: 2
-          # - name: multi-node-qwenw8a8-2node-longseq
-          #   config_file_path: Qwen3-235B-W8A8-longseq.yaml
-          #   size: 2
-          # - name: multi-node-qwen-disagg-pd
-          #   config_file_path: Qwen3-235B-disagg-pd.yaml
-          #   size: 2
-          # - name: multi-node-qwen-vl-disagg-pd
-          #   config_file_path: Qwen3-VL-235B-disagg-pd.yaml
-          #   size: 2
-          # - name: multi-node-kimi-k2-instruct-w8a8
-          #   config_file_path: Kimi-K2-Instruct-W8A8.yaml
-          #   size: 2
+          - name: multi-node-deepseek-r1-w8a8-longseq
+            config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+            size: 2
+          - name: multi-node-qwenw8a8-2node-longseq
+            config_file_path: Qwen3-235B-W8A8-longseq.yaml
+            size: 2
+          - name: multi-node-qwen-disagg-pd
+            config_file_path: Qwen3-235B-disagg-pd.yaml
+            size: 2
+          - name: multi-node-qwen-vl-disagg-pd
+            config_file_path: Qwen3-VL-235B-disagg-pd.yaml
+            size: 2
+          - name: multi-node-kimi-k2-instruct-w8a8
+            config_file_path: Kimi-K2-Instruct-W8A8.yaml
+            size: 2
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a3

--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -101,9 +101,28 @@ check_and_config() {
 }
 
 install_extra_components() {
-    echo "====> Installing extra components for DeepSeek-v3.2-w8a8"
-    source /usr/local/Ascend/ascend-toolkit/8.3.RC2/bisheng_toolkit/set_env.sh
-    python3 -m pip install "https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/triton_ascend-3.2.0.dev2025110717-cp311-cp311-manylinux_2_27_aarch64.whl"
+    echo "====> Installing extra components for DeepSeek-v3.2-exp-bf16"
+    
+    if ! wget -q https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/a3/CANN-custom_ops-sfa-linux.aarch64.run; then
+        echo "Failed to download CANN-custom_ops-sfa-linux.aarch64.run"
+        return 1
+    fi
+    chmod +x ./CANN-custom_ops-sfa-linux.aarch64.run
+    ./CANN-custom_ops-sfa-linux.aarch64.run --quiet
+    
+    if ! wget -q https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/a3/custom_ops-1.0-cp311-cp311-linux_aarch64.whl; then
+        echo "Failed to download custom_ops wheel"
+        return 1
+    fi
+    pip install custom_ops-1.0-cp311-cp311-linux_aarch64.whl
+    
+    export ASCEND_CUSTOM_OPP_PATH="/usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize${ASCEND_CUSTOM_OPP_PATH:+:${ASCEND_CUSTOM_OPP_PATH}}"
+    export LD_LIBRARY_PATH="/usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize/op_api/lib/${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    source /usr/local/Ascend/ascend-toolkit/set_env.sh
+    
+    rm -f CANN-custom_ops-sfa-linux.aarch64.run \
+          custom_ops-1.0-cp311-cp311-linux_aarch64.whl
+    echo "====> Extra components installation completed"
 }
 
 install_triton_ascend() {
@@ -142,17 +161,6 @@ kill_npu_processes() {
   sleep 4
 }
 
-upgrade_vllm_ascend_scr() {
-    # Fix me(Potabk): Remove this once our image build use
-    # The separate architecture build process currently suffers from errors during cross-compilation
-    # causing the image to fail to build correctly.
-    # This results in the nightly test code not being the latest version.
-    cd "$WORKSPACE/vllm-ascend"
-    # git pull origin main
-    git fetch origin pull/5921/head:pr-5921
-    git checkout pr-5921
-}
-
 run_tests_with_log() {
     set +e
     kill_npu_processes
@@ -174,10 +182,9 @@ main() {
     check_and_config
     show_vllm_info
     install_triton_ascend
-    if [[ "$CONFIG_YAML_PATH" == *"DeepSeek-V3_2-W8A8*.yaml" ]]; then
+    if [[ "$CONFIG_YAML_PATH" == *"DeepSeek-V3_2-Exp-bf16.yaml" ]]; then
         install_extra_components
     fi
-    upgrade_vllm_ascend_scr
     cd "$WORKSPACE/vllm-ascend"
     run_tests_with_log
 }


### PR DESCRIPTION
### What this PR does / why we need it?


#### Documentation Improvements

New Configuration: Added the layer_sharding parameter to the DeepSeek-V3.2-W8A8 deployment tutorial. This guides users to include `["q_b_proj", "o_proj"]` in their prefill node setup for better resource utilization.

#### CI and Testing Updates

Test Config Update: Updated the multi-node E2E test configuration file: tests/e2e/nightly/multi_node/config/DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml.

including disable `FLASHCOMM` and enable `FULL_DECODE_ONLY` and update performance baseline.

### Does this PR introduce any user-facing change?

Yes. The documentation now recommends a more optimized startup command for DeepSeek-V3.2-W8A8. Users following the updated tutorial will see improved performance in multi-node PD disaggregation environments.

### How was this patch tested?
CI Validation: The updated E2E test configuration has been verified through the nightly CI pipeline.

Environment: * vLLM version: v0.13.0

Base Commit: [11b6af5](https://github.com/vllm-project/vllm/commit/11b6af5280d6d6dfb8953af16e67b25f819b3be9)

Hardware: Ascend A3/A2 multi-node cluster.