### PR TITLE
[CI][310P] Add 310p tracked files in CI light.

### DIFF
--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -78,6 +78,8 @@ jobs:
             _310_tracker:
               - 'vllm_ascend/_310p/**'
               - 'vllm_ascend/worker/model_runner_v1.py'
+              - 'vllm_ascend/attention/attention_v1.py'
+              - 'vllm_ascend/ops/fused_moe/**'
               - 'CMakeLists.txt'
 
   ut:


### PR DESCRIPTION
### What this PR does / why we need it?
Add 310p tracked files in CI light.
'vllm_ascend/attention/attention_v1.py'
'vllm_ascend/ops/fused_moe/**'
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
CI test
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
