### PR TITLE
[CI][Nightly] Correct the nightly image build ref

### DIFF
--- a/.github/Dockerfile.nightly.a2
+++ b/.github/Dockerfile.nightly.a2
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:main
+FROM quay.io/ascend/vllm-ascend:releases-v0.13.0
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"

--- a/.github/Dockerfile.nightly.a3
+++ b/.github/Dockerfile.nightly.a3
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:main-a3
+FROM quay.io/ascend/vllm-ascend:releases-v0.13.0-a3
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"


### PR DESCRIPTION
The base image of releases/v0.13.0 should tagged as releases/v0.13.0-**
This pr cherry-pick from #6367

