### PR TITLE
[Misc] Bump mooncake version to v0.3.8.post1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:8.5.0-910b-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.7.post2"
+ARG MOONCAKE_TAG="v0.3.8.post1"
 ARG SOC_VERSION="ascend910b1"
 
 # Define environments

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:8.5.0-a3-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG=v0.3.7.post2
+ARG MOONCAKE_TAG=v0.3.8.post1
 ARG SOC_VERSION="ascend910_9391"
 
 COPY . /vllm-workspace/vllm-ascend/

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:8.5.0-a3-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.7.post2"
+ARG MOONCAKE_TAG="v0.3.8.post1"
 ARG SOC_VERSION="ascend910_9391"
 
 ENV SOC_VERSION=$SOC_VERSION \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -18,7 +18,7 @@
 FROM quay.io/ascend/cann:8.5.0-910b-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG MOONCAKE_TAG="v0.3.7.post2"
+ARG MOONCAKE_TAG="v0.3.8.post1"
 ARG SOC_VERSION="ascend910b1"
 
 ENV SOC_VERSION=$SOC_VERSION \

--- a/docs/source/tutorials/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/pd_colocated_mooncake_multi_instance.md
@@ -121,7 +121,7 @@ Moonshot AI. Installation and compilation guide:
 First, obtain the Mooncake project using the following command:
 
 ```bash
-git clone -b v0.3.7.post2 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+git clone -b v0.3.8.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
 cd Mooncake
 git submodule update --init --recursive
 ```

--- a/docs/source/tutorials/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/pd_disaggregation_mooncake_multi_node.md
@@ -177,7 +177,7 @@ Mooncake is the serving platform for Kimi, a leading LLM service provided by Moo
 First, we need to obtain the Mooncake project. Refer to the following command:
 
 ```shell
-git clone -b v0.3.7.post2 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+git clone -b v0.3.8.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
 ```
 
 (Optional) Replace go install url if the network is poor

--- a/docs/source/tutorials/pd_disaggregation_mooncake_single_node.md
+++ b/docs/source/tutorials/pd_disaggregation_mooncake_single_node.md
@@ -98,7 +98,7 @@ Mooncake is the serving platform for Kimi, a leading LLM service provided by Moo
 First, we need to obtain the Mooncake project. Refer to the following command:
 
 ```shell
-git clone -b v0.3.7.post2 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+git clone -b v0.3.8.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
 ```
 
 (Optional) Replace go install url if the network is poor

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -42,7 +42,7 @@ export PYTHONHASHSEED=0
         First, we need to obtain the Mooncake project. Refer to the following command:
 
         ```shell
-        git clone -b v0.3.7.post2 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+        git clone -b v0.3.8.post1 --depth 1 https://github.com/kvcache-ai/Mooncake.git
         ```
 
         (Optional) Replace go install url if the network is poor


### PR DESCRIPTION
### What this PR does / why we need it?
Since the mooncake has the newer [release](https://github.com/kvcache-ai/Mooncake/releases/tag/v0.3.8.post1), we pin the tag to latest release

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
