### PR TITLE
[Bugfix] Fix full-graph FIA seq length alignment in TND layout

### DIFF
--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -61,6 +61,20 @@ def enable_cp():
     return prefill_config.prefill_context_parallel_size > 1 or prefill_config.decode_context_parallel_size > 1
 
 
+def align_actual_seq_lengths_q(actual_seq_lengths_q: list[int], total_tokens: int) -> list[int]:
+    if not actual_seq_lengths_q:
+        return actual_seq_lengths_q
+    if actual_seq_lengths_q[-1] == total_tokens:
+        return actual_seq_lengths_q
+    if total_tokens < actual_seq_lengths_q[-1]:
+        return actual_seq_lengths_q
+    # In full-graph mode, query may be padded for cudagraph replay.
+    # Ensure TND requires last element equals total tokens.
+    aligned = list(actual_seq_lengths_q)
+    aligned[-1] = total_tokens
+    return aligned
+
+
 @dataclass
 class AscendPrefillContextParallelMetadata:
     """


### PR DESCRIPTION
### What this PR does / why we need it?
- Align `actual_seq_lengths_q` with padded `query` token count when running full-graph FIA updates to satisfy TND layout requirements.
- Move the alignment helper into `vllm_ascend/attention/utils.py` so future FIA-based update paths can reuse it.
- This prevents `queryT != actualSequenceLengthQ[-1]` mismatches that lead to `aclnnFusedInferAttentionScoreV3` tiling failures under full-graph mode.
- Fixes # (optional: link CI failure or issue if you have one)

### Does this PR introduce _any_ user-facing change?
No. This is a bug fix in full-graph parameter update alignment and does not change public APIs.

### How was this patch tested?
Not run locally. Reproduced/observed in CI (full-graph + speculative decode) and the fix is a targeted alignment change.
- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
