### PR TITLE
[Bugfix] Fix MoE model inference failure after sleep/wake_up

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -214,7 +214,7 @@ class NPUWorker(WorkerBase):
         model = self.model_runner.model
         if tags is None or "weights" in tags:
             for name, param in model.named_parameters():
-                if 'w2_weight' in name and param.shape[2] == hidden_size:
+                if 'w2_weight' in name and param.shape[1] == hidden_size:
                     parts = name.split('.')
                     param_name = parts[-1]
                     parent_module = model.get_submodule(".".join(parts[:-1]))
@@ -222,7 +222,7 @@ class NPUWorker(WorkerBase):
                     w2_data = param.transpose(1, 2)
                     w2_data = torch.nn.Parameter(w2_data, requires_grad=False)
                     setattr(parent_module, param_name, w2_data)
-                elif 'w13_weight' in name and param.shape[1] == hidden_size:
+                elif 'w13_weight' in name and param.shape[2] == hidden_size:
                     parts = name.split('.')
                     param_name = parts[-1]
                     parent_module = model.get_submodule(".".join(parts[:-1]))


### PR DESCRIPTION
### What this PR does / why we need it?                                                                                                                                                                        
                                                                                                                                                                                                                 
  This PR fixes a bug where MoE models (e.g., Qwen3-30B-A3B) fail to perform inference after `sleep()` and `wake_up()` operations.                                                                               
                                                                                                                                                                                                                 
  **Bug Description:**                                                                                                                                                                                           
                                                                                                                                                                                                                 
  When testing sleep mode with MoE models, the following error occurs after wake_up:                                                                                                                             
  AclNN_Parameter_Error(EZ1001): Dim 1 value of x[0] should be equal with dim 1 value of weight[0], but now is 2048 and 384 respectively.                                                                        
                                                                                                                                                                                                                 
  **Root Cause:**                                                                                                                                                                                                
                                                                                                                                                                                                                 
  The original code in `wake_up()` had incorrect condition checks for MoE weight transposition. It detected the **transposed** state and transposed again, causing dimension mismatch:                           
                                                                                                                                                                                                                 
                                                                                                                                                                                                    
```
  # Original (incorrect) - detects transposed state, then transposes again                                                                                                                                       
  if 'w2_weight' in name and param.shape[2] == hidden_size:  # transposed state                                                                                                                                  
      param.transpose(1, 2)  # wrong! causes double transpose                                                                                                                                                    
  elif 'w13_weight' in name and param.shape[1] == hidden_size:  # transposed state                                                                                                                               
      param.transpose(1, 2)  # wrong! causes double transpose          
```                                                                                                                                
                                                                                                                                                                                                                 
  The MoE weights have the following shapes:                                                                                                                                                                     
  - w13_weight original: [num_experts, 2*intermediate_size, hidden_size] (shape[2] == hidden_size)                                                                                                               
  - w13_weight transposed: [num_experts, hidden_size, 2*intermediate_size] (shape[1] == hidden_size)                                                                                                             
  - w2_weight original: [num_experts, hidden_size, intermediate_size] (shape[1] == hidden_size)                                                                                                                  
  - w2_weight transposed: [num_experts, intermediate_size, hidden_size] (shape[2] == hidden_size)                                                                                                                
                                                                                                                                                                                                                 
  During normal sleep/wake_up flow, weights are already in transposed state after process_weights_after_loading(). The original code incorrectly detected this transposed state and transposed again.            
                                                                                                                                                                                                                 
  **Fixs**                                                                                                                                                                                                          
                                                                                                                                                                                                                 
  Changed the condition checks to detect the original (non-transposed) state, so transposition only happens when weights are actually in original state (e.g., after RL weight reloading):                       
                                                                                                                                                                                                                                                                                                                                                           
 ```
 if 'w2_weight' in name and param.shape[1] == hidden_size:  # original state                                                                                                                                    
      param.transpose(1, 2)  # correct                                                                                                                                                                           
  elif 'w13_weight' in name and param.shape[2] == hidden_size:  # original state                                                                                                                                 
      param.transpose(1, 2)  # correct     
```                                                                                                                                                                      
                                                                                                                                                                                                                 
  This ensures:                                                                                                                                                                                                  
  1. Normal sleep/wake_up: Weights remain in transposed state, no re-transposition                                                                                                                               
  2. RL scenarios: After load_weights() reloads original-format weights, they are correctly transposed                                                                                                           
                                                                                                                                                                                                                 
  ### Does this PR introduce any user-facing change?                                                                                                                                                                 
                                                                                                                                                                                                                 
  No. This is a bugfix that makes MoE models work correctly with sleep mode.                                                                                                                                     
                                                                                                                                                                                                                 
  **Note:**  I'm not certain if this commit affects other RL scenarios. Please help check.                                                                                                                
                                                                                                                                                                                                                 
  ### How was this patch tested?                                                                                                                                                                                     
                                                                                                                                                                                                                 
  Tested with Qwen3-30B-A3B model (MoE architecture):                                                                                                                                                            
                                                                                                                                                                                                                 
```
  export  VLLM_SERVER_DEV_MODE="1"                                                                                                                                                                               
  export VLLM_WORKER_MULTIPROC_METHOD="spawn"                                                                                                                                                                    
  vllm serve /path/to/Qwen3-30B-A3B-Instruct/ \                                                                                                                                                  
      --tensor-parallel-size 4 \                                                                                                                                                                                 
      --enable-sleep-mode 
```
                                                                                                                                                                            
  Test steps:                                                                                                                                                                                                    
  1. Start vLLM server with --enable-sleep-mode                                                                                                                                                                  
  2. Send inference request → Success                                                                                                                                                                            
  3. Call POST /sleep endpoint                                                                                                                                                                                   
  4. Call POST /wake_up endpoint                                                                                                                                                                                 
  5. Send inference request → Success (previously failed with dimension mismatch error)                                                                                                                          
                                                                                                                                                                                                                 
  Also verified that non-MoE models (e.g., LLaMA-70B, Qwen3-8B) continue to work correctly. 


- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
