### PR TITLE
[Bugfix] Fix the issue when the FI Attention operator is used in graph mode with eagle enabled

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -620,7 +620,7 @@ class EagleProposer(VllmEagleProposer):
                     multi_steps_attn_metadata.append(per_layer_attn_metadata)
         else:
             # Copy the old attn_metadata and update
-            for draft_step in range(1, self.num_speculative_tokens):
+            for draft_step in range(1, self.num_speculative_tokens + 1):
                 common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
                     draft_step,
                     attn_metadata,


### PR DESCRIPTION
Fix the issue when the FI Attention operator is used in graph mode with eagle enabled
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
- Error Message: RuntimeError: npu_fused_infer_attention_score_out_symint:build/CMakeFiles/torch_npu.dir/compiler_depend.ts:482 NPU function error: call aclnnFusedInferAttentionScoreV3 failed, error code is 561002
E29999[PID: 65928] 2026-03-03-05:08:21.205.139 (E29999):  [InitOpInfoLib][InitOpKernel] Inconsistent format size [1] and data type size [2]![FUNC:InitUnknownFormatAndDtype][FILE:op_kernel_info_constructor.cc][LINE:959]
When layout is TND, queryT(8) must be equal to the last element of actualSequenceLengthQ(7)[FUNC:CheckFAISeqlenDataInTND][FILE:fused_infer_attention_score_tiling.cpp][LINE:942]
