### PR TITLE
[CI]: add production safeguards for 300I

### DIFF
--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -77,6 +77,8 @@ jobs:
               - '.github/workflows/pr_test_light.yaml'
             _310_tracker:
               - 'vllm_ascend/_310p/**'
+              - 'vllm_ascend/worker/model_runner_v1.py'
+              - 'CMakeLists.txt'
 
   ut:
     needs: [lint, changes]


### PR DESCRIPTION
Update 310p files tracker to enable 310p e2e test per PR.

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
