### PR TITLE
[Refactor][Misc] Remove vLLM version compatibility code

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -47,8 +47,6 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
-from vllm_ascend.utils import vllm_version_is
-
 logger = init_logger(__name__)
 
 
@@ -100,8 +98,7 @@ class RecomputeScheduler(Scheduler):
         # the KV cache of one request from prefill nodes.
         self.is_mtp_kv_consumer = self.vllm_config.speculative_config and \
                                   self.vllm_config.kv_transfer_config and \
-                                  self.vllm_config.kv_transfer_config.is_kv_consumer \
-                                    and vllm_version_is('0.13.0')
+                                  self.vllm_config.kv_transfer_config.is_kv_consumer
 
     def add_request(self, request: Request) -> None:
         # Fill in placeholder tokens to enable full graph compatibility. Without

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -50,8 +50,7 @@ from vllm_ascend.quantization.w8a8_dynamic import \
 from vllm_ascend.utils import (AscendDeviceType, enable_sp,
                                get_ascend_device_type, maybe_trans_nz,
                                npu_stream_switch, shared_expert_dp_enabled,
-                               shared_experts_calculation_stream,
-                               vllm_version_is)
+                               shared_experts_calculation_stream)
 
 
 @dataclass
@@ -460,14 +459,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         # Qwen3-Next specific gating mechanism
         if hasattr(self._shared_experts, "expert_gate") and \
             self._shared_experts.expert_gate is not None:
-            if vllm_version_is('0.13.0'):
-                # TODO(jianzs): remove this branch after vLLM new version is
-                # released
-                gate_out = self._shared_experts.expert_gate(
-                    hidden_states)  # type: ignore
-            else:
-                gate_out, _ = self._shared_experts.expert_gate(
-                    hidden_states)  # type: ignore
+            gate_out = self._shared_experts.expert_gate(hidden_states)
             shared_out = F.sigmoid(gate_out) * shared_out
         return shared_out
 

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -24,7 +24,6 @@ import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 import vllm_ascend.patch.platform.patch_set_cudagraph_sizes  # noqa
 from vllm_ascend import envs
-from vllm_ascend.utils import vllm_version_is
 
 USE_MULTI_BLOCK_POOL = False
 
