### PR TITLE
[CI] hot fix for nightly image  build tag

### DIFF
--- a/.github/Dockerfile.nightly.a2
+++ b/.github/Dockerfile.nightly.a2
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:v0.13.0-dev
+FROM quay.io/ascend/vllm-ascend:releases-v0.13.0
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"

--- a/.github/Dockerfile.nightly.a3
+++ b/.github/Dockerfile.nightly.a3
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:v0.13.0-dev-a3
+FROM quay.io/ascend/vllm-ascend:releases-v0.13.0-a3
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"


### PR DESCRIPTION
### What this PR does / why we need it?
The base image of `releases/v0.13.0` should tagged as `releases/v0.13.0-**`
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
