### PR TITLE
[Feat] Add partial RoPE support to fused QKV-RMSNorm-RoPE Triton kernel

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py
@@ -10,6 +10,7 @@ from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 NUM_TOKENS = [1, 4, 8, 16, 1024]
 NUM_QKV_HEADS = [(12, 1), (16, 1), (32, 4), (64, 4)]
 HEAD_SIZES = [128]
+ROTARY_DIMS = [64]
 EPS = [1e-6]
 DTYPES = [torch.bfloat16]
 SEEDS = [0]
@@ -18,23 +19,26 @@ DEFAULT_ATOL = 5e-2
 DEFAULT_RTOL = 5e-3
 
 
-def custom_rope(q, k, sin, cos):
-    rotary_dim = sin.shape[-1]
-    sin = sin.to(torch.float32)
-    cos = cos.to(torch.float32)
-    x1 = q[..., :rotary_dim // 2]
-    x2 = q[..., rotary_dim // 2:]
-    cat_x = torch.cat([-x2, x1], axis=-1)
-    mul1 = cat_x * sin
-    mul2 = q * cos
-    res1 = mul1 + mul2
+def custom_rope(q, k, sin, cos, rotary_dim=None):
+    head_dim = q.shape[-1]
+    if rotary_dim is None:
+        rotary_dim = head_dim
+    sin = sin[..., :rotary_dim].to(torch.float32)
+    cos = cos[..., :rotary_dim].to(torch.float32)
 
-    x1 = k[..., :rotary_dim // 2]
-    x2 = k[..., rotary_dim // 2:]
+    q_rope = q[..., :rotary_dim].to(torch.float32)
+    x1 = q_rope[..., :rotary_dim // 2]
+    x2 = q_rope[..., rotary_dim // 2:]
     cat_x = torch.cat([-x2, x1], axis=-1)
-    mul1 = cat_x * sin
-    mul2 = k * cos
-    res2 = mul1 + mul2
+    roped_q = cat_x * sin + q_rope * cos
+    res1 = torch.cat([roped_q.to(q.dtype), q[..., rotary_dim:]], dim=-1)
+
+    k_rope = k[..., :rotary_dim].to(torch.float32)
+    x1 = k_rope[..., :rotary_dim // 2]
+    x2 = k_rope[..., rotary_dim // 2:]
+    cat_x = torch.cat([-x2, x1], axis=-1)
+    roped_k = cat_x * sin + k_rope * cos
+    res2 = torch.cat([roped_k.to(k.dtype), k[..., rotary_dim:]], dim=-1)
     return res1, res2
 
 
@@ -190,6 +194,173 @@ def test_split_qkv_rmsnorm_rope_with_bias(num_tokens, num_q_heads,
 
     # rope
     q_gold, k_gold = custom_rope(_q, _k, sin.cpu(), cos.cpu())
+    q_gold = q_gold.reshape(num_tokens, -1)
+    k_gold = k_gold.reshape(num_tokens, -1)
+
+    # Compare the results.
+    torch.testing.assert_close(q.to(torch.float32).cpu(),
+                               q_gold,
+                               atol=DEFAULT_ATOL,
+                               rtol=DEFAULT_RTOL)
+
+    torch.testing.assert_close(k.to(torch.float32).cpu(),
+                               k_gold,
+                               atol=DEFAULT_ATOL,
+                               rtol=DEFAULT_RTOL)
+
+    torch.testing.assert_close(v.to(torch.float32).cpu(),
+                               v_gold.to(torch.float32),
+                               atol=DEFAULT_ATOL,
+                               rtol=DEFAULT_RTOL)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_q_heads, num_kv_heads", NUM_QKV_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("rotary_dim", ROTARY_DIMS)
+@pytest.mark.parametrize("eps", EPS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_split_qkv_rmsnorm_partial_rope(num_tokens, num_q_heads, num_kv_heads,
+                                        head_size, rotary_dim, eps, dtype,
+                                        seed, device):
+    torch.manual_seed(seed)
+    torch.set_default_device(device)
+    init_device_properties_triton()
+
+    q_hidden_size = num_q_heads * head_size
+    kv_hidden_size = num_kv_heads * head_size
+    qkv = torch.randn(num_tokens,
+                      q_hidden_size + kv_hidden_size * 2,
+                      dtype=dtype,
+                      device=device)
+    q_weight = torch.randn(head_size, dtype=dtype, device=device)
+    k_weight = torch.randn(head_size, dtype=dtype, device=device)
+    sin = torch.from_numpy(
+        np.random.uniform(0, 1,
+                          [num_tokens, 1, 1, head_size])).to(dtype).npu()
+    cos = torch.from_numpy(
+        np.random.uniform(0, 1,
+                          [num_tokens, 1, 1, head_size])).to(dtype).npu()
+    # fused kernel
+    q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(input=qkv,
+                                              q_weight=q_weight,
+                                              k_weight=k_weight,
+                                              q_hidden_size=q_hidden_size,
+                                              kv_hidden_size=kv_hidden_size,
+                                              head_dim=head_size,
+                                              eps=eps,
+                                              rotary_dim=rotary_dim,
+                                              cos=cos,
+                                              sin=sin)
+
+    # split
+    _q, _k, v_gold = qkv.cpu().split(
+        [q_hidden_size, kv_hidden_size, kv_hidden_size], dim=-1)
+    # norm
+    _q = rms_norm(_q.reshape(-1, head_size), q_weight.cpu(), eps)
+    _k = rms_norm(_k.reshape(-1, head_size), k_weight.cpu(), eps)
+    _q = _q.reshape(num_tokens, 1, -1, head_size)
+    _k = _k.reshape(num_tokens, 1, -1, head_size)
+
+    # rope
+    q_gold, k_gold = custom_rope(_q, _k, sin.cpu(), cos.cpu(),
+                                 rotary_dim=rotary_dim)
+    q_gold = q_gold.reshape(num_tokens, -1)
+    k_gold = k_gold.reshape(num_tokens, -1)
+
+    # Compare the results.
+    torch.testing.assert_close(q.to(torch.float32).cpu(),
+                               q_gold,
+                               atol=DEFAULT_ATOL,
+                               rtol=DEFAULT_RTOL)
+
+    torch.testing.assert_close(k.to(torch.float32).cpu(),
+                               k_gold,
+                               atol=DEFAULT_ATOL,
+                               rtol=DEFAULT_RTOL)
+
+    torch.testing.assert_close(v.to(torch.float32).cpu(),
+                               v_gold.to(torch.float32),
+                               atol=DEFAULT_ATOL,
+                               rtol=DEFAULT_RTOL)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_q_heads, num_kv_heads", NUM_QKV_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("rotary_dim", ROTARY_DIMS)
+@pytest.mark.parametrize("eps", EPS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_split_qkv_rmsnorm_partial_rope_with_bias(num_tokens, num_q_heads,
+                                                   num_kv_heads, head_size,
+                                                   rotary_dim, eps, dtype,
+                                                   seed, device):
+    torch.manual_seed(seed)
+    torch.set_default_device(device)
+    init_device_properties_triton()
+
+    q_hidden_size = num_q_heads * head_size
+    kv_hidden_size = num_kv_heads * head_size
+    qkv = torch.randn(num_tokens,
+                      q_hidden_size + kv_hidden_size * 2,
+                      dtype=dtype,
+                      device=device)
+    q_weight = torch.randn(head_size, dtype=dtype, device=device)
+    k_weight = torch.randn(head_size, dtype=dtype, device=device)
+    q_bias = torch.randn(head_size, dtype=dtype, device=device)
+    k_bias = torch.randn(head_size, dtype=dtype, device=device)
+    sin = torch.from_numpy(
+        np.random.uniform(0, 1,
+                          [num_tokens, 1, 1, head_size])).to(dtype).npu()
+    cos = torch.from_numpy(
+        np.random.uniform(0, 1,
+                          [num_tokens, 1, 1, head_size])).to(dtype).npu()
+    # fused kernel
+    q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(input=qkv,
+                                              q_weight=q_weight,
+                                              k_weight=k_weight,
+                                              q_hidden_size=q_hidden_size,
+                                              kv_hidden_size=kv_hidden_size,
+                                              head_dim=head_size,
+                                              eps=eps,
+                                              rotary_dim=rotary_dim,
+                                              q_bias=q_bias,
+                                              k_bias=k_bias,
+                                              cos=cos,
+                                              sin=sin)
+
+    # split
+    _q, _k, v_gold = qkv.cpu().split(
+        [q_hidden_size, kv_hidden_size, kv_hidden_size], dim=-1)
+    # norm
+    _q = rms_norm(_q.reshape(-1, head_size),
+                  q_weight.cpu(),
+                  eps,
+                  norm_bias=q_bias.cpu())
+    _k = rms_norm(_k.reshape(-1, head_size),
+                  k_weight.cpu(),
+                  eps,
+                  norm_bias=k_bias.cpu())
+    _q = _q.reshape(num_tokens, 1, -1, head_size)
+    _k = _k.reshape(num_tokens, 1, -1, head_size)
+
+    # rope
+    q_gold, k_gold = custom_rope(_q, _k, sin.cpu(), cos.cpu(),
+                                 rotary_dim=rotary_dim)
     q_gold = q_gold.reshape(num_tokens, -1)
     k_gold = k_gold.reshape(num_tokens, -1)
 

--- a/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
@@ -15,23 +15,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+Graph fusion pass for QKV Split + RMSNorm + RoPE on Ascend NPU.
+
+This pass uses PyTorch's Inductor pattern matcher to find subgraphs that
+perform QKV split → per-head RMSNorm → RoPE, and replaces them with a
+single fused Triton kernel call (torch.ops.vllm.qkv_rmsnorm_rope).
+
+Supported patterns:
+  1. Full RoPE (rotary_dim == head_dim): uses npu_apply_rotary_pos_emb
+  2. Full RoPE with bias: same as (1) but with RMSNorm bias
+  3. Partial RoPE (rotary_dim < head_dim): uses rope_forward_triton
+  4. Partial RoPE with bias: same as (3) but with RMSNorm bias
+"""
 import torch
 import torch._inductor.pattern_matcher as pm
 from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
+from vllm.attention.layer import Attention
 from vllm.compilation.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import Range
 from vllm.logger import logger
 
-from vllm_ascend.utils import vllm_version_is
 
-if vllm_version_is("v0.15.0"):
-    from vllm.attention.layer import Attention  # type: ignore
-else:
-    from vllm.model_executor.layers.attention import Attention
-
-
+# =============================================================================
+# Pattern 1: Full RoPE via npu_apply_rotary_pos_emb (no bias)
+# =============================================================================
 class QKNormRopeFusionPattern:
+    """Matches QKV split + RMSNorm + full RoPE (npu_apply_rotary_pos_emb)."""
+
     def __init__(self, vllm_config, head_dim, num_heads, num_kv_heads, eps=1e-6):
         self.vllm_config = vllm_config
         self.head_dim = head_dim
@@ -47,19 +59,21 @@ class QKNormRopeFusionPattern:
         qkv = torch.empty(T, self.q_size + 2 * self.kv_size, dtype=torch.bfloat16, device="npu")
         q_weight = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
         k_weight = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        # cos/sin for full RoPE: [1, T, 1, head_dim] (duplicated HF format)
         cos = torch.empty(1, T, 1, self.head_dim, dtype=torch.bfloat16, device="npu")
         sin = torch.empty(1, T, 1, self.head_dim, dtype=torch.bfloat16, device="npu")
         return [qkv, q_weight, k_weight, cos, sin]
 
     def register(self, pm_pass: PatternMatcherPass):
         def pattern(
-            qkv: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+                qkv: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
         ):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
             q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
             q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, q_weight, self.eps)
 
+            # BUG FIX: original code used self.kv_hidden_size (undefined), should be self.head_dim
             k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
             k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, k_weight, self.eps)
 
@@ -74,7 +88,7 @@ class QKNormRopeFusionPattern:
             return q_rope, k_rope, v
 
         def replacement(
-            qkv: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+                qkv: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
         ):
             results = torch.ops.vllm.qkv_rmsnorm_rope(
                 input=qkv,
@@ -83,19 +97,24 @@ class QKNormRopeFusionPattern:
                 q_hidden_size=self.q_size,
                 kv_hidden_size=self.kv_size,
                 head_dim=self.head_dim,
+                rotary_dim=self.head_dim,  # full RoPE: rotary_dim == head_dim
                 eps=self.eps,
                 q_bias=None,
                 k_bias=None,
                 sin=sin,
                 cos=cos,
             )
-
             return results
 
         pm.register_replacement(pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass)
 
 
+# =============================================================================
+# Pattern 2: Full RoPE via npu_apply_rotary_pos_emb (with bias)
+# =============================================================================
 class QKNormRopeFusionPatternWithBias:
+    """Matches QKV split + RMSNorm (with bias) + full RoPE."""
+
     def __init__(self, vllm_config, head_dim, num_heads, num_kv_heads, eps=1e-6):
         self.head_dim = head_dim
         self.num_heads = num_heads
@@ -115,18 +134,17 @@ class QKNormRopeFusionPatternWithBias:
         k_bias = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
         cos = torch.empty(1, T, 1, self.head_dim, dtype=torch.bfloat16, device="npu")
         sin = torch.empty(1, T, 1, self.head_dim, dtype=torch.bfloat16, device="npu")
-
         return [qkv, q_weight, k_weight, q_bias, k_bias, cos, sin]
 
     def register(self, pm_pass: PatternMatcherPass):
         def pattern(
-            qkv: torch.Tensor,
-            q_weight: torch.Tensor,
-            k_weight: torch.Tensor,
-            q_bias: torch.Tensor,
-            k_bias: torch.Tensor,
-            cos: torch.Tensor,
-            sin: torch.Tensor,
+                qkv: torch.Tensor,
+                q_weight: torch.Tensor,
+                k_weight: torch.Tensor,
+                q_bias: torch.Tensor,
+                k_bias: torch.Tensor,
+                cos: torch.Tensor,
+                sin: torch.Tensor,
         ):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
@@ -149,13 +167,13 @@ class QKNormRopeFusionPatternWithBias:
             return q_rope, k_rope, v
 
         def replacement(
-            qkv: torch.Tensor,
-            q_weight: torch.Tensor,
-            k_weight: torch.Tensor,
-            q_bias: torch.Tensor,
-            k_bias: torch.Tensor,
-            cos: torch.Tensor,
-            sin: torch.Tensor,
+                qkv: torch.Tensor,
+                q_weight: torch.Tensor,
+                k_weight: torch.Tensor,
+                q_bias: torch.Tensor,
+                k_bias: torch.Tensor,
+                cos: torch.Tensor,
+                sin: torch.Tensor,
         ):
             results = torch.ops.vllm.qkv_rmsnorm_rope(
                 input=qkv,
@@ -164,6 +182,7 @@ class QKNormRopeFusionPatternWithBias:
                 q_hidden_size=self.q_size,
                 kv_hidden_size=self.kv_size,
                 head_dim=self.head_dim,
+                rotary_dim=self.head_dim,  # full RoPE
                 eps=self.eps,
                 q_bias=q_bias,
                 k_bias=k_bias,
@@ -175,30 +194,249 @@ class QKNormRopeFusionPatternWithBias:
         pm.register_replacement(pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass)
 
 
+# =============================================================================
+# Pattern 3: Partial RoPE via rope_forward_triton (no bias)
+# =============================================================================
+class QKNormPartialRopeFusionPattern:
+    """
+    Matches QKV split + RMSNorm + partial RoPE (rope_forward_triton).
+
+    This pattern handles models where rotary_dim < head_dim (e.g., Qwen3-Next
+    with partial_rotary_factor=0.5). The RoPE is applied only to the first
+    rotary_dim dimensions of each head.
+    """
+
+    def __init__(self, vllm_config, head_dim, num_heads, num_kv_heads, rotary_dim, eps=1e-6):
+        self.vllm_config = vllm_config
+        self.head_dim = head_dim
+        self.rotary_dim = rotary_dim
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.eps = eps
+        self.device = vllm_config.device_config.device if vllm_config.device_config else None
+
+    def get_inputs(self):
+        T = 5
+        qkv = torch.empty(T, self.q_size + 2 * self.kv_size, dtype=torch.bfloat16, device="npu")
+        q_weight = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        k_weight = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        # cos/sin for partial RoPE: [1, T, 1, rotary_dim] (not head_dim!)
+        # This matches the actual cos/sin shape from set_cos_and_sin() for
+        # models with partial_rotary_factor.
+        cos = torch.empty(1, T, 1, self.rotary_dim, dtype=torch.bfloat16, device="npu")
+        sin = torch.empty(1, T, 1, self.rotary_dim, dtype=torch.bfloat16, device="npu")
+        return [qkv, q_weight, k_weight, cos, sin]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+                qkv: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor,
+                cos: torch.Tensor, sin: torch.Tensor,
+        ):
+            # QKV split
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+            # Per-head RMSNorm on Q
+            q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+            q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, q_weight, self.eps)
+
+            # Per-head RMSNorm on K
+            k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+            k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, k_weight, self.eps)
+
+            # Flatten back and reshape for rope_forward_triton
+            q_flat = q_norm_out.view(q.shape)
+            k_flat = k_norm_out.view(k.shape)
+
+            # Reshape cos/sin for rope_forward_triton
+            cos = cos.view(-1, self.rotary_dim)
+            sin = sin.view(-1, self.rotary_dim)
+
+            # Reshape to [tokens, heads, head_dim] for rope
+            q = q_flat.contiguous().view(q_flat.shape[0], -1, self.head_dim)
+            k = k_flat.contiguous().view(k_flat.shape[0], -1, self.head_dim)
+
+            # Partial RoPE via triton kernel
+            query, key = torch.ops.vllm.rope_forward_triton(
+                q, k, cos, sin, rope_dim=self.rotary_dim, is_neox_style=True
+            )
+
+            return query.view(q.shape), key.view(k.shape), v
+
+        def replacement(
+                qkv: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor,
+                cos: torch.Tensor, sin: torch.Tensor,
+        ):
+            results = torch.ops.vllm.qkv_rmsnorm_rope(
+                input=qkv,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                q_hidden_size=self.q_size,
+                kv_hidden_size=self.kv_size,
+                head_dim=self.head_dim,
+                rotary_dim=self.rotary_dim,  # partial RoPE: rotary_dim < head_dim
+                eps=self.eps,
+                q_bias=None,
+                k_bias=None,
+                sin=sin,
+                cos=cos,
+            )
+            return results
+
+        pm.register_replacement(pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass)
+
+
+# =============================================================================
+# Pattern 4: Partial RoPE via rope_forward_triton (with bias)
+# =============================================================================
+class QKNormPartialRopeFusionPatternWithBias:
+    """Matches QKV split + RMSNorm (with bias) + partial RoPE."""
+
+    def __init__(self, vllm_config, head_dim, num_heads, num_kv_heads, rotary_dim, eps=1e-6):
+        self.head_dim = head_dim
+        self.rotary_dim = rotary_dim
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.eps = eps
+        self.vllm_config = vllm_config
+        self.device = vllm_config.device_config.device if vllm_config.device_config else None
+
+    def get_inputs(self):
+        T = 5
+        qkv = torch.empty(T, self.q_size + 2 * self.kv_size, dtype=torch.bfloat16, device="npu")
+        q_weight = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        k_weight = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        q_bias = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        k_bias = torch.empty(self.head_dim, dtype=torch.bfloat16, device="npu")
+        cos = torch.empty(1, T, 1, self.rotary_dim, dtype=torch.bfloat16, device="npu")
+        sin = torch.empty(1, T, 1, self.rotary_dim, dtype=torch.bfloat16, device="npu")
+        return [qkv, q_weight, k_weight, q_bias, k_bias, cos, sin]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+                qkv: torch.Tensor,
+                q_weight: torch.Tensor,
+                k_weight: torch.Tensor,
+                q_bias: torch.Tensor,
+                k_bias: torch.Tensor,
+                cos: torch.Tensor,
+                sin: torch.Tensor,
+        ):
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+            q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+            q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, q_weight, self.eps)
+            q_normed = q_norm_out + q_bias
+
+            k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+            k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, k_weight, self.eps)
+            k_normed = k_norm_out + k_bias
+
+            q_flat = q_normed.view(q.shape)
+            k_flat = k_normed.view(k.shape)
+
+            cos = cos.view(-1, self.rotary_dim)
+            sin = sin.view(-1, self.rotary_dim)
+
+            q = q_flat.contiguous().view(q_flat.shape[0], -1, self.head_dim)
+            k = k_flat.contiguous().view(k_flat.shape[0], -1, self.head_dim)
+
+            query, key = torch.ops.vllm.rope_forward_triton(
+                q, k, cos, sin, rope_dim=self.rotary_dim, is_neox_style=True
+            )
+
+            return query.view(q.shape), key.view(k.shape), v
+
+        def replacement(
+                qkv: torch.Tensor,
+                q_weight: torch.Tensor,
+                k_weight: torch.Tensor,
+                q_bias: torch.Tensor,
+                k_bias: torch.Tensor,
+                cos: torch.Tensor,
+                sin: torch.Tensor,
+        ):
+            results = torch.ops.vllm.qkv_rmsnorm_rope(
+                input=qkv,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                q_hidden_size=self.q_size,
+                kv_hidden_size=self.kv_size,
+                head_dim=self.head_dim,
+                rotary_dim=self.rotary_dim,
+                eps=self.eps,
+                q_bias=q_bias,
+                k_bias=k_bias,
+                cos=cos,
+                sin=sin,
+            )
+            return results
+
+        pm.register_replacement(pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass)
+
+
+# =============================================================================
+# Fusion Pass
+# =============================================================================
 class QKNormRopeFusionPass(VllmInductorPass):
     """
-    A pass for fusing QKV split and RMSNorm operations into a single qk_rmsnorm operator.
+    Inductor pass that fuses QKV split + RMSNorm + RoPE into a single
+    Triton kernel (torch.ops.vllm.qkv_rmsnorm_rope).
+
+    Handles both full RoPE (via npu_apply_rotary_pos_emb) and partial RoPE
+    (via rope_forward_triton) patterns, with and without RMSNorm bias.
     """
 
     def __init__(self, vllm_config: VllmConfig):
         super().__init__(vllm_config)
-        self.pattern_match_passes: PatternMatcherPass = PatternMatcherPass(pass_name="qknorm_rope_fusion_pass")
+        self.pattern_match_passes: PatternMatcherPass = PatternMatcherPass(
+            pass_name="qknorm_rope_fusion_pass"
+        )
 
         dtype = vllm_config.model_config.dtype
         if dtype not in (torch.bfloat16, torch.float16):
-            logger.debug("QKNorm and Rope fusion not enabled: unsupported dtype %s", dtype)
+            logger.debug(
+                "QKNorm and Rope fusion not enabled: unsupported dtype %s", dtype
+            )
             return
 
-        # use one attn layer to get meta (such as head_dim) for QKNormRopeFusionPattern
-        attn_layers: dict[str, Attention] = get_layers_from_vllm_config(vllm_config, Attention)
+        # Get attention layer metadata (head_dim, num_heads, etc.)
+        attn_layers: dict[str, Attention] = get_layers_from_vllm_config(
+            vllm_config, Attention
+        )
         if len(attn_layers) == 0:
-            logger.debug("QKNorm and Rope fusion enabled, but no Attention layers were discovered.")
+            logger.debug(
+                "QKNorm and Rope fusion enabled, but no Attention layers were discovered."
+            )
             return
+
         layer = next(iter(attn_layers.values()))
+
+        # Determine rotary_dim from model config (for partial RoPE support)
+        model_config = vllm_config.model_config
+        rotary_dim = layer.head_size  # default: full RoPE
+        if hasattr(model_config.hf_text_config, "partial_rotary_factor"):
+            factor = model_config.hf_text_config.partial_rotary_factor
+            computed = int(layer.head_size * factor)
+            if computed < layer.head_size:
+                rotary_dim = computed
+                logger.debug(
+                    "Partial RoPE detected: head_dim=%d, rotary_dim=%d (factor=%.2f)",
+                    layer.head_size, rotary_dim, factor,
+                )
+
         for epsilon in [1e-6, 1e-5]:
             if layer.head_size != 128:
-                logger.debug("QKNorm and Rope fusion not enabled: head_dim %d is not equal of 128", layer.head_size)
+                logger.debug(
+                    "QKNorm and Rope fusion not enabled: head_dim %d is not 128",
+                    layer.head_size,
+                )
                 continue
+
+            # Register full RoPE patterns (npu_apply_rotary_pos_emb)
             QKNormRopeFusionPattern(
                 vllm_config=vllm_config,
                 head_dim=layer.head_size,
@@ -214,6 +452,27 @@ class QKNormRopeFusionPass(VllmInductorPass):
                 num_kv_heads=layer.num_kv_heads,
                 eps=epsilon,
             ).register(self.pattern_match_passes)
+
+            # Register partial RoPE patterns (rope_forward_triton)
+            # only when the model actually uses partial RoPE
+            if rotary_dim < layer.head_size:
+                QKNormPartialRopeFusionPattern(
+                    vllm_config=vllm_config,
+                    head_dim=layer.head_size,
+                    num_heads=layer.num_heads,
+                    num_kv_heads=layer.num_kv_heads,
+                    rotary_dim=rotary_dim,
+                    eps=epsilon,
+                ).register(self.pattern_match_passes)
+
+                QKNormPartialRopeFusionPatternWithBias(
+                    vllm_config=vllm_config,
+                    head_dim=layer.head_size,
+                    num_heads=layer.num_heads,
+                    num_kv_heads=layer.num_kv_heads,
+                    rotary_dim=rotary_dim,
+                    eps=epsilon,
+                ).register(self.pattern_match_passes)
 
     def __call__(self, graph: torch.fx.Graph):
         self.begin()

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py
@@ -14,6 +14,31 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+"""
+Fused Triton kernel: QKV Split + per-head RMSNorm + RoPE (neox-style).
+
+This module fuses three operations into a single kernel to eliminate
+intermediate global memory reads/writes between RMSNorm and RoPE:
+
+  QKV tensor ─┬─ Q ─→ RMSNorm ─→ RoPE ─→ Q_out
+               ├─ K ─→ RMSNorm ─→ RoPE ─→ K_out
+               └─ V ─→ copy ────────────→ V_out
+
+Supports both full RoPE (ROPE_DIM == HEAD_DIM) and partial RoPE
+(ROPE_DIM < HEAD_DIM, e.g., Qwen3-Next with partial_rotary_factor=0.5).
+
+For partial RoPE, only the first ROPE_DIM dimensions of each attention head
+are rotated; the remaining HEAD_DIM - ROPE_DIM dimensions pass through
+with RMSNorm applied but no rotation.
+
+Design decisions:
+  - All intermediate computation (RMSNorm, RoPE) is done in float32 for
+    numerical precision, matching the standalone _triton_rope kernel behavior.
+  - cos/sin are expected in duplicated HuggingFace format:
+    [cos_θ₀, cos_θ₁, ..., cos_θ_{d/2-1}, cos_θ₀, cos_θ₁, ..., cos_θ_{d/2-1}]
+  - The kernel uses a 2D grid (n_rows, n_cols) for row/column parallelism
+    across the batch and hidden dimensions respectively.
+"""
 
 import torch
 import triton  # type: ignore
@@ -25,192 +50,361 @@ from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 @triton.jit
 def split_qkv_rmsnorm_rope_kernel(
-    input_ptr,
-    sin_ptr,
-    cos_ptr,
-    q_ptr,
-    k_ptr,
-    v_ptr,
-    q_weight_ptr,
-    q_bias_ptr,
-    k_weight_ptr,
-    k_bias_ptr,
-    batch_size,
-    q_hidden_size: tl.constexpr,
-    kv_hidden_size: tl.constexpr,
-    total_hidden_size: tl.constexpr,
-    eps: tl.constexpr,
-    Q_BLOCK_SIZE: tl.constexpr,
-    KV_BLOCK_SIZE: tl.constexpr,
-    BIAS: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    HALF_HEAD_DIM: tl.constexpr,
+        # Input/output pointers
+        input_ptr,
+        sin_ptr,
+        cos_ptr,
+        q_ptr,
+        k_ptr,
+        v_ptr,
+        # Weight pointers
+        q_weight_ptr,
+        q_bias_ptr,
+        k_weight_ptr,
+        k_bias_ptr,
+        # Scalar args
+        batch_size,
+        # Compile-time constant args
+        q_hidden_size: tl.constexpr,
+        kv_hidden_size: tl.constexpr,
+        total_hidden_size: tl.constexpr,
+        eps: tl.constexpr,
+        Q_BLOCK_SIZE: tl.constexpr,
+        KV_BLOCK_SIZE: tl.constexpr,
+        BIAS: tl.constexpr,
+        HEAD_DIM: tl.constexpr,
+        ROPE_DIM: tl.constexpr,
+        HALF_ROPE_DIM: tl.constexpr,
 ):
+    """
+    Fused QKV Split + RMSNorm + RoPE kernel.
+
+    Grid layout: (n_rows, n_cols) where
+      - n_rows handles batch dimension parallelism
+      - n_cols handles hidden dimension parallelism (tiled by KV_BLOCK_SIZE)
+
+    Requirements:
+      - HEAD_DIM must be a power of 2 and equal to KV_BLOCK_SIZE
+      - Q_BLOCK_SIZE must be divisible by HEAD_DIM
+      - ROPE_DIM <= HEAD_DIM, and ROPE_DIM must be even
+      - cos/sin are [1, batch_size, 1, ROPE_DIM] flattened, stride ROPE_DIM per token
+    """
     row_pid = tl.program_id(0)
     col_pid = tl.program_id(1)
     row_step = tl.num_programs(0)
-    # q
+
+    # ==================== Q Section ====================
+    # Data flow: split Q from QKV → per-head RMSNorm → RoPE → store
     weight_values = tl.load(q_weight_ptr + tl.arange(0, HEAD_DIM))
     if BIAS:
         bias_values = tl.load(q_bias_ptr + tl.arange(0, HEAD_DIM))
+
     input_offset = row_pid * total_hidden_size
     output_offset = row_pid * q_hidden_size
     input_offset_step = row_step * total_hidden_size
     output_offset_step = row_step * q_hidden_size
+
     for row_idx in tl.range(row_pid, batch_size, row_step):
         col_indices = col_pid * Q_BLOCK_SIZE + tl.arange(0, Q_BLOCK_SIZE)
         valid_mask = col_indices < q_hidden_size
+
+        # Load Q slice: [Q_BLOCK_SIZE] → reshape to [num_heads_in_block, HEAD_DIM]
         input_values = (
-            tl.load(input_ptr + input_offset + col_indices, mask=valid_mask, other=0.0)
+            tl.load(
+                input_ptr + input_offset + col_indices,
+                mask=valid_mask,
+                other=0.0,
+                )
             .to(tl.float32)
             .reshape(Q_BLOCK_SIZE // HEAD_DIM, HEAD_DIM)
         )
+
+        # Per-head RMSNorm: x_norm = x / sqrt(mean(x^2) + eps) * weight [+ bias]
         squares = input_values * input_values
         variances = tl.sum(squares, axis=1) / HEAD_DIM
-        reciprocal_std = (1 / tl.sqrt(variances + eps)).reshape(Q_BLOCK_SIZE // HEAD_DIM, 1)
-        normalized_values = input_values * reciprocal_std  # (Q_BLOCK_SIZE//HEAD_DIM, HEAD_DIM)
-        if BIAS:
-            normalized_values = (normalized_values * weight_values + bias_values).to(tl.bfloat16)
-        else:
-            normalized_values = (normalized_values * weight_values).to(tl.bfloat16)
+        reciprocal_std = (1 / tl.sqrt(variances + eps)).reshape(
+            Q_BLOCK_SIZE // HEAD_DIM, 1
+        )
+        normalized_values = input_values * reciprocal_std
 
-        sc_offsets = row_idx * HEAD_DIM + tl.arange(0, HEAD_DIM)
-        sin = (tl.load(sin_ptr + sc_offsets)).reshape(1, HEAD_DIM)
-        cos = (tl.load(cos_ptr + sc_offsets)).reshape(1, HEAD_DIM)
-        x1 = tl.extract_slice(
-            normalized_values,
+        # Apply RMSNorm weight and optional bias (still in float32)
+        if BIAS:
+            output_values = normalized_values * weight_values + bias_values
+        else:
+            output_values = normalized_values * weight_values
+        # output_values shape: [Q_BLOCK_SIZE // HEAD_DIM, HEAD_DIM], dtype: float32
+
+        # --- RoPE (neox-style, in float32 for precision) ---
+        # cos/sin layout: flattened [1, batch, 1, ROPE_DIM], stride = ROPE_DIM per token
+        sc_offsets = row_idx * ROPE_DIM + tl.arange(0, ROPE_DIM)
+        sin_vals = (
+            tl.load(sin_ptr + sc_offsets).to(tl.float32).reshape(1, ROPE_DIM)
+        )
+        cos_vals = (
+            tl.load(cos_ptr + sc_offsets).to(tl.float32).reshape(1, ROPE_DIM)
+        )
+
+        # Start with full output (preserves passthrough dims for partial RoPE)
+        roped_q = output_values
+
+        # Extract the first ROPE_DIM columns for rotation
+        rope_part = tl.extract_slice(
+            output_values,
             offsets=(0, 0),
-            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            sizes=(Q_BLOCK_SIZE // HEAD_DIM, ROPE_DIM),
+            strides=(1, 1),
+        )
+
+        # Neox-style rotation: out = [-x2, x1] * sin + [x1, x2] * cos
+        # where x1 = first_half, x2 = second_half
+        x1 = tl.extract_slice(
+            rope_part,
+            offsets=(0, 0),
+            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
         x2 = tl.extract_slice(
-            normalized_values,
-            offsets=(0, HALF_HEAD_DIM),
-            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            rope_part,
+            offsets=(0, HALF_ROPE_DIM),
+            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
-        cat_x = tl.zeros((Q_BLOCK_SIZE // HEAD_DIM, HEAD_DIM), dtype=tl.bfloat16)
+        cat_x = tl.zeros(
+            (Q_BLOCK_SIZE // HEAD_DIM, ROPE_DIM), dtype=tl.float32
+        )
         cat_x = tl.insert_slice(
             cat_x,
             -x2,
             offsets=(0, 0),
-            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
         cat_x = tl.insert_slice(
             cat_x,
             x1,
-            offsets=(0, HALF_HEAD_DIM),
-            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            offsets=(0, HALF_ROPE_DIM),
+            sizes=(Q_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
-        roped_q = cat_x * sin + normalized_values * cos
+        roped_part = cat_x * sin_vals + rope_part * cos_vals
+
+        # Insert rotated part back (for full RoPE this replaces everything;
+        # for partial RoPE this only replaces the first ROPE_DIM columns)
+        roped_q = tl.insert_slice(
+            roped_q,
+            roped_part,
+            offsets=(0, 0),
+            sizes=(Q_BLOCK_SIZE // HEAD_DIM, ROPE_DIM),
+            strides=(1, 1),
+        )
+
+        # Store Q output (convert float32 → output dtype at store boundary)
         tl.store(
             q_ptr + output_offset + col_indices,
-            roped_q.reshape(Q_BLOCK_SIZE).to(q_ptr.dtype.element_ty),
+            roped_q.to(q_ptr.dtype.element_ty).reshape(Q_BLOCK_SIZE),
             mask=valid_mask,
-        )
+            )
         input_offset += input_offset_step
         output_offset += output_offset_step
 
+    # ==================== K Section ====================
+    # Data flow: split K from QKV → per-head RMSNorm → RoPE → store
     weight_values = tl.load(k_weight_ptr + tl.arange(0, HEAD_DIM))
     if BIAS:
         bias_values = tl.load(k_bias_ptr + tl.arange(0, HEAD_DIM))
+
     input_offset = row_pid * total_hidden_size + q_hidden_size
     output_offset = row_pid * kv_hidden_size
     output_offset_step = row_step * kv_hidden_size
+
     for row_idx in tl.range(row_pid, batch_size, row_step):
         col_indices = col_pid * KV_BLOCK_SIZE + tl.arange(0, KV_BLOCK_SIZE)
         valid_mask = col_indices < kv_hidden_size
+
+        # Load K slice: [KV_BLOCK_SIZE] → reshape to [num_kv_heads_in_block, HEAD_DIM]
         input_values = (
-            tl.load(input_ptr + input_offset + col_indices, mask=valid_mask, other=0.0)
+            tl.load(
+                input_ptr + input_offset + col_indices,
+                mask=valid_mask,
+                other=0.0,
+                )
             .to(tl.float32)
             .reshape(KV_BLOCK_SIZE // HEAD_DIM, HEAD_DIM)
         )
+
+        # Per-head RMSNorm
         squares = input_values * input_values
         variances = tl.sum(squares, axis=1) / HEAD_DIM
-        reciprocal_std = (1 / tl.sqrt(variances + eps)).reshape(KV_BLOCK_SIZE // HEAD_DIM, 1)
-        normalized_values = input_values * reciprocal_std  # (KV_BLOCK_SIZE/HEAD_DIM, HEAD_DIM)
+        reciprocal_std = (1 / tl.sqrt(variances + eps)).reshape(
+            KV_BLOCK_SIZE // HEAD_DIM, 1
+        )
+        normalized_values = input_values * reciprocal_std
+
         if BIAS:
-            normalized_values = (normalized_values * weight_values + bias_values).to(tl.bfloat16)
+            output_values = normalized_values * weight_values + bias_values
         else:
-            normalized_values = (normalized_values * weight_values).to(tl.bfloat16)
-        sc_offsets = row_idx * HEAD_DIM + tl.arange(0, HEAD_DIM)
-        sin = (tl.load(sin_ptr + sc_offsets)).reshape(1, HEAD_DIM)
-        cos = (tl.load(cos_ptr + sc_offsets)).reshape(1, HEAD_DIM)
-        x1 = tl.extract_slice(
-            normalized_values,
+            output_values = normalized_values * weight_values
+
+        # --- RoPE for K (same logic as Q, using KV_BLOCK_SIZE) ---
+        # NOTE: PR #6109 had a bug here using Q_BLOCK_SIZE instead of KV_BLOCK_SIZE
+        sc_offsets = row_idx * ROPE_DIM + tl.arange(0, ROPE_DIM)
+        sin_vals = (
+            tl.load(sin_ptr + sc_offsets).to(tl.float32).reshape(1, ROPE_DIM)
+        )
+        cos_vals = (
+            tl.load(cos_ptr + sc_offsets).to(tl.float32).reshape(1, ROPE_DIM)
+        )
+
+        roped_k = output_values
+
+        rope_part = tl.extract_slice(
+            output_values,
             offsets=(0, 0),
-            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            sizes=(KV_BLOCK_SIZE // HEAD_DIM, ROPE_DIM),
+            strides=(1, 1),
+        )
+
+        x1 = tl.extract_slice(
+            rope_part,
+            offsets=(0, 0),
+            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
         x2 = tl.extract_slice(
-            normalized_values,
-            offsets=(0, HALF_HEAD_DIM),
-            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            rope_part,
+            offsets=(0, HALF_ROPE_DIM),
+            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
-        cat_x = tl.zeros((KV_BLOCK_SIZE // HEAD_DIM, HEAD_DIM), dtype=tl.bfloat16)
+        cat_x = tl.zeros(
+            (KV_BLOCK_SIZE // HEAD_DIM, ROPE_DIM), dtype=tl.float32
+        )
         cat_x = tl.insert_slice(
             cat_x,
             -x2,
             offsets=(0, 0),
-            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
         cat_x = tl.insert_slice(
             cat_x,
             x1,
-            offsets=(0, HALF_HEAD_DIM),
-            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_HEAD_DIM),
+            offsets=(0, HALF_ROPE_DIM),
+            sizes=(KV_BLOCK_SIZE // HEAD_DIM, HALF_ROPE_DIM),
             strides=(1, 1),
         )
-        roped_k = cat_x * sin + normalized_values * cos
+        roped_part = cat_x * sin_vals + rope_part * cos_vals
 
+        roped_k = tl.insert_slice(
+            roped_k,
+            roped_part,
+            offsets=(0, 0),
+            sizes=(KV_BLOCK_SIZE // HEAD_DIM, ROPE_DIM),
+            strides=(1, 1),
+        )
+
+        # Store K output
         tl.store(
             k_ptr + output_offset + col_indices,
-            roped_k.to(tl.bfloat16).reshape(KV_BLOCK_SIZE),
+            roped_k.to(k_ptr.dtype.element_ty).reshape(KV_BLOCK_SIZE),
             mask=valid_mask,
-        )
+            )
         input_offset += input_offset_step
         output_offset += output_offset_step
 
-    input_offset = row_pid * total_hidden_size + q_hidden_size + kv_hidden_size
+    # ==================== V Section ====================
+    # Data flow: split V from QKV → copy to output (no norm, no RoPE)
+    input_offset = (
+            row_pid * total_hidden_size + q_hidden_size + kv_hidden_size
+    )
     output_offset = row_pid * kv_hidden_size
+
     for _ in tl.range(row_pid, batch_size, row_step):
         col_indices = col_pid * KV_BLOCK_SIZE + tl.arange(0, KV_BLOCK_SIZE)
         valid_mask = col_indices < kv_hidden_size
-        input_values = tl.load(input_ptr + input_offset + col_indices, mask=valid_mask, other=0.0)
-        tl.store(v_ptr + output_offset + col_indices, input_values, mask=valid_mask)
+        input_values = tl.load(
+            input_ptr + input_offset + col_indices,
+            mask=valid_mask,
+            other=0.0,
+            )
+        tl.store(
+            v_ptr + output_offset + col_indices,
+            input_values,
+            mask=valid_mask,
+            )
         input_offset += input_offset_step
         output_offset += output_offset_step
 
 
 def split_qkv_rmsnorm_rope_impl(
-    input: torch.Tensor,
-    sin: torch.Tensor,
-    cos: torch.Tensor,
-    q_weight: torch.Tensor,
-    k_weight: torch.Tensor,
-    q_hidden_size: int,
-    kv_hidden_size: int,
-    head_dim: int,
-    eps: float,
-    q_bias: torch.Tensor | None = None,
-    k_bias: torch.Tensor | None = None,
+        input: torch.Tensor,
+        sin: torch.Tensor,
+        cos: torch.Tensor,
+        q_weight: torch.Tensor,
+        k_weight: torch.Tensor,
+        q_hidden_size: int,
+        kv_hidden_size: int,
+        head_dim: int,
+        rotary_dim: int,
+        eps: float,
+        q_bias: torch.Tensor | None = None,
+        k_bias: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Host-side launcher for the fused QKV Split + RMSNorm + RoPE kernel.
+
+    Args:
+        input: [batch_size, q_hidden_size + 2 * kv_hidden_size]
+        sin, cos: [1, batch_size, 1, rotary_dim] or any shape that flattens
+                  to [batch_size * rotary_dim] with stride rotary_dim per token.
+                  Values are in duplicated HuggingFace format.
+        q_weight, k_weight: [head_dim] per-head RMSNorm weights
+        q_hidden_size: total Q dimension (num_q_heads * head_dim)
+        kv_hidden_size: total KV dimension (num_kv_heads * head_dim)
+        head_dim: dimension per attention head (must be power of 2)
+        rotary_dim: number of dimensions to apply RoPE
+                    (= head_dim for full RoPE, < head_dim for partial RoPE)
+        eps: RMSNorm epsilon
+        q_bias, k_bias: optional per-head biases [head_dim]
+
+    Returns:
+        (q_output, k_output, v_output) each as [batch_size, hidden_size]
+    """
     KV_BLOCK_SIZE = triton.next_power_of_2(head_dim)
-    assert head_dim == KV_BLOCK_SIZE
-    assert q_hidden_size % kv_hidden_size == 0
+    assert head_dim == KV_BLOCK_SIZE, (
+        f"head_dim ({head_dim}) must be a power of 2"
+    )
+    assert q_hidden_size % kv_hidden_size == 0, (
+        f"q_hidden_size ({q_hidden_size}) must be divisible by "
+        f"kv_hidden_size ({kv_hidden_size})"
+    )
+    assert rotary_dim <= head_dim, (
+        f"rotary_dim ({rotary_dim}) must be <= head_dim ({head_dim})"
+    )
+    assert rotary_dim % 2 == 0, (
+        f"rotary_dim ({rotary_dim}) must be even"
+    )
+
     Q_BLOCK_SIZE = q_hidden_size // kv_hidden_size * head_dim
     batch_size = input.shape[0]
     total_hidden_size = q_hidden_size + kv_hidden_size * 2
-    q_output = torch.empty(batch_size, q_hidden_size, device=input.device, dtype=input.dtype)
-    k_output = torch.empty(batch_size, kv_hidden_size, device=input.device, dtype=input.dtype)
-    v_output = torch.empty(batch_size, kv_hidden_size, device=input.device, dtype=input.dtype)
+
+    q_output = torch.empty(
+        batch_size, q_hidden_size, device=input.device, dtype=input.dtype
+    )
+    k_output = torch.empty(
+        batch_size, kv_hidden_size, device=input.device, dtype=input.dtype
+    )
+    v_output = torch.empty(
+        batch_size, kv_hidden_size, device=input.device, dtype=input.dtype
+    )
+
     n_cols = kv_hidden_size // KV_BLOCK_SIZE
     num_vectorcore = get_vectorcore_num()
-    assert num_vectorcore % n_cols == 0
+    assert num_vectorcore % n_cols == 0, (
+        f"num_vectorcore ({num_vectorcore}) must be divisible by "
+        f"n_cols ({n_cols})"
+    )
     n_rows = num_vectorcore // n_cols
     BIAS = q_bias is not None
 
@@ -234,26 +428,27 @@ def split_qkv_rmsnorm_rope_impl(
         KV_BLOCK_SIZE,
         BIAS,
         head_dim,
-        head_dim // 2,
-    )
+        rotary_dim,
+        rotary_dim // 2,
+        )
     return q_output, k_output, v_output
 
 
 def split_qkv_rmsnorm_rope_impl_fake(
-    input: torch.Tensor,
-    sin: torch.Tensor,
-    cos: torch.Tensor,
-    q_weight: torch.Tensor,
-    k_weight: torch.Tensor,
-    q_hidden_size: int,
-    kv_hidden_size: int,
-    head_dim: int,
-    eps: float,
-    q_bias: torch.Tensor | None = None,
-    k_bias: torch.Tensor | None = None,
+        input: torch.Tensor,
+        sin: torch.Tensor,
+        cos: torch.Tensor,
+        q_weight: torch.Tensor,
+        k_weight: torch.Tensor,
+        q_hidden_size: int,
+        kv_hidden_size: int,
+        head_dim: int,
+        rotary_dim: int,
+        eps: float,
+        q_bias: torch.Tensor | None = None,
+        k_bias: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    # Fake implementation for shape inference during Dynamo/AOT tracing.
-    # Note: sin and cos are not used in shape computation, but must be present in signature.
+    """Fake implementation for shape inference during Dynamo/AOT tracing."""
     batch_size = input.shape[0]
     q_output = torch.empty(
         batch_size,


### PR DESCRIPTION
Add support for partial Rotary Position Embedding where only a subset of head dimensions (rotary_dim < head_dim) receives rotation, while the remaining dimensions pass through unchanged.

Changes:
- Kernel: replace HALF_HEAD_DIM with ROPE_DIM/HALF_ROPE_DIM, extract rope_part for rotation and insert back, keep RoPE in float32, fix cos/sin offset to use ROPE_DIM stride instead of HEAD_DIM
- Fusion pass: add QKNormPartialRopeFusionPattern and QKNormPartialRopeFusionPatternWithBias for graph pattern matching, dynamically read rotary_dim from HF config partial_rotary_factor, fix cos/sin shape to use rotary_dim instead of head_dim, only register partial RoPE patterns when model actually uses it
- Tests: update custom_rope reference for partial RoPE, add test_split_qkv_rmsnorm_partial_rope and with_bias variants

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
