### PR TITLE
[CI] Revert pr-6708 to keep the old workflow that using CANN as the base container

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -17,71 +17,16 @@ on:
         type: boolean
 
 jobs:
-  select-image:
-    runs-on: linux-aarch64-a2b3-0
-    outputs:
-      image: ${{ steps.select.outputs.image }}
-      image_a3: ${{ steps.select.outputs.image_a3 }}
-      image_310p: ${{ steps.select.outputs.image_310p }}
-    steps:
-      - name: Select image based on base branch
-        id: select
-        env:
-          IMAGE_NAMESPACE: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend
-        run: |
-          BRANCH="${{ github.base_ref }}"
-          BRANCH_TAG="${BRANCH//\//-}"
-          MAIN_IMAGE="${{ inputs.image }}"
-          MAIN_IMAGE_A3="${{ inputs.image }}-a3"
-          MAIN_IMAGE_310P="${{ inputs.image }}-310p"
-          if [ "$BRANCH_TAG" = "main" ]; then
-            echo "Target branch is main, using main images: ${MAIN_IMAGE} / ${MAIN_IMAGE_A3} / ${MAIN_IMAGE_310P}"
-            echo "image=${MAIN_IMAGE}" >> $GITHUB_OUTPUT
-            echo "image_a3=${MAIN_IMAGE_A3}" >> $GITHUB_OUTPUT
-            echo "image_310p=${MAIN_IMAGE_310P}" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # while target branch is not main
-          BRANCH_IMAGE="${IMAGE_NAMESPACE}:${BRANCH_TAG}"
-          BRANCH_IMAGE_A3="${IMAGE_NAMESPACE}:${BRANCH_TAG}-a3"
-          BRANCH_IMAGE_310P="${IMAGE_NAMESPACE}:${BRANCH_TAG}-310p"
-          # Check if branch-specific A2 image exists via IMAGE_NAMESPACE, fallback to main if not
-          if docker manifest inspect "${BRANCH_IMAGE}" > /dev/null 2>&1; then
-            echo "Using branch image: ${BRANCH_IMAGE}"
-            echo "image=${BRANCH_IMAGE}" >> $GITHUB_OUTPUT
-          else
-            echo "Branch image not found, falling back to ${MAIN_IMAGE}"
-            echo "image=${MAIN_IMAGE}" >> $GITHUB_OUTPUT
-          fi
-          # Check if branch-specific A3 image exists via IMAGE_NAMESPACE, fallback to main if not
-          if docker manifest inspect "${BRANCH_IMAGE_A3}" > /dev/null 2>&1; then
-            echo "Using branch A3 image: ${BRANCH_IMAGE_A3}"
-            echo "image_a3=${BRANCH_IMAGE_A3}" >> $GITHUB_OUTPUT
-          else
-            echo "Branch A3 image not found, falling back to ${MAIN_IMAGE_A3}"
-            echo "image_a3=${MAIN_IMAGE_A3}" >> $GITHUB_OUTPUT
-          fi
-          # Check if branch-specific 310P image exists via IMAGE_NAMESPACE, fallback to main if not
-          if docker manifest inspect "${BRANCH_IMAGE_310P}" > /dev/null 2>&1; then
-            echo "Using branch 310P image: ${BRANCH_IMAGE_310P}"
-            echo "image_310p=${BRANCH_IMAGE_310P}" >> $GITHUB_OUTPUT
-          else
-            echo "Branch 310P image not found, falling back to ${MAIN_IMAGE_310P}"
-            echo "image_310p=${MAIN_IMAGE_310P}" >> $GITHUB_OUTPUT
-          fi
-
   e2e-light:
     name: singlecard-light
     if: ${{ inputs.type == 'light' }}
-    needs: [select-image]
     runs-on: linux-aarch64-a2b3-1
     strategy:
       fail-fast: false
       matrix:
         part: [0]
     container:
-      image: ${{ needs.select-image.outputs.image }}
+      image: ${{ inputs.image }}
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
@@ -89,8 +34,6 @@ jobs:
     steps:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Check npu and CANN info
         run: |
           npu-smi info
@@ -103,11 +46,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev clang-15
+
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -117,39 +63,19 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
+          pip install -r requirements-dev.txt
+          pip install -v -e .
 
       - name: Run vllm-project/vllm-ascend test
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
           VLLM_WORKER_MULTIPROC_METHOD: spawn
