### PR TITLE
[Feature] Add Yuanrong backend support to KV Pool.

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -16,7 +16,7 @@
 | :--- | :--- |
 | `lookup_rpc_port` | Port for RPC Communication Between Pooling Scheduler Process and Worker Process: Each Instance Requires a Unique Port Configuration. |
 | `load_async` | Whether to Enable Asynchronous Loading. The default value is false. |
-| `backend` | Set the storage backend for kvpool, with the default being mooncake. |
+| `backend` | Set the storage backend for kvpool (`mooncake`, `memcache`, `yuanrong`), with the default being `mooncake`. |
 | `consumer_is_to_put` | Whether Decode node put KV Cache into KV Pool. The default value is false. |
 | `consumer_is_to_load` | Whether Decode node load KV cache from KV Pool. The default value is false. |
 | `prefill_pp_size` | Prefill PP size, needs to be set when Prefill node enables PP. |
@@ -1088,3 +1088,132 @@ python -m vllm.entrypoints.openai.api_server \
   }' > log_pd_mix.log 2>&1 
 
 ```
+
+#### [2.Run Inference](#2run-inference)
+
+## Example of using Yuanrong as a KV Pool backend
+
+* Software:
+    * Install `openyuanrong-datasystem` on all nodes (`yr.datasystem` must be importable).
+
+### Install Yuanrong Datasystem
+
+```bash
+pip install openyuanrong-datasystem
+```
+
+### Start etcd
+
+Yuanrong Datasystem uses etcd for service discovery. The following example
+starts a single-node etcd cluster:
+
+```bash
+ETCD_VERSION="v3.5.12"
+ETCD_IP="127.0.0.1"
+if [ "$(uname -m)" = "aarch64" ]; then
+  ETCD_ARCH="linux-arm64"
+else
+  ETCD_ARCH="linux-amd64"
+fi
+wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-${ETCD_ARCH}.tar.gz
+tar -xvf etcd-${ETCD_VERSION}-${ETCD_ARCH}.tar.gz
+cd etcd-${ETCD_VERSION}-${ETCD_ARCH}
+sudo cp etcd etcdctl /usr/local/bin/
+
+etcd \
+  --name etcd-single \
+  --data-dir /tmp/etcd-data \
+  --listen-client-urls http://0.0.0.0:2379 \
+  --advertise-client-urls http://${ETCD_IP}:2379 \
+  --listen-peer-urls http://0.0.0.0:2380 \
+  --initial-advertise-peer-urls http://${ETCD_IP}:2380 \
+  --initial-cluster etcd-single=http://${ETCD_IP}:2380 &
+
+etcdctl --endpoints "${ETCD_IP}:2379" put key "value"
+etcdctl --endpoints "${ETCD_IP}:2379" get key
+```
+
+For production environments, refer to the official etcd clustering
+documentation: <https://etcd.io/docs/current/op-guide/clustering/>
+
+### Start Datasystem Worker
+
+Start a Datasystem worker on each node by using `dscli`:
+
+```bash
+dscli start -w \
+  --worker_address "${WORKER_IP}:31501" \
+  --etcd_address "${ETCD_IP}:2379" \
+  --shared_memory_size_mb 20480
+```
+
+The `--worker_address` value is consumed later by `DS_WORKER_ADDR`, so keep
+the host and port identical on the same node.
+
+For more parameters, refer to the `dscli` usage documentation on the Yuanrong
+Datasystem official site:
+<https://atomgit.com/openeuler/yuanrong-datasystem>
+
+To stop the worker:
+
+```bash
+dscli stop --worker_address "${WORKER_IP}:31501"
+```
+
+### Environment Variable Configuration
+
+Set the following environment variables on each node before starting vLLM:
+
+| Variable | Required | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `PYTHONHASHSEED` | Yes | `0` | Must be consistent across all nodes to guarantee uniform hash generation. |
+| `DS_WORKER_ADDR` | Yes | N/A | Datasystem worker address in `<host>:<port>` format. This must match the local `dscli start --worker_address` value. |
+| `DS_ENABLE_EXCLUSIVE_CONNECTION` | No | `0` | Passed to Yuanrong `HeteroClient.enable_exclusive_connection`. Use `1` to enable the exclusive connection mode when required by your deployment. |
+| `DS_ENABLE_REMOTE_H2D` | No | `0` | Passed to Yuanrong `HeteroClient.enable_remote_h2d`. Use `1` only when remote host-to-device transfer is enabled in your Datasystem deployment. |
+
+```bash
+export PYTHONHASHSEED=0
+export DS_WORKER_ADDR="${WORKER_IP}:31501"
+export DS_ENABLE_EXCLUSIVE_CONNECTION=0
+export DS_ENABLE_REMOTE_H2D=0
+```
+
+### Run AscendStoreConnector with Yuanrong backend
+
+Use `AscendStoreConnector` with `backend: "yuanrong"`:
+
+```bash
+python3 -m vllm.entrypoints.openai.api_server \
+    --model /xxxxx/Qwen2.5-7B-Instruct \
+    --port 8100 \
+    --trust-remote-code \
+    --enforce-eager \
+    --no-enable-prefix-caching \
+    --tensor-parallel-size 1 \
+    --data-parallel-size 1 \
+    --max-model-len 10000 \
+    --block-size 128 \
+    --max-num-batched-tokens 4096 \
+    --kv-transfer-config \
+    '{
+    "kv_connector": "AscendStoreConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+        "lookup_rpc_port": "1",
+        "backend": "yuanrong"
+    }
+}'
+```
+
+`lookup_rpc_port` is the RPC port used between the pooling scheduler process
+and the worker process. Each instance must use a unique port value.
+
+### Notes
+
+* The Yuanrong backend normalizes KV keys before calling Datasystem. Keys longer
+  than 255 characters or containing unsupported characters are rewritten, so do
+  not rely on the raw key string when debugging backend storage.
+* No extra buffer pre-registration step is required for Yuanrong. The backend
+  uses device pointers directly when building blob lists.
+
+#### [2.Run Inference](#2run-inference)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -1,0 +1,161 @@
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from vllm.config import ParallelConfig
+from vllm.logger import logger
+from vllm.utils.network_utils import split_host_port
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
+
+
+@dataclass
+class YuanrongConfig:
+    worker_addr: str
+    enable_exclusive_connection: bool
+    enable_remote_h2d: bool
+
+    @staticmethod
+    def load_from_env() -> "YuanrongConfig":
+        worker_addr = os.getenv("DS_WORKER_ADDR")
+        if not worker_addr:
+            raise ValueError("Environment variable DS_WORKER_ADDR is required, expected format '<host>:<port>'.")
+
+        return YuanrongConfig(
+            worker_addr=worker_addr,
+            enable_exclusive_connection=bool(int(os.getenv("DS_ENABLE_EXCLUSIVE_CONNECTION", "0"))),
+            enable_remote_h2d=bool(int(os.getenv("DS_ENABLE_REMOTE_H2D", "0"))),
+        )
+
+
+class YuanrongHelper:
+    _DS_KEY_MAX_LEN = 255
+    _DS_KEY_ALLOWED_PATTERN = re.compile(r"^[a-zA-Z0-9\-_!@#%\^\*\(\)\+\=\:;]+$")
+    _DS_KEY_INVALID_CHAR_PATTERN = re.compile(r"[^a-zA-Z0-9\-_!@#%\^\*\(\)\+\=\:;]")
+    _DS_KEY_HASH_SUFFIX_LEN = 16
+
+    def __init__(self, blob_cls, blob_list_cls):
+        self._blob_cls = blob_cls
+        self._blob_list_cls = blob_list_cls
+        self._device_id: int | None = None
+
+    def normalize_keys(self, keys: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for key in keys:
+            if len(key) <= self._DS_KEY_MAX_LEN and self._DS_KEY_ALLOWED_PATTERN.match(key):
+                normalized.append(key)
+                continue
+
+            sanitized = self._DS_KEY_INVALID_CHAR_PATTERN.sub("_", key)
+            hash_digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+            suffix = f"__{hash_digest[: self._DS_KEY_HASH_SUFFIX_LEN]}"
+            max_prefix_len = self._DS_KEY_MAX_LEN - len(suffix)
+            normalized.append(sanitized[:max_prefix_len] + suffix)
+        return normalized
+
+    def make_blob_lists(self, addrs_list: list[list[int]], sizes_list: list[list[int]]) -> list[Any]:
+        total = len(addrs_list)
+        if total != len(sizes_list):
+            raise ValueError("Address list and size list length mismatch.")
+
+        device_id = self._device_id
+        if device_id is None:
+            logger.error("Device id is not set. Call set_device() before using the yuanrong backend.")
+            raise RuntimeError("Yuanrong backend device id is not initialized.")
+
+        blob_lists: list[Any] = []
+        for addrs, sizes in zip(addrs_list, sizes_list):
+            if len(addrs) != len(sizes):
+                raise ValueError("Address list and size list length mismatch.")
+            blobs = [
+                self._blob_cls(addr, size)  # type: ignore[misc]
+                for addr, size in zip(addrs, sizes)
+            ]
+            blob_lists.append(
+                self._blob_list_cls(device_id, blobs)  # type: ignore[misc]
+            )
+        return blob_lists
+
+
+class YuanrongBackend(Backend):
+    def __init__(self, parallel_config: ParallelConfig):
+        try:
+            from yr.datasystem.hetero_client import Blob, DeviceBlobList, HeteroClient  # type: ignore[import-not-found]
+            from yr.datasystem.kv_client import SetParam  # type: ignore[import-not-found]
+            from yr.datasystem.object_client import WriteMode  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError("Please install openyuanrong-datasystem to use the yuanrong backend.") from exc
+
+        self.rank = parallel_config.rank
+        self._helper = YuanrongHelper(Blob, DeviceBlobList)
+        self._ds_set_param = SetParam()
+        self._ds_set_param.write_mode = WriteMode.NONE_L2_CACHE_EVICT
+
+        self.config = YuanrongConfig.load_from_env()
+        try:
+            host, port = split_host_port(self.config.worker_addr)
+        except Exception as exc:
+            raise ValueError(f"Invalid DS_WORKER_ADDR '{self.config.worker_addr}', expected '<host>:<port>'.") from exc
+        self._hetero_client = HeteroClient(
+            host,
+            int(port),
+            enable_exclusive_connection=self.config.enable_exclusive_connection,
+            enable_remote_h2d=self.config.enable_remote_h2d,
+        )
+        self._hetero_client.init()
+
+    def _ensure_device_ready(self):
+        if self._helper._device_id is None:
+            self.set_device()
+
+    def set_device(self):
+        device = torch.device(f"npu:{self.rank}")
+        torch.npu.set_device(device)
+        self._helper._device_id = int(torch.npu.current_device())
+
+    def register_buffer(self, ptrs: list[int], lengths: list[int]):
+        # Yuanrong APIs consume device pointers directly when building blob
+        # lists. No explicit pre-registration is required.
+        self._ensure_device_ready()
+
+    def exists(self, keys: list[str]) -> list[int]:
+        if len(keys) == 0:
+            return []
+        try:
+            keys = self._helper.normalize_keys(keys)
+            exists = self._hetero_client.exist(keys)  # type: ignore[union-attr]
+            return [1 if value else 0 for value in exists]
+        except Exception as exc:
+            logger.error("Failed to check keys %s: %s", keys, exc)
+            return [0] * len(keys)
+
+    def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+        if len(keys) == 0:
+            return
+        try:
+            self._ensure_device_ready()
+            keys = self._helper.normalize_keys(keys)
+            blob_lists = self._helper.make_blob_lists(addrs, sizes)
+            failed_keys = self._hetero_client.mget_h2d(  # type: ignore[union-attr]
+                keys, blob_lists, 0
+            )
+            for key in failed_keys:
+                logger.error("Failed to get key %s", key)
+        except Exception as exc:
+            logger.error("Failed to get keys %s: %s", keys, exc)
+
+    def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+        if len(keys) == 0:
+            return
+        try:
+            self._ensure_device_ready()
+            keys = self._helper.normalize_keys(keys)
+            blob_lists = self._helper.make_blob_lists(addrs, sizes)
+            self._hetero_client.mset_d2h(  # type: ignore[union-attr]
+                keys, blob_lists, self._ds_set_param
+            )
+        except Exception as exc:
+            logger.error("Failed to put keys %s: %s", keys, exc)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -40,6 +40,10 @@ backend_map = {
         "name": "MemcacheBackend",
         "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend",
     },
+    "yuanrong": {
+        "name": "YuanrongBackend",
+        "path": "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend",
+    },
 }
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
Added Yuanrong as a new KV Pool storage backend for `AscendStoreConnector`.

openYuanrong dataSystem is a memory-centric, near-compute distributed heterogeneous multi-level cache system. It provides high-performance data object and data stream access, HBM/DRAM/SSD multi-tier caching, and zero-copy data sharing between instances for distributed applications such as AI training and inference, agents, big data, and microservices.
> For additional context on openYuanrong datasystem, please refer to: https://atomgit.com/openeuler/yuanrong-datasystem

### Does this PR introduce _any_ user-facing change?
Yes. Users can now configure `AscendStoreConnector` to use the Yuanrong backend by setting `"backend": "yuanrong"` in the `kv_connector_extra_config`. This requires installing the `openyuanrong-datasystem` package and configuring environment variables such as `DS_WORKER_ADDR`.

### How was this patch tested?
The new Yuanrong backend was tested in a mixed deployment scenario to ensure its functionality. The setup and inference commands used for testing are now part of the updated documentation in `docs/source/user_guide/feature_guide/kv_pool.md`, allowing for easy reproduction of the test environment.

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ed359c497a728f08b5b41456c07a688ccd510fbc
