### PR TITLE
[CI] nightly test timeout

### DIFF
--- a/tests/e2e/nightly/single_node/models/test_deepseek_v3_2_w8a8.py
+++ b/tests/e2e/nightly/single_node/models/test_deepseek_v3_2_w8a8.py
@@ -85,6 +85,7 @@ async def test_models(model: str, tp_size: int, dp_size: int) -> None:
         "VLLM_ASCEND_ENABLE_MLAPO": "1",
         "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
         "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
+        "VLLM_ENGINE_READY_TIMEOUT_S": "1800"
     }
 
     server_args = [


### PR DESCRIPTION
### What this PR does / why we need it?

The nightly test is currently failing due to a [timeout](https://github.com/vllm-project/vllm-ascend/actions/runs/22547280169/job/65326335134).

As noted in #6778, this issue can be resolved by applying this fix.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

run nightly test.
