### PR TITLE
[CI]Style: Convert `test/` to ruff format(Batch #4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,14 @@ exclude = [
     "tests/e2e/vllm_interface/",
     "tests/e2e/weekly/",
     "tests/e2e/nightly/single_node/",
-
-    "tests/ut/_310p/",
-    "tests/ut/attention/",
-    "tests/ut/base.py",
+    
+    "tests/ut/batch_invariant/",
+    "tests/ut/compilation/",
+    "tests/ut/conftest.py",
+    "tests/ut/core/",
+    "tests/ut/device_allocator/",
+    "tests/ut/distributed/",
+    "tests/ut/eplb/",
     
     "tests/ut/batch_invariant/",
     "tests/ut/compilation/",

--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -78,4 +78,3 @@ def test_mm_encoder_attention_310_forward_oot_with_padding():
 
     assert out.shape == query.shape
     torch.testing.assert_close(out, query + 1.0)
-

--- a/tests/ut/_310p/quantization/test_modelslim_config_310.py
+++ b/tests/ut/_310p/quantization/test_modelslim_config_310.py
@@ -21,8 +21,8 @@ from vllm.model_executor.layers.linear import LinearBase
 
 from tests.ut.base import TestBase
 from vllm_ascend._310p.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod310
-from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend._310p.quantization.modelslim_config import AscendModelSlimConfig310
+from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 
 
 class TestAscendModelSlimConfig310(TestBase):

--- a/tests/ut/_310p/quantization/test_w8a8sc_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8sc_310.py
@@ -24,53 +24,46 @@ from vllm_ascend._310p.quantization.methods.w8a8sc import AscendW8A8SCLinearMeth
 
 
 class TestAscendW8A8SCLinearMethod310(TestBase):
-
     def setUp(self):
         self.method = AscendW8A8SCLinearMethod310()
 
     def test_get_weight_310(self):
         weight = self.method.get_weight(10, 20)
         self.assertEqual(weight["weight"].dtype, torch.int8)
-        self.assertEqual(weight["weight"].shape, (10 * 20, ))
+        self.assertEqual(weight["weight"].shape, (10 * 20,))
         self.assertEqual(weight["index"].dtype, torch.int8)
         index_len = math.ceil(10 / 256) * math.ceil(20 / 128) * 8
-        self.assertEqual(weight["index"].shape, (index_len, ))
+        self.assertEqual(weight["index"].shape, (index_len,))
         self.assertEqual(weight["info"].dtype, torch.int64)
-        self.assertEqual(weight["info"].shape, (5, ))
+        self.assertEqual(weight["info"].shape, (5,))
 
     def test_get_pertensor_param_310(self):
         params = self.method.get_pertensor_param(torch.float16)
         self.assertEqual(params["input_scale"].dtype, torch.float16)
         self.assertEqual(params["input_offset"].dtype, torch.int8)
-        self.assertEqual(params["input_scale"].shape, (1, ))
-        self.assertEqual(params["input_offset"].shape, (1, ))
+        self.assertEqual(params["input_scale"].shape, (1,))
+        self.assertEqual(params["input_offset"].shape, (1,))
 
     def test_get_perchannel_param_310(self):
         params = self.method.get_perchannel_param(10, torch.float16)
 
         self.assertEqual(params["quant_bias"].dtype, torch.int32)
         self.assertEqual(params["deq_scale"].dtype, torch.int64)
-        self.assertEqual(params["quant_bias"].shape, (10, ))
-        self.assertEqual(params["deq_scale"].shape, (10, ))
+        self.assertEqual(params["quant_bias"].shape, (10,))
+        self.assertEqual(params["deq_scale"].shape, (10,))
 
-    @pytest.mark.skip(
-        "Skip as npu_matmul_compress_dequant will be supported in PTA 26.0.0.")
+    @pytest.mark.skip("Skip as npu_matmul_compress_dequant will be supported in PTA 26.0.0.")
     @patch("torch.ops.vllm.quantize")
     @patch("torch_npu.npu_matmul_compress_dequant")
-    def test_apply_with_x_not_int8_310(self, mock_matmul_compress_dequant,
-                                       mock_quantize):
+    def test_apply_with_x_not_int8_310(self, mock_matmul_compress_dequant, mock_quantize):
         layer = MagicMock()
         layer.aclnn_input_scale = torch.randn(256)
         layer.aclnn_input_scale_reciprocal = 1.0 / layer.aclnn_input_scale
-        layer.aclnn_input_offset = torch.randint(-128,
-                                                 127, (256, ),
-                                                 dtype=torch.int8)
-        layer.weight = torch.randint(-128,
-                                     127, (256 * 128, ),
-                                     dtype=torch.int8)
-        layer.index = torch.randint(-128, 127, (8, ), dtype=torch.int8)
+        layer.aclnn_input_offset = torch.randint(-128, 127, (256,), dtype=torch.int8)
+        layer.weight = torch.randint(-128, 127, (256 * 128,), dtype=torch.int8)
+        layer.index = torch.randint(-128, 127, (8,), dtype=torch.int8)
         layer.deq_scale = torch.randn(128)
-        layer.quant_bias = torch.randint(-128, 127, (256, ))
+        layer.quant_bias = torch.randint(-128, 127, (256,))
         layer.params_dtype = torch.float16
 
         x = torch.randn(32, 128)
@@ -82,31 +75,25 @@ class TestAscendW8A8SCLinearMethod310(TestBase):
 
         output = self.method.apply(layer, x, tp_rank=0)
 
-        mock_quantize.assert_called_with(x, layer.aclnn_input_scale,
-                                         layer.aclnn_input_scale_reciprocal,
-                                         layer.aclnn_input_offset)
+        mock_quantize.assert_called_with(
+            x, layer.aclnn_input_scale, layer.aclnn_input_scale_reciprocal, layer.aclnn_input_offset
+        )
         mock_matmul_compress_dequant.assert_called_with(
-            expect_x_output, layer.weight, layer.index, layer.quant_bias,
-            layer.deq_scale)
+            expect_x_output, layer.weight, layer.index, layer.quant_bias, layer.deq_scale
+        )
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @pytest.mark.skip(
-        "Skip as npu_matmul_compress_dequant will be supported in PTA 26.0.0.")
+    @pytest.mark.skip("Skip as npu_matmul_compress_dequant will be supported in PTA 26.0.0.")
     @patch("torch.ops.vllm.quantize")
     @patch("torch_npu.npu_matmul_compress_dequant")
-    def test_apply_with_x_is_int8_310(self, mock_matmul_compress_dequant,
-                                      mock_quantize):
+    def test_apply_with_x_is_int8_310(self, mock_matmul_compress_dequant, mock_quantize):
         layer = MagicMock()
         layer.aclnn_input_scale = torch.randn(256)
-        layer.aclnn_input_offset = torch.randint(-128,
-                                                 127, (256, ),
-                                                 dtype=torch.int8)
-        layer.weight = torch.randint(-128,
-                                     127, (256 * 128, ),
-                                     dtype=torch.int8)
-        layer.index = torch.randint(-128, 127, (8, ), dtype=torch.int8)
+        layer.aclnn_input_offset = torch.randint(-128, 127, (256,), dtype=torch.int8)
+        layer.weight = torch.randint(-128, 127, (256 * 128,), dtype=torch.int8)
+        layer.index = torch.randint(-128, 127, (8,), dtype=torch.int8)
         layer.deq_scale = torch.randn(128)
-        layer.quant_bias = torch.randint(-128, 127, (256, ))
+        layer.quant_bias = torch.randint(-128, 127, (256,))
         layer.params_dtype = torch.float16
 
         x = torch.randint(-128, 127, (32, 128), dtype=torch.int8)
@@ -117,6 +104,5 @@ class TestAscendW8A8SCLinearMethod310(TestBase):
         output = self.method.apply(layer, x, tp_rank=0)
 
         mock_quantize.assert_not_called()
-        mock_matmul_compress_dequant.assert_called_with(
-            x, layer.weight, layer.index, layer.quant_bias, layer.deq_scale)
+        mock_matmul_compress_dequant.assert_called_with(x, layer.weight, layer.index, layer.quant_bias, layer.deq_scale)
         self.assertTrue(torch.equal(output, expected_y_output))

--- a/tests/ut/attention/test_attention_cp.py
+++ b/tests/ut/attention/test_attention_cp.py
@@ -1,4 +1,3 @@
-from typing import List
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -6,16 +5,14 @@ import torch
 from tests.ut.attention.utils import patch_distributed_groups
 from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import AscendMetadata
-from vllm_ascend.attention.context_parallel.attention_cp import \
-    AscendAttentionCPImpl
+from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionCPImpl
 from vllm_ascend.attention.context_parallel.common_cp import (
-    AscendMetadataForPrefill, AscendPCPMetadata,_npu_attention_update,
-    _npu_attn_out_lse_update,_out_lse_reshape,
-    _process_attn_out_lse,_update_out_and_lse)
+    AscendMetadataForPrefill,
+    AscendPCPMetadata,
+)
 
 
 class TestAscendAttentionCPImpl(TestBase):
-
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def setUp(self):
         self.layer = MagicMock()
@@ -30,15 +27,14 @@ class TestAscendAttentionCPImpl(TestBase):
         self.attn_metadata = MagicMock()
         self.attn_metadata.return_value = "1"
 
-        self.layer_no_quant = MagicMock(
-            spec=['layer_name', '_k_scale_float', '_v_scale_float'])
+        self.layer_no_quant = MagicMock(spec=["layer_name", "_k_scale_float", "_v_scale_float"])
         self.layer_no_quant.layer_name = "test_layer"
         self.layer_no_quant._k_scale_float = 1.0
         self.layer_no_quant._v_scale_float = 1.0
         self.mock_vllm_config = MagicMock()
         self.config_patcher = patch(
-            'vllm_ascend.attention.attention_v1.get_current_vllm_config',
-            return_value=self.mock_vllm_config)
+            "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
+        )
         self.config_patcher.start()
 
         self.impl = AscendAttentionCPImpl(
@@ -51,7 +47,8 @@ class TestAscendAttentionCPImpl(TestBase):
             kv_cache_dtype="float16",
             logits_soft_cap=None,
             attn_type=self.attention_type.DECODER,
-            kv_sharing_target_layer_name=None)
+            kv_sharing_target_layer_name=None,
+        )
 
     def test_init(self):
         self.assertEqual(self.impl.pcp_size, 2)
@@ -77,33 +74,31 @@ class TestAscendAttentionCPImpl(TestBase):
         attn_metadata.prefill.pcp_metadata.q_head_idx = torch.tensor([0])
         attn_metadata.prefill.pcp_metadata.q_tail_idx = torch.tensor([1])
         attn_metadata.prefill.pcp_metadata.q_full_idx = torch.tensor([0, 1])
-        attn_metadata.prefill.pcp_metadata.kv_with_q_head_mask_idx = torch.tensor(
-            [0])
-        attn_metadata.prefill.pcp_metadata.kv_with_q_tail_nomask_idx = torch.tensor(
-            [0])
-        attn_metadata.prefill.pcp_metadata.kv_with_q_tail_mask_idx = torch.tensor(
-            [0])
-        attn_metadata.prefill.pcp_metadata.pcp_fa_query_idx = torch.tensor(
-            [0, 1])
+        attn_metadata.prefill.pcp_metadata.kv_with_q_head_mask_idx = torch.tensor([0])
+        attn_metadata.prefill.pcp_metadata.kv_with_q_tail_nomask_idx = torch.tensor([0])
+        attn_metadata.prefill.pcp_metadata.kv_with_q_tail_mask_idx = torch.tensor([0])
+        attn_metadata.prefill.pcp_metadata.pcp_fa_query_idx = torch.tensor([0, 1])
         attn_metadata.prefill.pcp_metadata.pcp_use_hybrid_attn = False
 
-        output, attn_lse = self.impl._forward_prefill_cp(
-            query, key, value, attn_metadata)
+        output, attn_lse = self.impl._forward_prefill_cp(query, key, value, attn_metadata)
 
         self.assertEqual(output.shape[0], 2)
         self.assertEqual(output.shape[1], 4)
         self.assertEqual(output.shape[2], 128)
 
-    @patch('torch_npu.npu_attention_update')
+    @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
-    @patch(
-        'vllm_ascend.ascend_forward_context.get_forward_context'
-    )
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch_distributed_groups(dcp_size=2, pcp_size=2)
-    def test_forward_decode_pcp_dcp(self, mock_all2all, mock_dcp, mock_pcp,
-                                    mock_get_forward_context,
-                                    mock_npu_fused_infer_attention_score,
-                                    mock_npu_attention_update):
+    def test_forward_decode_pcp_dcp(
+        self,
+        mock_all2all,
+        mock_dcp,
+        mock_pcp,
+        mock_get_forward_context,
+        mock_npu_fused_infer_attention_score,
+        mock_npu_attention_update,
+    ):
         query = torch.randn(2, 4, 64)
         self.impl.key_cache = torch.randn(100, 64, 1, 64)
         self.impl.value_cache = torch.randn(100, 64, 1, 64)
@@ -113,8 +108,7 @@ class TestAscendAttentionCPImpl(TestBase):
 
         mock_get_forward_context.return_value = MagicMock(capturing=False)
 
-        def mock_npu_fused_infer_attention_score_func(query, k_nope, value,
-                                                      **common_kwargs):
+        def mock_npu_fused_infer_attention_score_func(query, k_nope, value, **common_kwargs):
             mock_output = torch.randn_like(query)
             mock_lse = torch.randn(query.shape[0], query.shape[1], 1)
             return mock_output, mock_lse
@@ -124,8 +118,7 @@ class TestAscendAttentionCPImpl(TestBase):
         attn_metadata = MagicMock()
         attn_metadata.decode_meta = MagicMock()
         attn_metadata.num_decodes_flatten = 5
-        attn_metadata.decode_meta.batch_seq_mask = torch.tensor(
-            [1, 0], dtype=torch.bool)
+        attn_metadata.decode_meta.batch_seq_mask = torch.tensor([1, 0], dtype=torch.bool)
         output = self.impl._forward_decode_pcp_dcp(query, attn_metadata)
 
         self.assertEqual(output.shape[0], 2)
@@ -139,26 +132,24 @@ class TestAscendAttentionCPImpl(TestBase):
         attn_metadata = MagicMock()
         attn_metadata.prefill = MagicMock()
         attn_metadata.prefill.chunked_context = MagicMock()
-        attn_metadata.prefill.chunked_context.cp_kv_recover_idx_for_chunk = torch.tensor(
-            [1, 2, 3, 0])
+        attn_metadata.prefill.chunked_context.cp_kv_recover_idx_for_chunk = torch.tensor([1, 2, 3, 0])
         output = self.impl._prefill_query_all_gather(attn_metadata, query)
 
         self.assertEqual(output.shape[0], 4)
         self.assertEqual(output.shape[1], 8)
         self.assertEqual(output.shape[2], 128)
 
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
+    @patch("torch.ops.npu.npu_fused_infer_attention_score")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_compute_prefill_context(self, mock_npu_attention):
-
         block_num = 100
         block_size = 128
         kv_num_heads = 1
         head_size = 128
-        kv_cache = (torch.randn(block_num, block_size, kv_num_heads,
-                                head_size),
-                    torch.randn(block_num, block_size, kv_num_heads,
-                                head_size))
+        kv_cache = (
+            torch.randn(block_num, block_size, kv_num_heads, head_size),
+            torch.randn(block_num, block_size, kv_num_heads, head_size),
+        )
 
         batch_size = 1024
         self.impl.head_size = head_size
@@ -171,37 +162,24 @@ class TestAscendAttentionCPImpl(TestBase):
         attn_metadata.prefill.chunked_context = MagicMock()
         local_context_lens_allranks = torch.tensor([[[256, 256], [256, 256]]])
         attn_metadata.prefill.chunked_context.local_context_lens_allranks = local_context_lens_allranks
-        attn_metadata.prefill.chunked_context.local_total_toks = local_context_lens_allranks[:,
-                                                                                             0,
-                                                                                             0].sum(
-                                                                                             )
+        attn_metadata.prefill.chunked_context.local_total_toks = local_context_lens_allranks[:, 0, 0].sum()
 
-        def mock_load_kv_for_chunk(attn_metadata, kv_cache,
-                                   local_chunked_kv_lens_rank, query,
-                                   total_toks):
-            return torch.randn(total_toks, kv_num_heads,
-                               head_size), torch.randn(total_toks,
-                                                       kv_num_heads, head_size)
+        def mock_load_kv_for_chunk(attn_metadata, kv_cache, local_chunked_kv_lens_rank, query, total_toks):
+            return torch.randn(total_toks, kv_num_heads, head_size), torch.randn(total_toks, kv_num_heads, head_size)
 
         self.impl._load_kv_for_chunk = MagicMock()
         self.impl._load_kv_for_chunk.side_effect = mock_load_kv_for_chunk
 
-        mock_npu_attention.return_value = torch.randn(batch_size, num_heads,
-                                                      head_size), torch.randn(
-                                                          batch_size,
-                                                          num_heads, 1)
+        mock_npu_attention.return_value = (
+            torch.randn(batch_size, num_heads, head_size),
+            torch.randn(batch_size, num_heads, 1),
+        )
 
-        context_output = self.impl._compute_prefill_context(
-            query, kv_cache, attn_metadata)
-        local_context_output = torch.cat(context_output,
-                                         dim=-1).permute([1, 2,
-                                                          0]).contiguous()
-        global_context_output = self.impl._gather_global_context_output(
-            local_context_output)
-        global_context_output = global_context_output.permute([2, 0, 1
-                                                               ]).contiguous()
-        result_output, result_lse = self.impl._update_global_context_output(
-            global_context_output)
+        context_output = self.impl._compute_prefill_context(query, kv_cache, attn_metadata)
+        local_context_output = torch.cat(context_output, dim=-1).permute([1, 2, 0]).contiguous()
+        global_context_output = self.impl._gather_global_context_output(local_context_output)
+        global_context_output = global_context_output.permute([2, 0, 1]).contiguous()
+        result_output, result_lse = self.impl._update_global_context_output(global_context_output)
 
         self.assertEqual(result_output.shape[0], batch_size)
         self.assertEqual(result_output.shape[1], self.impl.num_heads)
@@ -210,24 +188,26 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(result_lse.shape[1], self.impl.num_heads)
         self.assertEqual(result_lse.shape[2], 1)
 
-    @patch('torch_npu.atb.npu_paged_cache_load')
+    @patch("torch_npu.atb.npu_paged_cache_load")
     def test_load_kv_for_chunk(self, mock_npu_paged_cache_load):
         block_num = 100
         block_size = 128
         num_heads = 1
         head_size = 128
 
-        kv_cache = (torch.randn(block_num, block_size, num_heads, head_size),
-                    torch.randn(block_num, block_size, num_heads, head_size))
+        kv_cache = (
+            torch.randn(block_num, block_size, num_heads, head_size),
+            torch.randn(block_num, block_size, num_heads, head_size),
+        )
         query = torch.randn(4, 8, 128)
         total_toks = 256
         local_chunked_kv_lens_rank = torch.randn(total_toks)
 
         attn_metadata = MagicMock()
 
-        key, value = self.impl._load_kv_for_chunk(attn_metadata, kv_cache,
-                                                  local_chunked_kv_lens_rank,
-                                                  query, total_toks)
+        key, value = self.impl._load_kv_for_chunk(
+            attn_metadata, kv_cache, local_chunked_kv_lens_rank, query, total_toks
+        )
 
         self.assertEqual(key.shape[0], total_toks)
         self.assertEqual(key.shape[1], num_heads)
@@ -236,8 +216,8 @@ class TestAscendAttentionCPImpl(TestBase):
         self.assertEqual(value.shape[1], num_heads)
         self.assertEqual(value.shape[2], head_size)
 
-    @patch('torch_npu.Event', create=True)
-    @patch('torch_npu._npu_reshape_and_cache')
+    @patch("torch_npu.Event", create=True)
+    @patch("torch_npu._npu_reshape_and_cache")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_reshape_and_cache(self, mock_event_class, mock_npu_reshape_and_cache):
         num_tokens = 4
@@ -248,8 +228,10 @@ class TestAscendAttentionCPImpl(TestBase):
         self.impl.head_size = head_size
         self.impl.is_kv_producer = False
 
