### PR TITLE
[Bugfix][Ops] Add non-Triton fallback for qkv_rmsnorm_rope op

### DIFF
--- a/tests/ut/ops/test_split_qkv_rmsnorm_rope.py
+++ b/tests/ut/ops/test_split_qkv_rmsnorm_rope.py
@@ -1,0 +1,232 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Tests for the non-Triton fallback split_qkv_rmsnorm_rope op."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def default_vllm_config():
+    mock_config = MagicMock()
+    mock_config.compilation_config.custom_ops = ["all"]
+    from vllm.config import set_current_vllm_config
+
+    with set_current_vllm_config(mock_config):
+        yield mock_config
+
+
+class TestSplitQkvRmsnormRopeRegistration:
+    """Test that the non-Triton fallback registers the op correctly."""
+
+    def test_op_imported_when_no_triton(self):
+        """When HAS_TRITON is False, the fallback module should be imported
+        and the qkv_rmsnorm_rope op should be available."""
+        import vllm_ascend.ops as ops_module
+
+        fallback_module = "vllm_ascend.ops.split_qkv_rmsnorm_rope"
+        previous_fallback = sys.modules.pop(fallback_module, None)
+        try:
+            with patch("vllm.triton_utils.HAS_TRITON", False):
+                importlib.reload(ops_module)
+                assert fallback_module in sys.modules
+                assert hasattr(torch.ops.vllm, "qkv_rmsnorm_rope"), (
+                    "qkv_rmsnorm_rope op should be registered even when Triton is not available"
+                )
+        finally:
+            if previous_fallback is not None:
+                sys.modules[fallback_module] = previous_fallback
+            importlib.reload(ops_module)
+
+    def test_head_dim_must_be_even(self):
+        """head_dim must be even for RoPE to work correctly."""
+        from vllm_ascend.ops.split_qkv_rmsnorm_rope import (
+            split_qkv_rmsnorm_rope_impl,
+        )
+
+        odd_head_dim = 127
+        batch_size = 2
+        q_hidden_size = odd_head_dim * 4
+        kv_hidden_size = odd_head_dim
+        total = q_hidden_size + kv_hidden_size * 2
+
+        input_tensor = torch.randn(batch_size, total)
+        q_weight = torch.randn(odd_head_dim)
+        k_weight = torch.randn(odd_head_dim)
+        cos_sin_cache = torch.randn(100, odd_head_dim)
+        positions = torch.zeros(batch_size, dtype=torch.long)
+
+        with pytest.raises(AssertionError, match="head_dim must be even"):
+            split_qkv_rmsnorm_rope_impl(
+                input=input_tensor,
+                cos_sin_cache=cos_sin_cache,
+                positions=positions,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                q_hidden_size=q_hidden_size,
+                kv_hidden_size=kv_hidden_size,
+                head_dim=odd_head_dim,
+                eps=1e-6,
+            )
+
+    def test_fake_impl_output_shapes(self):
+        """The fake implementation should return correctly shaped tensors."""
+        from vllm_ascend.ops.split_qkv_rmsnorm_rope import (
+            split_qkv_rmsnorm_rope_impl_fake,
+        )
+
+        batch_size = 4
+        head_dim = 128
+        num_q_heads = 32
+        num_kv_heads = 4
+        q_hidden_size = num_q_heads * head_dim
+        kv_hidden_size = num_kv_heads * head_dim
+        total = q_hidden_size + kv_hidden_size * 2
+
+        input_tensor = torch.randn(batch_size, total)
+        q_weight = torch.randn(head_dim)
+        k_weight = torch.randn(head_dim)
+        cos_sin_cache = torch.randn(1024, head_dim)
+        positions = torch.zeros(batch_size, dtype=torch.long)
+
+        q, k, v = split_qkv_rmsnorm_rope_impl_fake(
+            input=input_tensor,
+            cos_sin_cache=cos_sin_cache,
+            positions=positions,
+            q_weight=q_weight,
+            k_weight=k_weight,
+            q_hidden_size=q_hidden_size,
+            kv_hidden_size=kv_hidden_size,
+            head_dim=head_dim,
+            eps=1e-6,
+        )
+
+        assert q.shape == (batch_size, q_hidden_size)
+        assert k.shape == (batch_size, kv_hidden_size)
+        assert v.shape == (batch_size, kv_hidden_size)
+
+    @patch("vllm_ascend.ops.split_qkv_rmsnorm_rope.torch_npu")
+    def test_impl_calls_npu_rms_norm(self, mock_torch_npu):
+        """The implementation should call npu_rms_norm for Q and K."""
+        from vllm_ascend.ops.split_qkv_rmsnorm_rope import (
+            split_qkv_rmsnorm_rope_impl,
+        )
+
+        head_dim = 128
+        batch_size = 2
+        num_q_heads = 4
+        num_kv_heads = 1
+        q_hidden_size = num_q_heads * head_dim
+        kv_hidden_size = num_kv_heads * head_dim
+        total = q_hidden_size + kv_hidden_size * 2
+
+        input_tensor = torch.randn(batch_size, total)
+        q_weight = torch.randn(head_dim)
+        k_weight = torch.randn(head_dim)
+        cos_sin_cache = torch.randn(1024, head_dim)
+        positions = torch.zeros(batch_size, dtype=torch.long)
+
+        # Mock npu_rms_norm to return the input unchanged
+        mock_torch_npu.npu_rms_norm.side_effect = lambda x, w, e: (x, None)
+
+        # Mock npu_rotary_embedding to return inputs unchanged
+        with patch("torch.ops.vllm.npu_rotary_embedding") as mock_rope:
+            mock_rope.side_effect = lambda pos, q, k, cache, hd, rd, neox: (q, k)
+
+            q, k, v = split_qkv_rmsnorm_rope_impl(
+                input=input_tensor,
+                cos_sin_cache=cos_sin_cache,
+                positions=positions,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                q_hidden_size=q_hidden_size,
+                kv_hidden_size=kv_hidden_size,
+                head_dim=head_dim,
+                eps=1e-6,
+            )
+
+            # npu_rms_norm should be called twice (once for Q, once for K)
+            assert mock_torch_npu.npu_rms_norm.call_count == 2
+            # npu_rotary_embedding should be called once
+            assert mock_rope.call_count == 1
+
+            # Output shapes should be correct
+            assert q.shape == (batch_size, q_hidden_size)
+            assert k.shape == (batch_size, kv_hidden_size)
+            assert v.shape == (batch_size, kv_hidden_size)
+
+    @patch("vllm_ascend.ops.split_qkv_rmsnorm_rope.torch_npu")
+    def test_impl_applies_bias(self, mock_torch_npu):
+        """When bias is provided, it should be added after RMSNorm."""
+        from vllm_ascend.ops.split_qkv_rmsnorm_rope import (
+            split_qkv_rmsnorm_rope_impl,
+        )
+
+        head_dim = 128
+        batch_size = 2
+        num_q_heads = 4
+        num_kv_heads = 1
+        q_hidden_size = num_q_heads * head_dim
+        kv_hidden_size = num_kv_heads * head_dim
+        total = q_hidden_size + kv_hidden_size * 2
+
+        input_tensor = torch.randn(batch_size, total)
+        q_weight = torch.randn(head_dim)
+        k_weight = torch.randn(head_dim)
+        q_bias = torch.randn(head_dim)
+        k_bias = torch.randn(head_dim)
+        cos_sin_cache = torch.randn(1024, head_dim)
+        positions = torch.zeros(batch_size, dtype=torch.long)
+
+        # Mock npu_rms_norm to return zeros so we can check bias is added
+        mock_torch_npu.npu_rms_norm.side_effect = lambda x, w, e: (torch.zeros_like(x), None)
+
+        with patch("torch.ops.vllm.npu_rotary_embedding") as mock_rope:
+            # Return q, k as-is to check bias was applied
+            mock_rope.side_effect = lambda pos, q, k, cache, hd, rd, neox: (q, k)
+
+            q, k, v = split_qkv_rmsnorm_rope_impl(
+                input=input_tensor,
+                cos_sin_cache=cos_sin_cache,
+                positions=positions,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                q_hidden_size=q_hidden_size,
+                kv_hidden_size=kv_hidden_size,
+                head_dim=head_dim,
+                eps=1e-6,
+                q_bias=q_bias,
+                k_bias=k_bias,
+            )
+
+            # With zeros from rms_norm + bias, q should have bias values
+            # repeated across heads
+            assert q.shape == (batch_size, q_hidden_size)
+            assert torch.allclose(
+                q,
+                q_bias.repeat(num_q_heads).expand(batch_size, -1),
+            )
+            assert k.shape == (batch_size, kv_hidden_size)
+            assert torch.allclose(
+                k,
+                k_bias.repeat(num_kv_heads).expand(batch_size, -1),
+            )
+            assert v.shape == (batch_size, kv_hidden_size)

