### PR TITLE
[0.13.0][Bugix] fix kv pcp+pooling+pd separation bug

### DIFF
--- a/vllm_ascend/distributed/mooncake_connector.py
+++ b/vllm_ascend/distributed/mooncake_connector.py
@@ -1458,7 +1458,8 @@ class MooncakeConnectorWorker:
         def get_remote_port_send_num(local_remote_block_port_mappings):
             remote_port_send_num: dict[int, dict[str, int | str]] = {}
             for port in range(self._prefill_tp_size * meta.remote_pcp_size):
-                remote_host_info = meta.remote_multi_nodes_meta_mapping.get(str(port), None)
+                remote_host_info = meta.remote_multi_nodes_meta_mapping.get(
+                    str(port), None)
                 if remote_host_info is None:
                     remote_host = meta.remote_host
                 else:


### PR DESCRIPTION
### What this PR does / why we need it?
Rectify the problem that the pcp and pd separation and kv pooling scenario.

In the pooling scenario, multi_nodes_meta_mapping is empty. As a result, an error is reported when the remote_host information is obtained through the get_remote_port_send_num method.
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

pick-from: https://github.com/vllm-project/vllm-ascend/pull/6153