### PR TITLE
【Ops】add matmul_gelu fusion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "csrc/third_party/catlass"]
 	path = csrc/third_party/catlass
 	url = https://gitcode.com/cann/catlass.git
-	branch = catlass-v1-stable
+	branch = v1.4.0

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -24,7 +24,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     ABSOLUTE_CATLASS_PATH=$(cd "${CATLASS_PATH}" && pwd)
     export CPATH=${ABSOLUTE_CATLASS_PATH}:${CPATH}
 
-    CUSTOM_OPS="grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;matmul_gelu"
+    CUSTOM_OPS="grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;matmul_gelu;"
     SOC_ARG="ascend910b"
 elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
@@ -50,20 +50,28 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
     TARGET_DIR="$SCRIPT_DIR/dispatch_ffn_combine/op_kernel/utils/"
     TARGET_FILE="$TARGET_DIR/$(basename "$HCCL_STRUCT_FILE_PATH")"
+    # for dispatch_ffn_combine_bf16
+    SCRIPT_DIR_BF16=$(cd "$(dirname "$0")" && pwd)
+    TARGET_DIR_BF16="$SCRIPT_DIR_BF16/dispatch_ffn_combine_bf16/op_kernel/utils/"
+    TARGET_FILE_BF16="$TARGET_DIR_BF16/$(basename "$HCCL_STRUCT_FILE_PATH")"
 
     echo "*************************************"
     echo $HCCL_STRUCT_FILE_PATH
     echo "$TARGET_DIR"
     cp "$HCCL_STRUCT_FILE_PATH" "$TARGET_DIR"
+    cp "$HCCL_STRUCT_FILE_PATH" "$TARGET_DIR_BF16"
 
     sed -i 's/struct HcclOpResParam {/struct HcclOpResParamCustom {/g' "$TARGET_FILE"
     sed -i 's/struct HcclRankRelationResV2 {/struct HcclRankRelationResV2Custom {/g' "$TARGET_FILE"
