### PR TITLE
[0.13.0][Bugfix] Fix setting of `speculative_config.enforce_eager` for dsv32

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -359,6 +359,18 @@ class NPUPlatform(Platform):
                 "needs to be equal if use pcp or dcp > 1 in P/D disaggregate and kv pool scenario."
             )
 
+        # NOTE: vllm sets `speculative_config.enforce_eager` as True if using
+        # deepseek_v32 with mtp. Since we support graph mode, we simply ignore
+        # it here. However, this fix will also implicitly ignore user setting of
+        # `speculative_config.enforce_eager`, we need to take care and remove it
+        # once vllm supports this feature.
+        speculative_config = vllm_config.speculative_config
+        if model_config and speculative_config and \
+            hasattr(model_config.hf_text_config, "model_type") and \
+            model_config.hf_text_config.model_type == "deepseek_v32" and \
+            speculative_config.enforce_eager:
+            speculative_config.enforce_eager = False
+
     @classmethod
     def import_kernels(cls) -> None:
         # Directly importing vllm_ascend_C prevents ASCEND_RT_VISIBLE_DEVICES


### PR DESCRIPTION
### What this PR does / why we need it?
This PR is cherry-picked from #5945. We leave only changes in platform.py.

This PR aims to fix setting of `speculative_config.enforce_eager` in deepseek v3.2 mtp. The point is that, vllm sets `speculative_config.enforce_eager` as True if using deepseek_v32 with mtp. Since we support graph mode, we simply ignore it here. However, this fix will also implicitly ignore user setting of `speculative_config.enforce_eager`, we need to take care and remove it once vllm supports this feature.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci
