### PR TITLE
[CI] skip 310 test for full test

### DIFF
--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -83,5 +83,5 @@ jobs:
       vllm: ${{ matrix.vllm_version }}
       runner: linux-aarch64-a2
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc2-910b-ubuntu22.04-py3.11
-      contains_310: true
+      contains_310: false
       type: full


### PR DESCRIPTION
Skip 310 test for full test. It's not stable now.

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
