### PR TITLE
[Main2Main] Upgrade to newest vLLM 0205

### DIFF
--- a/.github/workflows/_unit_test.yaml
+++ b/.github/workflows/_unit_test.yaml
@@ -72,8 +72,7 @@ jobs:
             --ignore tests/ut/kv_connector/test_remote_decode_lifecycle.py \
             --ignore tests/ut/core/test_scheduler_dynamic_batch.py \
             --ignore tests/ut/kv_connector/test_mooncake_connector.py \
-            --ignore tests/ut/worker/test_worker_v1.py \
-            --ignore tests/ut/spec_decode/test_mtp_proposer.py
+            --ignore tests/ut/worker/test_worker_v1.py
 
       - name: Upload coverage to Codecov
         # only upload coverage when commits merged

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=18e7cbbb158a86bdc76585e64ada795bf1c0d435
+          VLLM_COMMIT=80f921ba4bab2ea251d149305ea0f912c6fc218a
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3
+          VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
+          VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=81a90e52776503c6cbdccd30fbe53f61c9179bdf
+          VLLM_COMMIT=3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
+          VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
+          VLLM_COMMIT=1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=80f921ba4bab2ea251d149305ea0f912c6fc218a
+          VLLM_COMMIT=81a90e52776503c6cbdccd30fbe53f61c9179bdf
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
+          VLLM_COMMIT=d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
+          VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=13397841ab469cecf1ed425c3f52a9ffc38139b5
+          VLLM_COMMIT=18e7cbbb158a86bdc76585e64ada795bf1c0d435
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
+          VLLM_COMMIT=1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
+ARG VLLM_COMMIT=d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
+ARG VLLM_COMMIT=1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=81a90e52776503c6cbdccd30fbe53f61c9179bdf
+ARG VLLM_COMMIT=3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=18e7cbbb158a86bdc76585e64ada795bf1c0d435
+ARG VLLM_COMMIT=80f921ba4bab2ea251d149305ea0f912c6fc218a
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
+ARG VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
+ARG VLLM_COMMIT=1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
+ARG VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=13397841ab469cecf1ed425c3f52a9ffc38139b5
+ARG VLLM_COMMIT=18e7cbbb158a86bdc76585e64ada795bf1c0d435
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3
+ARG VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=7bd42e609d24501f59a8b405229ed91f4ca8037c
+ARG VLLM_COMMIT=a2522839d87d2b81b57458dfdbbcb27afb8191ae
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=80f921ba4bab2ea251d149305ea0f912c6fc218a
+ARG VLLM_COMMIT=81a90e52776503c6cbdccd30fbe53f61c9179bdf
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [13397841ab469cecf1ed425c3f52a9ffc38139b5, v0.15.0]
+        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0]
+        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0]
+        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0]
+        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
+        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 81a90e52776503c6cbdccd30fbe53f61c9179bdf
+      vllm: 3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0]
+        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0]
+        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 7bd42e609d24501f59a8b405229ed91f4ca8037c
+      vllm: a2522839d87d2b81b57458dfdbbcb27afb8191ae
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: a2522839d87d2b81b57458dfdbbcb27afb8191ae
+      vllm: d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
+        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
+        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 7bd42e609d24501f59a8b405229ed91f4ca8037c
+      vllm: 1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 18e7cbbb158a86bdc76585e64ada795bf1c0d435
+      vllm: 80f921ba4bab2ea251d149305ea0f912c6fc218a
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0]
+        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0]
+        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 80f921ba4bab2ea251d149305ea0f912c6fc218a
+      vllm: 81a90e52776503c6cbdccd30fbe53f61c9179bdf
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0]
+        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0]
+        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
+      vllm: 7bd42e609d24501f59a8b405229ed91f4ca8037c
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 13397841ab469cecf1ed425c3f52a9ffc38139b5
+      vllm: 18e7cbbb158a86bdc76585e64ada795bf1c0d435
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [13397841ab469cecf1ed425c3f52a9ffc38139b5, v0.15.0]
+        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [13397841ab469cecf1ed425c3f52a9ffc38139b5, v0.15.0]
+        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: a2522839d87d2b81b57458dfdbbcb27afb8191ae
+      vllm: 1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
+      vllm: 7bd42e609d24501f59a8b405229ed91f4ca8037c
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3
+      vllm: a2522839d87d2b81b57458dfdbbcb27afb8191ae
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -99,7 +99,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae]
+        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435]
+        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [13397841ab469cecf1ed425c3f52a9ffc38139b5]
+        vllm_version: [18e7cbbb158a86bdc76585e64ada795bf1c0d435]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c]
+        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf]
+        vllm_version: [3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [a2522839d87d2b81b57458dfdbbcb27afb8191ae]
+        vllm_version: [1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [80f921ba4bab2ea251d149305ea0f912c6fc218a]
+        vllm_version: [81a90e52776503c6cbdccd30fbe53f61c9179bdf]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a]
+        vllm_version: [7bd42e609d24501f59a8b405229ed91f4ca8037c]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/scripts/config.yaml
+++ b/.github/workflows/scripts/config.yaml
@@ -1,56 +1,81 @@
 e2e-singlecard:
   - name: tests/e2e/singlecard/compile/test_graphex_norm_quant_fusion.py
     estimated_time: 80
+    is_skipped: true
   - name: tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
     estimated_time: 80
+    is_skipped: true
   - name: tests/e2e/singlecard/test_auto_fit_max_mode_len.py
     estimated_time: 25
+    is_skipped: true
   - name: tests/e2e/singlecard/test_aclgraph_accuracy.py
     estimated_time: 480
+    is_skipped: true
   - name: tests/e2e/singlecard/test_aclgraph_batch_invariant.py
     estimated_time: 410
+    is_skipped: true
   - name: tests/e2e/singlecard/test_aclgraph_mem.py
     estimated_time: 130
+    is_skipped: true
   - name: tests/e2e/singlecard/test_async_scheduling.py
     estimated_time: 150
+    is_skipped: true
   - name: tests/e2e/singlecard/test_batch_invariant.py
     estimated_time: 320
+    is_skipped: true
   - name: tests/e2e/singlecard/test_camem.py
     estimated_time: 77
+    is_skipped: true
   - name: tests/e2e/singlecard/test_completion_with_prompt_embeds.py
     estimated_time: 76
+    is_skipped: true
   - name: tests/e2e/singlecard/test_cpu_offloading.py
     estimated_time: 132
+    is_skipped: true
   - name: tests/e2e/singlecard/test_guided_decoding.py
     estimated_time: 354
+    is_skipped: true
   - name: tests/e2e/singlecard/test_ilama_lora.py
     estimated_time: 95
+    is_skipped: true
   - name: tests/e2e/singlecard/test_llama32_lora.py
     estimated_time: 162
+    is_skipped: true
   - name: tests/e2e/singlecard/test_qwen3_multi_loras.py
     estimated_time: 65
+    is_skipped: true
   - name: tests/e2e/singlecard/test_models.py
     estimated_time: 300
+    is_skipped: true
   - name: tests/e2e/singlecard/test_multistream_overlap_shared_expert.py
     estimated_time: 200
+    is_skipped: true
   - name: tests/e2e/singlecard/test_quantization.py
     estimated_time: 200
+    is_skipped: true
   - name: tests/e2e/singlecard/test_sampler.py
     estimated_time: 200
+    is_skipped: true
   - name: tests/e2e/singlecard/test_vlm.py
     estimated_time: 354
+    is_skipped: true
   - name: tests/e2e/singlecard/test_xlite.py
     estimated_time: 45
+    is_skipped: true
   - name: tests/e2e/singlecard/compile/test_norm_quant_fusion.py
     estimated_time: 70
+    is_skipped: true
   - name: tests/e2e/singlecard/pooling/test_classification.py
     estimated_time: 120
+    is_skipped: true
   - name: tests/e2e/singlecard/pooling/test_embedding.py
     estimated_time: 270
+    is_skipped: true
   - name: tests/e2e/singlecard/pooling/test_scoring.py
     estimated_time: 500
+    is_skipped: true
   - name: tests/e2e/singlecard/spec_decode/test_mtp_eagle_correctness.py
-    estimated_time: 1500
+    estimated_time: 1800
   - name: tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
     estimated_time: 1800
   - name: tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -85,49 +110,70 @@ e2e-multicard-2-cards:
     is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_qwen3_performance.py
     estimated_time: 180
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_data_parallel.py
     estimated_time: 380
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_expert_parallel.py
     estimated_time: 170
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_external_launcher.py
     estimated_time: 300
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_full_graph_mode.py
     estimated_time: 400
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_ilama_lora_tp2.py
     estimated_time: 60
   # Run the test in a separate step to avoid oom
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_deepseek_multistream_moe_tp2
     estimated_time: 100
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_qwen3_w4a8_dynamic_tp2
     estimated_time: 80
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_qwen3_moe_sp_tp2
     estimated_time: 132
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_deepseek_w4a8_accuracy_tp2
     estimated_time: 132
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_qwen3_moe_fc2_tp2
     estimated_time: 140
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_deepseek_v2_lite_fc1_tp2
     estimated_time: 82
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_qwen3_dense_fc1_tp2
     estimated_time: 73
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_qwen3_dense_prefetch_mlp_weight_tp2
     estimated_time: 71
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_deepseek3_2_w8a8_pruning_mtp_tp2_ep
     estimated_time: 111
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_offline_inference_distributed.py::test_qwen3_w4a4_distributed_tp2
     estimated_time: 180
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_pipeline_parallel.py
     estimated_time: 270
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_prefix_caching.py
     estimated_time: 430
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_quantization.py
     estimated_time: 70
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_qwen3_moe.py
     estimated_time: 1050
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_single_request_aclgraph.py
     estimated_time: 215
+    is_skipped: true
   - name: tests/e2e/multicard/2-cards/test_disaggregated_encoder.py
     estimated_time: 90
+    is_skipped: true
 
 e2e-multicard-4-cards:
   # TODO: recover skipped tests

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 1c3a221d3b0f7a82cd9a6d56e10ea360e2435a1c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 13397841ab469cecf1ed425c3f52a9ffc38139b5, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 81a90e52776503c6cbdccd30fbe53f61c9179bdf, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 3e472e81f99b5bcf494369ee2d26ee9d6ceeffe3, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 18e7cbbb158a86bdc76585e64ada795bf1c0d435, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 80f921ba4bab2ea251d149305ea0f912c6fc218a, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -56,7 +56,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | 7bd42e609d24501f59a8b405229ed91f4ca8037c, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | a2522839d87d2b81b57458dfdbbcb27afb8191ae, v0.15.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
+++ b/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
@@ -130,8 +130,6 @@ def _run_worker_process(
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
 
-
-@pytest.mark.skip(reason="fix me")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [4, 36])
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})

