### PR TITLE
[Image] Fix docker image merge tag settings

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -178,7 +178,7 @@ jobs:
           #      which follow the rule from vLLM with prefix v
           # TODO(yikun): the post release might be considered as latest release
           tags: |
-            type=branch,suffix=${{ env.SUFFIX }}
+            type=ref,event=branch,suffix=${{ env.SUFFIX }}
             type=pep440,pattern={{raw}},suffix=${{ env.SUFFIX }}
             type=schedule,pattern=main,suffix=${{ env.SUFFIX }}
             type=raw,value=${{ inputs.workflow_dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' }},suffix=${{ env.SUFFIX }}


### PR DESCRIPTION
### What this PR does / why we need it?
Fix docker image merge tag settings, to use tag as the branch name.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
