### PR TITLE
[v0.13.0][cherry-pick][Bugfix] Fix seq_lens reset issue causing performance degradation

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -996,6 +996,8 @@ class NPUModelRunner(GPUModelRunner):
                                 1:pad_size +
                                 1] * self.uniform_decode_query_len + last_query_loc
                         self.query_start_loc.copy_to_gpu(num_reqs_padded + 1)
+                        self.seq_lens.np[num_reqs:].fill(0)
+                        self.seq_lens.copy_to_gpu(num_reqs_padded)
 
                     # So we are trying to simulate the behavior of GPUModelRunner's
                     # prepare_inputs for uniform decode mode by padding query_start_loc


### PR DESCRIPTION
### What this PR does / why we need it?
This cherry-picks #6158 

Now `seq_lens` was not being reset correctly after each step due to missing code that clears the sequence lengths. As a result, when processing a smaller batch after a larger batch, the `seq_lens` from the larger batch was still carried over. This caused the attention operator to compute using an unnecessarily larger sequence length, leading to an increased computation load and performance degradation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
