### PR TITLE
[Refactor][2/N](CP) change the type of num_computed_tokens_of_pcp_dcp to Tensor

### DIFF
--- a/tests/ut/attention/test_mla_cp.py
+++ b/tests/ut/attention/test_mla_cp.py
@@ -538,11 +538,11 @@ class TestAscendMLAImpl(TestBase):
         USED_BLOCKS = 3
         # pcp_size, dcp_size, nums_tokens_per_rank, nums_all_rank_context, num_prefills, num_decodes, num_seqs, cp_local_block_size, num_computed_tokens, num_computed_tokens_of_pcp_dcp
         test_cases = [
-            (2, 2, [4], [128], 1, 0, 1, 1, [[[32, 32], [32, 32]]]),
-            (1, 2, [4], [128], 1, 0, 1, 1, [[[64, 64]]]),
-            (2, 1, [4], [128], 1, 0, 1, 1, [[[64], [64]]]),
-            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, [[[32, 32], [32, 32]],
-                                                    [[32, 32], [32, 32]]]),
+            (2, 2, [4], [128], 1, 0, 1, 1, torch.tensor([[[32, 32], [32, 32]]])),
+            (1, 2, [4], [128], 1, 0, 1, 1, torch.tensor([[[64, 64]]])),
+            (2, 1, [4], [128], 1, 0, 1, 1, torch.tensor([[[64], [64]]])),
+            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, torch.tensor([[[32, 32], [32, 32]],
+                                                                 [[32, 32], [32, 32]]])),
         ]
         # kv cache tensor
         kv_cache_0 = torch.randn(NUM_BLOCKS,
@@ -637,11 +637,11 @@ class TestAscendMLAImpl(TestBase):
         max_model_len = 4096
         max_num_seqs = 25
         test_cases = [
-            (2, 2, [4], [128], 1, 0, 1, 1, [[[32, 32], [32, 32]]]),
-            (1, 2, [4], [128], 1, 0, 1, 1, [[[64, 64]]]),
-            (2, 1, [4], [128], 1, 0, 1, 1, [[[64], [64]]]),
-            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, [[[32, 32], [32, 32]],
-                                                    [[32, 32], [32, 32]]]),
+            (2, 2, [4], [128], 1, 0, 1, 1, torch.tensor([[[32, 32], [32, 32]]])),
+            (1, 2, [4], [128], 1, 0, 1, 1, torch.tensor([[[64, 64]]])),
+            (2, 1, [4], [128], 1, 0, 1, 1, torch.tensor([[[64], [64]]])),
+            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, torch.tensor([[[32, 32], [32, 32]],
+                                                                 [[32, 32], [32, 32]]])),
         ]
         for test_case in test_cases:
             pcp_size, dcp_size, nums_tokens_per_rank, nums_all_rank_context, num_prefills, num_decodes, num_seqs, cp_local_block_size, num_computed_tokens_of_pcp_dcp = test_case

--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -838,8 +838,8 @@ class TestPCPDCPGraphParams(TestBase):
         out = torch.randn(2, 16, 128)
         lse = torch.randn(2, 16, 8)
 
-        num_computed_tokens_of_pcp_dcp = torch.ones((2,2,2))
-        decode = AscendMetadataForDecode(num_computed_tokens_of_pcp_dcp)
+        num_computed_tokens_of_pcp_dcp_np = np.ones((2,2,2), dtype=np.int32)
+        decode = AscendMetadataForDecode(num_computed_tokens_of_pcp_dcp_np)
         metadata = AscendMetadata(num_actual_tokens_pcp_padded=[1, 1],
                                   actual_seq_lengths_q=actual_seq_lengths_q,
                                   num_decode_tokens=1,

--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -838,8 +838,7 @@ class TestPCPDCPGraphParams(TestBase):
         out = torch.randn(2, 16, 128)
         lse = torch.randn(2, 16, 8)
 
-        num_computed_tokens_of_pcp_dcp = np.array([[[1, 1], [1, 1]],
-                                                   [[1, 1], [1, 1]]])
+        num_computed_tokens_of_pcp_dcp = torch.ones((2,2,2))
         decode = AscendMetadataForDecode(num_computed_tokens_of_pcp_dcp)
         metadata = AscendMetadata(num_actual_tokens_pcp_padded=[1, 1],
                                   actual_seq_lengths_q=actual_seq_lengths_q,

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -221,7 +221,7 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
             num_computed_tokens_array = num_computed_tokens_array[:num_decodes]
             # TODO: numpy array mode of the shared memory is used to improve performance
             decode_metadata = AscendMetadataForDecode(
-                num_computed_tokens_of_pcp_dcp=num_computed_tokens_array,
+                num_computed_tokens_of_pcp_dcp_np=num_computed_tokens_array,
                 block_tables=block_table[:num_decodes],
             )
 
@@ -320,7 +320,9 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                     dcp_rank,
                 ) = param
                 attn_metadata = forward_context.attn_metadata[key]
-                actual_seq_lengths_kv = attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp[:, pcp_rank, dcp_rank]
+                actual_seq_lengths_kv = attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp_np[
+                    :, pcp_rank, dcp_rank
+                ]
                 pad_length = num_tokens - len(actual_seq_lengths_kv)
                 if pad_length > 0:
                     pad_tensor = np.zeros(pad_length, dtype=actual_seq_lengths_kv.dtype)

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -146,9 +146,7 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
             pcp_size = get_pcp_group().world_size
             if self.chunked_prefill_enabled and max_context_len_cpu > 0:
                 local_context_lens_allranks = (
-                    torch.tensor(num_computed_tokens_of_pcp_dcp)[num_decodes:num_reqs]
-                    .to(self.device)
-                    .to(dtype=torch.int32)
+                    num_computed_tokens_of_pcp_dcp[num_decodes:num_reqs].to(self.device).to(dtype=torch.int32)
                 )
                 local_chunked_kv_lens_rank = local_context_lens_allranks[:, self.pcp_rank, self.dcp_rank]
                 actual_seq_lengths_kv = torch.cumsum(local_chunked_kv_lens_rank, dim=0).tolist()
@@ -219,7 +217,7 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
             )
 
         if num_decodes > 0:
