### PR TITLE
(deprecated)[Lint]Style: Convert `vllm-ascend/` to ruff format(Batch #4)

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1483,12 +1483,12 @@ class MooncakeConnectorWorker:
             ):
                 for remote_port_list in remote_port_head_list:
                     for remote_port in remote_port_list:
-                        remote_port_send_num[remote_port]['num'] += 1
+                        remote_port_send_num[remote_port]["num"] += 1
             return remote_port_send_num
 
         if meta.remote_engine_id not in self.local_remote_block_port_mapping:
             self.local_remote_block_port_mapping[meta.remote_engine_id] = None
-        
+
         if self.local_remote_block_port_mapping[meta.remote_engine_id] is None:
             local_remote_block_port_mappings = get_local_remote_block_port_mappings(
             )


### PR DESCRIPTION
### What this PR does / why we need it?
**Scope of Changes**:
| File Path |
| :--- |
| `vllm_ascend/distributed/kv_transfer/__init__.py` |
| `vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py` |
| `vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py` |
| `vllm_ascend/xlite/xlite.py` |
| `vllm_ascend/xlite/xlite_model_runner.py` |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
