### PR TITLE
[0.13.0][Bugfix] fix npu memory is not released in cp

### DIFF
--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -874,8 +874,11 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                 cp_chunkedprefill_comm_stream().wait_stream(
                     torch.npu.current_stream())
                 with torch_npu.npu.stream(cp_chunkedprefill_comm_stream()):
+                    # If only local_context_output is used, the NPU memory cannot be released.
+                    # This problem can be avoided by using clone
+                    tmp_local_context_output = local_context_output.clone()
                     global_context_output = self._gather_global_context_output(
-                        local_context_output)
+                        tmp_local_context_output)
 
             if self.pcp_size > 1:
                 # compute the tail part and reorg output&lse // overlap the communication of output


### PR DESCRIPTION
### What this PR does / why we need it?
The npu memory is not released in the qwen context parallel chunk scenario. This pr resolve it.

The attention backend uses multiple streams. Variables created in the main stream are directly used in the communication stream. As a result, the NPU GPU memory of the variables is not released. This problem can be avoided by using the clone mode.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed. The fix was verified by observing that NPU memory is now correctly released in the described scenario.

pick-from https://github.com/vllm-project/vllm-ascend/pull/6480