-        kv_cache = (torch.randn(block_num, block_size, num_heads, head_size),
-                    torch.randn(block_num, block_size, num_heads, head_size))
+        kv_cache = (
+            torch.randn(block_num, block_size, num_heads, head_size),
+            torch.randn(block_num, block_size, num_heads, head_size),
+        )
 
         attn_metadata = MagicMock()
         attn_metadata.num_decode_tokens = 1
@@ -258,13 +240,10 @@ class TestAscendAttentionCPImpl(TestBase):
         attn_metadata.slot_mapping = torch.randn(2)
         attn_metadata.num_actual_tokens_pcp_padded = num_tokens * self.impl.pcp_size
         attn_metadata.prefill = MagicMock()
-        attn_metadata.prefill.pcp_metadata.pcp_allgather_restore_idx = torch.tensor(
-            [0, 3, 1, 2, 0, 0, 0, 0])
+        attn_metadata.prefill.pcp_metadata.pcp_allgather_restore_idx = torch.tensor([0, 3, 1, 2, 0, 0, 0, 0])
         attn_metadata.prefill.pcp_metadata.pcp_use_hybrid_attn = False
         attn_metadata.prefill.pcp_metadata.pcp_padded_tokens_fla = 0
-        attn_metadata.prefill.pcp_metadata.pcp_enter_fa_restore_idx = torch.arange(
-            num_tokens * 3 * self.impl.pcp_size
-        )
+        attn_metadata.prefill.pcp_metadata.pcp_enter_fa_restore_idx = torch.arange(num_tokens * 3 * self.impl.pcp_size)
         attn_metadata.prefill.pcp_metadata.pcp_unpad_mask = torch.tensor(
             [True, False, True, True, True, True, True, True]
         )
@@ -274,9 +253,7 @@ class TestAscendAttentionCPImpl(TestBase):
         value = torch.randn(num_tokens, num_heads, head_size)
         output = torch.rand(num_tokens, num_heads * head_size)
 
-        query, key, value, output = self.impl.reshape_and_cache(
-            query, key, value, kv_cache, attn_metadata, output
-        )
+        query, key, value, output = self.impl.reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
         self.assertEqual(key.shape[0], num_tokens * self.impl.pcp_size)
         self.assertEqual(key.shape[1], num_heads)
         self.assertEqual(key.shape[2], head_size)
@@ -286,7 +263,6 @@ class TestAscendAttentionCPImpl(TestBase):
 
 
 class TestUpdateNpuAttnOutLse(TestBase):
-
     @patch_distributed_groups(needs_mocks=False)
     def setUp(self):
         self.layer = MagicMock()
@@ -301,8 +277,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.attn_metadata = MagicMock()
         self.attn_metadata.return_value = "1"
 
-        self.layer_no_quant = MagicMock(
-            spec=['layer_name', '_k_scale_float', '_v_scale_float'])
+        self.layer_no_quant = MagicMock(spec=["layer_name", "_k_scale_float", "_v_scale_float"])
         self.layer_no_quant.layer_name = "test_layer"
         self.layer_no_quant._k_scale_float = 1.0
         self.layer_no_quant._v_scale_float = 1.0
@@ -317,7 +292,8 @@ class TestUpdateNpuAttnOutLse(TestBase):
             kv_cache_dtype="float16",
             logits_soft_cap=None,
             attn_type=self.attention_type.DECODER,
-            kv_sharing_target_layer_name=None)
+            kv_sharing_target_layer_name=None,
+        )
 
         self.impl.pcp_size = 1
         self.impl.dcp_size = 1
@@ -331,17 +307,15 @@ class TestUpdateNpuAttnOutLse(TestBase):
 
         # TND layout requires cumulative sum computation.
         self.q_seqlens_cumsum = self._cumsum(self.q_lens_per_batch)  # [32, 96]
-        self.kv_seqlens_nomask_cumsum = self._cumsum(
-            self.kv_lens_nomask_per_batch)  # [32, 96]
-        self.kv_seqlens_mask_cumsum = self._cumsum(
-            self.kv_lens_mask_per_batch)  # [32, 96]
+        self.kv_seqlens_nomask_cumsum = self._cumsum(self.kv_lens_nomask_per_batch)  # [32, 96]
+        self.kv_seqlens_mask_cumsum = self._cumsum(self.kv_lens_mask_per_batch)  # [32, 96]
 
         # Compute T value in TND layout
         self.q_total_tokens = self.q_seqlens_cumsum[-1]
         self.kv_total_nomask = self.kv_seqlens_nomask_cumsum[-1]  #
         self.kv_total_mask = self.kv_seqlens_mask_cumsum[-1]
 
-    def _cumsum(self, arr: List[int]) -> List[int]:
+    def _cumsum(self, arr: list[int]) -> list[int]:
         result = []
         total = 0
         for val in arr:
@@ -362,15 +336,15 @@ class TestUpdateNpuAttnOutLse(TestBase):
         pcp_metadata.tail_attn_nomask_seqlens = self.kv_seqlens_nomask_cumsum
         prefill_metadata.pcp_metadata = pcp_metadata
 
-        prefill_metadata.actual_seq_lengths_q = torch.tensor(
-            self.q_seqlens_cumsum)
+        prefill_metadata.actual_seq_lengths_q = torch.tensor(self.q_seqlens_cumsum)
 
         if with_chunked_context:
             chunked_context = AscendMetadataForPrefill.ChunkedContextMetadata(
                 actual_chunk_seq_lengths=self.kv_seqlens_mask_cumsum,
                 actual_seq_lengths_kv=self.kv_seqlens_mask_cumsum,
                 starts=None,
-                chunk_seq_mask_filtered_indices=None)
+                chunk_seq_mask_filtered_indices=None,
+            )
             prefill_metadata.chunked_context = chunked_context
         else:
             prefill_metadata.chunked_context = None
@@ -379,30 +353,26 @@ class TestUpdateNpuAttnOutLse(TestBase):
         attn_metadata.decode_meta = None
         return attn_metadata
 
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
+    @patch("torch.ops.npu.npu_fused_infer_attention_score")
     def test_attention_with_nomask_none(self, mock_npu_attention):
         # Mock input data
-        q = torch.randn(self.q_total_tokens, self.impl.num_heads,
-                        self.impl.head_size)
+        q = torch.randn(self.q_total_tokens, self.impl.num_heads, self.impl.head_size)
         q_seqlens = self.q_seqlens_cumsum
         k_nomask = None
         v_nomask = None
         kv_seqlens_nomask = self.kv_seqlens_nomask_cumsum
-        k_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads,
-                             self.impl.head_size)
-        v_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads,
-                             self.impl.head_size)
+        k_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads, self.impl.head_size)
+        v_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads, self.impl.head_size)
         kv_seqlens_mask = self.kv_seqlens_mask_cumsum
         mask = torch.randn(self.q_total_tokens, self.kv_total_mask)
         attn_metadata = self._build_attn_metadata(with_chunked_context=False)
         # Mock output
-        mock_npu_attention.return_value = torch.randn(96, 8, 64), torch.randn(
-            96, 8, 1)
+        mock_npu_attention.return_value = torch.randn(96, 8, 64), torch.randn(96, 8, 1)
 
         # Call the method under test
         output, attn_lse = self.impl._attention_with_nomask_and_mask(
-            q, q_seqlens, k_nomask, v_nomask, kv_seqlens_nomask, k_mask,
-            v_mask, kv_seqlens_mask, mask, attn_metadata)
+            q, q_seqlens, k_nomask, v_nomask, kv_seqlens_nomask, k_mask, v_mask, kv_seqlens_mask, mask, attn_metadata
+        )
 
         # Verify only mask attention was invoked
         mock_npu_attention.assert_called_with(
@@ -419,7 +389,8 @@ class TestUpdateNpuAttnOutLse(TestBase):
             antiquant_scale=None,
             softmax_lse_flag=True,
             actual_seq_lengths_kv=kv_seqlens_mask,
-            actual_seq_lengths=q_seqlens)
+            actual_seq_lengths=q_seqlens,
+        )
         # Assert the method call
         self.assertEqual(mock_npu_attention.call_count, 1)
         self.assertIsInstance(output, torch.Tensor)
@@ -427,35 +398,28 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.assertEqual(output.shape, (96, 8, 64))
         self.assertEqual(attn_lse.shape, (96, 8, 1))
 
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch('vllm_ascend.attention.context_parallel.attention_cp._update_out_and_lse')
-    def test_attention_with_nomask_and_mask_chunk(
-            self, mock_update_out_and_lse,
-            mock_npu_fused_infer_attention_score):
+    @patch("torch.ops.npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.attention.context_parallel.attention_cp._update_out_and_lse")
+    def test_attention_with_nomask_and_mask_chunk(self, mock_update_out_and_lse, mock_npu_fused_infer_attention_score):
         # Mock input data
-        q = torch.randn(self.q_total_tokens, self.impl.num_heads,
-                        self.impl.head_size)
-        k_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads,
-                               self.impl.head_size)
-        v_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads,
-                               self.impl.head_size)
-        k_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads,
-                             self.impl.head_size)
-        v_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads,
-                             self.impl.head_size)
+        q = torch.randn(self.q_total_tokens, self.impl.num_heads, self.impl.head_size)
+        k_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads, self.impl.head_size)
+        v_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads, self.impl.head_size)
+        k_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads, self.impl.head_size)
+        v_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads, self.impl.head_size)
 
         mask = torch.randn(self.q_total_tokens, self.kv_total_mask)
         attn_metadata = self._build_attn_metadata(with_chunked_context=True)
 
         # Mock output
-        mock_npu_fused_infer_attention_score.return_value = torch.randn(
-            self.q_total_tokens, self.impl.num_heads,
-            self.impl.head_size), torch.randn(self.q_total_tokens,
-                                              self.impl.num_heads, 1)
-        mock_update_out_and_lse.return_value = torch.randn(
-            self.q_total_tokens, self.impl.num_heads,
-            self.impl.head_size), torch.randn(self.q_total_tokens,
-                                              self.impl.num_heads, 1)
+        mock_npu_fused_infer_attention_score.return_value = (
+            torch.randn(self.q_total_tokens, self.impl.num_heads, self.impl.head_size),
+            torch.randn(self.q_total_tokens, self.impl.num_heads, 1),
+        )
+        mock_update_out_and_lse.return_value = (
+            torch.randn(self.q_total_tokens, self.impl.num_heads, self.impl.head_size),
+            torch.randn(self.q_total_tokens, self.impl.num_heads, 1),
+        )
         # Call the method under test
         output, attn_lse = self.impl._attention_with_nomask_and_mask(
             q=q,
@@ -467,40 +431,37 @@ class TestUpdateNpuAttnOutLse(TestBase):
             v_mask=v_mask,
             kv_seqlens_mask=self.kv_seqlens_mask_cumsum,
             mask=mask,
-            attn_metadata=attn_metadata)
+            attn_metadata=attn_metadata,
+        )
         # Assert the method call
         self.assertEqual(mock_npu_fused_infer_attention_score.call_count, 2)
         self.assertIsNotNone(output)
         self.assertIsNotNone(attn_lse)
 
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch('vllm_ascend.attention.context_parallel.attention_cp._npu_attn_out_lse_update')
+    @patch("torch.ops.npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.attention.context_parallel.attention_cp._npu_attn_out_lse_update")
     def test_attention_with_nomask_and_mask_nochunk(
-            self, mock_npu_attn_out_lse_update,
-            mock_npu_fused_infer_attention_score):
+        self, mock_npu_attn_out_lse_update, mock_npu_fused_infer_attention_score
+    ):
         # Mock input data
-        q = torch.randn(self.q_total_tokens, self.impl.num_heads,
-                        self.impl.head_size)
-        k_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads,
-                               self.impl.head_size)
-        v_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads,
-                               self.impl.head_size)
-        k_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads,
-                             self.impl.head_size)
-        v_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads,
-                             self.impl.head_size)
+        q = torch.randn(self.q_total_tokens, self.impl.num_heads, self.impl.head_size)
+        k_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads, self.impl.head_size)
+        v_nomask = torch.randn(self.kv_total_nomask, self.impl.num_kv_heads, self.impl.head_size)
+        k_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads, self.impl.head_size)
+        v_mask = torch.randn(self.kv_total_mask, self.impl.num_kv_heads, self.impl.head_size)
         mask = torch.randn(self.q_total_tokens, self.kv_total_mask)
 
         attn_metadata = self._build_attn_metadata(with_chunked_context=True)
         attn_metadata.prefill.chunked_context = None
 
         # Mock output
-        mock_npu_fused_infer_attention_score.return_value = torch.randn(
-            self.q_total_tokens, self.impl.num_heads,
-            self.impl.head_size), torch.randn(self.q_total_tokens,
-                                              self.impl.num_heads, 1)
+        mock_npu_fused_infer_attention_score.return_value = (
+            torch.randn(self.q_total_tokens, self.impl.num_heads, self.impl.head_size),
+            torch.randn(self.q_total_tokens, self.impl.num_heads, 1),
+        )
         mock_npu_attn_out_lse_update.return_value = torch.randn(
-            self.q_total_tokens, self.impl.num_heads, self.impl.head_size)
+            self.q_total_tokens, self.impl.num_heads, self.impl.head_size
+        )
 
         # Call the method under test
         output, attn_lse = self.impl._attention_with_nomask_and_mask(
@@ -513,16 +474,16 @@ class TestUpdateNpuAttnOutLse(TestBase):
             v_mask=v_mask,
             kv_seqlens_mask=self.kv_seqlens_mask_cumsum,
             mask=mask,
-            attn_metadata=attn_metadata)
+            attn_metadata=attn_metadata,
+        )
         # Assert the method call
         mock_npu_attn_out_lse_update.assert_called_once()
         self.assertEqual(mock_npu_fused_infer_attention_score.call_count, 2)
         self.assertIsNotNone(output)
         self.assertEqual(attn_lse, None)
 
-    @patch('vllm_ascend.attention.context_parallel.attention_cp._npu_attn_out_lse_update')
-    def test_update_chunk_attn_out_lse_with_current_attn_out_lse(
-            self, mock_npu_attn_out_lse_update):
+    @patch("vllm_ascend.attention.context_parallel.attention_cp._npu_attn_out_lse_update")
+    def test_update_chunk_attn_out_lse_with_current_attn_out_lse(self, mock_npu_attn_out_lse_update):
         # Mock input data
         current_attn_output_prefill = torch.randn(32764, 8, 128)
         current_attn_lse_prefill = torch.randn(32764, 8, 1)
@@ -531,10 +492,8 @@ class TestUpdateNpuAttnOutLse(TestBase):
         prefill_query = torch.randn(32764, 8, 128)
         # mock attn_metadata
         attn_metadata = self._build_attn_metadata(with_chunked_context=True)
-        attn_metadata.prefill.chunked_context.chunk_seq_mask_filtered_indices = torch.arange(
-            32764, dtype=torch.int32)
-        attn_metadata.prefill.chunked_context.kv_inverse_idx_for_chunk = torch.arange(
-            32764, dtype=torch.int32)
+        attn_metadata.prefill.chunked_context.chunk_seq_mask_filtered_indices = torch.arange(32764, dtype=torch.int32)
+        attn_metadata.prefill.chunked_context.kv_inverse_idx_for_chunk = torch.arange(32764, dtype=torch.int32)
         # Mock output
         mock_npu_attn_out_lse_update.return_value = torch.randn(32764, 8, 128)
         # test pcp_size > 1
@@ -544,22 +503,29 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.impl.pcp_group = None
         # Call the method under test
         self.impl._update_chunk_attn_out_lse_with_current_attn_out_lse(
-            current_attn_output_prefill, current_attn_lse_prefill,
-            attn_output_full_chunk, attn_lse_full_chunk, prefill_query,
-            attn_metadata)
+            current_attn_output_prefill,
+            current_attn_lse_prefill,
+            attn_output_full_chunk,
+            attn_lse_full_chunk,
+            prefill_query,
+            attn_metadata,
+        )
         # Assert the method call
         mock_npu_attn_out_lse_update.assert_called_once()
         # test pcp_size = 1
         self.impl.pcp_size = 1
         self.impl._update_chunk_attn_out_lse_with_current_attn_out_lse(
-            current_attn_output_prefill, current_attn_lse_prefill,
-            attn_output_full_chunk, attn_lse_full_chunk, prefill_query,
-            attn_metadata)
+            current_attn_output_prefill,
+            current_attn_lse_prefill,
+            attn_output_full_chunk,
+            attn_lse_full_chunk,
+            prefill_query,
+            attn_metadata,
+        )
         self.assertEqual(mock_npu_attn_out_lse_update.call_count, 2)
 
     @patch_distributed_groups(dcp_size=2, pcp_size=3)
-    def test_update_chunk_attn_out_lse_dcp2_pcp3(self, mock_all_to_all_single,
-                                                 mock_dcp, mock_pcp):
+    def test_update_chunk_attn_out_lse_dcp2_pcp3(self, mock_all_to_all_single, mock_dcp, mock_pcp):
         # Mock input data
         prefix_chunk_output = torch.randn(2, 4, 8)
         prefix_chunk_lse = torch.randn(2, 4, 1)
@@ -568,14 +534,10 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.impl.head_size = 8
 
         # Call the method under test
-        chunk_data = torch.cat([prefix_chunk_output, prefix_chunk_lse],
-                               dim=-1).permute([1, 2, 0]).contiguous()
-        global_context_output = self.impl._gather_global_context_output(
-            chunk_data)
-        global_context_output = global_context_output.permute([2, 0, 1
-                                                               ]).contiguous()
-        output, lse = self.impl._update_global_context_output(
-            global_context_output)
+        chunk_data = torch.cat([prefix_chunk_output, prefix_chunk_lse], dim=-1).permute([1, 2, 0]).contiguous()
+        global_context_output = self.impl._gather_global_context_output(chunk_data)
+        global_context_output = global_context_output.permute([2, 0, 1]).contiguous()
+        output, lse = self.impl._update_global_context_output(global_context_output)
 
         # Assert the method call
         self.assertIsInstance(output, torch.Tensor)
@@ -587,8 +549,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
         mock_pcp.all_gather.assert_called_once()
 
     @patch_distributed_groups(dcp_size=2)
-    def test_update_chunk_attn_out_lse_dcp2_pcp1(self, mock_all_to_all_single,
-                                                 mock_dcp, mock_pcp):
+    def test_update_chunk_attn_out_lse_dcp2_pcp1(self, mock_all_to_all_single, mock_dcp, mock_pcp):
         # Mock input data
         prefix_chunk_output = torch.randn(2, 4, 8)
         prefix_chunk_lse = torch.randn(2, 4, 1)
@@ -598,14 +559,10 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.impl.head_size = 8
 
         # Call the method under test
-        chunk_data = torch.cat([prefix_chunk_output, prefix_chunk_lse],
-                               dim=-1).permute([1, 2, 0]).contiguous()
-        global_context_output = self.impl._gather_global_context_output(
-            chunk_data)
-        global_context_output = global_context_output.permute([2, 0, 1
-                                                               ]).contiguous()
-        output, lse = self.impl._update_global_context_output(
-            global_context_output)
+        chunk_data = torch.cat([prefix_chunk_output, prefix_chunk_lse], dim=-1).permute([1, 2, 0]).contiguous()
+        global_context_output = self.impl._gather_global_context_output(chunk_data)
+        global_context_output = global_context_output.permute([2, 0, 1]).contiguous()
+        output, lse = self.impl._update_global_context_output(global_context_output)
 
         # Assert the method call
         self.assertIsInstance(output, torch.Tensor)
@@ -617,8 +574,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
         mock_pcp.all_gather.assert_not_called()
 
     @patch_distributed_groups(pcp_size=2)
-    def test_update_chunk_attn_out_lse_dcp1_pcp2(self, mock_all_to_all_single,
-                                                 mock_dcp, mock_pcp):
+    def test_update_chunk_attn_out_lse_dcp1_pcp2(self, mock_all_to_all_single, mock_dcp, mock_pcp):
         # Mock input data
         prefix_chunk_output = torch.randn(2, 4, 8)
         prefix_chunk_lse = torch.randn(2, 4, 1)
@@ -628,14 +584,10 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.impl.head_size = 8
 
         # Call the method under test