--- a/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
+++ b/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
@@ -207,9 +207,8 @@ def test_models_aclgraph_capture_replay_metrics_dp2(
     expected_exec_model = (total_steps + 1 + 1) * dp_size
 
     assert (
-        expected_exec_model - dp_size < num_execute_model <= expected_exec_model
-    ), f"Model execution count mismatch. Expected range: [{expected_exec_model - dp_size}, \
-    {expected_exec_model}], Got: {num_execute_model}"
+        num_execute_model == expected_exec_model
+    ), f"Model execution count mismatch. Expected: {expected_exec_model}, Got: {num_execute_model}"
 
     # Metric 3: Dummy Runs (Warmup & Alignment)
     # vLLM synchronizes globally every 32 steps.
@@ -229,8 +228,8 @@ def test_models_aclgraph_capture_replay_metrics_dp2(
     expected_dummy_run = (warmup_runs + padding_runs) * dp_size
 
     assert (
-        expected_dummy_run <= num_dummy_run <= expected_dummy_run + dp_size
-    ), f"Dummy run count mismatch. Expected: {expected_dummy_run}, Got: {num_dummy_run}, Tolerance: ±{dp_size}"
+        expected_dummy_run == num_dummy_run
+    ), f"Dummy run count mismatch. Expected: {expected_dummy_run}, Got: {num_dummy_run}"
 
     # Metric 4: Graph Replay (Inference Execution)
     # Replays happen for every aligned step across all graphs.

