### PR TITLE
[ST]Add e2e test cases for GraphEXAddRMSNorm and GraphEXSplitQKNorm

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -80,6 +80,8 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         if: ${{ inputs.type == 'light' }}
         run: |
+          pytest -sv --durations=0 tests/e2e/singlecard/compile/test_graphex_norm_quant_fusion.py
+          pytest -sv --durations=0 tests/e2e/singlecard/compile/test_graphex_split_qknorm_fusion.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_aclgraph_accuracy.py::test_piecewise_res_consistency
           pytest -sv --durations=0 tests/e2e/singlecard/test_quantization.py::test_qwen3_w8a8_quant
 
@@ -115,6 +117,8 @@ jobs:
 
           # compile
           pytest -sv --durations=0 tests/e2e/singlecard/compile/test_norm_quant_fusion.py
+          pytest -sv --durations=0 tests/e2e/singlecard/compile/test_graphex_norm_quant_fusion.py
+          pytest -sv --durations=0 tests/e2e/singlecard/compile/test_graphex_split_qknorm_fusion.py
   
           # model_runner_v2
           # pytest -sv --durations=0 tests/e2e/singlecard/model_runner_v2/test_basic.py


### PR DESCRIPTION
### What this PR does / why we need it?
We found the custom passes of NPUGraphEX have implemented fusion operator features, which still require E2E test case validation and guard. This PR implements E2E test cases for the AddRMSNormQuant and SplitQKVNormRope operator fusions under NPUGraphEX that are already in the codebase.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
