### PR TITLE
[0.13.0][bugfix]fix profiler initialization bug with calling stack

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -525,9 +525,9 @@ class NPUWorker(WorkerBase):
                 ],
                 with_stack=False,
                 profile_memory=bool(envs_vllm.\
-                    VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY) != '0' if envs_vllm.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY is not None else False,
+                    VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY != '0') if envs_vllm.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY is not None else False,
                 with_modules=bool(envs_vllm.\
-                    VLLM_TORCH_PROFILER_WITH_STACK) != '0' if envs_vllm.VLLM_TORCH_PROFILER_WITH_STACK is not None else True,
+                    VLLM_TORCH_PROFILER_WITH_STACK != '0') if envs_vllm.VLLM_TORCH_PROFILER_WITH_STACK is not None else True,
                 experimental_config=experimental_config,
                 on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(
                     torch_profiler_trace_dir))


### PR DESCRIPTION
### What this PR does / why we need it?
The initialization logic of profiler with calling stack tracing is wrong, leading to unexpected behavior of always tracing the calling stack even if `VLLM_TORCH_PROFILER_WITH_STACK=0`

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested with profiling tracing