### PR TITLE
[Main] Re-open skipped cases due to PTA upgrading and update the golden results

### DIFF
--- a/tests/e2e/singlecard/test_aclgraph_accuracy.py
+++ b/tests/e2e/singlecard/test_aclgraph_accuracy.py
@@ -76,10 +76,9 @@ CASE_DS_EX = LLMTestCase(model="vllm-ascend/DeepSeek-V2-Lite-W8A8",
                          prompts=PROMPTS_LONG,
                          golden_answers=[
                              '\n\nYour answer seems reasonable. Find out if you\'re right!\n\nSign up to access problem solutions.\n\nThat seems reasonable. Find out',
-                             '\n\nYour answer seems reasonable. Find out if you\'re right!\n\nSign up to access problem solutions.\n\nThat seems reasonable. Find out',
-                             '\n\nYour answer seems reasonable. Find out if you\'re right!\n\nSign up to access problem solutions.\n\nThat seems reasonable. Find out'
+                             '\n\nI\'m not sure how to approach this problem. I\'m not sure if I should use the law of total probability or if I should use',
+                             '\n\nLet $a, b, c$ be distinct numbers such that the equations $x^2 + ax + 1 = 0$and $'
                          ])
-
 
 @pytest.mark.parametrize("cur_case", [CASE_QWEN_ACLGRAPH, CASE_DS_ACLGRAPH])
 def test_piecewise_res_consistency(cur_case: LLMTestCase):
@@ -113,9 +112,7 @@ def test_full_decode_only_res_consistency(cur_case: LLMTestCase, monkeypatch):
                   sampling_params=cur_case.sampling_params,
                   golden_answers=cur_case.golden_answers)
 
-# This failed when PTA==2.9.0, fix me
-#@pytest.mark.parametrize("cur_case", [CASE_QWEN_EX, CASE_DS_EX])
-@pytest.mark.parametrize("cur_case", [CASE_QWEN_EX])
+@pytest.mark.parametrize("cur_case", [CASE_QWEN_EX, CASE_DS_EX])
 def test_npugraph_ex_res_consistency(cur_case: LLMTestCase, monkeypatch):
     monkeypatch.delenv("HCCL_OP_EXPANSION_MODE", raising=False)
     runner_kwargs = {


### PR DESCRIPTION
### What this PR does / why we need it?
Re-open `tests/e2e/singlecard/test_aclgraph_accuracy.py` and update its golden results to match PTA 2.9.0
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
