### PR TITLE
[0.13.0][CI] Change A2 Runner

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -112,7 +112,7 @@ jobs:
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Install tensorflow (for Molmo-7B-D-0924)
-        if: ${{ inputs.runner == 'linux-aarch64-a2-1' && contains(inputs.model_list, 'Molmo-7B-D-0924') }}
+        if: ${{ inputs.runner == 'linux-aarch64-a2b3-1' && contains(inputs.model_list, 'Molmo-7B-D-0924') }}
         shell: bash -l {0}
         run: |
           pip install tensorflow==2.19.1 --no-cache-dir

--- a/.github/workflows/labled_doctest.yaml
+++ b/.github/workflows/labled_doctest.yaml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         vllm_verison: [v0.9.1-dev, v0.9.1-dev-openeuler, main, main-openeuler]
     name: vLLM Ascend test
-    runs-on: linux-aarch64-a2-1
+    runs-on: linux-aarch64-a2b3-1
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:${{ matrix.vllm_verison }}
     steps:

--- a/.github/workflows/labled_download_model.yaml
+++ b/.github/workflows/labled_download_model.yaml
@@ -19,7 +19,7 @@ jobs:
   download-models:
     if: contains(github.event.pull_request.labels.*.name, 'model-download')
     name: Download models from ModelScope
-    runs-on: linux-aarch64-a2-0
+    runs-on: linux-aarch64-a2b3-0
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-cpu
 

--- a/.github/workflows/nightly_test_a2.yaml
+++ b/.github/workflows/nightly_test_a2.yaml
@@ -50,22 +50,22 @@ jobs:
       matrix:
         test_config:
           - name: qwen3-8b
-            os: linux-aarch64-a2-1
+            os: linux-aarch64-a2b3-1
             tests: tests/e2e/nightly/single_node/models/test_qwen3_8b.py
           - name: qwen3next
-            os: linux-aarch64-a2-4
+            os: linux-aarch64-a2b3-4
             ests: tests/e2e/nightly/single_node/models/test_qwen3_next.py
           - name: qwen3-32b
-            os: linux-aarch64-a2-4
+            os: linux-aarch64-a2b3-4
             tests: tests/e2e/nightly/single_node/models/test_qwen3_32b.py
           - name: qwen3-32b-in8-a2
-            os: linux-aarch64-a2-4
+            os: linux-aarch64-a2b3-4
             tests: tests/e2e/nightly/single_node/models/test_qwen3_32b_int8.py
           - name: test_custom_op
-            os: linux-aarch64-a2-1
+            os: linux-aarch64-a2b3-1
             tests: tests/e2e/nightly/single_node/ops/singlecard_ops
           - name: test_custom_op_multi_card
-            os: linux-aarch64-a2-4
+            os: linux-aarch64-a2b3-4
             tests: tests/e2e/nightly/single_node/ops/multicard_ops_a2/
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
@@ -93,7 +93,7 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a2
-      runner: linux-aarch64-a2-0
+      runner: linux-aarch64-a2b3-0
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a2'
       replicas: 1
       size: ${{ matrix.test_config.size }}
@@ -112,26 +112,26 @@ jobs:
       fail-fast: false
       matrix:
         test_config:
-          - os: linux-aarch64-a2-1
+          - os: linux-aarch64-a2b3-1
             model_list:
               - Qwen3-8B
               - Qwen2-Audio-7B-Instruct
               - Qwen3-8B-W8A8
               - Qwen3-VL-8B-Instruct
               - Qwen2.5-Omni-7B
-          - os: linux-aarch64-a2-1
+          - os: linux-aarch64-a2b3-1
             model_list:
               - ERNIE-4.5-21B-A3B-PT
               - InternVL3_5-8B-hf
               - Molmo-7B-D-0924
               - Llama-3.2-3B-Instruct
               - llava-onevision-qwen2-0.5b-ov-hf
-          - os: linux-aarch64-a2-2
+          - os: linux-aarch64-a2b3-2
             model_list:
               - Qwen3-30B-A3B
               - Qwen3-VL-30B-A3B-Instruct
               - Qwen3-30B-A3B-W8A8