-        chunk_data = torch.cat([prefix_chunk_output, prefix_chunk_lse],
-                               dim=-1).permute([1, 2, 0]).contiguous()
-        global_context_output = self.impl._gather_global_context_output(
-            chunk_data)
-        global_context_output = global_context_output.permute([2, 0, 1
-                                                               ]).contiguous()
-        output, lse = self.impl._update_global_context_output(
-            global_context_output)
+        chunk_data = torch.cat([prefix_chunk_output, prefix_chunk_lse], dim=-1).permute([1, 2, 0]).contiguous()
+        global_context_output = self.impl._gather_global_context_output(chunk_data)
+        global_context_output = global_context_output.permute([2, 0, 1]).contiguous()
+        output, lse = self.impl._update_global_context_output(global_context_output)
 
         # Assert the method call
         self.assertIsInstance(output, torch.Tensor)

--- a/tests/ut/attention/test_attention_mask.py
+++ b/tests/ut/attention/test_attention_mask.py
@@ -20,32 +20,27 @@ from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 
 
 class TestAttentionMaskBuilder(TestBase):
-
     def test_get_attn_mask(self):
         # if the len is less than max_seq_len, the attn_mask_cache will not be updated
         attention_mask_builder = AttentionMaskBuilder(torch.device("cpu"))
-        attn_mask = attention_mask_builder.get_attn_mask(max_seq_len=512,
-                                                         dtype=torch.float16)
+        attn_mask = attention_mask_builder.get_attn_mask(max_seq_len=512, dtype=torch.float16)
         self.assertEqual(attn_mask.shape, (512, 512))
-        self.assertEqual(attn_mask[0][-1],
-                         torch.tensor(float("-inf"), dtype=torch.float16))
+        self.assertEqual(attn_mask[0][-1], torch.tensor(float("-inf"), dtype=torch.float16))
         self.assertEqual(attention_mask_builder._seq_len_cached, 512)
-        self.assertEqual(attention_mask_builder.attn_mask_cache.shape,
-                         (512, 512))
-        self.assertEqual(attention_mask_builder.attn_mask_cache[0][-1],
-                         torch.tensor(float("-inf"), dtype=torch.float16))
+        self.assertEqual(attention_mask_builder.attn_mask_cache.shape, (512, 512))
+        self.assertEqual(
+            attention_mask_builder.attn_mask_cache[0][-1], torch.tensor(float("-inf"), dtype=torch.float16)
+        )
 
         # if the len is greater than max_seq_len, the attn_mask_cache will be updated
-        attn_mask = attention_mask_builder.get_attn_mask(max_seq_len=2048,
-                                                         dtype=torch.float16)
+        attn_mask = attention_mask_builder.get_attn_mask(max_seq_len=2048, dtype=torch.float16)
         self.assertEqual(attn_mask.shape, (2048, 2048))
-        self.assertEqual(attn_mask[0][-1],
-                         torch.tensor(float("-inf"), dtype=torch.float16))
+        self.assertEqual(attn_mask[0][-1], torch.tensor(float("-inf"), dtype=torch.float16))
         self.assertEqual(attention_mask_builder._seq_len_cached, 2048)
-        self.assertEqual(attention_mask_builder.attn_mask_cache.shape,
-                         (2048, 2048))
-        self.assertEqual(attention_mask_builder.attn_mask_cache[0][-1],
-                         torch.tensor(float("-inf"), dtype=torch.float16))
+        self.assertEqual(attention_mask_builder.attn_mask_cache.shape, (2048, 2048))
+        self.assertEqual(
+            attention_mask_builder.attn_mask_cache[0][-1], torch.tensor(float("-inf"), dtype=torch.float16)
+        )
 
     def test_get_splitfuse_attn_mask(self):
         attention_mask_builder = AttentionMaskBuilder(torch.device("cpu"))

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -3,16 +3,16 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from tests.ut.base import TestBase
-from vllm_ascend.attention.attention_v1 import (AscendAttentionBackend,
-                                                AscendAttentionBackendImpl,
-                                                AscendAttentionMetadataBuilder,
-                                                AscendAttentionState)
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionBackend,
+    AscendAttentionBackendImpl,
+    AscendAttentionMetadataBuilder,
+    AscendAttentionState,
+)
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
-from vllm_ascend.utils import AscendDeviceType
 
 
 class TestAscendAttentionBackend(TestBase):
-
     def setUp(self):
         self.mock_config = MagicMock()
 
@@ -22,24 +22,21 @@ class TestAscendAttentionBackend(TestBase):
 
         self.mock_config.parallel_config = mock_parallel_config
 
-        self.utils_patcher = patch(
-            'vllm_ascend.attention.utils.get_current_vllm_config',
-            return_value=self.mock_config)
+        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
         self.utils_patcher.start()
 
         from vllm_ascend.attention.utils import enable_cp
+
         enable_cp.cache_clear()
 
     def test_get_name(self):
         self.assertEqual(AscendAttentionBackend.get_name(), "CUSTOM")
 
     def test_get_impl_cls(self):
-        self.assertEqual(AscendAttentionBackend.get_impl_cls(),
-                         AscendAttentionBackendImpl)
+        self.assertEqual(AscendAttentionBackend.get_impl_cls(), AscendAttentionBackendImpl)
 
     def test_get_builder_cls(self):
-        self.assertEqual(AscendAttentionBackend.get_builder_cls(),
-                         AscendAttentionMetadataBuilder)
+        self.assertEqual(AscendAttentionBackend.get_builder_cls(), AscendAttentionMetadataBuilder)
 
     def test_get_kv_cache_shape_not(self):
         result = AscendAttentionBackend.get_kv_cache_shape(10, 20, 30, 40)
@@ -49,8 +46,7 @@ class TestAscendAttentionBackend(TestBase):
         src_kv_cache = [torch.zeros((10, 20)), torch.zeros((10, 20))]
         dst_kv_cache = [torch.zeros((10, 20)), torch.zeros((10, 20))]
         src_to_dst = torch.tensor([[0, 1], [2, 3]])
-        AscendAttentionBackend.swap_blocks(src_kv_cache, dst_kv_cache,
-                                           src_to_dst)
+        AscendAttentionBackend.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
         self.assertTrue(torch.all(dst_kv_cache[0][1] == src_kv_cache[0][0]))
         self.assertTrue(torch.all(dst_kv_cache[1][3] == src_kv_cache[1][2]))
 
@@ -63,7 +59,6 @@ class TestAscendAttentionBackend(TestBase):
 
 
 class TestAscendAttentionMetadataBuilder(TestBase):
-
     def setUp(self):
         self.mock_vllm_config = MagicMock()
         self.mock_vllm_config.speculative_config = None
@@ -74,22 +69,19 @@ class TestAscendAttentionMetadataBuilder(TestBase):
         self.mock_vllm_config.scheduler_config.max_num_seqs = 10
         self.mock_vllm_config.scheduler_config.decode_max_num_seqs = 10
         self.mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
-        self.mock_device = 'cpu:0'
+        self.mock_device = "cpu:0"
         torch.Tensor.pin_memory = lambda x: x  # noqa
-        self.builder = AscendAttentionMetadataBuilder(None, None,
-                                                      self.mock_vllm_config,
-                                                      self.mock_device)
+        self.builder = AscendAttentionMetadataBuilder(None, None, self.mock_vllm_config, self.mock_device)
 
     def test_reorder_batch(self):
         mock_input_batch = MagicMock()
         mock_scheduler_output = MagicMock()
 
-        result = self.builder.reorder_batch(mock_input_batch,
-                                            mock_scheduler_output)
+        result = self.builder.reorder_batch(mock_input_batch, mock_scheduler_output)
 
         self.assertFalse(result)
 
-    @patch('vllm_ascend.attention.attention_v1.AscendMetadata')
+    @patch("vllm_ascend.attention.attention_v1.AscendMetadata")
     def test_build(self, mock_ascend_metadata):
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=torch.tensor([0, 2, 5, 9]),
@@ -106,24 +98,22 @@ class TestAscendAttentionMetadataBuilder(TestBase):
             attn_state=AscendAttentionState.ChunkedPrefill,
             num_computed_tokens_cpu=None,
             seq_lens=None,
-            max_seq_len=6)
+            max_seq_len=6,
+        )
         mock_model = MagicMock()
 
         self.builder.build(1, common_attn_metadata, mock_model)
 
 
 class TestAscendAttentionBackendImpl(TestBase):
-
     def setUp(self):
         self.mock_event = MagicMock()
         self.mock_event.record.return_value = None
         self.mock_event.wait.return_value = None
 
         self.mock_stream = MagicMock()
-        self.event_patcher = patch('torch_npu.npu.Event',
-                                   return_value=self.mock_event)
-        self.stream_patcher = patch('torch_npu.npu.current_stream',
-                                    return_value=self.mock_stream)
+        self.event_patcher = patch("torch_npu.npu.Event", return_value=self.mock_event)
+        self.stream_patcher = patch("torch_npu.npu.current_stream", return_value=self.mock_stream)
 
         self.event_patcher.start()
         self.stream_patcher.start()
@@ -137,15 +127,14 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.attention_type.ENCODER = "encoder"
         self.attn_metadata = MagicMock()
         self.attn_metadata.return_value = "1"
-        self.layer_no_quant = MagicMock(
-            spec=['layer_name', '_k_scale_float', '_v_scale_float'])
+        self.layer_no_quant = MagicMock(spec=["layer_name", "_k_scale_float", "_v_scale_float"])
         self.layer_no_quant.layer_name = "test_layer"
         self.layer_no_quant._k_scale_float = 1.0
         self.layer_no_quant._v_scale_float = 1.0
         self.mock_vllm_config = MagicMock()
         self.config_patcher = patch(
-            'vllm_ascend.attention.attention_v1.get_current_vllm_config',
-            return_value=self.mock_vllm_config)
+            "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
+        )
         self.config_patcher.start()
 
         self.impl = AscendAttentionBackendImpl(
@@ -158,7 +147,8 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_cache_dtype="float16",
             logits_soft_cap=None,
             attn_type=self.attention_type.DECODER,
-            kv_sharing_target_layer_name=None)
+            kv_sharing_target_layer_name=None,
+        )
 
         self.impl_192 = AscendAttentionBackendImpl(
             num_heads=8,
@@ -170,7 +160,8 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_cache_dtype="float16",
             logits_soft_cap=None,
             attn_type=self.attention_type.DECODER,
-            kv_sharing_target_layer_name=None)
+            kv_sharing_target_layer_name=None,
+        )
 
         self.impl_error = AscendAttentionBackendImpl(
             num_heads=8,
@@ -182,7 +173,8 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_cache_dtype="float16",
             logits_soft_cap=None,
             attn_type=None,
-            kv_sharing_target_layer_name=None)
+            kv_sharing_target_layer_name=None,
+        )
 
         self.impl_swa = AscendAttentionBackendImpl(
             num_heads=8,
@@ -194,7 +186,8 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_cache_dtype="float16",
             logits_soft_cap=None,
             attn_type=self.attention_type.DECODER,
-            kv_sharing_target_layer_name=None)
+            kv_sharing_target_layer_name=None,
+        )
 
     def test_forward_no_attn_metadata(self):
         """Test forward pass when attn_metadata is None"""
@@ -205,17 +198,16 @@ class TestAscendAttentionBackendImpl(TestBase):
         layer = self.layer_no_quant
         output = torch.empty_like(query)
 
-        output = self.impl.forward(layer, query, key, value, kv_cache, None,
-                                   output)
+        output = self.impl.forward(layer, query, key, value, kv_cache, None, output)
 
         assert output.shape == (10, 8 * 64)
 
-    @patch('torch_npu._npu_reshape_and_cache')
-    @patch('torch_npu.npu_fused_infer_attention_score')
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_forward_fused_infer_attention(
-            self, mock_get_forward_context,
-            mock_npu_fused_infer_attention_score, mock_npu_reshape_and_cache):
+        self, mock_get_forward_context, mock_npu_fused_infer_attention_score, mock_npu_reshape_and_cache
+    ):
         """Test forward pass in PrefillCacheHit state"""
         query = torch.randn(10, 8, 64)
         key = torch.randn(10, 8, 64)
@@ -237,22 +229,19 @@ class TestAscendAttentionBackendImpl(TestBase):
         layer = self.layer_no_quant
 
         mock_get_forward_context.return_value = MagicMock(capturing=False)
-        mock_npu_fused_infer_attention_score.return_value = (torch.ones(
-            10, 8, 64), torch.ones(10, 8, 64))
-        output = self.impl.forward(layer, query, key, value, kv_cache,
-                                   metadata, output)
+        mock_npu_fused_infer_attention_score.return_value = (torch.ones(10, 8, 64), torch.ones(10, 8, 64))
+        output = self.impl.forward(layer, query, key, value, kv_cache, metadata, output)
 
         mock_npu_fused_infer_attention_score.assert_called_once()
         assert output.shape == (10, 8, 64)
 
-    @patch('vllm_ascend.attention.attention_v1.using_paged_attention')
-    @patch('torch_npu._npu_paged_attention')
-    @patch('torch_npu._npu_reshape_and_cache')
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    def test_forward_paged_attention(self, mock_get_forward_context,
-                                     mock_npu_reshape_and_cache,
-                                     mock_paged_attention,
-                                     mock_using_paged_attention):
+    @patch("vllm_ascend.attention.attention_v1.using_paged_attention")
+    @patch("torch_npu._npu_paged_attention")
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_forward_paged_attention(
+        self, mock_get_forward_context, mock_npu_reshape_and_cache, mock_paged_attention, mock_using_paged_attention
+    ):
         """Test forward pass in DecodeOnly state"""
         query = torch.randn(4, 8 * 64)
         key = torch.randn(4, 8 * 64)
@@ -273,18 +262,17 @@ class TestAscendAttentionBackendImpl(TestBase):
 
         mock_get_forward_context.return_value = MagicMock(capturing=False)
 
-        output = self.impl.forward(layer, query, key, value, kv_cache,
-                                   metadata, output)
+        output = self.impl.forward(layer, query, key, value, kv_cache, metadata, output)
 
         mock_paged_attention.assert_called_once()
         assert output.shape == (4, 8 * 64)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch('torch_npu.npu_fused_infer_attention_score')
-    @patch('torch_npu._npu_reshape_and_cache')
-    def test_forward_decode_only_swa(self, mock_npu_reshape_and_cache,
-                                     mock_fused_infer_attention_score,
-                                     mock_get_forward_context):
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    @patch("torch_npu._npu_reshape_and_cache")
+    def test_forward_decode_only_swa(
+        self, mock_npu_reshape_and_cache, mock_fused_infer_attention_score, mock_get_forward_context
+    ):
         """Test forward pass in DecodeOnly state"""
         query = torch.randn(10, 8 * 64)
         key = torch.randn(10, 8 * 64)
@@ -303,21 +291,23 @@ class TestAscendAttentionBackendImpl(TestBase):
         metadata.num_decodes = 10
         metadata.num_prefills = 0
         layer = self.layer_no_quant
-        mock_fused_infer_attention_score.return_value = (torch.ones(10, 8,
-                                                                    64), 1)
-        output = self.impl_swa.forward(layer, query, key, value, kv_cache,
-                                       metadata, output)
+        mock_fused_infer_attention_score.return_value = (torch.ones(10, 8, 64), 1)
+        output = self.impl_swa.forward(layer, query, key, value, kv_cache, metadata, output)
         print(output.shape)
         mock_fused_infer_attention_score.assert_called_once()
         assert output.shape == (10, 8, 64)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch('torch_npu._npu_paged_attention')
-    @patch('torch_npu.npu_fused_infer_attention_score')
-    @patch('torch_npu._npu_reshape_and_cache')
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("torch_npu._npu_paged_attention")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    @patch("torch_npu._npu_reshape_and_cache")
     def test_forward_decode_only_swa_seq_len_mismatch(
-            self, mock_npu_reshape_and_cache, mock_fused_infer_attention_score,
-            mock_paged_attention, mock_get_forward_context):
+        self,
+        mock_npu_reshape_and_cache,
+        mock_fused_infer_attention_score,
+        mock_paged_attention,
+        mock_get_forward_context,
+    ):
         """Test forward pass in DecodeOnly state when seq)len_mismatch"""
         query = torch.randn(10, 8, 64)
         key = torch.randn(10, 8, 64)
@@ -338,11 +328,9 @@ class TestAscendAttentionBackendImpl(TestBase):
 
         mock_get_forward_context.return_value = MagicMock(capturing=False)
 
-        mock_fused_infer_attention_score.return_value = (torch.ones(10, 8, 64),
-                                                         torch.ones(10, 8, 64))
+        mock_fused_infer_attention_score.return_value = (torch.ones(10, 8, 64), torch.ones(10, 8, 64))
 
-        output = self.impl_swa.forward(layer, query, key, value, kv_cache,
-                                       metadata, output)
+        output = self.impl_swa.forward(layer, query, key, value, kv_cache, metadata, output)
 
         mock_paged_attention.assert_not_called()
         mock_fused_infer_attention_score.assert_called_once()

--- a/tests/ut/attention/test_common_cp.py
+++ b/tests/ut/attention/test_common_cp.py
@@ -1,32 +1,30 @@
 import unittest
 from unittest.mock import MagicMock, patch
+
 import torch
 
 from vllm_ascend.attention.context_parallel.common_cp import (
     _npu_attention_update,
     _npu_attn_out_lse_update,
     _update_out_and_lse,
-    _out_lse_reshape
 )
 
-class TestCommonCP(unittest.TestCase):
 
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size')
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_dcp_group')
-    @patch('torch.distributed.all_to_all_single')
-    def test_process_attn_out_lse_complex(self, 
-                                        mock_all2all, 
-                                        mock_get_dcp_group, 
-                                        mock_get_dcp_size, 
-                                        mock_get_pcp_group):
+class TestCommonCP(unittest.TestCase):
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_pcp_group")
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size")
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_dcp_group")
+    @patch("torch.distributed.all_to_all_single")
+    def test_process_attn_out_lse_complex(
+        self, mock_all2all, mock_get_dcp_group, mock_get_dcp_size, mock_get_pcp_group
+    ):
         from vllm_ascend.attention.context_parallel.common_cp import _process_attn_out_lse
 
         pcp_size = 2
         dcp_size = 2
         mock_get_pcp_group.return_value.world_size = pcp_size
         mock_get_dcp_size.return_value = dcp_size
-        
+
         mock_group = MagicMock()
         mock_get_dcp_group.return_value.device_group = mock_group
 
@@ -36,6 +34,7 @@ class TestCommonCP(unittest.TestCase):
 
         def fake_all_gather(tensor, dim=0):
             return torch.cat([tensor, tensor], dim=dim)
+
         mock_get_pcp_group.return_value.all_gather = fake_all_gather
 
         output = _process_attn_out_lse(attn_output, softmax_lse)
@@ -50,25 +49,25 @@ class TestCommonCP(unittest.TestCase):
 
         mock_all2all.assert_called_once()
         called_args = mock_all2all.call_args
-        self.assertEqual(called_args.kwargs['group'], mock_group)
+        self.assertEqual(called_args.kwargs["group"], mock_group)
 
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size')
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_pcp_group")
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size")
     def test_process_attn_out_lse_simple(self, mock_get_dcp_size, mock_get_pcp_group):
         from vllm_ascend.attention.context_parallel.common_cp import _process_attn_out_lse
-        
+
         mock_get_pcp_group.return_value.world_size = 1
         mock_get_dcp_size.return_value = 1
-        
+
         attn_output = torch.randn(2, 4, 16)
         softmax_lse = torch.randn(2, 4, 1)
-        
+
         output = _process_attn_out_lse(attn_output, softmax_lse)
-        
+
         # concat: [2, 4, 16+1]
         self.assertEqual(output.shape, (2, 4, 17))
 
-    @patch('torch_npu.npu_attention_update')
+    @patch("torch_npu.npu_attention_update")
     def test_npu_attn_out_lse_update(self, mock_npu_attention_update):
         # Mock input data
         attn_lse_mask = torch.randn(8, 128, 1)
@@ -76,18 +75,10 @@ class TestCommonCP(unittest.TestCase):
         attn_out_mask = torch.randn(8, 128, 128)
         attn_out_nomask = torch.randn(8, 128, 128)
 
-        mock_npu_attention_update.return_value = (
-            torch.randn(8 * 128, 128), 
-            None
-        )
+        mock_npu_attention_update.return_value = (torch.randn(8 * 128, 128), None)
 
         # Call the method under test
-        output = _npu_attn_out_lse_update(
-            attn_lse_mask,
-            attn_lse_nomask,
-            attn_out_mask,
-            attn_out_nomask
-        )
+        output = _npu_attn_out_lse_update(attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask)
 
         # Assertions
         self.assertIsInstance(output, torch.Tensor)
