### PR TITLE
[Triton] Add muls_add triton kernel and integrate into GLM4 MoE

### DIFF
--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -24,6 +24,7 @@ import vllm_ascend.ops.register_custom_ops  # noqa
 
 if HAS_TRITON:
     import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope  # noqa
+    import vllm_ascend.ops.triton.muls_add  # noqa
 
 import vllm_ascend.ops.vocab_parallel_embedding  # noqa
 from vllm_ascend.ops.activation import AscendQuickGELU, AscendSiluAndMul

--- a/vllm_ascend/ops/triton/muls_add.py
+++ b/vllm_ascend/ops/triton/muls_add.py
@@ -1,0 +1,54 @@
+import torch
+import triton
+import triton.language as tl
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit
+def muls_add_kernel(
+    x_ptr,
+    y_ptr,
+    output_ptr,
+    scale,
+    n_elements,
+    n_blocks,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+    for block_id in range(pid, n_blocks, num_programs):
+        block_start = block_id * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(y_ptr + offsets, mask=mask)
+        output = x * scale + y
+        tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def muls_add_triton(x: torch.Tensor, y: torch.Tensor, scale: float) -> torch.Tensor:
+    assert x.shape == y.shape, "Input tensors must have the same shape."
+    hidden_size = x.shape[-1]
+
+    n_elements = x.numel()
+    output = torch.empty_like(x)
+
+    num_cores = get_vectorcore_num()
+
+    BLOCK_SIZE = max(hidden_size // 2, 1024)
+
+    num_blocks = (n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_programs = min(num_blocks, num_cores)
+
+    muls_add_kernel[(num_programs,)](
+        x,
+        y,
+        output,
+        scale,
+        n_elements,
+        num_blocks,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    return output

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -35,3 +35,4 @@ import vllm_ascend.patch.worker.patch_v2_eagle  # noqa
 import vllm_ascend.patch.worker.patch_v2_uva  # noqa
 import vllm_ascend.patch.worker.patch_huanyuan_vl  # noqa
 import vllm_ascend.patch.worker.patch_npugraph_ex_triton  # noqa
+import vllm_ascend.patch.worker.patch_glm4_moe  # noqa

--- a/vllm_ascend/patch/worker/patch_glm4_moe.py
+++ b/vllm_ascend/patch/worker/patch_glm4_moe.py
@@ -1,0 +1,31 @@
+import torch
+from vllm.model_executor.models.glm4_moe import Glm4MoE
+
+from vllm_ascend.ops.triton.muls_add import muls_add_triton
+
+
+def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    num_tokens, hidden_dim = hidden_states.shape
+    hidden_states = hidden_states.view(-1, hidden_dim)
+
+    router_logits = self.gate(hidden_states.to(dtype=torch.float32))
+
+    fused_moe_out = self.experts(hidden_states=hidden_states, router_logits=router_logits)
+
+    if self.shared_experts is not None:
+        shared_output, final_hidden_states = fused_moe_out
+        assert shared_output is not None
+        final_hidden_states = muls_add_triton(
+            x=final_hidden_states,
+            y=shared_output,
+            scale=float(self.routed_scaling_factor),
+        )
+    else:
+        final_hidden_states = fused_moe_out * self.routed_scaling_factor
+
+    if self.tp_size > 1:
+        final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
+    return final_hidden_states.view(num_tokens, hidden_dim)
+
+
+Glm4MoE.forward = forward


### PR DESCRIPTION
Add muls_add triton kernel for fused multiply-add operation and patch Glm4MoE forward to use it for performance acceleration on Ascend NPU.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
