### PR TITLE
[0.13.0][cherry-pick][BugFix][CI]Fix DeepSeek-R1-W8A8-longseq nightly CI

### DIFF
--- a/tests/e2e/nightly/multi_node/config/DeepSeek-R1-W8A8-longseq.yaml
+++ b/tests/e2e/nightly/multi_node/config/DeepSeek-R1-W8A8-longseq.yaml
@@ -12,6 +12,7 @@ env_common:
   HCCL_DETERMINISTIC: True
   TASK_QUEUE_ENABLE: 1
   HCCL_OP_RETRY_ENABLE: "L0:0, L1:0"
+  VLLM_NIXL_ABORT_REQUEST_TIMEOUT: 300000
 
 disaggregated_prefill:
   enabled: true
@@ -33,11 +34,11 @@ deployment:
           --enable-expert-parallel
           --seed 1024
           --quantization ascend
-          --max-num-seqs 4
-          --max-model-len 36864
+          --max-num-seqs 3
+          --max-model-len 32768
           --max-num-batched-tokens 16384
           --trust-remote-code
-          --gpu-memory-utilization 0.9
+          --gpu-memory-utilization 0.85
           --enable-chunked-prefill
           --speculative-config '{"num_speculative_tokens": 3, "method":"mtp"}'
           --kv-transfer-config
@@ -71,12 +72,12 @@ deployment:
         --enable-expert-parallel
         --seed 1024
         --quantization ascend
-        --max-num-seqs 4
-        --max-model-len 36864
+        --max-num-seqs 8
+        --max-model-len 32768
         --max-num-batched-tokens 256
         --trust-remote-code
-        --gpu-memory-utilization 0.9
-        --compilation_config '{"cudagraph_capture_sizes":[4,8,12,16],"cudagraph_mode": "FULL_DECODE_ONLY"}'
+        --gpu-memory-utilization 0.85
+        --compilation_config '{"cudagraph_capture_sizes":[4,8,16,32],"cudagraph_mode": "FULL_DECODE_ONLY"}'
         --enable-chunked-prefill
         --speculative-config '{"num_speculative_tokens": 3, "method":"mtp"}'
         --kv-transfer-config
@@ -103,7 +104,7 @@ benchmarks:
     dataset_path: vllm-ascend/gsm8k
     request_conf: vllm_api_general_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
-    max_out_len: 32768
-    batch_size: 512
+    max_out_len: 24576
+    batch_size: 16
     baseline: 95
     threshold: 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
The precision issue arose because the kv cache of the p-node had not been fetched for an extended period(>6min) and was forcibly freed. To avoid this problem, the batch size was reduced and the timeout period has also been extended.
cherry-pick from https://github.com/vllm-project/vllm-ascend/pull/6297

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
