### PR TITLE
[BugFix] fix metadata execute error: integer modulo by zero

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
@@ -65,7 +65,7 @@ class CPUKVCacheManager:
         self.num_cpu_blocks = num_cpu_blocks
         self.caching_hash_fn = sha256 if caching_hash_algo == "sha256" else hash
         self.use_eagle = use_eagle
-        self.block_pool = BlockPool(self.num_cpu_blocks, True, enable_kv_cache_events)
+        self.block_pool = BlockPool(self.num_cpu_blocks, True, self.block_size, enable_kv_cache_events)
         self.single_type_manager = get_manager_for_kv_cache_spec(
             kv_cache_spec=kv_cache_spec,
             block_pool=self.block_pool,


### PR DESCRIPTION
### What this PR does / why we need it?

Meet the following exception when use `CPUOffloadingConnector`.

```
pposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1578.)
(Worker_TP7_EP7 pid=55966)   object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)
(Worker_TP5_EP5 pid=55964) /vector-engine-workspace/alg-product/vllm/vllm/distributed/parallel_state.py:652: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1578.)
(Worker_TP5_EP5 pid=55964)   object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)
(APIServer pid=55742) INFO:     127.0.0.1:52624 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220] metadata execute error: integer modulo by zero
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220] Traceback (most recent call last):
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/metadata.py", line 217, in serve_step
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]     result = self.functions[func_name](*args, **kwargs)
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py", line 192, in cache_and_free_slots
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]     request,
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/core/single_type_kv_cache_manager.py", line 162, in cache_blocks
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]     self.block_pool.cache_full_blocks(
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/core/block_pool.py", line 251, in cache_full_blocks
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]     assert block_size % self.hash_block_size == 0
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220]            ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:220] ZeroDivisionError: integer modulo by zero
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:69] call metadata sever error: integer modulo by zero
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:36 [metadata.py:69] NoneType: None
(Worker_TP0_EP0 pid=55959) Exception in thread Thread-12 (_sending_finished):
(Worker_TP0_EP0 pid=55959) Traceback (most recent call last):
(Worker_TP0_EP0 pid=55959)   File "/usr/lib64/python3.11/threading.py", line 1045, in _bootstrap_inner
(Worker_TP0_EP0 pid=55959)     self.run()
(Worker_TP0_EP0 pid=55959)   File "/usr/lib64/python3.11/threading.py", line 982, in run
(Worker_TP0_EP0 pid=55959)     self._target(*self._args, **self._kwargs)
(Worker_TP0_EP0 pid=55959)   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_offload_connector.py", line 420, in _sending_finished
(Worker_TP0_EP0 pid=55959)     self.zmq_rpc_client.call("cache_and_free_slots", req_id)
(Worker_TP0_EP0 pid=55959)   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/metadata.py", line 70, in call
(Worker_TP0_EP0 pid=55959)     raise error
(Worker_TP0_EP0 pid=55959) ZeroDivisionError: integer modulo by zero
(APIServer pid=55742) INFO:     127.0.0.1:52624 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220] metadata execute error: integer modulo by zero
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220] Traceback (most recent call last):
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/metadata.py", line 217, in serve_step
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]     result = self.functions[func_name](*args, **kwargs)
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py", line 192, in cache_and_free_slots
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]     request,
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/core/single_type_kv_cache_manager.py", line 162, in cache_blocks
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]     self.block_pool.cache_full_blocks(
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/core/block_pool.py", line 251, in cache_full_blocks
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]     assert block_size % self.hash_block_size == 0
(Worker_TP0_EP0 pid=55959) ERROR 01-21 15:26:37 [metadata.py:220]            ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.15.0