@@ -37,12 +36,13 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv(
         "EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
-if os.getenv("SHM_BARRIER", "true").lower() in ("true", "1") or (
-        envs.VLLM_ASCEND_BALANCE_SCHEDULING and vllm_version_is("0.13.0")):
+if os.getenv("SHM_BARRIER",
+             "true").lower() in ("true",
+                                 "1") or envs.VLLM_ASCEND_BALANCE_SCHEDULING:
     import vllm_ascend.patch.platform.patch_core  # noqa
 
 if os.getenv("SHM_BARRIER", "true").lower() in ("true", "1"):
     import vllm_ascend.patch.platform.patch_message_queue  # noqa
 
-if envs.VLLM_ASCEND_BALANCE_SCHEDULING and vllm_version_is('0.13.0'):
+if envs.VLLM_ASCEND_BALANCE_SCHEDULING:
     import vllm_ascend.patch.platform.patch_balance_schedule  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,7 +18,6 @@ import os
 
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_ec_connector  # noqa
-import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_lora_model_manager  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
@@ -32,10 +31,6 @@ if USE_MULTI_BLOCK_POOL:
     import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
     import vllm_ascend.patch.platform.patch_vllm_config  # noqa
 
-if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv(
-        "EXPERT_MAP_RECORD", "false") == "true":
-    import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
-
 if os.getenv("SHM_BARRIER",
              "true").lower() in ("true",
                                  "1") or envs.VLLM_ASCEND_BALANCE_SCHEDULING:
@@ -46,3 +41,7 @@ if os.getenv("SHM_BARRIER", "true").lower() in ("true", "1"):
 
 if envs.VLLM_ASCEND_BALANCE_SCHEDULING:
     import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
+
+if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv(
+        "EXPERT_MAP_RECORD", "false") == "true":
+    import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -14,8 +14,7 @@ from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import (SchedulingPolicy,
                                               create_request_queue)
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
-from vllm.v1.engine.core import DPEngineCoreProc
+from vllm.v1.engine import EngineCoreEventType
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
@@ -570,53 +569,6 @@ class BalanceScheduler(Scheduler):
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
-
-
-class BalanceDPEngineCoreProc(DPEngineCoreProc):
-
-    def run_busy_loop(self):
-        """Core busy loop of the EngineCore for data parallel case."""
-
-        # Loop until process is sent a SIGINT or SIGTERM
-        while True:
-            # 1) Poll the input queue until there is work to do.
-            self._process_input_queue()
-
-            # 2) Step the engine core.
-            executed = self._process_engine_step()
-            self._maybe_publish_request_counts()
-
-            local_unfinished_reqs = self.scheduler.has_unfinished_requests()
-            if not executed:
-                if not local_unfinished_reqs and not self.engines_running:
-                    # All engines are idle.
-                    continue
-
-                # We are in a running state and so must execute a dummy pass
-                # if the model didn't execute any ready requests.
-                self.execute_dummy_batch()
-
-            # 3) All-reduce operation to determine global unfinished reqs.
-            self.engines_running = self._has_global_unfinished_reqs(
-                local_unfinished_reqs)
-            self.scheduler.balance_gather(self.dp_group)
-
-            if not self.engines_running:
-                if self.dp_rank == 0 or not self.has_coordinator:
-                    # Notify client that we are pausing the loop.
-                    logger.debug("Wave %d finished, pausing engine loop.",
-                                 self.current_wave)
-                    # In the coordinator case, dp rank 0 sends updates to the
-                    # coordinator. Otherwise (offline spmd case), each rank
-                    # sends the update to its colocated front-end process.
-                    client_index = -1 if self.has_coordinator else 0
-                    self.output_queue.put_nowait((
-                        client_index,
-                        EngineCoreOutputs(wave_complete=self.current_wave),
-                    ))
-                # Increment wave count and reset step counter.
-                self.current_wave += 1
-                self.step_counter = 0
 
 
 vllm.v1.core.sched.scheduler.Scheduler = BalanceScheduler

--- a/vllm_ascend/patch/platform/patch_core.py
+++ b/vllm_ascend/patch/platform/patch_core.py
@@ -9,7 +9,6 @@ from vllm.utils.system_utils import decorate_logs, set_process_title
 from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
 
 from vllm_ascend import envs
-from vllm_ascend.utils import vllm_version_is
 
 
 def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
@@ -46,8 +45,7 @@ def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
             # Set data parallel rank for this engine process.
             parallel_config.data_parallel_rank = dp_rank
             parallel_config.data_parallel_rank_local = local_dp_rank
-            if envs.VLLM_ASCEND_BALANCE_SCHEDULING and vllm_version_is(
-                    "0.13.0"):
+            if envs.VLLM_ASCEND_BALANCE_SCHEDULING:
                 from vllm_ascend.patch.platform.patch_balance_schedule import \
                     BalanceDPEngineCoreProc
                 engine_core = BalanceDPEngineCoreProc(*args, **kwargs)

--- a/vllm_ascend/patch/platform/patch_core.py
+++ b/vllm_ascend/patch/platform/patch_core.py
@@ -2,13 +2,63 @@ import os
 import signal
 
 from vllm.config import ParallelConfig
-from vllm.logger import logger
+from vllm.logger import init_logger
 from vllm.transformers_utils.config import \
     maybe_register_config_serialize_by_value
 from vllm.utils.system_utils import decorate_logs, set_process_title
+from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
 
 from vllm_ascend import envs
+
+logger = init_logger(__name__)
+
+
+class BalanceDPEngineCoreProc(DPEngineCoreProc):
+
+    def run_busy_loop(self):
+        """Core busy loop of the EngineCore for data parallel case."""
+
+        # Loop until process is sent a SIGINT or SIGTERM
+        while True:
+            # 1) Poll the input queue until there is work to do.
+            self._process_input_queue()
+
+            # 2) Step the engine core.
+            executed = self._process_engine_step()
+            self._maybe_publish_request_counts()
+
+            local_unfinished_reqs = self.scheduler.has_unfinished_requests()
+            if not executed:
+                if not local_unfinished_reqs and not self.engines_running:
+                    # All engines are idle.
+                    continue
+
+                # We are in a running state and so must execute a dummy pass
+                # if the model didn't execute any ready requests.
+                self.execute_dummy_batch()
+
+            # 3) All-reduce operation to determine global unfinished reqs.
+            self.engines_running = self._has_global_unfinished_reqs(
+                local_unfinished_reqs)
+            self.scheduler.balance_gather(self.dp_group)
+
+            if not self.engines_running:
+                if self.dp_rank == 0 or not self.has_coordinator:
+                    # Notify client that we are pausing the loop.
+                    logger.debug("Wave %d finished, pausing engine loop.",
+                                 self.current_wave)
+                    # In the coordinator case, dp rank 0 sends updates to the
+                    # coordinator. Otherwise (offline spmd case), each rank
+                    # sends the update to its colocated front-end process.
+                    client_index = -1 if self.has_coordinator else 0
+                    self.output_queue.put_nowait((
+                        client_index,
+                        EngineCoreOutputs(wave_complete=self.current_wave),
+                    ))
+                # Increment wave count and reset step counter.
+                self.current_wave += 1
+                self.step_counter = 0
 
 
 def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
@@ -46,8 +96,6 @@ def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
             parallel_config.data_parallel_rank = dp_rank
             parallel_config.data_parallel_rank_local = local_dp_rank
             if envs.VLLM_ASCEND_BALANCE_SCHEDULING:
-                from vllm_ascend.patch.platform.patch_balance_schedule import \
-                    BalanceDPEngineCoreProc
                 engine_core = BalanceDPEngineCoreProc(*args, **kwargs)
             else:
                 engine_core = DPEngineCoreProc(*args, **kwargs)

--- a/vllm_ascend/patch/worker/patch_model_runner.py
+++ b/vllm_ascend/patch/worker/patch_model_runner.py
@@ -2,14 +2,11 @@ from typing import cast
 
 import torch
 from vllm.distributed.parallel_state import get_pp_group
-from vllm.logger import logger
 from vllm.model_executor.models.interfaces_base import VllmModelForPooling
 from vllm.sampling_params import SamplingType
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-
-from vllm_ascend.utils import vllm_version_is
 
 
 # The current version of `GPUModelRunner._update_states` is v0.13.0.
@@ -290,9 +287,4 @@ def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
     self.input_batch.refresh_metadata()
 
 
-if vllm_version_is('0.13.0'):
-    GPUModelRunner._update_states = _update_states
-else:
-    logger.warning(
-        "vllm_version is not v0.13.0, patch GPUModelRunner._update_states failed!"
-    )
+GPUModelRunner._update_states = _update_states

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -109,7 +109,7 @@ from vllm_ascend.utils import (AscendDeviceType, ProfileExecuteDuration,
                                enable_sp, get_ascend_device_type,
                                is_drafter_moe_model, is_moe_model,
                                lmhead_tp_enable, maybe_trans_nz,
-                               set_weight_prefetch_method, vllm_version_is)
+                               set_weight_prefetch_method)
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.pcp_utils import PCPManager
 
