### PR TITLE
[Nightly] Change Qwen3-235B acc baseline

### DIFF
--- a/tests/e2e/nightly/multi_node/config/Qwen3-235B-A22B-A2.yaml
+++ b/tests/e2e/nightly/multi_node/config/Qwen3-235B-A22B-A2.yaml
@@ -68,5 +68,5 @@ benchmarks:
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
     max_out_len: 7680
     batch_size: 256
-    baseline: 96
+    baseline: 95
     threshold: 5


### PR DESCRIPTION
### What this PR does / why we need it?
After multiple rounds of testing, we should determine a reasonable accuracy baseline to keep CI monitored and prevent it from failing.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
