### PR TITLE
[bugfix][npugraph_ex]duplicate pattern issue

### DIFF
--- a/vllm_ascend/compilation/npugraph_ex_passes/graphex_allreduce_rmsnorm_fusion_pass.py
+++ b/vllm_ascend/compilation/npugraph_ex_passes/graphex_allreduce_rmsnorm_fusion_pass.py
@@ -22,8 +22,8 @@ from vllm.distributed import get_tensor_model_parallel_world_size, tensor_model_
 from vllm.distributed.parallel_state import get_tp_group
 
 from vllm_ascend.compilation.npugraph_ex_passes.utils.npugraph_ex_utils_check import (
-    extra_stream_scope_check,
     check_and_register_fusion_pass,
+    extra_stream_scope_check,
 )
 
 # computation-communication tiling block is 512

--- a/vllm_ascend/compilation/npugraph_ex_passes/graphex_norm_quant_fusion_pass.py
+++ b/vllm_ascend/compilation/npugraph_ex_passes/graphex_norm_quant_fusion_pass.py
@@ -23,8 +23,8 @@ from vllm.config.compilation import Range
 from vllm.logger import logger
 
 from vllm_ascend.compilation.npugraph_ex_passes.utils.npugraph_ex_utils_check import (
-    extra_stream_scope_check,
     check_and_register_fusion_pass,
+    extra_stream_scope_check,
 )
 
 

--- a/vllm_ascend/compilation/npugraph_ex_passes/graphex_qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/npugraph_ex_passes/graphex_qknorm_rope_fusion_pass.py
@@ -24,8 +24,8 @@ from vllm.config.compilation import Range
 from vllm.logger import logger
 
 from vllm_ascend.compilation.npugraph_ex_passes.utils.npugraph_ex_utils_check import (
-    extra_stream_scope_check,
     check_and_register_fusion_pass,
+    extra_stream_scope_check,
 )
 
 

--- a/vllm_ascend/compilation/npugraph_ex_passes/utils/npugraph_ex_utils_check.py
+++ b/vllm_ascend/compilation/npugraph_ex_passes/utils/npugraph_ex_utils_check.py
@@ -17,7 +17,6 @@
 #
 
 from torch._inductor.pattern_matcher import Match
-from vllm.config import VllmConfig
 from vllm.logger import logger
 
 
@@ -58,10 +57,10 @@ _register_patterns = set()
 
 
 def check_and_register_fusion_pass(pattern_class: type, **kwargs):
-    global _resgister_patterns
+    global _register_patterns
     eps = kwargs.get("eps", 1e-6)
     pattern_key = str(pattern_class.__name__) + str(eps)
-    if pattern_key in _resgister_patterns:
+    if pattern_key in _register_patterns:
         return
 
     pattern = pattern_class(**kwargs)


### PR DESCRIPTION
### What this PR does / why we need it?
When the draft model also uses vllmbackend for graph compilation, the fusion pass registration occurs again, resulting in errors due to duplicate patterns.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.15.0