-            num_computed_tokens_array = np.array(num_computed_tokens_of_pcp_dcp)
+            num_computed_tokens_array = num_computed_tokens_of_pcp_dcp.numpy()
             num_computed_tokens_array = num_computed_tokens_array[:num_decodes]
             # TODO: numpy array mode of the shared memory is used to improve performance
             decode_metadata = AscendMetadataForDecode(

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch_npu
@@ -83,7 +84,7 @@ class AscendMetadataForPrefill:
 class AscendMetadataForDecode:
     """Decode-specific metadata for Ascend attention with Context Parallelism."""
 
-    num_computed_tokens_of_pcp_dcp: torch.Tensor | None = None
+    num_computed_tokens_of_pcp_dcp_np: np.ndarray | None = None
     block_tables: torch.Tensor | None = None
 
 

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -83,8 +83,8 @@ class AscendMetadataForPrefill:
 class AscendMetadataForDecode:
     """Decode-specific metadata for Ascend attention with Context Parallelism."""
 
-    num_computed_tokens_of_pcp_dcp: list[list[list[int]]] | None = None
-    block_tables: torch.Tensor = None
+    num_computed_tokens_of_pcp_dcp: torch.Tensor | None = None
+    block_tables: torch.Tensor | None = None
 
 
 def _process_attn_out_lse(attn_output: torch.Tensor, softmax_lse: torch.Tensor) -> torch.Tensor:

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -145,7 +145,7 @@ class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
         assert long_seq_metadata is not None
         num_computed_tokens_of_pcp_dcp = long_seq_metadata.num_computed_tokens_of_pcp_dcp
         assert num_computed_tokens_of_pcp_dcp is not None
-        local_context_lens_allranks = torch.tensor(num_computed_tokens_of_pcp_dcp[self.num_decodes_flatten :]).reshape(
+        local_context_lens_allranks = num_computed_tokens_of_pcp_dcp[self.num_decodes_flatten :].reshape(
             -1, self.dcp_size * self.pcp_size
         )
         # Note(qcs): The max local context lengths
@@ -230,15 +230,11 @@ class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
         num_computed_tokens_of_pcp_dcp = long_seq_metadata.num_computed_tokens_of_pcp_dcp
         assert num_computed_tokens_of_pcp_dcp is not None
         # [bs, pcp_size, dcp_size]
-        num_computed_tokens_of_cp_dcp_array = np.array(num_computed_tokens_of_pcp_dcp)[: self.num_decodes_flatten]
-
-        cp_seq_len = num_computed_tokens_of_cp_dcp_array[:, self.pcp_rank, self.dcp_rank]
-        cp_seq_len = torch.tensor(cp_seq_len, dtype=torch.int32)
+        cp_seq_len = num_computed_tokens_of_pcp_dcp[: self.num_decodes_flatten, self.pcp_rank, self.dcp_rank]
         decode_metadata.cp_seq_len = cp_seq_len.tolist()
 
         actual_seq_lengths_q = torch.arange(self.num_decodes_flatten) + 1
         decode_metadata.actual_seq_lengths_q = actual_seq_lengths_q
-
         return decode_metadata
 
 

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -73,7 +73,7 @@ class AscendPrefillContextParallelMetadata:
 
     num_actual_tokens_pcp_padded: int = 0
 
-    num_computed_tokens_of_pcp_dcp: list[list[list[int]]] | None = None
+    num_computed_tokens_of_pcp_dcp: torch.Tensor | None = None
 
     q_head_idx_tensor: torch.Tensor = None
 


### PR DESCRIPTION
### What this PR does / why we need it?
In the current PCP code, `num_computed_tokens_of_pcp_dcp` appears in various types such as list and Tensor. This PR standardizes these mixed usages and uniformly sets the type to Tensor.
- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