--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -23,12 +23,17 @@ import vllm_ascend.ops.layernorm  # noqa
 import vllm_ascend.ops.register_custom_ops  # noqa
 
 if HAS_TRITON:
+    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_mrope  # noqa
     import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope  # noqa
-    import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_mrope
+else:
+    import vllm_ascend.ops.split_qkv_rmsnorm_rope  # noqa
 
 import vllm_ascend.ops.vocab_parallel_embedding  # noqa
 from vllm_ascend.ops.activation import AscendQuickGELU, AscendSiluAndMul
-from vllm_ascend.ops.rotary_embedding import AscendDeepseekScalingRotaryEmbedding, AscendRotaryEmbedding
+from vllm_ascend.ops.rotary_embedding import (
+    AscendDeepseekScalingRotaryEmbedding,
+    AscendRotaryEmbedding,
+)
 
 
 class dummyFusionOp:
@@ -40,13 +45,32 @@ class dummyFusionOp:
 
 def register_dummy_fusion_op() -> None:
     torch.ops._C_ascend.rms_norm = dummyFusionOp(name="rms_norm")
-    torch.ops._C_ascend.fused_add_rms_norm = dummyFusionOp(name="fused_add_rms_norm")
-    torch.ops._C_ascend.static_scaled_fp8_quant = dummyFusionOp(name="static_scaled_fp8_quant")
-    torch.ops._C_ascend.dynamic_scaled_fp8_quant = dummyFusionOp(name="dynamic_scaled_fp8_quant")
-    torch.ops._C_ascend.dynamic_per_token_scaled_fp8_quant = dummyFusionOp(name="dynamic_per_token_scaled_fp8_quant")
-    torch.ops._C_ascend.rms_norm_static_fp8_quant = dummyFusionOp(name="rms_norm_static_fp8_quant")
-    torch.ops._C_ascend.fused_add_rms_norm_static_fp8_quant = dummyFusionOp(name="fused_add_rms_norm_static_fp8_quant")
-    torch.ops._C_ascend.rms_norm_dynamic_per_token_quant = dummyFusionOp(name="rms_norm_dynamic_per_token_quant")
+    torch.ops._C_ascend.fused_add_rms_norm = dummyFusionOp(
+        name="fused_add_rms_norm"
+    )
+    torch.ops._C_ascend.static_scaled_fp8_quant = dummyFusionOp(
+        name="static_scaled_fp8_quant"
+    )
+    torch.ops._C_ascend.dynamic_scaled_fp8_quant = dummyFusionOp(
+        name="dynamic_scaled_fp8_quant"
+    )
+    torch.ops._C_ascend.dynamic_per_token_scaled_fp8_quant = dummyFusionOp(
+        name="dynamic_per_token_scaled_fp8_quant"
+    )
+    torch.ops._C_ascend.rms_norm_static_fp8_quant = dummyFusionOp(
+        name="rms_norm_static_fp8_quant"
+    )
+    torch.ops._C_ascend.fused_add_rms_norm_static_fp8_quant = dummyFusionOp(
+        name="fused_add_rms_norm_static_fp8_quant"
+    )
+    torch.ops._C_ascend.rms_norm_dynamic_per_token_quant = dummyFusionOp(
+        name="rms_norm_dynamic_per_token_quant"
+    )
 
 
-__all__ = ["AscendQuickGELU", "AscendSiluAndMul", "AscendRotaryEmbedding", "AscendDeepseekScalingRotaryEmbedding"]
+__all__ = [
+    "AscendQuickGELU",
+    "AscendSiluAndMul",
+    "AscendRotaryEmbedding",
+    "AscendDeepseekScalingRotaryEmbedding",
+]

