### PR TITLE
[Nightly] Increase VLLM_ENGINE_READY_TIMEOUT_S to avoid nightly failure

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -28,6 +28,8 @@ export VLLM_LOGGING_LEVEL="INFO"
 export GLOG_minloglevel=1
 # Set transformers to offline mode to avoid downloading models during tests
 export HF_HUB_OFFLINE="1"
+# Default is 600s
+export VLLM_ENGINE_READY_TIMEOUT_S=1800
 
 # Function to print section headers
 print_section() {


### PR DESCRIPTION
### What this PR does / why we need it?
After some observation, I found some cases failed for timeout, just like https://github.com/vllm-project/vllm-ascend/actions/runs/22280996034/job/64487867977#step:9:921 and  https://github.com/vllm-project/vllm-ascend/actions/runs/22315540111/job/64574590762#step:9:1809, this may caused by the excessively long model loading time (currently we are still loading weights from network storage), it is necessary to adjust the timeout seconds 600s -> 1800s
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9562912cead1f11e8540fb91306c5cbda66f0007
