### PR TITLE
[BugFix] Disable enable_shared_expert_dp by default if tensor_parallel_size=1

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -61,6 +61,7 @@ class AscendConfig:
         self.enable_shared_expert_dp = (
             additional_config.get("enable_shared_expert_dp", False)
             and vllm_config.parallel_config.enable_expert_parallel
+            and vllm_config.parallel_config.tensor_parallel_size > 1
         )
         from vllm_ascend.utils import enable_sp
 


### PR DESCRIPTION
### What this PR does / why we need it?

Disable enable_shared_expert_dp by default if tensor_parallel_size=1

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
