### PR TITLE
[main][bugfix] fix mooncake kv cache transfer when one P has multi nodes

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1170,7 +1170,7 @@ class MooncakeConnectorWorker:
             self.tp_num_need_pulls = num_d_block_heads // num_p_block_heads
         self.local_remote_block_port_mapping: dict[
             str, Optional[List[List[int]]]] = {}
-        self.remote_port_send_num: dict[str, dict[str, int | str]] = {}
+        self.remote_port_send_num: dict[str, dict[int, dict[str, int | str]]] = {}
 
     def _get_prefill_decode_size(self, vllm_config: VllmConfig):
         # get prefill tp and dp size from extra config
@@ -1457,7 +1457,7 @@ class MooncakeConnectorWorker:
             return local_remote_block_port_mappings
 
         def get_remote_port_send_num(local_remote_block_port_mappings):
-            remote_port_send_num: dict[int, dict[str, int]] = {}
+            remote_port_send_num: dict[int, dict[str, int | str]] = {}
             for port in range(self._prefill_tp_size * meta.remote_pcp_size):
                 remote_host = meta.remote_multi_nodes_meta_mapping[str(port)]['host']
                 remote_port_send_num[meta.remote_port + port] = {}


### PR DESCRIPTION
### What this PR does / why we need it?
In PD disaggregation case, when P has multi nodes, mooncake fails to send data. Fix the issue in this PR.

The details:
If a P rank does not need to transfer kv cache to any one D rank, D node should send a message to P node to release the kv
 cache in P node. If P has multi nodes, D node should know the corresponding IP in each P node, then D node can send message to the right P node. Otherwise, send data error will happen. This PR fix this issue by providing P nodes IP to D node through Parameter `remote_port_send_num`.

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