@@ -159,14 +85,13 @@ jobs:
   e2e-full:
     name: singlecard-full
     if: ${{ inputs.type == 'full' }}
-    needs: [select-image]
     runs-on: linux-aarch64-a2b3-1
     strategy:
       fail-fast: false
       matrix:
         part: [0, 1]
     container:
-      image: ${{ needs.select-image.outputs.image }}
+      image: ${{ inputs.image }}
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
@@ -175,8 +100,6 @@ jobs:
     steps:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Check npu and CANN info
         run: |
@@ -190,11 +113,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev clang-15
+
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -204,38 +130,18 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
-
+          pip install -r requirements-dev.txt
+          pip install -v -e .
       - name: Run e2e test
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
@@ -245,14 +151,13 @@ jobs:
   e2e-2-cards-light:
     name: multicard-2-light
     if: ${{ inputs.type == 'light' }}
-    needs: [select-image]
     runs-on: linux-aarch64-a3-2
     strategy:
       fail-fast: false
       matrix:
         part: [0]
     container:
-      image: ${{ needs.select-image.outputs.image_a3 }}
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
@@ -261,8 +166,6 @@ jobs:
     steps:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Check npu and CANN info
         run: |
           npu-smi info
@@ -275,11 +178,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev clang-15
+
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -289,38 +195,18 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
-
+          pip install -r requirements-dev.txt
+          pip install -v -e .
       - name: Run vllm-project/vllm-ascend test (light)
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         run: |
@@ -329,14 +215,13 @@ jobs:
   e2e-2-cards-full:
     name: multicard-2-full
     if: ${{ inputs.type == 'full' }}
-    needs: [select-image]
     runs-on: linux-aarch64-a3-2
     strategy:
       fail-fast: false
       matrix:
         part: [0]
     container:
-      image: ${{ needs.select-image.outputs.image_a3 }}
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
@@ -345,8 +230,6 @@ jobs:
     steps:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Check npu and CANN info
         run: |
           npu-smi info
@@ -359,11 +242,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev clang-15
+
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -373,38 +259,18 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
-
+          pip install -r requirements-dev.txt
+          pip install -v -e .
       - name: Run vllm-project/vllm-ascend test (full)
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         run: |
@@ -412,7 +278,6 @@ jobs:
 
       - name: Run vllm-project/vllm-ascend test (non triton)
         if: ${{ inputs.type == 'full' && matrix.part == 0 }}
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         run: |
@@ -422,14 +287,13 @@ jobs:
   e2e-4-cards-full:
     name: multicard-4-full
     if: ${{ inputs.type == 'full' }}
-    needs: [select-image]
     runs-on: linux-aarch64-a3-4
     strategy:
       fail-fast: false
       matrix:
         part: [0]
     container:
-      image: ${{ needs.select-image.outputs.image_a3 }}
+      image: m.daocloud.io/quay.io/ascend/cann:8.5.0-a3-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
@@ -437,8 +301,6 @@ jobs:
     steps:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Check npu and CANN info
         run: |
           npu-smi info
@@ -451,11 +313,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev clang-15
+
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -465,38 +330,19 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
+          pip install -r requirements-dev.txt
+          pip install -v -e .
 
       - name: Run vllm-project/vllm-ascend test for V1 Engine
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         run: |
@@ -506,24 +352,17 @@ jobs:
     name: 310p singlecard
     runs-on: linux-aarch64-310p-1
     if: ${{ inputs.contains_310 }}
-    needs: [select-image]
     container:
-      image: ${{ needs.select-image.outputs.image_310p }}
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-310p-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
         HF_HUB_OFFLINE: 1
     steps:
-      - name: Checkout vllm-project/vllm-ascend repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Check npu and CANN info
         run: |
           npu-smi info
           cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
-
       - name: Config mirrors
         run: |
           sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
@@ -531,11 +370,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Checkout vllm-project/vllm-ascend repo
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -545,38 +387,19 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
+          pip install -r requirements-dev.txt
+          pip install -v -e .
 
       - name: Run vllm-project/vllm-ascend test
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
           VLLM_WORKER_MULTIPROC_METHOD: spawn
@@ -587,24 +410,17 @@ jobs:
     name: 310p multicards 4cards
     runs-on: linux-aarch64-310p-4
     if: ${{ inputs.contains_310 }}