@@ -108,43 +99,40 @@ class TestCommonCP(unittest.TestCase):
         self.assertIsInstance(out_final, torch.Tensor)
         self.assertIsInstance(lse_final, torch.Tensor)
 
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size')
-    @patch('torch_npu.npu_attention_update')
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_pcp_group")
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size")
+    @patch("torch_npu.npu_attention_update")
     def test_npu_attention_update(self, mock_npu_update, mock_get_dcp, mock_get_pcp):
         pcp_size = 2
         dcp_size = 2
         mock_get_pcp.return_value.world_size = pcp_size
         mock_get_dcp.return_value = dcp_size
-        
+
         head_size = 64
-        S, H = 4, 8 # Sequence and Heads per segment
-        
+        S, H = 4, 8  # Sequence and Heads per segment
+
         attn_out_lse = torch.randn(pcp_size * S, dcp_size * H, head_size + 1)
-        
+
         # mock NPU op return (N=PCP*DCP=4, S*H=32) -> [4*32, 64]
         mock_npu_update.return_value = (torch.randn(pcp_size * dcp_size * S * H, head_size), None)
-        
+
         # test
         result = _npu_attention_update(head_size, attn_out_lse)
-        
+
         self.assertEqual(result.shape, (pcp_size * dcp_size * S, H, head_size))
         mock_npu_update.assert_called_once()
 
     def test_out_lse_reshape(self):
         # Mock input data
-        out_list = torch.randn(3, 2, 4,
-                               8)  # [N, batch_size, num_heads, head_size]
+        out_list = torch.randn(3, 2, 4, 8)  # [N, batch_size, num_heads, head_size]
         lse_list = torch.randn(3, 2, 4, 1)  # [N, batch_size, num_heads, 1]
 
         # Call the method under test
         out_final, lse_final = _update_out_and_lse(out_list, lse_list)
 
         # Assert the method call
-        self.assertEqual(out_final.shape,
-                         (2, 4, 8))  # [batch_size, num_heads, head_size]
-        self.assertEqual(lse_final.shape,
-                         (2, 4, 1))  # [batch_size, num_heads, 1]
+        self.assertEqual(out_final.shape, (2, 4, 8))  # [batch_size, num_heads, head_size]
+        self.assertEqual(lse_final.shape, (2, 4, 1))  # [batch_size, num_heads, 1]
 
         self.assertIsInstance(out_final, torch.Tensor)
         self.assertIsInstance(lse_final, torch.Tensor)

--- a/tests/ut/attention/test_mla_cp.py
+++ b/tests/ut/attention/test_mla_cp.py
@@ -8,7 +8,10 @@ from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.context_parallel.common_cp import (
-    CPChunkedContextMetadata, _npu_attention_update, _process_attn_out_lse)
+    CPChunkedContextMetadata,
+    _npu_attention_update,
+    _process_attn_out_lse,
+)
 from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaCPImpl
 from vllm_ascend.attention.mla_v1 import ChunkedContextMetadata
 
@@ -27,27 +30,17 @@ def get_pcp_split_info(pcp_rank, pcp_size, seq_lens):
         chunk_len = seq_len // 2
         chunk_seqlens.append(chunk_len)
         q_head_idx.extend(list(range(q_req_offset, q_req_offset + chunk_len)))
-        kv_with_q_head_nomask_idx.extend(
-            list(
-                range(kv_req_offset,
-                      kv_req_offset + chunk_len * q_head_chunk_id)))
+        kv_with_q_head_nomask_idx.extend(list(range(kv_req_offset, kv_req_offset + chunk_len * q_head_chunk_id)))
         kv_with_q_head_mask_idx.extend(
-            list(
-                range(kv_req_offset + chunk_len * q_head_chunk_id,
-                      kv_req_offset + chunk_len * (q_head_chunk_id + 1))))
+            list(range(kv_req_offset + chunk_len * q_head_chunk_id, kv_req_offset + chunk_len * (q_head_chunk_id + 1)))
+        )
         kv_with_q_head_nomask_seqlens.append(chunk_len * q_head_chunk_id)
 
-        q_tail_idx.extend(
-            list(range(q_req_offset + chunk_len,
-                       q_req_offset + chunk_len * 2)))
-        kv_with_q_tail_nomask_idx.extend(
-            list(
-                range(kv_req_offset,
-                      kv_req_offset + chunk_len * q_tail_chunk_id)))
+        q_tail_idx.extend(list(range(q_req_offset + chunk_len, q_req_offset + chunk_len * 2)))
+        kv_with_q_tail_nomask_idx.extend(list(range(kv_req_offset, kv_req_offset + chunk_len * q_tail_chunk_id)))
         kv_with_q_tail_mask_idx.extend(
-            list(
-                range(kv_req_offset + chunk_len * q_tail_chunk_id,
-                      kv_req_offset + chunk_len * (q_tail_chunk_id + 1))))
+            list(range(kv_req_offset + chunk_len * q_tail_chunk_id, kv_req_offset + chunk_len * (q_tail_chunk_id + 1)))
+        )
         kv_with_q_tail_nomask_seqlens.append(chunk_len * q_tail_chunk_id)
 
         q_req_offset += seq_len
@@ -65,75 +58,74 @@ def get_pcp_split_info(pcp_rank, pcp_size, seq_lens):
     )
 
 
-def get_chunk_metadata(pcp_size, dcp_size, num_prefills, num_decodes,
-                       block_size, num_computed_tokens_cpu, num_reqs,
-                       chunked_prefill_workspace_size,
-                       num_computed_tokens_of_pcp_dcp, cp_local_block_size):
+def get_chunk_metadata(
+    pcp_size,
+    dcp_size,
+    num_prefills,
+    num_decodes,
+    block_size,
+    num_computed_tokens_cpu,
+    num_reqs,
+    chunked_prefill_workspace_size,
+    num_computed_tokens_of_pcp_dcp,
+    cp_local_block_size,
+):
     reqs_start = num_decodes
     context_lens_cpu = num_computed_tokens_cpu[reqs_start:num_reqs]
     max_context_len_cpu = context_lens_cpu.max().item()
     num_prefills_with_context_cpu = (context_lens_cpu > 0).sum().item()
-    max_context_chunk = (chunked_prefill_workspace_size //
-                         num_prefills_with_context_cpu)
+    max_context_chunk = chunked_prefill_workspace_size // num_prefills_with_context_cpu
     max_context_chunk = max_context_chunk // block_size * block_size
 
     assert max_context_chunk > 0
-    num_chunks = (max_context_len_cpu + max_context_chunk -
-                  1) // max_context_chunk
-    chunk_starts = torch.arange(num_chunks, dtype=torch.int32) \
-                       .unsqueeze(1).expand(-1, num_prefills) * max_context_chunk
-    chunk_ends = torch.min(context_lens_cpu.unsqueeze(0),
-                           chunk_starts + max_context_chunk)
+    num_chunks = (max_context_len_cpu + max_context_chunk - 1) // max_context_chunk
+    chunk_starts = torch.arange(num_chunks, dtype=torch.int32).unsqueeze(1).expand(-1, num_prefills) * max_context_chunk
+    chunk_ends = torch.min(context_lens_cpu.unsqueeze(0), chunk_starts + max_context_chunk)
     chunk_seq_lens = (chunk_ends - chunk_starts).clamp(min=0)
-    cu_seq_lens_cpu = torch.zeros(num_chunks,
-                                  num_prefills + 1,
-                                  dtype=torch.int32)
-    torch.cumsum(chunk_seq_lens,
-                 dim=1,
-                 out=cu_seq_lens_cpu[:, 1:],
-                 dtype=torch.int32)
+    cu_seq_lens_cpu = torch.zeros(num_chunks, num_prefills + 1, dtype=torch.int32)
+    torch.cumsum(chunk_seq_lens, dim=1, out=cu_seq_lens_cpu[:, 1:], dtype=torch.int32)
 
     def cdiv(a, b):
         return (a + b - 1) // b
 
     if dcp_size * pcp_size > 1:
         if num_computed_tokens_of_pcp_dcp is not None:
-            local_context_lens_allranks = torch.tensor(
-                num_computed_tokens_of_pcp_dcp[reqs_start:num_reqs]).reshape(
-                    -1, dcp_size * pcp_size)
+            local_context_lens_allranks = torch.tensor(num_computed_tokens_of_pcp_dcp[reqs_start:num_reqs]).reshape(
+                -1, dcp_size * pcp_size
+            )
         # Note(qcs): The max local context lengths
         # padded to `cp_local_block_size`.
-        padded_local_context_lens_cpu = (cdiv(
-            context_lens_cpu,
-            cp_local_block_size * pcp_size * dcp_size,
-        ) * cp_local_block_size)
-        padded_local_max_context_chunk_across_ranks = (cdiv(
-            max_context_chunk,
-            cp_local_block_size * pcp_size * dcp_size,
-        ) * cp_local_block_size)
+        padded_local_context_lens_cpu = (
+            cdiv(
+                context_lens_cpu,
+                cp_local_block_size * pcp_size * dcp_size,
+            )
+            * cp_local_block_size
+        )
+        padded_local_max_context_chunk_across_ranks = (
+            cdiv(
+                max_context_chunk,
+                cp_local_block_size * pcp_size * dcp_size,
+            )
+            * cp_local_block_size
+        )
         local_chunk_starts = (
-            torch.arange(num_chunks, dtype=torch.int32).unsqueeze(1).expand(
-                -1, num_prefills) *
-            padded_local_max_context_chunk_across_ranks)
+            torch.arange(num_chunks, dtype=torch.int32).unsqueeze(1).expand(-1, num_prefills)
+            * padded_local_max_context_chunk_across_ranks
+        )
         local_chunk_ends = torch.min(
             padded_local_context_lens_cpu.unsqueeze(0),
             local_chunk_starts + padded_local_max_context_chunk_across_ranks,
         )
-        padded_local_chunk_seq_lens = (local_chunk_ends -
-                                       local_chunk_starts).clamp(min=0)
-        padded_local_cu_chunk_seq_lens_cpu = torch.zeros(num_chunks,
-                                                         num_prefills + 1,
-                                                         dtype=torch.int32)
+        padded_local_chunk_seq_lens = (local_chunk_ends - local_chunk_starts).clamp(min=0)
+        padded_local_cu_chunk_seq_lens_cpu = torch.zeros(num_chunks, num_prefills + 1, dtype=torch.int32)
         torch.cumsum(
             padded_local_chunk_seq_lens,
             dim=1,
             out=padded_local_cu_chunk_seq_lens_cpu[:, 1:],
             dtype=torch.int32,
         )
-        chunk_actual_seq_lengths_kv_list = [
-            torch.cumsum(chunk_seq_lens[i], dim=0).tolist()
-            for i in range(num_chunks)
-        ]
+        chunk_actual_seq_lengths_kv_list = [torch.cumsum(chunk_seq_lens[i], dim=0).tolist() for i in range(num_chunks)]
         chunked_context_metadata = CPChunkedContextMetadata(
             cu_seq_lens=cu_seq_lens_cpu.to(non_blocking=True),
             starts=local_chunk_starts.to(non_blocking=True),
@@ -146,13 +138,12 @@ def get_chunk_metadata(pcp_size, dcp_size, num_prefills, num_decodes,
             padded_chunk_seq_lens_npu=padded_local_chunk_seq_lens,
             padded_local_chunk_seq_lens=padded_local_chunk_seq_lens.tolist(),
             local_context_lens_allranks=local_context_lens_allranks.tolist(),
-            padded_local_cu_seq_lens=padded_local_cu_chunk_seq_lens_cpu.to(
-                non_blocking=True),
+            padded_local_cu_seq_lens=padded_local_cu_chunk_seq_lens_cpu.to(non_blocking=True),
             cu_seq_lens_lst=cu_seq_lens_cpu.tolist(),
             chunk_size=padded_local_max_context_chunk_across_ranks,
         )
     else:
-        chunked_context_metadata = (ChunkedContextMetadata(
+        chunked_context_metadata = ChunkedContextMetadata(
             cu_seq_lens=cu_seq_lens_cpu.to(non_blocking=True),
             starts=chunk_starts.to(non_blocking=True),
             seq_tot=chunk_seq_lens.sum(dim=1).tolist(),
@@ -160,21 +151,17 @@ def get_chunk_metadata(pcp_size, dcp_size, num_prefills, num_decodes,
             chunk_seq_lens=chunk_seq_lens,
             chunk_seq_lens_npu=chunk_seq_lens,
             workspace=None,
-        ))
+        )
     return chunked_context_metadata
 
 
 class TestAscendMLAImpl(TestBase):
-
-    @patch('vllm.distributed.parallel_state._TP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch("vllm.distributed.get_tensor_model_parallel_world_size",
-           return_value=2)
+    @patch("vllm.distributed.parallel_state._TP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch("vllm.distributed.get_tensor_model_parallel_world_size", return_value=2)
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
-    def setUp(self, ascend_config, get_current_vllm_config, mock_get_tp_size,
-              mock_tp):
+    def setUp(self, ascend_config, get_current_vllm_config, mock_get_tp_size, mock_tp):
         mock_tp.world_size = 2
         mock_tp.rank_in_group = MagicMock()
         mock_tp.device_group = MagicMock()
@@ -219,18 +206,20 @@ class TestAscendMLAImpl(TestBase):
             "rotary_emb": MagicMock(),
         }
 
-        self.impl = AscendMlaCPImpl(num_heads=num_heads,
-                                    head_size=head_size,
-                                    scale=scale,
-                                    num_kv_heads=num_kv_heads,
-                                    alibi_slopes=None,
-                                    sliding_window=None,
-                                    kv_cache_dtype=kv_cache_dtype,
-                                    blocksparse_params=None,
-                                    logits_soft_cap=None,
-                                    attn_type=None,
-                                    kv_sharing_target_layer_name=None,
-                                    **kwargs)
+        self.impl = AscendMlaCPImpl(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=kv_cache_dtype,
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
 
     def test_init(self):
         self.assertEqual(self.impl.num_heads, 256)
@@ -253,12 +242,9 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.dcp_size, 2)
 
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
-    @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method",
-           return_value=MagicMock())
+    @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method", return_value=MagicMock())
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
-    def test_mla_preprocess_dcp(self, mock_get_weight_prefetch_method,
-                                mock_maybe_all_gather_and_maybe_unpad):
-
+    def test_mla_preprocess_dcp(self, mock_get_weight_prefetch_method, mock_maybe_all_gather_and_maybe_unpad):
         self.impl.num_kv_heads = 1
         self.impl.num_heads = 16
         self.impl.qk_rope_head_dim = 64
@@ -272,10 +258,8 @@ class TestAscendMLAImpl(TestBase):
         hidden_size = 1024
         hidden_states = torch.randn(batch_size, hidden_size)
 
-        kv_cache0 = torch.randn(block_num, block_size, self.impl.num_kv_heads,
-                                self.impl.kv_lora_rank)
-        kv_cache1 = torch.randn(block_num, block_size, self.impl.num_kv_heads,
-                                self.impl.qk_rope_head_dim)
+        kv_cache0 = torch.randn(block_num, block_size, self.impl.num_kv_heads, self.impl.kv_lora_rank)
+        kv_cache1 = torch.randn(block_num, block_size, self.impl.num_kv_heads, self.impl.qk_rope_head_dim)
         kv_cache = (kv_cache0, kv_cache1)
 
         attn_metadata = MagicMock()
@@ -289,18 +273,17 @@ class TestAscendMLAImpl(TestBase):
         attn_metadata.decode.sin = torch.randn(2, 64)
 
         self.impl.q_a_layernorm = MagicMock()
-        self.impl.q_a_layernorm.return_value = torch.randn(
-            attn_metadata.num_actual_tokens, self.impl.q_lora_rank)
+        self.impl.q_a_layernorm.return_value = torch.randn(attn_metadata.num_actual_tokens, self.impl.q_lora_rank)
         self.impl.kv_a_proj_with_mqa = MagicMock()
         self.impl.kv_a_proj_with_mqa.return_value = [
-            torch.randn(batch_size, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
+            torch.randn(batch_size, self.impl.num_heads, self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
         ]
         self.impl.fused_qkv_a_proj = MagicMock()
         self.impl.fused_qkv_a_proj.return_value = [
             torch.randn(
-                attn_metadata.num_actual_tokens, self.impl.qk_rope_head_dim +
-                self.impl.kv_lora_rank + self.impl.q_lora_rank)
+                attn_metadata.num_actual_tokens,
+                self.impl.qk_rope_head_dim + self.impl.kv_lora_rank + self.impl.q_lora_rank,
+            )
         ]
 
         self.impl.rope_single = MagicMock(side_effect=lambda x, cos, sin: x)
@@ -309,32 +292,26 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl._q_proj_and_k_up_proj = MagicMock()
         self.impl._q_proj_and_k_up_proj.return_value = [
-            torch.randn(attn_metadata.num_decodes, self.impl.num_heads,
-                        self.impl.kv_lora_rank),
-            torch.randn(attn_metadata.num_decodes, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim)
+            torch.randn(attn_metadata.num_decodes, self.impl.num_heads, self.impl.kv_lora_rank),
+            torch.randn(attn_metadata.num_decodes, self.impl.num_heads, self.impl.qk_rope_head_dim),
         ]
 
         mock_maybe_all_gather_and_maybe_unpad.side_effect = lambda x, label: x
 
         decode_res, prefill_res = self.impl._mla_preprocess(
-            "mock_layer",
-            hidden_states,
-            kv_cache,
-            attn_metadata,
-            need_gather_q_kv=False)
+            "mock_layer", hidden_states, kv_cache, attn_metadata, need_gather_q_kv=False
+        )
 
         self.assertIsNotNone(decode_res)
         self.assertIsNone(prefill_res)
 
-    @patch('torch_npu._npu_reshape_and_cache')
+    @patch("torch_npu._npu_reshape_and_cache")
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
-    @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method",
-           return_value=MagicMock())
+    @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method", return_value=MagicMock())
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
-    def test_mla_preprocess_pcp(self, mock_get_weight_prefetch_method,
-                                mock_maybe_all_gather_and_maybe_unpad,
-                                mock_npu_reshape_and_cache):
+    def test_mla_preprocess_pcp(
+        self, mock_get_weight_prefetch_method, mock_maybe_all_gather_and_maybe_unpad, mock_npu_reshape_and_cache
+    ):
         self.impl.num_kv_heads = 1
         self.impl.num_heads = 16
         self.impl.qk_rope_head_dim = 64
@@ -348,10 +325,8 @@ class TestAscendMLAImpl(TestBase):
         hidden_size = 1024
         hidden_states = torch.randn(batch_size, hidden_size)
 
-        kv_cache0 = torch.randn(block_num, block_size, self.impl.num_kv_heads,
-                                self.impl.kv_lora_rank)
-        kv_cache1 = torch.randn(block_num, block_size, self.impl.num_kv_heads,
-                                self.impl.qk_rope_head_dim)
+        kv_cache0 = torch.randn(block_num, block_size, self.impl.num_kv_heads, self.impl.kv_lora_rank)
+        kv_cache1 = torch.randn(block_num, block_size, self.impl.num_kv_heads, self.impl.qk_rope_head_dim)
         kv_cache = (kv_cache0, kv_cache1)
 
         attn_metadata = MagicMock()
@@ -362,25 +337,23 @@ class TestAscendMLAImpl(TestBase):
         attn_metadata.num_actual_tokens = 2
         attn_metadata.num_actual_tokens_pcp_padded = 4
         attn_metadata.prefill.pcp_metadata = MagicMock()
-        attn_metadata.prefill.pcp_metadata.pcp_allgather_restore_idx = torch.arange(
-            4)
+        attn_metadata.prefill.pcp_metadata.pcp_allgather_restore_idx = torch.arange(4)
         attn_metadata.slot_mapping = torch.arange(4)
         attn_metadata.prefill.cos = torch.randn(2, 64)
         attn_metadata.prefill.sin = torch.randn(2, 64)
 
         self.impl.q_a_layernorm = MagicMock()
