### PR TITLE
[releases/v0.14.0] Upgrade CANN to 8.5.0 without upgrading PTA

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -140,7 +140,7 @@ jobs:
     name: multicard-2
     runs-on: linux-aarch64-a3-2
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc2-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
@@ -255,7 +255,7 @@ jobs:
     if: ${{ needs.e2e-2-cards.result == 'success' && inputs.type == 'full' }}
     runs-on: linux-aarch64-a3-4
     container:
-      image: m.daocloud.io/quay.io/ascend/cann:8.3.rc2-a3-ubuntu22.04-py3.11
+      image: m.daocloud.io/quay.io/ascend/cann:8.5.0-a3-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,13 +75,14 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        # vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [v0.13.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' }}
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
       runner: linux-aarch64-a2
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc2-910b-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       contains_310: false
       type: full

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,8 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 2c24bc6996cb165fce92f780b388a5e39b3f4060
+      # vllm: 2c24bc6996cb165fce92f780b388a5e39b3f4060
+      vllm: 0.13.0
   changes:
     runs-on: linux-aarch64-a2-0
     outputs:
@@ -84,7 +85,8 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        # vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [v0.13.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -96,7 +98,8 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        # vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060, v0.13.0]
+        vllm_version: [v0.13.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,8 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060]
+        # vllm_version: [2c24bc6996cb165fce92f780b388a5e39b3f4060]
+        vllm_version: [0.13.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_test_benchmarks.yaml
+++ b/.github/workflows/schedule_test_benchmarks.yaml
@@ -55,7 +55,7 @@ jobs:
             vllm_ascend_branch: main
       max-parallel: 1
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc2-910b-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi


### PR DESCRIPTION
### What this PR does / why we need it?
Upgrade CANN to 8.5.0 with PTA 2.8.0
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/2c24bc6996cb165fce92f780b388a5e39b3f4060
