### PR TITLE
[CI] Add wait wrapper for test_external_launcher

### DIFF
--- a/tests/e2e/multicard/2-cards/test_external_launcher.py
+++ b/tests/e2e/multicard/2-cards/test_external_launcher.py
@@ -36,9 +36,9 @@ MOE_MODELS = ["Qwen/Qwen3-30B-A3B"]
 DEVICE_NAME = torch_npu.npu.get_device_name(0)[:10]
 
 
+@wait_until_npu_memory_free
 @pytest.mark.parametrize("model", MODELS)
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "500"})
-@wait_until_npu_memory_free
 def test_qwen3_external_launcher(model):
     script = Path(
         __file__
@@ -79,9 +79,9 @@ def test_qwen3_external_launcher(model):
     assert proc.returncode == 0
 
 
+@wait_until_npu_memory_free
 @pytest.mark.skip(reason="CANN8.5 failed, capture stream failed, fix me")
 @pytest.mark.parametrize("model", MOE_MODELS)
-@wait_until_npu_memory_free
 def test_qwen3_moe_external_launcher_ep_tp2(model):
     script = Path(
         __file__
@@ -112,8 +112,8 @@ def test_qwen3_moe_external_launcher_ep_tp2(model):
     assert proc.returncode == 0
 
 
-@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
 @wait_until_npu_memory_free
+@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
 def test_qwen3_external_launcher_with_sleepmode():
     script = Path(
         __file__
@@ -158,8 +158,8 @@ def test_qwen3_external_launcher_with_sleepmode():
     assert proc.returncode == 0
 
 
-@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
 @wait_until_npu_memory_free
+@patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
 def test_qwen3_external_launcher_with_sleepmode_level2():
     script = Path(
         __file__
@@ -207,6 +207,7 @@ def test_qwen3_external_launcher_with_sleepmode_level2():
     assert proc.returncode == 0
 
 
+@wait_until_npu_memory_free
 @pytest.mark.skipif(
     DEVICE_NAME != "Ascend910B",
     reason="This test is only for Ascend910B devices.",
@@ -216,7 +217,6 @@ def test_qwen3_external_launcher_with_sleepmode_level2():
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
     "HCCL_BUFFSIZE": "500"
 })
-@wait_until_npu_memory_free
 def test_qwen3_external_launcher_with_matmul_allreduce(model):
     script = Path(
         __file__


### PR DESCRIPTION
### What this PR does / why we need it?
To avoid oom issue, we add the wait logic for the needed case 
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