--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -45,27 +45,13 @@ class dummyFusionOp:
 
 def register_dummy_fusion_op() -> None:
     torch.ops._C_ascend.rms_norm = dummyFusionOp(name="rms_norm")
-    torch.ops._C_ascend.fused_add_rms_norm = dummyFusionOp(
-        name="fused_add_rms_norm"
-    )
-    torch.ops._C_ascend.static_scaled_fp8_quant = dummyFusionOp(
-        name="static_scaled_fp8_quant"
-    )
-    torch.ops._C_ascend.dynamic_scaled_fp8_quant = dummyFusionOp(
-        name="dynamic_scaled_fp8_quant"
-    )
-    torch.ops._C_ascend.dynamic_per_token_scaled_fp8_quant = dummyFusionOp(
-        name="dynamic_per_token_scaled_fp8_quant"
-    )
-    torch.ops._C_ascend.rms_norm_static_fp8_quant = dummyFusionOp(
-        name="rms_norm_static_fp8_quant"
-    )
-    torch.ops._C_ascend.fused_add_rms_norm_static_fp8_quant = dummyFusionOp(
-        name="fused_add_rms_norm_static_fp8_quant"
-    )
-    torch.ops._C_ascend.rms_norm_dynamic_per_token_quant = dummyFusionOp(
-        name="rms_norm_dynamic_per_token_quant"
-    )
+    torch.ops._C_ascend.fused_add_rms_norm = dummyFusionOp(name="fused_add_rms_norm")
+    torch.ops._C_ascend.static_scaled_fp8_quant = dummyFusionOp(name="static_scaled_fp8_quant")
+    torch.ops._C_ascend.dynamic_scaled_fp8_quant = dummyFusionOp(name="dynamic_scaled_fp8_quant")
+    torch.ops._C_ascend.dynamic_per_token_scaled_fp8_quant = dummyFusionOp(name="dynamic_per_token_scaled_fp8_quant")
+    torch.ops._C_ascend.rms_norm_static_fp8_quant = dummyFusionOp(name="rms_norm_static_fp8_quant")
+    torch.ops._C_ascend.fused_add_rms_norm_static_fp8_quant = dummyFusionOp(name="fused_add_rms_norm_static_fp8_quant")
+    torch.ops._C_ascend.rms_norm_dynamic_per_token_quant = dummyFusionOp(name="rms_norm_dynamic_per_token_quant")
 
 
 __all__ = [

--- a/vllm_ascend/ops/split_qkv_rmsnorm_rope.py
+++ b/vllm_ascend/ops/split_qkv_rmsnorm_rope.py
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""
+Non-Triton fallback implementation of the fused split_qkv_rmsnorm_rope op.
+
+When Triton (triton-ascend) is not available (e.g., in A+X environments where
+triton and triton-ascend versions conflict), this module provides a native
+torch_npu-based implementation so that the `torch.ops.vllm.qkv_rmsnorm_rope`
+custom op is still registered and the QKNormRopeFusionPass can function
+correctly.
+
+See: https://github.com/vllm-project/vllm-ascend/issues/6737
+"""
+
+import torch
+import torch_npu  # noqa: F401
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def split_qkv_rmsnorm_rope_impl(
+    input: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    q_hidden_size: int,
+    kv_hidden_size: int,
+    head_dim: int,
+    eps: float,
+    q_bias: torch.Tensor | None = None,
+    k_bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused split-QKV + RMSNorm + RoPE using native torch_npu operators.
+
+    This is the non-Triton fallback path. It uses ``npu_rms_norm`` for
+    RMSNorm and the registered ``npu_rotary_embedding`` custom op for RoPE,
+    keeping the implementation consistent with the rest of the codebase.
+    """
+    assert head_dim % 2 == 0, "head_dim must be even for RoPE."
+
+    batch_size = input.shape[0]
+
+    # 1. Split input into Q, K, V portions
+    q_input = input[:, :q_hidden_size]
+    k_input = input[:, q_hidden_size : q_hidden_size + kv_hidden_size]
+    v_output = input[:, q_hidden_size + kv_hidden_size :].clone()
+
+    # 2. Reshape to [batch_size * num_heads, head_dim] for RMSNorm
+    q_input = q_input.reshape(-1, head_dim)
+    k_input = k_input.reshape(-1, head_dim)
+
+    # 3. Apply RMSNorm using fused NPU operator
+    q_normalized, _ = torch_npu.npu_rms_norm(q_input, q_weight, eps)
+    k_normalized, _ = torch_npu.npu_rms_norm(k_input, k_weight, eps)
+
+    # 4. Apply bias if present
+    if q_bias is not None:
+        q_normalized = q_normalized + q_bias
+    if k_bias is not None:
+        k_normalized = k_normalized + k_bias
+
+    # 5. Flatten back to [batch_size, hidden_size] for RoPE
+    q_flat = q_normalized.reshape(batch_size, q_hidden_size)
+    k_flat = k_normalized.reshape(batch_size, kv_hidden_size)
+
+    # 6. Apply RoPE via the already-registered npu_rotary_embedding custom op
+    #    This keeps the implementation consistent and avoids duplicating
+    #    RoPE logic. The op handles cos/sin cache indexing internally.
+    q_rope, k_rope = torch.ops.vllm.npu_rotary_embedding(
+        positions, q_flat, k_flat, cos_sin_cache, head_dim, head_dim, True
+    )
+
+    return q_rope, k_rope, v_output
+
+
+def split_qkv_rmsnorm_rope_impl_fake(
+    input: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    q_hidden_size: int,
+    kv_hidden_size: int,
+    head_dim: int,
+    eps: float,
+    q_bias: torch.Tensor | None = None,
+    k_bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fake implementation for shape inference during Dynamo/AOT tracing."""
+    batch_size = input.shape[0]
+    q_output = torch.empty(batch_size, q_hidden_size, device=input.device, dtype=input.dtype)
+    k_output = torch.empty(batch_size, kv_hidden_size, device=input.device, dtype=input.dtype)
+    v_output = torch.empty(batch_size, kv_hidden_size, device=input.device, dtype=input.dtype)
+    return q_output, k_output, v_output
+
+
+direct_register_custom_op(
+    op_name="qkv_rmsnorm_rope",
+    op_func=split_qkv_rmsnorm_rope_impl,
+    fake_impl=split_qkv_rmsnorm_rope_impl_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)


### PR DESCRIPTION
## What this PR does / why we need it?

Fixes #6737, Fixes #6578

In A+X environments, the `triton` 3.6 package (pulled in by xgrammar) conflicts with `triton-ascend` 3.2.0, causing `HAS_TRITON` to be `False`. This means the `qkv_rmsnorm_rope` custom op is never registered via the Triton-based implementation, but the `QKNormRopeFusionPass` still tries to use `torch.ops.vllm.qkv_rmsnorm_rope` as a replacement pattern, resulting in:

\\\
AttributeError: '_OpNamespace' 'vllm' object has no attribute 'qkv_rmsnorm_rope'
\\\

This PR adds a **native torch_npu-based fallback implementation** (solution 3 from the issue) that:

- Uses `npu_rms_norm` for RMSNorm computation
- **Reuses the already-registered `npu_rotary_embedding` custom op** for RoPE (instead of duplicating RoPE logic with `npu_apply_rotary_pos_emb`)
- Includes an assertion for even `head_dim` requirement
- Is conditionally imported only when Triton is not available (`else` branch)

### Key difference from #6782

This implementation reuses the existing `torch.ops.vllm.npu_rotary_embedding` op for the RoPE step rather than re-implementing RoPE from scratch with `torch_npu.npu_apply_rotary_pos_emb`. This keeps the code consistent with the rest of the codebase and reduces maintenance burden.

## Does this PR introduce _any_ user-facing change?

No. This is a transparent fallback for environments where Triton is not available.

## How was this patch tested?

- Unit tests added: `tests/ut/ops/test_split_qkv_rmsnorm_rope.py`
  - Tests op registration when Triton is unavailable
  - Tests `head_dim` even assertion
  - Tests fake impl output shapes
  - Tests that `npu_rms_norm` is called correctly
  - Tests bias application path

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
