### PR TITLE
[Nightly] Correct nightly image build ref

### DIFF
--- a/.github/Dockerfile.nightly.a2
+++ b/.github/Dockerfile.nightly.a2
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:releases-v0.13.0
+FROM quay.io/ascend/vllm-ascend:main
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"

--- a/.github/Dockerfile.nightly.a3
+++ b/.github/Dockerfile.nightly.a3
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:releases-v0.13.0-a3
+FROM quay.io/ascend/vllm-ascend:main-a3
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -20,9 +20,6 @@ name: 'e2e nightly test'
 on:
   workflow_call:
     inputs:
-      vllm:
-        required: true
-        type: string
       runner:
         required: true
         type: string

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -66,7 +66,6 @@ jobs:
             tests: tests/e2e/nightly/single_node/ops/multicard_ops_a2/
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
-      vllm: v0.14.1
       runner: ${{ matrix.test_config.os }}
       tests: ${{ matrix.test_config.tests }}
       name: ${{ matrix.test_config.name }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -161,7 +161,6 @@ jobs:
             tests: tests/e2e/nightly/single_node/models/test_deepseek_v3_2_w8a8.py
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
-      vllm: v0.14.1
       runner: ${{ matrix.test_config.os }}
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3'
       tests: ${{ matrix.test_config.tests }}
@@ -181,7 +180,6 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      vllm: v0.14.1
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3'
       tests: ${{ matrix.test_config.tests }}
       name: ${{ matrix.test_config.name }}


### PR DESCRIPTION
### What this PR does / why we need it?
The underlying tags for nightly image builds have been corrected, and some useless and confusing workflow fields have been removed.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