--- a/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
+++ b/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
@@ -130,6 +130,8 @@ def _run_worker_process(
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
 
+
+# @patch.dict(os.environ, clear=["HCCL_OP_EXPANSION_MODE","VLLM_WORKER_MULTIPROC_METHOD"])
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [4, 36])
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})

--- a/tests/e2e/singlecard/compile/backend.py
+++ b/tests/e2e/singlecard/compile/backend.py
@@ -19,15 +19,10 @@ from typing import Any, Callable, List, Optional, Sequence
 
 import torch.fx as fx
 from torch._inductor.decomposition import select_decomp_table
+from vllm.compilation.fx_utils import OpOverload
 from vllm.config import get_current_vllm_config
 
 from vllm_ascend.compilation.compiler_interface import compile_fx
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.fx_utils import OpOverload  # type: ignore
-else:
-    from vllm.compilation.passes.fx_utils import OpOverload
 
 
 class TestBackend:

--- a/tests/e2e/singlecard/compile/test_norm_quant_fusion.py
+++ b/tests/e2e/singlecard/compile/test_norm_quant_fusion.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn as nn
 import torch_npu
 import vllm.config
+from vllm.compilation.fx_utils import OpOverload
 from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
@@ -32,13 +33,6 @@ from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.compilation.passes.norm_quant_fusion_pass import \
     AddRMSNormQuantFusionPass
 from vllm_ascend.utils import enable_custom_op
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.fx_utils import OpOverload  # type: ignore
-else:
-    from vllm.compilation.passes.fx_utils import OpOverload
-
 
 
 class TestModelWithoutBias(nn.Module):

--- a/tests/e2e/singlecard/spec_decode/test_mtp_eagle_correctness.py
+++ b/tests/e2e/singlecard/spec_decode/test_mtp_eagle_correctness.py
@@ -120,9 +120,9 @@ def test_deepseek_mtp_correctness(model_name: str, num_speculative_tokens: int,
     del spec_llm
 
 
-@pytest.mark.skip(reason="Failed with CANN8.5, fix me")
-@pytest.mark.parametrize("model_name", MODELS_EAGLE)
-@pytest.mark.parametrize("model_name_main", MODELS_MAIN)
+# @pytest.mark.skip(reason="Failed with CANN8.5, fix me")
+@pytest.mark.parametrize("model_name", "/mnt/share/weight/Qwen3-8B-speculator.eagle3")
+@pytest.mark.parametrize("model_name_main", "/mnt/share/weight/Qwen3-8B")
 @pytest.mark.parametrize("num_speculative_tokens", [1, 2])
 @pytest.mark.parametrize("method", ["eagle", "eagle3"])
 @pytest.mark.parametrize("disable_padded_drafter_batch", [True, False])

--- a/tests/e2e/singlecard/test_llama32_lora.py
+++ b/tests/e2e/singlecard/test_llama32_lora.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from unittest.mock import patch
-
 import vllm
 import vllm.config
 from vllm.lora.request import LoRARequest
@@ -123,7 +121,6 @@ def generate_and_test(llm,
     print("removing lora")
 
 
-@pytest.mark.skip(reason="fix me")
 @patch.dict("os.environ", {"VLLM_USE_MODELSCOPE": "False"})
 def test_llama_lora(llama32_lora_files):
     vllm_model = VllmRunner(

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import torch
-from vllm.config import CacheConfig, CompilationMode, CUDAGraphMode, VllmConfig, set_current_vllm_config
+from vllm.config import CacheConfig, CompilationMode, CUDAGraphMode, VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import init_ascend_config
@@ -18,14 +18,9 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.cache_config = MagicMock(spec=CacheConfig)
         self.vllm_config.scheduler_config = MagicMock()
         self.vllm_config.model_config = MagicMock()
-        self.vllm_config.model_config.hf_text_config = MagicMock(spec=[])  # Empty spec to prevent hasattr from returning True
-        self.vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
-        self.vllm_config.compilation_config = MagicMock()
         self.device = torch.device("cpu")
         self.runner = MagicMock()
         self.runner.pin_memory = False
-        self.runner.pcp_size = 1
-        self.runner.dcp_size = 1
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -36,36 +31,25 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.model_config.uses_xdrope_dim = 0
         self.vllm_config.parallel_config.tensor_parallel_size = 1
         self.vllm_config.parallel_config.data_parallel_rank = 0
-        self.vllm_config.parallel_config.data_parallel_size = 1
-        self.vllm_config.parallel_config.prefill_context_parallel_size = 1
-        self.vllm_config.parallel_config.enable_expert_parallel = False
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.num_speculative_tokens = 2
         self.vllm_config.speculative_config.speculative_token_tree = str([
             (i + 1) * (0, ) for i in range(2)
         ])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
-        self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
-        self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
 
         self.mock_cpugpubuffer = patch(
             "vllm.v1.spec_decode.eagle.CpuGpuBuffer")
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
-            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs",
-            return_value=False
+            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs"
         )
         self.mock_supports_multimodal_inputs.start()
-
-        # Set the current vllm config
-        set_current_vllm_config(self.vllm_config)
 
     def tearDown(self):
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
-        # Clear the current vllm config
-        set_current_vllm_config(None)
 
     def test_initialization_eagle_graph(self):
         self.vllm_config.speculative_config.method = "eagle"
@@ -78,38 +62,34 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.scheduler_config.async_scheduling = False
         init_ascend_config(self.vllm_config)
 
-        with set_current_vllm_config(self.vllm_config):
-            proposer = EagleProposer(vllm_config=self.vllm_config,
-                                     device=self.device,
-                                     runner=self.runner)
+        proposer = EagleProposer(vllm_config=self.vllm_config,
+                                 device=self.device,
+                                 runner=self.runner)
 
-            self.assertEqual(proposer.hidden_size, 4096)
-            self.assertTrue(proposer.use_cuda_graph)
+        self.assertEqual(proposer.hidden_size, 4096)
+        self.assertTrue(proposer.use_cuda_graph)
 
-            expected_max_num_tokens = proposer.max_num_tokens
-            self.assertEqual(proposer.input_ids.shape, (expected_max_num_tokens, ))
-            self.assertEqual(proposer.positions.shape, (expected_max_num_tokens, ))
-            self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 4096))
-            self.assertEqual(proposer.arange.shape, (expected_max_num_tokens, ))
+        expected_max_num_tokens = proposer.max_num_tokens
+        self.assertEqual(proposer.input_ids.shape, (expected_max_num_tokens, ))
+        self.assertEqual(proposer.positions.shape, (expected_max_num_tokens, ))
+        self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 4096))
+        self.assertEqual(proposer.arange.shape, (expected_max_num_tokens, ))
 
     def test_initialization_eagle3_enforce_eager(self):
         self.vllm_config.speculative_config.method = "eagle3"
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 2048
         self.vllm_config.compilation_config.mode = CompilationMode.NONE
