### PR TITLE
[Platform] Enable ARM-only CPU binding with NUMA-balanced A3 policy and update docs/tests

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -39,8 +39,8 @@ The following table lists additional configuration options available in vLLM Asc
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
 | `multistream_overlap_gate`          | bool | `False` | Whether to enable multi-stream overlap gate. This option only takes effect on MoE models with shared experts.  |
 | `recompute_scheduler_enable`        | bool | `False` | Whether to enable recompute scheduler.                                                                    |
-| `enable_cpu_binding`                | bool | `False` | Whether to enable CPU Binding.                                                                            |
-| `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic batch feature                            |
+| `enable_cpu_binding`                | bool | `True`  | Whether to enable CPU binding. Only takes effect on ARM CPUs; when enabled, A3 uses NUMA-balanced binding strategy and other device types use NUMA-affinity's. |
+| `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic feature                            |
 | `enable_npugraph_ex`                | bool | `False` | Whether to enable npugraph_ex graph mode.                                                                 |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |
 | `enable_kv_nz`                      | bool | `False` | Whether to enable KV cache NZ layout. This option only takes effects on models using MLA (e.g., DeepSeek).                                      |

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -40,7 +40,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `multistream_overlap_gate`          | bool | `False` | Whether to enable multi-stream overlap gate. This option only takes effect on MoE models with shared experts.  |
 | `recompute_scheduler_enable`        | bool | `False` | Whether to enable recompute scheduler.                                                                    |
 | `enable_cpu_binding`                | bool | `True`  | Whether to enable CPU binding. Only takes effect on ARM CPUs; when enabled, A3 uses NUMA-balanced binding strategy and other device types use NUMA-affinity's. |
-| `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic feature                            |
+| `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic batch feature                            |
 | `enable_npugraph_ex`                | bool | `False` | Whether to enable npugraph_ex graph mode.                                                                 |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |
 | `enable_kv_nz`                      | bool | `False` | Whether to enable KV cache NZ layout. This option only takes effects on models using MLA (e.g., DeepSeek).                                      |

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pybind11
 pyyaml
 scipy
 pandas
+psutil
 setuptools>=64
 setuptools-scm>=8
 torch==2.9.0

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -70,7 +70,7 @@ class TestNPUWorker(TestBase):
         # Setup mock behavior
         mock_ops.register_dummy_fusion_op.return_value = None
         mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_cpu_binding = False
+        mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
 
         # Import and create NPUWorker instance
@@ -125,7 +125,7 @@ class TestNPUWorker(TestBase):
         self.model_config_mock.trust_remote_code = True
         mock_ops.register_dummy_fusion_op.return_value = None
         mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_cpu_binding = False
+        mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
 
         # Create NPUWorker instance
@@ -168,7 +168,7 @@ class TestNPUWorker(TestBase):
         self.cache_config_mock.cache_dtype = "float32"
         mock_ops.register_dummy_fusion_op.return_value = None
         mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_cpu_binding = False
+        mock_ascend_config.enable_cpu_binding = True
         mock_get_ascend_config.return_value = mock_ascend_config
 
         # Create NPUWorker instance

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -84,7 +84,7 @@ class AscendConfig:
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
-        self.enable_cpu_binding = additional_config.get("enable_cpu_binding", False)
+        self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
 
         self.pd_tp_ratio = 1
         self.pd_head_ratio = 1

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import psutil
 from vllm.logger import logger
+
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 ALLOWED_CPUS_PATH = "/proc/self/status"

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python3
 
 import os
+import platform
 import subprocess
 from collections import defaultdict
 
 import psutil
 from vllm.logger import logger
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 ALLOWED_CPUS_PATH = "/proc/self/status"
 ASCEND_RT_VISIBLE_DEVICES = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
