### PR TITLE
[CI] Fix doc test fail when load model with error information: 'Stale file handle'

### DIFF
--- a/tests/e2e/run_doctests.sh
+++ b/tests/e2e/run_doctests.sh
@@ -22,6 +22,7 @@ set -eo errexit
 . $(dirname "$0")/common.sh
 
 export VLLM_USE_MODELSCOPE=true
+export MODELSCOPE_HUB_FILE_LOCK=false
 
 _info "====> Start Quickstart test"
 . "${SCRIPT_DIR}/doctests/001-quickstart-test.sh"


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a `Stale file handle` error that occurs during doctests in the CI environment. The error appears when loading models from ModelScope, likely due to issues with network file systems used in CI.

The fix involves setting the `MODELSCOPE_HUB_FILE_LOCK` environment variable to `false` in the `run_doctests.sh` script. This disables file locking in the ModelScope hub, which is a common workaround for this type of file system error.

### Does this PR introduce _any_ user-facing change?

No, this change only affects the CI test execution environment and has no impact on users.

### How was this patch tested?

This change is validated by the CI pipeline. A successful run of the doctests indicates that the fix is effective.