### PR TITLE
[v0.13.0][bugfix] fix capture shape in sp_eagle_fullgraph

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -359,9 +359,6 @@ class NPUModelRunner(GPUModelRunner):
         self.reorder_batch_threshold: int | None = None
         self.long_seq_metadata = None
 
-        # TODO: remove it when flash_common1 is removed
-        self.sp_context = _set_sp_context(self)
-
     def _init_device_properties(self) -> None:
         self.num_sms = None
 
@@ -3019,9 +3016,9 @@ class NPUModelRunner(GPUModelRunner):
         attention_backends: list[set[type[AttentionBackend]]],
         kv_cache_groups: list[KVCacheGroupSpec],
     ) -> None:
-        with self.sp_context:
+        with update_pass_config(self):
             super()._check_and_update_cudagraph_mode(attention_backends,
-                                                    kv_cache_groups)
+                                                     kv_cache_groups)
 
         # NOTE: Since aclgraph_batch_sizes cannot be determined until here,
         # we set the graph params right before initializing the keys.
@@ -3125,12 +3122,14 @@ def _replace_gpu_model_runner_function_wrapper(target_module_name):
     finally:
         setattr(target_module, "graph_capture", graph_capture)
 
+
 # TODO: remove it when flash_common1 is removed
 @contextmanager
-def _set_sp_context(model_runner):
+def update_pass_config(model_runner):
     try:
         original_pass_config_sp = model_runner.compilation_config.pass_config.enable_sp
-        model_runner.compilation_config.pass_config.enable_sp = enable_sp(model_runner.vllm_config)
+        model_runner.compilation_config.pass_config.enable_sp = enable_sp(
+            model_runner.vllm_config)
         yield
     finally:
         model_runner.compilation_config.pass_config.enable_sp = original_pass_config_sp


### PR DESCRIPTION
### What this PR does / why we need it?
fix capture shape error in sp+eagle+fullgraph feature

Overall idea: Implement a solution from the vLLM community to handle the capture shape error when sp, fullgraph, and eagle are enabled simultaneously.

Implementation: Add a context manager to the modelrunner file to pass the value of enable_sp to the vLLM function _check_and_update_cudagraph_mode, so that it can detect whether sp is enabled, thereby achieving the reuse of the vLLM community function. This vllm function now includes checks for tp and num_spec, and then raises an error to resolve this issue.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ut and tests