+
+
+def is_arm_cpu() -> bool:
+    arch = platform.machine().lower()
+    if arch in {"x86_64", "amd64", "i386", "i686"}:
+        return False
+    if arch in {"aarch64", "arm64"} or arch.startswith("arm"):
+        return True
+    logger.warning(f"Unknown CPU architecture '{arch}', CPU binding will be disabled.")
+    return False
 
 
 def execute_command(cmd: list[str]) -> tuple[str, int]:
@@ -77,7 +89,7 @@ class DeviceInfo:
             devices_list = [int(x) for x in devices_str.split(",")]
             running_npu_set = set(devices_list) & running_npu_set
         if not running_npu_set:
-            raise RuntimeError("Can not get running npu info, you can use BIND_CPU=0 to skip.")
+            raise RuntimeError("Can not get running npu info.")
         return sorted(running_npu_set)
 
     def parse_allowed_cpus(self) -> list[int]:
@@ -202,7 +214,7 @@ class CpuAlloc:
             npu_num_this_node = min(npu_num_per_node, num_running_npu - index)
             if npu_num_this_node <= 0:
                 break
-            # Evenly distribute the CPUs of this NUMA node among npu_num_this_node NPUs.
+            # NUMA-balanced distribute the CPUs of this NUMA node among npu_num_this_node NPUs.
             total_cpu_num = len(cpus)
             base_cpu_num = total_cpu_num // npu_num_this_node
             extra_cpu_num = total_cpu_num % npu_num_this_node
@@ -217,9 +229,22 @@ class CpuAlloc:
                     index += 1
                 start_index = end_index
 
+    DEVICE_BINDING_MODE = {
+        AscendDeviceType.A3: "numa_balanced",
+    }
+
+    @classmethod
+    def _binding_mode(cls) -> str:
+        device_type = get_ascend_device_type()
+        return cls.DEVICE_BINDING_MODE.get(device_type, "affinity")
+
     def build_cpu_pools(self) -> None:
         self.build_cpu_node_map()
+        if self._binding_mode() == "numa_balanced":
+            self.handle_no_affinity()
+            return
         if not self.device_info.npu_affinity:
+            logger.warning("NPU affinity info not found, fallback to NUMA-balanced CPU binding.")
             self.handle_no_affinity()
             return
         for npu in self.device_info.running_npu_list:
@@ -282,5 +307,8 @@ class CpuAlloc:
 
 
 def bind_cpus(rank_id: int) -> None:
+    if not is_arm_cpu():
+        logger.info("CPU binding skipped: non-ARM CPU detected.")
+        return
     binder = CpuAlloc(rank_id)
     binder.run_all()


### PR DESCRIPTION
### What this PR does / why we need it?

- Keeps enable_cpu_binding default on, but skips binding on non‑ARM CPUs inside bind_cpus, with a clear log.
- Uses a table-driven binding policy: A3 uses NUMA‑balanced binding; other device types use NUMA‑affinity binding.
- Updates docs to reflect the exact behavior and adds/updates unit tests for the new logic.

### Related RFC
https://github.com/vllm-project/vllm-ascend/issues/6966

### Follow-up PRs
https://github.com/vllm-project/vllm-ascend/pull/6889 https://github.com/vllm-project/vllm-ascend/pull/6945

### Does this PR introduce _any_ user-facing change?

- Yes. CPU binding is now enabled by default via additional_config, and documented in the user guide.
- CPU binding behavior differs by device type (A3 vs. others).

### How was this patch tested?

Added/updated unit tests:

test_cpu_binding.py
1.   test_binding_mode_table covers A2 vs A3 binding mode mapping.
2.   test_build_cpu_pools_fallback_to_numa_balanced covers fallback when affinity info is missing.
3.   TestBindingSwitch.test_is_arm_cpu covers ARM/x86/unknown arch detection.
4.   test_bind_cpus_skip_non_arm covers non‑ARM skip path in bind_cpus.

test_worker_v1.py
1.   Updated mocks for enable_cpu_binding default True to align with new config default.

- vLLM version: v0.14.1
- vLLM main: d7de043
