### PR TITLE
[Test][BugFix] Fix torch.rand usage in triton penalty test

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_penality.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_penality.py
@@ -127,22 +127,22 @@ def create_test_data(
     repetiton_penalty = torch.ones(num_reqs, device=device, dtype=torch.float32)
     for i in range(num_reqs):
         if torch.rand(1) > 0.3:
-            repetiton_penalty[i] = torch.rand(1, device).item() * 0.8 + 0.6
+            repetiton_penalty[i] = torch.rand(1, device=device).item() * 0.8 + 0.6
 
     frequency_penalty = torch.zeros(num_reqs, device=device, dtype=torch.float32)
     for i in range(num_reqs):
         if torch.rand(1) > 0.5:
-            frequency_penalty[i] = torch.rand(1, device).item() * 0.2
+            frequency_penalty[i] = torch.rand(1, device=device).item() * 0.2
 
     presence_penalty = torch.zeros(num_reqs, device=device, dtype=torch.float32)
     for i in range(num_reqs):
         if torch.rand(1) > 0.5:
-            presence_penalty[i] = torch.rand(1, device).item() * 0.2
+            presence_penalty[i] = torch.rand(1, device=device).item() * 0.2
 
     temperature = torch.ones(num_reqs, device=device, dtype=torch.float32)
     for i in range(num_reqs):
         if torch.rand(1) > 0.2:
-            presence_penalty[i] = torch.rand(1, device).item() * 1.8 + 0.2
+            presence_penalty[i] = torch.rand(1, device=device).item() * 1.8 + 0.2
 
     idx_mapping = torch.randint(0, num_status, (num_reqs,), device=device, dtype=torch.int32)
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a `TypeError` in `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_penality.py` that was causing nightly test failures. The `torch.rand()` function was being called with the `device` string as a positional argument, which is incorrect. This has been corrected to use the `device` keyword argument.

Fixes #

### Does this PR introduce _any_ user-facing change?
No, this change only affects a test file.

### How was this patch tested?
CI is expected to pass with this fix.

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/13397841ab469cecf1ed425c3f52a9ffc38139b5
