### PR TITLE
[CI]Style: Convert `test/` to ruff format(Batch #3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ plugins.md029.enabled = false # ol-prefix
 # TODO: according to PEP8, there should be 120 characters per line
 line-length = 120
 # Folder to be modified
-exclude = [
-    "tests/e2e/nightly/single_node/",
-]
+exclude = []
 
 [tool.ruff.lint]
 select = [

--- a/tests/e2e/nightly/single_node/models/scripts/single_node_config.py
+++ b/tests/e2e/nightly/single_node/models/scripts/single_node_config.py
@@ -1,9 +1,9 @@
 import logging
 import os
-import regex as re
 from dataclasses import dataclass, field
 from typing import Any
 
+import regex as re
 import yaml
 from vllm.utils.network_utils import get_open_port
 

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -3,14 +3,14 @@ import json
 import logging
 import os
 import shlex
+import subprocess
+import sys
 from typing import Any
-import vllm
 
 import openai
 import psutil
 import pytest
-import subprocess
-import sys
+import vllm
 
 from tests.e2e.conftest import DisaggEpdProxy, RemoteEPDServer, RemoteOpenAIServer
 from tests.e2e.nightly.single_node.models.scripts.single_node_config import (
@@ -22,6 +22,7 @@ from tools.aisbench import run_aisbench_cases
 logger = logging.getLogger(__name__)
 
 configs = SingleNodeConfigLoader.from_yaml_cases()
+
 
 async def run_completion_test(config: SingleNodeConfig, server: "RemoteOpenAIServer | DisaggEpdProxy") -> None:
     client = server.get_async_client()
@@ -113,20 +114,24 @@ def run_benchmark_comparisons(config: SingleNodeConfig, results: Any) -> None:
         print(f"✅ Comparison passed: {eval_str} [threshold: {expected_threshold}]")
 
 
-async def run_check_rank0_process_count(config: SingleNodeConfig, server: "RemoteOpenAIServer | DisaggEpdProxy") -> None:
+async def run_check_rank0_process_count(
+    config: SingleNodeConfig, server: "RemoteOpenAIServer | DisaggEpdProxy"
+) -> None:
     proc = await asyncio.create_subprocess_exec(
-        "npu-smi", "info",
+        "npu-smi",
+        "info",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
     stdout_bytes, stderr_bytes = await proc.communicate()
     if proc.returncode == 0:
-        logger.info("npu-smi info:\n%s", stdout_bytes.decode(errors='ignore'))
+        logger.info("npu-smi info:\n%s", stdout_bytes.decode(errors="ignore"))
     else:
-        logger.warning("npu-smi info failed: %s", stderr_bytes.decode(errors='ignore'))
+        logger.warning("npu-smi info failed: %s", stderr_bytes.decode(errors="ignore"))
 
     vllm_serve_procs = [
-        p for p in psutil.process_iter(attrs=["pid", "cmdline"], ad_value=None)
+        p
+        for p in psutil.process_iter(attrs=["pid", "cmdline"], ad_value=None)
         if p.info["cmdline"]
         and any("vllm" in arg for arg in p.info["cmdline"])
         and any("serve" in arg for arg in p.info["cmdline"])
@@ -327,9 +332,7 @@ def _build_task_entry(case_key: str, case_config: dict[str, Any], result: Any) -
                 continue
             total_str = metric_data.get("total", "")
             try:
-                value = float(
-                    total_str.replace("token/s", "").replace("ms", "").replace("s", "").strip()
-                )
+                value = float(total_str.replace("token/s", "").replace("ms", "").replace("s", "").strip())
                 metrics[_PERF_METRIC_RENAME.get(metric_name, metric_name)] = round(value, 4)
             except (ValueError, AttributeError):
                 pass
@@ -361,8 +364,7 @@ def _save_benchmark_results_json(config: SingleNodeConfig, benchmark_keys: list[
     case_configs = [config.benchmarks[k] for k in benchmark_keys]
 
     tasks = [
-        _build_task_entry(key, case_cfg, result)
-        for key, case_cfg, result in zip(benchmark_keys, case_configs, results)
+        _build_task_entry(key, case_cfg, result) for key, case_cfg, result in zip(benchmark_keys, case_configs, results)
     ]
 
     passed = _all_passed(case_configs, results)
@@ -408,6 +410,7 @@ def _run_benchmarks(config: SingleNodeConfig, port: int) -> None:
     if "benchmark_comparisons" in config.test_content:
         run_benchmark_comparisons(config, result)
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("config", configs, ids=[config.name for config in configs])
 async def test_single_node(config: SingleNodeConfig) -> None:
@@ -416,7 +419,9 @@ async def test_single_node(config: SingleNodeConfig) -> None:
         for k, v in config.special_dependencies.items():
             command = [
                 sys.executable,
-                "-m", "pip", "install",
+                "-m",
+                "pip",
+                "install",
                 f"{k}=={v}",
             ]
             subprocess.call(command)

--- a/tests/e2e/nightly/single_node/ops/conftest.py
+++ b/tests/e2e/nightly/single_node/ops/conftest.py
@@ -1,9 +1,10 @@
 import time
 from datetime import datetime
+
 import pytest
 
-DURATION_THRESHOLD = 120  
-SLOW_COUNT_LIMIT = 5     
+DURATION_THRESHOLD = 120
+SLOW_COUNT_LIMIT = 5
 
 
 _per_file_slow_cases = {}
@@ -20,7 +21,6 @@ def pytest_runtest_teardown(item, nextitem):
     file_path = item.fspath
     duration = time.time() - item.start_time
 
-
     if file_path not in _per_file_slow_cases:
         _per_file_slow_cases[file_path] = 0
 
@@ -31,24 +31,23 @@ def pytest_runtest_teardown(item, nextitem):
 
         if cnt >= SLOW_COUNT_LIMIT:
             print(f"\n The number of timeout test cases  {file_path}   ≥{SLOW_COUNT_LIMIT}\n")
-            _current_file = file_path  
+            _current_file = file_path
 
 
 def pytest_runtest_call(item):
     if _current_file == item.fspath:
         print(f"CASE SKIP:{item.nodeid}")
-        pytest.skip(f"The use case takes too long.")
+        pytest.skip("The use case takes too long.")
 
-        
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """Hook to add timestamp to test reports"""
     start_time = datetime.now().strftime("[%H:%M:%S]")
-    
+
     outcome = yield
-    
+
     report = outcome.get_result()
-    
-    if report.when == 'call':
-        
+
+    if report.when == "call":
         print(f"{start_time}")

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py
@@ -12,7 +12,6 @@ enable_custom_op()
 
 
 class TestDispatchFFNCombine:
-
     def __init__(self, rank, world_size, port):
         self.rank = rank
         self.world_size = world_size
@@ -22,8 +21,7 @@ class TestDispatchFFNCombine:
     def get_hcomm(self, comm_group):
         hcomm_info = None
         if torch.__version__ > "2.0.1":
-            hcomm_info = comm_group._get_backend(
-                torch.device("npu")).get_hccl_comm_name(self.rank)
+            hcomm_info = comm_group._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
         else:
             hcomm_info = comm_group.get_hccl_comm_name(self.rank)
         return hcomm_info
@@ -74,8 +72,7 @@ class TestDispatchFFNCombine:
             "group_tp": None,
         }
         if ep_size and tp_size:
-            group_ep, group_tp = self.setup_ep_tp(self.rank, tp_size, ep_size,
-                                                  "hccl", None, None)
+            group_ep, group_tp = self.setup_ep_tp(self.rank, tp_size, ep_size, "hccl", None, None)
             hcomm_info_dist["ep_hcomm_info"] = self.get_hcomm(group_ep)
             hcomm_info_dist["tp_hcomm_info"] = self.get_hcomm(group_tp)
             hcomm_info_dist["group_ep"] = group_ep
@@ -99,16 +96,12 @@ class TestDispatchFFNCombine:
 
         torch_npu.npu.config.allow_internal_format = True
         x = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
-        weight1 = self.generate_random_tensor((e, k, n),
-                                              dtype=torch.int8).npu()
+        weight1 = self.generate_random_tensor((e, k, n), dtype=torch.int8).npu()
         weight1 = torch_npu.npu_format_cast(weight1, 29)
-        weight2 = self.generate_random_tensor((e, k2, n2),
-                                              dtype=torch.int8).npu()
+        weight2 = self.generate_random_tensor((e, k2, n2), dtype=torch.int8).npu()
         weight2 = torch_npu.npu_format_cast(weight2, 29)
 
-        expert_idx = torch.randint(0,
-                                   self.world_size * e, (m, topk),
-                                   dtype=torch.int32).npu()
+        expert_idx = torch.randint(0, self.world_size * e, (m, topk), dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()
@@ -119,11 +112,9 @@ class TestDispatchFFNCombine:
         scale1_npu = []
         scale2_npu = []
         for i in range(e):
-            weight1_nz_npu.append(
-                torch_npu.npu_format_cast(weight1[i].npu(), 29))
+            weight1_nz_npu.append(torch_npu.npu_format_cast(weight1[i].npu(), 29))
             scale1_npu.append(scale1[i].npu())
-            weight2_nz_npu.append(
-                torch_npu.npu_format_cast(weight2[i].npu(), 29))
+            weight2_nz_npu.append(torch_npu.npu_format_cast(weight2[i].npu(), 29))
             scale2_npu.append(scale2[i].npu())
 
         out = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
@@ -159,16 +150,12 @@ class TestDispatchFFNCombine:
 
         torch_npu.npu.config.allow_internal_format = True
         x = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
-        weight1 = self.generate_random_tensor((e, k, n),
-                                              dtype=torch.int8).npu()
+        weight1 = self.generate_random_tensor((e, k, n), dtype=torch.int8).npu()
         weight1 = torch_npu.npu_format_cast(weight1, 29)
-        weight2 = self.generate_random_tensor((e, k2, n2),
-                                              dtype=torch.int8).npu()
+        weight2 = self.generate_random_tensor((e, k2, n2), dtype=torch.int8).npu()
         weight2 = torch_npu.npu_format_cast(weight2, 29)
 
-        expert_idx = torch.randint(0,
-                                   self.world_size * e, (m, topk),
-                                   dtype=torch.int32).npu()
+        expert_idx = torch.randint(0, self.world_size * e, (m, topk), dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine_bf16.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine_bf16.py
@@ -12,7 +12,6 @@ enable_custom_op()
 
 
 class TestDispatchFFNCombine:
-
     def __init__(self, rank, world_size, port):
         self.rank = rank
         self.world_size = world_size
@@ -22,8 +21,7 @@ class TestDispatchFFNCombine:
     def get_hcomm(self, comm_group):
         hcomm_info = None
         if torch.__version__ > "2.0.1":
-            hcomm_info = comm_group._get_backend(
-                torch.device("npu")).get_hccl_comm_name(self.rank)
+            hcomm_info = comm_group._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
         else:
             hcomm_info = comm_group.get_hccl_comm_name(self.rank)
         return hcomm_info
@@ -74,8 +72,7 @@ class TestDispatchFFNCombine:
             "group_tp": None,
         }
         if ep_size and tp_size:
-            group_ep, group_tp = self.setup_ep_tp(self.rank, tp_size, ep_size,
-                                                  "hccl", None, None)
+            group_ep, group_tp = self.setup_ep_tp(self.rank, tp_size, ep_size, "hccl", None, None)
             hcomm_info_dist["ep_hcomm_info"] = self.get_hcomm(group_ep)
             hcomm_info_dist["tp_hcomm_info"] = self.get_hcomm(group_tp)
             hcomm_info_dist["group_ep"] = group_ep
@@ -99,16 +96,12 @@ class TestDispatchFFNCombine:
 
         torch_npu.npu.config.allow_internal_format = True
         x = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
-        weight1 = self.generate_random_tensor((e, k, n),
-                                              dtype=torch.bfloat16).npu()
+        weight1 = self.generate_random_tensor((e, k, n), dtype=torch.bfloat16).npu()
         weight1 = torch_npu.npu_format_cast(weight1, 29)
-        weight2 = self.generate_random_tensor((e, k2, n2),
-                                              dtype=torch.bfloat16).npu()
+        weight2 = self.generate_random_tensor((e, k2, n2), dtype=torch.bfloat16).npu()
         weight2 = torch_npu.npu_format_cast(weight2, 29)
 
-        expert_idx = torch.randint(0,
-                                   self.world_size * e, (m, topk),
-                                   dtype=torch.int32).npu()
+        expert_idx = torch.randint(0, self.world_size * e, (m, topk), dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()
@@ -118,11 +111,9 @@ class TestDispatchFFNCombine:
         scale1_npu = []
         scale2_npu = []
         for i in range(e):
-            weight1_nz_npu.append(
-                torch_npu.npu_format_cast(weight1[i].npu(), 29))
+            weight1_nz_npu.append(torch_npu.npu_format_cast(weight1[i].npu(), 29))
             scale1_npu.append(scale1[i].npu())
-            weight2_nz_npu.append(
-                torch_npu.npu_format_cast(weight2[i].npu(), 29))
+            weight2_nz_npu.append(torch_npu.npu_format_cast(weight2[i].npu(), 29))
             scale2_npu.append(scale2[i].npu())
 
         out = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
@@ -157,16 +148,12 @@ class TestDispatchFFNCombine:
 
         torch_npu.npu.config.allow_internal_format = True
         x = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
-        weight1 = self.generate_random_tensor((e, k, n),
-                                              dtype=torch.bfloat16).npu()
+        weight1 = self.generate_random_tensor((e, k, n), dtype=torch.bfloat16).npu()
         weight1 = torch_npu.npu_format_cast(weight1, 29)
-        weight2 = self.generate_random_tensor((e, k2, n2),
-                                              dtype=torch.bfloat16).npu()
+        weight2 = self.generate_random_tensor((e, k2, n2), dtype=torch.bfloat16).npu()
         weight2 = torch_npu.npu_format_cast(weight2, 29)
 
-        expert_idx = torch.randint(0,
-                                   self.world_size * e, (m, topk),
-                                   dtype=torch.int32).npu()
+        expert_idx = torch.randint(0, self.world_size * e, (m, topk), dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine_w4a8.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine_w4a8.py
@@ -12,40 +12,41 @@ enable_custom_op()
 
 DEVICE_OFFSET = 0
 
+
 def int32_to_8x_int4_float(tensor_int32):
     """
     Unpack each int32 value in the tensor into 8 signed int4 values and convert them to float32.
-    
+
     Logic:
     1. Extract the lower 4 bits -> 0th int4
     2. Shift right by 4 bits, extract the lower 4 bits -> 1st int4
     ...
     3. Shift right by 28 bits, extract the lower 4 bits -> 7th int4
-    
+
     For signed int4 (Two's complement):
     Binary 0000 ~ 0111 (0~7)  -> float 0.0 ~ 7.0
     Binary 1000 ~ 1111 (8~15) -> float -8.0 ~ -1.0
     """
-    
+
     # Ensure the dtype is int32 (for robustness, even if the input is already int32)
     if tensor_int32.dtype != torch.int32:
         tensor_int32 = tensor_int32.to(torch.int32)
-    
+
     original_shape = tensor_int32.shape
-    
+
     # 1. Create shift amounts [0, 4, 8, 12, 16, 20, 24, 28]
     # Reshape to (1, 1, ..., 8) for broadcasting
-    shifts = torch.arange(0, 32, 4, device=tensor_int32.device).view(*([1]*len(original_shape)), -1)
-    
+    shifts = torch.arange(0, 32, 4, device=tensor_int32.device).view(*([1] * len(original_shape)), -1)
+
     # 2. Expand dimension and shift right
     # unsqueeze(-1) adds a dimension -> [..., 1]
     # After shifting -> [..., 8]
     shifted = tensor_int32.unsqueeze(-1) >> shifts
-    
+
     # 3. Apply mask to keep only the lower 4 bits (0xF = 1111 binary)
     # The value range here is 0 ~ 15 (unsigned view)
     unpacked_unsigned = shifted & 0xF
-    
+
     # 4. Convert to signed int4 (-8 ~ 7)
     # If value >= 8, the highest bit is 1, representing a negative number.
     # In two's complement, 4-bit values 8~15 correspond to -8~-1.
@@ -53,14 +54,14 @@ def int32_to_8x_int4_float(tensor_int32):
     unpacked_signed = unpacked_unsigned.to(torch.int32)  # Ensure calculation precision
     mask = unpacked_signed >= 8
     unpacked_signed[mask] -= 16
-    
+
     # 5. Convert to float32
     result_float = unpacked_signed.to(torch.float32)
     result_flat = result_float.flatten(start_dim=-2)
     return result_flat
 
-class TestDispatchFFNCombine:
 
+class TestDispatchFFNCombine:
     def __init__(self, rank, world_size, port):
         self.rank = rank
         self.world_size = world_size
@@ -70,8 +71,7 @@ class TestDispatchFFNCombine:
     def get_hcomm(self, comm_group):
         hcomm_info = None
         if torch.__version__ > "2.0.1":
-            hcomm_info = comm_group._get_backend(
-                torch.device("npu")).get_hccl_comm_name(self.rank)
+            hcomm_info = comm_group._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
         else:
             hcomm_info = comm_group.get_hccl_comm_name(self.rank)
         return hcomm_info
@@ -122,8 +122,7 @@ class TestDispatchFFNCombine:
             "group_tp": None,
         }
         if ep_size and tp_size:
-            group_ep, group_tp = self.setup_ep_tp(self.rank, tp_size, ep_size,
-                                                  "hccl", None, None)
+            group_ep, group_tp = self.setup_ep_tp(self.rank, tp_size, ep_size, "hccl", None, None)
             hcomm_info_dist["ep_hcomm_info"] = self.get_hcomm(group_ep)
             hcomm_info_dist["tp_hcomm_info"] = self.get_hcomm(group_tp)
             hcomm_info_dist["group_ep"] = group_ep
@@ -147,22 +146,18 @@ class TestDispatchFFNCombine:
 
         torch_npu.npu.config.allow_internal_format = True
         x = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
-        weight1 = self.generate_random_tensor((e, k, n//8),
-                                              dtype=torch.int32).npu()
+        weight1 = self.generate_random_tensor((e, k, n // 8), dtype=torch.int32).npu()
         weight1 = torch_npu.npu_format_cast(weight1, 29)
-        weight2 = self.generate_random_tensor((e, k2, n2//8),
-                                              dtype=torch.int32).npu()
+        weight2 = self.generate_random_tensor((e, k2, n2 // 8), dtype=torch.int32).npu()
         weight2 = torch_npu.npu_format_cast(weight2, 29)
-        
+
         bias1 = int32_to_8x_int4_float(weight1.cpu())
         bias1_npu = bias1.sum(dim=-1).npu()
         bias2 = int32_to_8x_int4_float(weight2.cpu())
         bias2_npu = bias2.sum(dim=-1).npu()
 
         print("====generate bias====")
-        expert_idx = torch.randint(0,
-                                   self.world_size * e, (m, topk),
-                                   dtype=torch.int32).npu()
+        expert_idx = torch.randint(0, self.world_size * e, (m, topk), dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()
@@ -172,11 +167,9 @@ class TestDispatchFFNCombine:
         scale1_npu = []
         scale2_npu = []
         for i in range(e):
-            weight1_nz_npu.append(
-                torch_npu.npu_format_cast(weight1[i].npu(), 29))
+            weight1_nz_npu.append(torch_npu.npu_format_cast(weight1[i].npu(), 29))
             scale1_npu.append(scale1[i].npu())
-            weight2_nz_npu.append(
-                torch_npu.npu_format_cast(weight2[i].npu(), 29))
+            weight2_nz_npu.append(torch_npu.npu_format_cast(weight2[i].npu(), 29))
             scale2_npu.append(scale2[i].npu())
 
         out = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
@@ -188,8 +181,8 @@ class TestDispatchFFNCombine:
             expert_idx=expert_idx,
             scale1=scale1_npu,
             scale2=scale2_npu,
-            bias1 = bias1_npu,
-            bias2 = bias2_npu,
+            bias1=bias1_npu,
+            bias2=bias2_npu,
             probs=probs,
             group=self.hcomm_info,
             max_output_size=512,
@@ -210,18 +203,12 @@ class TestDispatchFFNCombine:
 
         torch_npu.npu.config.allow_internal_format = True
         x = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
-        weight1 = self.generate_random_tensor((e, k, n/8),
-                                              dtype=torch.int32).npu()
+        weight1 = self.generate_random_tensor((e, k, n / 8), dtype=torch.int32).npu()
         weight1 = torch_npu.npu_format_cast(weight1, 29)
-        weight2 = self.generate_random_tensor((e, k2, n2/8),
-                                              dtype=torch.int32).npu()
+        weight2 = self.generate_random_tensor((e, k2, n2 / 8), dtype=torch.int32).npu()
         weight2 = torch_npu.npu_format_cast(weight2, 29)
-        
-        
 
-        expert_idx = torch.randint(0,
-                                   self.world_size * e, (m, topk),
-                                   dtype=torch.int32).npu()
+        expert_idx = torch.randint(0, self.world_size * e, (m, topk), dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_gmm_combine_decode.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_gmm_combine_decode.py
@@ -1,10 +1,10 @@
 import gc
 import os
 import sys
+import time
 from pathlib import Path
 
 import numpy as np
-import time
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -31,14 +31,14 @@ BASE_KWARGS = {
     "with_mc2_mask": False,
     "dynamic_eplb": False,
     "w8a8_dynamic": True,
-    "is_nz": True
+    "is_nz": True,
 }
 
 
 def redirect_output(log_file_path):
     log_path = Path(LOG_NAME) / log_file_path
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    f = open(LOG_NAME + "/" + log_file_path, "w")
+    f = open(LOG_NAME + "/" + log_file_path, "w")  # noqa: SIM115
     os.dup2(f.fileno(), sys.stdout.fileno())
     os.dup2(f.fileno(), sys.stderr.fileno())
     return f
@@ -47,9 +47,7 @@ def redirect_output(log_file_path):
 def permute_weight(w: torch.Tensor, tile_n):
     *dims, n = w.shape
     order = list(range(len(dims))) + [-2, -3, -1]
-    return w.reshape(*dims, 2, n // tile_n,
-                     tile_n // 2).permute(order).reshape(*dims,
-                                                         n).contiguous()
+    return w.reshape(*dims, 2, n // tile_n, tile_n // 2).permute(order).reshape(*dims, n).contiguous()
 
 
 def output_to_file(rank_id):
@@ -57,28 +55,33 @@ def output_to_file(rank_id):
 
 
 class DecodeMoeOps(torch.nn.Module):
-
-    def __init__(self,
-                 gmm1_weight,
-                 gmm1_weight_scale,
-                 gmm2_weight,
-                 gmm2_weight_scale,
-                 ep_hcomm_info,
-                 batch_size,
-                 token_hidden_size,
-                 moe_intermediate_size,
-                 ep_world_size,
-                 moe_expert_num,
-                 global_rank_id,
-                 shared_expert_rank_num=0,
-                 dynamic_eplb=False,
-                 w8a8_dynamic=True,
-                 is_nz=True):
+    def __init__(
+        self,
+        gmm1_weight,
+        gmm1_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        ep_hcomm_info,
+        batch_size,
+        token_hidden_size,
+        moe_intermediate_size,
+        ep_world_size,
+        moe_expert_num,
+        global_rank_id,
+        shared_expert_rank_num=0,
+        dynamic_eplb=False,
+        w8a8_dynamic=True,
+        is_nz=True,
+    ):
         super().__init__()
         if w8a8_dynamic:
-            assert (gmm1_weight_scale is not None and gmm2_weight_scale is not None), "gmm1_weight_scale and gmm2_weight_scale must be provided for w8a8_dynamic"
+            assert gmm1_weight_scale is not None and gmm2_weight_scale is not None, (
+                "gmm1_weight_scale and gmm2_weight_scale must be provided for w8a8_dynamic"
+            )
         else:
-            assert (gmm1_weight_scale is None and gmm2_weight_scale is None), "gmm1_weight_scale and gmm2_weight_scale must be None for w8a8_dynamic"
+            assert gmm1_weight_scale is None and gmm2_weight_scale is None, (
+                "gmm1_weight_scale and gmm2_weight_scale must be None for w8a8_dynamic"
+            )
         self.ep_hcomm_info = ep_hcomm_info
         self.batch_size = batch_size
         self.token_hidden_size = token_hidden_size
@@ -88,91 +91,82 @@ class DecodeMoeOps(torch.nn.Module):
         self.global_rank_id = global_rank_id
         self.shared_expert_rank_num = shared_expert_rank_num
         is_shared_expert = global_rank_id < shared_expert_rank_num
-        moe_expert_num_per_rank = moe_expert_num // (ep_world_size -
-                                                     shared_expert_rank_num)
+        moe_expert_num_per_rank = moe_expert_num // (ep_world_size - shared_expert_rank_num)
         self.local_expert_num = 1 if is_shared_expert else moe_expert_num_per_rank
         self.ep_recv_count_size = self.local_expert_num * ep_world_size
         self.dynamic_eplb = dynamic_eplb
         self.w8a8_dynamic = w8a8_dynamic
         self.is_nz = is_nz
-        self.gmm1_weight = torch.empty([
-            self.local_expert_num, self.token_hidden_size,
-            self.moe_intermediate_size * 2
-        ])
-        self.gmm2_weight = torch.empty([
-            self.local_expert_num, self.moe_intermediate_size,
-            self.token_hidden_size
-        ])
+        self.gmm1_weight = torch.empty([self.local_expert_num, self.token_hidden_size, self.moe_intermediate_size * 2])
+        self.gmm2_weight = torch.empty([self.local_expert_num, self.moe_intermediate_size, self.token_hidden_size])
         if self.w8a8_dynamic:
-            self.gmm1_weight_scale = torch.empty(
-                [self.local_expert_num, self.moe_intermediate_size * 2])
-            self.gmm2_weight_scale = torch.empty(
-                [self.local_expert_num, self.token_hidden_size])
+            self.gmm1_weight_scale = torch.empty([self.local_expert_num, self.moe_intermediate_size * 2])
+            self.gmm2_weight_scale = torch.empty([self.local_expert_num, self.token_hidden_size])
         else:
             self.gmm1_weight_scale = None
             self.gmm2_weight_scale = None
             self.gmm1_weight_scale_fp32 = None
             self.gmm2_weight_scale_fp32 = None
-        self._process_weights_after_loading(gmm1_weight, gmm1_weight_scale,
-                                            gmm2_weight, gmm2_weight_scale)
+        self._process_weights_after_loading(gmm1_weight, gmm1_weight_scale, gmm2_weight, gmm2_weight_scale)
 
-    def _process_weights_after_loading(self, gmm1_weight, gmm1_weight_scale,
-                                       gmm2_weight, gmm2_weight_scale):
+    def _process_weights_after_loading(self, gmm1_weight, gmm1_weight_scale, gmm2_weight, gmm2_weight_scale):
         if self.w8a8_dynamic:
-            gmm1_weight = torch_npu.npu_format_cast(gmm1_weight,
-                                                    torch_npu.Format.FRACTAL_NZ)
-            gmm2_weight = torch_npu.npu_format_cast(gmm2_weight,
-                                                    torch_npu.Format.FRACTAL_NZ)
+            gmm1_weight = torch_npu.npu_format_cast(gmm1_weight, torch_npu.Format.FRACTAL_NZ)
+            gmm2_weight = torch_npu.npu_format_cast(gmm2_weight, torch_npu.Format.FRACTAL_NZ)
         self.gmm1_weight = torch.nn.Parameter(gmm1_weight, requires_grad=False)
         self.gmm2_weight = torch.nn.Parameter(gmm2_weight, requires_grad=False)
         if self.w8a8_dynamic:
-            self.gmm1_weight_scale = torch.nn.Parameter(gmm1_weight_scale,
-                                                        requires_grad=False)
-            self.gmm2_weight_scale = torch.nn.Parameter(gmm2_weight_scale,
-                                                        requires_grad=False)
-            self.gmm1_weight_scale_fp32 = torch.nn.Parameter(
-                gmm1_weight_scale.float(), requires_grad=False)
-            self.gmm2_weight_scale_fp32 = torch.nn.Parameter(
-                gmm2_weight_scale.float(), requires_grad=False)
+            self.gmm1_weight_scale = torch.nn.Parameter(gmm1_weight_scale, requires_grad=False)
+            self.gmm2_weight_scale = torch.nn.Parameter(gmm2_weight_scale, requires_grad=False)
+            self.gmm1_weight_scale_fp32 = torch.nn.Parameter(gmm1_weight_scale.float(), requires_grad=False)
+            self.gmm2_weight_scale_fp32 = torch.nn.Parameter(gmm2_weight_scale.float(), requires_grad=False)
 
-    def _apply_ops(self, x, expert_ids, smooth_scales, expert_scales,
-                   x_active_mask):
+    def _apply_ops(self, x, expert_ids, smooth_scales, expert_scales, x_active_mask):
         raise NotImplementedError("To be implemented in subclass")
 
-    def forward(self, x, expert_ids, smooth_scales, expert_scales,
-                x_active_mask):
-        return self._apply_ops(x, expert_ids, smooth_scales, expert_scales,
-                               x_active_mask)
+    def forward(self, x, expert_ids, smooth_scales, expert_scales, x_active_mask):
+        return self._apply_ops(x, expert_ids, smooth_scales, expert_scales, x_active_mask)
 
 
 class SmallOps(DecodeMoeOps):
-
-    def __init__(self,
-                 gmm1_weight,
-                 gmm1_weight_scale,
-                 gmm2_weight,
-                 gmm2_weight_scale,
-                 ep_hcomm_info,
-                 batch_size,
-                 token_hidden_size,
-                 moe_intermediate_size,
-                 ep_world_size,
-                 moe_expert_num,
-                 global_rank_id,
-                 shared_expert_rank_num=0,
-                 dynamic_eplb=False,
-                 w8a8_dynamic=True,
-                 is_nz=True):
-        super().__init__(gmm1_weight, gmm1_weight_scale, gmm2_weight,
-                         gmm2_weight_scale, ep_hcomm_info, batch_size,
-                         token_hidden_size, moe_intermediate_size,
-                         ep_world_size, moe_expert_num, global_rank_id,
-                         shared_expert_rank_num, dynamic_eplb, w8a8_dynamic,
-                         is_nz)
+    def __init__(
+        self,
+        gmm1_weight,
+        gmm1_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        ep_hcomm_info,
+        batch_size,
+        token_hidden_size,
+        moe_intermediate_size,
+        ep_world_size,
+        moe_expert_num,
+        global_rank_id,
+        shared_expert_rank_num=0,
+        dynamic_eplb=False,
+        w8a8_dynamic=True,
+        is_nz=True,
+    ):
+        super().__init__(
+            gmm1_weight,
+            gmm1_weight_scale,
+            gmm2_weight,
+            gmm2_weight_scale,
+            ep_hcomm_info,
+            batch_size,
+            token_hidden_size,
+            moe_intermediate_size,
+            ep_world_size,
+            moe_expert_num,
+            global_rank_id,
+            shared_expert_rank_num,
+            dynamic_eplb,
+            w8a8_dynamic,
+            is_nz,
+        )
         self.tp_hcomm_info = ""
 
-    def _apply_ops(self, x, expert_ids, smooth_scales, expert_scales,
-                   x_active_mask):
+    def _apply_ops(self, x, expert_ids, smooth_scales, expert_scales, x_active_mask):
         outputs = torch_npu.npu_moe_distribute_dispatch_v2(
             x=x,
             expert_ids=expert_ids,
@@ -192,7 +186,15 @@ class SmallOps(DecodeMoeOps):
             global_bs=self.batch_size * self.ep_world_size,
             expert_token_nums_type=1,  # 0代表前缀和，1代表各自数量
         )
-        expand_x, dynamic_scales, assist_info_for_combine, expert_token_nums, ep_send_counts, tp_send_counts, expand_scales = outputs
+        (
+            expand_x,
+            dynamic_scales,
+            assist_info_for_combine,
+            expert_token_nums,
+            ep_send_counts,
+            tp_send_counts,
+            expand_scales,
+        ) = outputs
         output_dtype = x.dtype
 
         y1_int32 = torch_npu.npu_grouped_matmul(
@@ -202,7 +204,8 @@ class SmallOps(DecodeMoeOps):
             group_list_type=1,  # 默认为0，代表前缀和形式
             group_type=0,  # 0代表m轴分组
             group_list=expert_token_nums,
-            output_dtype=torch.int32 if self.w8a8_dynamic else output_dtype)[0]
+            output_dtype=torch.int32 if self.w8a8_dynamic else output_dtype,
+        )[0]
         y1_scale = None
         if self.w8a8_dynamic:
             y1, y1_scale = torch_npu.npu_dequant_swiglu_quant(
@@ -218,15 +221,17 @@ class SmallOps(DecodeMoeOps):
             )
         else:
             y1 = torch_npu.npu_swiglu(y1_int32)
-        y2 = torch_npu.npu_grouped_matmul(x=[y1],
-                                          weight=[self.gmm2_weight],
-                                          scale=[self.gmm2_weight_scale] if self.w8a8_dynamic else None,
-                                          per_token_scale=[y1_scale] if self.w8a8_dynamic else None,
-                                          split_item=2,
-                                          group_list_type=1,
-                                          group_type=0,
-                                          group_list=expert_token_nums,
-                                          output_dtype=output_dtype)[0]
+        y2 = torch_npu.npu_grouped_matmul(
+            x=[y1],
+            weight=[self.gmm2_weight],
+            scale=[self.gmm2_weight_scale] if self.w8a8_dynamic else None,
+            per_token_scale=[y1_scale] if self.w8a8_dynamic else None,
+            split_item=2,
+            group_list_type=1,
+            group_type=0,
+            group_list=expert_token_nums,
+            output_dtype=output_dtype,
+        )[0]
         combine_output = torch_npu.npu_moe_distribute_combine_v2(
             expand_x=y2,
             expert_ids=expert_ids,
@@ -246,37 +251,49 @@ class SmallOps(DecodeMoeOps):
             expert_shard_type=0,
             shared_expert_num=1,
             shared_expert_rank_num=self.shared_expert_rank_num,
-            global_bs=self.batch_size * self.ep_world_size)
+            global_bs=self.batch_size * self.ep_world_size,
+        )
         return (combine_output, expert_token_nums)
 
 
 class FusionOp(DecodeMoeOps):
+    def __init__(
+        self,
+        gmm1_weight,
+        gmm1_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        ep_hcomm_info,
+        batch_size,
+        token_hidden_size,
+        moe_intermediate_size,
+        ep_world_size,
+        moe_expert_num,
+        global_rank_id,
+        shared_expert_rank_num=0,
+        dynamic_eplb=False,
+        w8a8_dynamic=True,
+        is_nz=True,
+    ):
+        super().__init__(
+            gmm1_weight,
+            gmm1_weight_scale,
+            gmm2_weight,
+            gmm2_weight_scale,
+            ep_hcomm_info,
+            batch_size,
+            token_hidden_size,
+            moe_intermediate_size,
+            ep_world_size,
+            moe_expert_num,
+            global_rank_id,
+            shared_expert_rank_num,
+            dynamic_eplb,
+            w8a8_dynamic,
+            is_nz,
+        )
 
-    def __init__(self,
-                 gmm1_weight,
-                 gmm1_weight_scale,
-                 gmm2_weight,
-                 gmm2_weight_scale,
-                 ep_hcomm_info,
-                 batch_size,
-                 token_hidden_size,
-                 moe_intermediate_size,
-                 ep_world_size,
-                 moe_expert_num,
-                 global_rank_id,
-                 shared_expert_rank_num=0,
-                 dynamic_eplb=False,
-                 w8a8_dynamic=True,
-                 is_nz=True):
-        super().__init__(gmm1_weight, gmm1_weight_scale, gmm2_weight,
-                         gmm2_weight_scale, ep_hcomm_info, batch_size,
-                         token_hidden_size, moe_intermediate_size,
-                         ep_world_size, moe_expert_num, global_rank_id,
-                         shared_expert_rank_num, dynamic_eplb, w8a8_dynamic,
-                         is_nz)
-
-    def _apply_ops(self, x, expert_ids, smooth_scales, expert_scales,
-                   x_active_mask):
+    def _apply_ops(self, x, expert_ids, smooth_scales, expert_scales, x_active_mask):
         smooth_scales = torch.zeros(128 * 1024 * 1024).npu()
         output = torch.ops._C_ascend.dispatch_gmm_combine_decode(
             x=x,
@@ -295,31 +312,21 @@ class FusionOp(DecodeMoeOps):
             shared_expert_num=1,
             shared_expert_rank_num=self.shared_expert_rank_num,
             quant_mode=0,
-            global_bs=self.batch_size * self.ep_world_size)
+            global_bs=self.batch_size * self.ep_world_size,
+        )
         return output
 
-    def _process_weights_after_loading(self, gmm1_weight, gmm1_weight_scale,
-                                       gmm2_weight, gmm2_weight_scale):
+    def _process_weights_after_loading(self, gmm1_weight, gmm1_weight_scale, gmm2_weight, gmm2_weight_scale):
         if self.is_nz:
-            gmm1_weight = torch_npu.npu_format_cast(gmm1_weight,
-                                                    torch_npu.Format.FRACTAL_NZ)
-            gmm2_weight = torch_npu.npu_format_cast(gmm2_weight,
-                                                    torch_npu.Format.FRACTAL_NZ)
+            gmm1_weight = torch_npu.npu_format_cast(gmm1_weight, torch_npu.Format.FRACTAL_NZ)
+            gmm2_weight = torch_npu.npu_format_cast(gmm2_weight, torch_npu.Format.FRACTAL_NZ)
 
         if self.dynamic_eplb:
-            self.gmm1_weight = [
-                weight.clone() for weight in gmm1_weight.unbind(dim=0)
-            ]
-            self.gmm2_weight = [
-                weight.clone() for weight in gmm2_weight.unbind(dim=0)
-            ]
+            self.gmm1_weight = [weight.clone() for weight in gmm1_weight.unbind(dim=0)]
+            self.gmm2_weight = [weight.clone() for weight in gmm2_weight.unbind(dim=0)]
             if self.w8a8_dynamic:
-                self.gmm1_weight_scale_fp32 = [
-                    weight.clone() for weight in gmm1_weight_scale.unbind(dim=0)
-                ]
-                self.gmm2_weight_scale_fp32 = [
-                    weight.clone() for weight in gmm2_weight_scale.unbind(dim=0)
-                ]
+                self.gmm1_weight_scale_fp32 = [weight.clone() for weight in gmm1_weight_scale.unbind(dim=0)]
+                self.gmm2_weight_scale_fp32 = [weight.clone() for weight in gmm2_weight_scale.unbind(dim=0)]
             else:
                 self.gmm1_weight_scale_fp32 = [torch.ones(1).npu().to(gmm1_weight.dtype)]
                 self.gmm2_weight_scale_fp32 = [torch.ones(1).npu().to(gmm2_weight.dtype)]
@@ -334,80 +341,88 @@ class FusionOp(DecodeMoeOps):
                 self.gmm2_weight_scale_fp32 = [torch.ones(1).npu().to(gmm2_weight.dtype)]
 
 
-def generate_datas(batch_size,
-                   token_hidden_size,
-                   moe_intermediate_size,
-                   ep_world_size,
-                   moe_expert_num,
-                   global_rank_id,
-                   shared_expert_rank_num=0,
-                   top_k=8,
-                   test_bfloat16=True,
-                   enable_dynamic_bs=False,
-                   with_mc2_mask=False,
-                   w8a8_dynamic=True):
+def generate_datas(
+    batch_size,
+    token_hidden_size,
+    moe_intermediate_size,
+    ep_world_size,
+    moe_expert_num,
+    global_rank_id,
+    shared_expert_rank_num=0,
+    top_k=8,
+    test_bfloat16=True,
+    enable_dynamic_bs=False,
+    with_mc2_mask=False,
+    w8a8_dynamic=True,
+):
     is_shared_expert = global_rank_id < shared_expert_rank_num
-    moe_expert_num_per_rank = moe_expert_num // (ep_world_size -
-                                                 shared_expert_rank_num)
+    moe_expert_num_per_rank = moe_expert_num // (ep_world_size - shared_expert_rank_num)
     actual_bs = int(
-        torch.randint(2 if with_mc2_mask else 1, batch_size, [1]).item(
-        ) if enable_dynamic_bs else batch_size)
+        torch.randint(2 if with_mc2_mask else 1, batch_size, [1]).item() if enable_dynamic_bs else batch_size
+    )
     local_expert_num = 1 if is_shared_expert else moe_expert_num_per_rank
     gmm1_input_dim = token_hidden_size
     gmm1_output_dim = moe_intermediate_size * 2
     gmm2_input_dim = moe_intermediate_size
     gmm2_output_dim = token_hidden_size
     x = torch.rand([actual_bs, token_hidden_size]) * 0.5 - 0.5
-    expert_ids = torch.arange(
-        global_rank_id * batch_size * top_k,
-        global_rank_id * batch_size * top_k + actual_bs * top_k).to(
-            torch.int32).view(actual_bs, top_k)
+    expert_ids = (
+        torch.arange(global_rank_id * batch_size * top_k, global_rank_id * batch_size * top_k + actual_bs * top_k)
+        .to(torch.int32)
+        .view(actual_bs, top_k)
+    )
     expert_ids = expert_ids % moe_expert_num
     gmm1_weight_scale = None
     gmm2_weight_scale = None
     if w8a8_dynamic:
         if is_shared_expert:
-            gmm1_weight = torch.ones([
-                local_expert_num, gmm1_input_dim, gmm1_output_dim
-            ]).to(torch.int8) * 4
-            gmm2_weight = torch.ones([
-                local_expert_num, gmm2_input_dim, gmm2_output_dim
-            ]).to(torch.int8) * 4
+            gmm1_weight = torch.ones([local_expert_num, gmm1_input_dim, gmm1_output_dim]).to(torch.int8) * 4
+            gmm2_weight = torch.ones([local_expert_num, gmm2_input_dim, gmm2_output_dim]).to(torch.int8) * 4
             gmm1_weight[:, :, ::2] = gmm1_weight[:, :, ::2] * -1
             gmm2_weight[:, :, ::2] = gmm2_weight[:, :, ::2] * -1
-            gmm1_weight_scale = torch.ones([local_expert_num, gmm1_output_dim
-                                            ]) * 0.0015
-            gmm2_weight_scale = torch.ones([local_expert_num, gmm2_output_dim
-                                            ]) * 0.0015
+            gmm1_weight_scale = torch.ones([local_expert_num, gmm1_output_dim]) * 0.0015
+            gmm2_weight_scale = torch.ones([local_expert_num, gmm2_output_dim]) * 0.0015
         else:
-            gmm1_weight = torch.randint(
-                -16, 16,
-                [local_expert_num, gmm1_input_dim, gmm1_output_dim]).to(torch.int8)
-            gmm2_weight = torch.randint(
-                -16, 16,
-                [local_expert_num, gmm2_input_dim, gmm2_output_dim]).to(torch.int8)
-            gmm1_weight_scale = torch.rand([local_expert_num, gmm1_output_dim
-                                            ]) * 0.003 + 0.0015
-            gmm2_weight_scale = torch.rand([local_expert_num, gmm2_output_dim
-                                            ]) * 0.003 + 0.0015
+            gmm1_weight = torch.randint(-16, 16, [local_expert_num, gmm1_input_dim, gmm1_output_dim]).to(torch.int8)
+            gmm2_weight = torch.randint(-16, 16, [local_expert_num, gmm2_input_dim, gmm2_output_dim]).to(torch.int8)
+            gmm1_weight_scale = torch.rand([local_expert_num, gmm1_output_dim]) * 0.003 + 0.0015
+            gmm2_weight_scale = torch.rand([local_expert_num, gmm2_output_dim]) * 0.003 + 0.0015
     else:
         if is_shared_expert:
-            gmm1_weight = torch.ones([
-                local_expert_num, gmm1_input_dim, gmm1_output_dim
-            ]).to(torch.bfloat16 if test_bfloat16 else torch.float16) * 0.5
-            gmm2_weight = torch.ones([
-                local_expert_num, gmm2_input_dim, gmm2_output_dim
-            ]).to(torch.bfloat16 if test_bfloat16 else torch.float16) * 0.5
+            gmm1_weight = (
+                torch.ones([local_expert_num, gmm1_input_dim, gmm1_output_dim]).to(
+                    torch.bfloat16 if test_bfloat16 else torch.float16
+                )
+                * 0.5
+            )
+            gmm2_weight = (
+                torch.ones([local_expert_num, gmm2_input_dim, gmm2_output_dim]).to(
+                    torch.bfloat16 if test_bfloat16 else torch.float16
+                )
+                * 0.5
+            )
         else:
-            gmm1_weight = torch.rand([local_expert_num, gmm1_input_dim, gmm1_output_dim]).to(torch.bfloat16 if test_bfloat16 else torch.float16) * 0.25
-            gmm2_weight = torch.rand([local_expert_num, gmm2_input_dim, gmm2_output_dim]).to(torch.bfloat16 if test_bfloat16 else torch.float16) * 0.25
+            gmm1_weight = (
+                torch.rand([local_expert_num, gmm1_input_dim, gmm1_output_dim]).to(
+                    torch.bfloat16 if test_bfloat16 else torch.float16
+                )
+                * 0.25
+            )
+            gmm2_weight = (
+                torch.rand([local_expert_num, gmm2_input_dim, gmm2_output_dim]).to(
+                    torch.bfloat16 if test_bfloat16 else torch.float16
+                )
+                * 0.25
+            )
         gmm1_weight[:, ::2, :] = gmm1_weight[:, ::2, :] * -1
         gmm2_weight[:, ::2, :] = gmm2_weight[:, ::2, :] * -1
     expert_scales = torch.rand(actual_bs, top_k)
     if test_bfloat16:
         x = x.bfloat16()
         if w8a8_dynamic:
-            assert (gmm1_weight_scale is not None and gmm2_weight_scale is not None), "gmm1_weight_scale and gmm2_weight_scale must be provided for w8a8_dynamic"
+            assert gmm1_weight_scale is not None and gmm2_weight_scale is not None, (
+                "gmm1_weight_scale and gmm2_weight_scale must be provided for w8a8_dynamic"
+            )
             gmm1_weight_scale = gmm1_weight_scale.bfloat16()
             gmm2_weight_scale = gmm2_weight_scale.bfloat16()
     else:
@@ -417,31 +432,33 @@ def generate_datas(batch_size,
     valid_token_num = actual_bs
     if with_mc2_mask:
         valid_token_num = int(torch.randint(1, actual_bs, [1]).item())
-        x_active_mask = torch.cat(
-            (torch.ones(valid_token_num),
-             torch.zeros(actual_bs - valid_token_num))).bool()
-    return (x, expert_ids, smooth_sales, expert_scales, x_active_mask), \
-            (gmm1_weight, gmm1_weight_scale, gmm2_weight, gmm2_weight_scale), \
-            actual_bs, valid_token_num
+        x_active_mask = torch.cat((torch.ones(valid_token_num), torch.zeros(actual_bs - valid_token_num))).bool()
+    return (
+        (x, expert_ids, smooth_sales, expert_scales, x_active_mask),
+        (gmm1_weight, gmm1_weight_scale, gmm2_weight, gmm2_weight_scale),
+        actual_bs,
+        valid_token_num,
+    )
 
 
-def run_once(local_rank_id,
-             batch_size,
-             token_hidden_size,
-             moe_intermediate_size,
-             ep_world_size,
-             moe_expert_num,
-             shared_expert_rank_num=0,
-             top_k=8,
-             test_bfloat16=True,
-             enable_dynamic_bs=False,
-             test_graph=False,
-             with_mc2_mask=False,
-             dynamic_eplb=False,
-             w8a8_dynamic=True,
-             is_nz=True):
-    log_file = redirect_output(f"local_rank_{local_rank_id}.log"
-                               ) if output_to_file(local_rank_id) else None
+def run_once(
+    local_rank_id,
+    batch_size,
+    token_hidden_size,
+    moe_intermediate_size,
+    ep_world_size,
+    moe_expert_num,
+    shared_expert_rank_num=0,
+    top_k=8,
+    test_bfloat16=True,
+    enable_dynamic_bs=False,
+    test_graph=False,
+    with_mc2_mask=False,
+    dynamic_eplb=False,
+    w8a8_dynamic=True,
+    is_nz=True,
+):
+    log_file = redirect_output(f"local_rank_{local_rank_id}.log") if output_to_file(local_rank_id) else None
     global_rank_id = local_rank_id  # 单机
     device_id = local_rank_id % 16
     torch_npu.npu.set_device(device_id)
@@ -449,40 +466,37 @@ def run_once(local_rank_id,
     # 初始化分布式环境
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "29500"  # 端口号随意
-    dist.init_process_group(backend="hccl",
-                            rank=local_rank_id,
-                            world_size=ep_world_size)
+    dist.init_process_group(backend="hccl", rank=local_rank_id, world_size=ep_world_size)
     ep_ranks_list = list(np.arange(0, ep_world_size))
     ep_group = dist.new_group(backend="hccl", ranks=ep_ranks_list)
     ep_group_small = dist.new_group(backend="hccl", ranks=ep_ranks_list)
 
-    ep_hcomm_info_fused = ep_group._get_backend(
-        torch.device("npu")).get_hccl_comm_name(local_rank_id)
-    ep_hcomm_info_small = ep_group_small._get_backend(
-        torch.device("npu")).get_hccl_comm_name(local_rank_id)
+    ep_hcomm_info_fused = ep_group._get_backend(torch.device("npu")).get_hccl_comm_name(local_rank_id)
+    ep_hcomm_info_small = ep_group_small._get_backend(torch.device("npu")).get_hccl_comm_name(local_rank_id)
     torch_npu.npu.synchronize(device_id)
 
-    parameter = (batch_size, token_hidden_size, moe_intermediate_size,
-                 ep_world_size, moe_expert_num, global_rank_id,
-                 shared_expert_rank_num)
+    parameter = (
+        batch_size,
+        token_hidden_size,
+        moe_intermediate_size,
+        ep_world_size,
+        moe_expert_num,
+        global_rank_id,
+        shared_expert_rank_num,
+    )
     input_datas, weight_datas, actual_bs, valid_token_num = generate_datas(
-        *parameter, top_k, test_bfloat16, enable_dynamic_bs, with_mc2_mask, w8a8_dynamic)
-    input_datas = [
-        data.npu() if data is not None else None for data in input_datas
-    ]
-    weight_datas = [
-        data.npu() if data is not None else None for data in weight_datas
-    ]
-    small_ops = SmallOps(*weight_datas, ep_hcomm_info_small, *parameter,
-                         dynamic_eplb, w8a8_dynamic, is_nz).npu()  # type: ignore
-    fused_ops = FusionOp(*weight_datas, ep_hcomm_info_fused, *parameter,
-                         dynamic_eplb, w8a8_dynamic, is_nz).npu()  # type: ignore
+        *parameter, top_k, test_bfloat16, enable_dynamic_bs, with_mc2_mask, w8a8_dynamic
+    )
+    input_datas = [data.npu() if data is not None else None for data in input_datas]
+    weight_datas = [data.npu() if data is not None else None for data in weight_datas]
+    small_ops = SmallOps(*weight_datas, ep_hcomm_info_small, *parameter, dynamic_eplb, w8a8_dynamic, is_nz).npu()  # type: ignore
+    fused_ops = FusionOp(*weight_datas, ep_hcomm_info_fused, *parameter, dynamic_eplb, w8a8_dynamic, is_nz).npu()  # type: ignore
     if test_graph:
         config = torchair.CompilerConfig()
         config.mode = "reduce-overhead"
         npu_backend = torchair.get_npu_backend(compiler_config=config)
         fused_ops = torch.compile(fused_ops, backend=npu_backend)
-    
+
     # test performance
     start_time = time.perf_counter()
     for _ in range(100):
@@ -510,12 +524,13 @@ def run_once(local_rank_id,
     if log_file is not None:
         log_file.close()
     try:
-        torch.testing.assert_close(small_op_token_output[0:valid_token_num].cpu(),
-                                   fused_op_token_output[0:valid_token_num].cpu(),
-                                   atol=2.0,
-                                   rtol=0.02)
-        torch.testing.assert_close(small_op_count_output.cpu(),
-                                   fused_op_count_output.cpu())
+        torch.testing.assert_close(
+            small_op_token_output[0:valid_token_num].cpu(),
+            fused_op_token_output[0:valid_token_num].cpu(),
+            atol=2.0,
+            rtol=0.02,
+        )
+        torch.testing.assert_close(small_op_count_output.cpu(), fused_op_count_output.cpu())
     except Exception as e:
         print(f"rank-{global_rank_id} Assert close Failed: {e}")
     else:
@@ -556,6 +571,7 @@ def test_dispatch_gmm_combine_decode_dynamic_eplb():
     ep_world_size = custom_kwargs["ep_world_size"]
     custom_args = tuple(custom_kwargs.values())
     mp.spawn(run_once, args=custom_args, nprocs=ep_world_size, join=True)
+
 
 if __name__ == "__main__":
     test_dispatch_gmm_combine_decode_base()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py
@@ -14,12 +14,7 @@ np.random.seed(seed)
 torch.manual_seed(seed)
 
 
-def npu_add_rms_norm_bias_golden(input_x1,
-                            input_x2,
-                            input_gamma,
-                            input_beta,
-                            kernelType,
-                            epsilon=0.000001):
+def npu_add_rms_norm_bias_golden(input_x1, input_x2, input_gamma, input_beta, kernelType, epsilon=0.000001):
     ori_x_shape = input_x1.shape
     ori_gamma_shape = input_gamma.shape
     xlength = len(ori_x_shape)
@@ -44,14 +39,14 @@ def npu_add_rms_norm_bias_golden(input_x1,
 
     if kernelType == 1:
         oriType = torch.float16
-        xOut = (input_x1.to(oriType) + input_x2.to(oriType))
+        xOut = input_x1.to(oriType) + input_x2.to(oriType)
     elif kernelType == 2:
         oriType = torch.bfloat16
-        x_fp32 = (input_x1.to(torchType32) + input_x2.to(torchType32))
+        x_fp32 = input_x1.to(torchType32) + input_x2.to(torchType32)
         xOut = x_fp32.to(oriType)
     else:
         oriType = torch.float32
-        xOut = (input_x1.to(torchType32) + input_x2.to(torchType32))
+        xOut = input_x1.to(torchType32) + input_x2.to(torchType32)
     x_fp32 = xOut.to(torchType32)
     avgFactor = 1 / gammaSize
     x_2 = torch.pow(x_fp32, 2)
@@ -79,11 +74,11 @@ def npu_add_rms_norm_bias_golden(input_x1,
 
 
 @pytest.mark.parametrize(
-    'row',
+    "row",
     [1, 16, 64, 77, 128, 255, 1000],
 )
 @pytest.mark.parametrize(
-    'col',
+    "col",
     [
         8,
         16,
@@ -113,28 +108,22 @@ def test_quant_fpx_linear(row: int, col: int, dtype, atol, rtol, kernelType):
     input_x2 = np.random.uniform(1, 10, size=tuple(shape_x)).astype(np.float32)
     input_x2_tensor = torch.tensor(input_x2).type(dataType)
 
-    input_gamma = np.random.uniform(1, 10,
-                                    size=tuple(shape_gamma)).astype(np.float32)
+    input_gamma = np.random.uniform(1, 10, size=tuple(shape_gamma)).astype(np.float32)
     input_gamma_tensor = torch.tensor(input_gamma).type(dataType)
 
-    input_beta = np.random.uniform(1, 10,
-                                   size=tuple(shape_gamma)).astype(np.float32)
+    input_beta = np.random.uniform(1, 10, size=tuple(shape_gamma)).astype(np.float32)
     grad_bias = torch.tensor(input_beta).type(dataType)
-    y, rstd, x = torch.ops._C_ascend.npu_add_rms_norm_bias(input_x1_tensor.npu(),
-                                                      input_x2_tensor.npu(),
-                                                      input_gamma_tensor.npu(),
-                                                      grad_bias.npu(), 1e-6)
+    y, rstd, x = torch.ops._C_ascend.npu_add_rms_norm_bias(
+        input_x1_tensor.npu(), input_x2_tensor.npu(), input_gamma_tensor.npu(), grad_bias.npu(), 1e-6
+    )
 
     y = y.cpu()
     rstd = rstd.cpu()
     x = x.cpu()
 
-    y1, rstd1, x1 = npu_add_rms_norm_bias_golden(input_x1_tensor,
-                                            input_x2_tensor,
-                                            input_gamma_tensor,
-                                            grad_bias,
-                                            kernelType,
-                                            epsilon=0.000001)
+    y1, rstd1, x1 = npu_add_rms_norm_bias_golden(
+        input_x1_tensor, input_x2_tensor, input_gamma_tensor, grad_bias, kernelType, epsilon=0.000001
+    )
 
     a = y1 > 1
     a1 = y1 <= 1

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_apply_top_k_top_p_custom.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_apply_top_k_top_p_custom.py
@@ -1,7 +1,9 @@
 import gc
+
 import numpy as np
 import pytest
 import torch
+
 from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
@@ -75,12 +77,7 @@ def assert_output_close(out_cpu, out_npu, rtol=1e-4, atol=1e-4):
     # 2. Check value consistency for valid elements
     valid_mask = (~mask_cpu) & (~mask_npu)
     if valid_mask.any():
-        torch.testing.assert_close(
-            out_cpu[valid_mask],
-            out_npu[valid_mask],
-            rtol=rtol,
-            atol=atol
-        )
+        torch.testing.assert_close(out_cpu[valid_mask], out_npu[valid_mask], rtol=rtol, atol=atol)
 
 
 # -----------------------------------------------------------------------------
@@ -88,10 +85,10 @@ def assert_output_close(out_cpu, out_npu, rtol=1e-4, atol=1e-4):
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize('vocab_size', [15206, 152064])
-@pytest.mark.parametrize('batch_size', [4, 8, 16, 32, 64, 96, 128, 256])
-@pytest.mark.parametrize('p_val', [0.5, 0.9, 0.99])
-@pytest.mark.parametrize('k_val', [50, 200, 1024, 4096, 8192])
+@pytest.mark.parametrize("vocab_size", [15206, 152064])
+@pytest.mark.parametrize("batch_size", [4, 8, 16, 32, 64, 96, 128, 256])
+@pytest.mark.parametrize("p_val", [0.5, 0.9, 0.99])
+@pytest.mark.parametrize("k_val", [50, 200, 1024, 4096, 8192])
 def test_npu_apply_top_k_top_p(vocab_size, batch_size, p_val, k_val):
     shape = [batch_size, vocab_size]
     dtype = torch.float32
@@ -109,9 +106,9 @@ def test_npu_apply_top_k_top_p(vocab_size, batch_size, p_val, k_val):
     torch.npu.reset_peak_memory_stats()
 
 
-@pytest.mark.parametrize('vocab_size', [15206, 152064])
-@pytest.mark.parametrize('batch_size', [4, 8, 16, 32, 64, 96, 128, 256])
-@pytest.mark.parametrize('k_val', [50, 200, 1024, 4096, 8192])
+@pytest.mark.parametrize("vocab_size", [15206, 152064])
+@pytest.mark.parametrize("batch_size", [4, 8, 16, 32, 64, 96, 128, 256])
+@pytest.mark.parametrize("k_val", [50, 200, 1024, 4096, 8192])
 def test_npu_apply_top_k(vocab_size, batch_size, k_val):
     shape = [batch_size, vocab_size]
     dtype = torch.float32
@@ -129,9 +126,9 @@ def test_npu_apply_top_k(vocab_size, batch_size, k_val):
     torch.npu.reset_peak_memory_stats()
 
 
-@pytest.mark.parametrize('vocab_size', [15206, 152064])
-@pytest.mark.parametrize('batch_size', [4, 8, 16, 32, 64, 96, 128, 256])
-@pytest.mark.parametrize('p_val', [0.5, 0.9, 0.99])
+@pytest.mark.parametrize("vocab_size", [15206, 152064])
+@pytest.mark.parametrize("batch_size", [4, 8, 16, 32, 64, 96, 128, 256])
+@pytest.mark.parametrize("p_val", [0.5, 0.9, 0.99])
 def test_npu_apply_top_p(vocab_size, batch_size, p_val):
     shape = [batch_size, vocab_size]
     dtype = torch.float32

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_batch_matmul_transpose.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_batch_matmul_transpose.py
@@ -12,28 +12,21 @@ torch.set_printoptions(threshold=float("inf"))
 
 
 class TestMatrixMultiplication(unittest.TestCase):
-
     def compute_golden(self, a, b, res1, m, n):
         """Compute reference result (golden)"""
-        torch.bmm(a.transpose(0, 1),
-                  b,
-                  out=res1.view(-1, m, n).transpose(0, 1))
+        torch.bmm(a.transpose(0, 1), b, out=res1.view(-1, m, n).transpose(0, 1))
 
     def assert_tensors_almost_equal(self, actual, expected, dtype):
         """Check if two tensors are approximately equal (considering floating point errors)"""
         self.assertEqual(actual.shape, expected.shape, "Shape mismatch")
 
         # Check for NaN
-        self.assertFalse(
-            torch.isnan(actual).any(), "Actual result contains NaN")
-        self.assertFalse(
-            torch.isnan(expected).any(), "Expected result contains NaN")
+        self.assertFalse(torch.isnan(actual).any(), "Actual result contains NaN")
+        self.assertFalse(torch.isnan(expected).any(), "Expected result contains NaN")
 
         # Check for Inf
-        self.assertFalse(
-            torch.isinf(actual).any(), "Actual result contains Inf")
-        self.assertFalse(
-            torch.isinf(expected).any(), "Expected result contains Inf")
+        self.assertFalse(torch.isinf(actual).any(), "Actual result contains Inf")
+        self.assertFalse(torch.isinf(expected).any(), "Expected result contains Inf")
 
         # Set different tolerances based on data type
         if dtype == torch.float16:
@@ -55,11 +48,11 @@ class TestMatrixMultiplication(unittest.TestCase):
                 f"Relative error too large: {relative_diff} > {rtol}. Max difference: {max_diff}",
             )
 
-        self.assertLessEqual(max_diff, atol,
-                             f"Absolute error too large: {max_diff} > {atol}")
+        self.assertLessEqual(max_diff, atol, f"Absolute error too large: {max_diff} > {atol}")
         gc.collect()
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
+
     def test_boundary_conditions(self):
         """Test boundary conditions"""
         test_cases = [
@@ -88,11 +81,9 @@ class TestMatrixMultiplication(unittest.TestCase):
                     res2 = torch.empty((b, m, n), dtype=dtype, device="npu")
 
                     self.compute_golden(a, b_tensor, res1, m, n)
-                    torch.ops._C_ascend.batch_matmul_transpose(
-                        a, b_tensor, res2)
+                    torch.ops._C_ascend.batch_matmul_transpose(a, b_tensor, res2)
 
-                    self.assert_tensors_almost_equal(res1.view(-1, m, n), res2,
-                                                     dtype)
+                    self.assert_tensors_almost_equal(res1.view(-1, m, n), res2, dtype)
         gc.collect()
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
@@ -110,21 +101,19 @@ class TestMatrixMultiplication(unittest.TestCase):
                 k = random.randint(1, 500)
                 n = random.randint(1, 500)
 
-                with self.subTest(dtype=dtype,
-                                  shape=f"Random ({b}, {m}, {k}, {n})"):
+                with self.subTest(dtype=dtype, shape=f"Random ({b}, {m}, {k}, {n})"):
                     a = torch.randn(b, m, k, dtype=dtype, device="npu")
                     b_tensor = torch.randn(m, k, n, dtype=dtype, device="npu")
                     res1 = torch.empty((b, m * n), dtype=dtype, device="npu")
                     res2 = torch.empty((b, m, n), dtype=dtype, device="npu")
 
                     self.compute_golden(a, b_tensor, res1, m, n)
-                    torch.ops._C_ascend.batch_matmul_transpose(
-                        a, b_tensor, res2)
-                    self.assert_tensors_almost_equal(res1.view(-1, m, n), res2,
-                                                     dtype)
+                    torch.ops._C_ascend.batch_matmul_transpose(a, b_tensor, res2)
+                    self.assert_tensors_almost_equal(res1.view(-1, m, n), res2, dtype)
         gc.collect()
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
+
     def test_zero_values(self):
         """Test zero input values"""
         dtypes = [torch.float16, torch.bfloat16]
@@ -140,12 +129,12 @@ class TestMatrixMultiplication(unittest.TestCase):
                 self.compute_golden(a, b_tensor, res1, m, n)
                 torch.ops._C_ascend.batch_matmul_transpose(a, b_tensor, res2)
 
-                self.assert_tensors_almost_equal(res1.view(-1, m, n), res2,
-                                                 dtype)
+                self.assert_tensors_almost_equal(res1.view(-1, m, n), res2, dtype)
                 self.assertTrue(torch.all(res2 == 0))
         gc.collect()
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_bgmv_expand.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_bgmv_expand.py
@@ -10,12 +10,12 @@ DEFAULT_ATOL = 1e-3
 DEFAULT_RTOL = 1e-3
 
 
-def bgmv_expand_cpu_impl(x: torch.Tensor, w: torch.Tensor,
-                         indices: torch.Tensor, y: torch.tensor,
-                         slice_offset: int, slice_size: int) -> torch.Tensor:
+def bgmv_expand_cpu_impl(
+    x: torch.Tensor, w: torch.Tensor, indices: torch.Tensor, y: torch.tensor, slice_offset: int, slice_size: int
+) -> torch.Tensor:
     W = w[indices, :, :].transpose(-1, -2).to(torch.float32)
     z = torch.bmm(x.unsqueeze(1).to(torch.float32), W).squeeze()
-    y[:, slice_offset:slice_offset + slice_size] += z
+    y[:, slice_offset : slice_offset + slice_size] += z
     return y
 
 
@@ -33,14 +33,10 @@ def test_bgmv_expand():
     y_npu = y.npu()
 
     y_out = bgmv_expand_cpu_impl(x, w, indices, y, 0, 128)
-    y_out_npu = torch.ops._C_ascend.bgmv_expand(x_npu, w_npu, indices_npu,
-                                                y_npu, 0, 128)
+    y_out_npu = torch.ops._C_ascend.bgmv_expand(x_npu, w_npu, indices_npu, y_npu, 0, 128)
 
     # Compare the results.
-    torch.testing.assert_close(y_out_npu.cpu(),
-                               y_out.cpu(),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(y_out_npu.cpu(), y_out.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_bgmv_shrink.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_bgmv_shrink.py
@@ -10,9 +10,9 @@ DEFAULT_ATOL = 1e-3
 DEFAULT_RTOL = 1e-3
 
 
-def bgmv_shrink_cpu_impl(x: torch.Tensor, w: torch.Tensor,
-                         indices: torch.Tensor, y: torch.tensor,
-                         scaling: float) -> torch.Tensor:
+def bgmv_shrink_cpu_impl(
+    x: torch.Tensor, w: torch.Tensor, indices: torch.Tensor, y: torch.tensor, scaling: float
+) -> torch.Tensor:
     W = w[indices, :, :].transpose(-1, -2).to(torch.float32)
     z = torch.bmm(x.unsqueeze(1).to(torch.float32), W).squeeze()
     y[:, :] += z * scaling
@@ -36,10 +36,7 @@ def test_bgmv_shrink():
     torch.ops._C_ascend.bgmv_shrink(x_npu, w_npu, indices_npu, y_npu, 0.5)
 
     # Compare the results.
-    torch.testing.assert_close(y_npu.cpu(),
-                               y.cpu(),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(y_npu.cpu(), y.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_causal_conv1d_310.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_causal_conv1d_310.py
@@ -33,7 +33,6 @@ def to_int64_tuple(t):
 def test_ascend_causal_conv1d_310_fn(
     dim, width, extra_state_len, seq_len, has_bias, silu_activation, has_initial_state
 ):
-
     torch.random.manual_seed(0)
     enable_custom_op()
     device = "npu"

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_copy_and_expand_eagle_inputs.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_copy_and_expand_eagle_inputs.py
@@ -19,6 +19,7 @@ SEED = 42
 # Golden reference (CPU, pure Python/NumPy)
 # ---------------------------------------------------------------------------
 
+
 def golden_copy_and_expand(
     target_token_ids: np.ndarray,
     target_positions: np.ndarray,
@@ -137,11 +138,18 @@ def golden_copy_and_expand(
 # NPU operator wrapper
 # ---------------------------------------------------------------------------
 
+
 def npu_op_exec(
-    target_token_ids, target_positions, next_token_ids,
-    query_start_loc, query_end_loc,
-    padding_token_id, parallel_drafting_token_id,
-    num_padding_slots, shift_input_ids, total_draft_tokens,
+    target_token_ids,
+    target_positions,
+    next_token_ids,
+    query_start_loc,
+    query_end_loc,
+    padding_token_id,
+    parallel_drafting_token_id,
+    num_padding_slots,
+    shift_input_ids,
+    total_draft_tokens,
 ):
     """Execute the custom Ascend NPU operator."""
     result = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
@@ -163,9 +171,16 @@ def npu_op_exec(
 # Test case generator
 # ---------------------------------------------------------------------------
 
-def generate_test_case(rng, num_reqs, num_padding_slots, shift_input_ids,
-                       min_tokens_per_req=2, max_tokens_per_req=64,
-                       max_rejected_per_req=5):
+
+def generate_test_case(
+    rng,
+    num_reqs,
+    num_padding_slots,
+    shift_input_ids,
+    min_tokens_per_req=2,
+    max_tokens_per_req=64,
+    max_rejected_per_req=5,
+):
     """Generate a random test case.
 
     Returns dict with all input arrays and expected parameters.
@@ -174,8 +189,7 @@ def generate_test_case(rng, num_reqs, num_padding_slots, shift_input_ids,
     parallel_drafting_token_id = 100
 
     # Generate per-request token counts
-    tokens_per_req = rng.integers(min_tokens_per_req, max_tokens_per_req + 1,
-                                  size=num_reqs)
+    tokens_per_req = rng.integers(min_tokens_per_req, max_tokens_per_req + 1, size=num_reqs)
     rejected_per_req = rng.integers(0, max_rejected_per_req + 1, size=num_reqs)
 
     # Build query_start_loc (cumulative)
@@ -241,13 +255,11 @@ def generate_test_case(rng, num_reqs, num_padding_slots, shift_input_ids,
 @pytest.mark.parametrize("num_padding_slots", [1, 2, 3, 5])
 @pytest.mark.parametrize("shift_input_ids", [False, True])
 @pytest.mark.parametrize("seed_offset", [0, 1])
-def test_copy_and_expand_eagle_inputs(num_reqs, num_padding_slots,
-                                       shift_input_ids, seed_offset):
+def test_copy_and_expand_eagle_inputs(num_reqs, num_padding_slots, shift_input_ids, seed_offset):
     """Test CopyAndExpandEagleInputs with parametrized configurations."""
     rng = np.random.default_rng(SEED + seed_offset)
 
-    case = generate_test_case(rng, num_reqs, num_padding_slots,
-                              shift_input_ids)
+    case = generate_test_case(rng, num_reqs, num_padding_slots, shift_input_ids)
 
     # Golden reference
     g_ids, g_pos, g_rej, g_msk, g_nti, g_hsm = golden_copy_and_expand(
@@ -285,20 +297,14 @@ def test_copy_and_expand_eagle_inputs(num_reqs, num_padding_slots,
     g_hsm_t = torch.from_numpy(g_hsm)
 
     # Compare outputs
-    torch.testing.assert_close(n_ids, g_ids_t, atol=0, rtol=0,
-                               msg="out_input_ids mismatch")
-    torch.testing.assert_close(n_pos, g_pos_t, atol=0, rtol=0,
-                               msg="out_positions mismatch")
-    torch.testing.assert_close(n_rej, g_rej_t, atol=0, rtol=0,
-                               msg="out_is_rejected_token_mask mismatch")
-    torch.testing.assert_close(n_msk, g_msk_t, atol=0, rtol=0,
-                               msg="out_is_masked_token_mask mismatch")
-    torch.testing.assert_close(n_nti, g_nti_t, atol=0, rtol=0,
-                               msg="out_new_token_indices mismatch")
+    torch.testing.assert_close(n_ids, g_ids_t, atol=0, rtol=0, msg="out_input_ids mismatch")
+    torch.testing.assert_close(n_pos, g_pos_t, atol=0, rtol=0, msg="out_positions mismatch")
+    torch.testing.assert_close(n_rej, g_rej_t, atol=0, rtol=0, msg="out_is_rejected_token_mask mismatch")
+    torch.testing.assert_close(n_msk, g_msk_t, atol=0, rtol=0, msg="out_is_masked_token_mask mismatch")
+    torch.testing.assert_close(n_nti, g_nti_t, atol=0, rtol=0, msg="out_new_token_indices mismatch")
 
     if shift_input_ids:
-        torch.testing.assert_close(n_hsm, g_hsm_t, atol=0, rtol=0,
-                                   msg="out_hidden_state_mapping mismatch")
+        torch.testing.assert_close(n_hsm, g_hsm_t, atol=0, rtol=0, msg="out_hidden_state_mapping mismatch")
 
 
 @pytest.mark.parametrize("num_reqs", [1])
@@ -307,9 +313,15 @@ def test_copy_and_expand_eagle_inputs(num_reqs, num_padding_slots,
 def test_minimal_case(num_reqs, num_padding_slots, shift_input_ids):
     """Test with minimal input (1 request, 1 padding slot)."""
     rng = np.random.default_rng(SEED + 100)
-    case = generate_test_case(rng, num_reqs, num_padding_slots,
-                              shift_input_ids, min_tokens_per_req=2,
-                              max_tokens_per_req=3, max_rejected_per_req=1)
+    case = generate_test_case(
+        rng,
+        num_reqs,
+        num_padding_slots,
+        shift_input_ids,
+        min_tokens_per_req=2,
+        max_tokens_per_req=3,
+        max_rejected_per_req=1,
+    )
 
     g_ids, g_pos, g_rej, g_msk, g_nti, g_hsm = golden_copy_and_expand(
         case["target_token_ids"],
@@ -347,11 +359,15 @@ def test_minimal_case(num_reqs, num_padding_slots, shift_input_ids):
 def test_large_tokens_per_request(num_reqs):
     """Test with larger token counts per request."""
     rng = np.random.default_rng(SEED + 200)
-    case = generate_test_case(rng, num_reqs, num_padding_slots=3,
-                              shift_input_ids=False,
-                              min_tokens_per_req=100,
-                              max_tokens_per_req=512,
-                              max_rejected_per_req=10)
+    case = generate_test_case(
+        rng,
+        num_reqs,
+        num_padding_slots=3,
+        shift_input_ids=False,
+        min_tokens_per_req=100,
+        max_tokens_per_req=512,
+        max_rejected_per_req=10,
+    )
 
     g_ids, g_pos, g_rej, g_msk, g_nti, g_hsm = golden_copy_and_expand(
         case["target_token_ids"],
@@ -389,11 +405,15 @@ def test_large_tokens_per_request(num_reqs):
 def test_large_tokens_shift_true(num_reqs):
     """Test with larger token counts and shift_input_ids=True."""
     rng = np.random.default_rng(SEED + 300)
-    case = generate_test_case(rng, num_reqs, num_padding_slots=4,
-                              shift_input_ids=True,
-                              min_tokens_per_req=50,
-                              max_tokens_per_req=256,
-                              max_rejected_per_req=8)
+    case = generate_test_case(
+        rng,
+        num_reqs,
+        num_padding_slots=4,
+        shift_input_ids=True,
+        min_tokens_per_req=50,
+        max_tokens_per_req=256,
+        max_rejected_per_req=8,
+    )
 
     g_ids, g_pos, g_rej, g_msk, g_nti, g_hsm = golden_copy_and_expand(
         case["target_token_ids"],
@@ -432,11 +452,15 @@ def test_large_tokens_shift_true(num_reqs):
 def test_no_rejected_tokens(num_reqs):
     """Test cases with zero rejected tokens."""
     rng = np.random.default_rng(SEED + 400)
-    case = generate_test_case(rng, num_reqs, num_padding_slots=2,
-                              shift_input_ids=False,
-                              min_tokens_per_req=5,
-                              max_tokens_per_req=20,
-                              max_rejected_per_req=0)
+    case = generate_test_case(
+        rng,
+        num_reqs,
+        num_padding_slots=2,
+        shift_input_ids=False,
+        min_tokens_per_req=5,
+        max_tokens_per_req=20,
+        max_rejected_per_req=0,
+    )
 
     g_ids, g_pos, g_rej, g_msk, g_nti, g_hsm = golden_copy_and_expand(
         case["target_token_ids"],

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py
@@ -31,11 +31,11 @@ from vllm.model_executor.layers.activation import SiluAndMul
 from vllm_ascend.ops.fused_moe.experts_selector import check_npu_moe_gating_top_k, select_experts
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
-    build_fused_experts_input,
-    build_mlp_compute_input,
     MoEQuantParams,
     MoERoutingParams,
     MoETokenDispatchInput,
+    build_fused_experts_input,
+    build_mlp_compute_input,
 )
 from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatcherWithAllGather
 from vllm_ascend.quantization.quant_type import QuantType

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gating_top_k_softmax.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gating_top_k_softmax.py
@@ -1,19 +1,20 @@
 import gc
+
 import pytest
 import torch
 import torch_npu
 
 
 @pytest.mark.parametrize(
-    'B',
+    "B",
     [1, 16, 64, 128, 32768],
 )
 @pytest.mark.parametrize(
-    'D',
+    "D",
     [8, 16, 32, 64, 128],
 )
 @pytest.mark.parametrize(
-    'top_k',
+    "top_k",
     [1, 2, 4, 8],
 )
 @pytest.mark.parametrize(
@@ -27,9 +28,7 @@ def test_quant_fpx_linear(B: int, D: int, top_k: int, dtype, atol, rtol):
     x = torch.rand((B, D), dtype=dtype).to("npu")
     # finished = torch.randint(1, size=(B,), dtype=torch.bool).to("npu")
     finished = None
-    y, expert_idx, row_idx = torch_npu.npu_moe_gating_top_k_softmax(x,
-                                                                    finished,
-                                                                    k=top_k)
+    y, expert_idx, row_idx = torch_npu.npu_moe_gating_top_k_softmax(x, finished, k=top_k)
 
     topk_weights = x.softmax(dim=-1)
     topk_weights, topk_ids = topk_weights.topk(top_k, dim=-1)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gmm_swiglu_quant_weight_nz_tensor_list.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gmm_swiglu_quant_weight_nz_tensor_list.py
@@ -11,9 +11,9 @@ torch_npu.npu.config.allow_internal_format = True
 enable_custom_op()
 
 
-def gmm_swiglu_quant(x: torch.Tensor, weight: torch.Tensor,
-                     perChannelScale: torch.Tensor,
-                     perTokenScale: torch.Tensor, m: int):
+def gmm_swiglu_quant(
+    x: torch.Tensor, weight: torch.Tensor, perChannelScale: torch.Tensor, perTokenScale: torch.Tensor, m: int
+):
     """
     Perform quantized GMM (Grouped Matrix Multiplication) operation with SwiGLU activation function.
 
@@ -42,20 +42,21 @@ def gmm_swiglu_quant(x: torch.Tensor, weight: torch.Tensor,
     c_temp6 = c_temp5 * gate  # Element-wise multiplication with gating values
 
     # Quantize the output
-    max = torch.max(
-        torch.abs(c_temp6),
-        -1).values  # Find maximum absolute value to calculate scaling factor
+    max = torch.max(torch.abs(c_temp6), -1).values  # Find maximum absolute value to calculate scaling factor
     quantScaleOutput = 127 / max  # Calculate quantization scaling factor
-    quantOutput = torch.round(c_temp6 * quantScaleOutput.reshape(m, 1)).to(
-        torch.int8)  # Quantize to int8
+    quantOutput = torch.round(c_temp6 * quantScaleOutput.reshape(m, 1)).to(torch.int8)  # Quantize to int8
     quantScaleOutput = 1 / quantScaleOutput  # Inverse quantization scaling factor for subsequent dequantization
 
     return quantOutput, quantScaleOutput
 
 
-def process_groups(x: torch.Tensor, weight: torch.Tensor,
-                   perChannelScale: torch.Tensor, perTokenScale: torch.Tensor,
-                   groupList: torch.Tensor):
+def process_groups(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    perChannelScale: torch.Tensor,
+    perTokenScale: torch.Tensor,
+    groupList: torch.Tensor,
+):
     """
     Process input data by groups and call GMM_Swiglu_quant function for quantized computation.
 
@@ -71,10 +72,8 @@ def process_groups(x: torch.Tensor, weight: torch.Tensor,
         quantScaleOutput (torch.Tensor): Quantization scaling factor with shape (M,).
     """
     M, N = x.shape[0], weight.shape[2]  # Get the shape of the input tensor
-    quantOutput = torch.zeros(M, N // 2).to(
-        torch.int8)  # Initialize quantized output tensor
-    quantScaleOutput = torch.zeros(M).to(
-        torch.float32)  # Initialize quantization scaling factor tensor
+    quantOutput = torch.zeros(M, N // 2).to(torch.int8)  # Initialize quantized output tensor
+    quantScaleOutput = torch.zeros(M).to(torch.float32)  # Initialize quantization scaling factor tensor
 
     start_idx = 0  # Starting index
     preV = 0  # Number of tokens in the previous group
@@ -86,12 +85,15 @@ def process_groups(x: torch.Tensor, weight: torch.Tensor,
         preV = currV  # Update number of tokens in the previous group
         if tempV > 0:
             # Call GMM_Swiglu_quant to process the current group
-            quantOutput[start_idx:start_idx + tempV], quantScaleOutput[start_idx:start_idx + tempV] = \
-                gmm_swiglu_quant(x[start_idx:start_idx + tempV],
-                                 weight[i],
-                                 perChannelScale[i],
-                                 perTokenScale[start_idx:start_idx + tempV],
-                                 tempV)
+            quantOutput[start_idx : start_idx + tempV], quantScaleOutput[start_idx : start_idx + tempV] = (
+                gmm_swiglu_quant(
+                    x[start_idx : start_idx + tempV],
+                    weight[i],
+                    perChannelScale[i],
+                    perTokenScale[start_idx : start_idx + tempV],
+                    tempV,
+                )
+            )
 
         start_idx += tempV  # Update starting index to process the next group
     return quantOutput, quantScaleOutput
@@ -123,25 +125,15 @@ def test_gmm_swiglu_quant_weight_nz_tensor_list():
 
     group_list = torch.tensor([2048, 4096, 6144, 8192], dtype=torch.int64)
 
-    output_cpu, output_scale_cpu = process_groups(x, weight, weight_scale,
-                                                  x_scale, group_list)
-    output_npu, output_scale_npu, _ = \
-        torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(x.npu(),
-                                                                              weight_nz_npu,
-                                                                              weight_scale_npu,
-                                                                              x_scale.npu(),
-                                                                              group_list.npu())
-    output_npu_valid = output_npu[:group_list[-1], :]
-    output_scale_npu_valid = output_scale_npu[:group_list[-1]]
+    output_cpu, output_scale_cpu = process_groups(x, weight, weight_scale, x_scale, group_list)
+    output_npu, output_scale_npu, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
+        x.npu(), weight_nz_npu, weight_scale_npu, x_scale.npu(), group_list.npu()
+    )
+    output_npu_valid = output_npu[: group_list[-1], :]
+    output_scale_npu_valid = output_scale_npu[: group_list[-1]]
 
-    torch.testing.assert_close(output_npu_valid.cpu(),
-                               output_cpu,
-                               atol=1,
-                               rtol=2**-13)
-    torch.testing.assert_close(output_scale_npu_valid.cpu(),
-                               output_scale_cpu,
-                               atol=1e-9,
-                               rtol=1e-6)
+    torch.testing.assert_close(output_npu_valid.cpu(), output_cpu, atol=1, rtol=2**-13)
+    torch.testing.assert_close(output_scale_npu_valid.cpu(), output_scale_cpu, atol=1e-9, rtol=1e-6)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_grouped_matmul_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_grouped_matmul_swiglu_quant.py
@@ -12,16 +12,14 @@ enable_custom_op()
 def x_int8_to_x_int4(x: torch.Tensor):
     m, k = x.shape
     x_high_4bit = torch.floor(x.to(torch.float16) // 16).to(torch.int8)
-    x_low_4bit = (
-        torch.bitwise_and(x.view(torch.int16), 0x0f0f).view(torch.int8) - 8)
+    x_low_4bit = torch.bitwise_and(x.view(torch.int16), 0x0F0F).view(torch.int8) - 8
     x_int4 = torch.empty((2 * m, k), dtype=torch.int8)
     x_int4[::2, :] = x_high_4bit
     x_int4[1::2, :] = x_low_4bit
     return x_int4
 
 
-def custom_mm(x: torch.Tensor, weight: torch.Tensor,
-              weight_scale: torch.Tensor, m: int):
+def custom_mm(x: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor, m: int):
     """
     Performing Quantized GMM (General Matrix Multiplication) Operation
     Parameters:
@@ -44,31 +42,30 @@ def custom_mm(x: torch.Tensor, weight: torch.Tensor,
         x_grouped = x.view(-1, k_group, per_group_ele).transpose(0, 1)
         weight_grouped = weight.view(k_group, per_group_ele, n)
 
-        c_temp = torch.bmm(x_grouped.to(torch.int32),
-                           weight_grouped.to(torch.int32)).to(torch.float16)
+        c_temp = torch.bmm(x_grouped.to(torch.int32), weight_grouped.to(torch.int32)).to(torch.float16)
         for k_idx in range(k_group):
-            mm_out += (c_temp[k_idx] *
-                       weight_scale[k_idx].view(1, -1).to(torch.float16)).to(
-                           torch.float16)
+            mm_out += (c_temp[k_idx] * weight_scale[k_idx].view(1, -1).to(torch.float16)).to(torch.float16)
     # perChannel scenario
-    elif len(weight_scale.shape) == 1 or (len(weight_scale.shape) == 2
-                                          and weight_scale.shape[0] == 1):
-        c_temp = torch.matmul(x.to(torch.int32),
-                              weight.to(torch.int32)).to(torch.float32)
+    elif len(weight_scale.shape) == 1 or (len(weight_scale.shape) == 2 and weight_scale.shape[0] == 1):
+        c_temp = torch.matmul(x.to(torch.int32), weight.to(torch.int32)).to(torch.float32)
         mm_out = c_temp * weight_scale.view(1, -1).to(torch.float16)
     return mm_out.to(torch.float32)
 
 
-def gmm_swiglu_quant_golden_a8_w4(x: torch.Tensor, weight: torch.Tensor,
-                                  weight_scale: torch.Tensor,
-                                  per_token_scale: torch.Tensor,
-                                  bias: torch.Tensor,
-                                  group_list: torch.Tensor):
+def gmm_swiglu_quant_golden_a8_w4(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    per_token_scale: torch.Tensor,
+    bias: torch.Tensor,
+    group_list: torch.Tensor,
+):
     """
     Process the input data by group and call the GMM_Swiglu_quant function for quantization computation.
     Parameters:
         x (torch.Tensor): Input tensor with shape (M, K), type INT8.
-        weight (torch.Tensor): List of weight tensors, each with shape (E, K, N), data type INT8 but data range INT4, representing INT4 values.
+        weight (torch.Tensor): List of weight tensors, each with shape (E, K, N),
+                               data type INT8 but data range INT4, representing INT4 values.
         weight_scale (torch.Tensor): Scaling factor for each channel.
           - In perGroup scenario: shape (E, k_group_num, N).
           - In perChannel scenario: shape (E, N).
@@ -95,31 +92,26 @@ def gmm_swiglu_quant_golden_a8_w4(x: torch.Tensor, weight: torch.Tensor,
         temp_v = int((curr_v - pre_v) * 2)
         # Update the number of tokens in the previous group
         pre_v = curr_v
-        if (temp_v > 0):
-            mm_out = custom_mm(x_int4[int(start_idx):int(start_idx + temp_v)],
-                               weight[i], weight_scale[i], temp_v)
-            mm_num_concat = ((mm_out[::2] * 16 + mm_out[1::2]) +
-                             bias[i].view(1, -1))
-            per_token_quant = mm_num_concat * per_token_scale[start_idx // 2:(
-                start_idx + temp_v) // 2].view(-1, 1)
+        if temp_v > 0:
+            mm_out = custom_mm(x_int4[int(start_idx) : int(start_idx + temp_v)], weight[i], weight_scale[i], temp_v)
+            mm_num_concat = (mm_out[::2] * 16 + mm_out[1::2]) + bias[i].view(1, -1)
+            per_token_quant = mm_num_concat * per_token_scale[start_idx // 2 : (start_idx + temp_v) // 2].view(-1, 1)
             swiglu, gate = per_token_quant.chunk(2, dim=-1)
             temp = swiglu * torch.sigmoid(swiglu)
             temp = temp * gate
             max_value = torch.max(torch.abs(temp), dim=-1).values
             quant_scale_output_temp = 127 / max_value
-            quant_output[start_idx // 2:(start_idx + temp_v) //
-                         2] = torch.round(temp *
-                                          quant_scale_output_temp.reshape(
-                                              temp_v // 2, 1)).to(torch.int8)
-            quant_scale_output[start_idx // 2:(start_idx + temp_v) //
-                               2] = 1 / quant_scale_output_temp
+            quant_output[start_idx // 2 : (start_idx + temp_v) // 2] = torch.round(
+                temp * quant_scale_output_temp.reshape(temp_v // 2, 1)
+            ).to(torch.int8)
+            quant_scale_output[start_idx // 2 : (start_idx + temp_v) // 2] = 1 / quant_scale_output_temp
         start_idx += temp_v
     return quant_output, quant_scale_output
 
 
 def generate_non_decreasing_sequence(length, upper_limit):
     # Generate random increasing sequence
-    random_increments = torch.randint(0, 128, (length, ))
+    random_increments = torch.randint(0, 128, (length,))
     sequence = torch.cumsum(random_increments, dim=0)
 
     # Make sure the last value is less than the upper limit
@@ -138,11 +130,8 @@ def test_grouped_matmul_swiglu_quant_kernel():
     torch.npu.config.allow_internal_format = True
     x = torch.randint(-5, 5, (M, K), dtype=torch.int8).npu()
     weight_ori = torch.randint(-5, 5, (E, K, N), dtype=torch.int8)
-    weight_nz = torch_npu.npu_format_cast(weight_ori.npu().to(torch.float32),
-                                          29)
-    pack_weight = torch_npu.npu_quantize(weight_nz,
-                                         torch.tensor([1.], device='npu'),
-                                         None, torch.quint4x2, -1, False)
+    weight_nz = torch_npu.npu_format_cast(weight_ori.npu().to(torch.float32), 29)
+    pack_weight = torch_npu.npu_quantize(weight_nz, torch.tensor([1.0], device="npu"), None, torch.quint4x2, -1, False)
 
     weight_scale = torch.randn(E, 1, N)
     scale_np = weight_scale.cpu().numpy()
@@ -150,12 +139,11 @@ def test_grouped_matmul_swiglu_quant_kernel():
     scale_uint64_tensor = torch.from_numpy(scale_np.astype(np.int64)).npu()
     pertoken_scale = torch.randn(M).to(torch.float32).npu()
     group_list = generate_non_decreasing_sequence(E, M).npu()
-    bias = torch.zeros((E, N), dtype=torch.float32,
-                       device="npu").uniform_(-5, 5)
+    bias = torch.zeros((E, N), dtype=torch.float32, device="npu").uniform_(-5, 5)
 
     output_golden, output_scale_golden = gmm_swiglu_quant_golden_a8_w4(
-        x.cpu(), weight_ori, weight_scale, pertoken_scale.cpu(), bias.cpu(),
-        group_list.cpu())
+        x.cpu(), weight_ori, weight_scale, pertoken_scale.cpu(), bias.cpu(), group_list.cpu()
+    )
 
     output, output_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant(
         x=x,
@@ -163,12 +151,10 @@ def test_grouped_matmul_swiglu_quant_kernel():
         bias=bias,
         group_list=group_list,
         weight_scale=scale_uint64_tensor,
-        x_scale=pertoken_scale)
+        x_scale=pertoken_scale,
+    )
     torch.testing.assert_close(output_golden, output.cpu(), atol=1, rtol=0.005)
-    torch.testing.assert_close(output_scale_golden,
-                               output_scale.cpu(),
-                               atol=1,
-                               rtol=0.005)
+    torch.testing.assert_close(output_scale_golden, output_scale.cpu(), atol=1, rtol=0.005)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_hamming_dist_top_k.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_hamming_dist_top_k.py
@@ -1,14 +1,14 @@
-import torch
-import torch_npu
-import torchair
-import numpy as np
-import torch.nn as nn
-
+import logging
 import unittest
 from unittest import TestCase
 
-import logging
+import numpy as np
+import torch
+import torch.nn as nn
+import torch_npu
+import torchair
 from torchair import logger
+
 from vllm_ascend.utils import enable_custom_op
 
 logger.setLevel(logging.DEBUG)
@@ -17,33 +17,36 @@ torch._logging.set_logs(graph_code=True)
 enable_custom_op()
 torch_npu.npu.config.allow_internal_format = True
 
+
 def run_tests():
     unittest.main()
 
+
 def unpackbits(x, dim=-1):
-    shape = x.shape
     x_np = x.cpu().numpy()
     unpacked = np.unpackbits(x_np, axis=dim)
     return torch.from_numpy(unpacked).to(x.device).to(dtype=torch.float16)
 
-def stable_topk_1d(input, k, largest=True, stable_index_order='ascending'):
+
+def stable_topk_1d(input, k, largest=True, stable_index_order="ascending"):
     values_with_indices = [(val.item(), idx) for idx, val in enumerate(input)]
-    
+
     if largest:
-        if stable_index_order == 'ascending':
+        if stable_index_order == "ascending":
             values_with_indices.sort(key=lambda x: (-x[0], x[1]))
         else:
             values_with_indices.sort(key=lambda x: (-x[0], -x[1]))
     else:
-        if stable_index_order == 'ascending':
+        if stable_index_order == "ascending":
             values_with_indices.sort(key=lambda x: (x[0], x[1]))
         else:
             values_with_indices.sort(key=lambda x: (x[0], -x[1]))
-    
+
     values = torch.tensor([x[0] for x in values_with_indices[:k]])
     indices = torch.tensor([x[1] for x in values_with_indices[:k]])
-    
+
     return values, indices
+
 
 def torch_hamming_distance_all(hash_q_op, hash_k_op, block_table_op, seq_len_op, chunk_op, top_k_op, sink, recent):
     print("torch_hamming_distance_all")
@@ -57,30 +60,30 @@ def torch_hamming_distance_all(hash_q_op, hash_k_op, block_table_op, seq_len_op,
     ds_top_k_ = None
     ds_top_k_idx_ = None
     # batch loop
-    for per_batch in range(batch) :
+    for per_batch in range(batch):
         # num_kv_head loop
-        for single_num_kv_head in range(num_kv_head) :
+        for single_num_kv_head in range(num_kv_head):
             hash_q_op_per_batch = hash_q_op[
                 per_batch : per_batch + 1,
                 single_num_kv_head * num_head_group : (single_num_kv_head + 1) * num_head_group,
                 :,
-                :
+                :,
             ]
             ds_top_k, sk_idx = torch_hamming_distance_topk(
                 hash_q_op_per_batch,
-                hash_k_op[:, single_num_kv_head:(single_num_kv_head+1), :, :], 
-                block_table_op[per_batch:(per_batch+1), :], 
-                seq_len_op[per_batch], 
-                chunk_op[per_batch], 
+                hash_k_op[:, single_num_kv_head : (single_num_kv_head + 1), :, :],
+                block_table_op[per_batch : (per_batch + 1), :],
+                seq_len_op[per_batch],
+                chunk_op[per_batch],
                 top_k_op[per_batch],
                 sink,
-                recent
+                recent,
             )
             if ds_top_k_ is None:
                 ds_top_k_ = ds_top_k
             else:
                 ds_top_k_ = torch.cat([ds_top_k_, ds_top_k], dim=-1)
-            
+
             if ds_top_k_idx_ is None:
                 ds_top_k_idx_ = sk_idx
             else:
@@ -90,29 +93,28 @@ def torch_hamming_distance_all(hash_q_op, hash_k_op, block_table_op, seq_len_op,
     assert ds_top_k_idx_ is not None
 
     top_k = top_k_op.max()
-    ds_top_k_r = ds_top_k_.reshape(batch, num_kv_head, 1, top_k)
     ds_top_k_idx_r = ds_top_k_idx_.reshape(batch, num_kv_head, top_k)
 
     return ds_top_k_idx_r
 
-def torch_hamming_distance_topk(hash_q_op, hash_k_op, block_table_op, seq_len, chunk_size, top_k, sink, recent):
 
+def torch_hamming_distance_topk(hash_q_op, hash_k_op, block_table_op, seq_len, chunk_size, top_k, sink, recent):
     # According to the current implementation of the Hamming operator,
     # convert data into bits for matrix multiplication to calculate the Hamming distance.
 
     # hash q op
-    batch, num_head, max_q_seqlen, head_dim = hash_q_op.shape # torch.Size([1, 16, 1, 72])
+    batch, num_head, max_q_seqlen, head_dim = hash_q_op.shape  # torch.Size([1, 16, 1, 72])
     assert max_q_seqlen == 1
     # hash k op
-    num_blocks, num_kv_head, block_size, head_dim = hash_k_op.shape # torch.Size([245, 1, 128, 72])
+    num_blocks, num_kv_head, block_size, head_dim = hash_k_op.shape  # torch.Size([245, 1, 128, 72])
 
     # Convert the query tensor into a binary bit representation; the current data type of a single element is uint8.
-    hash_q_op_unpack = unpackbits(hash_q_op, dim=-1) # torch.Size([1, 16, 1, 576])
-    hash_q_op_unpack = hash_q_op_unpack.squeeze(0).squeeze(1) # torch.Size([16, 576])
+    hash_q_op_unpack = unpackbits(hash_q_op, dim=-1)  # torch.Size([1, 16, 1, 576])
+    hash_q_op_unpack = hash_q_op_unpack.squeeze(0).squeeze(1)  # torch.Size([16, 576])
 
     # Based on the current operator implementation, perform bit-wise conversion on the 8×16 query,
     # with bit replacement rule: 1 → 1, 0 → -1.
-    hash_q_op_unpack = hash_q_op_unpack.where(hash_q_op_unpack == 1, torch.tensor(-1, device='cpu'))
+    hash_q_op_unpack = hash_q_op_unpack.where(hash_q_op_unpack == 1, torch.tensor(-1, device="cpu"))
 
     # Accumulate values row-wise and output the last row.
     hash_q_op_unpack_cumsum = torch.cumsum(hash_q_op_unpack, dim=0)[-1]
@@ -121,39 +123,35 @@ def torch_hamming_distance_topk(hash_q_op, hash_k_op, block_table_op, seq_len, c
     if num_head > 8:
         div = (num_head + 7) // 8
         reciprocalDiv = 1.0 / div
-        reciprocalDiv = torch.tensor((reciprocalDiv,), dtype=torch.float16, device='cpu')
+        reciprocalDiv = torch.tensor((reciprocalDiv,), dtype=torch.float16, device="cpu")
         hash_q_op_unpack_cumsum = hash_q_op_unpack_cumsum * reciprocalDiv
-    
+
     # In the operator implementation, the computation casts half to int4b_t.
     # When the value reaches 8, it is cast to 7 instead.
     hash_q_op_unpack_cumsum = torch.where(
         hash_q_op_unpack_cumsum == 8,
-        torch.tensor(
-            7,
-            dtype=hash_q_op_unpack_cumsum.dtype,
-            device='cpu'
-        ),
-        hash_q_op_unpack_cumsum
-    ) # torch.Size([576])
+        torch.tensor(7, dtype=hash_q_op_unpack_cumsum.dtype, device="cpu"),
+        hash_q_op_unpack_cumsum,
+    )  # torch.Size([576])
 
     # Extract non-zero elements from block_table_op.
     block_table_op_origin = block_table_op
     block_table_op = block_table_op[block_table_op != 0]
 
     # Select the hash K data at the positions specified by block_table_op from hash_k_op.
-    key_selected = hash_k_op[block_table_op,:,:,:] # torch.Size([240, 1, 128, 72])
+    key_selected = hash_k_op[block_table_op, :, :, :]  # torch.Size([240, 1, 128, 72])
 
     # Convert key tensor to binary bits.
     key_selected_unpack = unpackbits(key_selected, dim=-1)
 
     # Convert key to bits: 1 → 1, 0 → -1.
-    key_selected_unpack = key_selected_unpack.where(key_selected_unpack == 1, torch.tensor(-1, device='cpu'))
+    key_selected_unpack = key_selected_unpack.where(key_selected_unpack == 1, torch.tensor(-1, device="cpu"))
 
     # The product of Q and K
-    q_k_mul = torch.matmul(key_selected_unpack, hash_q_op_unpack_cumsum) # torch.Size([240, 1, 128])
+    q_k_mul = torch.matmul(key_selected_unpack, hash_q_op_unpack_cumsum)  # torch.Size([240, 1, 128])
 
     # Flatten into one dimension.
-    flat_q_k_mul = q_k_mul.view(-1) # (1, 33 * 16)
+    flat_q_k_mul = q_k_mul.view(-1)  # (1, 33 * 16)
     # Segment by chunkSize, and compute one maximum value within each segment.
 
     last_len = seq_len % chunk_size
@@ -162,24 +160,23 @@ def torch_hamming_distance_topk(hash_q_op, hash_k_op, block_table_op, seq_len, c
         effect_len = (seq_len // chunk_size + 1) * chunk_size
 
     # number of chunks
-    chunk_blocks = effect_len // chunk_size
     reduce_max_chunk = flat_q_k_mul[:effect_len].view(1, -1, chunk_size).max(dim=-1).values
 
     reduce_max_chunk[:, :sink] = 8192
     # skip_tail_size
     chunk_block_size = reduce_max_chunk.shape[1]
 
-    reduce_max_chunk[:, chunk_block_size - recent: chunk_block_size] = 8192
+    reduce_max_chunk[:, chunk_block_size - recent : chunk_block_size] = 8192
     topk_values, topk_indices = stable_topk_1d(reduce_max_chunk.view(-1), k=top_k, largest=True)
     topk_indices_new_sort, idx = torch.sort(topk_indices)
     block_table_indices = block_table_op_origin.view(-1)[topk_indices_new_sort]
-    
+
     return topk_values, block_table_indices
 
+
 class TestCustomHammingDistTopK(TestCase):
-    
     def setUp(self):
-        self.device = 'cpu'
+        self.device = "cpu"
         self.batch_size = 5
         self.num_head = 16
         self.num_kv_head = 1
@@ -191,35 +188,40 @@ class TestCustomHammingDistTopK(TestCase):
         self.chunk_size_value = 128
         self.device_id = 0
         self.DEVICE_ID = 0
-        
+
         self.seqlen_list = [30720] * self.batch_size
         self.seqlen = torch.tensor(self.seqlen_list, dtype=torch.int32, device=self.device)
         self.max_seq_len = max(self.seqlen_list)
-        self.chunk_size = torch.tensor([self.chunk_size_value] * self.batch_size, 
-                                      dtype=torch.int32, device=self.device)
-        self.top_k_list = [int(seq * self.sparse_ratio // self.chunk_size_value) 
-                         for seq in self.seqlen_list]
+        self.chunk_size = torch.tensor([self.chunk_size_value] * self.batch_size, dtype=torch.int32, device=self.device)
+        self.top_k_list = [int(seq * self.sparse_ratio // self.chunk_size_value) for seq in self.seqlen_list]
         self.top_k = torch.tensor(self.top_k_list, dtype=torch.int32, device=self.device)
         print("self.top_k_list", self.top_k_list, self.top_k)
         self.block_size = 128
         self.num_blocks_per_seq = (self.seqlen + self.block_size - 1) // self.block_size
         self.num_blocks = self.num_blocks_per_seq.sum().item() + 5
-        
+
         torch.manual_seed(42)
         np.random.seed(42)
-        
-        self.qhash = torch.randint(255, 
-                                  (self.batch_size, self.num_head, self.seqlen_q, self.compressed_dim), 
-                                  dtype=torch.uint8, device=self.device)
-        self.khash = torch.randint(255, 
-                                  (self.num_blocks, self.num_kv_head, self.block_size, self.compressed_dim),
-                                  dtype=torch.uint8, device=self.device)
+
+        self.qhash = torch.randint(
+            255,
+            (self.batch_size, self.num_head, self.seqlen_q, self.compressed_dim),
+            dtype=torch.uint8,
+            device=self.device,
+        )
+        self.khash = torch.randint(
+            255,
+            (self.num_blocks, self.num_kv_head, self.block_size, self.compressed_dim),
+            dtype=torch.uint8,
+            device=self.device,
+        )
         self.sink = 1
         self.recent = 4
 
         max_num_blocks_per_seq = (max(self.seqlen_list) + self.block_size - 1) // self.block_size + 5
-        self.block_table = torch.full((len(self.num_blocks_per_seq), max_num_blocks_per_seq), 
-                                     fill_value=0, dtype=torch.int32)
+        self.block_table = torch.full(
+            (len(self.num_blocks_per_seq), max_num_blocks_per_seq), fill_value=0, dtype=torch.int32
+        )
         start = 1
         for i, n in enumerate(self.num_blocks_per_seq):
             self.block_table[i, :n] = torch.arange(start, start + n, dtype=torch.int32)
@@ -229,78 +231,132 @@ class TestCustomHammingDistTopK(TestCase):
 
         self.support_offload = 1
         self.mask = torch.tensor([True, True, False, False, False])
-        
+
         torch.npu.set_device(self.device_id)
-        self.npu = f'npu:{self.device_id}'
+        self.npu = f"npu:{self.device_id}"
 
     def _run_eager_mode_without_support_offload_and_mask(self):
         output_eager = torch.ops._C_ascend.npu_hamming_dist_top_k(
-            self.qhash.to(self.npu), self.khash.to(self.npu), None, self.top_k.to(self.npu), 
-            self.seqlen.to(self.npu), self.chunk_size.to(self.npu), self.max_seq_len, 
-            self.sink, self.recent, None, self.block_table.to(self.npu), 
-            None, self.indices.to(self.npu)
+            self.qhash.to(self.npu),
+            self.khash.to(self.npu),
+            None,
+            self.top_k.to(self.npu),
+            self.seqlen.to(self.npu),
+            self.chunk_size.to(self.npu),
+            self.max_seq_len,
+            self.sink,
+            self.recent,
+            None,
+            self.block_table.to(self.npu),
+            None,
+            self.indices.to(self.npu),
         )
         return output_eager
 
     def _run_eager_mode_with_support_offload_and_mask(self):
         output_eager = torch.ops._C_ascend.npu_hamming_dist_top_k(
-            self.qhash.to(self.npu), self.khash.to(self.npu), None, self.top_k.to(self.npu), 
-            self.seqlen.to(self.npu), self.chunk_size.to(self.npu), self.max_seq_len, 
-            self.sink, self.recent, self.support_offload, self.block_table.to(self.npu), 
-            self.mask.to(self.npu), self.indices.to(self.npu)
+            self.qhash.to(self.npu),
+            self.khash.to(self.npu),
+            None,
+            self.top_k.to(self.npu),
+            self.seqlen.to(self.npu),
+            self.chunk_size.to(self.npu),
+            self.max_seq_len,
+            self.sink,
+            self.recent,
+            self.support_offload,
+            self.block_table.to(self.npu),
+            self.mask.to(self.npu),
+            self.indices.to(self.npu),
         )
         return output_eager
 
     def _run_graph_mode(self):
         class Network(nn.Module):
             def __init__(self):
-                super(Network, self).__init__()
+                super().__init__()
 
-            def forward(self, qhash, khash, khash_rope, top_k, seqlen, chunk_size, max_seq_len, 
-                       sink, recent, support_offload, block_table, mask, indices):
+            def forward(
+                self,
+                qhash,
+                khash,
+                khash_rope,
+                top_k,
+                seqlen,
+                chunk_size,
+                max_seq_len,
+                sink,
+                recent,
+                support_offload,
+                block_table,
+                mask,
+                indices,
+            ):
                 return torch.ops._C_ascend.npu_hamming_dist_top_k(
-                    qhash, khash, None, top_k, seqlen, chunk_size, max_seq_len, 
-                    sink, recent, support_offload, block_table, mask, indices
+                    qhash,
+                    khash,
+                    None,
+                    top_k,
+                    seqlen,
+                    chunk_size,
+                    max_seq_len,
+                    sink,
+                    recent,
+                    support_offload,
+                    block_table,
+                    mask,
+                    indices,
                 )
 
         npu_mode = Network().to(f"npu:{self.DEVICE_ID}")
         from torchair.configs.compiler_config import CompilerConfig
+
         config = CompilerConfig()
         config.mode = "reduce-overhead"
         npu_backend = torchair.get_npu_backend(compiler_config=config)
-        
+
         npu_mode = torch.compile(npu_mode, backend=npu_backend, dynamic=False)
         npu_out = npu_mode(
-            self.qhash.to(self.npu), self.khash.to(self.npu), None, self.top_k.to(self.npu), 
-            self.seqlen.to(self.npu), self.chunk_size.to(self.npu), self.max_seq_len, 
-            self.sink, self.recent, self.support_offload, self.block_table.to(self.npu), 
-            self.mask.to(self.npu), self.indices.to(self.npu)
+            self.qhash.to(self.npu),
+            self.khash.to(self.npu),
+            None,
+            self.top_k.to(self.npu),
+            self.seqlen.to(self.npu),
+            self.chunk_size.to(self.npu),
+            self.max_seq_len,
+            self.sink,
+            self.recent,
+            self.support_offload,
+            self.block_table.to(self.npu),
+            self.mask.to(self.npu),
+            self.indices.to(self.npu),
         )
         return npu_out
 
     def test_hamming_dist_top_k_compare(self):
         output_eager = self._run_eager_mode_with_support_offload_and_mask()
         output_graph = self._run_graph_mode()
-        
+
         print(f"===========output_eager {output_eager} ===================")
         print(f"===========output_graph {output_graph} ===================")
         self.assertEqual(output_eager.shape, output_graph.shape)
         self.assertTrue(torch.allclose(output_eager.float(), output_graph.float(), atol=1e-05))
 
     def test_hamming_dist_top_k(self, loop: int = 1, enable_assert: bool = True):
-        output_gd = torch_hamming_distance_all(self.qhash, self.khash,
-            self.block_table, self.seqlen, self.chunk_size, self.top_k, self.sink, self.recent)
+        output_gd = torch_hamming_distance_all(
+            self.qhash, self.khash, self.block_table, self.seqlen, self.chunk_size, self.top_k, self.sink, self.recent
+        )
         w = output_gd.shape[-1]
         print(f"output_gd shape: {output_gd.shape}")
-        print(f"output_gd: {output_gd[:,:,:w]}")
+        print(f"output_gd: {output_gd[:, :, :w]}")
 
         output_op = self._run_eager_mode_without_support_offload_and_mask()
         print(f"output_op shape: {output_op.shape}")
-        print(f"output_op: {output_op[:,:,:w]}")
-        assert torch.equal(
-            output_op[:, :, :w].to('cpu'),
-            output_gd[:, :, :w]
-        ), "Output from custom op does not match ground truth!"
+        print(f"output_op: {output_op[:, :, :w]}")
+        assert torch.equal(output_op[:, :, :w].to("cpu"), output_gd[:, :, :w]), (
+            "Output from custom op does not match ground truth!"
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py
@@ -8,9 +8,8 @@ from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
 
-@pytest.mark.skip(
-    reason="Failure of an individual operator use case causes failures of other operators."
-)
+
+@pytest.mark.skip(reason="Failure of an individual operator use case causes failures of other operators.")
 @pytest.mark.parametrize("cache_mode", ["krope_ctkv", "nzcache"])
 @torch.inference_mode()
 def test_mla_preprocess_kernel(cache_mode: str):
@@ -22,25 +21,24 @@ def test_mla_preprocess_kernel(cache_mode: str):
     dtype = torch.bfloat16
 
     hidden_states = torch.randn((token_num, N_7168), dtype=dtype).npu()
-    quant_scale0 = torch.randn((1, ), dtype=dtype).npu()
-    quant_offset0 = torch.randint(0, 7, (1, ), dtype=torch.int8).npu()
+    quant_scale0 = torch.randn((1,), dtype=dtype).npu()
+    quant_offset0 = torch.randint(0, 7, (1,), dtype=torch.int8).npu()
 
     wdqkv = torch.randint(0, 7, (1, 224, 2112, 32), dtype=torch.int8).npu()
     wdqkv = torch_npu.npu_format_cast(wdqkv.contiguous(), 29)
 
-    de_scale0 = torch.rand((2112, ), dtype=torch.float).npu()
-    bias0 = torch.randint(0, 7, (2112, ), dtype=torch.int32).npu()
+    de_scale0 = torch.rand((2112,), dtype=torch.float).npu()
+    bias0 = torch.randint(0, 7, (2112,), dtype=torch.int32).npu()
     gamma1 = torch.randn((1536), dtype=dtype).npu()
     beta1 = torch.randn((1536), dtype=dtype).npu()
-    quant_scale1 = torch.randn((1, ), dtype=dtype).npu()
-    quant_offset1 = torch.randint(0, 7, (1, ), dtype=torch.int8).npu()
+    quant_scale1 = torch.randn((1,), dtype=dtype).npu()
+    quant_offset1 = torch.randint(0, 7, (1,), dtype=torch.int8).npu()
 
-    wuq = torch.randint(0, 7, (1, 48, head_num * 192, 32),
-                        dtype=torch.int8).npu()
+    wuq = torch.randint(0, 7, (1, 48, head_num * 192, 32), dtype=torch.int8).npu()
     wuq = torch_npu.npu_format_cast(wuq.contiguous(), 29)
 
-    de_scale1 = torch.rand((head_num * 192, ), dtype=torch.float).npu()
-    bias1 = torch.randint(0, 7, (head_num * 192, ), dtype=torch.int32).npu()
+    de_scale1 = torch.rand((head_num * 192,), dtype=torch.float).npu()
+    bias1 = torch.randint(0, 7, (head_num * 192,), dtype=torch.int32).npu()
 
     gamma2 = torch.randn((512), dtype=dtype).npu()
 
@@ -49,16 +47,12 @@ def test_mla_preprocess_kernel(cache_mode: str):
 
     wuk = torch.randn((head_num, 128, 512), dtype=dtype).npu()
     wuk = torch_npu.npu_format_cast(wuk, 29)
-    kv_cache = torch.randint(0,
-                             7,
-                             (block_num, head_num * 512 // 32, block_size, 32),
-                             dtype=dtype).npu()
-    kv_cache_rope = torch.randn(
-        (block_num, head_num * 64 // 16, block_size, 16), dtype=dtype).npu()
+    kv_cache = torch.randint(0, 7, (block_num, head_num * 512 // 32, block_size, 32), dtype=dtype).npu()
+    kv_cache_rope = torch.randn((block_num, head_num * 64 // 16, block_size, 16), dtype=dtype).npu()
 
-    slotmapping = torch.randint(0, 7, (token_num, ), dtype=torch.int32).npu()
+    slotmapping = torch.randint(0, 7, (token_num,), dtype=torch.int32).npu()
 
-    ctkv_scale = torch.randn((1, ), dtype=dtype).npu()
+    ctkv_scale = torch.randn((1,), dtype=dtype).npu()
     qnope_scale = torch.randn((head_num), dtype=dtype).npu()
 
     q_nope_out = torch.empty(

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_nq.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_nq.py
@@ -8,9 +8,8 @@ from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
 
-@pytest.mark.skip(
-    reason="Failure of an individual operator use case causes failures of other operators."
-)
+
+@pytest.mark.skip(reason="Failure of an individual operator use case causes failures of other operators.")
 @torch.inference_mode()
 def test_mla_preprocess_kernel():
     token_num = 1
@@ -35,14 +34,10 @@ def test_mla_preprocess_kernel():
 
     wuk = torch.randn((head_num, 128, 512), dtype=dtype).npu()
     # wuk = torch_npu.npu_format_cast(wuk, 29)
-    kv_cache = torch.randint(0,
-                             7,
-                             (block_num, head_num * 512 // 32, block_size, 32),
-                             dtype=dtype).npu()
-    kv_cache_rope = torch.randn(
-        (block_num, head_num * 64 // 16, block_size, 16), dtype=dtype).npu()
+    kv_cache = torch.randint(0, 7, (block_num, head_num * 512 // 32, block_size, 32), dtype=dtype).npu()
+    kv_cache_rope = torch.randn((block_num, head_num * 64 // 16, block_size, 16), dtype=dtype).npu()
 
-    slotmapping = torch.randint(0, 7, (token_num, ), dtype=torch.int32).npu()
+    slotmapping = torch.randint(0, 7, (token_num,), dtype=torch.int32).npu()
 
     q_nope_out = torch.empty(
         (hidden_states.shape[0], wuk.shape[0], kv_cache.shape[-1]),

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_qdown.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_qdown.py
@@ -8,9 +8,8 @@ from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
 
-@pytest.mark.skip(
-    reason="Failure of an individual operator use case causes failures of other operators."
-)
+
+@pytest.mark.skip(reason="Failure of an individual operator use case causes failures of other operators.")
 @pytest.mark.parametrize("cache_mode", ["krope_ctkv", "nzcache"])
 @torch.inference_mode()
 def test_mla_preprocess_kernel(cache_mode: str):
@@ -22,25 +21,24 @@ def test_mla_preprocess_kernel(cache_mode: str):
     dtype = torch.bfloat16
 
     hidden_states = torch.randn((token_num, N_7168), dtype=dtype).npu()
-    quant_scale0 = torch.randn((1, ), dtype=dtype).npu()
-    quant_offset0 = torch.randint(0, 7, (1, ), dtype=torch.int8).npu()
+    quant_scale0 = torch.randn((1,), dtype=dtype).npu()
+    quant_offset0 = torch.randint(0, 7, (1,), dtype=torch.int8).npu()
 
     wdqkv = torch.randint(0, 7, (1, 224, 2112, 32), dtype=torch.int8).npu()
     wdqkv = torch_npu.npu_format_cast(wdqkv.contiguous(), 29)
 
-    de_scale0 = torch.rand((2112, ), dtype=torch.float).npu()
-    bias0 = torch.randint(0, 7, (2112, ), dtype=torch.int32).npu()
+    de_scale0 = torch.rand((2112,), dtype=torch.float).npu()
+    bias0 = torch.randint(0, 7, (2112,), dtype=torch.int32).npu()
     gamma1 = torch.randn((1536), dtype=dtype).npu()
     beta1 = torch.randn((1536), dtype=dtype).npu()
-    quant_scale1 = torch.randn((1, ), dtype=dtype).npu()
-    quant_offset1 = torch.randint(0, 7, (1, ), dtype=torch.int8).npu()
+    quant_scale1 = torch.randn((1,), dtype=dtype).npu()
+    quant_offset1 = torch.randint(0, 7, (1,), dtype=torch.int8).npu()
 
-    wuq = torch.randint(0, 7, (1, 48, head_num * 192, 32),
-                        dtype=torch.int8).npu()
+    wuq = torch.randint(0, 7, (1, 48, head_num * 192, 32), dtype=torch.int8).npu()
     wuq = torch_npu.npu_format_cast(wuq.contiguous(), 29)
 
-    de_scale1 = torch.rand((head_num * 192, ), dtype=torch.float).npu()
-    bias1 = torch.randint(0, 7, (head_num * 192, ), dtype=torch.int32).npu()
+    de_scale1 = torch.rand((head_num * 192,), dtype=torch.float).npu()
+    bias1 = torch.randint(0, 7, (head_num * 192,), dtype=torch.int32).npu()
 
     gamma2 = torch.randn((512), dtype=dtype).npu()
 
@@ -49,16 +47,12 @@ def test_mla_preprocess_kernel(cache_mode: str):
 
     wuk = torch.randn((head_num, 128, 512), dtype=dtype).npu()
     wuk = torch_npu.npu_format_cast(wuk, 29)
-    kv_cache = torch.randint(0,
-                             7,
-                             (block_num, head_num * 512 // 32, block_size, 32),
-                             dtype=dtype).npu()
-    kv_cache_rope = torch.randn(
-        (block_num, head_num * 64 // 16, block_size, 16), dtype=dtype).npu()
+    kv_cache = torch.randint(0, 7, (block_num, head_num * 512 // 32, block_size, 32), dtype=dtype).npu()
+    kv_cache_rope = torch.randn((block_num, head_num * 64 // 16, block_size, 16), dtype=dtype).npu()
 
-    slotmapping = torch.randint(0, 7, (token_num, ), dtype=torch.int32).npu()
+    slotmapping = torch.randint(0, 7, (token_num,), dtype=torch.int32).npu()
 
-    ctkv_scale = torch.randn((1, ), dtype=dtype).npu()
+    ctkv_scale = torch.randn((1,), dtype=dtype).npu()
     qnope_scale = torch.randn((head_num), dtype=dtype).npu()
 
     q_nope_out = torch.empty(
@@ -81,36 +75,38 @@ def test_mla_preprocess_kernel(cache_mode: str):
     q_rope_old = q_rope_out.clone()
     q_down_old = q_down.clone()
 
-    torch.ops._C_ascend.mla_preprocess(hidden_states,
-                                       wdqkv,
-                                       de_scale0,
-                                       gamma1,
-                                       beta1,
-                                       wuq,
-                                       de_scale1,
-                                       gamma2,
-                                       cos,
-                                       sin,
-                                       wuk,
-                                       kv_cache,
-                                       kv_cache_rope,
-                                       slotmapping,
-                                       quant_scale0=quant_scale0,
-                                       quant_offset0=quant_offset0,
-                                       bias0=bias0,
-                                       quant_scale1=quant_scale1,
-                                       quant_offset1=quant_offset1,
-                                       bias1=bias1,
-                                       ctkv_scale=ctkv_scale,
-                                       q_nope_scale=qnope_scale,
-                                       cache_mode=cache_mode,
-                                       quant_mode="per_tensor_quant_asymm",
-                                       enable_inner_out=True,
-                                       q_out0=q_nope_out,
-                                       kv_cache_out0=kv_cache,
-                                       q_out1=q_rope_out,
-                                       kv_cache_out1=kv_cache_rope,
-                                       inner_out=q_down)
+    torch.ops._C_ascend.mla_preprocess(
+        hidden_states,
+        wdqkv,
+        de_scale0,
+        gamma1,
+        beta1,
+        wuq,
+        de_scale1,
+        gamma2,
+        cos,
+        sin,
+        wuk,
+        kv_cache,
+        kv_cache_rope,
+        slotmapping,
+        quant_scale0=quant_scale0,
+        quant_offset0=quant_offset0,
+        bias0=bias0,
+        quant_scale1=quant_scale1,
+        quant_offset1=quant_offset1,
+        bias1=bias1,
+        ctkv_scale=ctkv_scale,
+        q_nope_scale=qnope_scale,
+        cache_mode=cache_mode,
+        quant_mode="per_tensor_quant_asymm",
+        enable_inner_out=True,
+        q_out0=q_nope_out,
+        kv_cache_out0=kv_cache,
+        q_out1=q_rope_out,
+        kv_cache_out1=kv_cache_rope,
+        inner_out=q_down,
+    )
     assert not torch.equal(q_nope_out, q_nope_old)
     assert not torch.equal(q_rope_out, q_rope_old)
     assert not torch.equal(q_down, q_down_old)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_moe_init_routing_custom.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_moe_init_routing_custom.py
@@ -24,10 +24,21 @@ def adapter_capacity(sorted_row_idx, sorted_expert_idx, capacity):
                 sorted_row_idx[i] = -1
 
 
-def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
-                            expert_capacity, expert_num, drop_pad_mode,
-                            expert_tokens_num_type, expert_tokens_num_flag,
-                            active_expert_range, quant_mode, row_idx_type):
+def moe_init_routing_golden(
+    x,
+    expert_idx,
+    scale,
+    offset,
+    active_num,
+    expert_capacity,
+    expert_num,
+    drop_pad_mode,
+    expert_tokens_num_type,
+    expert_tokens_num_flag,
+    active_expert_range,
+    quant_mode,
+    row_idx_type,
+):
     if drop_pad_mode == 1:
         if expert_num <= 0:
             print("expert num can not be 0")
@@ -38,11 +49,9 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
     h = x.shape[1]
     k = expert_idx.shape[-1]
     expert_idx_in = expert_idx.copy().reshape(-1)
-    actual_expert_total_num: int = np.sum((expert_idx_in >= expert_start)
-                                          & (expert_idx_in < expert_end))
+    actual_expert_total_num: int = np.sum((expert_idx_in >= expert_start) & (expert_idx_in < expert_end))
 
-    expert_idx_in[(expert_idx_in
-                   < expert_start)] = np.int32(np.iinfo(np.int32).max)
+    expert_idx_in[(expert_idx_in < expert_start)] = np.int32(np.iinfo(np.int32).max)
     sorted_expert_indices = np.argsort(expert_idx_in, axis=-1, kind="stable")
     sorted_expert_idx = expert_idx_in[sorted_expert_indices]
     if row_idx_type == 1:
@@ -50,48 +59,46 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
     else:
         expanded_row_idx = np.ones(num_rows * k).astype(np.int32) * -1
         tmp_indices = np.arange(actual_expert_total_num)
-        expanded_row_idx[
-            sorted_expert_indices[:actual_expert_total_num]] = tmp_indices
+        expanded_row_idx[sorted_expert_indices[:actual_expert_total_num]] = tmp_indices
 
     if not expert_tokens_num_flag:
         expert_tokens_count = torch.tensor([0])
     else:
         if drop_pad_mode == 0:
             if expert_tokens_num_type == 1:
-                expert_tokens_count = np.bincount(
-                    sorted_expert_idx[:actual_expert_total_num] - expert_start)
-                expert_tokens_count = np.concatenate([
-                    expert_tokens_count,
-                    np.zeros((expert_end - expert_start) -
-                             len(expert_tokens_count)).astype(np.int64)
-                ])
+                expert_tokens_count = np.bincount(sorted_expert_idx[:actual_expert_total_num] - expert_start)
+                expert_tokens_count = np.concatenate(
+                    [
+                        expert_tokens_count,
+                        np.zeros((expert_end - expert_start) - len(expert_tokens_count)).astype(np.int64),
+                    ]
+                )
             elif expert_tokens_num_type == 0:
-                expert_tokens_count = np.bincount(
-                    sorted_expert_idx[:actual_expert_total_num] - expert_start)
-                expert_tokens_count = np.concatenate([
-                    expert_tokens_count,
-                    np.zeros((expert_end - expert_start) -
-                             len(expert_tokens_count)).astype(np.int64)
-                ])
+                expert_tokens_count = np.bincount(sorted_expert_idx[:actual_expert_total_num] - expert_start)
+                expert_tokens_count = np.concatenate(
+                    [
+                        expert_tokens_count,
+                        np.zeros((expert_end - expert_start) - len(expert_tokens_count)).astype(np.int64),
+                    ]
+                )
                 expert_tokens_count = np.cumsum(expert_tokens_count)
             elif expert_tokens_num_type == 2:
-                expert_id, counts = np.unique(
-                    sorted_expert_idx[:actual_expert_total_num],
-                    return_counts=True)
+                expert_id, counts = np.unique(sorted_expert_idx[:actual_expert_total_num], return_counts=True)
                 expert_tokens_count = np.column_stack((expert_id, counts))
                 if expert_tokens_count.shape[0] < expert_num:
                     expert_tokens_count = np.concatenate(
-                        (expert_tokens_count, [
-                            [0, 0],
-                        ]), axis=0)
+                        (
+                            expert_tokens_count,
+                            [
+                                [0, 0],
+                            ],
+                        ),
+                        axis=0,
+                    )
         else:
-            expert_tokens_count = np.bincount(
-                sorted_expert_idx[:actual_expert_total_num] - expert_start)
-            zeros_array = np.zeros(
-                (expert_end - expert_start) - len(expert_tokens_count),
-                dtype=np.int64)
-            expert_tokens_count = np.concatenate(
-                [expert_tokens_count, zeros_array])
+            expert_tokens_count = np.bincount(sorted_expert_idx[:actual_expert_total_num] - expert_start)
+            zeros_array = np.zeros((expert_end - expert_start) - len(expert_tokens_count), dtype=np.int64)
+            expert_tokens_count = np.concatenate([expert_tokens_count, zeros_array])
         expert_tokens_count = expert_tokens_count.astype(np.int64)
 
     if drop_pad_mode == 0:
@@ -104,8 +111,7 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
         if scale is not None and quant_mode == -1:
             expanded_scale = scale[sorted_expert_indices[:active_num] // k]
     else:
-        adapter_capacity(sorted_expert_indices, sorted_expert_idx,
-                         expert_capacity)
+        adapter_capacity(sorted_expert_indices, sorted_expert_idx, expert_capacity)
 
         sort_row_tmp = np.full((expert_num * expert_capacity), -1, dtype=int)
         offset_tmp = 0
@@ -115,8 +121,7 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
                 if lastExpertId != sorted_expert_idx[i]:
                     offset_tmp = 0
                     lastExpertId = sorted_expert_idx[i]
-                sort_row_tmp[sorted_expert_idx[i] * expert_capacity +
-                             offset_tmp] = sorted_expert_indices[i]
+                sort_row_tmp[sorted_expert_idx[i] * expert_capacity + offset_tmp] = sorted_expert_indices[i]
                 offset_tmp = offset_tmp + 1
 
         expanded_row_idx = np.full(sorted_expert_indices.shape, -1)
@@ -124,24 +129,18 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
             if val != -1:
                 expanded_row_idx[val] = i
 
-        expanded_x_mask = np.full((expert_num * expert_capacity, h),
-                                  1,
-                                  dtype=int)
-        expanded_x = np.full((expert_num * expert_capacity, h),
-                             0,
-                             dtype=x.dtype)
+        expanded_x_mask = np.full((expert_num * expert_capacity, h), 1, dtype=int)
+        expanded_x = np.full((expert_num * expert_capacity, h), 0, dtype=x.dtype)
         for i, val in enumerate(sort_row_tmp):
             if val != -1:
                 expanded_x[i] = x[val // k]
-                expanded_x_mask[i] = np.full((h, ), 0, dtype=int)
+                expanded_x_mask[i] = np.full((h,), 0, dtype=int)
 
     if quant_mode == -1:
         expanded_x = expanded_x
         expanded_row_idx = expanded_row_idx
         if scale is not None and drop_pad_mode == 1:
-            expanded_scale = np.full((expert_num * expert_capacity, ),
-                                     0,
-                                     dtype=scale.dtype)
+            expanded_scale = np.full((expert_num * expert_capacity,), 0, dtype=scale.dtype)
             for i, val in enumerate(sort_row_tmp):
                 if val != -1:
                     expanded_scale[i] = scale[val // k]
@@ -178,14 +177,12 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
                 x_final = x_final * scale
             else:
                 if drop_pad_mode == 0:
-                    x_final = x_final * scale[sorted_expert_idx[:active_num] -
-                                              expert_start]
+                    x_final = x_final * scale[sorted_expert_idx[:active_num] - expert_start]
 
                 else:
                     for i, val in enumerate(sort_row_tmp):
                         if val != -1:
-                            x_final[i] = x_final[i] * scale[i //
-                                                            expert_capacity]
+                            x_final[i] = x_final[i] * scale[i // expert_capacity]
             x_abs = np.abs(x_final)
             x_max = np.max(x_abs, axis=-1, keepdims=True)
             expanded_scale = x_max / 127
@@ -200,43 +197,65 @@ def moe_init_routing_golden(x, expert_idx, scale, offset, active_num,
     return expanded_x, expanded_row_idx, expert_tokens_count, expanded_scale
 
 
-def npu_pta(x, expert_idx, scale, offset, active_num, expert_capacity,
-            expert_num, drop_pad_mode, expert_tokens_num_type,
-            expert_tokens_num_flag, quant_mode, active_expert_range,
-            row_idx_type):
-    expanded_x, expanded_row_idx, expert_token_cumsum_or_count, expanded_scale = torch.ops._C_ascend.npu_moe_init_routing_custom(
-        x,
-        expert_idx,
-        scale=scale,
-        offset=offset,
-        active_num=active_num,
-        expert_capacity=expert_capacity,
-        expert_num=expert_num,
-        drop_pad_mode=drop_pad_mode,
-        expert_tokens_num_type=expert_tokens_num_type,
-        expert_tokens_num_flag=expert_tokens_num_flag,
-        quant_mode=quant_mode,
-        active_expert_range=active_expert_range,
-        row_idx_type=row_idx_type)
+def npu_pta(
+    x,
+    expert_idx,
+    scale,
+    offset,
+    active_num,
+    expert_capacity,
+    expert_num,
+    drop_pad_mode,
+    expert_tokens_num_type,
+    expert_tokens_num_flag,
+    quant_mode,
+    active_expert_range,
+    row_idx_type,
+):
+    expanded_x, expanded_row_idx, expert_token_cumsum_or_count, expanded_scale = (
+        torch.ops._C_ascend.npu_moe_init_routing_custom(
+            x,
+            expert_idx,
+            scale=scale,
+            offset=offset,
+            active_num=active_num,
+            expert_capacity=expert_capacity,
+            expert_num=expert_num,
+            drop_pad_mode=drop_pad_mode,
+            expert_tokens_num_type=expert_tokens_num_type,
+            expert_tokens_num_flag=expert_tokens_num_flag,
+            quant_mode=quant_mode,
+            active_expert_range=active_expert_range,
+            row_idx_type=row_idx_type,
+        )
+    )
 
     return expanded_x, expanded_row_idx, expert_token_cumsum_or_count, expanded_scale
 
 
 def cmp_out_golden(x_golden, x_out, dtype):
-    if dtype == 'int8':
-        cmp = np.isclose(x_out.cpu().numpy()[:len(x_golden)], x_golden, atol=1)
+    if dtype == "int8":
+        cmp = np.isclose(x_out.cpu().numpy()[: len(x_golden)], x_golden, atol=1)
     else:
-        cmp = np.isclose(x_out.cpu().numpy()[:len(x_golden)],
-                         x_golden,
-                         rtol=1e-05,
-                         atol=1e-05)
+        cmp = np.isclose(x_out.cpu().numpy()[: len(x_golden)], x_golden, rtol=1e-05, atol=1e-05)
     return np.all(cmp)
 
 
-def run_moe_npu_case(x, expert_idx, scale, offset, active_num, expert_capacity,
-                     expert_num, drop_pad_mode, expert_tokens_num_type,
-                     expert_tokens_num_flag, quant_mode, active_expert_range,
-                     row_idx_type):
+def run_moe_npu_case(
+    x,
+    expert_idx,
+    scale,
+    offset,
+    active_num,
+    expert_capacity,
+    expert_num,
+    drop_pad_mode,
+    expert_tokens_num_type,
+    expert_tokens_num_flag,
+    quant_mode,
+    active_expert_range,
+    row_idx_type,
+):
     x_npu = x.npu()
     expert_idx_npu = expert_idx.npu()
     scale_npu = scale.npu() if scale is not None else None
@@ -247,35 +266,55 @@ def run_moe_npu_case(x, expert_idx, scale, offset, active_num, expert_capacity,
     scale_numpy = scale.numpy() if scale is not None else None
     offset_numpy = offset.numpy() if offset is not None else None
 
-    expanded_x_golden, expanded_row_idx_golden, expert_token_cumsum_or_count_golden, expanded_scale_golden = moe_init_routing_golden(
-        x_numpy, expert_idx_numpy, scale_numpy, offset_numpy, active_num,
-        expert_capacity, expert_num, drop_pad_mode, expert_tokens_num_type,
-        expert_tokens_num_flag, active_expert_range, quant_mode, row_idx_type)
+    expanded_x_golden, expanded_row_idx_golden, expert_token_cumsum_or_count_golden, expanded_scale_golden = (
+        moe_init_routing_golden(
+            x_numpy,
+            expert_idx_numpy,
+            scale_numpy,
+            offset_numpy,
+            active_num,
+            expert_capacity,
+            expert_num,
+            drop_pad_mode,
+            expert_tokens_num_type,
+            expert_tokens_num_flag,
+            active_expert_range,
+            quant_mode,
+            row_idx_type,
+        )
+    )
 
     expanded_x, expanded_row_idx, expert_token_cumsum_or_count, expanded_scale = npu_pta(
-        x_npu, expert_idx_npu, scale_npu, offset_npu, active_num,
-        expert_capacity, expert_num, drop_pad_mode, expert_tokens_num_type,
-        expert_tokens_num_flag, quant_mode, active_expert_range, row_idx_type)
+        x_npu,
+        expert_idx_npu,
+        scale_npu,
+        offset_npu,
+        active_num,
+        expert_capacity,
+        expert_num,
+        drop_pad_mode,
+        expert_tokens_num_type,
+        expert_tokens_num_flag,
+        quant_mode,
+        active_expert_range,
+        row_idx_type,
+    )
     if quant_mode == -1:
-        expanded_x_result = cmp_out_golden(expanded_x_golden, expanded_x,
-                                           "float32")
+        expanded_x_result = cmp_out_golden(expanded_x_golden, expanded_x, "float32")
     else:
-        expanded_x_result = cmp_out_golden(expanded_x_golden, expanded_x,
-                                           "int8")
+        expanded_x_result = cmp_out_golden(expanded_x_golden, expanded_x, "int8")
 
-    expanded_row_idx_result = cmp_out_golden(expanded_row_idx_golden,
-                                             expanded_row_idx, "int32")
+    expanded_row_idx_result = cmp_out_golden(expanded_row_idx_golden, expanded_row_idx, "int32")
 
     if expert_tokens_num_flag:
         expert_tokens_result = cmp_out_golden(
-            expert_token_cumsum_or_count_golden, expert_token_cumsum_or_count,
-            "int64")
+            expert_token_cumsum_or_count_golden, expert_token_cumsum_or_count, "int64"
+        )
     else:
         expert_tokens_result = True
 
     if quant_mode == 1 or (quant_mode == -1 and scale is not None):
-        expand_scale_result = cmp_out_golden(expanded_scale_golden.flatten(),
-                                             expanded_scale, "float32")
+        expand_scale_result = cmp_out_golden(expanded_scale_golden.flatten(), expanded_scale, "float32")
     else:
         expand_scale_result = True
 
@@ -292,13 +331,18 @@ def test_moe_init_routing_custom():
     quant_mode = [0, 1, -1]
     row_idx_type = [0, 1]
     scale_type = [0, 1, 2]
-    product_result = itertools.product(drop_pad_mode, expert_tokens_num_type,
-                                       expert_tokens_num_flag, quant_mode,
-                                       row_idx_type, scale_type)
+    product_result = itertools.product(
+        drop_pad_mode, expert_tokens_num_type, expert_tokens_num_flag, quant_mode, row_idx_type, scale_type
+    )
 
-    for idx, (drop_pad_mode_, expert_tokens_num_type_, expert_tokens_num_flag_,
-              quant_mode_, row_idx_type_,
-              scale_type_) in enumerate(product_result, 5):
+    for idx, (
+        drop_pad_mode_,
+        expert_tokens_num_type_,
+        expert_tokens_num_flag_,
+        quant_mode_,
+        row_idx_type_,
+        scale_type_,
+    ) in enumerate(product_result, 5):
         expert_num_ = random.randint(2, 500)
         expert_start = random.randint(0, expert_num_ - 1)
         expert_end = random.randint(expert_start + 1, expert_num_)
@@ -309,9 +353,7 @@ def test_moe_init_routing_custom():
         K = random.randint(1, 12)
         x_ = torch.randn(N, H, dtype=torch.float16) * 5
         expert_capacity_ = random.randint(1, N - 1) if N > 1 else 1
-        expert_idx_ = torch.randint(0,
-                                    expert_num_ - 1, (N, K),
-                                    dtype=torch.int32)
+        expert_idx_ = torch.randint(0, expert_num_ - 1, (N, K), dtype=torch.int32)
         active_num_ = N * K
 
         if drop_pad_mode_ == 1:
@@ -333,22 +375,28 @@ def test_moe_init_routing_custom():
                 scale_ = torch.randn(1, H, dtype=torch.float)
                 offset_ = None
             else:
-                scale_ = torch.randn(active_expert_range_[1] -
-                                     active_expert_range_[0],
-                                     H,
-                                     dtype=torch.float)
+                scale_ = torch.randn(active_expert_range_[1] - active_expert_range_[0], H, dtype=torch.float)
             offset_ = None
 
-        result_pta = run_moe_npu_case(x_, expert_idx_, scale_, offset_,
-                                      active_num_, expert_capacity_,
-                                      expert_num_, drop_pad_mode_,
-                                      expert_tokens_num_type_,
-                                      expert_tokens_num_flag_, quant_mode_,
-                                      active_expert_range_, row_idx_type_)
+        result_pta = run_moe_npu_case(
+            x_,
+            expert_idx_,
+            scale_,
+            offset_,
+            active_num_,
+            expert_capacity_,
+            expert_num_,
+            drop_pad_mode_,
+            expert_tokens_num_type_,
+            expert_tokens_num_flag_,
+            quant_mode_,
+            active_expert_range_,
+            row_idx_type_,
+        )
         if not result_pta:
             failed_test_cnt += 1
 
-    assert (failed_test_cnt == 0)
+    assert failed_test_cnt == 0
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_ngram_spec_decode.py
@@ -5,6 +5,7 @@ with parametrized test cases covering various configurations.
 """
 
 import time
+
 import numpy as np
 import pytest
 import torch
@@ -22,11 +23,12 @@ PERF_ITERS = 20
 # Golden reference (CPU, pure Python/NumPy)
 # ---------------------------------------------------------------------------
 
+
 def golden_ngram_spec_decode(
-    token_ids: np.ndarray,           # [B, M], int32,
+    token_ids: np.ndarray,  # [B, M], int32,
     num_tokens_no_spec: np.ndarray,  # [B], int32
-    sampled_token_ids: np.ndarray,   # [B, N], int32
-    discard_request_mask: np.ndarray, # [B], int32
+    sampled_token_ids: np.ndarray,  # [B, N], int32
+    discard_request_mask: np.ndarray,  # [B], int32
     vocab_size: int,
     min_n: int,
     max_n: int,
@@ -89,10 +91,10 @@ def golden_ngram_spec_decode(
                 if wc <= 0:
                     break
 
-                suffix = token_ids[i, nt - ngram_len: nt].tolist()
+                suffix = token_ids[i, nt - ngram_len : nt].tolist()
                 found = False
                 for pos in range(wc):
-                    window = token_ids[i, pos: pos + ngram_len].tolist()
+                    window = token_ids[i, pos : pos + ngram_len].tolist()
                     if window == suffix:
                         best_match_pos = pos
                         best_ngram_len = ngram_len
@@ -127,6 +129,7 @@ def golden_ngram_spec_decode(
 # ---------------------------------------------------------------------------
 # inputs construct helper
 # ---------------------------------------------------------------------------
+
 
 def _make_inputs(
     batch_size: int,
@@ -165,27 +168,24 @@ def _make_inputs(
         discard_mask = rng.rand(batch_size) < discard_rate
         discard_request_mask[discard_mask] = 1
 
-    return token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-           vocab_size, min_n, max_n, k
+    return token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
 
 
-def _run_npu(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-             vocab_size, min_n, max_n, k):
+def _run_npu(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k):
     token_ids_t = torch.from_numpy(token_ids).to("npu")
     num_tokens_t = torch.from_numpy(num_tokens_no_spec).to("npu")
     sampled_t = torch.from_numpy(sampled_token_ids).to("npu")
     discard_t = torch.from_numpy(discard_request_mask).to("npu")
 
     result = torch.ops._C_ascend.npu_ngram_spec_decode(
-        token_ids_t, num_tokens_t, sampled_t, discard_t,
-        vocab_size, min_n, max_n, k)
+        token_ids_t, num_tokens_t, sampled_t, discard_t, vocab_size, min_n, max_n, k
+    )
     torch.npu.synchronize()
 
     return result
 
 
-def _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-                  vocab_size, min_n, max_n, k):
+def _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k):
     token_ids_t = torch.from_numpy(token_ids.copy()).to("npu")
     num_tokens_t = torch.from_numpy(num_tokens_no_spec.copy()).to("npu")
     sampled_t = torch.from_numpy(sampled_token_ids.copy()).to("npu")
@@ -193,107 +193,132 @@ def _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_requ
 
     for _ in range(PERF_WARMUP):
         _ = torch.ops._C_ascend.npu_ngram_spec_decode(
-            token_ids_t, num_tokens_t, sampled_t, discard_t,
-            vocab_size, min_n, max_n, k)
+            token_ids_t, num_tokens_t, sampled_t, discard_t, vocab_size, min_n, max_n, k
+        )
     torch.npu.synchronize()
 
     t0 = time.perf_counter()
     for _ in range(PERF_ITERS):
         _ = torch.ops._C_ascend.npu_ngram_spec_decode(
-            token_ids_t, num_tokens_t, sampled_t, discard_t,
-            vocab_size, min_n, max_n, k)
+            token_ids_t, num_tokens_t, sampled_t, discard_t, vocab_size, min_n, max_n, k
+        )
     torch.npu.synchronize()
     elapsed_us = (time.perf_counter() - t0) * 1e6 / PERF_ITERS
 
-    print(f"  [perf] B={token_ids.shape[0]} M={token_ids.shape[1]} N={sampled_token_ids.shape[1]} "
-          f"k={k} min_n={min_n} max_n={max_n} -> {elapsed_us:.1f} us/call", flush=True)
+    print(
+        f"  [perf] B={token_ids.shape[0]} M={token_ids.shape[1]} N={sampled_token_ids.shape[1]} "
+        f"k={k} min_n={min_n} max_n={max_n} -> {elapsed_us:.1f} us/call",
+        flush=True,
+    )
 
 
 # ===========================================================================
 # Group 1: basic - basic function
 # ===========================================================================
 
-@pytest.mark.parametrize("batch_size,seq_len,max_new_tokens,k", [
-    (1, 16, 4, 3),
-    (4, 64, 8, 5),
-    (16, 128, 16, 5),
-])
+
+@pytest.mark.parametrize(
+    "batch_size,seq_len,max_new_tokens,k",
+    [
+        (1, 16, 4, 3),
+        (4, 64, 8, 5),
+        (16, 128, 16, 5),
+    ],
+)
 @torch.inference_mode()
 def test_ngram_spec_decode_basic(batch_size, seq_len, max_new_tokens, k):
     inputs = _make_inputs(batch_size, seq_len, max_new_tokens, k)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     # CPU golden
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     # NPU
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     # compare
-    assert result_ids.cpu().numpy().tolist() == golden_ids.tolist(), \
-        f"token_ids mismatch: B={batch_size}"
-    assert result_next.cpu().numpy().tolist() == golden_next.tolist(), \
-        f"next_token_ids mismatch: B={batch_size}"
-    assert result_draft.cpu().numpy().tolist() == golden_draft.tolist(), \
-        f"draft_token_ids mismatch: B={batch_size}"
-    assert result_valid.cpu().numpy().tolist() == golden_valid.tolist(), \
+    assert result_ids.cpu().numpy().tolist() == golden_ids.tolist(), f"token_ids mismatch: B={batch_size}"
+    assert result_next.cpu().numpy().tolist() == golden_next.tolist(), f"next_token_ids mismatch: B={batch_size}"
+    assert result_draft.cpu().numpy().tolist() == golden_draft.tolist(), f"draft_token_ids mismatch: B={batch_size}"
+    assert result_valid.cpu().numpy().tolist() == golden_valid.tolist(), (
         f"num_valid_draft_tokens mismatch: B={batch_size}"
+    )
 
-    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-                  vocab_size, min_n, max_n, k)
+    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k)
 
 
 # ===========================================================================
 # Group 2: padding / optional
 # ===========================================================================
 
-@pytest.mark.parametrize("batch_size,seq_len,max_new_tokens,k,invalid_rate", [
-    (4, 64, 8, 5, 0.3),
-    (4, 64, 8, 5, 0.7),
-    (4, 128, 16, 5, 0.5),
-])
+
+@pytest.mark.parametrize(
+    "batch_size,seq_len,max_new_tokens,k,invalid_rate",
+    [
+        (4, 64, 8, 5, 0.3),
+        (4, 64, 8, 5, 0.7),
+        (4, 128, 16, 5, 0.5),
+    ],
+)
 @torch.inference_mode()
 def test_ngram_spec_decode_padding(batch_size, seq_len, max_new_tokens, k, invalid_rate):
     inputs = _make_inputs(batch_size, seq_len, max_new_tokens, k, invalid_rate=invalid_rate)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
     assert result_draft.cpu().numpy().tolist() == golden_draft.tolist()
     assert result_valid.cpu().numpy().tolist() == golden_valid.tolist()
 
-    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-                  vocab_size, min_n, max_n, k)
+    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k)
 
 
 @pytest.mark.parametrize("discard_rate", [0.2, 0.5, 1.0])
 @torch.inference_mode()
 def test_ngram_spec_decode_discard(discard_rate):
     inputs = _make_inputs(4, 64, 8, 5, discard_rate=discard_rate)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
@@ -305,103 +330,130 @@ def test_ngram_spec_decode_discard(discard_rate):
 # Group 3: min_n / max_n / k
 # ===========================================================================
 
-@pytest.mark.parametrize("min_n,max_n,k", [
-    (1, 1, 3),
-    (2, 4, 5),
-    (1, 8, 10),
-    (3, 3, 1),
-    (5, 10, 8),
-])
+
+@pytest.mark.parametrize(
+    "min_n,max_n,k",
+    [
+        (1, 1, 3),
+        (2, 4, 5),
+        (1, 8, 10),
+        (3, 3, 1),
+        (5, 10, 8),
+    ],
+)
 @torch.inference_mode()
 def test_ngram_spec_decode_attrs(min_n, max_n, k):
     inputs = _make_inputs(4, 128, 16, k, min_n=min_n, max_n=max_n)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, _, _, _ = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, _, _, _ = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
     assert result_draft.cpu().numpy().tolist() == golden_draft.tolist()
     assert result_valid.cpu().numpy().tolist() == golden_valid.tolist()
 
-    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-                  vocab_size, min_n, max_n, k)
+    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k)
 
 
 # ===========================================================================
 # Group 4: large scale
 # ===========================================================================
 
+
 @torch.inference_mode()
 def test_ngram_spec_decode_prefill():
     inputs = _make_inputs(1, 2048, 16, 5, vocab_size=32000)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
     assert result_draft.cpu().numpy().tolist() == golden_draft.tolist()
     assert result_valid.cpu().numpy().tolist() == golden_valid.tolist()
 
-    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-                  vocab_size, min_n, max_n, k)
+    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k)
 
 
 @torch.inference_mode()
 def test_ngram_spec_decode_decode():
     inputs = _make_inputs(64, 32, 5, 3, vocab_size=32000)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
     assert result_draft.cpu().numpy().tolist() == golden_draft.tolist()
     assert result_valid.cpu().numpy().tolist() == golden_valid.tolist()
 
-    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-                  vocab_size, min_n, max_n, k)
+    _measure_perf(token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k)
 
 
 # ===========================================================================
 # Group 5: boundary
 # ===========================================================================
 
+
 @torch.inference_mode()
 def test_ngram_spec_decode_minimal():
     inputs = _make_inputs(1, 4, 1, 1, vocab_size=100)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
@@ -412,17 +464,23 @@ def test_ngram_spec_decode_minimal():
 @torch.inference_mode()
 def test_ngram_spec_decode_no_valid_sampled():
     inputs = _make_inputs(4, 64, 8, 5)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
     sampled_token_ids[:] = -1
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
@@ -432,29 +490,40 @@ def test_ngram_spec_decode_no_valid_sampled():
 
 @torch.inference_mode()
 def test_ngram_spec_decode_exact_match():
-    B, M, N, k = 2, 32, 4, 3
+    k = 3
     vocab_size = 1000
-    token_ids = np.array([
-        [1, 2, 3, 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0,
-         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [10, 20, 10, 20, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    ], dtype=np.int32)
+    token_ids = np.array(
+        [
+            [1, 2, 3, 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [10, 20, 10, 20, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=np.int32,
+    )
     num_tokens_no_spec = np.array([6, 5], dtype=np.int32)
     # sampled tokens
-    sampled_token_ids = np.array([
-        [1, 2, 3, -1],
-        [10, 20, -1, -1],
-    ], dtype=np.int32)
+    sampled_token_ids = np.array(
+        [
+            [1, 2, 3, -1],
+            [10, 20, -1, -1],
+        ],
+        dtype=np.int32,
+    )
     discard_request_mask = np.array([0, 0], dtype=np.int32)
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, 3, 5, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        3,
+        5,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, 3, 5, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, 3, 5, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
@@ -465,17 +534,23 @@ def test_ngram_spec_decode_exact_match():
 @torch.inference_mode()
 def test_ngram_spec_decode_full_capacity():
     inputs = _make_inputs(4, 48, 16, 5, min_n=2, max_n=4)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
     num_tokens_no_spec[:] = token_ids.shape[1] - sampled_token_ids.shape[1]
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()
@@ -486,16 +561,22 @@ def test_ngram_spec_decode_full_capacity():
 @torch.inference_mode()
 def test_ngram_spec_decode_k1():
     inputs = _make_inputs(4, 64, 8, 1, min_n=2, max_n=3)
-    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, \
-        vocab_size, min_n, max_n, k = inputs
+    token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k = inputs
 
     golden_ids, golden_next, golden_draft, golden_valid = golden_ngram_spec_decode(
-        token_ids.copy(), num_tokens_no_spec.copy(), sampled_token_ids.copy(),
-        discard_request_mask.copy(), vocab_size, min_n, max_n, k)
+        token_ids.copy(),
+        num_tokens_no_spec.copy(),
+        sampled_token_ids.copy(),
+        discard_request_mask.copy(),
+        vocab_size,
+        min_n,
+        max_n,
+        k,
+    )
 
     result_ids, result_next, result_draft, result_valid = _run_npu(
-        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask,
-        vocab_size, min_n, max_n, k)
+        token_ids, num_tokens_no_spec, sampled_token_ids, discard_request_mask, vocab_size, min_n, max_n, k
+    )
 
     assert result_ids.cpu().numpy().tolist() == golden_ids.tolist()
     assert result_next.cpu().numpy().tolist() == golden_next.tolist()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_moe_gating_top_k.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_moe_gating_top_k.py
@@ -30,17 +30,19 @@ def softmax_func(x, axis=None):
     return res, x_max, x_sum
 
 
-def moe_gating_top_k_numpy_ref(x: torch.Tensor,
-                               k: int,
-                               bias: torch.Tensor | None,
-                               k_group: int = 1,
-                               group_count: int = 1,
-                               group_select_mode: int = 0,
-                               renorm: int = 0,
-                               norm_type: int = 0,
-                               y2_flag: bool = False,
-                               routed_scaling_factor: float = 1.0,
-                               eps: float = 1e-20) -> tuple:
+def moe_gating_top_k_numpy_ref(
+    x: torch.Tensor,
+    k: int,
+    bias: torch.Tensor | None,
+    k_group: int = 1,
+    group_count: int = 1,
+    group_select_mode: int = 0,
+    renorm: int = 0,
+    norm_type: int = 0,
+    y2_flag: bool = False,
+    routed_scaling_factor: float = 1.0,
+    eps: float = 1e-20,
+) -> tuple:
     """NumPy reference implementation of MOE Gating TopK.
 
     For result comparison with NPU operator, ensure the consistency
@@ -90,22 +92,19 @@ def moe_gating_top_k_numpy_ref(x: torch.Tensor,
             group_x = numpy.amax(x, axis=-1)
         else:
             group_x = numpy.partition(x, -2, axis=-1)[..., -2:].sum(axis=-1)
-        indices = numpy.argsort(-group_x, axis=-1, kind='stable')[:, :k_group]
+        indices = numpy.argsort(-group_x, axis=-1, kind="stable")[:, :k_group]
 
         mask = numpy.ones((x.shape[0], group_count), dtype=bool)
         mask[numpy.arange(x.shape[0])[:, None], indices] = False
-        x = numpy.where(mask[..., None], float('-inf'), x)
+        x = numpy.where(mask[..., None], float("-inf"), x)
         x = x.reshape(x.shape[0], -1)
 
-    _, indices = torch.sort(torch.from_numpy(x),
-                            dim=-1,
-                            stable=True,
-                            descending=True)
+    _, indices = torch.sort(torch.from_numpy(x), dim=-1, stable=True, descending=True)
     indices = numpy.asarray(indices[:, :k])
 
     y = numpy.take_along_axis(original_x, indices, axis=1)
     if norm_type == 1 or renorm == 1:
-        y /= (numpy.sum(y, axis=-1, keepdims=True) + eps)
+        y /= numpy.sum(y, axis=-1, keepdims=True) + eps
     y *= routed_scaling_factor
 
     y2 = original_x if y2_flag else None
@@ -121,14 +120,16 @@ def moe_gating_top_k_numpy_ref(x: torch.Tensor,
 @pytest.mark.parametrize("k_ranges", [4, 8, 12, 16, 6, 32])
 @pytest.mark.parametrize("x_dim0_range", list(range(1, 17)))
 @pytest.mark.parametrize("x_dim1_range", [256, 128, 64, 208, 192, 160])
-def test_npu_moe_gating_topk_compare(group_select_mode: int,
-                                     renorm: int,
-                                     norm_type: int,
-                                     group_count: int,
-                                     k_ranges: int,
-                                     x_dim0_range: int,
-                                     x_dim1_range: int,
-                                     device: str = "npu"):
+def test_npu_moe_gating_topk_compare(
+    group_select_mode: int,
+    renorm: int,
+    norm_type: int,
+    group_count: int,
+    k_ranges: int,
+    x_dim0_range: int,
+    x_dim1_range: int,
+    device: str = "npu",
+):
     """Ascend NPU MOE Gating TopK operator test.
 
     Compare NPU kernel results with NumPy reference implementation
@@ -155,7 +156,7 @@ def test_npu_moe_gating_topk_compare(group_select_mode: int,
 
     # Construct test inputs
     x = numpy.random.uniform(-2, 2, (dim0, dim1)).astype(numpy.float32)
-    bias = numpy.random.uniform(-2, 2, (dim1, )).astype(numpy.float32)
+    bias = numpy.random.uniform(-2, 2, (dim1,)).astype(numpy.float32)
 
     x_tensor = torch.tensor(x, dtype=torch.float32)
     bias_tensor = torch.tensor(bias, dtype=torch.float32)
@@ -196,14 +197,8 @@ def test_npu_moe_gating_topk_compare(group_select_mode: int,
     )
 
     # Verify consistency between NPU and NumPy results
-    assert numpy.allclose(y.cpu().numpy(),
-                          y_npu.cpu().numpy(),
-                          rtol=RTOL_TOLERANCE,
-                          atol=ATOL_TOLERANCE)
-    assert numpy.allclose(expert_idx,
-                          expert_idx_npu.cpu().numpy(),
-                          rtol=RTOL_TOLERANCE,
-                          atol=ATOL_TOLERANCE)
+    assert numpy.allclose(y.cpu().numpy(), y_npu.cpu().numpy(), rtol=RTOL_TOLERANCE, atol=ATOL_TOLERANCE)
+    assert numpy.allclose(expert_idx, expert_idx_npu.cpu().numpy(), rtol=RTOL_TOLERANCE, atol=ATOL_TOLERANCE)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule.py
@@ -1,5 +1,4 @@
 import gc
-import os
 import random
 
 import numpy as np
@@ -16,8 +15,16 @@ torch.manual_seed(seed)
 
 
 def golden_recurrent_gated_delta_rule(
-    query, key, value, state, beta, scale, actual_seq_lengths,
-    ssm_state_indices, g, num_accepted_tokens,
+    query,
+    key,
+    value,
+    state,
+    beta,
+    scale,
+    actual_seq_lengths,
+    ssm_state_indices,
+    g,
+    num_accepted_tokens,
 ):
     """Pure torch/CPU golden implementation of recurrent gated delta rule.
 
@@ -42,16 +49,8 @@ def golden_recurrent_gated_delta_rule(
     initial_state = state.clone().to(torch.float32)
     T, n_heads_v, Dv = v.shape
     n_heads_k = q.shape[-2]
-    g = (
-        torch.ones(T, n_heads_v).to(torch.float32)
-        if g is None
-        else g.to(torch.float32).exp()
-    )
-    beta = (
-        torch.ones(T, n_heads_v).to(torch.float32)
-        if beta is None
-        else beta.to(torch.float32)
-    )
+    g = torch.ones(T, n_heads_v).to(torch.float32) if g is None else g.to(torch.float32).exp()
+    beta = torch.ones(T, n_heads_v).to(torch.float32) if beta is None else beta.to(torch.float32)
     o = torch.empty_like(v).to(torch.float32)
     if scale is None:
         scale = k.shape[-1] ** -0.5
@@ -62,9 +61,7 @@ def golden_recurrent_gated_delta_rule(
         if num_accepted_tokens is None:
             init_state = initial_state[ssm_state_indices[seq_start]]
         else:
-            init_state = initial_state[
-                ssm_state_indices[seq_start + num_accepted_tokens[i] - 1]
-            ]
+            init_state = initial_state[ssm_state_indices[seq_start + num_accepted_tokens[i] - 1]]
         for head_id in range(n_heads_v):
             S = init_state[head_id]
             for slot_id in range(seq_start, seq_start + actual_seq_lengths[i]):
@@ -92,7 +89,12 @@ def golden_recurrent_gated_delta_rule(
 @pytest.mark.parametrize("headdim_v", [128])
 @pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
 def test_recurrent_gated_delta_rule(
-    batch_size, mtp, headnum, headdim_k, headdim_v, state_dtype,
+    batch_size,
+    mtp,
+    headnum,
+    headdim_k,
+    headdim_v,
+    state_dtype,
 ):
     torch.manual_seed(seed)
     dtype = torch.bfloat16
@@ -102,10 +104,14 @@ def test_recurrent_gated_delta_rule(
 
     state = torch.rand((T, headnum_v, headdim_v, headdim_k)).to(state_dtype)
     query = torch.nn.functional.normalize(
-        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+        torch.rand((T, headnum_k, headdim_k)),
+        p=2,
+        dim=-1,
     ).to(dtype)
     key = torch.nn.functional.normalize(
-        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+        torch.rand((T, headnum_k, headdim_k)),
+        p=2,
+        dim=-1,
     ).to(dtype)
     value = torch.rand((T, headnum_v, headdim_v)).to(dtype)
     g = torch.rand((T, headnum_v), dtype=torch.float32)
@@ -115,16 +121,27 @@ def test_recurrent_gated_delta_rule(
     scale = headdim_k**-0.5
 
     out_golden, state_golden = golden_recurrent_gated_delta_rule(
-        query, key, value, state, beta, scale,
-        seq_lengths, ssm_state_indices, g, num_accepted_tokens,
+        query,
+        key,
+        value,
+        state,
+        beta,
+        scale,
+        seq_lengths,
+        ssm_state_indices,
+        g,
+        num_accepted_tokens,
     )
     out_golden = out_golden.to(torch.float32)
     state_golden = state_golden.to(torch.float32)
 
     # torch_npu op expects actual_seq_lengths = [start_pos, len1, len2, ..., lenB]
-    actual_seq_lengths_npu = torch.cat([
-        torch.zeros(1, dtype=torch.int32), seq_lengths,
-    ])
+    actual_seq_lengths_npu = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32),
+            seq_lengths,
+        ]
+    )
 
     state_npu = state.npu()
     npu_out = torch_npu.npu_recurrent_gated_delta_rule(
@@ -167,7 +184,12 @@ def test_recurrent_gated_delta_rule(
 @pytest.mark.parametrize("headdim_v", [128])
 @pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
 def test_recurrent_gated_delta_rule_no_accepted(
-    batch_size, mtp, headnum, headdim_k, headdim_v, state_dtype,
+    batch_size,
+    mtp,
+    headnum,
+    headdim_k,
+    headdim_v,
+    state_dtype,
 ):
     torch.manual_seed(seed)
     dtype = torch.bfloat16
@@ -177,10 +199,14 @@ def test_recurrent_gated_delta_rule_no_accepted(
 
     state = torch.rand((T, headnum_v, headdim_v, headdim_k)).to(state_dtype)
     query = torch.nn.functional.normalize(
-        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+        torch.rand((T, headnum_k, headdim_k)),
+        p=2,
+        dim=-1,
     ).to(dtype)
     key = torch.nn.functional.normalize(
-        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+        torch.rand((T, headnum_k, headdim_k)),
+        p=2,
+        dim=-1,
     ).to(dtype)
     value = torch.rand((T, headnum_v, headdim_v)).to(dtype)
     g = torch.rand((T, headnum_v), dtype=torch.float32)
@@ -189,15 +215,26 @@ def test_recurrent_gated_delta_rule_no_accepted(
     scale = headdim_k**-0.5
 
     out_golden, state_golden = golden_recurrent_gated_delta_rule(
-        query, key, value, state, beta, scale,
-        seq_lengths, ssm_state_indices, g, None,
+        query,
+        key,
+        value,
+        state,
+        beta,
+        scale,
+        seq_lengths,
+        ssm_state_indices,
+        g,
+        None,
     )
     out_golden = out_golden.to(torch.float32)
     state_golden = state_golden.to(torch.float32)
 
-    actual_seq_lengths_npu = torch.cat([
-        torch.zeros(1, dtype=torch.int32), seq_lengths,
-    ])
+    actual_seq_lengths_npu = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32),
+            seq_lengths,
+        ]
+    )
 
     state_npu = state.npu()
     npu_out = torch_npu.npu_recurrent_gated_delta_rule(

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_reshape_and_cache_bnsd.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_reshape_and_cache_bnsd.py
@@ -1,110 +1,106 @@
-import torch
-import torch_npu
-import copy
-import numpy as np
-
-import torchair
-import torch.nn as nn
-from vllm_ascend.utils import enable_custom_op
+import logging
 import unittest
 from unittest import TestCase
 
-import logging
+import numpy as np
+import torch
+import torch.nn as nn
+import torchair
 from torchair import logger
+
+from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
 logger.setLevel(logging.DEBUG)
 torch._logging.set_logs(graph_code=True)
 
+
 def run_tests():
     unittest.main()
 
+
 class TestCustomReshapeAndCacheBnsd(TestCase):
-    
     def setUp(self):
         torch.manual_seed(42)
         np.random.seed(42)
-        
+
         self.device_id = 0
         torch.npu.set_device(self.device_id)
-        self.npu = f'npu:{self.device_id}'
-        
+        self.npu = f"npu:{self.device_id}"
+
         self.num_blocks = 2
         self.num_kv_heads = 2
         self.block_size = 4
         self.head_size = 16
         self.token_num = 4
         self.bs = 1
-        
+
         self.hashk_op = torch.randn(self.token_num * self.num_kv_heads, self.head_size, dtype=torch.float16).npu()
-        self.hashk_cache_op = torch.randn(self.num_blocks, self.num_kv_heads, self.block_size,
-            self.head_size, dtype=torch.float16).npu()
+        self.hashk_cache_op = torch.randn(
+            self.num_blocks, self.num_kv_heads, self.block_size, self.head_size, dtype=torch.float16
+        ).npu()
         self.slot_mapping_op = torch.tensor([0, 1, 2, 3], dtype=torch.int32).npu()
         self.seq_lens_op = torch.tensor([self.token_num], dtype=torch.int32).npu()
         self.hashk_op_org = self.hashk_op.reshape(self.num_kv_heads, self.token_num, self.head_size)
-    
+
     def _run_eager_mode(self):
         return torch.ops._C_ascend.npu_reshape_and_cache_bnsd(
-            self.hashk_op, self.hashk_cache_op, self.slot_mapping_op, 
-            self.seq_lens_op, self.hashk_cache_op
+            self.hashk_op, self.hashk_cache_op, self.slot_mapping_op, self.seq_lens_op, self.hashk_cache_op
         )
-    
+
     def _run_graph_mode(self):
         class Network(nn.Module):
             def __init__(self):
-                super(Network, self).__init__()
+                super().__init__()
 
             def forward(self, hashk_op, hashk_cache_op, slot_mapping_op, seq_lens_op, k_cache_out):
                 return torch.ops._C_ascend.npu_reshape_and_cache_bnsd(
                     hashk_op, hashk_cache_op, slot_mapping_op, seq_lens_op, k_cache_out
                 )
-        
+
         npu_mode = Network().to(f"npu:{self.device_id}")
         from torchair.configs.compiler_config import CompilerConfig
+
         config = CompilerConfig()
         config.mode = "reduce-overhead"
         npu_backend = torchair.get_npu_backend(compiler_config=config)
-        
+
         npu_mode = torch.compile(npu_mode, backend=npu_backend, dynamic=False)
-        return npu_mode(
-            self.hashk_op, self.hashk_cache_op, self.slot_mapping_op, 
-            self.seq_lens_op, self.hashk_cache_op
-        )
-    
+        return npu_mode(self.hashk_op, self.hashk_cache_op, self.slot_mapping_op, self.seq_lens_op, self.hashk_cache_op)
+
     def _verify_results(self, output):
         for token_id in range(self.token_num):
             slot = self.slot_mapping_op[token_id].item()
             block_idx = slot // self.block_size
             block_offset = slot % self.block_size
-            
+
             for kv_head_id in range(self.num_kv_heads):
-                input_hashk = self.hashk_op_org[kv_head_id, token_id, :]
                 output_hashk = output[block_idx, kv_head_id, block_offset, :]
-        
+
         token_id = self.bs - 1
         slot = self.slot_mapping_op[token_id].item() + 1
         block_idx = slot // self.block_size
         block_offset = slot % self.block_size
-        
+
         for kv_head_id in range(self.num_kv_heads):
             output_hashk = output[block_idx, kv_head_id, block_offset, :]
             self.assertIsNotNone(output_hashk)
-    
+
     def test_reshape_and_cache_bnsd_compare(self):
         print("=========== test_reshape_and_cache_bnsd_compare begin ===================")
         output_eager = self._run_eager_mode()
         output_graph = self._run_graph_mode()
-        
+
         self.assertIsNotNone(output_eager, "output_eager should not be None")
         self.assertIsNotNone(output_graph, "output_graph should not be None")
-        
+
         self.assertEqual(output_eager.shape, output_graph.shape)
         self.assertTrue(torch.allclose(output_eager, output_graph, atol=1e-05))
         print("=========== test_reshape_and_cache_bnsd_compare end ===================")
-    
+
     def test_reshape_and_cache_bnsd_with_expected_output(self):
         print("=========== test_reshape_and_cache_bnsd_with_expected_output begin ===================")
-        
+
         num_blocks = 2
         num_kv_heads = 2
         block_size = 4
@@ -112,7 +108,7 @@ class TestCustomReshapeAndCacheBnsd(TestCase):
         bs = 1
         seq_lens_list = [8]
         token_num = sum(seq_lens_list)
-        
+
         key_in = torch.zeros(num_kv_heads, token_num, head_size, dtype=torch.uint8)
         val = 0
         for head_id in range(num_kv_heads):
@@ -121,38 +117,37 @@ class TestCustomReshapeAndCacheBnsd(TestCase):
                     key_in[head_id, token_id, dim_id] = val
                     val += 1
         key_in = key_in.reshape(num_kv_heads * token_num, head_size).npu()
-        key_cache_out = torch.randint(100, 200, (num_blocks, num_kv_heads, block_size,
-            head_size), dtype=torch.uint8).npu()
+        key_cache_out = torch.randint(
+            100, 200, (num_blocks, num_kv_heads, block_size, head_size), dtype=torch.uint8
+        ).npu()
         slot_mapping = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int32).npu()
         seq_lens = torch.tensor(seq_lens_list, dtype=torch.int32).npu()
         key_cache_out_cpu = key_cache_out.cpu().clone()
-        
+
         output = torch.ops._C_ascend.npu_reshape_and_cache_bnsd(
             key_in, key_cache_out, slot_mapping, seq_lens, key_cache_out
         )
-        
+
         expected = key_cache_out_cpu.clone()
         key_in_cpu = key_in.cpu().view(num_kv_heads, token_num, head_size)
         for token_id in range(token_num):
             slot = slot_mapping[token_id].cpu().item()
             block_idx = slot // block_size
             block_offset = slot % block_size
-            
+
             for head_id in range(num_kv_heads):
                 src_data = key_in_cpu[head_id, token_id, :]
                 expected[block_idx, head_id, block_offset, :] = src_data
-        
+
         self.assertIsNotNone(output, "output should not be None")
         self.assertEqual(output.shape, expected.shape, "output shape should match expected shape")
-        
+
         output_cpu = output.cpu()
         self.assertTrue(
             torch.equal(output_cpu, expected),
-            f"output should match expected values\n"
-            f"output:\n{output_cpu}\n"
-            f"expected:\n{expected}"
+            f"output should match expected values\noutput:\n{output_cpu}\nexpected:\n{expected}",
         )
-        
+
         print(f"bs: {bs}, seq_lens: {seq_lens_list}, total_tokens: {token_num}")
         print(f"key_in shape: {key_in.shape}")
         print(f"key_cache_out shape: {key_cache_out.shape}")
@@ -160,24 +155,21 @@ class TestCustomReshapeAndCacheBnsd(TestCase):
         print(f"output:\n{output_cpu}")
         print(f"expected:\n{expected}")
         print("=========== test_reshape_and_cache_bnsd_with_expected_output end ===================")
-    
+
     def test_reshape_and_cache_bnsd_bf16_shape(self):
         print("=========== test_reshape_and_cache_bnsd_bf16_shape begin ===================")
-        
+
         num_blocks = 1
         num_kv_heads = 2
         block_size = 4
         head_size = 4
         token_num = 4
-        bs = 1
-        
+
         key_in = torch.zeros(num_kv_heads, token_num, head_size, dtype=torch.bfloat16)
         for head_id in range(num_kv_heads):
             for token_id in range(token_num):
                 start_val = head_id * token_num * head_size + token_id * head_size
-                key_in[head_id, token_id, :] = torch.arange(
-                    start_val, start_val + head_size, dtype=torch.bfloat16
-                )
+                key_in[head_id, token_id, :] = torch.arange(start_val, start_val + head_size, dtype=torch.bfloat16)
         key_in = key_in.reshape(num_kv_heads * token_num, head_size).npu()
         key_cache_out = torch.zeros(num_blocks, num_kv_heads, block_size, head_size, dtype=torch.bfloat16).npu()
         slot_mapping = torch.tensor([0, 1, 2, 3], dtype=torch.int32).npu()
@@ -185,12 +177,12 @@ class TestCustomReshapeAndCacheBnsd(TestCase):
         output = torch.ops._C_ascend.npu_reshape_and_cache_bnsd(
             key_in, key_cache_out, slot_mapping, seq_lens, key_cache_out
         )
-        
+
         expected_shape = (num_blocks, num_kv_heads, block_size, head_size)
-        
+
         self.assertIsNotNone(output, "output should not be None")
         self.assertEqual(output.shape, expected_shape, "output shape should match expected shape")
-        
+
         print(f"output shape: {output.shape}")
         print(f"output:\n{output.cpu()}")
         print("=========== test_reshape_and_cache_bnsd_bf16_shape end ===================")

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_transpose_kv_cache_by_block.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_transpose_kv_cache_by_block.py
@@ -1,5 +1,4 @@
 import gc
-import random
 import unittest
 
 import torch
@@ -11,34 +10,36 @@ enable_custom_op()
 
 torch.set_printoptions(threshold=float("inf"))
 
+
 def clone_kv_cache(k_caches, v_caches):
     new_k_caches = [cache.clone() for cache in k_caches]
     new_v_caches = [cache.clone() for cache in v_caches]
     return new_k_caches, new_v_caches
 
+
 class TestTransposeKvCacheByBlock(unittest.TestCase):
-    def compute_golden(self, k_caches, v_caches, block_ids_tensor, block_size, num_kv_head, head_dim, num_need_pulls, layers, dtype):    
+    def compute_golden(
+        self, k_caches, v_caches, block_ids_tensor, block_size, num_kv_head, head_dim, num_need_pulls, layers, dtype
+    ):
         num_blocks = block_ids_tensor.shape[0]
-        
+
         block_ids_tensor = block_ids_tensor.to(dtype=torch.int32)
         block_offsets = torch.arange(0, block_size, dtype=torch.int32).npu()
-        slot_mapping = block_offsets.reshape(
-            (1, block_size)) + block_ids_tensor.reshape(
-                (num_blocks, 1)) * block_size
+        slot_mapping = block_offsets.reshape((1, block_size)) + block_ids_tensor.reshape((num_blocks, 1)) * block_size
         slot_mapping = slot_mapping.flatten()
         block_len = num_blocks * block_size
-        block_len_tensor = torch.tensor([block_len],dtype=torch.int32).npu()
-        
+        block_len_tensor = torch.tensor([block_len], dtype=torch.int32).npu()
+
         block_table = block_ids_tensor.view(1, -1)
-        seq_start_tensor = torch.tensor([0],dtype=torch.int32).npu()
-            
+        seq_start_tensor = torch.tensor([0], dtype=torch.int32).npu()
+
         k = torch.empty(block_len, num_kv_head, head_dim, dtype=dtype).npu()
         v = torch.empty(block_len, num_kv_head, head_dim, dtype=dtype).npu()
 
         for layer in range(layers):
             k_cache_layer = k_caches[layer]
             v_cache_layer = v_caches[layer]
-            
+
             torch_npu.atb.npu_paged_cache_load(
                 k_cache_layer,
                 v_cache_layer,
@@ -48,15 +49,15 @@ class TestTransposeKvCacheByBlock(unittest.TestCase):
                 key=k,
                 value=v,
             )
-            
+
             k = k.view(num_blocks, num_need_pulls, block_size, -1)
             k.transpose_(1, 2)
             k = k.contiguous().view(block_len, num_kv_head, -1)
-            
+
             v = v.view(num_blocks, num_need_pulls, block_size, -1)
             v.transpose_(1, 2)
             v = v.contiguous().view(block_len, num_kv_head, -1)
-            
+
             torch_npu._npu_reshape_and_cache(
                 key=k,
                 value=v,
@@ -79,7 +80,10 @@ class TestTransposeKvCacheByBlock(unittest.TestCase):
         dtypes = [torch.float16, torch.bfloat16]
         for dtype in dtypes:
             for layers, block_num, block_size, num_kv_head, head_dim, num_need_pulls in test_cases:
-                with self.subTest(dtype=dtype, shape=f"({layers}, {block_num}, {block_size}, {num_kv_head}, {head_dim}, {num_need_pulls})"):
+                with self.subTest(
+                    dtype=dtype,
+                    shape=f"({layers}, {block_num}, {block_size}, {num_kv_head}, {head_dim}, {num_need_pulls})",
+                ):
                     k_caches = []
                     v_caches = []
                     block_id_num = 33
@@ -89,34 +93,41 @@ class TestTransposeKvCacheByBlock(unittest.TestCase):
                         vcache = torch.randn(block_num, block_size, num_kv_head, head_dim, dtype=dtype, device="npu")
                         k_caches.append(kcache)
                         v_caches.append(vcache)
-                    
+
                     cloned_k_caches, cloned_v_caches = clone_kv_cache(k_caches, v_caches)
-                    self.compute_golden(cloned_k_caches, cloned_v_caches, block_ids_tensor, block_size, num_kv_head, head_dim, num_need_pulls, layers, dtype)
-                    torch.ops._C_ascend.transpose_kv_cache_by_block(k_caches, v_caches, block_ids_tensor, block_size, num_kv_head, head_dim, num_need_pulls, layers)
-                    
-                    for i in range (layers):
+                    self.compute_golden(
+                        cloned_k_caches,
+                        cloned_v_caches,
+                        block_ids_tensor,
+                        block_size,
+                        num_kv_head,
+                        head_dim,
+                        num_need_pulls,
+                        layers,
+                        dtype,
+                    )
+                    torch.ops._C_ascend.transpose_kv_cache_by_block(
+                        k_caches, v_caches, block_ids_tensor, block_size, num_kv_head, head_dim, num_need_pulls, layers
+                    )
+
+                    for i in range(layers):
                         self.assert_tensors_almost_equal(k_caches[i], cloned_k_caches[i], dtype)
                         self.assert_tensors_almost_equal(v_caches[i], cloned_v_caches[i], dtype)
         gc.collect()
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
 
-
     def assert_tensors_almost_equal(self, actual, expected, dtype):
         """Check if two tensors are approximately equal (considering floating point errors)"""
         self.assertEqual(actual.shape, expected.shape, "Shape mismatch")
 
         # Check for NaN
-        self.assertFalse(
-            torch.isnan(actual).any(), "Actual result contains NaN")
-        self.assertFalse(
-            torch.isnan(expected).any(), "Expected result contains NaN")
+        self.assertFalse(torch.isnan(actual).any(), "Actual result contains NaN")
+        self.assertFalse(torch.isnan(expected).any(), "Expected result contains NaN")
 
         # Check for Inf
-        self.assertFalse(
-            torch.isinf(actual).any(), "Actual result contains Inf")
-        self.assertFalse(
-            torch.isinf(expected).any(), "Expected result contains Inf")
+        self.assertFalse(torch.isinf(actual).any(), "Actual result contains Inf")
+        self.assertFalse(torch.isinf(expected).any(), "Expected result contains Inf")
 
         # Set different tolerances based on data type
         if dtype == torch.float16:
@@ -138,9 +149,7 @@ class TestTransposeKvCacheByBlock(unittest.TestCase):
                 f"Relative error too large: {relative_diff} > {rtol}. Max difference: {max_diff}",
             )
 
-        self.assertLessEqual(max_diff, atol,
-                             f"Absolute error too large: {max_diff} > {atol}")
+        self.assertLessEqual(max_diff, atol, f"Absolute error too large: {max_diff} > {atol}")
         gc.collect()
         torch.npu.empty_cache()
         torch.npu.reset_peak_memory_stats()
-        

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_vocabparallelembedding.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_vocabparallelembedding.py
@@ -1,5 +1,4 @@
 import gc
-from typing import Tuple
 
 import pytest
 import torch
@@ -12,27 +11,26 @@ enable_custom_op()
 
 # Test parameters
 DTYPES = [torch.int32]
-#SHAPES = [(100,), (5, 20), (3, 4, 5)]  # Various tensor shapes
-#SHAPES = [(3, 4, 8), (3, 4, 5)]  # Various tensor shapes
+# SHAPES = [(100,), (5, 20), (3, 4, 5)]  # Various tensor shapes
+# SHAPES = [(3, 4, 8), (3, 4, 5)]  # Various tensor shapes
 SHAPES = [(3, 4, 3)]
 DEVICES = [f"npu:{0}"]
 SEEDS = [0]
 
 
 def get_masked_input_and_mask_ref(
-        input_: torch.Tensor, org_vocab_start_index: int,
-        org_vocab_end_index: int, num_org_vocab_padding: int,
-        added_vocab_start_index: int,
-        added_vocab_end_index: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    input_: torch.Tensor,
+    org_vocab_start_index: int,
+    org_vocab_end_index: int,
+    num_org_vocab_padding: int,
+    added_vocab_start_index: int,
+    added_vocab_end_index: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Reference implementation for verification"""
-    org_vocab_mask = (input_ >= org_vocab_start_index) & (
-        input_ < org_vocab_end_index)
-    added_vocab_mask = (input_ >= added_vocab_start_index) & (
-        input_ < added_vocab_end_index)
-    added_offset = added_vocab_start_index - (
-        org_vocab_end_index - org_vocab_start_index) - num_org_vocab_padding
-    valid_offset = (org_vocab_start_index *
-                    org_vocab_mask) + (added_offset * added_vocab_mask)
+    org_vocab_mask = (input_ >= org_vocab_start_index) & (input_ < org_vocab_end_index)
+    added_vocab_mask = (input_ >= added_vocab_start_index) & (input_ < added_vocab_end_index)
+    added_offset = added_vocab_start_index - (org_vocab_end_index - org_vocab_start_index) - num_org_vocab_padding
+    valid_offset = (org_vocab_start_index * org_vocab_mask) + (added_offset * added_vocab_mask)
     vocab_mask = org_vocab_mask | added_vocab_mask
     masked_input = vocab_mask * (input_ - valid_offset)
     return masked_input, ~vocab_mask
@@ -44,7 +42,7 @@ def get_masked_input_and_mask_ref(
 @pytest.mark.parametrize("seed", SEEDS)
 @torch.inference_mode()
 def test_get_masked_input_and_mask(
-    shape: Tuple[int, ...],
+    shape: tuple[int, ...],
     dtype: torch.dtype,
     device: str,
     seed: int,
@@ -67,14 +65,24 @@ def test_get_masked_input_and_mask(
 
     # Get reference result
     ref_masked_input, ref_mask = get_masked_input_and_mask_ref(
-        input_tensor, test_case["org_start"], test_case["org_end"],
-        test_case["padding"], test_case["added_start"], test_case["added_end"])
+        input_tensor,
+        test_case["org_start"],
+        test_case["org_end"],
+        test_case["padding"],
+        test_case["added_start"],
+        test_case["added_end"],
+    )
 
     # Get custom op result
     print("input_tensor:", input_tensor)
     custom_masked_input, custom_mask = torch.ops._C_ascend.get_masked_input_and_mask(
-        input_tensor, test_case["org_start"], test_case["org_end"],
-        test_case["padding"], test_case["added_start"], test_case["added_end"])
+        input_tensor,
+        test_case["org_start"],
+        test_case["org_end"],
+        test_case["padding"],
+        test_case["added_start"],
+        test_case["added_end"],
+    )
 
     ref_masked_input = ref_masked_input.to(dtype)
     print("custom_masked_input:", custom_masked_input)
@@ -83,16 +91,9 @@ def test_get_masked_input_and_mask(
     print("ref_mask:", ref_mask)
     # Compare results
     torch.testing.assert_close(
-        custom_masked_input,
-        ref_masked_input,
-        rtol=1e-5,
-        atol=1e-5,
-        msg=f"Masked input mismatch for case: {test_case}")
-    torch.testing.assert_close(custom_mask,
-                               ref_mask,
-                               rtol=1e-5,
-                               atol=1e-5,
-                               msg=f"Mask mismatch for case: {test_case}")
+        custom_masked_input, ref_masked_input, rtol=1e-5, atol=1e-5, msg=f"Masked input mismatch for case: {test_case}"
+    )
+    torch.testing.assert_close(custom_mask, ref_mask, rtol=1e-5, atol=1e-5, msg=f"Mask mismatch for case: {test_case}")
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_penalties_triton.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_penalties_triton.py
@@ -4,10 +4,11 @@
 # Requires NPU and Triton-Ascend.
 
 import gc
+
 import pytest
 import torch
-
 from vllm.v1.sample.ops.penalties import apply_all_penalties as v1_apply_all_penalties
+
 from vllm_ascend.sample.penalties import apply_all_penalties as ascend_apply_all_penalties
 
 # Same scenario grid as test_apply_penalties_model_executor (equivalence + boundaries).
@@ -30,14 +31,10 @@ def _make_tokens(
     device: str,
 ) -> torch.Tensor:
     if mode == "all_padding":
-        return torch.full(
-            (num_seqs, seq_len), vocab_size, device=device, dtype=torch.int64
-        )
+        return torch.full((num_seqs, seq_len), vocab_size, device=device, dtype=torch.int64)
     if seq_len == 0:
         return torch.empty((num_seqs, 0), device=device, dtype=torch.int64)
-    tokens = torch.randint(
-        0, vocab_size, (num_seqs, seq_len), device=device, dtype=torch.int64
-    )
+    tokens = torch.randint(0, vocab_size, (num_seqs, seq_len), device=device, dtype=torch.int64)
     pad_mask = torch.rand(num_seqs, seq_len, device=device) > 0.7
     tokens[pad_mask] = vocab_size
     return tokens
@@ -69,12 +66,8 @@ def test_apply_all_penalties_v1_vs_ascend(
     logits_v1 = torch.randn(num_seqs, vocab_size, device=device, dtype=dtype)
     logits_ascend = logits_v1.clone()
 
-    prompt_tokens = _make_tokens(
-        num_seqs, max_prompt_len, vocab_size, token_mode, device
-    )
-    output_tokens = _make_tokens(
-        num_seqs, max_output_len, vocab_size, token_mode, device
-    )
+    prompt_tokens = _make_tokens(num_seqs, max_prompt_len, vocab_size, token_mode, device)
+    output_tokens = _make_tokens(num_seqs, max_output_len, vocab_size, token_mode, device)
     output_token_ids = [row.tolist() for row in output_tokens.cpu()]
 
     presence_penalties = torch.rand(num_seqs, device=device, dtype=torch.float32) * 0.2
@@ -100,9 +93,7 @@ def test_apply_all_penalties_v1_vs_ascend(
 
     atol = 1e-2 if dtype == torch.bfloat16 else 1e-3
     rtol = 1e-2 if dtype == torch.bfloat16 else 1e-3
-    assert torch.allclose(
-        logits_ascend.float(), logits_v1.float(), atol=atol, rtol=rtol
-    ), (
+    assert torch.allclose(logits_ascend.float(), logits_v1.float(), atol=atol, rtol=rtol), (
         f"Max diff: {(logits_ascend.float() - logits_v1.float()).abs().max().item()}"
     )
     gc.collect()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bad_words.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bad_words.py
@@ -40,7 +40,7 @@ def create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req
                 break
             # Create a bad word with specific tokens
             bad_word = torch.tensor([100 + req_idx * 10 + bw_idx] * bad_word_length, dtype=torch.int32, device=device)
-            bad_word_token_ids[req_idx, offset:offset+bad_word_length] = bad_word
+            bad_word_token_ids[req_idx, offset : offset + bad_word_length] = bad_word
             bad_word_offsets[req_idx, bw_idx] = offset
             offset += bad_word_length
             actual_bad_words += 1
@@ -73,27 +73,35 @@ def create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req
     expanded_local_pos = torch.full((num_tokens,), bad_word_length - 1, dtype=torch.int32, device=device)
 
     return (
-        logits, expanded_idx_mapping, bad_word_token_ids, bad_word_offsets, num_bad_words,
-        all_token_ids, prompt_len, total_len, input_ids, expanded_local_pos
+        logits,
+        expanded_idx_mapping,
+        bad_word_token_ids,
+        bad_word_offsets,
+        num_bad_words,
+        all_token_ids,
+        prompt_len,
+        total_len,
+        input_ids,
+        expanded_local_pos,
     )
 
 
-@pytest.mark.parametrize("num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length", BAD_WORDS_TEST_CASES)
+@pytest.mark.parametrize(
+    "num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length", BAD_WORDS_TEST_CASES
+)
 @torch.inference_mode()
-def test_apply_bad_words_different_shapes(num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device="npu"):
+def test_apply_bad_words_different_shapes(
+    num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device="npu"
+):
     """Test apply_bad_words with different input shapes"""
-    test_data = create_test_data(
-        num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device
-    )
+    test_data = create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device)
 
     # Make a copy of logits to compare
     logits_before = test_data[0].clone()
     logits_after = test_data[0].clone()
 
     # Apply bad words
-    apply_bad_words(
-        logits_after, *test_data[1:], num_bad_words_per_req
-    )
+    apply_bad_words(logits_after, *test_data[1:], num_bad_words_per_req)
 
     # Verify that logits were modified
     assert not torch.allclose(logits_before, logits_after), "Logits should be modified when bad words are present"
@@ -109,18 +117,14 @@ def test_apply_bad_words_no_bad_words(device="npu"):
     num_bad_words_per_req = 0
     bad_word_length = 3
 
-    test_data = create_test_data(
-        num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device
-    )
+    test_data = create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device)
 
     # Make a copy of logits to compare
     logits_before = test_data[0].clone()
     logits_after = test_data[0].clone()
 
     # Apply bad words
-    apply_bad_words(
-        logits_after, *test_data[1:], num_bad_words_per_req
-    )
+    apply_bad_words(logits_after, *test_data[1:], num_bad_words_per_req)
 
     # Verify that logits were not modified
     assert torch.allclose(logits_before, logits_after), "Logits should not be modified when no bad words are present"
@@ -138,21 +142,19 @@ def test_apply_bad_words_edge_cases(device="npu"):
     bad_word_length = 2
 
     print("\nTesting edge case: maximum bad words")
-    test_data = create_test_data(
-        num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device
-    )
+    test_data = create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device)
 
     # Make a copy of logits to compare
     logits_before = test_data[0].clone()
     logits_after = test_data[0].clone()
 
     # Apply bad words
-    apply_bad_words(
-        logits_after, *test_data[1:], num_bad_words_per_req
-    )
+    apply_bad_words(logits_after, *test_data[1:], num_bad_words_per_req)
 
     # Verify that logits were modified
-    assert not torch.allclose(logits_before, logits_after), "Logits should be modified when maximum bad words are present"
+    assert not torch.allclose(logits_before, logits_after), (
+        "Logits should be modified when maximum bad words are present"
+    )
     print("Maximum bad words test passed")
 
 
@@ -168,21 +170,19 @@ def test_apply_bad_words_token_limit(device="npu"):
     num_bad_words_per_req = 32
     bad_word_length = 32  # 32 * 32 = 1024 tokens (exactly at limit)
 
-    test_data = create_test_data(
-        num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device
-    )
+    test_data = create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device)
 
     # Make a copy of logits to compare
     logits_before = test_data[0].clone()
     logits_after = test_data[0].clone()
 
     # Apply bad words
-    apply_bad_words(
-        logits_after, *test_data[1:], num_bad_words_per_req
-    )
+    apply_bad_words(logits_after, *test_data[1:], num_bad_words_per_req)
 
     # Verify that logits were modified
-    assert not torch.allclose(logits_before, logits_after), "Logits should be modified when total tokens are within limit"
+    assert not torch.allclose(logits_before, logits_after), (
+        "Logits should be modified when total tokens are within limit"
+    )
     print("Total tokens within limit test passed")
 
     # Test case 2: Total tokens exceeding limit (this should still work but only process up to limit)
@@ -190,18 +190,14 @@ def test_apply_bad_words_token_limit(device="npu"):
     num_bad_words_per_req = 33
     bad_word_length = 32  # 33 * 32 = 1056 tokens (exceeding limit)
 
-    test_data = create_test_data(
-        num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device
-    )
+    test_data = create_test_data(num_tokens, vocab_size, num_requests, num_bad_words_per_req, bad_word_length, device)
 
     # Make a copy of logits to compare
     logits_before = test_data[0].clone()
     logits_after = test_data[0].clone()
 
     # Apply bad words
-    apply_bad_words(
-        logits_after, *test_data[1:], num_bad_words_per_req
-    )
+    apply_bad_words(logits_after, *test_data[1:], num_bad_words_per_req)
 
     # Verify that logits were modified (even though we exceed the limit)
     assert not torch.allclose(logits_before, logits_after), "Logits should be modified when total tokens exceed limit"

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_memcpy.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_batch_memcpy.py
@@ -3,6 +3,7 @@ import torch
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_batch_memcpy(dtype):
     element_size = 2 if dtype == torch.bfloat16 else 4
@@ -15,15 +16,11 @@ def test_batch_memcpy(dtype):
     dst_tensors_list = []
     dst_addr_list = []
     for i in range(len(sizes)):
-        src_tensors_list.append(
-            torch.rand(sizes[i].item() // element_size, dtype=dtype, device=device)
-        )
+        src_tensors_list.append(torch.rand(sizes[i].item() // element_size, dtype=dtype, device=device))
         src_addr_list.append(src_tensors_list[-1].data_ptr())
-        dst_tensors_list.append(
-            torch.empty(sizes[i].item() // element_size, dtype=dtype, device=device)
-        )
+        dst_tensors_list.append(torch.empty(sizes[i].item() // element_size, dtype=dtype, device=device))
         dst_addr_list.append(dst_tensors_list[-1].data_ptr())
-    
+
     src_addr_list = torch.tensor(src_addr_list, dtype=torch.int64, device=device)
     dst_addr_list = torch.tensor(dst_addr_list, dtype=torch.int64, device=device)
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_bincount.py
@@ -1,7 +1,9 @@
-import torch
 import pytest
+import torch
 from vllm.triton_utils import triton
+
 from vllm_ascend.worker.v2.sample.penalties import _bincount_kernel
+
 
 def torch_bincount(
     expanded_idx_mapping: torch.Tensor,
@@ -10,7 +12,6 @@ def torch_bincount(
     prefill_len: torch.Tensor,
     prompt_bin_mask: torch.Tensor,
     output_bin_counts: torch.Tensor,
-
 ):
     req_indices = expanded_idx_mapping
     prompt_bin_mask[req_indices] = 0
@@ -28,7 +29,7 @@ def torch_bincount(
             token = tokens[pos].item()
             bin_idx = token // 32
             bit_idx = token % 32
-            prompt_bin_mask[req_idx, bin_idx] |= (1 << bit_idx)
+            prompt_bin_mask[req_idx, bin_idx] |= 1 << bit_idx
 
         for pos in range(p_len, pref_len):
             token = tokens[pos].item()
@@ -37,9 +38,9 @@ def torch_bincount(
 
 @pytest.mark.skip(reason="atomic_or operator hangs in current npu_ir version")
 def test_bincount_kernel():
-    '''
+    """
     Compute the prompt binary mask and token bincount using the Triton kernel.
-    
+
     Args:
         expanded_idx_mapping: Tensor containing the indices of requests to process.
         all_token_ids: Batch of input token IDs for all requests.
@@ -48,7 +49,7 @@ def test_bincount_kernel():
         prompt_bin_mask: Output binary mask tensor to mark prompt tokens.
         output_bin_counts: Output tensor to store token frequency counts.
         max_prefill_len: Maximum prefill length to limit kernel processing.
-    '''
+    """
 
     torch.manual_seed(42)
 
@@ -111,12 +112,14 @@ def test_bincount_kernel():
     )
 
     # ========== Verify results ==========
-    assert torch.equal(prompt_bin_mask, ref_prompt_bin_mask), \
-        f"prompt_bin_mask triton output differs from torch reference.\n" \
-        f"Max diff: {torch.max(torch.abs(prompt_bin_mask - ref_prompt_bin_mask))}\n" \
+    assert torch.equal(prompt_bin_mask, ref_prompt_bin_mask), (
+        f"prompt_bin_mask triton output differs from torch reference.\n"
+        f"Max diff: {torch.max(torch.abs(prompt_bin_mask - ref_prompt_bin_mask))}\n"
         f"Mean diff: {torch.mean(torch.abs(prompt_bin_mask - ref_prompt_bin_mask))}"
+    )
 
-    assert torch.equal(output_bin_counts, ref_output_bin_counts), \
-        f"output_bin_counts triton output differs from torch reference.\n" \
-        f"Max diff: {torch.max(torch.abs(output_bin_counts - ref_output_bin_counts))}\n" \
+    assert torch.equal(output_bin_counts, ref_output_bin_counts), (
+        f"output_bin_counts triton output differs from torch reference.\n"
+        f"Max diff: {torch.max(torch.abs(output_bin_counts - ref_output_bin_counts))}\n"
         f"Mean diff: {torch.mean(torch.abs(output_bin_counts - ref_output_bin_counts))}"
+    )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_causal_conv1d.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_causal_conv1d.py
@@ -1,48 +1,36 @@
-from typing import Optional
-
 import gc
+
 import pytest
 import torch
-import torch.nn.functional as F
 
-from vllm_ascend.ops.triton.mamba.causal_conv1d import (PAD_SLOT_ID,
-                                                        causal_conv1d_fn)
-from vllm_ascend.ops.triton.mamba.causal_conv1d import \
-    causal_conv1d_update_npu as causal_conv1d_update
-from vllm_ascend._310p.ops.causal_conv1d import (
-    causal_conv1d_fn as causal_conv1d_fn_ref,
-    causal_conv1d_update as causal_conv1d_update_ref
-)
+from vllm_ascend._310p.ops.causal_conv1d import causal_conv1d_fn as causal_conv1d_fn_ref
+from vllm_ascend._310p.ops.causal_conv1d import causal_conv1d_update as causal_conv1d_update_ref
+from vllm_ascend.ops.triton.mamba.causal_conv1d import PAD_SLOT_ID, causal_conv1d_fn
+from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_update_npu as causal_conv1d_update
 from vllm_ascend.utils import enable_custom_op
 
-def validate_cmp(y_cal, y_ref, dtype, device='npu'):
+
+def validate_cmp(y_cal, y_ref, dtype, device="npu"):
     y_cal = y_cal.to(device)
     y_ref = y_ref.to(device)
     if dtype == torch.float16:
-        torch.testing.assert_close(y_ref,
-                                   y_cal,
-                                   rtol=3e-03,
-                                   atol=1e-02,
-                                   equal_nan=True)
+        torch.testing.assert_close(y_ref, y_cal, rtol=3e-03, atol=1e-02, equal_nan=True)
     elif dtype == torch.bfloat16:
-        torch.testing.assert_close(y_ref,
-                                   y_cal,
-                                   rtol=1e-02,
-                                   atol=1e-02,
-                                   equal_nan=True)
+        torch.testing.assert_close(y_ref, y_cal, rtol=1e-02, atol=1e-02, equal_nan=True)
     elif dtype == torch.float32:
-        torch.testing.assert_close(y_ref,
-                                   y_cal,
-                                   rtol=1e-03,
-                                   atol=4e-03,
-                                   equal_nan=True)
-    elif dtype == torch.int32 or dtype == torch.int64 or dtype == torch.int16 or dtype == torch.int8 or dtype == torch.uint32:
-        assert torch.equal(y_cal, y_ref)
-    elif dtype == torch.bool:
+        torch.testing.assert_close(y_ref, y_cal, rtol=1e-03, atol=4e-03, equal_nan=True)
+    elif (
+        dtype == torch.int32
+        or dtype == torch.int64
+        or dtype == torch.int16
+        or dtype == torch.int8
+        or dtype == torch.uint32
+        or dtype == torch.bool
+    ):
         assert torch.equal(y_cal, y_ref)
     else:
-        raise ValueError(
-            'Invalid parameter \"dtype\" is found : {}'.format(dtype))
+        raise ValueError('Invalid parameter "dtype" is found : {}'.format(dtype))
+
 
 def to_int64_tuple(t):
     t = t.to(torch.int64)
@@ -50,17 +38,18 @@ def to_int64_tuple(t):
         return (t.item(),)
     return tuple(t.tolist())
 
-@pytest.mark.parametrize('has_initial_state', [False, True])
-@pytest.mark.parametrize('itype', [torch.bfloat16])
-@pytest.mark.parametrize('silu_activation', [True])
-@pytest.mark.parametrize('has_bias', [True])
-@pytest.mark.parametrize('seq_len', [[128, 1024, 2048, 4096]])
-@pytest.mark.parametrize('extra_state_len', [0, 2])
-@pytest.mark.parametrize('width', [4])
-@pytest.mark.parametrize('dim', [2048])
-def test_ascend_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
-                       silu_activation, itype, has_initial_state):
 
+@pytest.mark.parametrize("has_initial_state", [False, True])
+@pytest.mark.parametrize("itype", [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [True])
+@pytest.mark.parametrize("has_bias", [True])
+@pytest.mark.parametrize("seq_len", [[128, 1024, 2048, 4096]])
+@pytest.mark.parametrize("extra_state_len", [0, 2])
+@pytest.mark.parametrize("width", [4])
+@pytest.mark.parametrize("dim", [2048])
+def test_ascend_causal_conv1d(
+    dim, width, extra_state_len, seq_len, has_bias, silu_activation, itype, has_initial_state
+):
     torch.random.manual_seed(0)
     enable_custom_op()
     device = "npu"
@@ -68,31 +57,22 @@ def test_ascend_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
     state_len = width - 1 + extra_state_len
 
     x = torch.randn(cu_seqlen, dim, device=device, dtype=itype).transpose(0, 1)
-    weight = torch.randn(dim, width, device=device, dtype=itype)#
-    query_start_loc = torch.cumsum(torch.tensor([0] + seq_len,
-                                                device=device,
-                                                dtype=torch.int32),
-                                   dim=0).to(dtype=torch.int32)
+    weight = torch.randn(dim, width, device=device, dtype=itype)  #
+    query_start_loc = torch.cumsum(torch.tensor([0] + seq_len, device=device, dtype=torch.int32), dim=0).to(
+        dtype=torch.int32
+    )
     cache_indices = torch.arange(num_seq, device=device, dtype=torch.int32)
-    has_initial_state_tensor = torch.tensor([has_initial_state] * num_seq,
-                                            device=device,
-                                            dtype=torch.bool)
+    has_initial_state_tensor = torch.tensor([has_initial_state] * num_seq, device=device, dtype=torch.bool)
     activation = None if not silu_activation else "silu"
 
     if has_initial_state:
-        conv_states = torch.randn((num_seq, state_len, dim),
-                                  device=device,
-                                  dtype=itype).transpose(-1, -2)
-        conv_states_ref = torch.randn(
-            (num_seq, state_len, dim), device=device,
-            dtype=itype).transpose(-1, -2).copy_(conv_states)
+        conv_states = torch.randn((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2)
+        conv_states_ref = (
+            torch.randn((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2).copy_(conv_states)
+        )
     else:
-        conv_states = torch.zeros((num_seq, state_len, dim),
-                                  device=device,
-                                  dtype=itype).transpose(-1, -2)
-        conv_states_ref = torch.zeros((num_seq, state_len, dim),
-                                      device=device,
-                                      dtype=itype).transpose(-1, -2)
+        conv_states = torch.zeros((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2)
+        conv_states_ref = torch.zeros((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2)
 
     if has_bias:
         bias = torch.randn(dim, device=device, dtype=itype)
@@ -107,7 +87,8 @@ def test_ascend_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
         conv_states=conv_states_ref,
         has_initial_state=has_initial_state_tensor,
         cache_indices=cache_indices,
-        query_start_loc=query_start_loc)
+        query_start_loc=query_start_loc,
+    )
     # out = causal_conv1d_fn(x,
     #                        weight,
     #                        bias=bias,
@@ -116,42 +97,40 @@ def test_ascend_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
     #                        has_initial_state=has_initial_state_tensor,
     #                        cache_indices=cache_indices,
     #                        query_start_loc=query_start_loc)
-    x_origin=x.transpose(-1, -2)
-    weight_origin=weight.transpose(-1, -2)
-    conv_states_origin=conv_states.transpose(-1, -2)
+    x_origin = x.transpose(-1, -2)
+    weight_origin = weight.transpose(-1, -2)
+    conv_states_origin = conv_states.transpose(-1, -2)
     activation_num = 1 if activation else 0
     out = torch.ops._C_ascend.npu_causal_conv1d_custom(
-                    x_origin,
-                    weight_origin,
-                    conv_state=conv_states_origin,
-                    bias_opt=bias,
-                    query_start_loc_opt=to_int64_tuple(query_start_loc),
-                    cache_indices_opt=to_int64_tuple(cache_indices),
-                    initial_state_mode_opt=to_int64_tuple(has_initial_state_tensor),
-                    num_accepted_tokens_opt=[],
-                    activation_mode=activation_num,
-                    pad_slot_id=PAD_SLOT_ID,
-                    run_mode=0
-                ).transpose(-1, -2)
+        x_origin,
+        weight_origin,
+        conv_state=conv_states_origin,
+        bias_opt=bias,
+        query_start_loc_opt=to_int64_tuple(query_start_loc),
+        cache_indices_opt=to_int64_tuple(cache_indices),
+        initial_state_mode_opt=to_int64_tuple(has_initial_state_tensor),
+        num_accepted_tokens_opt=[],
+        activation_mode=activation_num,
+        pad_slot_id=PAD_SLOT_ID,
+        run_mode=0,
+    ).transpose(-1, -2)
     validate_cmp(out, out_ref, itype)
     validate_cmp(conv_states, conv_states_ref, itype)
 
 
-@pytest.mark.skip(    
+@pytest.mark.skip(
     reason="To use this tirton ops:causal_conv1d_fn, you need to set `get_forward_context`. After\
           the model side dumps the data, Zeng Tian has made the necessary fixes."
 )
-@pytest.mark.parametrize('has_initial_state', [False, True])
-@pytest.mark.parametrize('itype', [torch.bfloat16])
-@pytest.mark.parametrize('silu_activation', [True])
-@pytest.mark.parametrize('has_bias', [True])
-@pytest.mark.parametrize('seq_len', [[128, 1024, 2048, 4096]])
-@pytest.mark.parametrize('extra_state_len', [0, 2])
-@pytest.mark.parametrize('width', [2, 4])
-@pytest.mark.parametrize('dim', [4160])
-def test_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
-                       silu_activation, itype, has_initial_state):
-
+@pytest.mark.parametrize("has_initial_state", [False, True])
+@pytest.mark.parametrize("itype", [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [True])
+@pytest.mark.parametrize("has_bias", [True])
+@pytest.mark.parametrize("seq_len", [[128, 1024, 2048, 4096]])
+@pytest.mark.parametrize("extra_state_len", [0, 2])
+@pytest.mark.parametrize("width", [2, 4])
+@pytest.mark.parametrize("dim", [4160])
+def test_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias, silu_activation, itype, has_initial_state):
     torch.random.manual_seed(0)
 
     device = "npu"
@@ -160,30 +139,19 @@ def test_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
 
     x = torch.randn(cu_seqlen, dim, device=device, dtype=itype).transpose(0, 1)
     weight = torch.randn(dim, width, device=device, dtype=itype)
-    query_start_loc = torch.cumsum(torch.tensor([0] + seq_len,
-                                                device=device,
-                                                dtype=torch.int32),
-                                   dim=0)
+    query_start_loc = torch.cumsum(torch.tensor([0] + seq_len, device=device, dtype=torch.int32), dim=0)
     cache_indices = torch.arange(num_seq, device=device, dtype=torch.int32)
-    has_initial_state_tensor = torch.tensor([has_initial_state] * num_seq,
-                                            device=device,
-                                            dtype=torch.bool)
+    has_initial_state_tensor = torch.tensor([has_initial_state] * num_seq, device=device, dtype=torch.bool)
     activation = None if not silu_activation else "silu"
 
     if has_initial_state:
-        conv_states = torch.randn((num_seq, state_len, dim),
-                                  device=device,
-                                  dtype=itype).transpose(-1, -2)
-        conv_states_ref = torch.randn(
-            (num_seq, state_len, dim), device=device,
-            dtype=itype).transpose(-1, -2).copy_(conv_states)
+        conv_states = torch.randn((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2)
+        conv_states_ref = (
+            torch.randn((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2).copy_(conv_states)
+        )
     else:
-        conv_states = torch.zeros((num_seq, state_len, dim),
-                                  device=device,
-                                  dtype=itype).transpose(-1, -2)
-        conv_states_ref = torch.zeros((num_seq, state_len, dim),
-                                      device=device,
-                                      dtype=itype).transpose(-1, -2)
+        conv_states = torch.zeros((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2)
+        conv_states_ref = torch.zeros((num_seq, state_len, dim), device=device, dtype=itype).transpose(-1, -2)
 
     if has_bias:
         bias = torch.randn(dim, device=device, dtype=itype)
@@ -198,15 +166,18 @@ def test_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
         conv_states=conv_states_ref,
         has_initial_state=has_initial_state_tensor,
         cache_indices=cache_indices,
-        query_start_loc=query_start_loc)
-    out = causal_conv1d_fn(x,
-                           weight,
-                           bias=bias,
-                           activation=activation,
-                           conv_states=conv_states,
-                           has_initial_state=has_initial_state_tensor,
-                           cache_indices=cache_indices,
-                           query_start_loc=query_start_loc)
+        query_start_loc=query_start_loc,
+    )
+    out = causal_conv1d_fn(
+        x,
+        weight,
+        bias=bias,
+        activation=activation,
+        conv_states=conv_states,
+        has_initial_state=has_initial_state_tensor,
+        cache_indices=cache_indices,
+        query_start_loc=query_start_loc,
+    )
 
     validate_cmp(out, out_ref, itype)
     validate_cmp(conv_states, conv_states_ref, itype)
@@ -215,7 +186,7 @@ def test_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
     torch.npu.reset_peak_memory_stats()
 
 
-@pytest.mark.skip(    
+@pytest.mark.skip(
     reason="In this scenario, using tirton ops:causal_conv1d_update will cause an overflow. \
         Later, Zeng Tian was responsible for fixing this issue."
 )
@@ -228,9 +199,9 @@ def test_causal_conv1d(dim, width, extra_state_len, seq_len, has_bias,
 # tests correctness in case subset of the sequences are padded
 @pytest.mark.parametrize("with_padding", [True, False])
 @pytest.mark.parametrize("batch_size", [3, 64])
-def test_causal_conv1d_update_with_batch_gather(batch_size, with_padding, dim,
-                                                width, seqlen, has_bias,
-                                                silu_activation, itype):
+def test_causal_conv1d_update_with_batch_gather(
+    batch_size, with_padding, dim, width, seqlen, has_bias, silu_activation, itype
+):
     device = "npu"
     rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (3e-3, 5e-3)
     if itype == torch.bfloat16:
@@ -242,33 +213,24 @@ def test_causal_conv1d_update_with_batch_gather(batch_size, with_padding, dim,
     total_entries = 10 * batch_size
 
     # x will be (batch, dim, seqlen) with contiguous along dim-axis
-    x = torch.randn(padded_batch_size, seqlen, dim, device=device,
-                    dtype=itype).transpose(1, 2)
+    x = torch.randn(padded_batch_size, seqlen, dim, device=device, dtype=itype).transpose(1, 2)
 
     x_ref = x.clone()
 
-    conv_state_indices = torch.randperm(total_entries)[:batch_size].to(
-        dtype=torch.int32, device=device)
-    unused_states_bool = torch.ones(total_entries,
-                                    dtype=torch.bool,
-                                    device=device)
+    conv_state_indices = torch.randperm(total_entries)[:batch_size].to(dtype=torch.int32, device=device)
+    unused_states_bool = torch.ones(total_entries, dtype=torch.bool, device=device)
     unused_states_bool[conv_state_indices] = False
     padded_state_indices = torch.concat(
         [
             conv_state_indices,
-            torch.as_tensor(
-                [PAD_SLOT_ID] * padding, dtype=torch.int32, device=device),
+            torch.as_tensor([PAD_SLOT_ID] * padding, dtype=torch.int32, device=device),
         ],
         dim=0,
     )
 
     # conv_state will be (cache_lines, dim, state_len)
     # with contiguous along dim-axis
-    conv_state = torch.randn(total_entries,
-                             width - 1,
-                             dim,
-                             device=device,
-                             dtype=itype).transpose(1, 2)
+    conv_state = torch.randn(total_entries, width - 1, dim, device=device, dtype=itype).transpose(1, 2)
 
     conv_state_for_padding_test = conv_state.clone()
 
@@ -291,8 +253,7 @@ def test_causal_conv1d_update_with_batch_gather(batch_size, with_padding, dim,
     ).transpose(1, 2)
 
     assert torch.equal(conv_state[conv_state_indices, :], conv_state_ref)
-    assert torch.equal(conv_state[unused_states_bool],
-                       conv_state_for_padding_test[unused_states_bool])
+    assert torch.equal(conv_state[unused_states_bool], conv_state_for_padding_test[unused_states_bool])
     assert torch.allclose(out[:batch_size], out_ref, rtol=rtol, atol=atol)
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping.py
@@ -1,16 +1,13 @@
 import torch
-import pytest
-from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.block_table import _compute_slot_mappings_kernel as \
-    ref_compute_slot_mappings_kernel
-from vllm_ascend.worker.v2.block_table import _compute_slot_mappings_kernel as \
-    ascend_compute_slot_mappings_kernel
+from vllm.v1.worker.gpu.block_table import _compute_slot_mappings_kernel as ref_compute_slot_mappings_kernel
+
+from vllm_ascend.worker.v2.block_table import _compute_slot_mappings_kernel as ascend_compute_slot_mappings_kernel
+
 
 def test_compute_slot_mapping_npu_kernel():
-
     """
     Computes the physical slot IDs in KV cache for each token in the current batch.
-    This function maps the logical positions of tokens to their actual storage locations 
+    This function maps the logical positions of tokens to their actual storage locations
     in the block-managed KV cache, which is critical for efficient memory access in LLM inference.
 
     Input:
@@ -34,7 +31,6 @@ def test_compute_slot_mapping_npu_kernel():
         - slot_mappings (torch.Tensor): [num_kv_cache_groups, max_num_batched_tokens], int32 → Output slot ID tensor
     """
 
-
     torch.manual_seed(42)
 
     device = "npu" if torch.npu.is_available() else "cuda" if torch.cuda.is_available() else "cpu"
@@ -42,7 +38,7 @@ def test_compute_slot_mapping_npu_kernel():
     max_num_batched_tokens = 8192
     idx_mapping = torch.tensor([63], dtype=torch.int32, device=device)
     query_start_loc = torch.tensor([0, 5], dtype=torch.int32, device=device)
-    positions = torch.tensor([0,1,2,3,4,0,0,0], dtype=torch.int64, device=device)
+    positions = torch.tensor([0, 1, 2, 3, 4, 0, 0, 0], dtype=torch.int64, device=device)
 
     num_kv_cache_groups = 1
     max_num_reqs = 64
@@ -64,7 +60,7 @@ def test_compute_slot_mapping_npu_kernel():
     num_groups = num_kv_cache_groups
 
     try:
-        ascend_compute_slot_mappings_kernel[(num_groups, num_reqs+1)](
+        ascend_compute_slot_mappings_kernel[(num_groups, num_reqs + 1)](
             max_num_batched_tokens,
             idx_mapping,
             query_start_loc,
@@ -82,7 +78,7 @@ def test_compute_slot_mapping_npu_kernel():
             TOTAL_BLOCK_SIZE=4096,
         )
 
-        ref_compute_slot_mappings_kernel[(num_groups, num_reqs+1)](
+        ref_compute_slot_mappings_kernel[(num_groups, num_reqs + 1)](
             max_num_batched_tokens,
             idx_mapping,
             query_start_loc,
@@ -99,13 +95,15 @@ def test_compute_slot_mapping_npu_kernel():
             TRITON_BLOCK_SIZE=1024,  # type: ignore
         )
 
-         # ========== Verify results ==========
-        assert torch.equal(slot_mappings, ref_slot_mappings), \
-            f"ascend output differs from gpu reference.\n" \
-            f"Max diff: {torch.max(torch.abs(slot_mappings - ref_slot_mappings))}\n" \
+        # ========== Verify results ==========
+        assert torch.equal(slot_mappings, ref_slot_mappings), (
+            f"ascend output differs from gpu reference.\n"
+            f"Max diff: {torch.max(torch.abs(slot_mappings - ref_slot_mappings))}\n"
             f"Mean diff: {torch.mean(torch.abs(slot_mappings - ref_slot_mappings).float())}"
+        )
 
     except Exception as e:
-        print(f'Error during executionm: {e}')
+        print(f"Error during executionm: {e}")
         import traceback
+
         traceback.print_exc()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_token_logprobs.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_token_logprobs.py
@@ -1,8 +1,10 @@
 import random
-import torch
+
 import pytest
-from vllm.triton_utils import tl, triton
+import torch
+
 from vllm_ascend.worker.v2.sample.logprob import compute_token_logprobs
+
 
 def torch_compute_token_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
     """Pure PyTorch reference implementation of topk log softmax.
@@ -27,11 +29,12 @@ def torch_compute_token_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) 
 
     return result.to(torch.float32)
 
+
 # Common vocab sizes from mainstream models
 VOCAB_SIZES = [
-    32000,   # LLaMA / LLaMA2 / Mistral
-    50257,   # GPT-2
-    65024,   # ChatGLM
+    32000,  # LLaMA / LLaMA2 / Mistral
+    50257,  # GPT-2
+    65024,  # ChatGLM
     128256,  # LLaMA3
     151936,  # Qwen2
 ]
@@ -42,11 +45,7 @@ TOPK_VALUES = [1, 2, 5, 10, 32, 64]
 
 @pytest.mark.parametrize(
     "batch_size, vocab_size, topk",
-    [
-        (random.randint(1, 64), vocab_size, topk)
-        for vocab_size in VOCAB_SIZES
-        for topk in TOPK_VALUES
-    ],
+    [(random.randint(1, 64), vocab_size, topk) for vocab_size in VOCAB_SIZES for topk in TOPK_VALUES],
 )
 def test_topk_log_softmax_kernel(batch_size, vocab_size, topk):
     """
@@ -79,11 +78,12 @@ def test_topk_log_softmax_kernel(batch_size, vocab_size, topk):
     max_diff = torch.max(torch.abs(logprobs_triton - logprobs_ref)).item()
     mean_diff = torch.mean(torch.abs(logprobs_triton - logprobs_ref)).item()
 
-    assert torch.allclose(logprobs_triton, logprobs_ref, atol=1e-4, rtol=1e-5), \
-        f"Triton topk_log_softmax kernel output differs from torch reference.\n" \
-        f"batch_size={batch_size}, vocab_size={vocab_size}, topk={topk}\n" \
-        f"Max diff: {max_diff}\n" \
+    assert torch.allclose(logprobs_triton, logprobs_ref, atol=1e-4, rtol=1e-5), (
+        f"Triton topk_log_softmax kernel output differs from torch reference.\n"
+        f"batch_size={batch_size}, vocab_size={vocab_size}, topk={topk}\n"
+        f"Max diff: {max_diff}\n"
         f"Mean diff: {mean_diff}"
+    )
 
 
 @pytest.mark.parametrize("vocab_size", VOCAB_SIZES)
@@ -105,15 +105,16 @@ def test_topk_log_softmax_edge_cases(vocab_size):
     logprobs_triton = compute_token_logprobs(logits, token_ids)
     logprobs_ref = torch_compute_token_logprobs(logits, token_ids)
 
-    assert torch.allclose(logprobs_triton, logprobs_ref, atol=1e-4, rtol=1e-5), \
+    assert torch.allclose(logprobs_triton, logprobs_ref, atol=1e-4, rtol=1e-5), (
         f"Edge case (1,1) failed for vocab_size={vocab_size}"
+    )
 
     # Test case 2: Logits with extreme values
     logits_extreme = torch.randn((4, vocab_size), dtype=torch.float32, device=device)
-    logits_extreme[0, 0] = 100.0   # Very large positive
+    logits_extreme[0, 0] = 100.0  # Very large positive
     logits_extreme[1, 0] = -100.0  # Very large negative
-    logits_extreme[2, :] = 0.0     # All zeros
-    logits_extreme[3, :] = 1.0     # All ones
+    logits_extreme[2, :] = 0.0  # All zeros
+    logits_extreme[3, :] = 1.0  # All ones
 
     token_ids = torch.zeros((4, 5), dtype=torch.int64, device=device)
     token_ids[:, 0] = 0  # Include the extreme value position
@@ -123,8 +124,9 @@ def test_topk_log_softmax_edge_cases(vocab_size):
     logprobs_triton = compute_token_logprobs(logits_extreme, token_ids)
     logprobs_ref = torch_compute_token_logprobs(logits_extreme, token_ids)
 
-    assert torch.allclose(logprobs_triton, logprobs_ref, atol=1e-4, rtol=1e-5), \
+    assert torch.allclose(logprobs_triton, logprobs_ref, atol=1e-4, rtol=1e-5), (
         f"Extreme values test failed for vocab_size={vocab_size}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -158,8 +160,7 @@ def test_topk_log_softmax_deterministic(batch_size, vocab_size, topk):
         results.append(result.clone())
 
     for i in range(1, len(results)):
-        assert torch.equal(results[0], results[i]), \
-            f"Non-deterministic results detected in run {i}"
+        assert torch.equal(results[0], results[i]), f"Non-deterministic results detected in run {i}"
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
@@ -187,8 +188,8 @@ def test_topk_log_softmax_dtypes(dtype):
     # Use slightly larger tolerance for float16 due to precision loss
     atol = 1e-3 if dtype == torch.float16 else 1e-4
 
-    assert torch.allclose(logprobs_triton, logprobs_ref, atol=atol, rtol=1e-4), \
-        f"dtype {dtype} test failed"
+    assert torch.allclose(logprobs_triton, logprobs_ref, atol=atol, rtol=1e-4), f"dtype {dtype} test failed"
+
 
 if __name__ == "__main__":
     # Run a quick sanity check

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_topk_logprobs.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_topk_logprobs.py
@@ -1,17 +1,19 @@
-import torch
 import pytest
-from vllm_ascend.worker.v2.sample.logprob import compute_topk_logprobs
+import torch
+
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.worker.v2.sample.logprob import compute_topk_logprobs
 
 
-@pytest.mark.parametrize("batch_size,vocab_size,num_logprobs", [
-    (48, 102400, 5),
-    (96, 102400, 0),
-    (24, 151936, 1),
-    (1, 32000, 10),
-])
-
-
+@pytest.mark.parametrize(
+    "batch_size,vocab_size,num_logprobs",
+    [
+        (48, 102400, 5),
+        (96, 102400, 0),
+        (24, 151936, 1),
+        (1, 32000, 10),
+    ],
+)
 def test_compute_topk_logprobs(batch_size, vocab_size, num_logprobs):
     """Test compute_topk_logprobs for correctness of IDs, logprobs, and ranks.
     Args:
@@ -22,7 +24,7 @@ def test_compute_topk_logprobs(batch_size, vocab_size, num_logprobs):
     init_device_properties_triton()
     # ========== 1. Setup test data ==========
     torch.manual_seed(42)
-    device = 'npu'
+    device = "npu"
 
     logits = torch.randn(batch_size, vocab_size, device=device, dtype=torch.float32)
     sampled_token_ids = torch.randint(0, vocab_size, (batch_size,), device=device, dtype=torch.int64)
@@ -45,14 +47,15 @@ def test_compute_topk_logprobs(batch_size, vocab_size, num_logprobs):
     ref_ranks = (logits > sampled_logits).sum(dim=1).to(torch.int64)
 
     # ========== 4. Verify results ==========
-    assert torch.equal(triton_output.logprob_token_ids, ref_token_ids), \
+    assert torch.equal(triton_output.logprob_token_ids, ref_token_ids), (
         "Token IDs (Sampled + TopK) do not match between Triton and PyTorch."
+    )
 
-    assert torch.equal(triton_output.selected_token_ranks, ref_ranks), \
-        f"Token Ranks do not match.\n" \
-        f"Triton: {triton_output.selected_token_ranks}\n" \
-        f"PyTorch: {ref_ranks}"
+    assert torch.equal(triton_output.selected_token_ranks, ref_ranks), (
+        f"Token Ranks do not match.\nTriton: {triton_output.selected_token_ranks}\nPyTorch: {ref_ranks}"
+    )
 
-    assert torch.allclose(triton_output.logprobs, ref_logprobs, rtol=1e-4, atol=1e-4), \
-        f"Logprobs values differ between Triton and PyTorch.\n" \
+    assert torch.allclose(triton_output.logprobs, ref_logprobs, rtol=1e-4, atol=1e-4), (
+        f"Logprobs values differ between Triton and PyTorch.\n"
         f"Max diff: {torch.max(torch.abs(triton_output.logprobs - ref_logprobs))}"
+    )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py
@@ -1,50 +1,39 @@
 import gc
+
 import pytest
 import torch
 from einops import rearrange
 from vllm.model_executor.models.qwen3_next import Qwen3NextGatedDeltaNet
 
-from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import \
-    fused_qkvzba_split_reshape_cat
+from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 
 
-def validate_cmp(y_cal, y_ref, dtype, device='npu'):
+def validate_cmp(y_cal, y_ref, dtype, device="npu"):
     y_cal = y_cal.to(device)
     y_ref = y_ref.to(device)
-    if dtype == torch.float16:
-        torch.testing.assert_close(y_ref,
-                                   y_cal,
-                                   rtol=5e-03,
-                                   atol=5e-03,
-                                   equal_nan=True)
-    elif dtype == torch.bfloat16:
-        torch.testing.assert_close(y_ref,
-                                   y_cal,
-                                   rtol=5e-03,
-                                   atol=5e-03,
-                                   equal_nan=True)
+    if dtype == torch.float16 or dtype == torch.bfloat16:
+        torch.testing.assert_close(y_ref, y_cal, rtol=5e-03, atol=5e-03, equal_nan=True)
     elif dtype == torch.float32:
-        torch.testing.assert_close(y_ref,
-                                   y_cal,
-                                   rtol=1e-03,
-                                   atol=1e-03,
-                                   equal_nan=True)
-    elif dtype == torch.int32 or dtype == torch.int64 or dtype == torch.int16 or dtype == torch.int8 or dtype == torch.uint32:
-        assert torch.equal(y_cal, y_ref)
-    elif dtype == torch.bool:
+        torch.testing.assert_close(y_ref, y_cal, rtol=1e-03, atol=1e-03, equal_nan=True)
+    elif (
+        dtype == torch.int32
+        or dtype == torch.int64
+        or dtype == torch.int16
+        or dtype == torch.int8
+        or dtype == torch.uint32
+        or dtype == torch.bool
+    ):
         assert torch.equal(y_cal, y_ref)
     else:
-        raise ValueError(
-            'Invalid parameter \"dtype\" is found : {}'.format(dtype))
+        raise ValueError('Invalid parameter "dtype" is found : {}'.format(dtype))
 
 
-@pytest.mark.parametrize("seq_len", [1,  64, 1024, 2048])
+@pytest.mark.parametrize("seq_len", [1, 64, 1024, 2048])
 @pytest.mark.parametrize("num_heads_qk", [2, 4, 8])
 @pytest.mark.parametrize("num_heads_v", [8])
 @pytest.mark.parametrize("head_qk_dim", [256])
 @pytest.mark.parametrize("head_v_dim", [128])
-@pytest.mark.parametrize("dtype",
-                         [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_fused_qkvzba_split_reshape_cat(
     seq_len,
     num_heads_qk,
@@ -59,16 +48,11 @@ def test_fused_qkvzba_split_reshape_cat(
     torch.random.manual_seed(0)
     device = "npu"
 
-    projected_states_qkvz = torch.randn(seq_len,
-                                        2 * head_qk_dim * num_heads_qk +
-                                        2 * head_v_dim * num_heads_v,
-                                        dtype=dtype,
-                                        device=device)
+    projected_states_qkvz = torch.randn(
+        seq_len, 2 * head_qk_dim * num_heads_qk + 2 * head_v_dim * num_heads_v, dtype=dtype, device=device
+    )
 
-    projected_states_ba = torch.randn(seq_len,
-                                      2 * num_heads_v,
-                                      dtype=dtype,
-                                      device=device)
+    projected_states_ba = torch.randn(seq_len, 2 * num_heads_v, dtype=dtype, device=device)
 
     projected_states_qkvz_copy = projected_states_qkvz.clone()
     projected_states_ba_copy = projected_states_ba.clone()
@@ -90,9 +74,9 @@ def test_fused_qkvzba_split_reshape_cat(
     gdn.tp_size = 1
 
     query, key, value, z_ref, b_ref, a_ref = gdn.fix_query_key_value_ordering(
-        mixed_qkvz=projected_states_qkvz, mixed_ba=projected_states_ba)
-    query, key, value = map(lambda x: rearrange(x, 'l p d -> l (p d)'),
-                            (query, key, value))
+        mixed_qkvz=projected_states_qkvz, mixed_ba=projected_states_ba
+    )
+    query, key, value = map(lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value))
     mixed_qkv_ref = torch.cat((query, key, value), dim=-1)
 
     validate_cmp(mixed_qkv, mixed_qkv_ref, dtype)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_sigmoid_gating_delta_rule.py
@@ -1,30 +1,22 @@
 import gc
+
 import torch
 from vllm.model_executor.layers.fla.ops import fused_recurrent_gated_delta_rule
 from vllm.model_executor.models.qwen3_next import fused_gdn_gating
 
-from vllm_ascend.ops.triton.fla.sigmoid_gating import \
-    fused_sigmoid_gating_delta_rule_update
+from vllm_ascend.ops.triton.fla.sigmoid_gating import fused_sigmoid_gating_delta_rule_update
 
 
 def test_triton_fusion_ops():
     q = torch.randn(1, 1, 4, 128, dtype=torch.bfloat16).npu()
     k = torch.randn(1, 1, 4, 128, dtype=torch.bfloat16).npu()
     v = torch.randn(1, 1, 8, 128, dtype=torch.bfloat16).npu()
-    a = torch.tensor([[
-        -2.6094, -0.2617, -0.3848, 2.2656, 3.6250, -0.7383, -1.0938, -0.0505
-    ]]).bfloat16().npu()
-    b = torch.tensor(
-        [[0.4277, 0.8906, 1.6875, 2.3750, 4.1562, 0.3809, 1.0625,
-          3.6719]]).bfloat16().npu()
+    a = torch.tensor([[-2.6094, -0.2617, -0.3848, 2.2656, 3.6250, -0.7383, -1.0938, -0.0505]]).bfloat16().npu()
+    b = torch.tensor([[0.4277, 0.8906, 1.6875, 2.3750, 4.1562, 0.3809, 1.0625, 3.6719]]).bfloat16().npu()
     non_spec_state_indices_tensor = torch.tensor([2]).int().npu()
     non_spec_query_start_loc = torch.tensor([0, 1]).int().npu()
-    a_log = torch.tensor([
-        -2.6875, -3.2031, -3.3438, -2.7812, -3.0625, -4.0312, -5.3750, 5.7188
-    ]).bfloat16().npu()
-    dt_bias = torch.tensor(
-        [-4.7812, -5.0938, -5.5000, 9.4375, 7.6250, -4.3750, -3.0938,
-         0.9688]).bfloat16().npu()
+    a_log = torch.tensor([-2.6875, -3.2031, -3.3438, -2.7812, -3.0625, -4.0312, -5.3750, 5.7188]).bfloat16().npu()
+    dt_bias = torch.tensor([-4.7812, -5.0938, -5.5000, 9.4375, 7.6250, -4.3750, -3.0938, 0.9688]).bfloat16().npu()
     ssm_state1 = torch.ones(1, 8, 128, 128, dtype=torch.bfloat16).npu()
 
     core_attn_out_non_spec_fused = fused_sigmoid_gating_delta_rule_update(
@@ -47,24 +39,21 @@ def test_triton_fusion_ops():
     g, beta = fused_gdn_gating(a_log, a, b, dt_bias)
     g_non_spec = g
     beta_non_spec = beta
-    core_attn_out_non_spec_split, last_recurrent_state = (
-        fused_recurrent_gated_delta_rule(
-            q=q,
-            k=k,
-            v=v,
-            g=g_non_spec,
-            beta=beta_non_spec,
-            initial_state=ssm_state2,
-            inplace_final_state=True,
-            cu_seqlens=non_spec_query_start_loc,
-            ssm_state_indices=non_spec_state_indices_tensor,
-            use_qk_l2norm_in_kernel=True,
-        ))
-    torch.testing.assert_close(core_attn_out_non_spec_fused,
-                               core_attn_out_non_spec_split,
-                               rtol=1e-02,
-                               atol=1e-02,
-                               equal_nan=True)
+    core_attn_out_non_spec_split, last_recurrent_state = fused_recurrent_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g_non_spec,
+        beta=beta_non_spec,
+        initial_state=ssm_state2,
+        inplace_final_state=True,
+        cu_seqlens=non_spec_query_start_loc,
+        ssm_state_indices=non_spec_state_indices_tensor,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.testing.assert_close(
+        core_attn_out_non_spec_fused, core_attn_out_non_spec_split, rtol=1e-02, atol=1e-02, equal_nan=True
+    )
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_gdn_chunk_meta.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_gdn_chunk_meta.py
@@ -18,13 +18,13 @@ import gc
 import pytest
 import torch
 
-from vllm_ascend.ops.triton.gdn_chunk_meta import build_chunk_meta_device
 from vllm_ascend.ops.triton.fla.utils import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
     prepare_final_chunk_indices,
     prepare_update_chunk_offsets,
 )
+from vllm_ascend.ops.triton.gdn_chunk_meta import build_chunk_meta_device
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py
@@ -1,4 +1,5 @@
 import gc
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -8,7 +9,7 @@ from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'D', 'dtype'),
+    ("B", "T", "H", "D", "dtype"),
     [
         pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
         for test in [

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_log_softmax.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_log_softmax.py
@@ -1,14 +1,18 @@
-import torch
 import pytest
+import torch
 from vllm.triton_utils import triton
+
 from vllm_ascend.worker.v2.sample.logprob import _topk_log_softmax_kernel
 
 
-@pytest.mark.parametrize("batch_size,vocab_size,num_logprobs", [
-    (48, 102400, 50),
-    (96, 102400, 1),
-    (24, 151936, 8),
-])
+@pytest.mark.parametrize(
+    "batch_size,vocab_size,num_logprobs",
+    [
+        (48, 102400, 50),
+        (96, 102400, 1),
+        (24, 151936, 8),
+    ],
+)
 def test_topk_log_softmax_kernel(batch_size, vocab_size, num_logprobs):
     """Test _topk_log_softmax_kernel for computing log probabilities
     Args:
@@ -20,19 +24,14 @@ def test_topk_log_softmax_kernel(batch_size, vocab_size, num_logprobs):
     torch.manual_seed(42)
 
     # Generate random logits
-    logits = torch.randn(batch_size, vocab_size, device='npu', dtype=torch.float32)
+    logits = torch.randn(batch_size, vocab_size, device="npu", dtype=torch.float32)
 
     # Generate token_ids for which to compute logprobs
-    token_ids = torch.randint(0, vocab_size, (batch_size, num_logprobs), 
-                             device='npu', dtype=torch.int64)
+    token_ids = torch.randint(0, vocab_size, (batch_size, num_logprobs), device="npu", dtype=torch.int64)
 
     # ========== Execute test ==========
     # Prepare output tensor
-    triton_output = torch.empty(
-        batch_size, num_logprobs,
-        dtype=torch.float32,
-        device='npu'
-    )
+    triton_output = torch.empty(batch_size, num_logprobs, dtype=torch.float32, device="npu")
 
     # Invoke Triton kernel
     _topk_log_softmax_kernel[(batch_size,)](
@@ -58,7 +57,8 @@ def test_topk_log_softmax_kernel(batch_size, vocab_size, num_logprobs):
             ref_output[i, j] = torch_logprobs[i, token_id]
 
     # ========== Verify results ==========
-    assert torch.allclose(triton_output, ref_output, rtol=1e-3, atol=1e-3), \
-        f"Triton output differs from PyTorch reference.\n" \
-        f"Max diff: {torch.max(torch.abs(triton_output - ref_output))}\n" \
+    assert torch.allclose(triton_output, ref_output, rtol=1e-3, atol=1e-3), (
+        f"Triton output differs from PyTorch reference.\n"
+        f"Max diff: {torch.max(torch.abs(triton_output - ref_output))}\n"
         f"Mean diff: {torch.mean(torch.abs(triton_output - ref_output))}"
+    )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_min_p.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_min_p.py
@@ -1,7 +1,8 @@
-import torch
 import pytest
-from vllm_ascend.worker.v2.sample.min_p import apply_min_p
+import torch
+
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.worker.v2.sample.min_p import apply_min_p
 
 
 def torch_min_p_torch(
@@ -9,53 +10,54 @@ def torch_min_p_torch(
     expanded_idx_mapping: torch.Tensor,
     min_p: torch.Tensor,
 ):
-
     num_tokens, _ = logits.shape
     out = logits.clone()
-    
+
     for token_idx in range(num_tokens):
         req_state_idx = expanded_idx_mapping[token_idx].item()
-        
+
         min_p_val = min_p[req_state_idx].item()
         if min_p_val == 0.0:
             continue
-        
+
         token_logits = out[token_idx]
         max_val = token_logits.max()
         threshold = max_val + torch.log(torch.tensor(min_p_val, device=logits.device))
         token_logits = torch.where(token_logits < threshold, -torch.inf, token_logits)
         out[token_idx] = token_logits
-    
+
     return out
 
-@pytest.mark.parametrize("num_reqs,vocab_size", [
-    (48, 102400),
-    (96, 102400),
-    (24, 151936),
-    (1, 32000),
-])
 
+@pytest.mark.parametrize(
+    "num_reqs,vocab_size",
+    [
+        (48, 102400),
+        (96, 102400),
+        (24, 151936),
+        (1, 32000),
+    ],
+)
 def test_apply_min_p_kernel(num_reqs, vocab_size):
-
     """Test apply_min_p for computing Min-P sampling mask
     Args:
         num_reqs: Number of sequences in the batch
         vocab_size: Size of the vocabulary
     """
-    
+
     init_device_properties_triton()
     # ========== Setup test data ==========
     torch.manual_seed(42)
 
     # Generate random logits (using float32 as specified in your kernel)
-    device = 'npu'
+    device = "npu"
 
     original_logits = torch.randn(num_reqs, vocab_size, device=device, dtype=torch.float32)
 
     triton_logits = original_logits.clone()
     ref_logits = original_logits.clone()
 
-    expanded_idx_mapping = torch.arange(num_reqs-1, -1, -1, device=device, dtype=torch.int32)
+    expanded_idx_mapping = torch.arange(num_reqs - 1, -1, -1, device=device, dtype=torch.int32)
 
     # Generate random min_p values (valid range is typically (0, 1.0])
     min_p = torch.empty(num_reqs, device=device, dtype=torch.float32).uniform_(0.01, 0.5)
@@ -76,12 +78,14 @@ def test_apply_min_p_kernel(num_reqs, vocab_size):
     triton_inf_mask = torch.isinf(triton_logits)
     ref_inf_mask = torch.isinf(ref_logits)
 
-    assert torch.equal(triton_inf_mask, ref_inf_mask), \
+    assert torch.equal(triton_inf_mask, ref_inf_mask), (
         "Masked positions (where logits == -inf) do not match between Triton and PyTorch."
+    )
 
     valid_triton_logits = triton_logits[~triton_inf_mask]
     valid_ref_logits = ref_logits[~ref_inf_mask]
 
-    assert torch.allclose(valid_triton_logits, valid_ref_logits, rtol=1e-4, atol=1e-4), \
-        f"Logits values differ between Triton and PyTorch reference.\n" \
+    assert torch.allclose(valid_triton_logits, valid_ref_logits, rtol=1e-4, atol=1e-4), (
+        f"Logits values differ between Triton and PyTorch reference.\n"
         f"Max diff: {torch.max(torch.abs(valid_triton_logits - valid_ref_logits))}"
+    )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_mrope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_mrope.py
@@ -1,5 +1,4 @@
 import gc
-from typing import List
 
 import pytest
 import torch
@@ -20,10 +19,8 @@ DEFAULT_ATOL = 1e-3
 DEFAULT_RTOL = 1e-3
 
 
-def pytorch_forward_native(q, k, cos, sin, mrope_section, head_size,
-                           rotary_dim, mrope_interleaved):
-    """PyTorch-native implementation equivalent to forward().
-    """
+def pytorch_forward_native(q, k, cos, sin, mrope_section, head_size, rotary_dim, mrope_interleaved):
+    """PyTorch-native implementation equivalent to forward()."""
 
     num_tokens = q.shape[0]
     n_q_head = q.shape[1] // head_size
@@ -46,10 +43,8 @@ def pytorch_forward_native(q, k, cos, sin, mrope_section, head_size,
 
         if mrope_interleaved:
             cos_offsets = torch.arange(0, head_size // 2, device=q.device)
-            h_mask = (
-                (cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section[1])
-            w_mask = (
-                (cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section[2])
+            h_mask = ((cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section[1])
+            w_mask = ((cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section[2])
             t_mask = ~(h_mask | w_mask)
 
             cos_row[t_mask] = token_cos[t_mask, 0]
@@ -102,27 +97,12 @@ def pytorch_forward_native(q, k, cos, sin, mrope_section, head_size,
     return q_result, k_result
 
 
-def create_test_data(num_tokens, n_q_head, n_kv_head, rotary_dim, head_size,
-                     device, dtype):
-    q = torch.randn(num_tokens,
-                    n_q_head * head_size,
-                    dtype=dtype,
-                    device=device)
-    k = torch.randn(num_tokens,
-                    n_kv_head * head_size,
-                    dtype=dtype,
-                    device=device)
+def create_test_data(num_tokens, n_q_head, n_kv_head, rotary_dim, head_size, device, dtype):
+    q = torch.randn(num_tokens, n_q_head * head_size, dtype=dtype, device=device)
+    k = torch.randn(num_tokens, n_kv_head * head_size, dtype=dtype, device=device)
 
-    sin = torch.randn(3,
-                      num_tokens,
-                      rotary_dim // 2,
-                      dtype=dtype,
-                      device=device)
-    cos = torch.randn(3,
-                      num_tokens,
-                      rotary_dim // 2,
-                      dtype=dtype,
-                      device=device)
+    sin = torch.randn(3, num_tokens, rotary_dim // 2, dtype=dtype, device=device)
+    cos = torch.randn(3, num_tokens, rotary_dim // 2, dtype=dtype, device=device)
 
     norm = torch.sqrt(cos**2 + sin**2)
     cos = cos / norm
@@ -142,7 +122,7 @@ def create_test_data(num_tokens, n_q_head, n_kv_head, rotary_dim, head_size,
 @pytest.mark.parametrize("device", DEVICES)
 @torch.inference_mode()
 def test_mrotary_embedding_triton_kernel(
-    mrope_section: List[int],
+    mrope_section: list[int],
     num_tokens: int,
     num_q_heads: int,
     num_k_heads: int,
@@ -158,36 +138,29 @@ def test_mrotary_embedding_triton_kernel(
     if rotary_dim == -1:
         rotary_dim = head_size
 
-    q_trt, k_trt, cos, sin = create_test_data(num_tokens=num_tokens,
-                                              n_q_head=num_q_heads,
-                                              n_kv_head=num_k_heads,
-                                              head_size=head_size,
-                                              rotary_dim=rotary_dim,
-                                              device=device,
-                                              dtype=dtype)
+    q_trt, k_trt, cos, sin = create_test_data(
+        num_tokens=num_tokens,
+        n_q_head=num_q_heads,
+        n_kv_head=num_k_heads,
+        head_size=head_size,
+        rotary_dim=rotary_dim,
+        device=device,
+        dtype=dtype,
+    )
 
     q_gold, k_gold = q_trt.clone(), k_trt.clone()
 
-    q_trt, k_trt = triton_mrope(q_trt, k_trt, cos, sin, mrope_section,
-                                head_size, rotary_dim, True)
+    q_trt, k_trt = triton_mrope(q_trt, k_trt, cos, sin, mrope_section, head_size, rotary_dim, True)
 
-    q_gold, k_gold = pytorch_forward_native(q_gold, k_gold, cos, sin,
-                                            mrope_section, head_size,
-                                            rotary_dim, True)
+    q_gold, k_gold = pytorch_forward_native(q_gold, k_gold, cos, sin, mrope_section, head_size, rotary_dim, True)
     atol = DEFAULT_ATOL
     rtol = DEFAULT_RTOL
     if dtype == torch.bfloat16:
         atol = 1e-02
         rtol = 1e-02
     # Compare the results.
-    torch.testing.assert_close(q_trt.view(q_gold.size()),
-                               q_gold,
-                               atol=atol,
-                               rtol=rtol)
-    torch.testing.assert_close(k_trt.view(k_gold.size()),
-                               k_gold,
-                               atol=atol,
-                               rtol=rtol)
+    torch.testing.assert_close(q_trt.view(q_gold.size()), q_gold, atol=atol, rtol=rtol)
+    torch.testing.assert_close(k_trt.view(k_gold.size()), k_gold, atol=atol, rtol=rtol)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_muls_add.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_muls_add.py
@@ -31,4 +31,3 @@ def test_muls_add_triton_correctness(shape, dtype, scale):
     assert out_triton.shape == out_ref.shape
     assert out_triton.dtype == out_ref.dtype
     assert torch.allclose(out_triton, out_ref, rtol=rtol, atol=atol)
-

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_penality.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_penality.py
@@ -1,4 +1,5 @@
 import gc
+
 import pytest
 import torch
 
@@ -39,10 +40,7 @@ def pytorch_apply_penalties(
     num_status = prompt_bin_mask.shape[0]
     num_packed = prompt_bin_mask.shape[1]
 
-    prompt_masks_unpacked = torch.zeros(
-        num_status, vocab_size, dtype=torch.bool,
-        device=device
-    )
+    prompt_masks_unpacked = torch.zeros(num_status, vocab_size, dtype=torch.bool, device=device)
 
     for state_idx in range(num_status):
         for packed_idx in range(num_packed):
@@ -56,7 +54,7 @@ def pytorch_apply_penalties(
 
     for token_idx in range(num_tokens):
         req_state_idx = idx_mapping[token_idx].item()
-        
+
         rep_penalty = repetition_penalty[req_state_idx].item()
         freq_penalty = frequency_penalty[req_state_idx].item()
         pres_penalty = presence_penalty[req_state_idx].item()
@@ -71,17 +69,17 @@ def pytorch_apply_penalties(
 
         current_prompt_mask = prompt_masks_unpacked[req_state_idx]
         base_output_counts = output_bin_counts[req_state_idx]
-        
+
         # Compute cumulative draft counts
         pos = expanded_local_pos[token_idx].item()
         start_idx_in_batch = token_idx - pos
         draft_counts = torch.zeros(vocab_size, device=device, dtype=torch.int32)
-        
+
         for prev_pos in range(num_speculative_tokens):
             if prev_pos < pos:
                 prev_token = token_ids[start_idx_in_batch + prev_pos + 1].item()
                 draft_counts[prev_token] += 1
-        
+
         # Total counts = base output counts + cumulative draft counts
         total_output_counts = base_output_counts + draft_counts
         output_bin_mask = total_output_counts > 0
@@ -133,20 +131,15 @@ def create_test_data(
         if torch.rand(1) > 0.5:
             presence_penalty[i] = torch.rand(1, device=device).item() * 0.2
 
-    idx_mapping = torch.randint(
-        0, num_status, (num_tokens,), device=device,
-        dtype=torch.int32
-    )
-    
+    idx_mapping = torch.randint(0, num_status, (num_tokens,), device=device, dtype=torch.int32)
+
     # Create token_ids for speculative decoding
     token_ids = torch.randint(0, vocab_size, (num_tokens,), device=device, dtype=torch.int32)
-    
+
     # Create expanded_local_pos (position within speculative decoding window)
     expanded_local_pos = torch.zeros(num_tokens, device=device, dtype=torch.int32)
     for i in range(num_tokens):
-        expanded_local_pos[i] = torch.randint(
-            0, num_speculative_tokens + 1, (1,)
-        ).item()
+        expanded_local_pos[i] = torch.randint(0, num_speculative_tokens + 1, (1,)).item()
 
     num_packed = (vocab_size + 31) // 32
     prompt_bin_mask = torch.zeros(num_status, num_packed, device=device, dtype=torch.int32)
@@ -158,13 +151,12 @@ def create_test_data(
         for token_id in prompt_tokens:
             packed_idx = token_id // 32
             bit_pos = token_id % 32
-            prompt_bin_mask[state_idx, packed_idx] |= (1 << bit_pos)
+            prompt_bin_mask[state_idx, packed_idx] |= 1 << bit_pos
 
     output_bin_counts = torch.zeros(num_status, vocab_size, device=device, dtype=torch.int32)
     for state_idx in range(num_status):
         num_output_tokens = max(1, vocab_size // 20)
-        output_tokens = torch.randint(0, vocab_size,
-                                      (num_output_tokens, ))
+        output_tokens = torch.randint(0, vocab_size, (num_output_tokens,))
         counts = torch.randint(1, 10, (num_output_tokens,))
 
         for token, count in zip(output_tokens, counts):
@@ -183,7 +175,8 @@ def create_test_data(
         num_speculative_tokens,
     )
 
-@pytest.mark.skip(    
+
+@pytest.mark.skip(
     reason="The test case failed and took one hour. Yang Cheng \
         has been notified to fix it after the holiday."
 )
@@ -195,15 +188,7 @@ def create_test_data(
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
 @torch.inference_mode()
-def test_apply_penalties(
-    num_tokens,
-    vocab_size,
-    num_status,
-    num_speculative_tokens,
-    dtype,
-    seed,
-    device
-):
+def test_apply_penalties(num_tokens, vocab_size, num_status, num_speculative_tokens, dtype, seed, device):
     (
         logits_triton,
         idx_mapping,
@@ -222,7 +207,7 @@ def test_apply_penalties(
         num_speculative_tokens=num_speculative_tokens,
         device=device,
         dtype=dtype,
-        seed=seed
+        seed=seed,
     )
 
     logits_pytorch = logits_triton.clone()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_post_update.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_post_update.py
@@ -1,18 +1,19 @@
-from typing import Dict, Any
+from typing import Any
 
-import torch
 import pytest
+import torch
 from vllm.v1.worker.gpu.input_batch import post_update as post_update_gpu
+
 from vllm_ascend.worker.v2.input_batch import post_update as post_update_npu
 
 
-def generate_test_data(num_reqs: int, max_num_reqs: int, vocab_size: int, num_speculative_steps: int, device: str) -> \
-        Dict[str, Any]:
+def generate_test_data(
+    num_reqs: int, max_num_reqs: int, vocab_size: int, num_speculative_steps: int, device: str
+) -> dict[str, Any]:
     """
     Generate random test data.
     Return a dictionary containing all input tensors and the additional field 'expected_query_lens' for validation.
     """
-    num_cols = num_speculative_steps + 1
 
     if num_reqs > max_num_reqs:
         raise ValueError("num_reqs cannot be larger than max_num_reqs")
@@ -21,17 +22,17 @@ def generate_test_data(num_reqs: int, max_num_reqs: int, vocab_size: int, num_sp
     num_computed_tokens = torch.randint(0, 100, (max_num_reqs,), dtype=torch.int32, device=device)
     last_sampled_tokens = torch.randint(0, vocab_size, (max_num_reqs,), dtype=torch.int32, device=device)
     output_bin_counts = torch.randint(0, 10, (max_num_reqs, vocab_size), dtype=torch.int32, device=device)
-    sampled_tokens = torch.randint(0, vocab_size, (num_reqs, num_speculative_steps + 1), dtype=torch.int32,
-                                   device=device)
+    sampled_tokens = torch.randint(
+        0, vocab_size, (num_reqs, num_speculative_steps + 1), dtype=torch.int32, device=device
+    )
     num_sampled = torch.randint(1, num_speculative_steps + 2, (num_reqs,), dtype=torch.int32, device=device)
     num_rejected = torch.randint(0, num_speculative_steps + 1, (num_reqs,), dtype=torch.int32, device=device)
     num_rejected = torch.min(num_rejected, num_sampled - 1)
 
     query_lengths = torch.randint(1, 20, (num_reqs,), dtype=torch.int32, device=device)
-    query_start_loc = torch.cat([
-        torch.tensor([0], dtype=torch.int32, device=device),
-        torch.cumsum(query_lengths, dim=0)
-    ])
+    query_start_loc = torch.cat(
+        [torch.tensor([0], dtype=torch.int32, device=device), torch.cumsum(query_lengths, dim=0)]
+    )
     total_len = torch.randint(50, 200, (max_num_reqs,), dtype=torch.int32, device=device)
 
     max_model_len = 3000  # 或者可以从total_len的最大值获取
@@ -47,15 +48,18 @@ def generate_test_data(num_reqs: int, max_num_reqs: int, vocab_size: int, num_sp
         "num_rejected": num_rejected,
         "query_start_loc": query_start_loc,
         "all_token_ids": all_token_ids,
-        "total_len": total_len
+        "total_len": total_len,
     }
 
 
-@pytest.mark.parametrize("num_reqs,max_num_reqs,vocab_size,num_speculative_steps", [
-    (36, 36, 200, 2),
-    (48, 48, 32000, 5),
-    (128, 128, 32000, 5),
-])
+@pytest.mark.parametrize(
+    "num_reqs,max_num_reqs,vocab_size,num_speculative_steps",
+    [
+        (36, 36, 200, 2),
+        (48, 48, 32000, 5),
+        (128, 128, 32000, 5),
+    ],
+)
 def test_post_update(num_reqs: int, max_num_reqs: int, vocab_size: int, num_speculative_steps: int):
     """Test _topk_log_softmax_kernel for computing log probabilities
     Args:
@@ -65,17 +69,18 @@ def test_post_update(num_reqs: int, max_num_reqs: int, vocab_size: int, num_spec
     """
     torch.manual_seed(42)
 
-    post_update_params = ["idx_mapping",
-                          "num_computed_tokens",
-                          "last_sampled_tokens",
-                          "output_bin_counts",
-                          "sampled_tokens",
-                          "num_sampled",
-                          "num_rejected",
-                          "query_start_loc",
-                          "all_token_ids",
-                          "total_len"
-                          ]
+    post_update_params = [
+        "idx_mapping",
+        "num_computed_tokens",
+        "last_sampled_tokens",
+        "output_bin_counts",
+        "sampled_tokens",
+        "num_sampled",
+        "num_rejected",
+        "query_start_loc",
+        "all_token_ids",
+        "total_len",
+    ]
 
     data = generate_test_data(num_reqs, max_num_reqs, vocab_size, num_speculative_steps, device="npu")
     kernel_inputs_gpu = {k: data[k].clone() for k in post_update_params}
@@ -89,9 +94,12 @@ def test_post_update(num_reqs: int, max_num_reqs: int, vocab_size: int, num_spec
     torch.npu.synchronize()
 
     # ========== Verify results ==========
-    assert torch.allclose(kernel_inputs_gpu["output_bin_counts"], kernel_inputs_npu["output_bin_counts"], rtol=1e-3,
-                          atol=1e-3), \
-        f"Triton output differs from PyTorch reference.\n" \
-        f"Max diff: {torch.max(torch.abs(kernel_inputs_npu['output_bin_counts'] - kernel_inputs_npu['output_bin_counts']))}\n" \
-        f"Mean diff: {torch.mean(torch.abs(kernel_inputs_npu['output_bin_counts'] - kernel_inputs_npu['output_bin_counts']))}"
-
+    assert torch.allclose(
+        kernel_inputs_gpu["output_bin_counts"], kernel_inputs_npu["output_bin_counts"], rtol=1e-3, atol=1e-3
+    ), (
+        f"Triton output differs from PyTorch reference.\n"
+        f"Max diff: "
+        f"{torch.max(torch.abs(kernel_inputs_gpu['output_bin_counts'] - kernel_inputs_npu['output_bin_counts']))}\n"
+        f"Mean diff: "
+        f"{torch.mean(torch.abs(kernel_inputs_gpu['output_bin_counts'] - kernel_inputs_npu['output_bin_counts']))}"
+    )

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py
@@ -1,14 +1,12 @@
 import gc
+
 import pytest
 import torch
 from vllm.triton_utils import triton
 
-from vllm_ascend.ops.triton.spec_decode.utils import \
-    prepare_inputs_padded_kernel
-from vllm_ascend.ops.triton.triton_utils import (get_vectorcore_num,
-                                                 init_device_properties_triton)
-from vllm_ascend.spec_decode.eagle_proposer import \
-    _PREPARE_INPUTS_BLOCK_SIZE as BLOCK_SIZE
+from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
+from vllm_ascend.spec_decode.eagle_proposer import _PREPARE_INPUTS_BLOCK_SIZE as BLOCK_SIZE
 
 
 def prepare_inputs_padded_ref(
@@ -16,10 +14,12 @@ def prepare_inputs_padded_ref(
     valid_sampled_tokens_count,
     query_start_loc,
 ):
-    num_draft_tokens = torch.cat([
-        cu_num_draft_tokens[0:1],
-        cu_num_draft_tokens[1:] - cu_num_draft_tokens[:-1],
-    ])
+    num_draft_tokens = torch.cat(
+        [
+            cu_num_draft_tokens[0:1],
+            cu_num_draft_tokens[1:] - cu_num_draft_tokens[:-1],
+        ]
+    )
 
     num_rejected_tokens = torch.where(
         num_draft_tokens > 0,
@@ -38,28 +38,20 @@ def test_prepare_inputs_padded(num_reqs):
     device = "npu"
     torch.manual_seed(0)
 
-    draft_lens = torch.randint(1,
-                               6, (num_reqs, ),
-                               device=device,
-                               dtype=torch.int32)
+    draft_lens = torch.randint(1, 6, (num_reqs,), device=device, dtype=torch.int32)
 
     cu_num_draft_tokens = torch.cumsum(draft_lens, dim=0).to(torch.int32)
 
     valid_sampled_tokens_count = torch.zeros_like(draft_lens)
     for i in range(num_reqs):
-        valid_sampled_tokens_count[i] = torch.randint(0, draft_lens[i] + 2,
-                                                      (1, )).item()
+        valid_sampled_tokens_count[i] = torch.randint(0, draft_lens[i] + 2, (1,)).item()
 
     seq_lens = draft_lens + 1
-    query_start_loc = torch.zeros(num_reqs + 1,
-                                  device=device,
-                                  dtype=torch.int32)
+    query_start_loc = torch.zeros(num_reqs + 1, device=device, dtype=torch.int32)
     query_start_loc[1:] = torch.cumsum(seq_lens, dim=0)
 
     # Run PyTorch reference
-    out_ref = prepare_inputs_padded_ref(cu_num_draft_tokens,
-                                        valid_sampled_tokens_count,
-                                        query_start_loc)
+    out_ref = prepare_inputs_padded_ref(cu_num_draft_tokens, valid_sampled_tokens_count, query_start_loc)
 
     # Run Triton kernel
     out_tri = torch.empty(num_reqs, dtype=torch.int32, device=device)
@@ -67,7 +59,7 @@ def test_prepare_inputs_padded(num_reqs):
     num_blocks_needed = triton.cdiv(num_reqs, BLOCK_SIZE)
     num_vector_core = get_vectorcore_num()
     grid_size = min(num_blocks_needed, num_vector_core)
-    grid = (grid_size, )
+    grid = (grid_size,)
 
     prepare_inputs_padded_kernel[grid](
         cu_num_draft_tokens,

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -1,15 +1,16 @@
 import gc
+
 import pytest
 import torch
-from vllm.v1.sample.rejection_sampler import \
-    rejection_random_sample_kernel as original_rejection_random_sample_kernel
+from vllm.v1.sample.rejection_sampler import rejection_random_sample_kernel as original_rejection_random_sample_kernel
 
 from vllm_ascend.ops.triton.reject_sample import (
-    cal_grid_and_block_size, rejection_random_sample_block_verify_kernel,
-    rejection_random_sample_kernel)
+    cal_grid_and_block_size,
+    rejection_random_sample_block_verify_kernel,
+    rejection_random_sample_kernel,
+)
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
-from vllm_ascend.sample.rejection_sampler import \
-    rejection_random_sample_block_verify_pytorch
+from vllm_ascend.sample.rejection_sampler import rejection_random_sample_block_verify_pytorch
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -23,50 +24,25 @@ def setup_device_properties():
 @pytest.mark.parametrize("batch_size", [1, 8, 32, 64, 128, 256, 512, 1024])
 @torch.inference_mode()
 def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
-    device = 'npu'
+    device = "npu"
     torch.manual_seed(0)
-    draft_probs = torch.rand(batch_size * max_spec_len,
-                             vocab_size,
-                             dtype=torch.float32,
-                             device=device)
-    target_probs = torch.rand(batch_size * max_spec_len,
-                              vocab_size,
-                              dtype=torch.float32,
-                              device=device)
-    bonus_token_ids = torch.randint(low=0,
-                                    high=vocab_size,
-                                    size=(batch_size, 1),
-                                    dtype=torch.int64,
-                                    device=device)
-    draft_token_ids = torch.randint(low=0,
-                                    high=vocab_size,
-                                    size=(batch_size * max_spec_len, ),
-                                    dtype=torch.int64,
-                                    device=device)
-    output_token_ids = torch.empty((batch_size, max_spec_len + 1),
-                                   dtype=torch.int64,
-                                   device=device)
+    draft_probs = torch.rand(batch_size * max_spec_len, vocab_size, dtype=torch.float32, device=device)
+    target_probs = torch.rand(batch_size * max_spec_len, vocab_size, dtype=torch.float32, device=device)
+    bonus_token_ids = torch.randint(low=0, high=vocab_size, size=(batch_size, 1), dtype=torch.int64, device=device)
+    draft_token_ids = torch.randint(
+        low=0, high=vocab_size, size=(batch_size * max_spec_len,), dtype=torch.int64, device=device
+    )
+    output_token_ids = torch.empty((batch_size, max_spec_len + 1), dtype=torch.int64, device=device)
     original_output_token_ids = output_token_ids.clone()
     num_tokens = draft_token_ids.shape[0]
-    uniform_probs = torch.rand((num_tokens, ),
-                               dtype=torch.float32,
-                               device=device)
+    uniform_probs = torch.rand((num_tokens,), dtype=torch.float32, device=device)
     num_draft_tokens = [max_spec_len] * batch_size
-    num_draft_tokens = torch.tensor(num_draft_tokens,
-                                    dtype=torch.int32,
-                                    device=device)
-    cu_num_draft_tokens = torch.cumsum(num_draft_tokens,
-                                       dim=0,
-                                       dtype=torch.int32)
-    is_greedy_ptr = torch.full((batch_size, ),
-                               False,
-                               dtype=torch.bool,
-                               device=device)
-    recovered_ids = torch.zeros_like(draft_token_ids,
-                                     dtype=torch.int64,
-                                     device=device)
+    num_draft_tokens = torch.tensor(num_draft_tokens, dtype=torch.int32, device=device)
+    cu_num_draft_tokens = torch.cumsum(num_draft_tokens, dim=0, dtype=torch.int32)
+    is_greedy_ptr = torch.full((batch_size,), False, dtype=torch.bool, device=device)
+    recovered_ids = torch.zeros_like(draft_token_ids, dtype=torch.int64, device=device)
     grid, block_size = cal_grid_and_block_size(batch_size)
-    original_rejection_random_sample_kernel[(batch_size, )](
+    original_rejection_random_sample_kernel[(batch_size,)](
         original_output_token_ids,
         cu_num_draft_tokens,
         draft_token_ids,
@@ -80,37 +56,35 @@ def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
         vocab_size,
         NO_DRAFT_PROBS=draft_probs is None,
     )
-    rejection_random_sample_kernel[(grid, )](output_token_ids,
-                                             cu_num_draft_tokens,
-                                             draft_token_ids,
-                                             draft_probs,
-                                             target_probs,
-                                             bonus_token_ids,
-                                             recovered_ids,
-                                             uniform_probs,
-                                             is_greedy_ptr,
-                                             max_spec_len,
-                                             vocab_size,
-                                             batch_size,
-                                             NO_DRAFT_PROBS=draft_probs
-                                             is None,
-                                             BLOCK_SIZE=block_size)
+    rejection_random_sample_kernel[(grid,)](
+        output_token_ids,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        bonus_token_ids,
+        recovered_ids,
+        uniform_probs,
+        is_greedy_ptr,
+        max_spec_len,
+        vocab_size,
+        batch_size,
+        NO_DRAFT_PROBS=draft_probs is None,
+        BLOCK_SIZE=block_size,
+    )
     torch.npu.synchronize()
     assert torch.equal(original_output_token_ids, output_token_ids)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
 
+
 DEVICE = "npu"
 BATCH_SIZE = 7
 MAX_SPEC_LEN = 3
 VOCAB_SIZE = 5
-CU_NUM_DRAFT_TOKENS = torch.tensor([2, 2, 5, 8, 11, 14, 15],
-                                   dtype=torch.int32,
-                                   device=DEVICE)
-DRAFT_TOKEN_IDS = torch.tensor([0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0],
-                               dtype=torch.int64,
-                               device=DEVICE)
+CU_NUM_DRAFT_TOKENS = torch.tensor([2, 2, 5, 8, 11, 14, 15], dtype=torch.int32, device=DEVICE)
+DRAFT_TOKEN_IDS = torch.tensor([0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0], dtype=torch.int64, device=DEVICE)
 NUM_TOKENS = DRAFT_TOKEN_IDS.shape[0]
 DRAFT_PROBS = None
 TARGET_PROBS = torch.tensor(
@@ -132,34 +106,31 @@ TARGET_PROBS = torch.tensor(
         [0.4, 0.1, 0.3, 0.1, 0.1],  # 1
     ],
     dtype=torch.float32,
-    device=DEVICE)
-UNIFORM_PROBS = torch.tensor([
-    0.9,
-    0.0,
-    0.9,
-    0.7,
-    0.8,
-    0.5,
-    0.45,
-    1.0,
-    0.5,
-    0.45,
-    1.0,
-    0.39,
-    0.4,
-    0.1,
-    0.3,
-],
-                             dtype=torch.float32,
-                             device=DEVICE)
-BONUS_TOKEN_IDS = torch.full((BATCH_SIZE, ),
-                             MAX_SPEC_LEN + 1,
-                             dtype=torch.int64,
-                             device=DEVICE)
-RECOVERED_TOKEN_IDS = torch.full((NUM_TOKENS, ),
-                                 MAX_SPEC_LEN,
-                                 dtype=torch.int64,
-                                 device=DEVICE)
+    device=DEVICE,
+)
+UNIFORM_PROBS = torch.tensor(
+    [
+        0.9,
+        0.0,
+        0.9,
+        0.7,
+        0.8,
+        0.5,
+        0.45,
+        1.0,
+        0.5,
+        0.45,
+        1.0,
+        0.39,
+        0.4,
+        0.1,
+        0.3,
+    ],
+    dtype=torch.float32,
+    device=DEVICE,
+)
+BONUS_TOKEN_IDS = torch.full((BATCH_SIZE,), MAX_SPEC_LEN + 1, dtype=torch.int64, device=DEVICE)
+RECOVERED_TOKEN_IDS = torch.full((NUM_TOKENS,), MAX_SPEC_LEN, dtype=torch.int64, device=DEVICE)
 IS_GREEDY = torch.zeros(BATCH_SIZE, dtype=torch.bool, device=DEVICE)
 IS_GREEDY[4] = True
 
@@ -177,25 +148,21 @@ IS_GREEDY[4] = True
 @pytest.mark.parametrize("vocab_size", [VOCAB_SIZE])
 @torch.inference_mode()
 def test_rejection_sampler_block_verify_triton_kernel(
-        cu_num_draft_tokens,  # [batch_size]
-        draft_token_ids,  # [num_tokens]
-        draft_probs,  # [num_tokens, vocab_size] or None
-        target_probs,  # [num_tokens, vocab_size]
-        bonus_token_ids,  # [batch_size]
-        recovered_token_ids,  # [num_tokens]
-        uniform_probs,  # [num_tokens]
-        is_greedy,  # [batch_size]
-        batch_size,  # int
-        max_spec_len,  # int
-        vocab_size,  # int
+    cu_num_draft_tokens,  # [batch_size]
+    draft_token_ids,  # [num_tokens]
+    draft_probs,  # [num_tokens, vocab_size] or None
+    target_probs,  # [num_tokens, vocab_size]
+    bonus_token_ids,  # [batch_size]
+    recovered_token_ids,  # [num_tokens]
+    uniform_probs,  # [num_tokens]
+    is_greedy,  # [batch_size]
+    batch_size,  # int
+    max_spec_len,  # int
+    vocab_size,  # int
 ) -> None:
-
     grid, block_size = cal_grid_and_block_size(batch_size)
 
-    output_token_ids_ref = torch.full((batch_size, max_spec_len + 1),
-                                      -1,
-                                      dtype=torch.int64,
-                                      device=DEVICE)
+    output_token_ids_ref = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=DEVICE)
 
     output_token_ids_triton = output_token_ids_ref.clone()
 
@@ -211,9 +178,10 @@ def test_rejection_sampler_block_verify_triton_kernel(
         is_greedy=is_greedy,
         max_spec_len=max_spec_len,
         vocab_size=vocab_size,
-        IS_NGRAM=draft_probs is None)
+        IS_NGRAM=draft_probs is None,
+    )
 
-    rejection_random_sample_block_verify_kernel[(grid, )](
+    rejection_random_sample_block_verify_kernel[(grid,)](
         output_token_ids_ptr=output_token_ids_triton,
         cu_num_draft_tokens_ptr=cu_num_draft_tokens,
         draft_token_ids_ptr=draft_token_ids,
@@ -227,7 +195,8 @@ def test_rejection_sampler_block_verify_triton_kernel(
         vocab_size=vocab_size,
         vec_len=batch_size,
         NO_DRAFT_PROBS=draft_probs is None,
-        BLOCK_SIZE=block_size)
+        BLOCK_SIZE=block_size,
+    )
     torch.npu.synchronize()
     assert torch.equal(output_token_ids_ref, output_token_ids_triton)
     gc.collect()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
@@ -38,8 +38,8 @@ DEFAULT_RTOL = 1e-3
 
 
 def rotate_neox(x: torch.Tensor) -> torch.Tensor:
-    x1 = x[..., :x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2:]
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
     return torch.cat((-x2, x1), dim=-1)
 
 
@@ -50,9 +50,7 @@ def rotate_gptj(x: torch.Tensor) -> torch.Tensor:
     return x.flatten(-2)
 
 
-def _rope_pytorch_native(
-        query, key, cos, sin, rope_dim,
-        is_neox_style) -> tuple[torch.Tensor, torch.Tensor | None]:
+def _rope_pytorch_native(query, key, cos, sin, rope_dim, is_neox_style) -> tuple[torch.Tensor, torch.Tensor | None]:
     """PyTorch-native implementation equivalent to forward()."""
     assert key is not None
     orig_dtype = query.dtype
@@ -82,9 +80,8 @@ def _rope_pytorch_native(
         key = key_rot.to(orig_dtype)
     return query, key
 
-def _rope_siso_pytorch_native(
-        query, cos, sin, rope_dim,
-        is_neox_style) -> tuple[torch.Tensor, torch.Tensor | None]:
+
+def _rope_siso_pytorch_native(query, cos, sin, rope_dim, is_neox_style) -> tuple[torch.Tensor, torch.Tensor | None]:
     """PyTorch-native implementation equivalent to forward()."""
     assert query is not None
     orig_dtype = query.dtype
@@ -134,53 +131,20 @@ def test_rotary_embedding_triton_kernel(
     init_device_properties_triton()
     sin = torch.randn(num_tokens, rotary_dim // 2, dtype=dtype, device=device)
     cos = torch.randn(num_tokens, rotary_dim // 2, dtype=dtype, device=device)
-    q_trt = torch.randn(num_tokens,
-                        num_q_heads,
-                        head_size,
-                        dtype=dtype,
-                        device=device)
-    k_trt = torch.randn(num_tokens,
-                        num_k_heads,
-                        head_size,
-                        dtype=dtype,
-                        device=device)
-    q_gold = torch.randn(num_tokens,
-                         num_q_heads,
-                         head_size,
-                         dtype=dtype,
-                         device=device)
-    k_gold = torch.randn(num_tokens,
-                         num_k_heads,
-                         head_size,
-                         dtype=dtype,
-                         device=device)
+    q_trt = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)
+    k_trt = torch.randn(num_tokens, num_k_heads, head_size, dtype=dtype, device=device)
+    q_gold = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)
+    k_gold = torch.randn(num_tokens, num_k_heads, head_size, dtype=dtype, device=device)
     q_trt.copy_(q_gold)
     k_trt.copy_(k_gold)
-    q_trt, k_trt = rope_forward_triton(q_trt,
-                                       k_trt,
-                                       cos,
-                                       sin,
-                                       rope_dim=rotary_dim,
-                                       is_neox_style=is_neox_style)
-    q_gold, k_gold = _rope_pytorch_native(q_gold,
-                                          k_gold,
-                                          cos,
-                                          sin,
-                                          rope_dim=rotary_dim,
-                                          is_neox_style=is_neox_style)
+    q_trt, k_trt = rope_forward_triton(q_trt, k_trt, cos, sin, rope_dim=rotary_dim, is_neox_style=is_neox_style)
+    q_gold, k_gold = _rope_pytorch_native(q_gold, k_gold, cos, sin, rope_dim=rotary_dim, is_neox_style=is_neox_style)
     # Compare the results.
-    torch.testing.assert_close(q_trt.view(q_gold.size()),
-                               q_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
-    torch.testing.assert_close(k_trt.view(k_gold.size()),
-                               k_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(q_trt.view(q_gold.size()), q_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(k_trt.view(k_gold.size()), k_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
-
 
 
 @pytest.mark.parametrize("max_position_embeddings", MAX_POSITION_EMBEDDINGS)
@@ -209,50 +173,20 @@ def test_rotary_embedding_triton_kernel_with_cos_sin_cache(
     init_device_properties_triton()
     cos_sin_cache = torch.randn(max_position_embeddings, rotary_dim, dtype=dtype, device=device)
     positions = torch.randint(low=0, high=max_position_embeddings, size=(num_tokens,), dtype=torch.int64, device=device)
-    q_trt = torch.randn(num_tokens,
-                        num_q_heads,
-                        head_size,
-                        dtype=dtype,
-                        device=device)
-    k_trt = torch.randn(num_tokens,
-                        num_k_heads,
-                        head_size,
-                        dtype=dtype,
-                        device=device)
-    q_gold = torch.randn(num_tokens,
-                         num_q_heads,
-                         head_size,
-                         dtype=dtype,
-                         device=device)
-    k_gold = torch.randn(num_tokens,
-                         num_k_heads,
-                         head_size,
-                         dtype=dtype,
-                         device=device)
+    q_trt = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)
+    k_trt = torch.randn(num_tokens, num_k_heads, head_size, dtype=dtype, device=device)
+    q_gold = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)
+    k_gold = torch.randn(num_tokens, num_k_heads, head_size, dtype=dtype, device=device)
     q_trt.copy_(q_gold)
     k_trt.copy_(k_gold)
-    q_trt, k_trt = rope_forward_triton(q_trt,
-                                       k_trt,
-                                       cos_sin_cache=cos_sin_cache,
-                                       positions=positions,
-                                       rope_dim=rotary_dim,
-                                       is_neox_style=is_neox_style)
+    q_trt, k_trt = rope_forward_triton(
+        q_trt, k_trt, cos_sin_cache=cos_sin_cache, positions=positions, rope_dim=rotary_dim, is_neox_style=is_neox_style
+    )
     cos, sin = cos_sin_cache.index_select(0, positions).chunk(2, dim=-1)
-    q_gold, k_gold = _rope_pytorch_native(q_gold,
-                                          k_gold,
-                                          cos,
-                                          sin,
-                                          rope_dim=rotary_dim,
-                                          is_neox_style=is_neox_style)
+    q_gold, k_gold = _rope_pytorch_native(q_gold, k_gold, cos, sin, rope_dim=rotary_dim, is_neox_style=is_neox_style)
     # Compare the results.
-    torch.testing.assert_close(q_trt.view(q_gold.size()),
-                               q_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
-    torch.testing.assert_close(k_trt.view(k_gold.size()),
-                               k_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(q_trt.view(q_gold.size()), q_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(k_trt.view(k_gold.size()), k_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
@@ -284,32 +218,13 @@ def test_rotary_embedding_triton_kernel_siso(
         rotary_dim = head_size
     sin = torch.randn(num_tokens, rotary_dim // 2, dtype=dtype, device=device)
     cos = torch.randn(num_tokens, rotary_dim // 2, dtype=dtype, device=device)
-    q_trt = torch.randn(num_tokens,
-                        num_q_heads,
-                        head_size,
-                        dtype=dtype,
-                        device=device)
-    q_gold = torch.randn(num_tokens,
-                         num_q_heads,
-                         head_size,
-                         dtype=dtype,
-                         device=device)
+    q_trt = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)
+    q_gold = torch.randn(num_tokens, num_q_heads, head_size, dtype=dtype, device=device)
     q_trt.copy_(q_gold)
-    q_trt = rope_forward_triton_siso(q_trt,
-                                       cos,
-                                       sin,
-                                       rope_dim=rotary_dim,
-                                       is_neox_style=is_neox_style)
-    q_gold = _rope_siso_pytorch_native(q_gold,
-                                          cos,
-                                          sin,
-                                          rope_dim=rotary_dim,
-                                          is_neox_style=is_neox_style)
+    q_trt = rope_forward_triton_siso(q_trt, cos, sin, rope_dim=rotary_dim, is_neox_style=is_neox_style)
+    q_gold = _rope_siso_pytorch_native(q_gold, cos, sin, rope_dim=rotary_dim, is_neox_style=is_neox_style)
     # Compare the results.
-    torch.testing.assert_close(q_trt.view(q_gold.size()),
-                               q_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(q_trt.view(q_gold.size()), q_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
@@ -29,18 +29,18 @@ def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.T
     return x_t
 
 
-def rms_norm(x: torch.Tensor,
-            norm_weight: torch.Tensor,
-            eps,
-            norm_bias=None,
+def rms_norm(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps,
+    norm_bias=None,
 ):
     x = x.cpu()
     norm_weight = norm_weight.cpu()
 
     x = x.to(torch.float32)
     norm_weight = norm_weight.to(torch.float32).cpu()
-    reciprocal_std = 1 / torch.sqrt(
-        torch.mean(x ** 2, axis=-1, keepdims=True) + eps)
+    reciprocal_std = 1 / torch.sqrt(torch.mean(x**2, axis=-1, keepdims=True) + eps)
     out = x * reciprocal_std * norm_weight
 
     if norm_bias is not None:
@@ -51,19 +51,19 @@ def rms_norm(x: torch.Tensor,
 
 
 def naive_split_qkv_rmsnorm_mrope(
-        qkv: torch.Tensor,
-        q_weight: torch.Tensor,
-        q_bias: torch.Tensor,
-        k_weight: torch.Tensor,
-        k_bias: torch.Tensor,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        num_q_heads: int,
-        num_kv_heads: int,
-        head_size: int,
-        eps: float,
-        mrope_section: list[int],
-        rope_dim: int,
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    q_bias: torch.Tensor,
+    k_weight: torch.Tensor,
+    k_bias: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    eps: float,
+    mrope_section: list[int],
+    rope_dim: int,
 ):
     q_size = num_q_heads * head_size
     kv_size = num_kv_heads * head_size
@@ -141,19 +141,19 @@ def naive_split_qkv_rmsnorm_mrope(
 
 
 def naive_split_qkv_rmsnorm_mrope_interleaved(
-        qkv: torch.Tensor,
-        q_weight: torch.Tensor,
-        q_bias: torch.Tensor,
-        k_weight: torch.Tensor,
-        k_bias: torch.Tensor,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        num_q_heads: int,
-        num_kv_heads: int,
-        head_size: int,
-        eps: float,
-        mrope_section: list[int],
-        rope_dim: int,
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    q_bias: torch.Tensor,
+    k_weight: torch.Tensor,
+    k_bias: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    eps: float,
+    mrope_section: list[int],
+    rope_dim: int,
 ):
     q_size = num_q_heads * head_size
     kv_size = num_kv_heads * head_size
@@ -183,7 +183,7 @@ def naive_split_qkv_rmsnorm_mrope_interleaved(
 
         q_token = q_reshaped[token_idx]
         k_token = k_reshaped[token_idx]
-        
+
         q1 = q_token[:, :half_rd]
         q2 = q_token[:, half_rd:rotary_dim]
         k1 = k_token[:, :half_rd]
@@ -233,7 +233,6 @@ def test_split_qkv_rmsnorm_mrope(
     is_interleaved: bool,
     has_gate: bool,
 ):
-
     torch.set_default_device(device)
     init_device_properties_triton()
     rope_dim = 2 * sum(mrope_section)
@@ -242,101 +241,86 @@ def test_split_qkv_rmsnorm_mrope(
 
     # input tensor
     if has_gate:
-        qkv = torch.randn(num_tokens,
-                          2 * q_size + kv_size * 2,
-                          dtype=dtype,
-                          device=device)
+        qkv = torch.randn(num_tokens, 2 * q_size + kv_size * 2, dtype=dtype, device=device)
     else:
-        qkv = torch.randn(num_tokens,
-                          q_size + kv_size * 2,
-                          dtype=dtype,
-                          device=device)
+        qkv = torch.randn(num_tokens, q_size + kv_size * 2, dtype=dtype, device=device)
     q_weight = torch.randn(head_size, dtype=dtype, device=device)
     k_weight = torch.randn(head_size, dtype=dtype, device=device)
     q_bias = None
     k_bias = None
 
-    cos_sin = torch.randn(3, num_tokens, rope_dim, dtype=dtype,
-                          device=device)
+    cos_sin = torch.randn(3, num_tokens, rope_dim, dtype=dtype, device=device)
     cos, sin = cos_sin.chunk(2, dim=-1)
-    
+
     cos = cos.contiguous()
     sin = sin.contiguous()
 
     if has_gate:
-        q_gate_data = qkv[:, :q_size * 2].view(-1, num_q_heads, head_size * 2)
+        q_gate_data = qkv[:, : q_size * 2].view(-1, num_q_heads, head_size * 2)
         q_data, golden_gate = torch.chunk(q_gate_data, 2, dim=-1)
         golden_gate = golden_gate.reshape(-1, q_size)
         q_data = q_data.reshape(-1, q_size)
-        k_data = qkv[:, 2 * q_size:2 * q_size + kv_size]
-        v_data = qkv[:, 2 * q_size + kv_size:]
+        k_data = qkv[:, 2 * q_size : 2 * q_size + kv_size]
+        v_data = qkv[:, 2 * q_size + kv_size :]
         qkv_for_ref = torch.cat([q_data, k_data, v_data], dim=-1)
     else:
         qkv_for_ref = qkv
 
     if is_interleaved:
-        golden_q, golden_k, golden_v = naive_split_qkv_rmsnorm_mrope_interleaved(qkv_for_ref.cpu(),
-                                                                 q_weight.cpu(),
-                                                                 q_bias,
-                                                                 k_weight.cpu(),
-                                                                 k_bias,
-                                                                 cos.cpu(),
-                                                                 sin.cpu(),
-                                                                 num_q_heads,
-                                                                 num_kv_heads,
-                                                                 head_size,
-                                                                 eps,
-                                                                 mrope_section,
-                                                                 rope_dim)
+        golden_q, golden_k, golden_v = naive_split_qkv_rmsnorm_mrope_interleaved(
+            qkv_for_ref.cpu(),
+            q_weight.cpu(),
+            q_bias,
+            k_weight.cpu(),
+            k_bias,
+            cos.cpu(),
+            sin.cpu(),
+            num_q_heads,
+            num_kv_heads,
+            head_size,
+            eps,
+            mrope_section,
+            rope_dim,
+        )
     else:
-        golden_q, golden_k, golden_v = naive_split_qkv_rmsnorm_mrope(qkv_for_ref.cpu(),
-                                                                    q_weight.cpu(),
-                                                                    q_bias,
-                                                                    k_weight.cpu(),
-                                                                    k_bias,
-                                                                    cos.cpu(),
-                                                                    sin.cpu(),
-                                                                    num_q_heads,
-                                                                    num_kv_heads,
-                                                                    head_size,
-                                                                    eps,
-                                                                    mrope_section,
-                                                                    rope_dim)
+        golden_q, golden_k, golden_v = naive_split_qkv_rmsnorm_mrope(
+            qkv_for_ref.cpu(),
+            q_weight.cpu(),
+            q_bias,
+            k_weight.cpu(),
+            k_bias,
+            cos.cpu(),
+            sin.cpu(),
+            num_q_heads,
+            num_kv_heads,
+            head_size,
+            eps,
+            mrope_section,
+            rope_dim,
+        )
 
     real_q, real_k, real_v, real_gate = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
-            qkv=qkv,
-            q_weight=q_weight,
-            k_weight=k_weight,
-            cos_sin=cos_sin,
-            num_q_heads=num_q_heads,
-            num_kv_heads=num_kv_heads,
-            head_size=head_size,
-            eps=eps,
-            mrope_section=mrope_section,
-            is_interleaved=is_interleaved,
-            rope_dim=rope_dim,
-            has_gate=has_gate,
+        qkv=qkv,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        cos_sin=cos_sin,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        eps=eps,
+        mrope_section=mrope_section,
+        is_interleaved=is_interleaved,
+        rope_dim=rope_dim,
+        has_gate=has_gate,
     )
 
-    torch.testing.assert_close(real_q.cpu(),
-                               golden_q.cpu(),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(real_q.cpu(), golden_q.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
-    torch.testing.assert_close(real_k.cpu(),
-                               golden_k.cpu(),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(real_k.cpu(), golden_k.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
-    torch.testing.assert_close(real_v.cpu(),
-                               golden_v.cpu(),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(real_v.cpu(), golden_v.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     if has_gate:
-        torch.testing.assert_close(real_gate.cpu(),
-                                golden_gate.cpu(),
-                                atol=DEFAULT_ATOL,
-                                rtol=DEFAULT_RTOL)
+        torch.testing.assert_close(real_gate.cpu(), golden_gate.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py
@@ -29,16 +29,16 @@ def custom_rope(q, k, sin, cos):
     q_pass = q[..., rotary_dim:]
     k_pass = k[..., rotary_dim:]
 
-    x1 = q_rot[..., :rotary_dim // 2]
-    x2 = q_rot[..., rotary_dim // 2:]
+    x1 = q_rot[..., : rotary_dim // 2]
+    x2 = q_rot[..., rotary_dim // 2 :]
     cat_x = torch.cat([-x2, x1], axis=-1)
     mul1 = cat_x * sin
     mul2 = q_rot * cos
     q_rot = mul1 + mul2
     res1 = torch.cat([q_rot, q_pass], dim=-1)
 
-    x1 = k_rot[..., :rotary_dim // 2]
-    x2 = k_rot[..., rotary_dim // 2:]
+    x1 = k_rot[..., : rotary_dim // 2]
+    x2 = k_rot[..., rotary_dim // 2 :]
     cat_x = torch.cat([-x2, x1], axis=-1)
     mul1 = cat_x * sin
     mul2 = k_rot * cos
@@ -55,8 +55,7 @@ def rms_norm(
 ):
     input = input.to(torch.float32)
     norm_weight = norm_weight.to(torch.float32)
-    reciprocal_std = 1 / torch.sqrt(
-        torch.mean(input**2, axis=-1, keepdims=True) + eps)
+    reciprocal_std = 1 / torch.sqrt(torch.mean(input**2, axis=-1, keepdims=True) + eps)
     out = input * reciprocal_std * norm_weight
     if norm_bias is not None:
         norm_bias = norm_bias.to(torch.float32)
@@ -74,42 +73,39 @@ def rms_norm(
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("rope_dim", ROPE_DIMS)
 @torch.inference_mode()
-def test_split_qkv_rmsnorm_rope(max_position_embeddings, num_tokens, num_q_heads, num_kv_heads,
-                                head_size, eps, dtype, seed, device, rope_dim):
+def test_split_qkv_rmsnorm_rope(
+    max_position_embeddings, num_tokens, num_q_heads, num_kv_heads, head_size, eps, dtype, seed, device, rope_dim
+):
     torch.manual_seed(seed)
     torch.set_default_device(device)
     init_device_properties_triton()
 
     q_hidden_size = num_q_heads * head_size
     kv_hidden_size = num_kv_heads * head_size
-    qkv = torch.randn(num_tokens,
-                      q_hidden_size + kv_hidden_size * 2,
-                      dtype=dtype,
-                      device=device)
+    qkv = torch.randn(num_tokens, q_hidden_size + kv_hidden_size * 2, dtype=dtype, device=device)
     q_weight = torch.randn(head_size, dtype=dtype, device=device)
     k_weight = torch.randn(head_size, dtype=dtype, device=device)
-    cos_sin_cache = torch.from_numpy(
-        np.random.uniform(0, 1,
-                          [max_position_embeddings, rope_dim])).to(dtype).npu()
+    cos_sin_cache = torch.from_numpy(np.random.uniform(0, 1, [max_position_embeddings, rope_dim])).to(dtype).npu()
     positions = torch.randint(low=0, high=max_position_embeddings, size=(num_tokens,), dtype=torch.int64, device=device)
     # fused kernel
-    q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(input=qkv,
-                                              q_weight=q_weight,
-                                              k_weight=k_weight,
-                                              q_hidden_size=q_hidden_size,
-                                              kv_hidden_size=kv_hidden_size,
-                                              head_dim=head_size,
-                                              eps=eps,
-                                              cos_sin_cache=cos_sin_cache,
-                                              positions=positions)
-    
+    q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(
+        input=qkv,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        q_hidden_size=q_hidden_size,
+        kv_hidden_size=kv_hidden_size,
+        head_dim=head_size,
+        eps=eps,
+        cos_sin_cache=cos_sin_cache,
+        positions=positions,
+    )
+
     cos, sin = cos_sin_cache.index_select(0, positions).view(num_tokens, 2, -1).repeat(1, 1, 2).chunk(2, dim=-2)
     cos = cos.unsqueeze(1)
     sin = sin.unsqueeze(1)
 
     # split
-    _q, _k, v_gold = qkv.cpu().split(
-        [q_hidden_size, kv_hidden_size, kv_hidden_size], dim=-1)
+    _q, _k, v_gold = qkv.cpu().split([q_hidden_size, kv_hidden_size, kv_hidden_size], dim=-1)
     # norm
     _q = rms_norm(_q.reshape(-1, head_size), q_weight.cpu(), eps)
     _k = rms_norm(_k.reshape(-1, head_size), k_weight.cpu(), eps)
@@ -122,20 +118,13 @@ def test_split_qkv_rmsnorm_rope(max_position_embeddings, num_tokens, num_q_heads
     k_gold = k_gold.reshape(num_tokens, -1)
 
     # Compare the results.
-    torch.testing.assert_close(q.to(torch.float32).cpu(),
-                               q_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(q.to(torch.float32).cpu(), q_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
-    torch.testing.assert_close(k.to(torch.float32).cpu(),
-                               k_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(k.to(torch.float32).cpu(), k_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
-    torch.testing.assert_close(v.to(torch.float32).cpu(),
-                               v_gold.to(torch.float32),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(
+        v.to(torch.float32).cpu(), v_gold.to(torch.float32), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL
+    )
 
     gc.collect()
     torch.npu.empty_cache()
@@ -152,56 +141,46 @@ def test_split_qkv_rmsnorm_rope(max_position_embeddings, num_tokens, num_q_heads
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("rope_dim", ROPE_DIMS)
 @torch.inference_mode()
-def test_split_qkv_rmsnorm_rope_with_bias(max_position_embeddings, num_tokens, num_q_heads,
-                                          num_kv_heads, head_size, eps, dtype,
-                                          seed, device, rope_dim):
+def test_split_qkv_rmsnorm_rope_with_bias(
+    max_position_embeddings, num_tokens, num_q_heads, num_kv_heads, head_size, eps, dtype, seed, device, rope_dim
+):
     torch.manual_seed(seed)
     torch.set_default_device(device)
     init_device_properties_triton()
 
     q_hidden_size = num_q_heads * head_size
     kv_hidden_size = num_kv_heads * head_size
-    qkv = torch.randn(num_tokens,
-                      q_hidden_size + kv_hidden_size * 2,
-                      dtype=dtype,
-                      device=device)
+    qkv = torch.randn(num_tokens, q_hidden_size + kv_hidden_size * 2, dtype=dtype, device=device)
     q_weight = torch.randn(head_size, dtype=dtype, device=device)
     k_weight = torch.randn(head_size, dtype=dtype, device=device)
     q_bias = torch.randn(head_size, dtype=dtype, device=device)
     k_bias = torch.randn(head_size, dtype=dtype, device=device)
-    cos_sin_cache = torch.from_numpy(
-        np.random.uniform(0, 1,
-                          [max_position_embeddings, rope_dim])).to(dtype).npu()
+    cos_sin_cache = torch.from_numpy(np.random.uniform(0, 1, [max_position_embeddings, rope_dim])).to(dtype).npu()
     positions = torch.randint(low=0, high=max_position_embeddings, size=(num_tokens,), dtype=torch.int64, device=device)
     # fused kernel
-    q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(input=qkv,
-                                              q_weight=q_weight,
-                                              k_weight=k_weight,
-                                              q_hidden_size=q_hidden_size,
-                                              kv_hidden_size=kv_hidden_size,
-                                              head_dim=head_size,
-                                              eps=eps,
-                                              q_bias=q_bias,
-                                              k_bias=k_bias,
-                                              cos_sin_cache=cos_sin_cache,
-                                              positions=positions)
-    
+    q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(
+        input=qkv,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        q_hidden_size=q_hidden_size,
+        kv_hidden_size=kv_hidden_size,
+        head_dim=head_size,
+        eps=eps,
+        q_bias=q_bias,
+        k_bias=k_bias,
+        cos_sin_cache=cos_sin_cache,
+        positions=positions,
+    )
+
     cos, sin = cos_sin_cache.index_select(0, positions).view(num_tokens, 2, -1).repeat(1, 1, 2).chunk(2, dim=-2)
     cos = cos.unsqueeze(1)
     sin = sin.unsqueeze(1)
 
     # split
-    _q, _k, v_gold = qkv.cpu().split(
-        [q_hidden_size, kv_hidden_size, kv_hidden_size], dim=-1)
+    _q, _k, v_gold = qkv.cpu().split([q_hidden_size, kv_hidden_size, kv_hidden_size], dim=-1)
     # norm
-    _q = rms_norm(_q.reshape(-1, head_size),
-                  q_weight.cpu(),
-                  eps,
-                  norm_bias=q_bias.cpu())
-    _k = rms_norm(_k.reshape(-1, head_size),
-                  k_weight.cpu(),
-                  eps,
-                  norm_bias=k_bias.cpu())
+    _q = rms_norm(_q.reshape(-1, head_size), q_weight.cpu(), eps, norm_bias=q_bias.cpu())
+    _k = rms_norm(_k.reshape(-1, head_size), k_weight.cpu(), eps, norm_bias=k_bias.cpu())
     _q = _q.reshape(num_tokens, 1, -1, head_size)
     _k = _k.reshape(num_tokens, 1, -1, head_size)
 
@@ -211,20 +190,13 @@ def test_split_qkv_rmsnorm_rope_with_bias(max_position_embeddings, num_tokens, n
     k_gold = k_gold.reshape(num_tokens, -1)
 
     # Compare the results.
-    torch.testing.assert_close(q.to(torch.float32).cpu(),
-                               q_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(q.to(torch.float32).cpu(), q_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
-    torch.testing.assert_close(k.to(torch.float32).cpu(),
-                               k_gold,
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(k.to(torch.float32).cpu(), k_gold, atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
-    torch.testing.assert_close(v.to(torch.float32).cpu(),
-                               v_gold.to(torch.float32),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(
+        v.to(torch.float32).cpu(), v_gold.to(torch.float32), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL
+    )
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_tp_rmsnorm_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_tp_rmsnorm_rope.py
@@ -21,10 +21,8 @@ DEFAULT_RTOL = 5e-3
 
 
 def _build_rope(num_tokens, rotary_dim, dtype, device):
-    cos = torch.from_numpy(
-        np.random.uniform(0, 1, [num_tokens, rotary_dim // 2])).to(dtype).to(device)
-    sin = torch.from_numpy(
-        np.random.uniform(0, 1, [num_tokens, rotary_dim // 2])).to(dtype).to(device)
+    cos = torch.from_numpy(np.random.uniform(0, 1, [num_tokens, rotary_dim // 2])).to(dtype).to(device)
+    sin = torch.from_numpy(np.random.uniform(0, 1, [num_tokens, rotary_dim // 2])).to(dtype).to(device)
     return cos.contiguous(), sin.contiguous()
 
 
@@ -97,15 +95,12 @@ def _reference_impl(
     q_var = q_f32.pow(2).mean(dim=-1, keepdim=True)
     k_var = k_f32.pow(2).mean(dim=-1, keepdim=True)
 
-    q_out = (q_f32 * torch.rsqrt(q_var + eps) * q_weight.to(torch.float32)).to(
-        orig_dtype)
-    k_out = (k_f32 * torch.rsqrt(k_var + eps) * k_weight.to(torch.float32)).to(
-        orig_dtype)
+    q_out = (q_f32 * torch.rsqrt(q_var + eps) * q_weight.to(torch.float32)).to(orig_dtype)
+    k_out = (k_f32 * torch.rsqrt(k_var + eps) * k_weight.to(torch.float32)).to(orig_dtype)
 
     q_3d = q_out.view(q.shape[0], -1, head_dim).contiguous()
     k_3d = k_out.view(k.shape[0], -1, head_dim).contiguous()
-    q_3d, k_3d = _apply_rope_neox(q_3d, k_3d, cos.contiguous(), sin.contiguous(),
-                                  rotary_dim)
+    q_3d, k_3d = _apply_rope_neox(q_3d, k_3d, cos.contiguous(), sin.contiguous(), rotary_dim)
 
     return (
         q_3d.view(q.shape[0], q_hidden_size).contiguous(),
@@ -124,8 +119,9 @@ def _reference_impl(
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", DEVICES)
 @torch.inference_mode()
-def test_split_qkv_tp_rmsnorm_rope(num_tokens, num_q_heads, num_kv_heads, head_dim,
-                             rotary_dim, tp_world, eps, dtype, seed, device):
+def test_split_qkv_tp_rmsnorm_rope(
+    num_tokens, num_q_heads, num_kv_heads, head_dim, rotary_dim, tp_world, eps, dtype, seed, device
+):
     torch.manual_seed(seed)
     np.random.seed(seed)
     torch.set_default_device(device)
@@ -134,14 +130,9 @@ def test_split_qkv_tp_rmsnorm_rope(num_tokens, num_q_heads, num_kv_heads, head_d
     q_hidden_size = num_q_heads * head_dim
     kv_hidden_size = num_kv_heads * head_dim
 
-    qkv = torch.randn(num_tokens,
-                      q_hidden_size + kv_hidden_size * 2,
-                      dtype=dtype,
-                      device=device)
-    q_weight = torch.randn(q_hidden_size, dtype=torch.float32,
-                           device=device) * 0.1 + 1.0
-    k_weight = torch.randn(kv_hidden_size, dtype=torch.float32,
-                           device=device) * 0.1 + 1.0
+    qkv = torch.randn(num_tokens, q_hidden_size + kv_hidden_size * 2, dtype=dtype, device=device)
+    q_weight = torch.randn(q_hidden_size, dtype=torch.float32, device=device) * 0.1 + 1.0
+    k_weight = torch.randn(kv_hidden_size, dtype=torch.float32, device=device) * 0.1 + 1.0
     cos, sin = _build_rope(num_tokens, rotary_dim, dtype, device)
 
     q_fused, k_fused, v_fused = _fused_impl(
@@ -171,18 +162,9 @@ def test_split_qkv_tp_rmsnorm_rope(num_tokens, num_q_heads, num_kv_heads, head_d
         sin=sin,
     )
 
-    torch.testing.assert_close(q_fused.to(torch.float32),
-                               q_ref.to(torch.float32),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
-    torch.testing.assert_close(k_fused.to(torch.float32),
-                               k_ref.to(torch.float32),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
-    torch.testing.assert_close(v_fused.to(torch.float32),
-                               v_ref.to(torch.float32),
-                               atol=DEFAULT_ATOL,
-                               rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(q_fused.to(torch.float32), q_ref.to(torch.float32), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(k_fused.to(torch.float32), k_ref.to(torch.float32), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(v_fused.to(torch.float32), v_ref.to(torch.float32), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_temperature.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_temperature.py
@@ -1,17 +1,19 @@
 import random
-import torch
+
 import pytest
-from vllm.triton_utils import triton
+import torch
+
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature
 
 # Common vocab sizes from mainstream models
 VOCAB_SIZES = [
-    32000,   # LLaMA / LLaMA2 / Mistral
-    50257,   # GPT-2
-    65024,   # ChatGLM
+    32000,  # LLaMA / LLaMA2 / Mistral
+    50257,  # GPT-2
+    65024,  # ChatGLM
     128256,  # LLaMA3
     151936,  # Qwen2
 ]
+
 
 def torch_apply_temperature(
     logits: torch.Tensor,
@@ -33,12 +35,10 @@ def torch_apply_temperature(
             continue
         logits[token_idx] = logits[token_idx].float() / temp
 
+
 @pytest.mark.parametrize(
     "num_tokens, vocab_size",
-    [
-        (random.randint(1, 64), vocab_size)
-        for vocab_size in VOCAB_SIZES
-    ],
+    [(random.randint(1, 64), vocab_size) for vocab_size in VOCAB_SIZES],
 )
 def test_temperature_kernel(num_tokens, vocab_size):
     """
@@ -54,15 +54,11 @@ def test_temperature_kernel(num_tokens, vocab_size):
     torch.manual_seed(42)
 
     # Build input tensors
-    logits_triton = torch.randn(
-        (num_tokens, vocab_size), dtype=torch.float32
-    ).npu()
+    logits_triton = torch.randn((num_tokens, vocab_size), dtype=torch.float32).npu()
     logits_ref = logits_triton.clone()
 
     num_requests = num_tokens
-    expanded_idx_mapping = torch.arange(
-        num_tokens, dtype=torch.int32
-    ).npu()
+    expanded_idx_mapping = torch.arange(num_tokens, dtype=torch.int32).npu()
 
     # Include edge cases: 0.0 and 1.0 should leave logits unchanged
     temperature = torch.rand(num_requests, dtype=torch.float32).npu()
@@ -78,7 +74,8 @@ def test_temperature_kernel(num_tokens, vocab_size):
     torch_apply_temperature(logits_ref, expanded_idx_mapping, temperature)
 
     # ========== Verify results ==========
-    assert torch.allclose(logits_triton, logits_ref, atol=1e-4, rtol=1e-5), \
-        f"Triton temperature kernel output differs from torch reference.\n" \
-        f"Max diff: {torch.max(torch.abs(logits_triton - logits_ref))}\n" \
+    assert torch.allclose(logits_triton, logits_ref, atol=1e-4, rtol=1e-5), (
+        f"Triton temperature kernel output differs from torch reference.\n"
+        f"Max diff: {torch.max(torch.abs(logits_triton - logits_ref))}\n"
         f"Mean diff: {torch.mean(torch.abs(logits_triton - logits_ref).float())}"
+    )


### PR DESCRIPTION
### What this PR does / why we need it?
| File Path |
| :--- |
| `tests/e2e/nightly/single_node/models/scripts/test_single_node.py` |
| `tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_matmul_allreduce_add_rmsnorm.py` |
| `tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py` |
| `tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine_bf16.py` |
| `tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_gmm_combine_decode.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_rms_norm_bias.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_apply_top_k_top_p_custom.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_batch_matmul_transpose.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_bgmv_expand.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_bgmv_shrink.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_gating_top_k_softmax.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_gmm_swiglu_quant_weight_nz_tensor_list.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_grouped_matmul_swiglu_quant.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_nq.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_qdown.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_moe_init_routing_custom.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_moe_gating_top_k.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_transpose_kv_cache_by_block.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/test_vocabparallelembedding.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_causal_conv1d.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_sigmoid_gating_delta_rule.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_l2norm.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_mrope.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_muls_add.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_penality.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py` |
| `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_rope.py` |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