-        self.vllm_config.compilation_config.pass_config = MagicMock()
-        self.vllm_config.compilation_config.pass_config.enable_sp = False
         self.vllm_config.model_config.enforce_eager = True
         init_ascend_config(self.vllm_config)
 
-        with set_current_vllm_config(self.vllm_config):
-            proposer = EagleProposer(vllm_config=self.vllm_config,
-                                     device=self.device,
-                                     runner=self.runner)
+        proposer = EagleProposer(vllm_config=self.vllm_config,
+                                 device=self.device,
+                                 runner=self.runner)
 
-            self.assertEqual(proposer.hidden_size, 2048)
-            self.assertFalse(proposer.use_cuda_graph)
-            expected_max_num_tokens = proposer.max_num_tokens
-            self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
+        self.assertEqual(proposer.hidden_size, 2048)
+        self.assertFalse(proposer.use_cuda_graph)
+        expected_max_num_tokens = proposer.max_num_tokens
+        self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
 
     def test_initialization_eagle3_full_graph_async(self):
         self.vllm_config.speculative_config.method = "eagle3"
@@ -120,15 +100,14 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.scheduler_config.async_scheduling = True
         init_ascend_config(self.vllm_config)
 
-        with set_current_vllm_config(self.vllm_config):
-            proposer = EagleProposer(vllm_config=self.vllm_config,
-                                     device=self.device,
-                                     runner=self.runner)
+        proposer = EagleProposer(vllm_config=self.vllm_config,
+                                 device=self.device,
+                                 runner=self.runner)
 
-            self.assertEqual(proposer.hidden_size, 2048)
-            self.assertTrue(proposer.use_cuda_graph)
-            expected_max_num_tokens = proposer.max_num_tokens
-            self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
+        self.assertEqual(proposer.hidden_size, 2048)
+        self.assertTrue(proposer.use_cuda_graph)
+        expected_max_num_tokens = proposer.max_num_tokens
+        self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
 
     def test_initialization_mtp_full_graph_async(self):
         self.vllm_config.speculative_config.method = "mtp"
@@ -139,15 +118,14 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.scheduler_config.async_scheduling = True
         init_ascend_config(self.vllm_config)
 
-        with set_current_vllm_config(self.vllm_config):
-            proposer = EagleProposer(vllm_config=self.vllm_config,
-                                     device=self.device,
-                                     runner=self.runner)
+        proposer = EagleProposer(vllm_config=self.vllm_config,
+                                 device=self.device,
+                                 runner=self.runner)
 
-            self.assertEqual(proposer.hidden_size, 2048)
-            self.assertFalse(proposer.use_cuda_graph)
-            expected_max_num_tokens = proposer.max_num_tokens
-            self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
+        self.assertEqual(proposer.hidden_size, 2048)
+        self.assertFalse(proposer.use_cuda_graph)
+        expected_max_num_tokens = proposer.max_num_tokens
+        self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
 
 
 class TestEagleProposerLoadModel(TestBase):
@@ -159,8 +137,6 @@ class TestEagleProposerLoadModel(TestBase):
         self.device = torch.device("cpu")
         self.runner = MagicMock()
         self.runner.pin_memory = False
-        self.runner.pcp_size = 1
-        self.runner.dcp_size = 1
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -171,17 +147,12 @@ class TestEagleProposerLoadModel(TestBase):
         self.vllm_config.model_config.uses_xdrope_dim = 0
         self.vllm_config.parallel_config.tensor_parallel_size = 1
         self.vllm_config.parallel_config.data_parallel_rank = 0
-        self.vllm_config.parallel_config.data_parallel_size = 1
-        self.vllm_config.parallel_config.prefill_context_parallel_size = 1
-        self.vllm_config.parallel_config.enable_expert_parallel = False
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.num_speculative_tokens = 2
         self.vllm_config.speculative_config.speculative_token_tree = str([
             (i + 1) * (0, ) for i in range(2)
         ])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
-        self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
-        self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
@@ -189,13 +160,9 @@ class TestEagleProposerLoadModel(TestBase):
             "vllm.v1.spec_decode.eagle.CpuGpuBuffer")
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
-            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs",
-            return_value=False
+            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs"
         )
         self.mock_supports_multimodal_inputs.start()
-
-        # Set the current vllm config
-        set_current_vllm_config(self.vllm_config)
         self.proposer = EagleProposer(vllm_config=self.vllm_config,
                                       device=self.device,
                                       runner=self.runner)
@@ -203,8 +170,6 @@ class TestEagleProposerLoadModel(TestBase):
     def tearDown(self):
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
-        # Clear the current vllm config
-        set_current_vllm_config(None)
 
     @patch(
         "vllm_ascend.spec_decode.eagle_proposer.get_layers_from_vllm_config")
