### PR TITLE
[0.13.0][Bugfix] fix pcp aclgraph qwen FIA bug

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -422,14 +422,7 @@ def update_attn_dcp_pcp_params(update_stream, forward_context, runtime_shape):
                 actual_seq_lengths_kv = np.concatenate(
                     [actual_seq_lengths_kv, pad_tensor])
 
-            actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q[:
-                                                                      attn_metadata
-                                                                      .
-                                                                      num_decode_tokens]
-            if (runtime_shape - len(actual_seq_lengths_q)):
-                actual_seq_lengths_q = actual_seq_lengths_q + [
-                    actual_seq_lengths_q[-1]
-                ] * (runtime_shape - len(actual_seq_lengths_q))
+            actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
             if dcp_size > 1:
                 num_heads = num_heads * dcp_size
 


### PR DESCRIPTION
### What this PR does / why we need it?

[releases/v0.13.0] In the pcp full graph Qwen model scenario, the inconsistency between the Q shape and actual q len of the FIA operator is fixed.
PR for main branch: https://github.com/vllm-project/vllm-ascend/pull/6037

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
vLLM version: v0.13.0