-        self.impl.q_a_layernorm.return_value = torch.randn(
-            attn_metadata.num_actual_tokens, self.impl.q_lora_rank)
+        self.impl.q_a_layernorm.return_value = torch.randn(attn_metadata.num_actual_tokens, self.impl.q_lora_rank)
         self.impl.kv_a_proj_with_mqa = MagicMock()
         self.impl.kv_a_proj_with_mqa.return_value = [
-            torch.randn(batch_size, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
+            torch.randn(batch_size, self.impl.num_heads, self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
         ]
         self.impl.fused_qkv_a_proj = MagicMock()
         self.impl.fused_qkv_a_proj.return_value = [
             torch.randn(
-                attn_metadata.num_actual_tokens, self.impl.qk_rope_head_dim +
-                self.impl.kv_lora_rank + self.impl.q_lora_rank)
+                attn_metadata.num_actual_tokens,
+                self.impl.qk_rope_head_dim + self.impl.kv_lora_rank + self.impl.q_lora_rank,
+            )
         ]
 
         self.impl.rope_single = MagicMock(side_effect=lambda x, cos, sin: x)
@@ -389,47 +362,41 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl._q_proj_and_k_up_proj = MagicMock()
         self.impl._q_proj_and_k_up_proj.return_value = [
-            torch.randn(attn_metadata.num_decodes, self.impl.num_heads,
-                        self.impl.kv_lora_rank),
-            torch.randn(attn_metadata.num_decodes, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim)
+            torch.randn(attn_metadata.num_decodes, self.impl.num_heads, self.impl.kv_lora_rank),
+            torch.randn(attn_metadata.num_decodes, self.impl.num_heads, self.impl.qk_rope_head_dim),
         ]
 
         mock_maybe_all_gather_and_maybe_unpad.side_effect = lambda x, label: x
 
         self.impl.kv_a_layernorm = MagicMock()
         self.impl.kv_a_layernorm.return_value = torch.randn(
-            attn_metadata.num_prefill_tokens, self.impl.num_kv_heads,
-            self.impl.kv_lora_rank)
+            attn_metadata.num_prefill_tokens, self.impl.num_kv_heads, self.impl.kv_lora_rank
+        )
 
         self.impl.q_proj = MagicMock()
         self.impl.q_proj.return_value = [
-            torch.randn(attn_metadata.num_prefill_tokens, self.impl.num_heads,
-                        self.impl.qk_head_dim)
+            torch.randn(attn_metadata.num_prefill_tokens, self.impl.num_heads, self.impl.qk_head_dim)
         ]
         self.impl.kv_b_proj = MagicMock()
         self.impl.kv_b_proj.return_value = [
-            torch.randn(attn_metadata.num_prefill_tokens * self.impl.pcp_size,
-                        self.impl.num_heads,
-                        self.impl.v_head_dim + self.impl.qk_nope_head_dim)
+            torch.randn(
+                attn_metadata.num_prefill_tokens * self.impl.pcp_size,
+                self.impl.num_heads,
+                self.impl.v_head_dim + self.impl.qk_nope_head_dim,
+            )
         ]
         self.impl.rope_single = MagicMock(side_effect=lambda x, cos, sin: x)
         self.impl.exec_kv_decode = MagicMock()
         self.impl.exec_kv_decode.return_value = [MagicMock(), MagicMock()]
         self.impl.exec_kv_prefill = MagicMock()
         self.impl.exec_kv_prefill.return_value = [
-            torch.randn(attn_metadata.num_prefill_tokens, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim),
-            torch.randn(attn_metadata.num_prefill_tokens, self.impl.num_heads,
-                        self.impl.kv_lora_rank)
+            torch.randn(attn_metadata.num_prefill_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim),
+            torch.randn(attn_metadata.num_prefill_tokens, self.impl.num_heads, self.impl.kv_lora_rank),
         ]
 
         decode_res, prefill_res = self.impl._mla_preprocess(
-            "mock_layer",
-            hidden_states,
-            kv_cache,
-            attn_metadata,
-            need_gather_q_kv=False)
+            "mock_layer", hidden_states, kv_cache, attn_metadata, need_gather_q_kv=False
+        )
         self.assertIsNone(decode_res)
         self.assertIsNotNone(prefill_res)
 
@@ -454,13 +421,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[1], N)
         self.assertEqual(result.shape[2], self.impl.kv_lora_rank + 1)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score")
-    @patch('torch_npu.npu_attention_update')
+    @patch("torch_npu.npu_attention_update")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
-    def test_forward_decode_pcp_dcp(self, mock_npu_attention_update,
-                                    mock_npu_fused_infer_attention_score,
-                                    mock_get_forward_context):
+    def test_forward_decode_pcp_dcp(
+        self, mock_npu_attention_update, mock_npu_fused_infer_attention_score, mock_get_forward_context
+    ):
         self.impl.dcp_size = 2
         self.impl.pcp_size = 2
         self.impl.num_kv_heads = 1
@@ -486,20 +453,17 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl.enable_kv_nz = True
 
-        mock_npu_attention_update.return_value = (torch.randn(
-            B, self.impl.num_heads, self.impl.kv_lora_rank), None)
+        mock_npu_attention_update.return_value = (torch.randn(B, self.impl.num_heads, self.impl.kv_lora_rank), None)
         mock_npu_fused_infer_attention_score.return_value = [
             torch.randn(B, N, self.impl.kv_lora_rank),
-            torch.randn(B, N, 1)
+            torch.randn(B, N, 1),
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
 
         self.impl._v_up_proj = MagicMock()
-        self.impl._v_up_proj.return_value = torch.randn(
-            B, self.impl.v_head_dim)
+        self.impl._v_up_proj.return_value = torch.randn(B, self.impl.v_head_dim)
 
-        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS,
-                                           attn_metadata)
+        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS, attn_metadata)
 
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], self.impl.v_head_dim)
@@ -508,38 +472,43 @@ class TestAscendMLAImpl(TestBase):
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     @patch_distributed_groups(dcp_size=2, pcp_size=2)
-    def test_compute_prefill_context_with_dcp_pcp(self, mock_all2all, mock_dcp,
-                                                  mock_pcp, mock_fia,
-                                                  mock_update, mock_load):
-
+    def test_compute_prefill_context_with_dcp_pcp(
+        self, mock_all2all, mock_dcp, mock_pcp, mock_fia, mock_update, mock_load
+    ):
         def mock_fia_attn(*args, **kwargs):
             q = args[0]
             v = args[2]
-            return (torch.randn(q.shape[0],
-                                v.shape[1],
-                                v.shape[2],
-                                dtype=torch.float16),
-                    torch.randn(v.shape[1], q.shape[0], dtype=torch.float16))
+            return (
+                torch.randn(q.shape[0], v.shape[1], v.shape[2], dtype=torch.float16),
+                torch.randn(v.shape[1], q.shape[0], dtype=torch.float16),
+            )
 
         mock_fia.side_effect = mock_fia_attn
 
         def mock_kv_b_proj(kv_c_normed):
-            return (torch.randn(kv_c_normed.shape[0],
-                                self.impl.num_heads,
-                                self.impl.v_head_dim +
-                                self.impl.qk_nope_head_dim,
-                                dtype=torch.float16), )
+            return (
+                torch.randn(
+                    kv_c_normed.shape[0],
+                    self.impl.num_heads,
+                    self.impl.v_head_dim + self.impl.qk_nope_head_dim,
+                    dtype=torch.float16,
+                ),
+            )
 
-        def mock_reorg_kvcache(allgatered_kv_c_normed: torch.Tensor,
-                               allgatered_k_pe: torch.Tensor,
-                               chunked_context: CPChunkedContextMetadata,
-                               chunk_idx: int, toks: int):
+        def mock_reorg_kvcache(
+            allgatered_kv_c_normed: torch.Tensor,
+            allgatered_k_pe: torch.Tensor,
+            chunked_context: CPChunkedContextMetadata,
+            chunk_idx: int,
+            toks: int,
+        ):
             return torch.randn(
                 chunked_context.cu_seq_lens_lst[chunk_idx][-1],
                 allgatered_kv_c_normed.shape[1],
-                allgatered_kv_c_normed.shape[2]), torch.randn(
-                    chunked_context.cu_seq_lens_lst[chunk_idx][-1],
-                    allgatered_k_pe.shape[1], allgatered_k_pe.shape[2])
+                allgatered_kv_c_normed.shape[2],
+            ), torch.randn(
+                chunked_context.cu_seq_lens_lst[chunk_idx][-1], allgatered_k_pe.shape[1], allgatered_k_pe.shape[2]
+            )
 
         # mock proj
         self.impl.kv_b_proj.side_effect = mock_kv_b_proj
@@ -552,59 +521,56 @@ class TestAscendMLAImpl(TestBase):
         mock_update.side_effect = mock_update_fn
         NUM_BLOCKS, BLOCK_SIZE = 10, 32  # fixed
         USED_BLOCKS = 3
-        # pcp_size, dcp_size, nums_tokens_per_rank, nums_all_rank_context, num_prefills, num_decodes, num_seqs, cp_local_block_size, num_computed_tokens, num_computed_tokens_of_pcp_dcp
+        # pcp_size, dcp_size, nums_tokens_per_rank, nums_all_rank_context, num_prefills, num_decodes,
+        # num_seqs, cp_local_block_size, num_computed_tokens, num_computed_tokens_of_pcp_dcp
         test_cases = [
             (2, 2, [4], [128], 1, 0, 1, 1, [[[32, 32], [32, 32]]]),
             (1, 2, [4], [128], 1, 0, 1, 1, [[[64, 64]]]),
             (2, 1, [4], [128], 1, 0, 1, 1, [[[64], [64]]]),
-            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, [[[32, 32], [32, 32]],
-                                                    [[32, 32], [32, 32]]]),
+            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, [[[32, 32], [32, 32]], [[32, 32], [32, 32]]]),
         ]
         # kv cache tensor
-        kv_cache_0 = torch.randn(NUM_BLOCKS,
-                                 BLOCK_SIZE,
-                                 self.impl.num_heads,
-                                 self.impl.kv_lora_rank,
-                                 dtype=torch.float16)
-        kv_cache_1 = torch.randn(NUM_BLOCKS,
-                                 BLOCK_SIZE,
-                                 self.impl.num_heads,
-                                 self.impl.v_head_dim,
-                                 dtype=torch.float16)
+        kv_cache_0 = torch.randn(
+            NUM_BLOCKS, BLOCK_SIZE, self.impl.num_heads, self.impl.kv_lora_rank, dtype=torch.float16
+        )
+        kv_cache_1 = torch.randn(NUM_BLOCKS, BLOCK_SIZE, self.impl.num_heads, self.impl.v_head_dim, dtype=torch.float16)
         kv_cache = [kv_cache_0, kv_cache_1]
         max_model_len = 4096
         max_num_seqs = 25
         # create chunk context
-        chunked_prefill_workspace_size = min(
-            max(8 * max_model_len, 4 * max_num_seqs * BLOCK_SIZE), 128 * 1024)
-        self.impl.prefill_mask = torch.triu(
-            torch.ones(10, 10, dtype=torch.float16), 1)
+        chunked_prefill_workspace_size = min(max(8 * max_model_len, 4 * max_num_seqs * BLOCK_SIZE), 128 * 1024)
+        self.impl.prefill_mask = torch.triu(torch.ones(10, 10, dtype=torch.float16), 1)
         for test_case in test_cases:
-            pcp_size, dcp_size, nums_tokens_per_rank, nums_all_rank_context, num_prefills, num_decodes, num_seqs, cp_local_block_size, num_computed_tokens_of_pcp_dcp = test_case
+            (
+                pcp_size,
+                dcp_size,
+                nums_tokens_per_rank,
+                nums_all_rank_context,
+                num_prefills,
+                num_decodes,
+                num_seqs,
+                cp_local_block_size,
+                num_computed_tokens_of_pcp_dcp,
+            ) = test_case
             mock_dcp.world_size = dcp_size
             mock_pcp.world_size = pcp_size
             assert len(nums_tokens_per_rank) == len(nums_all_rank_context)
             nums_context_per_rank = []
             for num_all_rank_context in nums_all_rank_context:
                 assert num_all_rank_context % (pcp_size * dcp_size) == 0
-                nums_context_per_rank.append(num_all_rank_context //
-                                             (pcp_size * dcp_size))
+                nums_context_per_rank.append(num_all_rank_context // (pcp_size * dcp_size))
             self.impl.dcp_size = dcp_size
             self.impl.pcp_size = pcp_size
             # create input
-            query = torch.randn(sum(nums_tokens_per_rank),
-                                self.impl.num_heads,
-                                self.impl.qk_head_dim,
-                                dtype=torch.float16)
-            q_nope = query[..., :self.impl.qk_nope_head_dim]
-            q_pe = query[..., self.impl.qk_nope_head_dim:]
-            prefix_out = torch.randn(sum(nums_tokens_per_rank),
-                                     self.impl.num_heads,
-                                     self.impl.v_head_dim,
-                                     dtype=torch.float16)
-            prefix_lse = torch.randn(self.impl.num_heads,
-                                     sum(nums_tokens_per_rank),
-                                     dtype=torch.float16)
+            query = torch.randn(
+                sum(nums_tokens_per_rank), self.impl.num_heads, self.impl.qk_head_dim, dtype=torch.float16
+            )
+            q_nope = query[..., : self.impl.qk_nope_head_dim]
+            q_pe = query[..., self.impl.qk_nope_head_dim :]
+            prefix_out = torch.randn(
+                sum(nums_tokens_per_rank), self.impl.num_heads, self.impl.v_head_dim, dtype=torch.float16
+            )
+            prefix_lse = torch.randn(self.impl.num_heads, sum(nums_tokens_per_rank), dtype=torch.float16)
             chunk_ctx = get_chunk_metadata(
                 pcp_size,
                 dcp_size,
@@ -615,27 +581,26 @@ class TestAscendMLAImpl(TestBase):
                 num_reqs=num_seqs,
                 chunked_prefill_workspace_size=chunked_prefill_workspace_size,
                 num_computed_tokens_of_pcp_dcp=num_computed_tokens_of_pcp_dcp,
-                cp_local_block_size=cp_local_block_size)
+                cp_local_block_size=cp_local_block_size,
+            )
             meta = MagicMock()
             prefill_meta = MagicMock()
             prefill_meta.query_lens = torch.tensor(nums_tokens_per_rank)
-            prefill_meta.block_table = torch.randint(
-                0, USED_BLOCKS, (1, 64))  # (batch, max_blocks)
+            prefill_meta.block_table = torch.randint(0, USED_BLOCKS, (1, 64))  # (batch, max_blocks)
             prefill_meta.chunked_context = chunk_ctx
             meta.prefill = prefill_meta
 
-            with patch.object(self.impl, '_reorg_kvcache') as mock_reorg:
+            with patch.object(self.impl, "_reorg_kvcache") as mock_reorg:
                 mock_reorg.side_effect = mock_reorg_kvcache
 
                 out, lse = self.impl._compute_prefill_context(
-                    q_nope, q_pe, kv_cache, self.impl.qk_rope_head_dim, meta,
-                    prefix_out, prefix_lse)
+                    q_nope, q_pe, kv_cache, self.impl.qk_rope_head_dim, meta, prefix_out, prefix_lse
+                )
 
             iters = len(chunk_ctx.seq_tot)
             self.impl.dcp_size = 1
             self.impl.pcp_size = 1
-            self.assertEqual(mock_reorg.call_count,
-                             iters * (1 if dcp_size * pcp_size > 1 else 0))
+            self.assertEqual(mock_reorg.call_count, iters * (1 if dcp_size * pcp_size > 1 else 0))
             self.assertEqual(mock_load.call_count, iters)
             self.assertEqual(mock_fia.call_count, iters)
             mock_reorg.reset_mock()
@@ -647,8 +612,7 @@ class TestAscendMLAImpl(TestBase):
             self.assertEqual(out.shape, prefix_out.shape)
 
     @patch_distributed_groups(dcp_size=2, pcp_size=2)
-    def test_reorg_kvcache_with_dcp_pcp(self, mock_all2all, mock_dcp,
-                                        mock_pcp):
+    def test_reorg_kvcache_with_dcp_pcp(self, mock_all2all, mock_dcp, mock_pcp):
         BLOCK_SIZE = 128  # fixed
         max_model_len = 4096
         max_num_seqs = 25
@@ -656,11 +620,20 @@ class TestAscendMLAImpl(TestBase):
             (2, 2, [4], [128], 1, 0, 1, 1, [[[32, 32], [32, 32]]]),
             (1, 2, [4], [128], 1, 0, 1, 1, [[[64, 64]]]),
             (2, 1, [4], [128], 1, 0, 1, 1, [[[64], [64]]]),
-            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, [[[32, 32], [32, 32]],
-                                                    [[32, 32], [32, 32]]]),
+            (2, 2, [4, 7], [128, 128], 2, 0, 2, 1, [[[32, 32], [32, 32]], [[32, 32], [32, 32]]]),
         ]
         for test_case in test_cases:
-            pcp_size, dcp_size, nums_tokens_per_rank, nums_all_rank_context, num_prefills, num_decodes, num_seqs, cp_local_block_size, num_computed_tokens_of_pcp_dcp = test_case
+            (
+                pcp_size,
+                dcp_size,
+                nums_tokens_per_rank,
+                nums_all_rank_context,
+                num_prefills,
+                num_decodes,
+                num_seqs,
+                cp_local_block_size,
+                num_computed_tokens_of_pcp_dcp,
+            ) = test_case
             if pcp_size * dcp_size == 1:
                 continue
             self.impl.dcp_size = dcp_size
@@ -670,9 +643,7 @@ class TestAscendMLAImpl(TestBase):
             mock_pcp.world_size = pcp_size
             mock_pcp.all_gather.reset_mock()
 
-            chunked_prefill_workspace_size = min(
-                max(8 * max_model_len, 4 * max_num_seqs * BLOCK_SIZE),
-                128 * 1024)
+            chunked_prefill_workspace_size = min(max(8 * max_model_len, 4 * max_num_seqs * BLOCK_SIZE), 128 * 1024)
             chunked_context = get_chunk_metadata(
                 pcp_size,
                 dcp_size,
@@ -683,15 +654,16 @@ class TestAscendMLAImpl(TestBase):
                 num_reqs=num_seqs,
                 chunked_prefill_workspace_size=chunked_prefill_workspace_size,
                 num_computed_tokens_of_pcp_dcp=num_computed_tokens_of_pcp_dcp,
-                cp_local_block_size=cp_local_block_size)
+                cp_local_block_size=cp_local_block_size,
+            )
 
             for i in range(len(chunked_context.seq_tot)):
                 allgatered_kv_c_normed = torch.randn(
-                    chunked_context.seq_tot[i], self.impl.num_heads,
-                    self.impl.kv_lora_rank)
-                allgatered_k_pe = torch.randn(chunked_context.seq_tot[i],
-                                              self.impl.num_heads,
-                                              self.impl.qk_rope_head_dim)
+                    chunked_context.seq_tot[i], self.impl.num_heads, self.impl.kv_lora_rank
+                )
+                allgatered_k_pe = torch.randn(
+                    chunked_context.seq_tot[i], self.impl.num_heads, self.impl.qk_rope_head_dim
+                )
                 result_kv, result_k_pe = self.impl._reorg_kvcache(
                     allgatered_kv_c_normed,
                     allgatered_k_pe,
@@ -699,23 +671,20 @@ class TestAscendMLAImpl(TestBase):
                     chunk_idx=i,
                     toks=chunked_context.seq_tot[i],
                 )
-                self.assertEqual(result_kv.shape,
-                                 (chunked_context.cu_seq_lens_lst[i][-1],
-                                  self.impl.num_heads, self.impl.kv_lora_rank))
+                self.assertEqual(
+                    result_kv.shape,
+                    (chunked_context.cu_seq_lens_lst[i][-1], self.impl.num_heads, self.impl.kv_lora_rank),
+                )
                 self.assertEqual(
                     result_k_pe.shape,
-                    (chunked_context.cu_seq_lens_lst[i][-1],
-                     self.impl.num_heads, self.impl.qk_rope_head_dim))
+                    (chunked_context.cu_seq_lens_lst[i][-1], self.impl.num_heads, self.impl.qk_rope_head_dim),
+                )
 
-                self.assertEqual(result_kv.shape[0],
-                                 chunked_context.cu_seq_lens_lst[i][-1])
-                self.assertEqual(result_k_pe.shape[0],
-                                 chunked_context.cu_seq_lens_lst[i][-1])
+                self.assertEqual(result_kv.shape[0], chunked_context.cu_seq_lens_lst[i][-1])
+                self.assertEqual(result_k_pe.shape[0], chunked_context.cu_seq_lens_lst[i][-1])
 
