### PR TITLE
[Feature] Add save_sharded_state support for NPUWorker

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -499,3 +499,19 @@ class NPUWorker(WorkerBase):
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()
+
+    def save_sharded_state(
+        self,
+        path: str,
+        pattern: str | None = None,
+        max_size: int | None = None,
+    ) -> None:
+        """Save the model weights in sharded state format for fast loading."""
+        from vllm.model_executor.model_loader import ShardedStateLoader
+
+        ShardedStateLoader.save_model(
+            self.model_runner.model,
+            path,
+            pattern=pattern,
+            max_size=max_size,
+        )


### PR DESCRIPTION
  ## Summary

  Add `save_sharded_state` method to `NPUWorker`, enabling users to convert model weights to pre-sharded format on Ascend NPU.

  ## Motivation

  The `sharded_state` format is crucial for fast model loading with tensor parallelism - each worker loads only its own shard instead of the full checkpoint. However, vllm-ascend previously lacked the ability to **create** sharded checkpoints on NPU.

  This PR adds the `save_sharded_state` method to `NPUWorker`, allowing users to:
  1. Convert existing checkpoints to sharded format using NPU
  2. Then load them with `--load-format sharded_state` for faster startup

  ## Performance

  Model loading time for **Llama3-70B**:

  | Tensor Parallel | Original | Sharded State | Speedup |
  |-----------------|----------|---------------|---------|
  | TP=4            | 10.54s   | 3.94s         | **2.7x** |
  | TP=16           | 7.22s    | 0.99s         | **7.3x** |

  The speedup scales with tensor parallelism since each worker only loads its own shard.

  ## Usage

  **Step 1: Convert weights to sharded format (The example is in vllm dir, not vllm-ascend) **
  ```bash
  python examples/offline_inference/save_sharded_state.py \
      --model /path/to/model \
      --tensor-parallel-size 4 \
      --output /path/to/sharded-model

  Step 2: Serve with sharded state
  vllm serve /path/to/sharded-model \
      --tensor-parallel-size 4 \
      --load-format sharded_state

  Test Plan

  - Test save_sharded_state.py with TP=4 on NPU
  - Test serving with --load-format sharded_state
  - Verify model outputs match original model
- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
