### PR TITLE
[Bugfix]: Fix AttributeError when using MTP with sparse attention (SFA) and context parallelism

### DIFF
--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -26,6 +26,7 @@ from vllm.distributed import get_ep_group
 from vllm.forward_context import get_forward_context
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD, maybe_trans_nz
 
@@ -202,6 +203,15 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
         if self.new_quant_version and self.tp_size > 16:
             raise ValueError("The current weight does not support moe part tp>16.")
+
+        try:
+            device_group = get_mc2_group().device_group
+            # TODO: Try local_rank = ep_group.rank_in_group
+            local_rank = torch.distributed.get_rank(group=device_group)
+            backend = device_group._get_backend(torch.device("npu"))
+            self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+        except AttributeError:
+            self.moe_all_to_all_group_name = ""
 
     def get_weight(
         self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype


### PR DESCRIPTION
### What this PR does / why we need it?
Fix https://github.com/vllm-project/vllm-ascend/actions/runs/22451755861/job/65042549921
When enabling MTP with sparse attention (SFA backend) and PCP/DCP context parallelism simultaneously, the following error occurs:
`AttributeError: 'AscendSFAMetadata' object has no attribute 'decode'`

Root cause: The MTP proposer's `_propose` method assumed all attention metadata follows the MLA structure, which has a nested `.decode` sub-object (`AscendMLADecodeMetadata`) containing `block_table` and `cp_seq_len`. However, `AscendSFAMetadata` uses a flat structure where `block_table` sits at the top level and there is no `.decode` attribute.(for sfa, the framework does not distinguish between the prefill and decode stages.)

Two locations were affected (both only reachable when `pcp_size` * `dcp_size` > 1):

1. Block table folding (step == 0):
   MTP needs to fold the PCP-expanded block_table back to [batch_size] rows after the first draft step. The code accessed `attn_metadata_i.decode.block_table` directly, crashing on SFA. Fixed by using `getattr(attn_metadata_i, "decode", attn_metadata_i)` to transparently handle both MLA (.decode.block_table) and SFA (.block_table). Additionally, for SFA CP, the forward pass uses `sfa_cp_metadata.block_table_cp` rather than the top-level `block_table`, so this tensor is also folded accordingly.

2. CP-local sequence length update (each MTP step > 0): 
   MLA CP requires `decode.cp_seq_len` to inform the attention kernel of each rank's local KV slice length. SFA CP instead all-gathers the full KV cache via `gather_kv_cross_cp` and uses the complete `seq_lens` directly, so no `cp_seq_len` update is needed. The existing `attn_metadata_i.seq_lens += 1` at line 498 is sufficient. Fixed by guarding the assignment with `if getattr(attn_metadata_i, "decode", None) is not None`.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.15.0
- vLLM main: https://github.com/vllm-project/vllm/commit/83b47f67b1dfad505606070ae4d9f83e50ad4ebd
