### PR TITLE
[Bugfix] Improve Triton stability on Ascend for large grids

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -16,6 +16,7 @@
 #
 
 import math
+import os
 from typing import Optional, Tuple
 
 import torch
@@ -545,6 +546,9 @@ class AscendDeepseekScalingRotaryEmbedding(DeepseekScalingRotaryEmbedding):
 
 class AscendMRotaryEmbedding(MRotaryEmbedding):
 
+    # Empirical safety threshold for large Triton grids on Ascend NPU
+    _ASCEND_TRITON_GRID_LIMIT = 65535
+
     def forward_triton(self,
                        positions: torch.Tensor,
                        query: torch.Tensor,
@@ -565,6 +569,12 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
         key_shape = key.shape
 
         assert self.mrope_section
+
+        # When the grid becomes large, enable TRITON_ALL_BLOCKS_PARALLEL 
+        # to avoid scheduler/runtime failures.
+        if (query_shape[0] > self._ASCEND_TRITON_GRID_LIMIT and 
+                os.environ.get("TRITON_ALL_BLOCKS_PARALLEL") != "1"):
+            os.environ["TRITON_ALL_BLOCKS_PARALLEL"] = "1"
 
         q, k = triton_mrope(
             query,


### PR DESCRIPTION
### What this PR does / why we need it?
Improve Triton stability on Ascend for large grids
set `TRITON_ALL_BLOCKS_PARALLEL=1` when grids > 65535

<img width="1909" height="180" alt="7e912975b9b2d337bfae2087b8d9b5d2" src="https://github.com/user-attachments/assets/aecfa80a-d0e1-4168-b18f-c0009e24f245" />



### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
