### PR TITLE
[CI]Disable early exit to complete all tests

### DIFF
--- a/.github/workflows/READMD.md
+++ b/.github/workflows/READMD.md
@@ -47,8 +47,10 @@ To speed up CI execution, we support splitting large test suites into multiple p
 The partitioning algorithm uses a Greedy Approach to achieve load balancing, aiming to make the total estimated runtime of each partition as equal as possible.
 
 1. **Read Configuration**: The script reads all non-skipped test cases and their `estimated_time` from `config.yaml`.
-2. **Sort**: Test cases are sorted by `estimated_time` in descending order.
+2. **Sort(Balanced Assignment)**: Test cases are sorted by `estimated_time` in descending order. This ensures that the heaviest tasks are distributed first to achieve optimal load balancing across partitions.
 3. **Assign**: Iterating through the sorted test cases, each case is assigned to the partition (Bucket) with the current minimum total time.
+4. **Re-sort (Fast Feedback)**: Within each partition, tests are re-sorted by `estimated_time` in ascending order. This allows the CI to cover as many test cases as possible in the early stages.
+    > TIP: If you need to prioritize a new test case, you can temporarily set its estimated_time to 0 to ensure it runs first, then update it to the actual value later.
 
 ### How to Modify Partitioning Logic
 

--- a/.github/workflows/scripts/run_suite.py
+++ b/.github/workflows/scripts/run_suite.py
@@ -74,6 +74,7 @@ def auto_partition(files, rank, size):
 
     # Return the files corresponding to the indices in the specified rank's partition
     indices = partitions[rank]
+    indices.sort(key=lambda i: files[i].estimated_time)
     return [files[i] for i in indices]
 
 

--- a/tests/e2e/singlecard/test_aclgraph_accuracy.py
+++ b/tests/e2e/singlecard/test_aclgraph_accuracy.py
@@ -25,7 +25,7 @@ CASE_QWEN_ACLGRAPH = LLMTestCase(
     model="Qwen/Qwen3-0.6B",
     prompts=PROMPTS_SHORT,
     golden_answers=[
-        " Lina. I'm a 2-year-old student from China. I'm interested in studying in the US. I want to know if there are any",
+        " Lina. I'm a 22-year-old student from China. I'm interested in studying in the US. I want to know if there are any",
         ' the same as the president of the United Nations. This is because the president of the United States is the same as the president of the United Nations. The president',
         ' Paris. The capital of France is also the capital of the Republic of France. The capital of France is also the capital of the European Union. The capital of',
         ' not just a technological frontier but a profound transformation of how we live, work, and interact with the world. As we stand at the intersection of artificial intelligence and'


### PR DESCRIPTION
### What this PR does / why we need it?
1. Disable the feature to exit early upon encountering an error in order to complete all tests.
2. Within each partition, tests are re-sorted by `estimated_time` in ascending order. This allows the CI to cover as many test cases as possible in the early stages.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.14.1
- vLLM main: https://github.com/vllm-project/vllm/commit/dc917cceb877dfd13f98c538c4c96158047d98bd
