### PR TITLE
[Main2Main] Upgrade vllm commit to releases/v0.14.0

### DIFF
--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=2c24bc6996cb165fce92f780b388a5e39b3f4060
+          VLLM_COMMIT=d68209402ddab3f54a09bc1f4de9a9495a283b60
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> $GITHUB_ENV
 
       - name: Checkout repository

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [d68209402ddab3f54a09bc1f4de9a9495a283b60, v0.13.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 2c24bc6996cb165fce92f780b388a5e39b3f4060
+      vllm: d68209402ddab3f54a09bc1f4de9a9495a283b60
   changes:
     runs-on: linux-aarch64-a2-0
     outputs:
@@ -84,7 +84,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [d68209402ddab3f54a09bc1f4de9a9495a283b60, v0.13.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -96,7 +96,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [d68209402ddab3f54a09bc1f4de9a9495a283b60, v0.13.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060]
+        vllm_version: [d68209402ddab3f54a09bc1f4de9a9495a283b60]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -53,7 +53,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0 tag | >= 3.10, < 3.12   | 8.3.RC2 | 2.8.0 / 2.8.0 |
+|     main    | d68209402ddab3f54a09bc1f4de9a9495a283b60, v0.13.0 tag | >= 3.10, < 3.12   | 8.3.RC2 | 2.8.0 / 2.8.0 |
 
 ## Release cadence
 


### PR DESCRIPTION
### What this PR does / why we need it?
Upgrade vllm commit to releases/v0.14.0
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