-          - os: linux-aarch64-a2-4
+          - os: linux-aarch64-a2b3-4
             model_list:
               - Qwen3-Next-80B-A3B-Instruct
               - Qwen3-Omni-30B-A3B-Instruct

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: linux-aarch64-a2-0
+    runs-on: linux-aarch64-a2b3-0
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') && contains(github.event.pull_request.labels.*.name, 'ready-for-test') }}
     outputs:
       e2e_tracker: ${{ steps.filter.outputs.e2e_tracker }}
@@ -80,6 +80,6 @@ jobs:
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
-      runner: linux-aarch64-a2
+      runner: linux-aarch64-a2b3
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       type: full

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
     with:
       vllm: v0.13.0
   changes:
-    runs-on: linux-aarch64-a2-0
+    runs-on: linux-aarch64-a2b3-0
     outputs:
       e2e_tracker: ${{ steps.filter.outputs.e2e_tracker }}
       ut_tracker: ${{ steps.filter.outputs.ut_tracker }}
@@ -99,6 +99,6 @@ jobs:
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
-      runner: linux-aarch64-a2
+      runner: linux-aarch64-a2b3
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       type: light

--- a/.github/workflows/schedule_test_vllm_main.yaml
+++ b/.github/workflows/schedule_test_vllm_main.yaml
@@ -34,6 +34,6 @@ jobs:
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: main
-      runner: linux-aarch64-a2
+      runner: linux-aarch64-a2b3
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       type: full

--- a/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
+++ b/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
@@ -1,5 +1,4 @@
 model_name: "OpenGVLab/InternVL3_5-8B-hf"
-runner: "linux-aarch64-a2-1"
 hardware: "Atlas A2 Series"
 model: "vllm-vlm"
 tasks:

--- a/tests/e2e/nightly/single_node/models/test_qwen3_32b_int8.py
+++ b/tests/e2e/nightly/single_node/models/test_qwen3_32b_int8.py
@@ -45,10 +45,10 @@ api_keyword_args = {
 }
 
 batch_size_dict = {
-    "linux-aarch64-a2-4": 72,
+    "linux-aarch64-a2b3-4": 72,
     "linux-aarch64-a3-4": 76,
 }
-VLLM_CI_RUNNER = os.getenv("VLLM_CI_RUNNER", "linux-aarch64-a2-4")
+VLLM_CI_RUNNER = os.getenv("VLLM_CI_RUNNER", "linux-aarch64-a2b3-4")
 performance_batch_size = batch_size_dict.get(VLLM_CI_RUNNER, 1)
 
 aisbench_cases = [{

--- a/tests/e2e/nightly/single_node/models/test_qwen3_next.py
+++ b/tests/e2e/nightly/single_node/models/test_qwen3_next.py
@@ -27,10 +27,10 @@ api_keyword_args = {
 }
 
 batch_size_dict = {
-    "linux-aarch64-a2-4": 64,
+    "linux-aarch64-a2b3-4": 64,
     "linux-aarch64-a3-4": 64,
 }
-VLLM_CI_RUNNER = os.getenv("VLLM_CI_RUNNER", "linux-aarch64-a2-4")
+VLLM_CI_RUNNER = os.getenv("VLLM_CI_RUNNER", "linux-aarch64-a2b3-4")
 performance_batch_size = batch_size_dict.get(VLLM_CI_RUNNER, 1)
 
 aisbench_cases = [{


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the CI runner configuration from "linux-aarch64-a2-X" to "linux-aarch64-a2b3-X" in the `test_qwen3_32b_int8.py` and `test_qwen3_next.py` files. Additionally, the "runner" field is removed from the `InternVL3_5-8B-hf.yaml` configuration. This change is necessary to align with the updated A2 runner environment in the CI system.

Fixes #

### Does this PR introduce _any_ user-facing change?
No, this PR does not introduce any user-facing changes. It is an internal CI configuration update.

### How was this patch tested?
The changes are related to CI runner configurations. The expectation is that existing CI tests will pass with these updates, validating the new runner setup.