@@ -239,12 +204,11 @@ class TestEagleProposerLoadModel(TestBase):
         mock_get_model.return_value = MagicMock()
         mock_get_model.return_value.model.embed_tokens.weight = weight
 
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.load_model(mock_model)
-            mock_get_model.assert_called_once()
-            self.assertEqual(self.proposer.attn_layer_names, ["layer3"])
-            self.assertIs(self.proposer.model.model.embed_tokens,
-                          mock_model.model.embed_tokens)
+        self.proposer.load_model(mock_model)
+        mock_get_model.assert_called_once()
+        self.assertEqual(self.proposer.attn_layer_names, ["layer3"])
+        self.assertIs(self.proposer.model.model.embed_tokens,
+                      mock_model.model.embed_tokens)
 
     @patch(
         "vllm_ascend.spec_decode.eagle_proposer.get_layers_from_vllm_config")
@@ -269,12 +233,11 @@ class TestEagleProposerLoadModel(TestBase):
         mock_get_model.return_value = MagicMock(model=MagicMock(
             embed_tokens=original_embed))
 
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.load_model(mock_model)
+        self.proposer.load_model(mock_model)
 
-            self.assertIsNot(self.proposer.model.model.embed_tokens,
-                             mock_model.model.embed_tokens)
-            self.assertEqual(self.proposer.attn_layer_names, ["layer2"])
+        self.assertIsNot(self.proposer.model.model.embed_tokens,
+                         mock_model.model.embed_tokens)
+        self.assertEqual(self.proposer.attn_layer_names, ["layer2"])
 
     @patch(
         "vllm_ascend.spec_decode.eagle_proposer.get_layers_from_vllm_config")
@@ -303,11 +266,10 @@ class TestEagleProposerLoadModel(TestBase):
         self.proposer.model = MagicMock()
         self.proposer.name = SpecDcodeType.EAGLE
 
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.load_model(mock_model)
-            self.assertEqual(mock_model.get_language_model.call_count, 2)
-            self.assertIs(self.proposer.model.lm_head,
-                          mock_model.get_language_model.return_value.lm_head)
+        self.proposer.load_model(mock_model)
+        self.assertEqual(mock_model.get_language_model.call_count, 2)
+        self.assertIs(self.proposer.model.lm_head,
+                      mock_model.get_language_model.return_value.lm_head)
 
 
 class TestEagleProposerDummyRun(TestBase):
@@ -331,19 +293,13 @@ class TestEagleProposerDummyRun(TestBase):
         self.vllm_config.model_config.uses_mrope = False
         self.vllm_config.model_config.uses_xdrope_dim = 0
         self.vllm_config.model_config.use_mla = False
-        self.vllm_config.model_config.hf_text_config = MagicMock(spec=[])  # Empty spec to prevent hasattr from returning True
-        self.vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
         self.vllm_config.parallel_config.tensor_parallel_size = 1
         self.vllm_config.parallel_config.data_parallel_rank = 0
-        self.vllm_config.parallel_config.data_parallel_size = 1
-        self.vllm_config.parallel_config.prefill_context_parallel_size = 1
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.speculative_token_tree = str([
             (i + 1) * (0, ) for i in range(4)
         ])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
-        self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
-        self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
@@ -351,28 +307,9 @@ class TestEagleProposerDummyRun(TestBase):
             "vllm.v1.spec_decode.eagle.CpuGpuBuffer")
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
-            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs",
-            return_value=False
+            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs"
         )
         self.mock_supports_multimodal_inputs.start()
-
-        # Mock parallel state functions
-        self.mock_tp_world_size = patch(
-            "vllm_ascend.ascend_forward_context.get_tensor_model_parallel_world_size",
-            return_value=1
-        )
-        self.mock_tp_world_size.start()
-
-        mock_dp_group = MagicMock()
-        mock_dp_group.world_size = 1
-        self.mock_dp_group = patch(
-            "vllm_ascend.ascend_forward_context.get_dp_group",
-            return_value=mock_dp_group
-        )
-        self.mock_dp_group.start()
-
-        # Set the current vllm config
-        set_current_vllm_config(self.vllm_config)
         self.proposer = EagleProposer(vllm_config=self.vllm_config,
                                       device=self.device,
                                       runner=self.runner)
@@ -383,10 +320,6 @@ class TestEagleProposerDummyRun(TestBase):
     def tearDown(self):
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
-        self.mock_tp_world_size.stop()
-        self.mock_dp_group.stop()
-        # Clear the current vllm config
-        set_current_vllm_config(None)
 
     # cpu does not support parallel-group, let alone `sp`
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context",
@@ -397,12 +330,11 @@ class TestEagleProposerDummyRun(TestBase):
         with_prefill = False
 
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
-            self.proposer.dummy_run(num_tokens=num_tokens,
-                                    with_prefill=with_prefill)
+        self.proposer.enable_shared_expert_dp = False
+        self.proposer.dummy_run(num_tokens=num_tokens,
+                                with_prefill=with_prefill)
 