-    needs: [select-image]
     container:
-      image: ${{ needs.select-image.outputs.image_310p }}
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-310p-ubuntu22.04-py3.11
       env:
         VLLM_LOGGING_LEVEL: ERROR
         VLLM_USE_MODELSCOPE: True
         HF_HUB_OFFLINE: 1
     steps:
-      - name: Checkout vllm-project/vllm-ascend repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Check npu and CANN info
         run: |
           npu-smi info
           cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
-
       - name: Config mirrors
         run: |
           sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
@@ -612,11 +428,14 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
           apt install git -y
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Checkout vllm-project/vllm-ascend repo
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
           apt-get -y install `cat packages.txt`
+          apt-get -y install gcc g++ cmake libnuma-dev
 
       - name: Checkout vllm-project/vllm repo
         uses: actions/checkout@v6
@@ -626,38 +445,19 @@ jobs:
           path: ./vllm-empty
           fetch-depth: 1
 
-      - name: Install vllm-project/vllm
+      - name: Install vllm-project/vllm from source
+        working-directory: ./vllm-empty
         run: |
-          pip uninstall -y vllm
-          rm -rf /vllm-workspace/vllm
-          cp -r ./vllm-empty /vllm-workspace/vllm
-          VLLM_TARGET_DEVICE=empty pip install -v -e /vllm-workspace/vllm/
+          VLLM_TARGET_DEVICE=empty pip install -e .
 
       - name: Install vllm-project/vllm-ascend
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
-          DEST="/vllm-workspace/vllm-ascend"
-          IMAGE_SHA=$(git -C "${DEST}" log -1 --format=%H 2>/dev/null || echo "")
-          cp -rT . "${DEST}/"
-          if [ -n "$IMAGE_SHA" ] && git cat-file -e "${IMAGE_SHA}" 2>/dev/null; then
-            C_CHANGES=$(git diff "${IMAGE_SHA}"..HEAD --name-only -- \
-              csrc/ cmake/ CMakeLists.txt setup.py requirements.txt requirements-dev.txt)
-            echo "[debug] C_CHANGES=${C_CHANGES:-<empty>}"
-          else
-            echo "[debug] IMAGE_SHA not found in local history (empty or unreachable), forcing reinstall"
-            C_CHANGES="yes"
-          fi
-          pip install -r ${DEST}/requirements-dev.txt
-          if [ -n "$C_CHANGES" ]; then
-            echo "[debug] C code / build changes detected, reinstalling vllm-ascend..."
-            pip install -v -e "${DEST}/"
-          else
-            echo "[debug] No C code / build changes detected, skipping reinstall."
-          fi
+          pip install -r requirements-dev.txt
+          pip install -v -e .
 
       - name: Run vllm-project/vllm-ascend test
-        working-directory: /vllm-workspace/vllm-ascend
         env:
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
           VLLM_WORKER_MULTIPROC_METHOD: spawn

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -96,7 +96,8 @@ jobs:
         fi
         # Replace / with - for use in image tags
         branch="${branch//\//-}"
-        echo "ref=quay.io/ascend/vllm-ascend:${branch}-${{ inputs.suffix }}" >> $GITHUB_OUTPUT
+        suffix="${{ inputs.suffix }}"
+        echo "ref=quay.io/ascend/vllm-ascend:${branch}${suffix:+-${suffix}}" >> $GITHUB_OUTPUT
 
     - name: Build and push
       uses: docker/build-push-action@v6

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -81,6 +81,6 @@ jobs:
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:main
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       contains_310: false
       type: full

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -107,6 +107,6 @@ jobs:
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:main
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       contains_310: ${{ needs.changes.outputs._310_tracker == 'true' }}
       type: light

--- a/.github/workflows/schedule_test_vllm_main.yaml
+++ b/.github/workflows/schedule_test_vllm_main.yaml
@@ -34,6 +34,6 @@ jobs:
     uses: ./.github/workflows/_e2e_test.yaml
     with:
       vllm: main
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:main
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
       contains_310: false
       type: full


### PR DESCRIPTION
### What this PR does / why we need it?
Revert pr-6708 to keep the old workflow that using CANN as the base container
- Related PR: https://github.com/vllm-project/vllm-ascend/pull/6708
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
