### PR TITLE
[bugfix] change graph.recompiler to graph.recompile

### DIFF
--- a/vllm_ascend/compilation/npu_graph_ex_pass_manager.py
+++ b/vllm_ascend/compilation/npu_graph_ex_pass_manager.py
@@ -47,7 +47,7 @@ class NpuGraphEXPassManager:
         for pass_ in self.passes:
             if pass_.is_applicable_for_range(compile_range):
                 pass_(graph)
-        graph.recompiler()
+        graph.recompile()
         return graph
 
     def add(self, pass_: VllmInductorPass):


### PR DESCRIPTION
### What this PR does / why we need it?
Address the API error when compiling computational graphs on NPU，change graph.recompiler() to graph.recompile() 
- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
