### PR TITLE
[Bugfix] Adding mooncake library path to fix error: `server failed to start with mooncake connector`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ RUN apt-get update -y && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+# To keep mooncake can be found
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
 RUN pip config set global.index-url ${PIP_INDEX_URL}
 
 # Install vLLM

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -47,6 +47,9 @@ RUN apt-get update -y && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
+# To keep mooncake can be found
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -48,6 +48,9 @@ RUN yum update -y && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 
+# To keep mooncake can be found
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -48,6 +48,9 @@ RUN yum update -y && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 
+# To keep mooncake can be found
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.16.0


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request addresses a critical startup failure within Dockerized environments related to the mooncake connector. By explicitly setting the LD_LIBRARY_PATH environment variable in the Dockerfiles, it ensures that the necessary shared libraries for mooncake are correctly located, allowing the server to initialize without errors. This fix is applied consistently across various Dockerfile configurations to provide a robust solution.

Related Issue: 
- https://github.com/vllm-project/vllm-ascend/issues/6949

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
