### PR TITLE
[0.13.0][cherry-pick][BugFix] fix 3vl dense model load quant weight

### DIFF
--- a/vllm_ascend/quantization/quant_config.py
+++ b/vllm_ascend/quantization/quant_config.py
@@ -210,6 +210,11 @@ QUANT_MODEL_PREFIX_MAPPINGS = {
         "language_model.lm_head.": "lm_head.",
         "language_model.model.": "model.language_model.",
     },
+    "qwen3_vl_text": {
+        "visual.": "model.visual.",
+        "language_model.lm_head.": "lm_head.",
+        "language_model.model.": "model.language_model.",
+    },
 }
 
 packed_modules_model_mapping = {


### PR DESCRIPTION
cherry pick from pr #6100 

What this PR does / why we need it?
Fix Qwen3VL dense quant model load weights Error.

Does this PR introduce any user-facing change?
no

How was this patch tested?
The Qwen3VL quantized model service initialized successfully. Inference requests are processed correctly, and valid responses are returned.

vLLM version: v0.13.0
vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60