### PR TITLE
[Fix] Skip process_weights_after_loading for non-FusedMoE layers

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -73,6 +73,8 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
 
     def process_weights_after_loading(self, layer):
+        if not isinstance(layer, FusedMoE):
+            return
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
 
         w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 
 import torch
 from vllm.distributed import get_tensor_model_parallel_rank
-from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase, FusedMoeWeightScaleSupported
+from vllm.model_executor.layers.fused_moe import FusedMoE, FusedMoEMethodBase, FusedMoeWeightScaleSupported
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.linear import LinearMethodBase, RowParallelLinear
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -268,6 +268,8 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if not isinstance(layer, FusedMoE):
+            return
         if hasattr(self.quant_method, "process_weights_after_loading"):
             self.quant_method.process_weights_after_loading(layer)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Add isinstance check in `AscendUnquantizedFusedMoEMethod` and `AscendFusedMoEMethod` to guard process_weights_after_loading against being called on non-FusedMoE layer instances.

see https://github.com/vllm-project/vllm/pull/35178

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with existing test.

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83b47f67b1dfad505606070ae4d9f83e50ad4ebd
