### PR TITLE
[BugFix] Improve GDN layer detection for multimodal models

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1127,7 +1127,16 @@ def check_gdn_layer(vllm_config) -> bool:
         return False
 
     hf_config = model_config.hf_config
-    if not hasattr(hf_config, "layer_types"):
-        return False
 
-    return "linear_attention" in hf_config.layer_types
+    # Use `or []` to prevent errors when layer_types is None
+    layer_types = getattr(hf_config, "layer_types", None) or []
+    if "linear_attention" in layer_types:
+        return True
+
+    text_config = getattr(hf_config, "text_config", None)
+    if text_config:
+        text_layer_types = getattr(text_config, "layer_types", None) or []
+        if "linear_attention" in text_layer_types:
+            return True
+
+    return False


### PR DESCRIPTION
## Summary
- Enhanced `check_gdn_layer()` function to properly detect GDN layers in multimodal models
- Added support for checking `text_config.layer_types` in addition to root-level `layer_types`
- Fixed potential None reference errors when `layer_types` attribute is missing

## Changes
- Modified `vllm_ascend/utils.py`:
  - Replaced `hasattr()` check with safer `getattr()` approach
  - Added fallback to empty list when `layer_types` is None
  - Added secondary check for `text_config.layer_types` to support models like Qwen-Omni

## Motivation
Previous implementation only checked `layer_types` at the root config level, which failed to detect GDN layers in multimodal models where this information is nested under `text_config`. Additionally, it could raise errors when `layer_types` was None.

---

Co-authored-by: wanghuanjun2113 <wanghuanjun2113@gmail.com>
Co-authored-by: SlightwindSec <slightwindsec@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
