### PR TITLE
[BugFix]  Fixed an accuracy issue caused by the fact that the attention calculation result was not saved to the output when the FIA used the sliding window method.

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -766,7 +766,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
             and self.sliding_window is not None
             and attn_metadata.seq_lens.shape[0] == query.size(0)
         ):
-            return self._forward_fia_slidingwindow(query, attn_metadata, output)
+            attn_output = self._forward_fia_slidingwindow(query, attn_metadata, output)
+            num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+            output[:num_tokens] = attn_output[:num_tokens]
+            return output
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(key, value, attn_metadata)
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
         query = query[:num_tokens]


### PR DESCRIPTION

### What this PR does / why we need it?
Issue: The model using _forward_fia_slidingwindow returns incorrect answers during the decode phase.
<img width="1449" height="207" alt="image" src="https://github.com/user-attachments/assets/7eceffcf-dd5f-4cc8-990f-dcacf1a6efeb" />

<img width="1225" height="641" alt="image" src="https://github.com/user-attachments/assets/0b190f15-a8fc-4341-a522-ca1a0ce91522" />

Fixed an accuracy issue caused by the fact that the attention calculation result was not saved to the output when the FIA used the sliding window method on branch main.

### Does this PR introduce _any_ user-facing change?
No change.

### How was this patch tested?
After the fix, the accuracy of the responses is correct.
<img width="1723" height="249" alt="image" src="https://github.com/user-attachments/assets/1f500570-d401-41d9-91b1-ffbcc191e289" />

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.15.0
