### PR TITLE
[CI] Add workfolw_dispatch for nightly image build

### DIFF
--- a/.github/workflows/schedule_nightly_image_build.yaml
+++ b/.github/workflows/schedule_nightly_image_build.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     # UTC+8: 20pm, 23pm
     - cron: '0 12,15 * * *'
+  workflow_dispatch: 
 
 # This workflow builds and pushes Docker images for nightly-ci
 # It will be built base on the quay.io/ascend/vllm-ascend:main


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, the nightly image is built at 20 PM and 23 PM UTC+8. Due to some timeliness requirements, we need to add a new trigger method for nightly image builds.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d68209402ddab3f54a09bc1f4de9a9495a283b60
