### PR TITLE
[CI] Remove tranformers version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ requires = [
     "psutil",
     "setuptools>=64",
     "setuptools-scm>=8",
-    "transformers<=4.57.1",
     "torch-npu==2.8.0",
     "torch==2.8.0",
     "torchvision",
@@ -33,16 +32,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.pymarkdown]
-plugins.md004.style = "sublist" # ul-style
-plugins.md007.indent = 4 # ul-indent
-plugins.md007.start_indented = true # ul-indent
-plugins.md013.enabled = false # line-length
-plugins.md041.enabled = false # first-line-h1
-plugins.md033.enabled = false # inline-html
-plugins.md046.enabled = false # code-block-style
-plugins.md024.allow_different_nesting = true # no-duplicate-headers
-plugins.md029.enabled = false # ol-prefix
 
 [tool.ruff]
 # TODO: according to PEP8, there should be 80 characters per line

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,5 @@ numba
 torch-npu==2.8.0
 
 arctic-inference==0.1.1
-transformers>=4.57.3
 fastapi<0.124.0
 triton-ascend==3.2.0


### PR DESCRIPTION
### What this PR does / why we need it?
Do not limit transformers version. use the version vllm use. and prepare for the coming transformers-v5 https://github.com/vllm-project/vllm/pull/30566
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
