### PR TITLE
[CI][Lint] Show lint diff on failure

### DIFF
--- a/.github/workflows/_pre_commit.yml
+++ b/.github/workflows/_pre_commit.yml
@@ -56,4 +56,4 @@ jobs:
         TERM: xterm-256color
         SHELLCHECK_OPTS: "--exclude=SC2046,SC2006,SC2086" # Exclude SC2046, SC2006, SC2086 for actionlint
       run: |
-        pre-commit run --all-files --hook-stage manual
+        pre-commit run --all-files --hook-stage manual --show-diff-on-failure


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, some of lint checks default automatic code correction but only shows which files were modified (without specifying the changes); in a CI environment, we can make a small optimization to show which lines were modified to give the developers some specifying hint.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
