### PR TITLE
[Bugfix] fix the wrong use of extract_slice and insert_slice

### DIFF
--- a/vllm_ascend/ops/triton/activation/swiglu_quant.py
+++ b/vllm_ascend/ops/triton/activation/swiglu_quant.py
@@ -4,7 +4,7 @@ from vllm.triton_utils import tl, triton
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 try:
-    import triton.language.extra.cann.extension as extension
+    import triton.language.extra.cann.extension as extension  # type: ignore
 
     extract_slice = extension.extract_slice
 except ImportError:

--- a/vllm_ascend/ops/triton/fla/solve_tril.py
+++ b/vllm_ascend/ops/triton/fla/solve_tril.py
@@ -15,7 +15,7 @@ from vllm.triton_utils import tl, triton
 from .utils import prepare_chunk_indices
 
 try:
-    import triton.language.extra.cann.extension as extension
+    import triton.language.extra.cann.extension as extension  # type: ignore
 
     insert_slice = extension.insert_slice
     extract_slice = extension.extract_slice

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py
@@ -23,7 +23,7 @@ from vllm.utils.torch_utils import direct_register_custom_op
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 try:
-    import triton.language.extra.cann.extension as extension
+    import triton.language.extra.cann.extension as extension  # type: ignore
 
     insert_slice = extension.insert_slice
     extract_slice = extension.extract_slice


### PR DESCRIPTION
### What this PR does / why we need it?
fix the wrong use of extract_slice and insert_slice. In the TritonAscend main branch, extract_slice and insert_slice are located in the triton.language.extra.cann.extension library, rather than in the triton.language library
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