-                self.assertEqual(mock_dcp.all_gather.call_count,
-                                 (1 if dcp_size > 1 else 0))
-                self.assertEqual(mock_pcp.all_gather.call_count,
-                                 (1 if pcp_size > 1 else 0))
+                self.assertEqual(mock_dcp.all_gather.call_count, (1 if dcp_size > 1 else 0))
+                self.assertEqual(mock_pcp.all_gather.call_count, (1 if pcp_size > 1 else 0))
 
     def test_out_lse_reshape(self):
         test_cases = [10, 1, 128, 512]
@@ -730,7 +699,7 @@ class TestAscendMLAImpl(TestBase):
             assert out.shape == (num_tokens * num_heads, head_dim)
             assert out.is_contiguous()
 
-            assert lse.shape == (num_tokens * num_heads, )
+            assert lse.shape == (num_tokens * num_heads,)
             assert lse.is_contiguous()
 
             expected_out = attn_out.contiguous().view(-1, head_dim)
@@ -739,17 +708,14 @@ class TestAscendMLAImpl(TestBase):
             assert torch.allclose(out, expected_out)
             assert torch.allclose(lse, expected_lse)
 
-    @patch('torch_npu.npu_attention_update')
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
-    @patch('vllm.distributed.parallel_state._PCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    @patch('vllm_ascend.attention.context_parallel.common_cp.get_dcp_group')
-    @patch('vllm.distributed.parallel_state._DCP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
-    def test_npu_attention_update_with_dcp_pcp(self, mock_dcp,
-                                               mock_get_dcp_group, mock_pcp,
-                                               mock_get_pcp_group,
-                                               mock_npu_attention_update):
+    @patch("torch_npu.npu_attention_update")
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_pcp_group")
+    @patch("vllm.distributed.parallel_state._PCP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch("vllm_ascend.attention.context_parallel.common_cp.get_dcp_group")
+    @patch("vllm.distributed.parallel_state._DCP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    def test_npu_attention_update_with_dcp_pcp(
+        self, mock_dcp, mock_get_dcp_group, mock_pcp, mock_get_pcp_group, mock_npu_attention_update
+    ):
         NUM_TOKENS = 10  # fixed
         test_cases = [(1, 1), (1, 2), (2, 1), (2, 2), (2, 3)]
         for test_case in test_cases:
@@ -758,21 +724,15 @@ class TestAscendMLAImpl(TestBase):
             num_heads, head_dim = self.impl.num_heads, self.impl.kv_lora_rank + 1
 
             def mock_out_lse_reshape(attn_out, attn_lse):
-                attn_out = attn_out.contiguous().view(
-                    attn_out.shape[0] * attn_out.shape[1], attn_out.shape[2])
-                attn_lse = attn_lse.contiguous().view(
-                    attn_lse.shape[0] * attn_lse.shape[1] * attn_lse.shape[2])
+                attn_out = attn_out.contiguous().view(attn_out.shape[0] * attn_out.shape[1], attn_out.shape[2])
+                attn_lse = attn_lse.contiguous().view(attn_lse.shape[0] * attn_lse.shape[1] * attn_lse.shape[2])
                 return attn_out, attn_lse
 
             self.impl._out_lse_reshape = MagicMock()
             self.impl._out_lse_reshape.side_effect = mock_out_lse_reshape
 
-            def mock_npu_attention_update_effect(attn_lse_split_cp,
-                                                 attn_out_split_cp,
-                                                 update_type):
-                return torch.randn_like(
-                    attn_out_split_cp[0]), torch.randn_like(
-                        attn_lse_split_cp[0])
+            def mock_npu_attention_update_effect(attn_lse_split_cp, attn_out_split_cp, update_type):
+                return torch.randn_like(attn_out_split_cp[0]), torch.randn_like(attn_lse_split_cp[0])
 
             mock_npu_attention_update.side_effect = mock_npu_attention_update_effect
 
@@ -783,18 +743,15 @@ class TestAscendMLAImpl(TestBase):
             mock_dcp.world_size = self.impl.dcp_size
             mock_dcp_group = MagicMock()
             mock_get_dcp_group.return_value = mock_dcp_group
-            attn_out_lse = torch.randn(self.impl.pcp_size * NUM_TOKENS,
-                                       self.impl.dcp_size * num_heads,
-                                       head_dim)
+            attn_out_lse = torch.randn(self.impl.pcp_size * NUM_TOKENS, self.impl.dcp_size * num_heads, head_dim)
             out = _npu_attention_update(self.impl.kv_lora_rank, attn_out_lse)
             self.impl.dcp_size = 1
             self.impl.pcp_size = 1
             assert out.shape == (NUM_TOKENS, num_heads, self.impl.kv_lora_rank)
-    
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch('vllm_ascend.attention.context_parallel.mla_cp._npu_attn_out_lse_update')
-    def test_attention_with_mask_and_nomask_with_dcp_pcp(
-            self, mock_npu_attn_update, mock_npu_fia):
+
+    @patch("torch.ops.npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.attention.context_parallel.mla_cp._npu_attn_out_lse_update")
+    def test_attention_with_mask_and_nomask_with_dcp_pcp(self, mock_npu_attn_update, mock_npu_fia):
         num_heads = self.impl.num_heads
         v_head_dim = self.impl.v_head_dim
         qk_nope_head_dim = self.impl.qk_nope_head_dim
@@ -806,18 +763,20 @@ class TestAscendMLAImpl(TestBase):
             out = torch.randn(q_tokens, num_heads, v_head_dim, dtype=torch.float16)
             lse = torch.randn(q_tokens, num_heads, 1, dtype=torch.float32)
             return out, lse
+
         mock_npu_fia.side_effect = mock_npu_fia_effect
 
         def mock_update_effect(lse_mask, lse_nomask, out_mask, out_nomask):
             return torch.randn_like(out_mask)
+
         mock_npu_attn_update.side_effect = mock_update_effect
-        
-        test_cases = [([8], 2, 2), ([8, 12], 2, 2)] 
+
+        test_cases = [([8], 2, 2), ([8, 12], 2, 2)]
         for test_case in test_cases:
             scheduled_tokens, pcp_size, dcp_size = test_case
             nums_tokens_per_rank = [num // pcp_size for num in scheduled_tokens]
             seq_len_q, seq_len_k = sum(nums_tokens_per_rank), sum(scheduled_tokens)
-            
+
             q_nope = torch.randn(seq_len_q, num_heads, qk_nope_head_dim, dtype=torch.float16)
             q_pe = torch.randn(seq_len_q, num_heads, qk_rope_head_dim, dtype=torch.float16)
             k_nope = torch.randn(seq_len_k, num_heads, qk_nope_head_dim, dtype=torch.float16)
@@ -846,7 +805,7 @@ class TestAscendMLAImpl(TestBase):
                     attn_mask_seqlens=torch.tensor([chunk_seqlens, chunk_seqlens], dtype=torch.int32),
                     attn_nomask_seqlens=torch.tensor([kv_with_q_head_nomask_seqlens], dtype=torch.int32),
                     mask=mask,
-                    attn_metadata=attn_metadata
+                    attn_metadata=attn_metadata,
                 )
 
                 self.assertEqual(output_head.shape, (q_head_idx.shape[0], num_heads, v_head_dim))
@@ -857,13 +816,13 @@ class TestAscendMLAImpl(TestBase):
 
                 mock_npu_fia.reset_mock()
                 mock_npu_attn_update.reset_mock()
-    
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch('vllm_ascend.attention.context_parallel.mla_cp._npu_attn_out_lse_update')
-    @patch('vllm_ascend.attention.context_parallel.mla_cp._update_out_and_lse')
+
+    @patch("torch.ops.npu.npu_fused_infer_attention_score")
+    @patch("vllm_ascend.attention.context_parallel.mla_cp._npu_attn_out_lse_update")
+    @patch("vllm_ascend.attention.context_parallel.mla_cp._update_out_and_lse")
     def test_attention_with_mask_and_nomask_trigger_chunked(
-            self, mock_update_out_lse, mock_npu_attn_update, mock_npu_fia):
-        
+        self, mock_update_out_lse, mock_npu_attn_update, mock_npu_fia
+    ):
         num_heads = self.impl.num_heads
         v_head_dim = self.impl.v_head_dim
         qk_nope_head_dim = self.impl.qk_nope_head_dim
@@ -874,17 +833,19 @@ class TestAscendMLAImpl(TestBase):
             out = torch.randn(q_tokens, num_heads, v_head_dim, dtype=torch.float16)
             lse = torch.randn(q_tokens, num_heads, 1, dtype=torch.float32)
             return out, lse
+
         mock_npu_fia.side_effect = mock_npu_fia_effect
 
         def mock_chunked_update_effect(outs, lses):
-            return outs[0], lses[0] 
+            return outs[0], lses[0]
+
         mock_update_out_lse.side_effect = mock_chunked_update_effect
 
-        test_cases = [([8], 2, 2)] 
+        test_cases = [([8], 2, 2)]
         for test_case in test_cases:
             scheduled_tokens, pcp_size, dcp_size = test_case
             nums_tokens_per_rank = [num // pcp_size for num in scheduled_tokens]
-            
+
             q_nope = torch.randn(sum(nums_tokens_per_rank), num_heads, qk_nope_head_dim, dtype=torch.float16)
             q_pe = torch.randn(sum(nums_tokens_per_rank), num_heads, qk_rope_head_dim, dtype=torch.float16)
             k_nope = torch.randn(sum(scheduled_tokens), num_heads, qk_nope_head_dim, dtype=torch.float16)
@@ -914,7 +875,7 @@ class TestAscendMLAImpl(TestBase):
                     attn_mask_seqlens=torch.tensor([chunk_seqlens, chunk_seqlens], dtype=torch.int32),
                     attn_nomask_seqlens=torch.tensor([kv_with_q_head_nomask_seqlens], dtype=torch.int32),
                     mask=mask,
-                    attn_metadata=attn_metadata
+                    attn_metadata=attn_metadata,
                 )
 
                 if kv_with_q_head_nomask_idx is not None and kv_with_q_head_nomask_idx.numel() > 0:
@@ -928,5 +889,5 @@ class TestAscendMLAImpl(TestBase):
 
                 mock_npu_fia.reset_mock()
                 mock_update_out_lse.reset_mock()
-            
+
             self.assertTrue(update_called_at_least_once, "Test case data did not trigger nomask branch at all!")

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -4,23 +4,24 @@ from unittest.mock import MagicMock, patch
 import torch
 from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.distributed.parallel_state import GroupCoordinator
-from vllm.model_executor.layers.linear import (LinearBase,
-                                               UnquantizedLinearMethod)
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.mla_v1 import (AscendMLABackend,
-                                          AscendMLADecodeMetadata,
-                                          AscendMLAImpl, AscendMLAMetadata,
-                                          AscendMLAMetadataBuilder,
-                                          AscendMLAPrefillMetadata,
-                                          ChunkedContextMetadata)
+from vllm_ascend.attention.mla_v1 import (
+    AscendMLABackend,
+    AscendMLADecodeMetadata,
+    AscendMLAImpl,
+    AscendMLAMetadata,
+    AscendMLAMetadataBuilder,
+    AscendMLAPrefillMetadata,
+    ChunkedContextMetadata,
+)
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 
 
 class TestAscendMLABackend(TestBase):
-
     def setUp(self):
         self.mock_config = MagicMock()
 
@@ -30,20 +31,18 @@ class TestAscendMLABackend(TestBase):
 
         self.mock_config.parallel_config = mock_parallel_config
 
-        self.utils_patcher = patch(
-            'vllm_ascend.attention.utils.get_current_vllm_config',
-            return_value=self.mock_config)
+        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
         self.utils_patcher.start()
 
         from vllm_ascend.attention.utils import enable_cp
+
         enable_cp.cache_clear()
 
     def test_get_name(self):
         self.assertEqual(AscendMLABackend.get_name(), "ASCEND_MLA")
 
     def test_get_builder_cls(self):
-        self.assertEqual(AscendMLABackend.get_builder_cls(),
-                         AscendMLAMetadataBuilder)
+        self.assertEqual(AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
         result = AscendMLABackend.get_kv_cache_shape(2, 4, 8, 128)
@@ -55,7 +54,6 @@ class TestAscendMLABackend(TestBase):
 
 
 class TestAscendMLAPrefillMetadata(TestBase):
-
     def test_ascend_mla_prefill_metadata_default(self):
         attn_mask = torch.tensor([[1, 0], [1, 1]], dtype=torch.bool)
         query_lens = [1, 2]
@@ -67,15 +65,17 @@ class TestAscendMLAPrefillMetadata(TestBase):
         max_query_len = 2
         max_seq_lens = 2
 
-        metadata = AscendMLAPrefillMetadata(attn_mask=attn_mask,
-                                            query_lens=query_lens,
-                                            seq_lens=seq_lens,
-                                            context_lens=context_lens,
-                                            input_positions=input_positions,
-                                            query_start_loc=query_start_loc,
-                                            block_table=block_table,
-                                            max_query_len=max_query_len,
-                                            max_seq_lens=max_seq_lens)
+        metadata = AscendMLAPrefillMetadata(
+            attn_mask=attn_mask,
+            query_lens=query_lens,
+            seq_lens=seq_lens,
+            context_lens=context_lens,
+            input_positions=input_positions,
+            query_start_loc=query_start_loc,
+            block_table=block_table,
+            max_query_len=max_query_len,
+            max_seq_lens=max_seq_lens,
+        )
         self.assertIs(metadata.attn_mask, attn_mask)
         self.assertEqual(metadata.query_lens, query_lens)
         self.assertEqual(metadata.seq_lens, seq_lens)
@@ -103,7 +103,8 @@ class TestAscendMLAPrefillMetadata(TestBase):
             workspace=workspace,
             chunk_seq_lens=chunk_seq_lens,
             chunk_seq_lens_npu=chunk_seq_lens,
-            chunk_actual_seq_lengths_kv_list=[[2, 4]])
+            chunk_actual_seq_lengths_kv_list=[[2, 4]],
+        )
 
         metadata = AscendMLAPrefillMetadata(
             attn_mask=torch.tensor([[1, 0], [1, 1]], dtype=torch.bool),
@@ -115,7 +116,8 @@ class TestAscendMLAPrefillMetadata(TestBase):
             block_table=torch.tensor([[0, 1], [2, 3]]),
             max_query_len=2,
             max_seq_lens=2,
-            chunked_context=chunked_context)
+            chunked_context=chunked_context,
+        )
 
         self.assertIsNotNone(metadata.chunked_context)
         self.assertIs(metadata.chunked_context.cu_seq_lens, cu_seq_lens)
@@ -124,12 +126,10 @@ class TestAscendMLAPrefillMetadata(TestBase):
         self.assertEqual(metadata.chunked_context.max_seq_lens, max_seq_lens)
         self.assertIs(metadata.chunked_context.workspace, workspace)
         self.assertIs(metadata.chunked_context.chunk_seq_lens, chunk_seq_lens)
-        self.assertIs(metadata.chunked_context.chunk_seq_lens_npu,
-                      chunk_seq_lens)
+        self.assertIs(metadata.chunked_context.chunk_seq_lens_npu, chunk_seq_lens)
 
 
 class TestAscendMLADecodeMetadata(TestBase):
-
     def test_ascend_mla_decode_metadata_default(self):
         input_positions = torch.tensor([[1, 2, 3, 4], [1, 2, 3, 4]])
         block_table = torch.tensor([[0, 3, 2, 1], [0, 2, 1, 3]])
@@ -139,13 +139,15 @@ class TestAscendMLADecodeMetadata(TestBase):
         attn_mask = None
         cp_seq_len = torch.tensor([2, 3])
 
-        metadata = AscendMLADecodeMetadata(input_positions=input_positions,
-                                           block_table=block_table,
-                                           seq_lens=seq_lens,
-                                           max_seq_lens=max_seq_lens,
-                                           seq_lens_list=seq_lens_list,
-                                           attn_mask=attn_mask,
-                                           cp_seq_len=cp_seq_len)
+        metadata = AscendMLADecodeMetadata(
+            input_positions=input_positions,
+            block_table=block_table,
+            seq_lens=seq_lens,
+            max_seq_lens=max_seq_lens,
+            seq_lens_list=seq_lens_list,
+            attn_mask=attn_mask,
+            cp_seq_len=cp_seq_len,
+        )
 
         self.assertIs(metadata.input_positions, input_positions)
         self.assertIs(metadata.block_table, block_table)
@@ -157,7 +159,6 @@ class TestAscendMLADecodeMetadata(TestBase):
 
 
 class TestAscendMLAMetadata(TestBase):
-
     def test_ascend_mla_metadata_default(self):
         num_actual_tokens_pcp_padded = 100
         num_actual_tokens = 100
@@ -181,10 +182,24 @@ class TestAscendMLAMetadata(TestBase):
         prefill = None
 
         metadata = AscendMLAMetadata(
-            num_actual_tokens_pcp_padded, num_actual_tokens, slot_mapping,
-            query_start_loc, seq_lens, seq_lens, block_tables, num_decodes,
-            num_decode_tokens, num_prefills, num_input_tokens, query_lens,
-            head_dim, attn_mask, attn_state, decode, prefill)
+            num_actual_tokens_pcp_padded,
+            num_actual_tokens,
+            slot_mapping,
+            query_start_loc,
+            seq_lens,
+            seq_lens,
+            block_tables,
+            num_decodes,
+            num_decode_tokens,
+            num_prefills,
+            num_input_tokens,
+            query_lens,
+            head_dim,
+            attn_mask,
+            attn_state,
+            decode,
+            prefill,
+        )
 
         self.assertEqual(metadata.num_actual_tokens, num_actual_tokens)
         self.assertIs(metadata.slot_mapping, slot_mapping)
@@ -204,12 +219,12 @@ class TestAscendMLAMetadata(TestBase):
 
 
 class TestAscendMLAMetadataBuilder(TestBase):
-
     def setUp(self):
         # Mock parent class __init__ to avoid complex initialization,
         # but still set the essential attributes that child class needs
-        def mock_parent_init(self, kv_cache_spec, layer_names, vllm_config,
-                             device, metadata_cls, supports_dcp_with_varlen):
+        def mock_parent_init(
+            self, kv_cache_spec, layer_names, vllm_config, device, metadata_cls, supports_dcp_with_varlen
+        ):
             self.metadata_cls = metadata_cls
             self.kv_cache_spec = kv_cache_spec
             self.model_config = vllm_config.model_config
@@ -217,15 +232,14 @@ class TestAscendMLAMetadataBuilder(TestBase):
             self.device = device
             self.chunked_prefill_workspace_size = 128 * 1024
             self.chunked_prefill_workspace = torch.empty(
-                (self.chunked_prefill_workspace_size,
-                 vllm_config.model_config.get_head_size()),
+                (self.chunked_prefill_workspace_size, vllm_config.model_config.get_head_size()),
                 dtype=vllm_config.model_config.dtype,
                 device=device,
             )
 
         self.parent_init_patcher = patch(
-            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__",
-            mock_parent_init)
+            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__", mock_parent_init
+        )
         self.parent_init_patcher.start()
 
     def tearDown(self):
@@ -241,21 +255,16 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
-        mock_device = 'cpu'
+        mock_device = "cpu"
 
         mock_vllm_config.speculative_config = None
 
         ascend_config = MagicMock()
-        with patch("vllm_ascend.attention.mla_v1.get_ascend_config",
-                   return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
-                                               mock_device)
+        with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
+            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
 
-            self.assertEqual(builder.block_size,
-                             mock_vllm_config.cache_config.block_size)
-            self.assertEqual(
-                builder.chunked_prefill_enabled,
-                mock_vllm_config.scheduler_config.enable_chunked_prefill)
+            self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
+            self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
 
     def test_ascend_mla_metadata_builder_spec_decode(self):
         mock_vllm_config = MagicMock()
@@ -267,30 +276,25 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
-        mock_device = 'cpu'
+        mock_device = "cpu"
 
         mock_spec_config = MagicMock()
         mock_spec_config.num_speculative_tokens = 3
         mock_vllm_config.speculative_config = mock_spec_config
 
         ascend_config = MagicMock()
-        with patch("vllm_ascend.attention.mla_v1.get_ascend_config",
-                   return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
-                                               mock_device)
+        with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
+            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
 