@@ -772,10 +772,8 @@ class NPUModelRunner(GPUModelRunner):
 
         # _prepare_inputs may reorder the batch, so we must gather
         # multi-modal outputs after that to ensure the correct order
-        if vllm_version_is('0.13.0'):
-            model_kwargs = self._init_model_kwargs(num_input_tokens)
-        else:
-            model_kwargs = self._init_model_kwargs()
+        model_kwargs = self._init_model_kwargs(num_input_tokens)
+
         if self.is_multimodal_model and not self.model_config.is_encoder_decoder:
             self.multimodal_cpu_fields = ["grid_thw"]
             self._prepare_multimodal_fields()
@@ -1606,16 +1604,11 @@ class NPUModelRunner(GPUModelRunner):
                 logits = None
             else:
                 if self.input_batch.pooling_params:
-                    if vllm_version_is('0.13.0'):
-                        pool_output = self._pool(
-                            hidden_states,
-                            scheduler_output.total_num_scheduled_tokens,
-                            num_scheduled_tokens_np)
-                    else:
-                        pool_output = self._pool(
-                            hidden_states,
-                            scheduler_output.total_num_scheduled_tokens,
-                            num_scheduled_tokens_np, kv_connector_output)
+                    pool_output = self._pool(
+                        hidden_states,
+                        scheduler_output.total_num_scheduled_tokens,
+                        num_scheduled_tokens_np)
+
                     if self.debugger is not None:
                         self.debugger.stop()
                         self.debugger.step()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -38,6 +38,7 @@ from vllm.distributed.kv_transfer import (ensure_kv_transfer_initialized,
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
+from vllm.model_executor.utils import set_random_seed
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.mem_constants import GiB_bytes
@@ -58,16 +59,11 @@ from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.utils import (AscendDeviceType, check_ascend_device_type,
                                enable_sp, get_ascend_device_type,
-                               register_ascend_customop, vllm_version_is)
+                               register_ascend_customop)
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
-
-if vllm_version_is("0.13.0"):
-    from vllm.model_executor.utils import set_random_seed
-else:
-    from vllm.utils.torch_utils import set_random_seed
 
 torch_non_c_binding_in_graph_functions_npu = dict.fromkeys(
     ["torch.npu.current_stream"],


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request removes the `vllm_version_is` utility function and its usages across the codebase. This cleanup simplifies the code by removing conditional logic that handled compatibility with different versions of the vLLM library. By standardizing on a single version path (likely v0.13.0 or newer), the code becomes more readable and easier to maintain.

The changes include:
- Removing the `vllm_version_is` function.
- Eliminating conditional code blocks that depended on the vLLM version.
- Refactoring code, such as moving `BalanceDPEngineCoreProc` to a more appropriate location.

### Does this PR introduce _any_ user-facing change?
No, this PR is an internal refactoring and does not introduce any user-facing changes.

### How was this patch tested?
CI is expected to pass. The changes should be covered by existing tests.