### PR TITLE
[CI] Add approve function

### DIFF
--- a/.github/workflows/bot_approve.yaml
+++ b/.github/workflows/bot_approve.yaml
@@ -1,0 +1,147 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+name: Bot Approve
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  approve:
+    name: Committer approve action
+    runs-on: ubuntu-latest
+    # Only run on PR comments (not plain issue comments) starting with /approve
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/approve')
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Validate committer, add approved label, and trigger E2E-Full if needed
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            // Step 1: Precise /approve detection (trim to handle leading whitespace)
+            const commentBody = context.payload.comment.body.trim();
+            if (!commentBody.startsWith('/approve')) {
+              console.log('Comment does not start with /approve, skipping.');
+              return;
+            }
+
+            const commenter = context.payload.comment.user.login;
+            console.log(`Comment author: ${commenter}`);
+
+            // Step 2: Check committer status via GitHub API (repo collaborator permission)
+            let isCommitter = false;
+            try {
+              const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                username: commenter,
+              });
+              // Committers have 'write', 'maintain', or 'admin' permission
+              isCommitter = ['write', 'maintain', 'admin'].includes(permData.permission);
+              console.log(`${commenter} permission level: ${permData.permission}`);
+            } catch (e) {
+              // 404 means the user is not a collaborator at all
+              console.log(`${commenter} is not a collaborator (${e.status ?? e.message})`);
+            }
+
+            // [TEST ONLY] Committer check disabled for local testing
+            if (!isCommitter) {
+              console.log(`${commenter} is not a committer. Skipping.`);
+              return;
+            }
+
+            console.log(`${commenter} is a committer: ${isCommitter}. Proceeding (check bypassed for testing).`);
+
+            const prNumber = context.payload.issue.number;
+            const owner    = context.repo.owner;
+            const repo     = context.repo.repo;
+
+            // Step 3: Fetch PR details (head SHA + current labels)
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const headSha    = pr.head.sha;
+            const labelNames = pr.labels.map(l => l.name);
+            console.log(`PR head SHA: ${headSha}`);
+            console.log(`Current labels: ${labelNames.join(', ') || '(none)'}`);
+
+            // Step 4: Add "approved" label to record the approval
+            if (!labelNames.includes('approved')) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: ['approved'],
+              });
+              console.log(`Added "approved" label for PR #${prNumber} (approved by @${commenter}).`);
+              labelNames.push('approved');
+            } else {
+              console.log('"approved" label already present.');
+            }
+
+            // Step 5: Check whether E2E-Full has already been triggered for this commit
+            const { data: runsData } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              head_sha: headSha,
+              per_page: 100,
+            });
+
+            const e2eFullRun = runsData.workflow_runs.find(run =>
+              run.name === 'E2E-Full' &&
+              ['queued', 'in_progress', 'completed'].includes(run.status)
+            );
+
+            if (e2eFullRun) {
+              console.log(
+                `E2E-Full already triggered ` +
+                `(id: ${e2eFullRun.id}, status: ${e2eFullRun.status}). Skipping.`
+              );
+              return;
+            }
+
+            // Step 6: Add missing labels to trigger pr_test_full.yaml (E2E-Full)
+            const REQUIRED_LABELS = ['ready', 'ready-for-test'];
+            const missingLabels = REQUIRED_LABELS.filter(l => !labelNames.includes(l));
+
+            if (missingLabels.length === 0) {
+              console.log('Both "ready" and "ready-for-test" labels already present. No action needed.');
+              return;
+            }
+
+            console.log(`E2E-Full not yet triggered. Adding labels: ${missingLabels.join(', ')}`);
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: missingLabels,
+            });
+            console.log('Labels added. E2E-Full (pr_test_full.yaml) will be triggered.');


### PR DESCRIPTION
### What this PR does / why we need it?

Add a Bot Approve GitHub Actions workflow (.github/workflows/bot_approve.yaml) that allows committers to trigger E2E-Full tests via a /approve comment on a PR.

When a committer comments /approve on a PR, the workflow will:

1. Verify the commenter has write/maintain/admin permission on the repository via GitHub API (no hardcoded allowlist needed)
2. Add an approved label to the PR to record the approval
3. Check if E2E-Full tests have already been triggered for the current commit (to avoid duplicate runs)
4. If not yet triggered, add ready and ready-for-test labels to kick off pr_test_full.yaml (E2E-Full)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