-            self.assertEqual(builder.block_size,
-                             mock_vllm_config.cache_config.block_size)
-            self.assertEqual(
-                builder.chunked_prefill_enabled,
-                mock_vllm_config.scheduler_config.enable_chunked_prefill)
+            self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
+            self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm_ascend.attention.attention_mask.get_pcp_group')
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
+    @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
+    @patch("vllm.distributed.parallel_state.get_pcp_group")
     def test_ascend_mla_metadata_builder_build_full_graph(
-            self, mock_get_pcp_group, mock_get_pcp_group_mask,
-            mock_get_cos_and_sin_mla):
+        self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
+    ):
         pcp_group = MagicMock()
         pcp_group.world_size = 1
         mock_get_pcp_group.return_value = pcp_group
@@ -305,7 +309,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
-        mock_device = 'cpu'
+        mock_device = "cpu"
         torch.Tensor.pin_memory = lambda x: x  # noqa
 
         mock_spec_config = MagicMock()
@@ -313,8 +317,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_spec_config.disable_padded_drafter_batch = True
         mock_vllm_config.speculative_config = mock_spec_config
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
-                                           mock_device)
+        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
         common_metadata = MagicMock()
         common_metadata.graph_pad_size = 8
         common_metadata.num_reqs = 4
@@ -322,18 +325,15 @@ class TestAscendMLAMetadataBuilder(TestBase):
         common_metadata.max_query_len = 5
         common_metadata.seq_lens_cpu = torch.Tensor([9, 10, 8, 8]).int()
         common_metadata.query_start_loc = torch.Tensor([0, 1, 2, 4, 5]).int()
-        common_metadata.query_start_loc_cpu = torch.Tensor([0, 1, 2, 4,
-                                                            5]).int()
+        common_metadata.query_start_loc_cpu = torch.Tensor([0, 1, 2, 4, 5]).int()
         common_metadata.positions = torch.Tensor([1, 2, 3, 4, 5, 6]).int()
         block_table = torch.Tensor([[1, 0], [2, 0], [3, 0], [4, 0]]).int()
         common_metadata.block_table_tensor = block_table
         common_metadata.prefill_context_parallel_metadata = None
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([6, 6]),
-                                                 torch.Tensor([6, 6]))
+        mock_get_cos_and_sin_mla.return_value = (torch.tensor([6, 6]), torch.Tensor([6, 6]))
         metadata = builder.build(0, common_metadata)
 
-        self.assertEqual(metadata.decode.actual_seq_lengths_q,
-                         [1, 2, 4, 5, 6, 6, 7, 8])
+        self.assertEqual(metadata.decode.actual_seq_lengths_q, [1, 2, 4, 5, 6, 6, 7, 8])
         self.assertEqual(metadata.decode.block_table.shape[0], 8)
 
     def test_reorder_batch(self):
@@ -348,14 +348,12 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
-        mock_device = 'cpu'
+        mock_device = "cpu"
 
         mock_vllm_config.speculative_config = None
 
-        with patch("vllm_ascend.attention.mla_v1.get_ascend_config",
-                   return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
-                                               mock_device)
+        with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
+            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
             builder.decode_threshold = 1
 
         input_batch = MagicMock()
@@ -363,12 +361,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
         scheduler_output = MagicMock()
         scheduler_output.num_scheduled_tokens = {0: 1, 1: 3, 2: 1, 3: 2}
-        scheduler_output.scheduled_spec_decode_tokens = {
-            0: [],
-            1: [1],
-            2: [],
-            3: []
-        }
+        scheduler_output.scheduled_spec_decode_tokens = {0: [], 1: [1], 2: [], 3: []}
 
         input_batch.swap_states = MagicMock()
 
@@ -388,17 +381,15 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
-        mock_device = 'cpu'
+        mock_device = "cpu"
         mock_vllm_config.speculative_config = None
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
-                                           mock_device)
+        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
         input_seq_lens = [1, 2, 4, 5]
         expect_output = [1, 2, 4, 5, 6, 6, 7, 8]
         num_reqs = 4
         num_reqs_pad_size = 4
-        output_seq_lens = builder.pad_actual_seq_len_q_mtp_disable_pad(
-            num_reqs_pad_size, num_reqs, input_seq_lens)
+        output_seq_lens = builder.pad_actual_seq_len_q_mtp_disable_pad(num_reqs_pad_size, num_reqs, input_seq_lens)
         self.assertEqual(output_seq_lens, expect_output)
 
     def test_pad_actual_seq_lens_q_mtp_enable_pad(self):
@@ -412,30 +403,30 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.decode_max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
-        mock_device = 'cpu'
+        mock_device = "cpu"
         mock_vllm_config.speculative_config = None
 
         common_metadata = MagicMock()
         common_metadata.actual_seq_lengths_q = [2, 4, 6, 8]
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config,
-                                           mock_device)
+        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
         input_seq_lens = [2, 4, 6]
         expect_output = [2, 4, 6, 8]
         num_reqs = 3
         num_reqs_pad_size = 1
         output_seq_lens = builder.pad_actual_seq_len_q_mtp_enable_pad(
-            num_reqs_pad_size, num_reqs, input_seq_lens, common_metadata)
+            num_reqs_pad_size, num_reqs, input_seq_lens, common_metadata
+        )
         self.assertEqual(output_seq_lens, expect_output)
 
 
 class TestAscendMLAMetadataBuilderBuild(TestBase):
-
     def setUp(self):
         # Mock parent class __init__ to avoid complex initialization,
         # but still set the essential attributes that child class needs
-        def mock_parent_init(self, kv_cache_spec, layer_names, vllm_config,
-                             device, metadata_cls, supports_dcp_with_varlen):
+        def mock_parent_init(
+            self, kv_cache_spec, layer_names, vllm_config, device, metadata_cls, supports_dcp_with_varlen
+        ):
             self.metadata_cls = metadata_cls
             self.kv_cache_spec = kv_cache_spec
             self.model_config = vllm_config.model_config
@@ -443,15 +434,14 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             self.device = device
             self.chunked_prefill_workspace_size = 128 * 1024
             self.chunked_prefill_workspace = torch.empty(
-                (self.chunked_prefill_workspace_size,
-                 vllm_config.model_config.get_head_size()),
+                (self.chunked_prefill_workspace_size, vllm_config.model_config.get_head_size()),
                 dtype=vllm_config.model_config.dtype,
                 device=device,
             )
 
         self.parent_init_patcher = patch(
-            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__",
-            mock_parent_init)
+            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__", mock_parent_init
+        )
         self.parent_init_patcher.start()
 
         self.mock_vllm_config = MagicMock(spec=VllmConfig)
@@ -463,8 +453,7 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.mock_vllm_config.scheduler_config = mock_scheduler_config
         self.mock_vllm_config.speculative_config = None
         self.mock_device = torch.device("cpu")
-        fake_weight_path = os.path.join(os.path.dirname(__file__), "..",
-                                        "fake_weight")
+        fake_weight_path = os.path.join(os.path.dirname(__file__), "..", "fake_weight")
         model_config = ModelConfig(
             model=fake_weight_path,
             skip_tokenizer_init=True,
@@ -481,15 +470,14 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.parent_init_patcher.stop()
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm_ascend.attention.attention_mask.get_pcp_group')
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
+    @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
+    @patch("vllm.distributed.parallel_state.get_pcp_group")
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
-    def test_build_prefix_no_cache_metadata(self, mock_npu_available,
-                                            mock_zeros, mock_get_pcp_group,
-                                            mock_get_pcp_group_mask,
-                                            mock_get_cos_and_sin_mla):
+    def test_build_prefix_no_cache_metadata(
+        self, mock_npu_available, mock_zeros, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
+    ):
         mock_npu_available.return_value = False
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
@@ -498,7 +486,7 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         mock_get_pcp_group_mask.return_value = pcp_group
 
         def zeros_override(*args, **kwargs):
-            kwargs.pop('pin_memory', None)
+            kwargs.pop("pin_memory", None)
             return mock_zeros._mock_wraps(*args, **kwargs)
 
         mock_zeros.side_effect = zeros_override
@@ -517,7 +505,8 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             attn_state=AscendAttentionState.PrefillNoCache,
             num_computed_tokens_cpu=None,
             seq_lens=None,
-            max_seq_len=6)
+            max_seq_len=6,
+        )
 
         base_inputs = {
             "num_actual_tokens": 10,
@@ -528,31 +517,29 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             "num_prefills": 2,
         }
 
-        builder = AscendMLAMetadataBuilder(kv_cache_spec=self.kv_cache_spec,
-                                           layer_names=["layer_0", "layer_1"],
-                                           vllm_config=self.mock_vllm_config,
-                                           device=self.mock_device)
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10),
-                                                 torch.Tensor(10))
+        builder = AscendMLAMetadataBuilder(
+            kv_cache_spec=self.kv_cache_spec,
+            layer_names=["layer_0", "layer_1"],
+            vllm_config=self.mock_vllm_config,
+            device=self.mock_device,
+        )
+        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
-        self.assertEqual(metadata.num_actual_tokens,
-                         base_inputs["num_actual_tokens"])
-        self.assertTrue(
-            torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
+        self.assertEqual(metadata.num_actual_tokens, base_inputs["num_actual_tokens"])
+        self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm_ascend.attention.attention_mask.get_pcp_group')
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
+    @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
+    @patch("vllm.distributed.parallel_state.get_pcp_group")
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
-    def test_build_chunked_prefix_metadata(self, mock_npu_available,
-                                           mock_zeros, mock_get_pcp_group,
-                                           mock_get_pcp_group_mask,
-                                           mock_get_cos_and_sin_mla):
+    def test_build_chunked_prefix_metadata(
+        self, mock_npu_available, mock_zeros, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
+    ):
         mock_npu_available.return_value = False
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
@@ -561,7 +548,7 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         mock_get_pcp_group_mask.return_value = pcp_group
 
         def zeros_override(*args, **kwargs):
-            kwargs.pop('pin_memory', None)
+            kwargs.pop("pin_memory", None)
             return mock_zeros._mock_wraps(*args, **kwargs)
 
         mock_zeros.side_effect = zeros_override
@@ -581,7 +568,8 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             attn_state=AscendAttentionState.ChunkedPrefill,
             num_computed_tokens_cpu=None,
             seq_lens=None,
-            max_seq_len=6)
+            max_seq_len=6,
+        )
 
         base_inputs = {
             "num_actual_tokens": 15,
@@ -592,27 +580,24 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             "num_prefills": 3,
         }
 
-        builder = AscendMLAMetadataBuilder(kv_cache_spec=self.kv_cache_spec,
-                                           layer_names=["layer_0", "layer_1"],
-                                           vllm_config=self.mock_vllm_config,
-                                           device=self.mock_device)
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10),
-                                                 torch.Tensor(10))
+        builder = AscendMLAMetadataBuilder(
+            kv_cache_spec=self.kv_cache_spec,
+            layer_names=["layer_0", "layer_1"],
+            vllm_config=self.mock_vllm_config,
+            device=self.mock_device,
+        )
+        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
-        self.assertEqual(metadata.num_actual_tokens,
-                         base_inputs["num_actual_tokens"])
-        self.assertTrue(
-            torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
+        self.assertEqual(metadata.num_actual_tokens, base_inputs["num_actual_tokens"])
+        self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm_ascend.attention.attention_mask.get_pcp_group')
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    def test_build_decode_only_metadata(self, mock_get_pcp_group,
-                                        mock_get_pcp_group_mask,
-                                        mock_get_cos_and_sin_mla):
+    @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
+    @patch("vllm.distributed.parallel_state.get_pcp_group")
+    def test_build_decode_only_metadata(self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
         pcp_group.world_size = 1
@@ -634,7 +619,8 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             attn_state=AscendAttentionState.DecodeOnly,
             num_computed_tokens_cpu=None,
             seq_lens=None,
-            max_seq_len=6)
+            max_seq_len=6,
+        )
 
         base_inputs = {
             "num_actual_tokens": 3,
@@ -644,27 +630,26 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             "num_decodes": 3,
         }
 
-        builder = AscendMLAMetadataBuilder(kv_cache_spec=self.kv_cache_spec,
-                                           layer_names=["layer_0", "layer_1"],
-                                           vllm_config=self.mock_vllm_config,
-                                           device=self.mock_device)
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]),
-                                                 torch.Tensor([10, 10]))
+        builder = AscendMLAMetadataBuilder(
+            kv_cache_spec=self.kv_cache_spec,
+            layer_names=["layer_0", "layer_1"],
+            vllm_config=self.mock_vllm_config,
+            device=self.mock_device,
+        )
+        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]), torch.Tensor([10, 10]))
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
-        self.assertEqual(metadata.num_actual_tokens,
-                         base_inputs["num_actual_tokens"])
-        self.assertTrue(
-            torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
+        self.assertEqual(metadata.num_actual_tokens, base_inputs["num_actual_tokens"])
+        self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    @patch('vllm_ascend.attention.attention_mask.get_pcp_group')
-    @patch('vllm.distributed.parallel_state.get_pcp_group')
-    def test_build_for_graph_capture_decode_only(self, mock_get_pcp_group,
-                                                 mock_get_pcp_group_mask,
-                                                 mock_get_cos_and_sin_mla):
+    @patch("vllm_ascend.attention.attention_mask.get_pcp_group")
+    @patch("vllm.distributed.parallel_state.get_pcp_group")
+    def test_build_for_graph_capture_decode_only(
+        self, mock_get_pcp_group, mock_get_pcp_group_mask, mock_get_cos_and_sin_mla
+    ):
         torch.Tensor.pin_memory = lambda x: x  # noqa
         pcp_group = MagicMock()
         pcp_group.world_size = 1
@@ -686,7 +671,8 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             attn_state=AscendAttentionState.DecodeOnly,
             num_computed_tokens_cpu=None,
             seq_lens=None,
-            max_seq_len=6)
+            max_seq_len=6,
+        )
 
         base_inputs = {
             "num_actual_tokens": 3,
@@ -696,20 +682,18 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             "num_decodes": 3,
         }
 
-        builder = AscendMLAMetadataBuilder(kv_cache_spec=self.kv_cache_spec,
-                                           layer_names=["layer_0", "layer_1"],
-                                           vllm_config=self.mock_vllm_config,
-                                           device=self.mock_device)
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]),
-                                                 torch.Tensor([10, 10]))
-        metadata = builder.build_for_graph_capture(
-            common_attn_metadata, AscendAttentionState.DecodeOnly)
+        builder = AscendMLAMetadataBuilder(
+            kv_cache_spec=self.kv_cache_spec,
+            layer_names=["layer_0", "layer_1"],
+            vllm_config=self.mock_vllm_config,
+            device=self.mock_device,
+        )
+        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]), torch.Tensor([10, 10]))
+        metadata = builder.build_for_graph_capture(common_attn_metadata, AscendAttentionState.DecodeOnly)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
-        self.assertEqual(metadata.num_actual_tokens,
-                         base_inputs["num_actual_tokens"])
-        self.assertTrue(
-            torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
+        self.assertEqual(metadata.num_actual_tokens, base_inputs["num_actual_tokens"])
+        self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
@@ -730,26 +714,26 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             attn_state=AscendAttentionState.PrefillNoCache,
             num_computed_tokens_cpu=None,
             seq_lens=None,
-            max_seq_len=6)
+            max_seq_len=6,
+        )
 
-        builder = AscendMLAMetadataBuilder(kv_cache_spec=self.kv_cache_spec,
-                                           layer_names=["layer_0", "layer_1"],
-                                           vllm_config=self.mock_vllm_config,
-                                           device=self.mock_device)
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10),
-                                                 torch.Tensor(10))
+        builder = AscendMLAMetadataBuilder(
+            kv_cache_spec=self.kv_cache_spec,
+            layer_names=["layer_0", "layer_1"],
+            vllm_config=self.mock_vllm_config,
+            device=self.mock_device,
+        )
+        mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         with self.assertRaises(NotImplementedError) as ctx:
-            builder.build_for_graph_capture(
-                common_attn_metadata, AscendAttentionState.PrefillNoCache)
+            builder.build_for_graph_capture(common_attn_metadata, AscendAttentionState.PrefillNoCache)
         self.assertIn(
             "Currently we only support building dummy metadata for DecodeOnly and SpecDecoding state",
-            str(ctx.exception))
+            str(ctx.exception),
+        )
 
 
 class TestAscendMLAImpl(TestBase):
-
-    @patch('vllm.distributed.parallel_state._TP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch("vllm.distributed.parallel_state._TP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def setUp(self, get_current_vllm_config, mock_tp):
         mock_tp.world_size = 2
@@ -795,18 +779,20 @@ class TestAscendMLAImpl(TestBase):
             "rotary_emb": MagicMock(),
         }
 
-        self.impl = AscendMLAImpl(num_heads=num_heads,
-                                  head_size=head_size,
-                                  scale=scale,
-                                  num_kv_heads=num_kv_heads,
-                                  alibi_slopes=None,
-                                  sliding_window=None,
-                                  kv_cache_dtype=kv_cache_dtype,
-                                  blocksparse_params=None,
-                                  logits_soft_cap=None,
-                                  attn_type=None,
-                                  kv_sharing_target_layer_name=None,
-                                  **kwargs)
+        self.impl = AscendMLAImpl(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=kv_cache_dtype,
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
         self.impl.fa_quant_layer = False
 
     def test_init(self):
@@ -830,13 +816,10 @@ class TestAscendMLAImpl(TestBase):
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
         x = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
-        q_proj_output = torch.randn(batch_size, self.impl.num_heads,
-                                    self.impl.qk_head_dim)
-        self.impl.q_proj.return_value = (q_proj_output, )
-        if not hasattr(self.impl, 'W_UK_T') or self.impl.W_UK_T is None:
-            self.impl.W_UK_T = torch.randn(self.impl.num_heads,
-                                           self.impl.qk_nope_head_dim,
-                                           self.impl.kv_lora_rank)
+        q_proj_output = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
+        self.impl.q_proj.return_value = (q_proj_output,)
+        if not hasattr(self.impl, "W_UK_T") or self.impl.W_UK_T is None:
+            self.impl.W_UK_T = torch.randn(self.impl.num_heads, self.impl.qk_nope_head_dim, self.impl.kv_lora_rank)
         result = self.impl._q_proj_and_k_up_proj(x)
         ql_nope, q_pe = result
         self.assertEqual(ql_nope.shape[0], batch_size)
@@ -846,14 +829,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(q_pe.shape[1], self.impl.num_heads)
         self.assertEqual(q_pe.shape[2], self.impl.qk_rope_head_dim)
 
-    @patch('torch_npu.npu_format_cast')
+    @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading(self, mock_format_cast):
         layer = MagicMock(spec=LinearBase)
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim +
-                                         self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -871,18 +853,15 @@ class TestAscendMLAImpl(TestBase):
     def test_compute_prefill_context_none(self):
         batch_size = 4
         kv_cache = torch.randn(10, 1, 1, 192)
-        query = torch.randn(batch_size, self.impl.num_heads,
-                            self.impl.qk_head_dim)
+        query = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
         metadata = MagicMock()
         metadata.prefill = None
         prefix_out = torch.randn(2, 16, 128)
         prefix_lse = torch.randn(2, 16, 8)
-        q_pe = query[..., self.impl.qk_nope_head_dim:]
-        q_nope = query[..., :self.impl.qk_nope_head_dim]
+        q_pe = query[..., self.impl.qk_nope_head_dim :]
+        q_nope = query[..., : self.impl.qk_nope_head_dim]
 
-        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache,
-                                                      32, metadata, prefix_out,
-                                                      prefix_lse)
+        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, metadata, prefix_out, prefix_lse)
 
         self.assertTrue(torch.equal(prefix_out, out))
         self.assertTrue(torch.equal(prefix_lse, lse))
@@ -896,15 +875,15 @@ class TestAscendMLAImpl(TestBase):
         latent_kv_dim = self.impl.kv_lora_rank
         num_blocks, block_size = 100, 20
         query = torch.randn(S, N, D)
-        q_nope = query[..., :self.impl.qk_nope_head_dim]
-        q_pe = query[..., self.impl.qk_nope_head_dim:]
+        q_nope = query[..., : self.impl.qk_nope_head_dim]
+        q_pe = query[..., self.impl.qk_nope_head_dim :]
         kv_cache_0 = torch.randn(num_blocks, block_size, N, latent_kv_dim)
         kv_cache_1 = torch.randn(num_blocks, block_size, N, D)
         kv_cache = [kv_cache_0, kv_cache_1]
         prefix_out = torch.randn(S, N, VD)
         prefix_lse = torch.randn(N, S)
 
