### PR TITLE
[Lint] Adapt lint tools for windows

### DIFF
--- a/tools/actionlint.sh
+++ b/tools/actionlint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/check_repo.sh
+++ b/tools/check_repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/collect_user_first_contribution.sh
+++ b/tools/collect_user_first_contribution.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/install_flash_infer_attention_score_ops_a2.sh
+++ b/tools/install_flash_infer_attention_score_ops_a2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/install_flash_infer_attention_score_ops_a3.sh
+++ b/tools/install_flash_infer_attention_score_ops_a3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/mooncake_installer.sh
+++ b/tools/mooncake_installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/png-lint.sh
+++ b/tools/png-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.

--- a/tools/sphinx-lint.sh
+++ b/tools/sphinx-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.


### PR DESCRIPTION
### What this PR does / why we need it?
If users run bash format.sh with `git bash` on windows system, there exists `Executable /bin/bash not found` error. This is because in Windows Git Bash environment, the Bash executable is actually located at `/usr/bin/bash`, while the `/bin` directory may not exist, or may be just an empty directory or a broken symlink that does not contain bash.

### Does this PR introduce _any_ user-facing change?
None

### How was this patch tested?
With this PR and `pre-commit` installed, windows coders can directly run `bash format.sh` to clean lint issues.

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
