### PR TITLE
[Doc] Upgrade outdated ut doc

### DIFF
--- a/docs/source/developer_guide/contribution/testing.md
+++ b/docs/source/developer_guide/contribution/testing.md
@@ -40,24 +40,15 @@ export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu/ https://mirror
 # src path
 export SRC_WORKSPACE=/vllm-workspace
 mkdir -p $SRC_WORKSPACE
-# workspace
-export WORKSPACE=/workspace
-mkdir -p $WORKSPACE
-# TAG
-export SRC_TAG=v0.11.0
-cd $SRC_WORKSPACE
-python -m venv $SRC_TAG
-source $SRC_TAG/bin/activate
 
 apt-get update -y
 apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake libnuma-dev curl gnupg2
 
-# v0.11.0
-git clone -b v0.11.0-dev https://github.com/vllm-project/vllm-ascend.git
-git clone -b v0.11.0 https://github.com/vllm-project/vllm.git
+git clone -b |vllm_ascend_version| --depth 1 https://github.com/vllm-project/vllm-ascend.git
+git clone --depth 1 https://github.com/vllm-project/vllm.git
 
 # vllm
-cd $WORKSPACE/vllm
+cd $SRC_WORKSPACE/vllm
 VLLM_TARGET_DEVICE=empty python3 -m pip install .
 python3 -m pip uninstall -y triton
 


### PR DESCRIPTION
### What this PR does / why we need it?
For cpu env, we should set `SOC_VERSION` to mock different NPU chips for different compilation paths
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/11b6af5280d6d6dfb8953af16e67b25f819b3be9
