### PR TITLE
[0.13.0][Feat] Merge the multi eagle graphs to one graph

### DIFF
--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -295,6 +295,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform.get_global_graph_pool.return_value = self.mock_graph_pool
         mock_get_forward_context.return_value = self.mock_forward_context
         self.mock_forward_context.cudagraph_runtime_mode = CUDAGraphMode.FULL
+        self.mock_forward_context.is_draft_model = False
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()
@@ -366,6 +367,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform.get_global_graph_pool.return_value = self.mock_graph_pool
         mock_get_forward_context.return_value = self.mock_forward_context
         self.mock_forward_context.cudagraph_runtime_mode = CUDAGraphMode.FULL
+        self.mock_forward_context.is_draft_model = False
 
         # Mock torch.npu.NPUGraph
         mock_npu_graph = MagicMock()

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -20,6 +20,7 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.model_config = MagicMock()
         self.device = torch.device("cpu")
         self.runner = MagicMock()
+        self.runner.pin_memory = False
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -97,6 +98,23 @@ class TestEagleProposerInitialization(TestBase):
                                  runner=self.runner)
 
         self.assertEqual(proposer.hidden_size, 2048)
+        self.assertTrue(proposer.use_cuda_graph)
+        self.assertEqual(proposer.hidden_states.shape, (1024, 2048))
+
+    def test_initialization_mtp_full_graph_async(self):
+        self.vllm_config.speculative_config.method = "mtp"
+        self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 2048
+        self.vllm_config.compilation_config.mode = CompilationMode.VLLM_COMPILE
+        self.vllm_config.model_config.enforce_eager = False
+        self.vllm_config.speculative_config.enforce_eager = False
+        self.vllm_config.scheduler_config.async_scheduling = True
+        init_ascend_config(self.vllm_config)
+
+        proposer = EagleProposer(vllm_config=self.vllm_config,
+                                 device=self.device,
+                                 runner=self.runner)
+
+        self.assertEqual(proposer.hidden_size, 2048)
         self.assertFalse(proposer.use_cuda_graph)
         self.assertEqual(proposer.hidden_states.shape, (1024, 2048))
 
@@ -109,6 +127,7 @@ class TestEagleProposerLoadModel(TestBase):
         self.vllm_config.speculative_config.method = "eagle"
         self.device = torch.device("cpu")
         self.runner = MagicMock()
+        self.runner.pin_memory = False
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -248,6 +267,9 @@ class TestEagleProposerDummyRun(TestBase):
         self.vllm_config.speculative_config.num_speculative_tokens = 4
         self.device = torch.device("cpu")
         self.runner = MagicMock()
+        self.runner.pcp_size = 1
+        self.runner.dcp_size = 1
+        self.runner.pin_memory = False
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -255,6 +277,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.vllm_config.model_config.dtype = torch.float16
         self.vllm_config.model_config.max_model_len = 2048
         self.vllm_config.model_config.uses_mrope = False
+        self.vllm_config.model_config.use_mla = False
         self.vllm_config.parallel_config.tensor_parallel_size = 1
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.speculative_token_tree = str([
@@ -274,6 +297,7 @@ class TestEagleProposerDummyRun(TestBase):
                                       device=self.device,
                                       runner=self.runner)
         self.proposer.model = MagicMock()
+        self.proposer._runnable = MagicMock()
         self.proposer.update_stream = MagicMock()
 
     def tearDown(self):
@@ -293,7 +317,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.dummy_run(num_tokens=num_tokens,
                                 with_prefill=with_prefill)
 
-        self.assertTrue(self.proposer.model.call_count == 4)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
 
     # cpu does not support parallel-group, let alone `sp`
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context",
@@ -304,7 +328,7 @@ class TestEagleProposerDummyRun(TestBase):
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         self.proposer.enable_shared_expert_dp = False
         self.proposer.dummy_run(num_tokens=64, with_prefill=True, num_reqs=4)
-        self.assertTrue(self.proposer.model.call_count == 4)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
 
     @patch("vllm_ascend.spec_decode.eagle_proposer.update_attn_params")
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context")
@@ -324,7 +348,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.dummy_run(num_tokens=64,
                                 in_graph_capturing=True,
                                 aclgraph_runtime_mode=CUDAGraphMode.FULL)
-        self.assertTrue(self.proposer.model.call_count == 4)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
         mock_update_attn_params.assert_not_called()
         self.proposer.use_cuda_graph = last_use_cuda_graph
 
@@ -346,8 +370,8 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.dummy_run(num_tokens=64,
                                 in_graph_capturing=False,
                                 aclgraph_runtime_mode=CUDAGraphMode.FULL)
-        self.assertTrue(self.proposer.model.call_count == 4)
-        self.assertTrue(mock_update_attn_params.call_count == 4)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
+        self.assertTrue(mock_update_attn_params.call_count == 1)
         self.proposer.use_cuda_graph = last_use_cuda_graph
 
 
@@ -364,6 +388,7 @@ class TestEagleProposerHelperMethods(TestBase):
         self.runner.input_batch.req_ids = [0, 1, 2]
         self.runner.arange_np = np.arange(10)
         self.runner.input_batch.num_reqs = 3
+        self.runner.pin_memory = False
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024

--- a/tests/ut/spec_decode/test_mtp_proposer.py
+++ b/tests/ut/spec_decode/test_mtp_proposer.py
@@ -73,6 +73,7 @@ class TestMtpProposer:
         runner.max_num_tokens = 4096
         runner.max_num_reqs = 256
         runner.reserved_mc2_mask = None
+        runner.pin_memory = False
         return runner
 
     @patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")


### PR DESCRIPTION
### What this PR does / why we need it?
This PR is mainly cherry-picked fron #5940.

Major difference from #5940 is:
1. remove `piece_all_attn_layer_name`, which is never used in #5940
2. remain `attn_metadata` update process in `attn_update_stack_num_spec_norm` instead of `common_attn_metadata` update and rebuild `attn_metadata` process in #5940

Minor change in this PR is:
1. `self.cudagraph_batch_sizes` is replaced with `self.runner.cudagraph_batch_sizes`, since the former one is not correct (self.cudagraph_batch_sizes[-1] is not guarantee to be valid)

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci
