### PR TITLE
[v0.13.0][Fusion]add checks to skip fusion where split_rmsnorm_rope is not supported

### DIFF
--- a/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
@@ -256,10 +256,11 @@ class QKNormRopeFusionPass(VllmInductorPass):
         layer = next(iter(attn_layers.values()))
         rope_dim = get_rope_dim(vllm_config)
         if layer.head_size != 128 or rope_dim != layer.head_size:
-            logger.debug(f"Currently, QKNorm and Rope fusion is only supported where"
-                         f"rotary_dim == head_size and head_size == 128. But rotary_dim"
-                         f"is {rope_dim} and head_size is {layer.head_size}. Therefore"
-                         f"the fusion is skipped.")
+            logger.debug(
+                f"Currently, QKNorm and Rope fusion is only supported where"
+                f"rotary_dim == head_size and head_size == 128. But rotary_dim"
+                f"is {rope_dim} and head_size is {layer.head_size}. Therefore"
+                f"the fusion is skipped.")
             return
 
         for epsilon in [1e-6, 1e-5]:

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -50,7 +50,7 @@ def get_rope_dim(vllm_config):
                            model_config.hf_text_config.partial_rotary_factor)
         elif hasattr(model_config.hf_text_config, "rotary_dim"):
             rope_dim = int(model_config.hf_text_config.rotary_dim)
-    
+
     return rope_dim
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
With #6602 , `npu_rotary_embedding` unifies all rope implementation in AscendRotaryEmbedding, but allows a wider range of application of fusion op `split_qkv_rmsnorm_rope`. This PR restricts the fusion of `split_qkv_rmsnorm_rope` to only cases where `head_size` == 128 && `rotary_dim` == `head_size`.  Further enhancement and generalization of this op will be accomplished by @whx-sjtu .

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
