### PR TITLE
[EPLB][Bugfix][v0.13.0] Incorporate the warm up of the EPLB into the profile run.

### DIFF
--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -60,7 +60,6 @@ class D2DExpertWeightLoader:
                 layer_id][global_expert_id_to_send].item()
             for src_tensor in self.eplb_adaptor.expert_param_per_layer[
                     layer_id][local_expert_id]:
-                src_tensor = src_tensor.clone()
                 self.comm_op_list.append(
                     dist.P2POp(dist.isend, src_tensor, dst_rank))
 

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -35,6 +35,7 @@ class EplbUpdator:
         self.eplb_process = eplb_process
         self.shared_dict = self.eplb_process.shared_dict
         self.moe_imbalance_dict: dict[int, float] = {}
+        self._gather_buffer = None
 
     def set_adaptor(self, adaptor):
         self.adaptor = adaptor
@@ -139,7 +140,7 @@ class EplbUpdator:
 
     def forward_end(self):
         if self.wakeup_eplb_worker_flag():
-            self.compute_and_set_moe_load(is_clear=True)
+            self.compute_and_set_moe_load()
             self.wakeup_eplb_worker()
 
         if self.update_expert_weight_flag(
@@ -148,34 +149,28 @@ class EplbUpdator:
 
         self.update_iteration()
 
-    def compute_and_set_moe_load(self, is_clear=False):
+    def compute_and_set_moe_load(self):
         local_load = self.adaptor.get_rank_expert_workload()
 
-        self._gather_buffer = None
-        if dist.is_initialized():
-            self.world_size = dist.get_world_size()
-            self.device = local_load.device
-            if self._gather_buffer is None:
-                shape = (self.world_size, *local_load.shape)
-                self._gather_buffer = torch.empty(shape,
-                                                  dtype=local_load.dtype,
-                                                  device=self.device)
-
-            dist.all_gather_into_tensor(self._gather_buffer, local_load)
-
-            moe_load = self._gather_buffer.permute(1, 0, 2)
-            self.shared_dict["moe_load"] = moe_load.cpu()
-            logger.debug(
-                f"[ModelRunner] Updated shared_dict['moe_load'] shape={moe_load.shape}"
-            )
+        self.world_size = dist.get_world_size()
+        self.device = local_load.device
+        if self._gather_buffer is None:
+            shape = (self.world_size, *local_load.shape)
+            self._gather_buffer = torch.empty(shape,
+                                              dtype=local_load.dtype,
+                                              device=self.device)
         else:
-            moe_load = local_load.unsqueeze(1)
-            self.shared_dict["moe_load"] = moe_load.cpu()
-            logger.debug(
-                f"[ModelRunner] Updated shared_dict['moe_load'] shape={moe_load.shape}"
-            )
+            self._gather_buffer.zero_()
 
-        if dist.is_initialized() and dist.get_rank() == 0:
+        dist.all_gather_into_tensor(self._gather_buffer, local_load)
+
+        moe_load = self._gather_buffer.permute(1, 0, 2)
+        self.shared_dict["moe_load"] = moe_load.cpu()
+        logger.debug(
+            f"[ModelRunner] Updated shared_dict['moe_load'] shape={moe_load.shape}"
+        )
+
+        if dist.get_rank() == 0:
             self.compute_moe_imbalance(moe_load)
             self.summarize_moe_imbalance()
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2328,6 +2328,7 @@ class NPUModelRunner(GPUModelRunner):
             self.max_num_tokens = math.ceil(self.max_num_tokens /
                                             (self.pcp_size * 2)) * 2
         super().profile_run()
+        self.eplb_warmup()
         self.max_num_tokens = origin_max_num_tokens
 
     def eplb_warmup(self):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -377,7 +377,6 @@ class NPUWorker(WorkerBase):
 
     def compile_or_warm_up_model(self) -> None:
         # Note: need to adapt for graph mode.
-        self.model_runner.eplb_warmup()
         warmup_sizes = (self.vllm_config.compilation_config.compile_sizes
                         or []).copy()
         if not self.model_config.enforce_eager:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html
-->
### What this PR does / why we need it?
#6020 
1. Incorporate the warm up of the EPLB into the profile run.
2. Reusing the same gather buffer

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?

qwen3-235b aime baseline
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2024 | 604a78 | accuracy | gen | 86.67 |

eplb The OOM issue does not occur.
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2024 | 604a78 | accuracy | gen | 86.67 |
