### PR TITLE
【work around】reset the None reference count to prevent it from droppi…

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -17,6 +17,7 @@
 # Adapted from vllm-project/vllm/vllm/worker/gpu_model_runner.py
 #
 
+import ctypes
 import math
 import sys
 from collections import defaultdict
@@ -135,6 +136,10 @@ if get_ascend_device_type() == AscendDeviceType._310P:
 
 
 SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
+
+# TODO: remove this after python update to 3.12
+NONE_REF_COUNT_THRESHOLDS = 500000
+U32_MAX = 0xFFFFFFFF
 
 
 @dataclass
@@ -1403,6 +1408,11 @@ class NPUModelRunner(GPUModelRunner):
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
+
+        # TODO: remove this after python update to 3.12
+        refcountNone = sys.getrefcount(None)
+        if refcountNone < NONE_REF_COUNT_THRESHOLDS:
+            ctypes.c_long.from_address(id(None)).value = U32_MAX - 1
 
         if self.execute_model_state is None:
             # Nothing to do (PP non-final rank case), output isn't used.


### PR DESCRIPTION
…ng to zero and causing a crash.

### What this PR does / why we need it?

work around: reset the None reference count to prevent it from dropping to zero and causing a crash.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
