### PR TITLE
[Refactor] Extract update graph params context

### DIFF
--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -30,8 +30,8 @@ from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaCPImpl
 from vllm_ascend.attention.mla_v1 import (AscendMLADecodeMetadata,
                                           AscendMLAMetadata)
 from vllm_ascend.compilation.acl_graph import (
-    ACLGraphEntry, ACLGraphWrapper, get_draft_graph_params, get_graph_params,
-    set_draft_graph_params, set_graph_params,
+    ACLGraphEntry, ACLGraphWrapper, UpdateGraphParams, get_draft_graph_params,
+    get_graph_params, set_draft_graph_params, set_graph_params,
     update_draft_graph_params_workspaces)
 
 
@@ -814,9 +814,14 @@ class TestPCPDCPGraphParams(TestBase):
              out, lse))
 
         with patch("torch_npu._C._npu_setStream", return_value=None):
-            AscendMlaCPImpl.update_graph_params(
-                self.update_stream, forward_context, 4
+            update_ctx = UpdateGraphParams(
+                self.update_stream,
+                forward_context,
+                4,
+                None,
+                graph_params=self.graph_params,
             )
+            AscendMlaCPImpl.update_graph_params(update_ctx)
 
         _mock_graph_task_end.assert_called_once()
 
@@ -856,8 +861,13 @@ class TestPCPDCPGraphParams(TestBase):
              out, lse, 2, 0, 0))
 
         with patch("torch_npu._C._npu_setStream", return_value=None):
-            AscendAttentionCPImpl.update_graph_params(
-                self.update_stream, forward_context, 4, None
+            update_ctx = UpdateGraphParams(
+                self.update_stream,
+                forward_context,
+                4,
+                None,
+                graph_params=self.graph_params,
             )
+            AscendAttentionCPImpl.update_graph_params(update_ctx)
 
         _mock_graph_task_end.assert_called_once()

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -277,24 +277,21 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         self.dcp_group = get_dcp_group().device_group if self.dcp_size > 1 else None
 
     @staticmethod
-    def update_graph_params(
-        update_stream,
-        forward_context,
-        num_tokens,
-        vllm_config=None,
-        speculative_config=None,
-        num_dcp_pcp_tokens=None,
-        draft_attn_metadatas=None,
-    ):
-        graph_params = get_graph_params()
+    def get_graph_params(forward_context):
+        return get_graph_params()
+
+    @staticmethod
+    def update_graph_params(update_ctx):
+        if update_ctx.graph_params is None:
+            raise ValueError("graph_params must be provided for attention CP update")
         # FIXME: Behold! We are using a temporary hack here to update the args
         # for each layer's attention op in the graph.
-        with torch.npu.stream(update_stream):
+        with torch.npu.stream(update_ctx.update_stream):
             for key, param, handle, event in zip(
-                forward_context.attn_metadata,
-                graph_params.attn_params[num_tokens],
-                graph_params.handles[num_tokens],
-                graph_params.events[num_tokens],
+                update_ctx.forward_context.attn_metadata,
+                update_ctx.graph_params.attn_params[update_ctx.num_tokens],
+                update_ctx.graph_params.handles[update_ctx.num_tokens],
+                update_ctx.graph_params.events[update_ctx.num_tokens],
             ):
                 (
                     q_nope,
@@ -313,9 +310,9 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                     pcp_rank,
                     dcp_rank,
                 ) = param
-                attn_metadata = forward_context.attn_metadata[key]
+                attn_metadata = update_ctx.forward_context.attn_metadata[key]
                 actual_seq_lengths_kv = attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp[:, pcp_rank, dcp_rank]
-                pad_length = num_tokens - len(actual_seq_lengths_kv)
+                pad_length = update_ctx.num_tokens - len(actual_seq_lengths_kv)
                 if pad_length > 0:
                     pad_tensor = np.zeros(pad_length, dtype=actual_seq_lengths_kv.dtype)
                     actual_seq_lengths_kv = np.concatenate([actual_seq_lengths_kv, pad_tensor])
@@ -325,7 +322,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                 if dcp_size > 1:
                     num_heads = num_heads * dcp_size
 
-                torch.npu.graph_task_update_begin(update_stream, handle)
+                torch.npu.graph_task_update_begin(update_ctx.update_stream, handle)
 
                 torch_npu.npu_fused_infer_attention_score.out(
                     q_nope,
@@ -343,12 +340,12 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                     block_size=block_size,
                     actual_seq_lengths_kv=actual_seq_lengths_kv,
                     actual_seq_lengths=actual_seq_lengths_q,
-                    workspace=graph_params.workspaces.get(num_tokens),
+                    workspace=update_ctx.graph_params.workspaces.get(update_ctx.num_tokens),
                     out=[attn_output, softmax_lse],
                 )
-                torch.npu.graph_task_update_end(update_stream)
+                torch.npu.graph_task_update_end(update_ctx.update_stream)
 
-                event.record(update_stream)
+                event.record(update_ctx.update_stream)
 
     def _attention_with_nomask_and_mask(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

Reduce the long parameter list for update_graph_params by introducing a single
context object built in update_full_graph_params. This matches the intent of
"extract params" and makes the update call chain easier to follow.

**Changes:**
- Add UpdateGraphParams in acl_graph and build it in update_full_graph_params
- Update backends to accept a single context object
- Adjust unit tests that call update_graph_params directly

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not run (structural refactor).
- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