-            self.assertTrue(self.proposer._runnable.call_count == 1)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
 
     # cpu does not support parallel-group, let alone `sp`
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context",
@@ -411,10 +343,9 @@ class TestEagleProposerDummyRun(TestBase):
     def test_dummy_run_with_prefill(self, mock_context, mock_get_context):
         mock_context.return_value.__enter__.return_value = None
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
-            self.proposer.dummy_run(num_tokens=64, with_prefill=True, num_reqs=4)
-            self.assertTrue(self.proposer._runnable.call_count == 1)
+        self.proposer.enable_shared_expert_dp = False
+        self.proposer.dummy_run(num_tokens=64, with_prefill=True, num_reqs=4)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
 
     @patch("vllm_ascend.spec_decode.eagle_proposer.update_full_graph_params")
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context")
@@ -430,14 +361,13 @@ class TestEagleProposerDummyRun(TestBase):
         mock_get_context.return_value = mock_return_context
         self.proposer.use_cuda_graph = True
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
-            self.proposer.dummy_run(num_tokens=64,
-                                    in_graph_capturing=True,
-                                    aclgraph_runtime_mode=CUDAGraphMode.FULL)
-            self.assertTrue(self.proposer._runnable.call_count == 1)
-            mock_update_full_graph_params.assert_not_called()
-            self.proposer.use_cuda_graph = last_use_cuda_graph
+        self.proposer.enable_shared_expert_dp = False
+        self.proposer.dummy_run(num_tokens=64,
+                                in_graph_capturing=True,
+                                aclgraph_runtime_mode=CUDAGraphMode.FULL)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
+        mock_update_full_graph_params.assert_not_called()
+        self.proposer.use_cuda_graph = last_use_cuda_graph
 
     @patch("vllm_ascend.spec_decode.eagle_proposer.update_full_graph_params")
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context")
@@ -453,14 +383,13 @@ class TestEagleProposerDummyRun(TestBase):
         mock_get_context.return_value = mock_return_context
         self.proposer.use_cuda_graph = True
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
-        with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
-            self.proposer.dummy_run(num_tokens=64,
-                                    in_graph_capturing=False,
-                                    aclgraph_runtime_mode=CUDAGraphMode.FULL)
-            self.assertTrue(self.proposer._runnable.call_count == 1)
-            self.assertTrue(mock_update_full_graph_params.call_count == 1)
-            self.proposer.use_cuda_graph = last_use_cuda_graph
+        self.proposer.enable_shared_expert_dp = False
+        self.proposer.dummy_run(num_tokens=64,
+                                in_graph_capturing=False,
+                                aclgraph_runtime_mode=CUDAGraphMode.FULL)
+        self.assertTrue(self.proposer._runnable.call_count == 1)
+        self.assertTrue(mock_update_full_graph_params.call_count == 1)
+        self.proposer.use_cuda_graph = last_use_cuda_graph
 
 
 class TestEagleProposerHelperMethods(TestBase):
@@ -477,8 +406,6 @@ class TestEagleProposerHelperMethods(TestBase):
         self.runner.arange_np = np.arange(10)
         self.runner.input_batch.num_reqs = 3
         self.runner.pin_memory = False
-        self.runner.pcp_size = 1
-        self.runner.dcp_size = 1
 
         self.vllm_config.cache_config.block_size = 16
         self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
@@ -489,17 +416,12 @@ class TestEagleProposerHelperMethods(TestBase):
         self.vllm_config.model_config.uses_xdrope_dim = 0
         self.vllm_config.parallel_config.tensor_parallel_size = 1
         self.vllm_config.parallel_config.data_parallel_rank = 0
-        self.vllm_config.parallel_config.data_parallel_size = 1
-        self.vllm_config.parallel_config.prefill_context_parallel_size = 1
-        self.vllm_config.parallel_config.enable_expert_parallel = False
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.num_speculative_tokens = 2
         self.vllm_config.speculative_config.speculative_token_tree = str([
             (i + 1) * (0, ) for i in range(2)
         ])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
-        self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
-        self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
@@ -507,13 +429,9 @@ class TestEagleProposerHelperMethods(TestBase):
             "vllm.v1.spec_decode.eagle.CpuGpuBuffer")
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
-            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs",
-            return_value=False
+            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs"
         )
         self.mock_supports_multimodal_inputs.start()
-
-        # Set the current vllm config
-        set_current_vllm_config(self.vllm_config)
         self.proposer = EagleProposer(vllm_config=self.vllm_config,
                                       device=self.device,
                                       runner=self.runner)
@@ -521,8 +439,6 @@ class TestEagleProposerHelperMethods(TestBase):
     def tearDown(self):
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
-        # Clear the current vllm config
-        set_current_vllm_config(None)
 
     # TODO: This is equivalent to disable_padded_drafter_batch=True.
     # We need to add a test_prepare_inputs_padded in future.
@@ -533,11 +449,10 @@ class TestEagleProposerHelperMethods(TestBase):
         num_rejected = torch.tensor([1, 0, 1], device=self.device)
         mock_return_attn = MagicMock()
 
-        with set_current_vllm_config(self.vllm_config):
-            with patch.object(self.proposer,
-                              'prepare_inputs',
-                              return_value=(mock_return_attn,
-                                            torch.tensor([1, 2, 4]))):
-                return_attn, indices = self.proposer.prepare_inputs(
-                    mock_attn, num_rejected)
-                self.assertEqual(indices.tolist(), [1, 2, 4])
+        with patch.object(self.proposer,
+                          'prepare_inputs',
+                          return_value=(mock_return_attn,
+                                        torch.tensor([1, 2, 4]))):
+            return_attn, indices = self.proposer.prepare_inputs(
+                mock_attn, num_rejected)
+            self.assertEqual(indices.tolist(), [1, 2, 4])

--- a/tests/ut/spec_decode/test_mtp_proposer.py
+++ b/tests/ut/spec_decode/test_mtp_proposer.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from vllm.config import (CacheConfig, CompilationConfig, CUDAGraphMode,
                          ModelConfig, SchedulerConfig, SpeculativeConfig,
-                         VllmConfig, set_current_vllm_config)
+                         VllmConfig)
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
@@ -20,8 +20,7 @@ class TestMtpProposer:
     @pytest.fixture(autouse=True)
     def patch_supports_multimodal_inputs(self):
         with patch(
-                "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs",
-                return_value=False
+                "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs"
         ):
             yield
 
@@ -39,21 +38,16 @@ class TestMtpProposer:
         config.speculative_config.speculative_token_tree = str([
             (i + 1) * (0, ) for i in range(2)
         ])
-        config.speculative_config.disable_padded_drafter_batch = False
 
         config.model_config = MagicMock(spec=ModelConfig)
         config.model_config.dtype = torch.float16
         config.model_config.max_model_len = 2048
         config.model_config.uses_mrope = False
         config.model_config.uses_xdrope_dim = 0
