### PR TITLE
[P/D][PCP]bugfix pcp force free twice caused logger error

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -444,6 +444,8 @@ class KVCacheRecvingThread(threading.Thread):
                 f"{remote_request_id}: {e}",
                 exc_info=True)
         finally:
+            self._send_done_signal_to_free_remote_port(remote_request_id, remote_host,
+                                                       remote_port_send_num)
             if all_task_done:
                 self.task_tracker.update_done_task_count(request_id)
                 if request_id in self.proc_not_transfer_request:
@@ -455,8 +457,6 @@ class KVCacheRecvingThread(threading.Thread):
             self._send_done_recv_signal(remote_request_id, remote_host,
                                         remote_handshake_port,
                                         remote_port_send_num)
-            self._send_done_signal_to_free_remote_port(remote_request_id, remote_host,
-                                                       remote_port_send_num)
 
     def _send_done_signal_to_free_remote_port(self, request_id, remote_host,
                                               remote_port_send_num):


### PR DESCRIPTION
### What this PR does / why we need it?
The issue of the D node mistakenly sending the pull-end signal twice, leading to the P node printing logger errors abnormally, has been resolved.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
By ci
- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
