### PR TITLE
[refactor]Optimized the kvcache usage of Deepseek v3.2

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2440,7 +2440,7 @@ class NPUModelRunner(GPUModelRunner):
                     elif self.use_sparse:
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         sparse_sum_head_size = sum(self._get_sparse_kv_cache_ratio())
-                        k_tensor_split_factor, v_tensor_split_factor, dsa_k_cache_factor = [
+                        k_tensor_split_factor, v_tensor_split_factor, dsa_k_cache_factor = [  # type: ignore
                             sparse_sum_head_size / ratio for ratio in self._get_sparse_kv_cache_ratio()
                         ]
                         dsa_k_cache_size = int(kv_cache_tensor.size // dsa_k_cache_factor)


### PR DESCRIPTION
### What this PR does / why we need it?

For deepseek v3.2, DSA use FullAttentionSpec, allocate 2 * mla page size bytes, and we use half of that for k cache in DSA

However, the actual proportion of k cache is not high, which results in a large amount of kvcache being wasted. The proportion of discarded kvcache is (576-128)/(576 x 2) = 0.388.

Run the same script to start DeepSeek V3.2 on a single A3 server. The following shows the comparison of kvcache usage:
Before refactoring
```
[kv_cache_utils.py:1307] GPU KV cache size: 15,872 tokens
```
After refactoring
```
[kv_cache_utils.py:1307] GPU KV cache size: 25,984 tokens
```

This pull request refactors the KV cache allocation for Deepseek v3.2 models that use sparse attention. It replaces the use of `FullAttentionSpec` with `MLAAttentionSpec` and introduces a more principled way of calculating KV cache tensor split factors based on model configuration.

This change removes hardcoded values and correctly sizes the cache tensors, leading to optimized memory usage and improved code maintainability.

### Does this PR introduce _any_ user-facing change?

No, this is an internal optimization and does not introduce any user-facing changes.

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d7e17aaacd5ed1b4b4be6bcfef3a1b7cbc84fc9a
