### PR TITLE
[Eagle3]enhance skipping dp allreduce and add it into eagle proposer

### DIFF
--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -272,7 +272,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.runner.pcp_size = 1
         self.runner.dcp_size = 1
         self.runner.pin_memory = False
-        self.runner._sync_metadata_across_dp.return_value = (8, 8, False, 0)
+        self.runner._sync_metadata_across_dp.return_value = (8, torch.tensor([8]), False)
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -386,7 +386,6 @@ class EagleProposer(VllmEagleProposer):
             num_tokens,
             num_tokens_across_dp,
             _,
-            _,
         ) = self.runner._sync_metadata_across_dp(num_tokens,
                                                  is_draft_model=True)
         with set_ascend_forward_context(
@@ -542,7 +541,6 @@ class EagleProposer(VllmEagleProposer):
         (
             num_input_tokens,
             num_tokens_across_dp,
-            _,
             _,
         ) = self.runner._sync_metadata_across_dp(num_input_tokens,
                                                  is_draft_model=True)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -443,7 +443,7 @@ class NPUModelRunner(GPUModelRunner):
         num_tokens: int,
         with_prefill: bool = False,
         is_draft_model: bool = False
-    ) -> tuple[int, Optional[torch.Tensor], bool, int]:
+    ) -> tuple[int, Optional[torch.Tensor], bool]:
         # TODO: In vLLM, the only thing that needs to be synced is num_tokens, but in
         # our case, we still need to sync the other two flags as well. So we need to
         # include them in the all_reduce operation, and more over, we CANNOT skip it


### PR DESCRIPTION
### What this PR does / why we need it?
This PR：

1.  Enhances the logic of `_skip_all_reduce_across_dp_group` to skip all cpu dp allreduce for dense models. This is also for purpose  2.
2. Adds `_skip_all_reduce_across_dp_group` into eagle_proposer. Now models like Qwen3-235b supports eagle3 spec decode. A typical setting for these moe models on pd disaggregation often introduce `dp_size > 1`. This requires `set_forward_context` to call a cpu dp allreduce to retrieve `num_tokens_across_dp` on all cases. Skipping this allreduce greatly improves performance.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
