### PR TITLE
[Community] Nominate whx-sjtu as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,11 +19,6 @@
 # benchmark
 /benchmarks @wangxiyuan
 
-# c++ source code
-/cmake @zzzzwwjj
-/csrc @zzzzwwjj
-/CMakeLists.txt @zzzzwwjj
-
 # docs
 /docs  @wangxiyuan @Yikun @LCAIZJ
 /.readthedocs.yaml  @wangxiyuan @Yikun
@@ -35,8 +30,13 @@
 # tests
 /tests @wangxiyuan
 
+# c++ source code
+/cmake @zzzzwwjj
+/csrc @zzzzwwjj
+/CMakeLists.txt @zzzzwwjj
+
 # python source code
-/vllm_ascend/attention @weijinqian0
+/vllm_ascend/attention @weijinqian0 @whx-sjtu
 /vllm_ascend/compilation @yiz-liu
 /vllm_ascend/core @wangxiyuan @MengqingCao
 /vllm_ascend/device @weijinqian0 @zzzzwwjj
@@ -46,10 +46,10 @@
 /vllm_ascend/kv_offload @nalinaly
 /vllm_ascend/lora @paulyu12
 /vllm_ascend/model_loader @wangxiyuan
-/vllm_ascend/ops @zzzzwwjj @realliujiaxu
+/vllm_ascend/ops @zzzzwwjj @realliujiaxu @whx-sjtu
 /vllm_ascend/patch @wangxiyuan
 /vllm_ascend/quantization @wangxiyuan
-/vllm_ascend/sample @realliujiaxu
+/vllm_ascend/sample @realliujiaxu @whx-sjtu
 /vllm_ascend/spec_decode @wangxiyuan
 /vllm_ascend/worker @MengqingCao
 /vllm_ascend/xlite @wangxiyuan

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -17,6 +17,7 @@
 | Jie Wen| [@zzzzwwjj](https://github.com/zzzzwwjj) | 2025/12 |
 | Chao Lei| [@LCAIZJ](https://github.com/LCAIZJ) | 2025/12 |
 | JiaXu Liu| [@realliujiaxu](https://github.com/realliujiaxu) | 2025/12 |
+| HeXiang Wang| [@whx-sjtu](https://github.com/whx-sjtu) | 2026/01 |
 
 ## Contributors
 


### PR DESCRIPTION
Since the first release v0.13.0rc2 and v0.14.0rc1 in 2026 are released. We consider to refresh the maintainer team. I nominate  whx-sjtu as the new maintainer.  Nominate reason:

#### ✅Review Quality‌:
He has completed[ 80+ reviews](https://github.com/vllm-project/vllm-ascend/pulls?q=is%3Apr+commenter%3Awhx-sjtu+-author%3Awhx-sjtu) since Oct. 2025, including[#pullrequestreview-3459750305](https://github.com/vllm-project/vllm-ascend/pull/4168#pullrequestreview-3459750305),[#discussion_r2453770390](https://github.com/vllm-project/vllm-ascend/pull/3612#discussion_r2453770390),  #discussion_r2472268022,[#discussion_r2480554911](https://github.com/vllm-project/vllm-ascend/pull/3931#discussion_r2480554911) with high quality.

#### ✅ Sustained Contributions
He has deep understanding of ‌vLLM‌ and ‌vLLM Ascend‌ codebases and solid contributions of more than[ 60+ PR merged](https://github.com/vllm-project/vllm-ascend/pulls?q=is%3Apr+author%3Awhx-sjtu+is%3Amerged+), including contributions both to vLLM and vLLM-Ascend. Especially, performance optimization, disaggregated-prefill, scheduler, accuracy bugfix and MLA related contributions are the main reason why I nominated him:
- Performance Optimization: On behalf of the Ascend computing product line, he contributed the first PR[ Pull Request #13](https://github.com/vllm-project/vllm-ascend/pull/13) to vllm-ascend which introduce MindIE Turbo to improve performance. After that he continues to contribued many PRs to optimize performance of vLLM-Ascend including[ Pull Request #18](https://github.com/vllm-project/vllm-ascend/pull/18),[ Pull request #204](https://github.com/vllm-project/vllm-ascend/pull/204),[ Pull Request #2002](https://github.com/vllm-project/vllm-ascend/pull/2002) and[ Pull Request #1614](https://github.com/vllm-project/vllm-ascend/pull/1614) etc..
- Disaggregated Prefill: He construct the baseline for p2p disaggregated-prefill of v0 in[ Pull Request #694](https://github.com/vllm-project/vllm-ascend/pull/694), which later also becomes baseline for current v1 p2p disaggregated-prefill.
- Ascend Scheduler: He develops AscendScheduler in[ Pull Request #543](https://github.com/vllm-project/vllm-ascend/pull/543), which provides v0-style scheduling strategy in v1 engine and welcomed by many users. What's more he continues to imporve AscendScheduler in[ Pull Request #943](https://github.com/vllm-project/vllm-ascend/pull/943),[ Pull Request #822](https://github.com/vllm-project/vllm-ascend/pull/822).

#### ✅Quality Contribution‌:
- Accuracy Bugfix: He manages to fix many important and urgent accuracy-related bugs including[ [Pull Request #3163](https://github.com/vllm-project/vllm-ascend/pull/3163),[ Pull Request #95](https://github.com/vllm-project/vllm-ascend/pull/95) and[ Pull Request #1498](https://github.com/vllm-project/vllm-ascend/pull/1498).
- PluggableLayer: He designs PluggableLayer for full layer pluggablility:[ [PluggableLayer][1/N] Define PluggableLayer by whx-sjtu · Pull Request #32331 · vllm-project/vllm](https://github.com/vllm-project/vllm/pull/32331)
- MLA Refactor: During the reconstruction of the MLA part, he made a series of efforts to make the architecture of the MLA layer successfully attracted the attention of the vllm community, and made the MLA layer support custom op in[ Pull Request #23332](https://github.com/vllm-project/vllm/pull/23332).
- MoE Refactor for glm4_moe: He manages to make glm4_moe reuse `SharedFusedMoE` by contributing to vllm community in[ Pull Request #24849](https://github.com/vllm-project/vllm/pull/24849). This not only solves the accuracy issue of GLM4.5, but also helps with the refactor of our MoE backend.

#### ✅Community Involvement‌: 
In 2025 Q2/Q3, he leads [[RFC]: Performance optimation of decode in DeepSeek Large EP situation. · Issue #2905 · vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend/issues/2905#issue-3412546861) which optimizes performance of large EP situation.

He leads refactor of deepseek models and successfully delete all LLM models in vLLM-Ascend:
- [[Model][1/N] Delete deepseek v2/v3 modeling codes. by whx-sjtu · Pull Request #3189 · vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend/pull/3189)
- [ [Model][2/N] Remove deepseek_mtp modeling. by whx-sjtu · Pull Request #3561 · vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend/pull/3561)
- [ [Model][3/N] Refactor sfa into mla and remove deepseek_v3_2.py by whx-sjtu · Pull Request #3769 · vllm-project/vllm-ascend](https://github.com/vllm-project/vllm-ascend/pull/3769) 
- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
