### PR TITLE
[Bugfix] Specify tensorflow version in accuracy test to avoid segmentation fault

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -111,7 +111,7 @@ jobs:
         if: ${{ inputs.runner == 'linux-aarch64-a2-1' && contains(inputs.model_list, 'Molmo-7B-D-0924') }}
         shell: bash -l {0}
         run: |
-          pip install tensorflow --no-cache-dir
+          pip install tensorflow==2.19.1 --no-cache-dir
 
       - name: Resolve vllm-ascend version
         run: |

--- a/.github/workflows/nightly_test_a2.yaml
+++ b/.github/workflows/nightly_test_a2.yaml
@@ -103,10 +103,7 @@ jobs:
       ${{
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' ||
-        (
-          contains(github.event.pull_request.labels.*.name, 'accuracy-test') &&
-          contains(github.event.pull_request.labels.*.name, 'ready-for-test')
-        )
+        contains(github.event.pull_request.labels.*.name, 'accuracy-test')
       }}
     strategy:
       fail-fast: false


### PR DESCRIPTION

### What this PR does / why we need it?
Specify tensorflow version in accuracy test to avoid segmentation fault

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
