### PR TITLE
[CI]fix nightly multi node test error for wait for pod ready

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -14,7 +14,11 @@ export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 # cann and atb environment setup
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 source /usr/local/Ascend/cann-8.5.0/share/info/ascendnpu-ir/bin/set_env.sh
+
+set +eu
 source /usr/local/Ascend/nnal/atb/set_env.sh
+set -eu
+
 # Home path for aisbench
 export BENCHMARK_HOME=${WORKSPACE}/vllm-ascend/benchmark
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes the issue where nightly multi-node tests hang during the "wait for pod ready" stage due to strict shell mode.

issue: https://github.com/vllm-project/vllm-ascend/actions/runs/21874130621/job/63137883914

bug:
<img width="1170" height="381" alt="截屏2026-02-11 11 16 44_副本" src="https://github.com/user-attachments/assets/714cc93c-0239-46f5-ab8e-30281e050ae2" />

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/13397841ab469cecf1ed425c3f52a9ffc38139b5
