### PR TITLE
[Bugfix] Fix the acceptance rates dorp issue when applying eagle3 to QuaRot model

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -305,3 +305,14 @@
 #       https://github.com/vllm-project/vllm/pull/34336
 #    Future Plan:
 #       Remove this patch when vLLM merges the PR.
+# ** 16. File: worker/patch_qwen3_quarot.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.models.llama_eagle3.Eagle3LlamaForCausalLM.load_weights`
+#    Why:
+#       vllm-ascend reused the loading logic of drafter model from vllm,
+#       but vllm doesn't need to apply to Ascend quantization.
+#    How：
+#       Dynamically replace the `load_weights` function at runtime,
+#       and fix `target_config` into the new implementation with a closure.
+#    Future Plan:
+#       Remove this patch when vLLM merges the PR.

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -35,3 +35,4 @@ import vllm_ascend.patch.worker.patch_huanyuan_vl  # noqa
 import vllm_ascend.patch.worker.patch_routed_experts_capturer  # noqa
 import vllm_ascend.patch.worker.patch_npugraph_ex_triton  # noqa
 import vllm_ascend.patch.worker.patch_kimi_k25  # noqa
+import vllm_ascend.patch.worker.patch_qwen3_quarot  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_quarot.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_quarot.py
@@ -1,0 +1,79 @@
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+import torch
+from safetensors.torch import load_file
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    process_eagle_weight,
+)
+
+
+def patch_load_weights(target_config):
+    Eagle3LlamaForCausalLM.load_weights = make_load_weights(target_config)
+
+
+def make_load_weights(target_config):
+    logger = logging.getLogger(__name__)
+    quant_cfg = target_config.quant_config
+    rotation_matrix3 = None
+
+    model_path = target_config.model_config.model
+    try:
+        rotation_rel_path = quant_cfg.quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
+    except KeyError as e:
+        logger.error(
+            "Invalid quant_config: missing key "
+            "quant_description['optional']['quarot']['rotation_map']['global_rotation']. "
+            "If you don't use quarot model, please ignore it. "
+            f"Error: {e}"
+        )
+    else:
+        rotation_path = Path(model_path) / rotation_rel_path
+        try:
+            safetensor_data = load_file(rotation_path)
+            Q = safetensor_data["global_rotation"]
+            rotation_matrix3 = torch.block_diag(Q, Q, Q)
+        except Exception as e:
+            logger.error(
+                f"Failed to load rotation weight from '{rotation_path}'. "
+                "If you don't use quarot model, please ignore it. "
+                f"Error: {e}"
+            )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        for name, loaded_weight in weights:
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "fc." in name and rotation_matrix3 is not None:
+                loaded_weight = loaded_weight @ rotation_matrix3.to(loaded_weight.dtype)
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())
+
+    return load_weights

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -106,6 +106,7 @@ from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.eplb.utils import model_register
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
+from vllm_ascend.patch.worker.patch_qwen3_quarot import patch_load_weights
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.eagle_proposer import EagleProposer
@@ -2419,6 +2420,8 @@ class NPUModelRunner(GPUModelRunner):
                 model_register(self.model)
             if self.drafter:
                 logger.info("Loading drafter model...")
+                if self.vllm_config.quant_config is not None:
+                    patch_load_weights(self.vllm_config)
                 with get_tp_context(self.drafter):
                     self.drafter.load_model(self.model)
                 if self.use_aux_hidden_state_outputs:


### PR DESCRIPTION

### What this PR does / why we need it?
When using the target model after rotational quantization, the acceptance rate decreases because the fc weight of the draft model has not undergone rotational quantization(issue: #6445). We fixed this issue by performing rotation quantization on the fc weight of the draft model in the same way as the main model when loading draft model.
### Does this PR introduce _any_ user-facing change?
The bug was previously resolved by using the tool in the Issue(#5974). If your version has already adapted to this PR, please use the original eagle3 weights matching target model quantified by new version modelslim and do not use that tool.
### How was this patch tested?
```python
import gc
import torch
import os
from vllm.v1.metrics.reader import Counter, Vector
from vllm import LLM, SamplingParams
from vllm.distributed.parallel_state import (destroy_distributed_environment,
                                             destroy_model_parallel)

os.environ["ASCEND_RT_VISIBLE_DEVICES"] = "0,1"

TP = 2
K = 4
QUANTIZATION = True
# QUANTIZATION = False
MODEL_PATH = "Qwen/Qwen3-32B-w8a8-quarot-eagle3-new" if QUANTIZATION else "Qwen/Qwen3-32B"

def clean_up():
    destroy_model_parallel()
    destroy_distributed_environment()
    gc.collect()
    torch.npu.empty_cache()

if __name__ == '__main__':
    prompts = [
        "Who are you?",
    ]
    sampling_params = SamplingParams(temperature=0.6, top_p=0.95, top_k=40, ignore_eos=True, max_tokens=200)

    llm_kwargs = dict(
        disable_log_stats=False,
        model=MODEL_PATH,
        tensor_parallel_size=TP,
        enforce_eager=True,
        gpu_memory_utilization=0.9,
        speculative_config={
            "model": "RedHatAI/Qwen3-32B-speculator.eagle3",
            "method": "eagle3",
            "num_speculative_tokens": K,
        },
        max_model_len=4096, 
        enable_prefix_caching=False,
        compilation_config={
            "cudagraph_mode": "FULL_DECODE_ONLY",
            "cudagraph_capture_sizes": [4],
        },)
    
    if QUANTIZATION:
        llm_kwargs["quantization"] = "ascend"

    llm = LLM(**llm_kwargs)

    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        # print(output.outputs[0].token_ids)
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

    total_num_output_tokens = sum(
        len(output.outputs[0].token_ids) for output in outputs
    )

    metrics = llm.get_metrics()
    print('metrics------------------')
    num_drafts = 0
    num_draft_tokens = 0
    num_accepted_tokens = 0
    acceptance_counts = [0] * K
    for metric in metrics:
        if metric.name == "vllm:spec_decode_num_drafts":
            assert isinstance(metric, Counter)
            num_drafts += metric.value
        elif metric.name == "vllm:spec_decode_num_draft_tokens":
            assert isinstance(metric, Counter)
            num_draft_tokens += metric.value
        elif metric.name == "vllm:spec_decode_num_accepted_tokens":
            assert isinstance(metric, Counter)
            num_accepted_tokens += metric.value
        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
            assert isinstance(metric, Vector)
            for pos in range(len(metric.values)):
                acceptance_counts[pos] += metric.values[pos]

    print("-" * 50)
    print(f"total_num_output_tokens: {total_num_output_tokens}")
    print(f"num_drafts: {num_drafts}")
    print(f"num_draft_tokens: {num_draft_tokens}")
    print(f"num_accepted_tokens: {num_accepted_tokens}")
    acceptance_length = 1 + (num_accepted_tokens / num_drafts) if num_drafts > 0 else 1
    print(f"mean acceptance length: {acceptance_length:.2f}")
    print("-" * 50)

    # print acceptance at each token position
    for i in range(len(acceptance_counts)):
        acceptance_rate = acceptance_counts[i] / num_drafts if num_drafts > 0 else 0
        print(f"acceptance at token {i}: {acceptance_rate:.2f}")

    del llm
    clean_up()
```
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
