### PR TITLE
[Performance] Optimize the performance of `FastGELU` and `NewGELU`

### DIFF
--- a/tests/ut/ops/a3_2/test_activation.py
+++ b/tests/ut/ops/a3_2/test_activation.py
@@ -18,9 +18,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from vllm.config import set_current_vllm_config
-from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul
+from vllm.model_executor.layers.activation import FastGELU, NewGELU, QuickGELU, SiluAndMul
 
 from vllm_ascend.ops.activation import (
+    AscendFastGELU,
+    AscendNewGELU,
     AscendQuickGELU,
     AscendSiluAndMul,
     AscendSwigluOAIAndMul,
@@ -44,6 +46,42 @@ def default_vllm_config():
 
     with set_current_vllm_config(mock_config):
         yield mock_config
+
+
+@patch("torch_npu.npu_gelu", side_effect=lambda x, approximate: x + 1)
+def test_FastGELU_forward(mock_gelu, dummy_tensor, default_vllm_config):
+    layer = FastGELU()
+    out = layer.forward(dummy_tensor)
+
+    assert torch.allclose(out, dummy_tensor + 1)
+    mock_gelu.assert_called_once_with(dummy_tensor, approximate="tanh")
+
+
+@patch("torch_npu.npu_gelu", side_effect=lambda x, approximate: x + 1)
+def test_AscendFastGELU_forward_oot(mock_gelu, dummy_tensor, default_vllm_config):
+    layer = AscendFastGELU()
+    out = layer.forward_oot(dummy_tensor)
+
+    assert torch.allclose(out, dummy_tensor + 1)
+    mock_gelu.assert_called_once_with(dummy_tensor, approximate="tanh")
+
+
+@patch("torch_npu.npu_gelu", side_effect=lambda x, approximate: x + 1)
+def test_NewGELU_forward(mock_gelu, dummy_tensor, default_vllm_config):
+    layer = NewGELU()
+    out = layer.forward(dummy_tensor)
+
+    assert torch.allclose(out, dummy_tensor + 1)
+    mock_gelu.assert_called_once_with(dummy_tensor, approximate="tanh")
+
+
+@patch("torch_npu.npu_gelu", side_effect=lambda x, approximate: x + 1)
+def test_AscendNewGELU_forward_oot(mock_gelu, dummy_tensor, default_vllm_config):
+    layer = AscendNewGELU()
+    out = layer.forward_oot(dummy_tensor)
+
+    assert torch.allclose(out, dummy_tensor + 1)
+    mock_gelu.assert_called_once_with(dummy_tensor, approximate="tanh")
 
 
 @patch("torch_npu.npu_fast_gelu", side_effect=lambda x: x + 1)

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -18,6 +18,8 @@
 import torch
 import torch_npu
 from vllm.model_executor.layers.activation import (
+    FastGELU,
+    NewGELU,
     QuickGELU,
     SiluAndMul,
     SiluAndMulWithClamp,
@@ -28,8 +30,24 @@ from vllm.model_executor.layers.activation import (
 from vllm_ascend.utils import get_weight_prefetch_method
 
 
+class AscendFastGELU(FastGELU):
+    def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
+        import torch_npu
+
+        out = torch_npu.npu_gelu(x, approximate="tanh")
+        return out
+
+
+class AscendNewGELU(NewGELU):
+    def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
+        import torch_npu
+
+        out = torch_npu.npu_gelu(x, approximate="tanh")
+        return out
+
+
 class AscendQuickGELU(QuickGELU):
-    def forward_oot(self, x: torch.tensor) -> torch.Tensor:
+    def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
         out = torch_npu.npu_fast_gelu(x)
         return out
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -673,6 +673,8 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     from vllm.model_executor.custom_op import CustomOp
 
     from vllm_ascend.ops.activation import (
+        AscendFastGELU,
+        AscendNewGELU,
         AscendQuickGELU,
         AscendSiluAndMul,
         AscendSiluAndMulWithClamp,
@@ -707,6 +709,8 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
     global REGISTERED_ASCEND_OPS
     REGISTERED_ASCEND_OPS = {
+        "NewGELU": AscendNewGELU,
+        "FastGELU": AscendFastGELU,
         "QuickGELU": AscendQuickGELU,
         "SiluAndMul": AscendSiluAndMul,
         "SiluAndMulClamp": AscendSiluAndMulWithClamp,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the performance of the `NewGELU` and `FastGelu` activation function for Ascend NPUs. It replaces the generic PyTorch implementation with a hardware-accelerated version, `torch_npu.npu_gelu`. This change is expected to improve performance in the prefill stage by approximately 20% for models like GPT2.

By examining the source code of torch, we can see that it calls the aclnnGelu operator at the lower level, and its calculation formula is exactly the same as NewGelu.

https://www.hiascend.com/document/detail/zh/canncommercial/850/API/ascendcopapi/atlasascendc_api_07_0771.html

<img width="1611" height="392" alt="image" src="https://github.com/user-attachments/assets/9a70decd-f7df-42d5-8490-c9a560921618" />

https://github.com/vllm-project/vllm/blob/v0.13.0/vllm/model_executor/layers/activation.py#L300-L303

```
class NewGELU(CustomOp):
    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
        """PyTorch-native implementation equivalent to forward()."""
        c = math.sqrt(2.0 / math.pi)
        return 0.5 * x * (1.0 + torch.tanh(c * (x + 0.044715 * torch.pow(x, 3.0))))
```

It can be observed that FastGelu's calculation formula merely applies the [Distributive Property](https://en.wikipedia.org/wiki/Distributive_property) for transformation, making it equivalent as well. In practical testing, the inference results of gelu_new and gelu_fast are also completely identical.

https://github.com/vllm-project/vllm/blob/v0.13.0/vllm/model_executor/layers/activation.py#L325-L327

```
class FastGELU(CustomOp):
    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
        """PyTorch-native implementation equivalent to forward()."""
        # math.sqrt(2.0 / math.pi) == 0.7978845608
        return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
```

### Does this PR introduce _any_ user-facing change?

No user-facing changes are introduced.

### How was this patch tested?

The changes have been verified to work correctly with the GPT2 model.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