-        self.impl.kv_b_proj.return_value = (torch.randn(8, N, VD + AND), )
+        self.impl.kv_b_proj.return_value = (torch.randn(8, N, VD + AND),)
 
         # Mock FIA to return output and lse
         mock_fia.return_value = (torch.randn(S, N, VD), torch.randn(N, S))
@@ -924,12 +903,9 @@ class TestAscendMLAImpl(TestBase):
 
         meta = MagicMock()
         meta.prefill = prefill_meta
-        self.impl.prefill_mask = torch.triu(
-            torch.ones(512, 512, device=q_nope.device, dtype=q_nope.dtype), 1)
+        self.impl.prefill_mask = torch.triu(torch.ones(512, 512, device=q_nope.device, dtype=q_nope.dtype), 1)
 
-        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache,
-                                                      32, meta, prefix_out,
-                                                      prefix_lse)
+        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse)
 
         mock_load.assert_called_once()
         mock_fia.assert_called_once()
@@ -937,37 +913,29 @@ class TestAscendMLAImpl(TestBase):
 
         self.assertEqual(out.shape, prefix_out.shape)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.attention.mla_v1.AscendMLAImpl._v_up_proj")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
-    def test_forward_decode_without_graph(self,
-                                          mock_npu_fused_infer_attention_score_v2,
-                                          mock_up_proj,
-                                          mock_get_forward_context):
+    def test_forward_decode_without_graph(
+        self, mock_npu_fused_infer_attention_score_v2, mock_up_proj, mock_get_forward_context
+    ):
         num_tokens = 100
         block_size = 4
-        q_nope = torch.randn(num_tokens, self.impl.num_heads,
-                             self.impl.qk_nope_head_dim)
-        q_pe = torch.randn(num_tokens, self.impl.num_heads,
-                           self.impl.qk_rope_head_dim)
-        k_nope = torch.randn(num_tokens, self.impl.num_heads,
-                             self.impl.qk_nope_head_dim)
-        k_pe = torch.randn(num_tokens, self.impl.num_heads,
-                           self.impl.qk_rope_head_dim)
+        q_nope = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_nope_head_dim)
+        q_pe = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim)
+        k_nope = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_nope_head_dim)
+        k_pe = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim)
         metadata = MagicMock()
         metadata.decode = MagicMock()
         metadata.decode.block_table = MagicMock()
         metadata.decode.actual_seq_lengths = 10
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(num_tokens, self.impl.num_heads,
-                        self.impl.kv_lora_rank), None
+            torch.randn(num_tokens, self.impl.num_heads, self.impl.kv_lora_rank),
+            None,
         ]
-        mock_up_proj.return_value = torch.randn(num_tokens,
-                                                self.impl.num_heads,
-                                                self.impl.v_head_dim)
+        mock_up_proj.return_value = torch.randn(num_tokens, self.impl.num_heads, self.impl.v_head_dim)
         mock_get_forward_context.return_value = MagicMock(capturing=False)
-        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe,
-                                           block_size, metadata)
+        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, block_size, metadata)
         self.assertEqual(result.shape[0], num_tokens)
         self.assertEqual(result.shape[1], self.impl.num_heads)
         self.assertEqual(result.shape[2], self.impl.v_head_dim)
@@ -975,10 +943,8 @@ class TestAscendMLAImpl(TestBase):
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
 
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
-    @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method",
-           return_value=MagicMock())
-    def test_mla_preprocess(self, mock_get_weight_prefetch_method,
-                            mock_maybe_all_gather_and_maybe_unpad):
+    @patch("vllm_ascend.attention.mla_v1.get_weight_prefetch_method", return_value=MagicMock())
+    def test_mla_preprocess(self, mock_get_weight_prefetch_method, mock_maybe_all_gather_and_maybe_unpad):
         mock_maybe_all_gather_and_maybe_unpad.side_effect = lambda x, label: x
         batch_size = 4
         seq_len = 8
@@ -1001,53 +967,42 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl.q_a_layernorm = MagicMock()
         self.impl.q_a_layernorm.return_value = torch.randn(
-            attn_metadata.num_actual_tokens, self.impl.num_heads,
-            self.impl.qk_rope_head_dim)
+            attn_metadata.num_actual_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim
+        )
         self.impl.kv_a_proj_with_mqa = MagicMock()
         self.impl.kv_a_proj_with_mqa.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
+            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
         ]
         self.impl.fused_qkv_a_proj = MagicMock()
         self.impl.fused_qkv_a_proj.return_value = [
             torch.randn(
-                num_prefill_tokens, self.impl.num_heads,
-                self.impl.qk_rope_head_dim + self.impl.kv_lora_rank +
-                self.impl.q_lora_rank)
+                num_prefill_tokens,
+                self.impl.num_heads,
+                self.impl.qk_rope_head_dim + self.impl.kv_lora_rank + self.impl.q_lora_rank,
+            )
         ]
         self.impl.q_proj = MagicMock()
-        self.impl.q_proj.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads,
-                        self.impl.qk_head_dim)
-        ]
+        self.impl.q_proj.return_value = [torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_head_dim)]
         self.impl.kv_b_proj = MagicMock()
         self.impl.kv_b_proj.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads,
-                        self.impl.v_head_dim + self.impl.qk_nope_head_dim)
+            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.v_head_dim + self.impl.qk_nope_head_dim)
         ]
         self.impl.rope_single = MagicMock(side_effect=lambda x, cos, sin: x)
         self.impl.exec_kv_decode = MagicMock()
         self.impl.exec_kv_decode.return_value = [MagicMock(), MagicMock()]
         self.impl.exec_kv_prefill = MagicMock()
         self.impl.exec_kv_prefill.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads,
-                        self.impl.qk_rope_head_dim),
-            torch.randn(num_prefill_tokens, self.impl.num_heads,
-                        self.impl.kv_lora_rank)
+            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim),
+            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.kv_lora_rank),
         ]
         self.impl._q_proj_and_k_up_proj = MagicMock()
-        self.impl._q_proj_and_k_up_proj.return_value = [
-            MagicMock(), MagicMock()
-        ]
+        self.impl._q_proj_and_k_up_proj.return_value = [MagicMock(), MagicMock()]
         self.impl.num_kv_heads = self.impl.num_heads
         self.impl.is_kv_producer = False
 
         decode_res, prefill_res = self.impl._mla_preprocess(
-            "mock_layer",
-            hidden_states,
-            kv_cache,
-            attn_metadata,
-            need_gather_q_kv=False)
+            "mock_layer", hidden_states, kv_cache, attn_metadata, need_gather_q_kv=False
+        )
 
         self.assertIsNotNone(decode_res)
         self.assertIsNotNone(prefill_res)
@@ -1067,13 +1022,13 @@ class TestAscendMLAImpl(TestBase):
         kv_cache = [MagicMock(), MagicMock()]
 
         mock_kv_rmsnorm_rope_cache.return_value = [
-            None, None,
+            None,
+            None,
             torch.randn(B, N, 1, self.impl.qk_rope_head_dim),
-            torch.randn(B, N, 1, self.impl.kv_lora_rank)
+            torch.randn(B, N, 1, self.impl.kv_lora_rank),
         ]
 
-        k_pe, k_nope = self.impl.exec_kv_prefill(kv_no_split, cos, sin,
-                                                 kv_cache, slots)
+        k_pe, k_nope = self.impl.exec_kv_prefill(kv_no_split, cos, sin, kv_cache, slots)
 
         self.assertEqual(k_pe.shape[-1], self.impl.qk_rope_head_dim)
         self.assertEqual(k_nope.shape[-1], self.impl.kv_lora_rank)
@@ -1094,19 +1049,19 @@ class TestAscendMLAImpl(TestBase):
 
         mock_kv_rmsnorm_rope_cache.return_value = [
             torch.randn(B, N, 1, self.impl.qk_rope_head_dim),
-            torch.randn(B, N, 1, self.impl.kv_lora_rank), None, None
+            torch.randn(B, N, 1, self.impl.kv_lora_rank),
+            None,
+            None,
         ]
 
-        k_pe, k_nope = self.impl.exec_kv_decode(kv_no_split, cos, sin,
-                                                kv_cache, slots)
+        k_pe, k_nope = self.impl.exec_kv_decode(kv_no_split, cos, sin, kv_cache, slots)
 
         self.assertEqual(k_pe.shape[-1], self.impl.qk_rope_head_dim)
         self.assertEqual(k_nope.shape[-1], self.impl.kv_lora_rank)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
-    def test_forward_decode(self, mock_npu_fused_infer_attention_score_v2,
-                            mock_get_forward_context):
+    def test_forward_decode(self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context):
         B = 2
         N = self.impl.num_kv_heads
         BS = 100
@@ -1126,12 +1081,9 @@ class TestAscendMLAImpl(TestBase):
         attn_metadata.decode.actual_seq_kvlen = MagicMock()
         self.impl.enable_kv_nz = True
 
-        mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(B, N, self.impl.kv_lora_rank), None
-        ]
+        mock_npu_fused_infer_attention_score_v2.return_value = [torch.randn(B, N, self.impl.kv_lora_rank), None]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
-        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS,
-                                           attn_metadata)
+        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS, attn_metadata)
 
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], N)

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -2,29 +2,25 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import torch
+from vllm.distributed.parallel_state import GroupCoordinator
 
 from tests.ut.attention.utils import patch_distributed_groups
 from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm.distributed.parallel_state import GroupCoordinator
 
-if 'torch_npu._inductor' not in sys.modules:
-    sys.modules['torch_npu._inductor'] = MagicMock()
+if "torch_npu._inductor" not in sys.modules:
+    sys.modules["torch_npu._inductor"] = MagicMock()
 
-from vllm_ascend.attention.sfa_v1 import (AscendSFABackend, AscendSFAImpl,
-                                          AscendSFAMetadata,
-                                          AscendSFAMetadataBuilder)
+from vllm_ascend.attention.sfa_v1 import AscendSFABackend, AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
 from vllm_ascend.utils import enable_dsa_cp
 
 
 class TestAscendSFABackend(TestBase):
-
     def test_get_name(self):
         self.assertEqual(AscendSFABackend.get_name(), "ASCEND_SFA")
 
     def test_get_builder_cls(self):
-        self.assertEqual(AscendSFABackend.get_builder_cls(),
-                         AscendSFAMetadataBuilder)
+        self.assertEqual(AscendSFABackend.get_builder_cls(), AscendSFAMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
         result = AscendSFABackend.get_kv_cache_shape(2, 4, 8, 128)
@@ -36,7 +32,6 @@ class TestAscendSFABackend(TestBase):
 
 
 class TestAscendSFAMetadata(TestBase):
-
     def test_ascend_sfa_metadata_default(self):
         num_actual_tokens = 100
         slot_mapping = torch.randn(100, 4, 1024)
@@ -83,9 +78,7 @@ class TestAscendSFAMetadata(TestBase):
 
 
 class TestAscendSFAMetadataBuilder(TestBase):
-
-    @patch('vllm.distributed.parallel_state._TP',
-           new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch("vllm.distributed.parallel_state._TP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
     def setUp(self, mock_tp):
         mock_tp.world_size = 2
         mock_tp.rank_in_group = MagicMock()
@@ -104,14 +97,14 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
         self.mock_cfg.speculative_config.num_speculative_tokens = 0
 
-        self.patcher = patch("vllm.config.get_current_vllm_config",
-                             return_value=self.mock_cfg)
+        self.patcher = patch("vllm.config.get_current_vllm_config", return_value=self.mock_cfg)
         self.patcher.start()
 
         # Mock parent class __init__ to avoid complex initialization,
         # but still set the essential attributes that child class needs
-        def mock_parent_init(self, kv_cache_spec, layer_names, vllm_config,
-                             device, metadata_cls, supports_dcp_with_varlen):
+        def mock_parent_init(
+            self, kv_cache_spec, layer_names, vllm_config, device, metadata_cls, supports_dcp_with_varlen
+        ):
             self.metadata_cls = metadata_cls
             self.kv_cache_spec = kv_cache_spec
             self.model_config = vllm_config.model_config
@@ -119,15 +112,14 @@ class TestAscendSFAMetadataBuilder(TestBase):
             self.device = device
             self.chunked_prefill_workspace_size = 128 * 1024
             self.chunked_prefill_workspace = torch.empty(
-                (self.chunked_prefill_workspace_size,
-                 vllm_config.model_config.get_head_size()),
+                (self.chunked_prefill_workspace_size, vllm_config.model_config.get_head_size()),
                 dtype=vllm_config.model_config.dtype,
                 device=device,
             )
 
         self.parent_init_patcher = patch(
-            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__",
-            mock_parent_init)
+            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__", mock_parent_init
+        )
         self.parent_init_patcher.start()
 
         if hasattr(enable_dsa_cp, "cache_clear"):
@@ -152,10 +144,9 @@ class TestAscendSFAMetadataBuilder(TestBase):
         vllm_config.speculative_config = speculative_config
         device = torch.device("cpu")
 
-        builder = AscendSFAMetadataBuilder(kv_cache_spec=kv_cache_spec,
-                                           layer_names=layer_names,
-                                           vllm_config=vllm_config,
-                                           device=device)
+        builder = AscendSFAMetadataBuilder(
+            kv_cache_spec=kv_cache_spec, layer_names=layer_names, vllm_config=vllm_config, device=device
+        )
 
         assert builder.device == device
         assert builder.vllm_config == vllm_config
@@ -190,18 +181,15 @@ class TestAscendSFAMetadataBuilder(TestBase):
         vllm_config.speculative_config = speculative_config
         device = torch.device("cpu")
 
-        builder = AscendSFAMetadataBuilder(kv_cache_spec=kv_cache_spec,
-                                           layer_names=layer_names,
-                                           vllm_config=vllm_config,
-                                           device=device)
+        builder = AscendSFAMetadataBuilder(
+            kv_cache_spec=kv_cache_spec, layer_names=layer_names, vllm_config=vllm_config, device=device
+        )
 
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
-        common_attn_metadata.query_start_loc = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
-        common_attn_metadata.query_start_loc_cpu = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
         common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
         common_attn_metadata.positions = torch.randn(100)
@@ -212,8 +200,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.sin = None
         common_attn_metadata.num_input_tokens = 100
 
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(100),
-                                                 torch.randn(100))
+        mock_get_cos_and_sin_mla.return_value = (torch.randn(100), torch.randn(100))
 
         metadata = builder.build(
             common_prefix_len=10,
@@ -228,7 +215,8 @@ class TestAscendSFAMetadataBuilder(TestBase):
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_ascend_sfa_metadata_builder_build_for_graph_capture(
-            self, mock_get_cos_and_sin_mla, mock_get_current_vllm_config):
+        self, mock_get_cos_and_sin_mla, mock_get_current_vllm_config
+    ):
         cfg = MagicMock()
         cfg.model_config = MagicMock()
         cfg.model_config.hf_text_config = MagicMock()
@@ -248,18 +236,15 @@ class TestAscendSFAMetadataBuilder(TestBase):
         vllm_config.speculative_config = speculative_config
         device = torch.device("cpu")
 
-        builder = AscendSFAMetadataBuilder(kv_cache_spec=kv_cache_spec,
-                                           layer_names=layer_names,
-                                           vllm_config=vllm_config,
-                                           device=device)
+        builder = AscendSFAMetadataBuilder(
+            kv_cache_spec=kv_cache_spec, layer_names=layer_names, vllm_config=vllm_config, device=device
+        )
 
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
-        common_attn_metadata.query_start_loc = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
-        common_attn_metadata.query_start_loc_cpu = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+        common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
         common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
         common_attn_metadata.positions = torch.randn(100)
@@ -270,8 +255,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.sin = None
         common_attn_metadata.num_input_tokens = 100
 
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(100),
-                                                 torch.randn(100))
+        mock_get_cos_and_sin_mla.return_value = (torch.randn(100), torch.randn(100))
 
         attn_metadata = builder.build_for_graph_capture(
             common_attn_metadata=common_attn_metadata,

--- a/tests/ut/attention/utils.py
+++ b/tests/ut/attention/utils.py
@@ -4,43 +4,38 @@ from unittest.mock import MagicMock, patch
 from vllm.distributed.parallel_state import all_gather_fake
 
 
-def patch_distributed_groups(dcp_size=1,
-                             dcp_rank=0,
-                             pcp_size=1,
-                             pcp_rank=0,
-                             needs_mocks=True):
+def patch_distributed_groups(dcp_size=1, dcp_rank=0, pcp_size=1, pcp_rank=0, needs_mocks=True):
     """
     Decorator to patch common distributed group mocks with configuration
-    
+
     Args:
         dcp_size: DCP world size (default: 1)
         dcp_rank: DCP rank (default: 0)
         pcp_size: PCP world size (default: 1)
         pcp_rank: PCP rank (default: 0)
-        needs_mocks: Whether to pass mock objects as the first arguments 
-             after 'self' to the decorated function. 
-             If True, the decorated function receives: 
+        needs_mocks: Whether to pass mock objects as the first arguments
+             after 'self' to the decorated function.
+             If True, the decorated function receives:
                  func(self, mock_all_to_all_single, mock_dcp, mock_pcp, *args, **kwargs)
-             If False, mocks are not passed and function receives: 
+             If False, mocks are not passed and function receives:
                  func(self, *args, **kwargs)
              (default: True)
     """
 
     def decorator(func):
-
         @wraps(func)
-        @patch('torch.distributed.all_to_all_single')
-        @patch('vllm.distributed.parallel_state._PCP')
-        @patch('vllm.distributed.parallel_state._DCP')
-        def wrapper(self, mock_dcp, mock_pcp, mock_all_to_all_single, *args,
-                    **kwargs):
+        @patch("torch.distributed.all_to_all_single")
+        @patch("vllm.distributed.parallel_state._PCP")
+        @patch("vllm.distributed.parallel_state._DCP")
+        def wrapper(self, mock_dcp, mock_pcp, mock_all_to_all_single, *args, **kwargs):
             mock_dcp.rank_in_group = dcp_rank
             mock_dcp.world_size = dcp_size
             mock_dcp.device_group = MagicMock()
 
             mock_dcp.all_gather = MagicMock()
             mock_dcp.all_gather.side_effect = lambda input_, dim: all_gather_fake(
-                input_, dim, mock_dcp.world_size, "mock_dcp_group")
+                input_, dim, mock_dcp.world_size, "mock_dcp_group"
+            )
 
             mock_pcp.rank_in_group = pcp_rank
             mock_pcp.world_size = pcp_size
@@ -48,14 +43,13 @@ def patch_distributed_groups(dcp_size=1,
 
             mock_pcp.all_gather = MagicMock()
             mock_pcp.all_gather.side_effect = lambda input_, dim: all_gather_fake(
-                input_, dim, mock_pcp.world_size, "mock_pcp_group")
+                input_, dim, mock_pcp.world_size, "mock_pcp_group"
+            )
 
-            mock_all_to_all_single.side_effect = lambda output, input, *a, **kw: output.copy_(
-                input)
+            mock_all_to_all_single.side_effect = lambda output, input, *a, **kw: output.copy_(input)
 
             if needs_mocks:
-                return func(self, mock_all_to_all_single, mock_dcp, mock_pcp,
-                            *args, **kwargs)
+                return func(self, mock_all_to_all_single, mock_dcp, mock_pcp, *args, **kwargs)
             else:
                 return func(self, *args, **kwargs)
 

--- a/tests/ut/base.py
+++ b/tests/ut/base.py
@@ -21,14 +21,13 @@ from vllm_ascend.utils import adapt_patch, register_ascend_customop
 
 
 class TestBase(unittest.TestCase):
-
     def __init__(self, *args, **kwargs):
         # adapt patch by default.
         adapt_patch(True)
         adapt_patch()
         register_ascend_customop()
         super().setUp()
-        super(TestBase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class PytestBase:


### PR DESCRIPTION
### What this PR does / why we need it?
| File Path |
| :--- |
| `tests/ut/_310p/quantization/test_modelslim_config_310.py` |
| `tests/ut/_310p/quantization/test_w8a8sc_310.py` |
| `tests/ut/attention/test_attention_cp.py` |
| `tests/ut/attention/test_attention_mask.py` |
| `tests/ut/attention/test_attention_v1.py` |
| `tests/ut/attention/test_mla_cp.py` |
| `tests/ut/attention/test_mla_v1.py` |
| `tests/ut/attention/test_sfa_v1.py` |
| `tests/ut/attention/utils.py` |
| `tests/ut/base.py` |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
