### PR TITLE
[Bugfix] Fix wrong computed_tokens when meet exception.

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -576,7 +576,7 @@ class KVPoolWorker:
             # all tokens where found, return the maximal end
         except Exception as e:
             logger.error(f"Remote connection failed in contains: {e}")
-            return start
+            return 0
         return end
 
     def lookup_scheduler(
@@ -633,7 +633,7 @@ class KVPoolWorker:
         # all tokens where found, return the maximal end
         except Exception as e:
             logger.error(f"Remote connection failed in contains: {e}")
-            return start
+            return 0
         return end
 
     def check_all_layers_exists(self, res: list[int], num_layers: int) -> list[int]:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Fix wrong computed_tokens when meet exception. This pull request addresses a bug in the KV transfer mechanism where an exception during token lookup operations could lead to an incorrect count of computed_tokens. By modifying the exception handling in both the lookup and lookup_scheduler functions to return 0 instead of the start index, the system now correctly indicates that no tokens were successfully processed when a remote connection failure occurs. This enhancement improves the robustness and accuracy of token management within the vllm_ascend distributed KV pool.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

NO.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