-        config.model_config.hf_text_config = MagicMock(spec=[])  # Empty spec to prevent hasattr from returning True
-        config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
+        config.model_config.hf_text_config = None
         config.model_config.hf_config = None
         config.parallel_config.tensor_parallel_size = 1
         config.parallel_config.data_parallel_rank = 0
-        config.parallel_config.data_parallel_size = 1
-        config.parallel_config.prefill_context_parallel_size = 1
-        config.parallel_config.enable_expert_parallel = False
         config.speculative_config.draft_tensor_parallel_size = 1
 
         config.load_config = None
@@ -68,8 +62,6 @@ class TestMtpProposer:
         config.compilation_config = MagicMock(spec=CompilationConfig)
         config.compilation_config.cudagraph_capture_sizes = [1, 2, 4, 8]
         config.compilation_config.static_forward_context = dict()
-        config.compilation_config.pass_config = MagicMock()
-        config.compilation_config.pass_config.enable_sp = False
 
         config.device_config = MagicMock()
         config.device_config.device = torch.device("cpu")
@@ -95,19 +87,18 @@ class TestMtpProposer:
         mock_cpu_gpu_buffer.return_value = mock_buffer_instance
 
         # Test basic initialization
-        with set_current_vllm_config(vllm_config):
-            proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
+        proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
 
-            assert proposer.vllm_config == vllm_config
-            assert proposer.device == torch.device("cpu")
-            assert proposer.dtype == torch.float16
-            assert proposer.num_speculative_tokens == 2
-            assert proposer.hidden_size == 4096
+        assert proposer.vllm_config == vllm_config
+        assert proposer.device == torch.device("cpu")
+        assert proposer.dtype == torch.float16
+        assert proposer.num_speculative_tokens == 2
+        assert proposer.hidden_size == 4096
 
-            # Test with mrope enabled
-            assert hasattr(proposer, "positions")
-            assert not hasattr(proposer, "mrope_positions")
-            assert proposer.use_sparse is False
+        # Test with mrope enabled
+        assert hasattr(proposer, "positions")
+        assert not hasattr(proposer, "mrope_positions")
+        assert proposer.use_sparse is False
 
     @patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
     def test_init_with_aclgraph(self, mock_cpu_gpu_buffer, vllm_config,
@@ -117,75 +108,64 @@ class TestMtpProposer:
         runner._use_aclgraph.return_value = True
         vllm_config.scheduler_config.async_scheduling = False
         vllm_config.speculative_config.enforce_eager = False
-        with set_current_vllm_config(vllm_config):
-            proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
+        proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
 
-            assert proposer.use_cuda_graph is True
+        assert proposer.use_cuda_graph is True
 
-    @patch("vllm_ascend.ascend_forward_context.get_dp_group")
-    @patch("vllm_ascend.ascend_forward_context.get_tensor_model_parallel_world_size", return_value=1)
     @patch("vllm_ascend.spec_decode.mtp_proposer.get_forward_context")
     @patch("vllm_ascend.spec_decode.mtp_proposer.set_ascend_forward_context")
     @patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
     def test_dummy_run(self, mock_cpu_gpu_buffer, mock_set_context,
-                       mock_get_forward_context, mock_tp_world_size, mock_dp_group, vllm_config, runner):
+                       mock_get_forward_context, vllm_config, runner):
         mock_buffer_instance = MagicMock()
         mock_cpu_gpu_buffer.return_value = mock_buffer_instance
-        mock_dp_group.return_value.world_size = 1
-        with set_current_vllm_config(vllm_config):
-            proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
+        proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
+        proposer.model = MagicMock()
+        proposer.enable_shared_expert_dp = False
+        runner._sync_metadata_across_dp.return_value = (8, 8, False)
 
-            # Mock _runnable to prevent actual execution
-            proposer._runnable = MagicMock()
-            proposer.enable_shared_expert_dp = False
-            runner._sync_metadata_across_dp.return_value = (8, 8, False)
+        mock_get_forward_context = MagicMock()
+        mock_get_forward_context.cudagraph_runtime_mode = None
+        mock_get_forward_context.capturing = True
+        # Execute
+        proposer.dummy_run(8)
 
-            mock_get_forward_context = MagicMock()
-            mock_get_forward_context.cudagraph_runtime_mode = None
-            mock_get_forward_context.capturing = True
-            # Execute
-            proposer.dummy_run(8)
+        # Verify
+        runner._sync_metadata_across_dp.assert_called_once()
+        mock_set_context.assert_called()
 
-            # Verify
-            runner._sync_metadata_across_dp.assert_called_once()
+        # Check that model was called correct number of times
+        assert proposer.model.call_count == vllm_config.speculative_config.num_speculative_tokens
 
-            # Check that _runnable was called
-            assert proposer._runnable.call_count == 1
-
-    @patch("vllm_ascend.ascend_forward_context.get_dp_group")
-    @patch("vllm_ascend.ascend_forward_context.get_tensor_model_parallel_world_size", return_value=1)
     @patch("vllm_ascend.spec_decode.mtp_proposer.get_forward_context")
     @patch("vllm_ascend.spec_decode.mtp_proposer.set_ascend_forward_context")
     @patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
     def test_dummy_run_full_graph(self, mock_cpu_gpu_buffer, mock_set_context,
-                                  mock_get_forward_context, mock_tp_world_size, mock_dp_group, vllm_config,
+                                  mock_get_forward_context, vllm_config,
                                   runner):
         # Setup
         mock_buffer_instance = MagicMock()
         mock_cpu_gpu_buffer.return_value = mock_buffer_instance
-        mock_dp_group.return_value.world_size = 1
-        with set_current_vllm_config(vllm_config):
-            proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
+        proposer = MtpProposer(vllm_config, torch.device("cpu"), runner)
+        proposer.enable_shared_expert_dp = False
+        proposer.model = MagicMock()
+        runner._sync_metadata_across_dp.return_value = (8, 8, False)
+        runner.attn_groups = []
 
