### PR TITLE
[Main][Feat]Set the Profiler parameters by setting --profiler-config consistent with vLLM

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -489,14 +489,14 @@ class NPUWorker(WorkerBase):
         ensure_ec_transfer_initialized(self.vllm_config)
 
     def _init_profiler(self):
-        # Torch profiler. Enabled and configured through env vars:
-        # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
-        if envs_vllm.VLLM_TORCH_PROFILER_DIR:
+        # Torch profiler. Enabled and configured by setting --profiler-config when launching the server:
+        # profiler_config.torch_profiler_dir=/path/to/save/trace
+        if self.vllm_config.profiler_config is not None and self.vllm_config.profiler_config.torch_profiler_dir:
             if envs_ascend.MSMONITOR_USE_DAEMON:
                 raise RuntimeError(
-                    "MSMONITOR_USE_DAEMON and VLLM_TORCH_PROFILER_DIR cannot be both set at the same time."
+                    "MSMONITOR_USE_DAEMON and torch_profiler_dir in profiler_config cannot be both set at the same time."
                 )
-            torch_profiler_trace_dir = envs_vllm.VLLM_TORCH_PROFILER_DIR
+            torch_profiler_trace_dir = self.vllm_config.profiler_config.torch_profiler_dir
             logger.info("Profiling enabled. Traces will be saved to: %s",
                         torch_profiler_trace_dir)
 
@@ -517,9 +517,8 @@ class NPUWorker(WorkerBase):
                     torch_npu.profiler.ProfilerActivity.CPU,
                     torch_npu.profiler.ProfilerActivity.NPU,
                 ],
-                with_stack=envs_vllm.VLLM_TORCH_PROFILER_WITH_STACK,
-                profile_memory=envs_vllm.\
-                    VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY,
+                with_stack=self.vllm_config.profiler_config.torch_profiler_with_stack,
+                profile_memory=self.vllm_config.profiler_config.torch_profiler_with_memory,
                 with_modules=False,
                 experimental_config=experimental_config,
                 on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(


### PR DESCRIPTION
### What this PR does / why we need it?
Starting from version v0.13.0 of vLLM, due to the integration of this [PR:29912](https://github.com/vllm-project/vllm/pull/29912) the method for profiling with PyTorch Profiler has changed. Profiling parameters are no longer set via environment variables; instead, they are configured using --profiler-config. The latest documentation can be found at: [profile-with-pytorch-profiler](https://docs.vllm.ai/en/stable/contributing/profiling/#profile-with-pytorch-profiler)
This change has resulted in an issue where profiling results cannot be obtained in vllm-ascend when using the environment variables VLLM_TORCH_PROFILER_WITH_STACK and VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY. To enable normal profiling in vllm-ascend and align its profiling parameter configuration method with that of vllm, this PR is submitted.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed with existing test.

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
