### PR TITLE
[Bugfix] Fix structured outputs errors: `TypeError: apply_token_bitmask_inplace_cpu()`

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -99,8 +99,7 @@ jobs:
           pytest -sv --durations=0 tests/e2e/singlecard/test_camem.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_completion_with_prompt_embeds.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_cpu_offloading.py
-          # xgrammar has parameter mismatching bug, please follows: https://github.com/vllm-project/vllm-ascend/issues/5524
-          # pytest -sv --durations=0 tests/e2e/singlecard/test_guided_decoding.py
+          pytest -sv --durations=0 tests/e2e/singlecard/test_guided_decoding.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_ilama_lora.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_llama32_lora.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_qwen3_multi_loras.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires = [
     "msgpack",
     "quart",
     "numba",
+    "xgrammar>=0.1.30",
     "fastapi<0.124.0",
     "opencv-python-headless<=4.11.0.86", # Required to avoid numpy version conflict with vllm
     "compressed_tensors>=0.11.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ setuptools-scm>=8
 torch==2.9.0
 torchvision
 wheel
+xgrammar>=0.1.30
 pandas-stubs
 opencv-python-headless<=4.11.0.86 # Required to avoid numpy version conflict with vllm
 compressed_tensors>=0.11.0


### PR DESCRIPTION
### What this PR does / why we need it?
Fix https://github.com/vllm-project/vllm-ascend/issues/5524

The detailed error is:
```
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[], scheduled_cached_reqs=CachedRequestData(req_ids=['0-bb58a236', '1-a4a0cd3b'],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[None, None],num_computed_tokens=[74, 74],num_output_tokens=[12, 12]), num_scheduled_tokens={1-a4a0cd3b: 1, 0-bb58a236: 1}, total_num_scheduled_tokens=2, scheduled_spec_decode_tokens={}, scheduled_encoder_inputs={}, num_common_prefix_blocks=[0], finished_req_ids=[], free_encoder_mm_hashes=[], preempted_req_ids=[], has_structured_output_requests=true, pending_structured_output_tokens=true, num_invalid_spec_tokens=null, kv_connector_metadata=null, ec_connector_metadata=null)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938] EngineCore encountered a fatal error.
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938] Traceback (most recent call last):
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/engine/core.py", line 929, in run_engine_core
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     engine_core.run_busy_loop()
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/engine/core.py", line 956, in run_busy_loop
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     self._process_engine_step()
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/engine/core.py", line 989, in _process_engine_step
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/engine/core.py", line 487, in step_with_batch_queue
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     model_output = future.result()
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]                    ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/usr/local/python3.11.14/lib/python3.11/concurrent/futures/_base.py", line 449, in result
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     return self.__get_result()
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]            ^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/usr/local/python3.11.14/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     raise self._exception
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/executor/uniproc_executor.py", line 79, in collective_rpc
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/serial_utils.py", line 461, in run_method
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     return func(*args, **kwargs)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     return func(*args, **kwargs)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/worker.py", line 361, in sample_tokens
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     return self.model_runner.sample_tokens(grammar_output)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     return func(*args, **kwargs)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 1655, in sample_tokens
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     apply_grammar_bitmask(scheduler_output, grammar_output,
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/vllm-workspace/vllm/vllm/v1/structured_output/utils.py", line 119, in apply_grammar_bitmask
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=index_tensor)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/usr/local/python3.11.14/lib/python3.11/site-packages/xgrammar/matcher.py", line 142, in apply_token_bitmask_inplace
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     apply_token_bitmask_inplace_cpu(logits, bitmask, vocab_size, indices)
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]   File "/usr/local/python3.11.14/lib/python3.11/site-packages/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py", line 45, in apply_token_bitmask_inplace_cpu
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     _core.kernels.apply_token_bitmask_inplace_cpu(
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938] TypeError: apply_token_bitmask_inplace_cpu(): incompatible function arguments. The following argument types are supported:
(EngineCore_DP0 pid=30021) ERROR 01-22 11:49:54 [core.py:938]     1. apply_token_bitmask_inplace_cpu(logits_ptr: int, logits_shape: tuple[int, int], logits_strides: tuple[int, int], bitmask_ptr: int, bitmask_shape: tuple[int, int], bitmask_strides: tuple[int, int], vocab_size: int, indices: collections.abc.Sequence[int] | None, logit_type: str) -> None
```
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.13.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