-            # Mock _runnable to prevent actual execution
-            proposer._runnable = MagicMock()
-            proposer.enable_shared_expert_dp = False
-            runner._sync_metadata_across_dp.return_value = (8, 8, False)
-            runner.attn_groups = []
+        mock_get_forward_context = MagicMock()
+        mock_get_forward_context.cudagraph_runtime_mode = None
+        mock_get_forward_context.capturing = True
+        # Execute
+        proposer.dummy_run(num_tokens=8,
+                           num_reqs=5,
+                           aclgraph_runtime_mode=CUDAGraphMode.FULL)
 
-            mock_get_forward_context = MagicMock()
-            mock_get_forward_context.cudagraph_runtime_mode = None
-            mock_get_forward_context.capturing = True
-            # Execute
-            proposer.dummy_run(num_tokens=8,
-                               num_reqs=5,
-                               aclgraph_runtime_mode=CUDAGraphMode.FULL)
+        # Verify
+        runner._sync_metadata_across_dp.assert_called_once()
+        mock_set_context.assert_called()
 
-            # Verify
-            runner._sync_metadata_across_dp.assert_called_once()
-
-            # Check that _runnable was called
-            assert proposer._runnable.call_count == 1
+        # Check that model was called correct number of times
+        assert proposer.model.call_count == vllm_config.speculative_config.num_speculative_tokens
 
     @patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
     def test_prepare_next_token_ids_cpu(self, mock_cpu_gpu_buffer):

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -17,16 +17,9 @@
 #
 
 from torch import fx as fx
+from vllm.compilation.inductor_pass import get_pass_context
+from vllm.compilation.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig
-
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.inductor_pass import get_pass_context  # type: ignore
-    from vllm.compilation.vllm_inductor_pass import VllmInductorPass  # type: ignore
-else:
-    from vllm.compilation.passes.inductor_pass import get_pass_context
-    from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
 
 
 class GraphFusionPassManager:

--- a/vllm_ascend/compilation/npu_graph_ex_pass_manager.py
+++ b/vllm_ascend/compilation/npu_graph_ex_pass_manager.py
@@ -17,16 +17,9 @@
 #
 
 from torch import fx as fx
+from vllm.compilation.inductor_pass import get_pass_context
+from vllm.compilation.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig
-
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.inductor_pass import get_pass_context  # type: ignore
-    from vllm.compilation.vllm_inductor_pass import VllmInductorPass  # type: ignore
-else:
-    from vllm.compilation.passes.inductor_pass import get_pass_context
-    from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
 
 
 class NpuGraphEXPassManager:

--- a/vllm_ascend/compilation/npugraph_ex_passes/graphex_allreduce_rmsnorm_fusion_pass.py
+++ b/vllm_ascend/compilation/npugraph_ex_passes/graphex_allreduce_rmsnorm_fusion_pass.py
@@ -17,6 +17,7 @@
 import torch
 import torchair
 from torch._inductor.pattern_matcher import Match
+from vllm.compilation.inductor_pass import get_pass_context
 from vllm.config import VllmConfig
 from vllm.config.compilation import Range
 from vllm.distributed import get_tensor_model_parallel_world_size, tensor_model_parallel_all_reduce
@@ -26,12 +27,6 @@ from vllm_ascend.compilation.npugraph_ex_passes.utils.npugraph_ex_utils_check im
     check_and_register_fusion_pass,
     extra_stream_scope_check,
 )
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.inductor_pass import get_pass_context  # type: ignore
-else:
-    from vllm.compilation.passes.inductor_pass import get_pass_context
 
 # computation-communication tiling block is 512
 ALLREDUCE_NORM_FUSE_THREHOLD = 512

--- a/vllm_ascend/compilation/passes/allreduce_rmsnorm_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/allreduce_rmsnorm_fusion_pass.py
@@ -17,18 +17,12 @@
 import torch
 import torch._inductor.pattern_matcher as pm
 from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
+from vllm.compilation.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig
 from vllm.config.compilation import Range
 from vllm.distributed import get_tensor_model_parallel_world_size, tensor_model_parallel_all_reduce
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
-
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.vllm_inductor_pass import VllmInductorPass  # type: ignore
-else:
-    from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
 
 # computation-communication tiling block is 512
 ALLREDUCE_NORM_FUSE_THREHOLD = 512

--- a/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
@@ -18,16 +18,12 @@
 import torch
 import torch._inductor.pattern_matcher as pm
 from torch._inductor.pattern_matcher import PatternMatcherPass
+from vllm.compilation.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig
 from vllm.config.compilation import Range
 from vllm.logger import logger
 
-from vllm_ascend.utils import enable_custom_op, vllm_version_is
-
-if vllm_version_is("0.15.0"):
-    from vllm.compilation.vllm_inductor_pass import VllmInductorPass  # type: ignore
-else:
-    from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
+from vllm_ascend.utils import enable_custom_op
 
 
 class AddRMSNormQuantPattern:

--- a/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
@@ -18,6 +18,7 @@
 import torch
 import torch._inductor.pattern_matcher as pm
 from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
+from vllm.compilation.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import Range
 from vllm.logger import logger
@@ -26,9 +27,7 @@ from vllm_ascend.utils import vllm_version_is
 
 if vllm_version_is("v0.15.0"):
     from vllm.attention.layer import Attention  # type: ignore
-    from vllm.compilation.vllm_inductor_pass import VllmInductorPass  # type: ignore
 else:
-    from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
     from vllm.model_executor.layers.attention import Attention
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
1. Fix test_aclgraph_capture_replay_metrics_dp2 assertion to use range check for execute_model count due to https://github.com/vllm-project/vllm/pull/33652
2. Fix test_llama_lora expected outputs have minor differences in generated SQL formatting (e.g., count(*) → COUNT(*)).
3. Fix no attribute 'data'  due to not adapt v0.15.0 in https://github.com/vllm-project/vllm-ascend/pull/6560 No.4 issue
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.15.0
