### PR TITLE
[Bugfix] Fix vllm-ascend 0.13.0 error: `TypeError: apply_token_bitmask_inplace_cpu(): incompatible function arguments`

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -100,8 +100,7 @@ jobs:
           pytest -sv --durations=0 tests/e2e/singlecard/test_camem.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_completion_with_prompt_embeds.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_cpu_offloading.py
-          # xgrammar has parameter mismatching bug, please follows: https://github.com/vllm-project/vllm-ascend/issues/5524
-          # pytest -sv --durations=0 tests/e2e/singlecard/test_guided_decoding.py
+          pytest -sv --durations=0 tests/e2e/singlecard/test_guided_decoding.py
           # torch 2.8 doesn't work with lora, fix me
           pytest -sv --durations=0 tests/e2e/singlecard/test_ilama_lora.py
           pytest -sv --durations=0 tests/e2e/singlecard/test_models.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires = [
     "msgpack",
     "quart",
     "numba",
+    "xgrammar>=0.1.30",
     "fastapi<0.124.0",
     "opencv-python-headless<=4.11.0.86", # Required to avoid numpy version conflict with vllm
     "compressed_tensors>=0.11.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,6 @@ pytest-asyncio
 pytest-mock
 lm-eval==0.4.9.2
 types-jsonschema
-xgrammar
 zmq
 types-psutil
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ setuptools-scm>=8
 torch==2.8.0
 torchvision
 wheel
+xgrammar>=0.1.30
 pandas-stubs
 opencv-python-headless<=4.11.0.86 # Required to avoid numpy version conflict with vllm
 compressed_tensors>=0.11.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
This pull request resolves a critical TypeError encountered in vllm-ascend 0.13.0 by refining the dependency management for the xgrammar package. The change ensures that xgrammar is consistently installed as a core requirement with a specified minimum version, preventing runtime issues caused by an incorrect or missing version of this dependency.

Highlights
Dependency Management: The xgrammar package has been promoted from a development-only dependency to a core runtime dependency, now specified with a minimum version of 0.1.30.
Bug Fix: This change addresses a TypeError related to apply_token_bitmask_inplace_cpu() in vllm-ascend 0.13.0, likely by ensuring the correct version of xgrammar is installed.

- Fix https://github.com/vllm-project/vllm-ascend/issues/6820
- Related previous PR: https://github.com/vllm-project/vllm-ascend/pull/6151
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
