### PR TITLE
Add Worker Interface:check_health

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -571,7 +571,7 @@ class NPUWorker(WorkerBase):
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()
-    
+
     def check_health(self) -> None:
         import subprocess
 


### PR DESCRIPTION
This pull request introduces a new capability to monitor the health of NPU cards directly from the Worker class. This enhancement allows for proactive detection of NPU issues by executing the npu-smi command, improving system reliability and operational visibility within the vllm_ascend worker environment.
more details see https://github.com/vllm-project/vllm-ascend/issues/4112
- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/13397841ab469cecf1ed425c3f52a9ffc38139b5