+    sed -i 's/struct HcclOpResParam {/struct HcclOpResParamCustom {/g' "$TARGET_FILE_BF16"
+    sed -i 's/struct HcclRankRelationResV2 {/struct HcclRankRelationResV2Custom {/g' "$TARGET_FILE_BF16"
 
     CUSTOM_OPS_ARRAY=(
         "grouped_matmul_swiglu_quant_weight_nz_tensor_list"
-        "lightning_indexer"
+        "lightning_indexer_vllm"
         "sparse_flash_attention"
         "dispatch_ffn_combine"
+        "dispatch_ffn_combine_bf16"
         "dispatch_gmm_combine_decode"
         "moe_combine_normal"
         "moe_dispatch_normal"
@@ -74,7 +82,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "add_rms_norm_bias"
         "apply_top_k_top_p_custom"
         "transpose_kv_cache_by_block"
-	      "matmul_gelu"
+        "matmul_gelu"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -84,7 +84,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "add_rms_norm_bias"
         "apply_top_k_top_p_custom"
         "transpose_kv_cache_by_block"
-        "matmul_gelu"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -11,11 +11,11 @@ if [[ "$SOC_VERSION" =~ ^ascend310 ]]; then
     exit 0
 elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     # ASCEND910B (A2) series
-    # depdendency: catlass
+    # dependency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
     if [[ ! -d "${CATLASS_PATH}" ]]; then
-        echo "depdendency catlass is missing, try to fetch it..."
+        echo "dependency catlass is missing, try to fetch it..."
         if ! git submodule update --init --recursive; then
             echo "fetch failed"
             exit 1
@@ -28,17 +28,17 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     SOC_ARG="ascend910b"
 elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
-    # depdendency: catlass
+    # dependency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
     if [[ ! -d "${CATLASS_PATH}" ]]; then
-        echo "depdendency catlass is missing, try to fetch it..."
+        echo "dependency catlass is missing, try to fetch it..."
         if ! git submodule update --init --recursive; then
             echo "fetch failed"
             exit 1
         fi
     fi
-    # depdendency: cann-toolkit file moe_distribute_base.h
+    # dependency: cann-toolkit file moe_distribute_base.h
     HCCL_STRUCT_FILE_PATH=$(find -L "${ASCEND_TOOLKIT_HOME}" -name "moe_distribute_base.h" 2>/dev/null | head -n1)
     if [ -z "$HCCL_STRUCT_FILE_PATH" ]; then
         echo "cannot find moe_distribute_base.h file in CANN env"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -11,11 +11,11 @@ if [[ "$SOC_VERSION" =~ ^ascend310 ]]; then
     exit 0
 elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     # ASCEND910B (A2) series
-    # dependency: catlass
+    # depdendency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
     if [[ ! -d "${CATLASS_PATH}" ]]; then
-        echo "dependency catlass is missing, try to fetch it..."
+        echo "depdendency catlass is missing, try to fetch it..."
         if ! git submodule update --init --recursive; then
             echo "fetch failed"
             exit 1
@@ -24,21 +24,21 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     ABSOLUTE_CATLASS_PATH=$(cd "${CATLASS_PATH}" && pwd)
     export CPATH=${ABSOLUTE_CATLASS_PATH}:${CPATH}
 
-    CUSTOM_OPS="grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;"
+    CUSTOM_OPS="grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;matmul_gelu"
     SOC_ARG="ascend910b"
 elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
-    # dependency: catlass
+    # depdendency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
     if [[ ! -d "${CATLASS_PATH}" ]]; then
-        echo "dependency catlass is missing, try to fetch it..."
+        echo "depdendency catlass is missing, try to fetch it..."
         if ! git submodule update --init --recursive; then
             echo "fetch failed"
             exit 1
         fi
     fi
-    # dependency: cann-toolkit file moe_distribute_base.h
+    # depdendency: cann-toolkit file moe_distribute_base.h
     HCCL_STRUCT_FILE_PATH=$(find -L "${ASCEND_TOOLKIT_HOME}" -name "moe_distribute_base.h" 2>/dev/null | head -n1)
     if [ -z "$HCCL_STRUCT_FILE_PATH" ]; then
         echo "cannot find moe_distribute_base.h file in CANN env"
@@ -50,28 +50,20 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
     TARGET_DIR="$SCRIPT_DIR/dispatch_ffn_combine/op_kernel/utils/"
     TARGET_FILE="$TARGET_DIR/$(basename "$HCCL_STRUCT_FILE_PATH")"
-    # for dispatch_ffn_combine_bf16
-    SCRIPT_DIR_BF16=$(cd "$(dirname "$0")" && pwd)
-    TARGET_DIR_BF16="$SCRIPT_DIR_BF16/dispatch_ffn_combine_bf16/op_kernel/utils/"
-    TARGET_FILE_BF16="$TARGET_DIR_BF16/$(basename "$HCCL_STRUCT_FILE_PATH")"
 
     echo "*************************************"
     echo $HCCL_STRUCT_FILE_PATH
     echo "$TARGET_DIR"
     cp "$HCCL_STRUCT_FILE_PATH" "$TARGET_DIR"
-    cp "$HCCL_STRUCT_FILE_PATH" "$TARGET_DIR_BF16"
 
     sed -i 's/struct HcclOpResParam {/struct HcclOpResParamCustom {/g' "$TARGET_FILE"
     sed -i 's/struct HcclRankRelationResV2 {/struct HcclRankRelationResV2Custom {/g' "$TARGET_FILE"
-    sed -i 's/struct HcclOpResParam {/struct HcclOpResParamCustom {/g' "$TARGET_FILE_BF16"
-    sed -i 's/struct HcclRankRelationResV2 {/struct HcclRankRelationResV2Custom {/g' "$TARGET_FILE_BF16"
 
     CUSTOM_OPS_ARRAY=(
         "grouped_matmul_swiglu_quant_weight_nz_tensor_list"
-        "lightning_indexer_vllm"
+        "lightning_indexer"
         "sparse_flash_attention"
         "dispatch_ffn_combine"
-        "dispatch_ffn_combine_bf16"
         "dispatch_gmm_combine_decode"
         "moe_combine_normal"
         "moe_dispatch_normal"
@@ -82,6 +74,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "add_rms_norm_bias"
         "apply_top_k_top_p_custom"
         "transpose_kv_cache_by_block"
+	      "matmul_gelu"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -13,6 +13,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     # ASCEND910B (A2) series
     # dependency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
+    rm -rf ${ROOT_DIR}/csrc/third_party/catlass
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
     if [[ ! -d "${CATLASS_PATH}" ]]; then
         echo "dependency catlass is missing, try to fetch it..."
@@ -30,6 +31,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
     # dependency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
+    rm -rf ${ROOT_DIR}/csrc/third_party/catlass
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
     if [[ ! -d "${CATLASS_PATH}" ]]; then
         echo "dependency catlass is missing, try to fetch it..."

--- a/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
+++ b/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
@@ -26,7 +26,7 @@ at::Tensor matmul_gelu_impl(const at::Tensor &x, const at::Tensor &weight, const
     TORCH_CHECK(x.sizes()[1] == weight.sizes()[1] || x.sizes()[1] == weight.sizes()[0], "The x second dim should be same as weight first or second dim");
     TORCH_CHECK(
         x.scalar_type() == at::kHalf || x.scalar_type() == at::kFloat,
-        "float16、float32 or bfloat16 tensor expected but got a tensor with dtype: ",
+        "float16、float32 tensor expected but got a tensor with dtype: ",
         x.scalar_type());
      TORCH_CHECK(
         x.scalar_type() == weight.scalar_type() && x.scalar_type() == bias.scalar_type(),

--- a/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
+++ b/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MATMUL_GELU_TORCH_ADPT_H
+#define MATMUL_GELU_TORCH_ADPT_H
+namespace vllm_ascend {
+
+at::Tensor matmul_gelu_impl(const at::Tensor &x, const at::Tensor &weight, const at::Tensor &bias)
+{
+    TORCH_CHECK(x.dim() == 2, "The x should be 2D");
+    TORCH_CHECK(weight.dim() == 2, "The weight should be 2D");
+    TORCH_CHECK(bias.dim() == 1, "The bias should be 1D");
+    TORCH_CHECK(weight.sizes()[0] == bias.sizes()[0] || weight.sizes()[1] == bias.sizes()[0], "The weight first or second dim should be same as bias first dim");
+    TORCH_CHECK(x.sizes()[1] == weight.sizes()[1] || x.sizes()[1] == weight.sizes()[0], "The x second dim should be same as weight first or second dim");
+    TORCH_CHECK(
+        x.scalar_type() == at::kHalf || x.scalar_type() == at::kFloat,
+        "float16、float32 or bfloat16 tensor expected but got a tensor with dtype: ",
+        x.scalar_type());
+     TORCH_CHECK(
+        x.scalar_type() == weight.scalar_type() && x.scalar_type() == bias.scalar_type(),
+        "The dtype of x, weight and bias should be same");
+
+	int m = x.sizes()[0];
+	int n = bias.sizes()[0];
+	auto options = x.options();
+
+    at::Tensor gelu_output = at::empty({m,n}, x.options());
+    EXEC_NPU_CMD(
+        aclnnMatmulGelu,
+        x,
+        weight,
+        bias,
+		gelu_output);
+    return gelu_output;
+}
+#endif

--- a/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
+++ b/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
@@ -23,8 +23,8 @@ at::Tensor matmul_gelu(const at::Tensor &x, const at::Tensor &weight, const at::
     TORCH_CHECK(x.dim() == 2, "The x should be 2D");
     TORCH_CHECK(weight.dim() == 2, "The weight should be 2D");
     TORCH_CHECK(bias.dim() == 1, "The bias should be 1D");
-    TORCH_CHECK(weight.sizes()[0] == bias.sizes()[0] || weight.sizes()[1] == bias.sizes()[0], "The weight first or second dim should be same as bias first dim");
-    TORCH_CHECK(x.sizes()[1] == weight.sizes()[1] || x.sizes()[1] == weight.sizes()[0], "The x second dim should be same as weight first or second dim");
+    TORCH_CHECK(weight.sizes()[0] == bias.sizes()[0] , "The weight first dim should be same as bias first dim");
+    TORCH_CHECK(x.sizes()[1] == weight.sizes()[1] , "The x second dim should be same as weight second dim");
     TORCH_CHECK(
         x.scalar_type() == at::kHalf || x.scalar_type() == at::kFloat,
         "float16 or float32 tensor expected but got a tensor with dtype: ",

--- a/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
+++ b/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
@@ -18,7 +18,7 @@
 #define MATMUL_GELU_TORCH_ADPT_H
 namespace vllm_ascend {
 
-at::Tensor matmul_gelu_impl(const at::Tensor &x, const at::Tensor &weight, const at::Tensor &bias)
+at::Tensor matmul_gelu(const at::Tensor &x, const at::Tensor &weight, const at::Tensor &bias)
 {
     TORCH_CHECK(x.dim() == 2, "The x should be 2D");
     TORCH_CHECK(weight.dim() == 2, "The weight should be 2D");
@@ -27,7 +27,7 @@ at::Tensor matmul_gelu_impl(const at::Tensor &x, const at::Tensor &weight, const
     TORCH_CHECK(x.sizes()[1] == weight.sizes()[1] || x.sizes()[1] == weight.sizes()[0], "The x second dim should be same as weight first or second dim");
     TORCH_CHECK(
         x.scalar_type() == at::kHalf || x.scalar_type() == at::kFloat,
-        "float16、float32 tensor expected but got a tensor with dtype: ",
+        "float16 or float32 tensor expected but got a tensor with dtype: ",
         x.scalar_type());
      TORCH_CHECK(
         x.scalar_type() == weight.scalar_type() && x.scalar_type() == bias.scalar_type(),
@@ -45,5 +45,7 @@ at::Tensor matmul_gelu_impl(const at::Tensor &x, const at::Tensor &weight, const
         bias,
 		gelu_output);
     return gelu_output;
+}
+
 }
 #endif

--- a/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
+++ b/csrc/matmul_gelu/matmul_gelu_torch_adpt.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef MATMUL_GELU_TORCH_ADPT_H
 #define MATMUL_GELU_TORCH_ADPT_H
 namespace vllm_ascend {

--- a/csrc/matmul_gelu/op_host/CMakeLists.txt
+++ b/csrc/matmul_gelu/op_host/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # This file is a part of the CANN Open Software.
 # Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.

--- a/csrc/matmul_gelu/op_host/CMakeLists.txt
+++ b/csrc/matmul_gelu/op_host/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This file is a part of the CANN Open Software.
+# Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ======================================================================================================================
+set(_DISPATCH_GMM_INC_OPTS)
+if (EXISTS ${CMAKE_SOURCE_DIR}/third_party/catlass/include)
+    list(APPEND _DISPATCH_GMM_INC_OPTS -I${CMAKE_SOURCE_DIR}/third_party/catlass/include)
+else()
+    message(FATAL_ERROR "dependency catlass is missing, you can fetch it by running 'git submodule update --init --recursive'")
+endif()
+
+add_ops_compile_options(
+        OP_NAME MatmulGelu
+        OPTIONS --cce-auto-sync=off
+                -Wno-deprecated-declarations
+                -Werror
+                ${_DISPATCH_GMM_INC_OPTS}
+)
+
+target_sources(op_host_aclnnInner PRIVATE
+        matmul_gelu_def.cpp
+)
+
+target_sources(opapi PRIVATE
+        aclnn_matmul_gelu.cpp
+)
+
+if (NOT BUILD_OPEN_PROJECT)
+    target_sources(aclnn_ops_train PRIVATE
+        aclnn_matmul_gelu.cpp
+    )
+
+    target_sources(aclnn_ops_infer PRIVATE
+        aclnn_matmul_gelu.cpp
+    )
+endif ()
+
+target_sources(optiling PRIVATE
+        matmul_gelu_tiling.cpp
+)
+
+target_include_directories(optiling PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+
+file(GLOB _GMM_Aclnn_header "${CMAKE_CURRENT_SOURCE_DIR}/aclnn_matmul_gelu.h")
+
+install(FILES ${_GMM_Aclnn_header}
+        DESTINATION ${ACLNN_INC_INSTALL_DIR} OPTIONAL
+)

--- a/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.cpp
+++ b/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.cpp
@@ -1,11 +1,17 @@
-/**
- * Copyright (c) 2025 Huawei Technologies Co., Ltd.
- * This file is a part of the CANN Open Software.
- * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- * See LICENSE in the root of the software repository for the full text of the License.
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <string.h>

--- a/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.cpp
+++ b/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#include <string.h>
+#include "graph/types.h"
+#include "aclnn/opdev/platform.h"
+#include "aclnn_matmul_gelu.h"
+
+enum NnopbaseHcclServerType {
+    NNOPBASE_HCCL_SERVER_TYPE_AICPU = 0,
+    NNOPBASE_HCCL_SERVER_TYPE_MTE,
+    NNOPBASE_HCCL_SERVER_TYPE_END
+};
+extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, NnopbaseHcclServerType sType);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern aclnnStatus aclnnInnerMatmulGeluGetWorkspaceSize(
+    const aclTensor *x,
+    const aclTensor *weight,
+    const aclTensor *bias,
+    const aclTensor *out,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+extern aclnnStatus aclnnInnerMatmulGelu(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+
+aclnnStatus aclnnMatmulGeluGetWorkspaceSize(
+    const aclTensor *x,
+    const aclTensor *weight,
+    const aclTensor *bias,
+    const aclTensor *out,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    bool transB = false;
+    bool weightNz = true;
+
+    aclnnStatus ret = aclnnInnerMatmulGeluGetWorkspaceSize(x, weight, bias, out, workspaceSize, executor);
+    return ret;
+}
+
+aclnnStatus aclnnMatmulGelu(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream)
+{
+    if (NnopbaseSetHcclServerType) {
+        NnopbaseSetHcclServerType(executor, NNOPBASE_HCCL_SERVER_TYPE_MTE);
+    }
+    aclnnStatus ret = aclnnInnerMatmulGelu(workspace, workspaceSize, executor, stream);
+    return ret;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.cpp
+++ b/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.cpp
@@ -45,9 +45,6 @@ aclnnStatus aclnnMatmulGeluGetWorkspaceSize(
     uint64_t *workspaceSize,
     aclOpExecutor **executor)
 {
-    bool transB = false;
-    bool weightNz = true;
-
     aclnnStatus ret = aclnnInnerMatmulGeluGetWorkspaceSize(x, weight, bias, out, workspaceSize, executor);
     return ret;
 }

--- a/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.h
+++ b/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.h
@@ -1,7 +1,19 @@
-
 /*
- * calution: this file was generated automaticlly donot change it.
-*/
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 #ifndef ACLNN_MATMUL_GELU_H_
 #define ACLNN_MATMUL_GELU_H_

--- a/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.h
+++ b/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-/* funtion: aclnnMatmulGeluGetWorkspaceSize
+/* function: aclnnMatmulGeluGetWorkspaceSize
  * parameters :
  * x : required
  * weight : required
@@ -42,7 +42,7 @@ aclnnStatus aclnnMatmulGeluGetWorkspaceSize(
     uint64_t *workspaceSize,
     aclOpExecutor **executor);
 
-/* funtion: aclnnMatmulGelu
+/* function: aclnnMatmulGelu
  * parameters :
  * workspace : workspace memory addr(input).
  * workspaceSize : size of workspace(input).

--- a/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.h
+++ b/csrc/matmul_gelu/op_host/aclnn_matmul_gelu.h
@@ -1,0 +1,51 @@
+
+/*
+ * calution: this file was generated automaticlly donot change it.
+*/
+
+#ifndef ACLNN_MATMUL_GELU_H_
+#define ACLNN_MATMUL_GELU_H_
+
+#include "aclnn/acl_meta.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* funtion: aclnnMatmulGeluGetWorkspaceSize
+ * parameters :
+ * x : required
+ * weight : required
+ * bias : required
+ * out : required
+ * workspaceSize : size of workspace(output).
+ * executor : executor context(output).
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnMatmulGeluGetWorkspaceSize(
+    const aclTensor *x,
+    const aclTensor *weight,
+    const aclTensor *bias,
+    const aclTensor *out,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/* funtion: aclnnMatmulGelu
+ * parameters :
+ * workspace : workspace memory addr(input).
+ * workspaceSize : size of workspace(input).
+ * executor : executor context(input).
+ * stream : acl stream.
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnMatmulGelu(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/csrc/matmul_gelu/op_host/matmul_gelu_def.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_def.cpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file grouped_matmul_swiglu_quant_weight_nz_tensor_list_def.cpp
+ * \brief
+ */
+
+#include <cstdint>
+#include "register/op_def_registry.h"
+
+
+namespace ops {
+class MatmulGelu : public OpDef {
+public:
+    explicit MatmulGelu(const char* name) : OpDef(name)
+    {
+        this->Input("x")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("weight")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("bias")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("output")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->AICore().AddConfig("ascend910b");
+
+    }
+};
+
+OP_ADD(MatmulGelu);
+}  // namespace ops

--- a/csrc/matmul_gelu/op_host/matmul_gelu_def.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_def.cpp
@@ -1,16 +1,17 @@
-/**
- * Copyright (c) 2025 Huawei Technologies Co., Ltd.
- * This file is a part of the CANN Open Software.
- * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- * See LICENSE in the root of the software repository for the full text of the License.
- */
-
-/*!
- * \file grouped_matmul_swiglu_quant_weight_nz_tensor_list_def.cpp
- * \brief
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <cstdint>

--- a/csrc/matmul_gelu/op_host/matmul_gelu_proto.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_proto.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include "graph/utils/type_utils.h"
+#include "register/op_def_registry.h"
+
+
+namespace ge {
+namespace ops {
+const int64_t X_INDEX = 0;
+const int64_t BIAS_INDEX = 2;
+const int64_t M_DIM_INDEX = 0;
+const int64_t N_DIM_INDEX = 0;
+
+static ge::graphStatus InferShape(gert::InferShapeContext* context)
+{
+    const gert::Shape* x_shape = context->GetInputShape(X_INDEX);
+    const gert::Shape* bias_shape = context->GetInputShape(BIAS_INDEX);
+    gert::Shape* outShape = context->GetOutputShape(0);
+    int64_t m = xShape->GetDim(M_DIM_INDEX);
+    int64_t n = bias_shape->GetDim(N_DIM_INDEX);
+    outShape->SetDimNum(2);
+    outShape->SetDim(0, m);
+    outShape->SetDim(1, n);
+
+    return GRAPH_SUCCESS;
+}
+static ge::graphStatus InferDataType(gert::InferDataTypeContext *context)
+{
+const auto inputDataType = context->GetInputDataType(0);
+context->SetOutputDataType(0, inputDataType);
+return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP(MatmulGelu)
+    .InferShape(InferShape)
+    .InferDataType(InferDataType);
+}
+
+}

--- a/csrc/matmul_gelu/op_host/matmul_gelu_proto.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_proto.cpp
@@ -31,7 +31,7 @@ static ge::graphStatus InferShape(gert::InferShapeContext* context)
     const gert::Shape* x_shape = context->GetInputShape(X_INDEX);
     const gert::Shape* bias_shape = context->GetInputShape(BIAS_INDEX);
     gert::Shape* outShape = context->GetOutputShape(0);
-    int64_t m = xShape->GetDim(M_DIM_INDEX);
+    int64_t m = x_shape->GetDim(M_DIM_INDEX);
     int64_t n = bias_shape->GetDim(N_DIM_INDEX);
     outShape->SetDimNum(2);
     outShape->SetDim(0, m);

--- a/csrc/matmul_gelu/op_host/matmul_gelu_proto.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_proto.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "../op_kernel/matmul_gelu_tiling.h"
 #include "register/op_def_registry.h"
@@ -7,21 +22,6 @@
 
 #include "log/ops_log.h"
 #include "error/ops_error.h"
-
-//static ge::graphStatus TilingFunc(gert::TilingContext* context)
-//{
-//  Matmul_geluTilingData tiling;
-//  const gert::StorageShape* x1_shape = context->GetInputShape(0);
-//  int32_t data_sz = 1;
-//  for (int i = 0; i < x1_shape->GetStorageShape().GetDimNum(); i++)
-//    data_sz *= x1_shape->GetStorageShape().GetDim(i);
-//  tiling.set_size(data_sz);
-//  context->SetBlockDim(8);
-//  tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
-//  context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
-//
-//  return ge::GRAPH_SUCCESS;
-//}
 
 constexpr size_t INPUT_INDEX_X = 0;
 constexpr size_t INPUT_INDEX_WEIGHT = 1;

--- a/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
@@ -1,0 +1,78 @@
+
+#include "../op_kernel/matmul_gelu_tiling.h"
+#include "register/op_def_registry.h"
+
+#include "graph/utils/type_utils.h"
+#include "tiling/tiling_api.h"
+
+#include "log/ops_log.h"
+#include "error/ops_error.h"
+
+//static ge::graphStatus TilingFunc(gert::TilingContext* context)
+//{
+//  Matmul_geluTilingData tiling;
+//  const gert::StorageShape* x1_shape = context->GetInputShape(0);
+//  int32_t data_sz = 1;
+//  for (int i = 0; i < x1_shape->GetStorageShape().GetDimNum(); i++)
+//    data_sz *= x1_shape->GetStorageShape().GetDim(i);
+//  tiling.set_size(data_sz);
+//  context->SetBlockDim(8);
+//  tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+//  context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+//
+//  return ge::GRAPH_SUCCESS;
+//}
+
+constexpr size_t INPUT_INDEX_X = 0;
+constexpr size_t INPUT_INDEX_WEIGHT = 1;
+constexpr size_t INPUT_INDEX_BIAS = 2;
+
+static ge::graphStatus TilingFunc(gert::TilingContext* context)
+{
+    MatmulGeluTilingData *tiling = context->GetTilingData<MatmulGeluTilingData>();
+
+    const ge::DataType xDataType = context->GetInputDesc(INPUT_INDEX_X)->GetDataType();
+    const gert::Shape xShape = context->GetInputShape(INPUT_INDEX_X)->GetStorageShape();
+    const gert::Shape weightShape = context->GetInputShape(INPUT_INDEX_WEIGHT)->GetStorageShape();
+    const gert::Shape BiasShape = context->GetInputShape(INPUT_INDEX_BIAS)->GetStorageShape();
+    size_t  m = xShape.GetDim(0);
+    size_t  k = xShape.GetDim(1);
+    size_t  n = BiasShape.GetDim(0);
+    tiling->m = m;
+    tiling->n = n;
+    tiling->k = k;
+
+    if (k == weightShape.GetDim(0)) {
+        tiling->transB = false;
+    } else if (k == weightShape.GetDim(1)) {
+        tiling->transB = true;
+    } else {
+        return ge::GRAPH_FAILED;
+    }
+
+    auto platformInfo = context->GetPlatformInfo();
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+    const int64_t totalCoreNum = ascendcPlatform.GetCoreNumAic();
+
+    size_t* currentWorkspace = context->GetWorkspaceSizes(1);
+    size_t systemWorkspacesSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    const size_t elementSize = (xDataType == ge::DT_FLOAT) ? sizeof(float) : 2;
+    const size_t userWorkspaceSize = m * n * 4;
+    currentWorkspace[0] = systemWorkspacesSize + userWorkspaceSize;
+
+    context->SetBlockDim(totalCoreNum);
+    // context->SetTilingKey(static_cast<uint64_t>(xDataType));
+
+    return ge::GRAPH_SUCCESS;
+}
+
+struct MatmulGeluCompileInfo {};
+ge::graphStatus TilingParseForMatmulGelu(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(MatmulGelu)
+    .Tiling(TilingFunc)
+    .TilingParse<MatmulGeluCompileInfo>(TilingParseForMatmulGelu);

--- a/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
@@ -56,8 +56,7 @@ static ge::graphStatus TilingFunc(gert::TilingContext* context)
 
     size_t* currentWorkspace = context->GetWorkspaceSizes(1);
     size_t systemWorkspacesSize = ascendcPlatform.GetLibApiWorkSpaceSize();
-    const size_t elementSize = (xDataType == ge::DT_FLOAT) ? sizeof(float) : 2;
-    const size_t userWorkspaceSize = m * n * 4;
+    const size_t userWorkspaceSize = m * n * sizeof(float);
     currentWorkspace[0] = systemWorkspacesSize + userWorkspaceSize;
 
     context->SetBlockDim(totalCoreNum);

--- a/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
@@ -60,7 +60,6 @@ static ge::graphStatus TilingFunc(gert::TilingContext* context)
     currentWorkspace[0] = systemWorkspacesSize + userWorkspaceSize;
 
     context->SetBlockDim(totalCoreNum);
-    // context->SetTilingKey(static_cast<uint64_t>(xDataType));
 
     return ge::GRAPH_SUCCESS;
 }

--- a/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
+++ b/csrc/matmul_gelu/op_host/matmul_gelu_tiling.cpp
@@ -42,13 +42,7 @@ static ge::graphStatus TilingFunc(gert::TilingContext* context)
     tiling->n = n;
     tiling->k = k;
 
-    if (k == weightShape.GetDim(0)) {
-        tiling->transB = false;
-    } else if (k == weightShape.GetDim(1)) {
-        tiling->transB = true;
-    } else {
-        return ge::GRAPH_FAILED;
-    }
+    tiling->transB = true;
 
     auto platformInfo = context->GetPlatformInfo();
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);

--- a/csrc/matmul_gelu/op_kernel/kernel_matmul_activation.hpp
+++ b/csrc/matmul_gelu/op_kernel/kernel_matmul_activation.hpp
@@ -1,12 +1,18 @@
-/**
- * Copyright (c) 2025 Huawei Technologies Co., Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * CANN Open Software License Agreement Version 2.0 (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- * See LICENSE in the root of the software repository for the full text of the License.
- */
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef CATLASS_GEMM_KERNEL_MATMUL_EPILOGUE_HPP
 #define CATLASS_GEMM_KERNEL_MATMUL_EPILOGUE_HPP

--- a/csrc/matmul_gelu/op_kernel/kernel_matmul_activation.hpp
+++ b/csrc/matmul_gelu/op_kernel/kernel_matmul_activation.hpp
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef CATLASS_GEMM_KERNEL_MATMUL_EPILOGUE_HPP
+#define CATLASS_GEMM_KERNEL_MATMUL_EPILOGUE_HPP
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+
+namespace Catlass::Gemm::Kernel {
+
+// Template for matmul add kernel. Compute C(fp32) = A * B, D = Cast(Activation(C))
+template <
+    class BlockMmad_,
+    class BlockEpilogue_,
+    class BlockScheduler_
+>
+class MatmulActivation {
+public:
+    // BlockMmad的内核
+    using BlockMmad = BlockMmad_;
+    using ArchTag = typename BlockMmad::ArchTag;
+    using L1TileShape = typename BlockMmad::L1TileShape;
+    using ElementA = typename BlockMmad::ElementA;
+    using LayoutA = typename BlockMmad::LayoutA;
+    using ElementB = typename BlockMmad::ElementB;
+    using LayoutB = typename BlockMmad::LayoutB;
+    using ElementC = typename BlockMmad::ElementC;
+    using LayoutC = typename BlockMmad::LayoutC;
+    using ElementBias = typename BlockMmad::ElementBias;
+
+    // 后处理的内核
+    using BlockEpilogue = BlockEpilogue_;
+    using ElementD = typename BlockEpilogue::ElementD;
+    using LayoutD = typename BlockEpilogue::LayoutD;
+    using EpilogueParams = typename BlockEpilogue::Params;
+
+    using BlockScheduler = BlockScheduler_;
+
+    static_assert(std::is_same_v<typename BlockEpilogue::ElementC, ElementC> &&
+        std::is_same_v<typename BlockEpilogue::LayoutC, LayoutC>,
+        "The CType of Mmad and Epilogue should be consistent.");
+
+    /// Parameters structure
+    struct Params {
+        // Data members
+        GemmCoord problemShape;
+        GM_ADDR ptrA;
+        LayoutA layoutA;
+        GM_ADDR ptrB;
+        LayoutB layoutB;
+        GM_ADDR ptrBias;
+        GM_ADDR ptrWorkspace;
+        EpilogueParams epilogueParams;
+
+        // Methods
+        CATLASS_HOST_DEVICE
+        Params() {}
+
+        CATLASS_HOST_DEVICE
+        Params(
+            GemmCoord const &problemShape_,
+            GM_ADDR ptrA_, LayoutA const &layoutA_,
+            GM_ADDR ptrB_, LayoutB const &layoutB_,
+            GM_ADDR ptrBias_,
+            GM_ADDR ptrWorkspace_, EpilogueParams const &epilogueParams_
+        ) : problemShape(problemShape_), ptrA(ptrA_), layoutA(layoutA_), ptrB(ptrB_), layoutB(layoutB_), ptrBias(ptrBias_),
+            ptrWorkspace(ptrWorkspace_), epilogueParams(epilogueParams_) {}
+    };
+
+    struct Arguments {
+        GemmCoord problemShape;
+        size_t elementSize;
+        GM_ADDR ptrA;
+        GM_ADDR ptrB;
+        GM_ADDR ptrBias;
+        GM_ADDR ptrD;
+    };
+
+    static bool CanImplement(const Arguments &args)
+    {
+        return true;
+    }
+
+    static size_t GetWorkspaceSize(const Arguments &args)
+    {
+        return args.elementSize * args.problemShape.m() * args.problemShape.n();
+    }
+
+    static Params ToUnderlyingArguments(const Arguments &args, uint8_t *workspace)
+    {
+        GemmCoord problemShape = args.problemShape;
+        uint32_t m = problemShape.m();
+        uint32_t n = problemShape.n();
+        uint32_t k = problemShape.k();
+        LayoutA layoutA{m, k};
+        LayoutB layoutB{k, n};
+        LayoutC layoutC{m, n};
+        // 传出
+        typename BlockEpilogue::Params epilogueParams{workspace, layoutC, args.ptrD, layoutC};
+        Params params{problemShape,
+            args.ptrA, layoutA, // A矩阵
+            args.ptrB, layoutB, // B矩阵
+            args.ptrBias, // bias
+            workspace,
+            epilogueParams};
+        return params;
+    }
+
+    // Methods
+    CATLASS_DEVICE
+    MatmulActivation() {}
+
+    template <int32_t CORE_TYPE = g_coreType>
+    CATLASS_DEVICE
+    void operator()(Params const &params);
+
+    template <>
+    CATLASS_DEVICE
+    void operator()<AscendC::AIC>(Params const &params)
+    {
+        BlockScheduler matmulBlockScheduler(params.problemShape, MakeCoord(L1TileShape::M, L1TileShape::N));
+        uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops();
+
+        BlockMmad blockMmad(resource);
+
+        // Represent the full gm
+        AscendC::GlobalTensor<ElementA> gmA;
+        gmA.SetGlobalBuffer((__gm__ ElementA *)params.ptrA);
+        AscendC::GlobalTensor<ElementB> gmB;
+        gmB.SetGlobalBuffer((__gm__ ElementB *)params.ptrB);
+        AscendC::GlobalTensor<ElementC> gmC;
+        gmC.SetGlobalBuffer((__gm__ ElementC *)params.ptrWorkspace);
+        layout::RowMajor layoutC(params.problemShape.m(), params.problemShape.n());
+        AscendC::GlobalTensor<ElementBias> gmBias;
+        gmBias.SetGlobalBuffer((__gm__ ElementBias *)params.ptrBias);
+
+        for (uint32_t loopIdx = AscendC::GetBlockIdx(); loopIdx < coreLoops; loopIdx += AscendC::GetBlockNum()) {
+            // Compute block location
+            GemmCoord blockCoord = matmulBlockScheduler.GetBlockCoord(loopIdx);
+            GemmCoord actualBlockShape = matmulBlockScheduler.GetActualBlockShape(blockCoord);
+
+            // Compute initial location in logical coordinates
+            MatrixCoord offsetA{blockCoord.m() * L1TileShape::M, blockCoord.k() * L1TileShape::K};
+            MatrixCoord offsetB{blockCoord.k() * L1TileShape::K, blockCoord.n() * L1TileShape::N};
+            MatrixCoord offsetC{blockCoord.m() * L1TileShape::M, blockCoord.n() * L1TileShape::N};
+            int64_t gmOffsetA = params.layoutA.GetOffset(offsetA);
+            int64_t gmOffsetB = params.layoutB.GetOffset(offsetB);
+            int64_t gmOffsetC = layoutC.GetOffset(offsetC);
+            int64_t gmOffsetBias = blockCoord.n() * L1TileShape::N;
+
+            // Compute block-scoped matrix multiply-add
+            blockMmad(
+                gmA[gmOffsetA], params.layoutA,
+                gmB[gmOffsetB], params.layoutB,
+                gmC[gmOffsetC], layoutC,
+                gmBias[gmOffsetBias],
+                actualBlockShape);
+
+            Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagAicFinishStore);
+        }
+
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    template <>
+    CATLASS_DEVICE
+    void operator()<AscendC::AIV>(Params const &params)
+    {
+        BlockScheduler matmulBlockScheduler(params.problemShape, MakeCoord(L1TileShape::M, L1TileShape::N));
+        uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops();
+
+        BlockEpilogue blockEpilogue(resource, params.epilogueParams);
+
+        // Represent the full gm
+        AscendC::GlobalTensor<ElementC> gmC;
+        gmC.SetGlobalBuffer((__gm__ ElementC *)params.ptrWorkspace);
+        layout::RowMajor layoutC(params.problemShape.m(), params.problemShape.n());
+
+        // Get aicore information
+        uint32_t aicoreIndex = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
+        uint32_t aicoreNum = AscendC::GetBlockNum();
+        uint32_t subcoreIndex = AscendC::GetSubBlockIdx();
+
+        // Loop through the epilogue calculations of each basic block
+        GemmCoord blockShape = L1TileShape::ToCoord();
+        for (uint32_t loopIdx = aicoreIndex; loopIdx < coreLoops; loopIdx += aicoreNum) {
+            // Compute block location
+            GemmCoord blockCoord = matmulBlockScheduler.GetBlockCoord(loopIdx);
+            GemmCoord actualBlockShape = matmulBlockScheduler.GetActualBlockShape(blockCoord);
+            // Get the data and layout of C under the current basic block
+            auto gmBlockC = gmC[layoutC.GetOffset(blockCoord.GetCoordMN() * blockShape.GetCoordMN())];
+            auto layoutBlockC = layoutC.GetTileLayout(actualBlockShape.GetCoordMN());
+            // Synchronize cross core
+            Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE3>(flagAicFinishStore);
+            // Actual calculatioin logic for performing block-scoped epilogue
+            blockEpilogue(blockShape, blockCoord, actualBlockShape, gmBlockC, layoutBlockC);
+        }
+
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+private:
+    // ID used for inter-core synchronization
+    static constexpr Arch::FlagID FLAG_AIC_FINISH_STORE = 0;
+    static constexpr Arch::FlagID RV_FLAG_AIC_FINISH_STORE = 1;
+    Arch::CrossCoreFlagWithReverse<> flagAicFinishStore{FLAG_AIC_FINISH_STORE, RV_FLAG_AIC_FINISH_STORE};
+    Arch::Resource<ArchTag> resource;
+};
+
+} // namespace Catlass::Gemm::Kernel
+
+#endif // CATLASS_GEMM_KERNEL_MATMUL_EPILOGUE_HPP

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu.cpp
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu.cpp
@@ -1,0 +1,69 @@
+/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+        limitations under the License.
+==============================================================================*/
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+
+#include "matmul_gelu_kernel.h"
+
+using namespace MatmulGelu_Kernel;
+
+
+extern "C" __global__ __aicore__ void matmul_gelu(GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR output,
+                                                     GM_ADDR workspace, GM_ADDR tiling)
+{
+    if (GetSysWorkSpacePtr() == nullptr) {
+        return;
+    }
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    REGISTER_TILING_DEFAULT(MatmulGeluTilingData);
+    GET_TILING_DATA(tiling_data, tiling);
+
+    // if (TILING_KEY_IS(DT_BF16)) {
+    //     // bf16
+    //     if (!tiling_data.transB) {
+    //         MatmulGeluImpl<layout::RowMajor, bfloat16_t>(problemShape, x, weight, bias, output);
+    //     } else {
+    //         MatmulGeluImpl<layout::ColumnMajor, bfloat16_t>(problemShape, x, weight, bias, output);
+    //     }
+    // } else if (TILING_KEY_IS(DT_FLOAT)) {
+    //     // float32
+    //     if (!tiling_data.transB) {
+    //         MatmulGeluImpl<layout::RowMajor, float>(problemShape, x, weight, bias, output);
+    //     } else {
+    //         MatmulGeluImpl<layout::ColumnMajor, float>(problemShape, x, weight, bias, output);
+    //     }
+    // } else if (TILING_KEY_IS(DT_FLOAT16)) {
+    //     // float16
+    //     if (!tiling_data.transB) {
+    //         MatmulGeluImpl<layout::RowMajor, half>(problemShape, x, weight, bias, output);
+    //     } else {
+    //         MatmulGeluImpl<layout::ColumnMajor, half>(problemShape, x, weight, bias, output);
+    //     }
+    // }
+    if (!tiling_data.transB) {
+        MatmulGeluImpl<layout::RowMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
+    } else {
+        MatmulGeluImpl<layout::ColumnMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
+    }
+    // if (tiling_data.m >= 1024) {
+    //     MatmulGeluImpl<layout::RowMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
+    // } else if (tiling_data.m >= 512) {
+    //     MatmulGeluImpl<layout::RowMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
+    // } else {
+    //     MatmulGeluImpl<layout::RowMajor, half, 112, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
+    // }
+// 128x256x128_128x256x64
+}

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu.cpp
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu.cpp
@@ -1,17 +1,18 @@
-/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-        limitations under the License.
-==============================================================================*/
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "kernel_operator.h"
 #include "lib/matmul_intf.h"

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu.cpp
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu.cpp
@@ -31,39 +31,10 @@ extern "C" __global__ __aicore__ void matmul_gelu(GM_ADDR x, GM_ADDR weight, GM_
     REGISTER_TILING_DEFAULT(MatmulGeluTilingData);
     GET_TILING_DATA(tiling_data, tiling);
 
-    // if (TILING_KEY_IS(DT_BF16)) {
-    //     // bf16
-    //     if (!tiling_data.transB) {
-    //         MatmulGeluImpl<layout::RowMajor, bfloat16_t>(problemShape, x, weight, bias, output);
-    //     } else {
-    //         MatmulGeluImpl<layout::ColumnMajor, bfloat16_t>(problemShape, x, weight, bias, output);
-    //     }
-    // } else if (TILING_KEY_IS(DT_FLOAT)) {
-    //     // float32
-    //     if (!tiling_data.transB) {
-    //         MatmulGeluImpl<layout::RowMajor, float>(problemShape, x, weight, bias, output);
-    //     } else {
-    //         MatmulGeluImpl<layout::ColumnMajor, float>(problemShape, x, weight, bias, output);
-    //     }
-    // } else if (TILING_KEY_IS(DT_FLOAT16)) {
-    //     // float16
-    //     if (!tiling_data.transB) {
-    //         MatmulGeluImpl<layout::RowMajor, half>(problemShape, x, weight, bias, output);
-    //     } else {
-    //         MatmulGeluImpl<layout::ColumnMajor, half>(problemShape, x, weight, bias, output);
-    //     }
-    // }
     if (!tiling_data.transB) {
         MatmulGeluImpl<layout::RowMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
     } else {
         MatmulGeluImpl<layout::ColumnMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
     }
-    // if (tiling_data.m >= 1024) {
-    //     MatmulGeluImpl<layout::RowMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
-    // } else if (tiling_data.m >= 512) {
-    //     MatmulGeluImpl<layout::RowMajor, half, 128, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
-    // } else {
-    //     MatmulGeluImpl<layout::RowMajor, half, 112, 256, 256, 64>(tiling_data, x, weight, bias, output, workspace);
-    // }
-// 128x256x128_128x256x64
+
 }

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu_kernel.h
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu_kernel.h
@@ -1,18 +1,17 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+        limitations under the License.
+==============================================================================*/
 
 #ifndef _CUSTOM_MATMUL_GELU_KERNEL_H
 #define _CUSTOM_MATMUL_GELU_KERNEL_H
@@ -36,8 +35,10 @@
 #include "./kernel_matmul_activation.hpp"
 #include "matmul_gelu_tiling.h"
 
+
 namespace MatmulGelu_Kernel {
 using namespace Catlass;
+
 template <class LayoutWeight, class InDType, uint32_t m, uint32_t n, uint32_t k1, uint32_t k0>
 CATLASS_DEVICE void MatmulGeluImpl(MatmulGeluTilingData tiling_data, GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR output, GM_ADDR workspace)
 {
@@ -65,7 +66,6 @@ CATLASS_DEVICE void MatmulGeluImpl(MatmulGeluTilingData tiling_data, GM_ADDR x, 
         using BlockMmad = Gemm::Block::BlockMmad<MmadDispatchPolicy, L1TileShape, L0TileShape, AType, BType, CType, BiasType>;
         using EpilogueDispatchPolicy = Epilogue::EpilogueAtlasA2ElemWiseNoSource;
 
-        // Define epilogue
         constexpr uint32_t computeLength = (m * n) / 2;
         using TileElemWiseEpilogue = Epilogue::Tile::TileElemWiseGelu<ArchTag, CType, computeLength>;
         using EpilogueTileCopy = Epilogue::Tile::TileCopy<
@@ -76,13 +76,12 @@ CATLASS_DEVICE void MatmulGeluImpl(MatmulGeluTilingData tiling_data, GM_ADDR x, 
         using BlockEpilogue =
         Epilogue::Block::BlockEpilogue<EpilogueDispatchPolicy, CType, DType, TileElemWiseEpilogue, EpilogueTileCopy>;
         using EpilogueParams = typename BlockEpilogue::Params;
-
-        // 内部模板函数：处理具体的BlockScheduler类型
-        auto runMatmulKernel = [&]<typename BlockSchedulerType>() {
+        if (tiling_data.m > tiling_data.n) {
+                // Define BlockScheduler
+                // Swizzle offset is 3 and direction is 0.
+                using BlockScheduler = typename Gemm::Block::GemmIdentityBlockSwizzle<3, 0>;
                 // Kernel level
-                using MatmulKernel = Gemm::Kernel::MatmulActivation<BlockMmad, BlockEpilogue, BlockSchedulerType>;
-
-                // Prepare params
+                using MatmulKernel = Gemm::Kernel::MatmulActivation<BlockMmad, BlockEpilogue, BlockScheduler>;
                 LayoutA layoutA{problemShape.m(), problemShape.k()};
                 LayoutB layoutB{problemShape.k(), problemShape.n()};
                 LayoutC layoutC{problemShape.m(), problemShape.n()};
@@ -98,17 +97,27 @@ CATLASS_DEVICE void MatmulGeluImpl(MatmulGeluTilingData tiling_data, GM_ADDR x, 
                                 );
                 MatmulKernel matmulKernel;
                 matmulKernel(params);
-        };
-
-        // 根据条件选择不同的BlockScheduler并执行
-        if (tiling_data.m > tiling_data.n) {
-                // Swizzle offset is 3 and direction is 0.
-                using BlockScheduler = typename Gemm::Block::GemmIdentityBlockSwizzle<3, 0>;
-                runMatmulKernel.template operator()<BlockScheduler>();
         } else {
+                // Define BlockScheduler
                 // Swizzle offset is 3 and direction is 1.
                 using BlockScheduler = typename Gemm::Block::GemmIdentityBlockSwizzle<3, 1>;
-                runMatmulKernel.template operator()<BlockScheduler>();
+                // Kernel level
+                using MatmulKernel = Gemm::Kernel::MatmulActivation<BlockMmad, BlockEpilogue, BlockScheduler>;
+                LayoutA layoutA{problemShape.m(), problemShape.k()};
+                LayoutB layoutB{problemShape.k(), problemShape.n()};
+                LayoutC layoutC{problemShape.m(), problemShape.n()};
+
+                EpilogueParams epilogueParams(workspace, layoutC, output, layoutC);
+                typename MatmulKernel::Params params(
+                                problemShape,
+                                x, layoutA,
+                                weight, layoutB,
+                                bias,
+                                workspace,
+                                epilogueParams
+                                );
+                MatmulKernel matmulKernel;
+                matmulKernel(params);
         }
 }
 }  // namespace CustomMatmulGelu_Kernel

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu_kernel.h
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu_kernel.h
@@ -1,17 +1,18 @@
-/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-        limitations under the License.
-==============================================================================*/
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef _CUSTOM_MATMUL_GELU_KERNEL_H
 #define _CUSTOM_MATMUL_GELU_KERNEL_H
@@ -35,24 +36,6 @@ See the License for the specific language governing permissions and
 #include "./kernel_matmul_activation.hpp"
 #include "matmul_gelu_tiling.h"
 
-
-namespace MatmulGelu_Kernel {
-using namespace Catlass;
-
-华为
- matmul_gelu_kernel.h
-该文件中的函数MatmulGeluImpl中的
-if (tiling_data.m > tiling_data.n)
- 和
-else代码块很相似，只有
-BlockScheduler
-不一样，请帮忙重构代码消除重复代码​
-TRAE AI
-我需要重构MatmulGeluImpl函数，消除if-else分支中的重复代码。通过分析发现，两个分支只有BlockScheduler模板参数不同，可以创建一个内部模板函数来处理这个差异。
-
-
-matmul_gelu_kernel.h
-Apply
 namespace MatmulGelu_Kernel {
 using namespace Catlass;
 template <class LayoutWeight, class InDType, uint32_t m, uint32_t n, uint32_t k1, uint32_t k0>

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu_kernel.h
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu_kernel.h
@@ -1,0 +1,155 @@
+/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+        limitations under the License.
+==============================================================================*/
+
+#ifndef _CUSTOM_MATMUL_GELU_KERNEL_H
+#define _CUSTOM_MATMUL_GELU_KERNEL_H
+
+#include <acl/acl.h>
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/epilogue/block/block_epilogue.hpp"
+#include "catlass/epilogue/dispatch_policy.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+#include "catlass/epilogue/tile/tile_elemwise_gelu.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "catlass/gemm/device/device_gemm.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/status.hpp"
+
+#include "./kernel_matmul_activation.hpp"
+#include "matmul_gelu_tiling.h"
+
+
+namespace MatmulGelu_Kernel {
+using namespace Catlass;
+
+template <class LayoutWeight, class InDType, uint32_t m, uint32_t n, uint32_t k1, uint32_t k0>
+CATLASS_DEVICE void MatmulGeluImpl(MatmulGeluTilingData tiling_data, GM_ADDR x, GM_ADDR weight, GM_ADDR bias, GM_ADDR output, GM_ADDR workspace)
+{
+        Catlass::GemmCoord problemShape{tiling_data.m, tiling_data.n, tiling_data.k};
+
+        // Define ArchTag
+        using ArchTag = Arch::AtlasA2;
+
+        using LayoutA = layout::RowMajor;
+        using LayoutB = LayoutWeight;
+        using LayoutD = layout::RowMajor;
+        using LayoutBias = layout::VectorLayout;
+        using LayoutC = layout::RowMajor;
+
+        // if (tiling_data.m >= 4096) {
+        //         m_ = 128;
+        //         n_ = 256;
+        //         k1_ = 256;
+        //         k0_ = 64;   
+        // }
+        // if (tiling_data.m <= 16) {
+        //         m_ = 112;
+        //         n_ = 256;
+        //         k1_ = 192;
+        //         k0_ = 48;   
+        // }
+       
+      
+        // constexpr int k1 = 512 / sizeof(InDType);
+        // constexpr int k0 = 128 / sizeof(InDType);
+
+        // Block level, define BlockMmad
+        constexpr bool enableUnitFlag = true;
+        using MmadDispatchPolicy = Gemm::MmadAtlasA2PingpongBias<enableUnitFlag>;
+        // 128x256x256_128x256x64
+        // using L1TileShape = GemmShape<128, 256, 256>;
+        // using L0TileShape = GemmShape<128, 256, 64>;
+        using L1TileShape = GemmShape<m, n, k1>;
+        using L0TileShape = GemmShape<m, n, k0>;
+        using AType = Gemm::GemmType<half, LayoutA>;
+        using BType = Gemm::GemmType<half, LayoutB>;
+        using CType = Gemm::GemmType<float, LayoutC>;
+        using BiasType = Gemm::GemmType<InDType, LayoutBias>;
+        using DType = Gemm::GemmType<half, LayoutC>;
+        using BlockMmad = Gemm::Block::BlockMmad<MmadDispatchPolicy, L1TileShape, L0TileShape, AType, BType, CType, BiasType>;
+        using EpilogueDispatchPolicy = Epilogue::EpilogueAtlasA2ElemWiseNoSource;
+
+        // constexpr uint32_t computeLength = 16384 * 2; // 64 * 128 * 2B
+        // constexpr uint32_t computeLength = L0TileShape::M * L0TileShape::N; // 64 * 128 * 2B
+        constexpr uint32_t computeLength = (m * n) / 2;
+        using TileElemWiseEpilogue = Epilogue::Tile::TileElemWiseGelu<ArchTag, CType, computeLength>;
+        using EpilogueTileCopy = Epilogue::Tile::TileCopy<
+                ArchTag,
+                CType, // CopyGmtoUbC
+                DType  // CopyUbtoGmD
+                >;
+        using BlockEpilogue =
+        Epilogue::Block::BlockEpilogue<EpilogueDispatchPolicy, CType, DType, TileElemWiseEpilogue, EpilogueTileCopy>;
+        using EpilogueParams = typename BlockEpilogue::Params;
+        if (tiling_data.m > tiling_data.n) {
+                // Define BlockScheduler
+                // Swizzle offset is 3 and direction is 0.
+                using BlockScheduler = typename Gemm::Block::GemmIdentityBlockSwizzle<3, 0>;
+                // Kernel level
+                using MatmulKernel = Gemm::Kernel::MatmulActivation<BlockMmad, BlockEpilogue, BlockScheduler>;
+                // Prepare params
+                // typename MatmulKernel::Arguments arguments{problemShape, sizeof(InDType), x, weight, bias, output};
+                // typename MatmulKernel::Params params = MatmulKernel::ToUnderlyingArguments(arguments, (uint8_t *)workspace);
+                // AscendC::printf("yyyyyyyyyyyyyyyy m: %d, n: %d, k: %d\n", problemShape.m(), problemShape.n(), problemShape.k());
+                LayoutA layoutA{problemShape.m(), problemShape.k()};
+                LayoutB layoutB{problemShape.k(), problemShape.n()};
+                LayoutC layoutC{problemShape.m(), problemShape.n()};
+
+                EpilogueParams epilogueParams(workspace, layoutC, output, layoutC);
+                typename MatmulKernel::Params params(
+                                problemShape,
+                                x, layoutA,
+                                weight, layoutB,
+                                bias,
+                                workspace,
+                                epilogueParams
+                                );
+                MatmulKernel matmulKernel;
+                matmulKernel(params);
+        } else {
+                // Define BlockScheduler
+                // Swizzle offset is 3 and direction is 1.
+                using BlockScheduler = typename Gemm::Block::GemmIdentityBlockSwizzle<3, 1>;
+                // Kernel level
+                using MatmulKernel = Gemm::Kernel::MatmulActivation<BlockMmad, BlockEpilogue, BlockScheduler>;
+                // Prepare params
+                // typename MatmulKernel::Arguments arguments{problemShape, sizeof(InDType), x, weight, bias, output};
+                // typename MatmulKernel::Params params = MatmulKernel::ToUnderlyingArguments(arguments, (uint8_t *)workspace);
+                // AscendC::printf("yyyyyyyyyyyyyyyy m: %d, n: %d, k: %d\n", problemShape.m(), problemShape.n(), problemShape.k());
+                LayoutA layoutA{problemShape.m(), problemShape.k()};
+                LayoutB layoutB{problemShape.k(), problemShape.n()};
+                LayoutC layoutC{problemShape.m(), problemShape.n()};
+
+                EpilogueParams epilogueParams(workspace, layoutC, output, layoutC);
+                typename MatmulKernel::Params params(
+                                problemShape,
+                                x, layoutA,
+                                weight, layoutB,
+                                bias,
+                                workspace,
+                                epilogueParams
+                                );
+                MatmulKernel matmulKernel;
+                matmulKernel(params);
+        }
+}
+}  // namespace CustomMatmulGelu_Kernel
+
+#endif

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu_tiling.h
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu_tiling.h
@@ -1,17 +1,18 @@
-/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-        limitations under the License.
-==============================================================================*/
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef ASCENDC_OP_KERNEL_MATMUL_GELU_TILING_H
 #define ASCENDC_OP_KERNEL_MATMUL_GELU_TILING_H

--- a/csrc/matmul_gelu/op_kernel/matmul_gelu_tiling.h
+++ b/csrc/matmul_gelu/op_kernel/matmul_gelu_tiling.h
@@ -1,0 +1,32 @@
+/* Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+        limitations under the License.
+==============================================================================*/
+
+#ifndef ASCENDC_OP_KERNEL_MATMUL_GELU_TILING_H
+#define ASCENDC_OP_KERNEL_MATMUL_GELU_TILING_H
+
+#include <cstdint>
+#include "kernel_tiling/kernel_tiling.h"
+
+
+struct MatmulGeluTilingData
+{
+        uint32_t m;
+        uint32_t n;
+        uint32_t k;
+        bool transB;
+};
+
+
+#endif

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -585,7 +585,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> add_layer_norm(
      TORCH_CHECK(
         x2.scalar_type() == gamma.scalar_type() && x2.scalar_type() == beta.scalar_type() &&
         x2.scalar_type() == x1.scalar_type(),
-        "The dtype of x2, gamma, beta and a1 should be same");
+        "The dtype of x1, x2, gamma and beta should be same");
 
     std::vector<int64_t> shape;
     for (int64_t index = 0; index < x1.dim() - gamma.dim(); index++) {

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -436,8 +436,8 @@ at::Tensor matmul_gelu_meta(const at::Tensor &x, const at::Tensor &weight, const
     TORCH_CHECK(x.dim() == 2, "The x should be 2D");
     TORCH_CHECK(weight.dim() == 2, "The weight should be 2D");
     TORCH_CHECK(bias.dim() == 1, "The bias should be 1D");
-    TORCH_CHECK(weight.sym_size(0) == bias.sym_size(0) || weight.sym_size(1) == bias.sym_size(0), "The weight first or second dim should be same as bias first dim");
-    TORCH_CHECK(x.sym_size(1) == weight.sym_size(1) || x.sym_size(1) == weight.sym_size(0), "The x second dim should be same as weight first or second dim");
+    TORCH_CHECK(weight.sym_size(0) == bias.sym_size(0), "The weight first dim should be same as bias first dim");
+    TORCH_CHECK(x.sym_size(1) == weight.sym_size(1), "The x second dim should be same as weight second dim");
     TORCH_CHECK(
         x.scalar_type() == at::kHalf || x.scalar_type() == at::kFloat,
         "float16 or float32 tensor expected but got a tensor with dtype: ",

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -431,6 +431,51 @@ void transpose_kv_cache_by_block_meta(
     return;
 }
 
+at::Tensor matmul_gelu_meta(const at::Tensor &x, const at::Tensor &weight, const at::Tensor &bias)
+{
+    TORCH_CHECK(x.dim() == 2, "The x should be 2D");
+    TORCH_CHECK(weight.dim() == 2, "The weight should be 2D");
+    TORCH_CHECK(bias.dim() == 1, "The bias should be 1D");
+    TORCH_CHECK(weight.sym_size(0) == bias.sym_size(0) || weight.sym_size(1) == bias.sym_size(0), "The weight first or second dim should be same as bias first dim");
+    TORCH_CHECK(x.sym_size(1) == weight.sym_size(1) || x.sym_size(1) == weight.sym_size(0), "The x second dim should be same as weight first or second dim");
+    TORCH_CHECK(
+        x.scalar_type() == at::kHalf || x.scalar_type() == at::kFloat,
+        "float16 or float32 tensor expected but got a tensor with dtype: ",
+        x.scalar_type());
+     TORCH_CHECK(
+        x.scalar_type() == weight.scalar_type() && x.scalar_type() == bias.scalar_type(),
+        "The dtype of x, weight and bias should be same");
+
+    auto m = x.sym_size(0);
+    auto n = bias.sym_size(0);
+
+    at::Tensor gelu_output = at::empty_symint({m, n}, x.options());
+    return gelu_output;
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> add_layer_norm_meta(
+    const at::Tensor& x1,
+    const at::Tensor& x2,
+    const at::Tensor& gamma,
+    const at::Tensor& beta,
+    double epsilon,
+    bool additional_output)
+{
+    c10::SymDimVector shape;
+    for (int64_t index = 0; index < x1.dim() - gamma.dim(); index++) {
+        shape.push_back(x1.sym_size(index));
+    }
+    shape.push_back(1);
+
+    at::Tensor y = at::empty_symint(x1.sym_sizes(), x1.options());
+    at::Tensor x = at::empty_symint(x1.sym_sizes(), x1.options());
+
+    at::Tensor mean = at::empty_symint(shape, x1.options().dtype(at::kFloat));
+    at::Tensor rstd = at::empty_symint(shape, x1.options().dtype(at::kFloat));
+
+    return std::make_tuple(y, mean, rstd, x);
+}
+
 } // namespace meta
 } // namespace vllm_ascend
 
@@ -471,5 +516,9 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_add_rms_norm_bias", &vllm_ascend::meta::npu_add_rms_norm_bias_meta);
     // transpose_kv_cache_by_block
     ops.impl("transpose_kv_cache_by_block", &vllm_ascend::meta::transpose_kv_cache_by_block_meta);
+    // matmul_gelu
+    ops.impl("matmul_gelu", &vllm_ascend::meta::matmul_gelu_meta);
+    // add_layer_norm
+    ops.impl("add_layer_norm", &vllm_ascend::meta::add_layer_norm_meta);
 }
 }

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_layer_norm.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_add_layer_norm.py
@@ -1,0 +1,86 @@
+import gc
+import random
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+seed = 45
+random.seed(seed)
+np.random.seed(seed)
+torch.manual_seed(seed)
+
+
+def npu_add_layer_norm_golden(input_x1,
+                            input_x2,
+                            input_gamma,
+                            input_beta,
+                            epsilon=1e-05):
+    ori_x_shape = input_x1.shape
+    layerNorm = nn.LayerNorm(ori_x_shape[-1], eps=epsilon)
+    layerNorm.weight = nn.Parameter(input_gamma)
+    layerNorm.bias = nn.Parameter(input_beta)
+
+    return layerNorm(input_x1 + input_x2)
+
+
+relative_tol = 1e-3
+absolute_tol = 1e-3
+error_tol = 1e-3
+
+
+def verify_result(output, golden):
+    output = output.cpu().detach().numpy().reshape(-1)
+    golden = golden.cpu().detach().numpy().reshape(-1)
+    different_element_results = np.isclose(output,
+                                           golden,
+                                           rtol=relative_tol,
+                                           atol=absolute_tol,
+                                           equal_nan=True)
+    different_element_indexes = np.where(different_element_results == False)[0]
+    error_ratio = float(different_element_indexes.size) / golden.size
+    return error_ratio <= error_tol
+
+
+@pytest.mark.parametrize(
+    'm',
+    [1, 3, 16, 64, 128, 255, 8192]
+)
+
+@pytest.mark.parametrize(
+    'n',
+    [
+        512,
+        1024,
+        4096,
+    ],
+)
+
+def test_add_layer_norm(m: int, n: int):
+    x1 = torch.randn(m, n).half().npu()
+    x2 = torch.randn(m, n).half().npu()
+    gamma = torch.randn(n).half().npu()
+    beta = torch.randn(n).half().npu()
+    torch.npu.synchronize()
+    y = torch.ops._C_ascend.add_layer_norm(x1,
+                                              x2,
+                                              gamma,
+                                              beta,
+                                              1e-5)[0]
+
+    torch.npu.synchronize()
+
+    y1 = npu_add_layer_norm_golden(x1,
+                                x2,
+                                gamma,
+                                beta,
+                                1e-05)
+    torch.npu.synchronize()
+    assert verify_result(y, y1)
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_matmul_gelu.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_matmul_gelu.py
@@ -1,0 +1,85 @@
+import gc
+import random
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+seed = 45
+random.seed(seed)
+np.random.seed(seed)
+torch.manual_seed(seed)
+
+
+
+def npu_matmul_gelu_golden(x,
+                            weight,
+                            bias):
+    res= torch.nn.functional.gelu(torch.mm(x, weight) + bias)
+    return res
+
+
+relative_tol = 1e-3
+absolute_tol = 1e-3
+error_tol = 1e-3
+
+
+def verify_result(output, golden):
+    output = output.cpu().detach().numpy().reshape(-1)
+    golden = golden.cpu().detach().numpy().reshape(-1)
+    different_element_results = np.isclose(output,
+                                           golden,
+                                           rtol=relative_tol,
+                                           atol=absolute_tol,
+                                           equal_nan=True)
+    different_element_indexes = np.where(different_element_results == False)[0]
+    error_ratio = float(different_element_indexes.size) / golden.size
+    return error_ratio <= error_tol
+
+
+@pytest.mark.parametrize(
+    'm',
+    [1, 3, 16, 64, 128, 255, 8192]
+)
+@pytest.mark.parametrize(
+    'n',
+    [
+        512,
+        1024,
+        4096,
+    ],
+)
+@pytest.mark.parametrize(
+    'k',
+    [
+        128,
+        256,
+        512,
+        1024,
+    ],
+)
+
+def test_matmul_gelu(m: int, n: int, k: int):
+
+    x = torch.randn(m, k).half().npu()
+    weight = torch.randn(n, k).half().npu()
+    weight_t = weight.transpose(1, 0).contiguous()
+    bias = torch.randn(n).half().npu()
+    torch.npu.synchronize()
+    y = torch.ops._C_ascend.matmul_gelu(x,
+                                      weight,
+                                      bias)
+    torch.npu.synchronize()
+
+    y1 = npu_matmul_gelu_golden(x,
+                                weight_t,
+                                bias)
+    torch.npu.synchronize()
+    assert verify_result(y, y1)
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/patch/worker/patch_bert.py
+++ b/vllm_ascend/patch/worker/patch_bert.py
@@ -41,11 +41,9 @@ def _decode_token_type_ids(input_ids: torch.Tensor) -> torch.Tensor:
 class AscendBertOutput(nn.Module):
     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states, _ = self.dense(hidden_states)
-        hidden_states = torch.ops._C_ascend.add_layer_norm(hidden_states,
-                                                           input_tensor,
-                                                           self.LayerNorm.weight,
-                                                           self.LayerNorm.bias,
-                                                           self.LayerNorm.eps)[0]
+        hidden_states = torch.ops._C_ascend.add_layer_norm(
+        hidden_states, input_tensor, self.LayerNorm.weight, self.LayerNorm.bias, self.LayerNorm.eps
+        )[0]
         return hidden_states
 
 

--- a/vllm_ascend/patch/worker/patch_bert.py
+++ b/vllm_ascend/patch/worker/patch_bert.py
@@ -39,9 +39,7 @@ def _decode_token_type_ids(input_ids: torch.Tensor) -> torch.Tensor:
     return token_type_ids
 
 class AscendBertOutput(nn.Module):
-    def forward(
-            self, hidden_states: torch.Tensor, input_tensor: torch.Tensor
-    ) -> torch.Tensor:
+    def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states, _ = self.dense(hidden_states)
         hidden_states = torch.ops._C_ascend.add_layer_norm(hidden_states,
                                                            input_tensor,
@@ -52,15 +50,11 @@ class AscendBertOutput(nn.Module):
 
 
 class AscendBertSelfOutput(nn.Module):
-    def forward(
-        self, hidden_states: torch.Tensor, input_tensor: torch.Tensor
-    ) -> torch.Tensor:
+    def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states, _ = self.dense(hidden_states)
-        hidden_states = torch.ops._C_ascend.add_layer_norm(hidden_states,
-                                                           input_tensor,
-                                                           self.LayerNorm.weight,
-                                                           self.LayerNorm.bias,
-                                                           self.LayerNorm.eps)[0]
+        hidden_states = torch.ops._C_ascend.add_layer_norm(
+        hidden_states, input_tensor, self.LayerNorm.weight, self.LayerNorm.bias, self.LayerNorm.eps
+        )[0]
         return hidden_states
 
 class AscendBertIntermediate(nn.Module):

--- a/vllm_ascend/patch/worker/patch_bert.py
+++ b/vllm_ascend/patch/worker/patch_bert.py
@@ -17,7 +17,6 @@
 
 import torch
 from torch import nn
-
 from vllm.model_executor.models import bert
 
 # aclgraph does not support shift operator for now
@@ -38,6 +37,7 @@ def _decode_token_type_ids(input_ids: torch.Tensor) -> torch.Tensor:
 
     return token_type_ids
 
+
 class AscendBertOutput(nn.Module):
     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states, _ = self.dense(hidden_states)
@@ -55,6 +55,7 @@ class AscendBertSelfOutput(nn.Module):
         )[0]
         return hidden_states
 
+
 class AscendBertIntermediate(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         if isinstance(self.intermediate_act_fn, nn.GELU):
@@ -64,10 +65,10 @@ class AscendBertIntermediate(nn.Module):
             hidden_states = self.intermediate_act_fn(hidden_states)
         return hidden_states
 
+
 bert._encode_token_type_ids = _encode_token_type_ids
 bert._decode_token_type_ids = _decode_token_type_ids
 
 bert.BertOutput.forward = AscendBertOutput.forward
 bert.BertSelfOutput.forward = AscendBertSelfOutput.forward
 bert.BertIntermediate.forward = AscendBertIntermediate.forward
-

--- a/vllm_ascend/patch/worker/patch_bert.py
+++ b/vllm_ascend/patch/worker/patch_bert.py
@@ -16,6 +16,8 @@
 #
 
 import torch
+from torch import nn
+
 from vllm.model_executor.models import bert
 
 # aclgraph does not support shift operator for now
@@ -36,6 +38,44 @@ def _decode_token_type_ids(input_ids: torch.Tensor) -> torch.Tensor:
 
     return token_type_ids
 
+class AscendBertOutput(nn.Module):
+    def forward(
+            self, hidden_states: torch.Tensor, input_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        hidden_states, _ = self.dense(hidden_states)
+        hidden_states = torch.ops._C_ascend.add_layer_norm(hidden_states,
+                                                           input_tensor,
+                                                           self.LayerNorm.weight,
+                                                           self.LayerNorm.bias,
+                                                           self.LayerNorm.eps)[0]
+        return hidden_states
+
+
+class AscendBertSelfOutput(nn.Module):
+    def forward(
+        self, hidden_states: torch.Tensor, input_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        hidden_states, _ = self.dense(hidden_states)
+        hidden_states = torch.ops._C_ascend.add_layer_norm(hidden_states,
+                                                           input_tensor,
+                                                           self.LayerNorm.weight,
+                                                           self.LayerNorm.bias,
+                                                           self.LayerNorm.eps)[0]
+        return hidden_states
+
+class AscendBertIntermediate(nn.Module):
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if isinstance(self.intermediate_act_fn, nn.GELU):
+            hidden_states = torch.ops._C_ascend.matmul_gelu(hidden_states, self.dense.weight, self.dense.bias)
+        else:
+            hidden_states, _ = self.dense(hidden_states)
+            hidden_states = self.intermediate_act_fn(hidden_states)
+        return hidden_states
 
 bert._encode_token_type_ids = _encode_token_type_ids
 bert._decode_token_type_ids = _decode_token_type_ids
+
+bert.BertOutput.forward = AscendBertOutput.forward
+bert.BertSelfOutput.forward = AscendBertSelfOutput.forward
+bert.BertIntermediate.forward = AscendBertIntermediate.forward
+

--- a/vllm_ascend/patch/worker/patch_bert.py
+++ b/vllm_ascend/patch/worker/patch_bert.py
@@ -42,7 +42,7 @@ class AscendBertOutput(nn.Module):
     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states, _ = self.dense(hidden_states)
         hidden_states = torch.ops._C_ascend.add_layer_norm(
-        hidden_states, input_tensor, self.LayerNorm.weight, self.LayerNorm.bias, self.LayerNorm.eps
+            hidden_states, input_tensor, self.LayerNorm.weight, self.LayerNorm.bias, self.LayerNorm.eps
         )[0]
         return hidden_states
 
@@ -51,7 +51,7 @@ class AscendBertSelfOutput(nn.Module):
     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states, _ = self.dense(hidden_states)
         hidden_states = torch.ops._C_ascend.add_layer_norm(
-        hidden_states, input_tensor, self.LayerNorm.weight, self.LayerNorm.bias, self.LayerNorm.eps
+            hidden_states, input_tensor, self.LayerNorm.weight, self.LayerNorm.bias, self.LayerNorm.eps
         )[0]
         return hidden_states
 


### PR DESCRIPTION
### What this PR does / why we need it?
add matmul_gelu and add_layer_norm fusion operator, both are fused by triton on gpu
### Does this PR introduce _any_ user-facing change?
no 
### How was this patch tested?
tested by vllm bench with bge-reranker-v2-m3,  qps boost about 8
` vllm bench serve --model bge-reranker-v2-m3 --backend vllm-rerank  --dataset-name random-rerank --tokenizer /home/data/bge-reranker-v2-m3/  --random-input-len 512 --host 10.44.124.218 --port 9095 --endpoint /v1/rerank --ready-check-timeout-sec 8000 --max-concurrency 16 --result-dir ./results/ --append-result  --save-detailed --label "embedding_16" --num-prompts 1024 --request-rate 200 --random-batch-size 4`

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83b47f67b1dfad505606070ae4d9f83e50ad4ebd
