### PR TITLE
[Doc] Fix broken chunked-prefill URL in supported features

### DIFF
--- a/docs/source/user_guide/support_matrix/supported_features.md
+++ b/docs/source/user_guide/support_matrix/supported_features.md
@@ -42,7 +42,7 @@ You can check the [support status of vLLM V1 Engine][v1_user_guide]. Below is th
 [LoRA]: https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/lora.html
 [graph_mode]: https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/graph_mode.html
 [apc]: https://github.com/vllm-project/vllm-ascend/issues/732
-[cp]: https://docs.vllm.ai/en/stable/performance/optimization.html#chunked-prefill
+[cp]: https://docs.vllm.ai/en/stable/configuration/optimization.html#chunked-prefill
 [1P1D]: https://github.com/vllm-project/vllm-ascend/pull/950
 [context_parallel]: https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/context_parallel.html
 [sleep_mode]: https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/sleep_mode.html


### PR DESCRIPTION
## What this PR does / why we need it?

Fixes the broken URL for chunked-prefill in the supported features documentation page.

The chunked prefill documentation URL was moved from `performance/optimization.html` to `configuration/optimization.html` in upstream vLLM docs. This PR updates the link to point to the correct location.

**Before**: https://docs.vllm.ai/en/stable/performance/optimization.html#chunked-prefill (404)
**After**: https://docs.vllm.ai/en/stable/configuration/optimization.html#chunked-prefill (working)

## Does this PR introduce _any_ user-facing change?

Yes - fixes a broken documentation link that users encounter when clicking 'Chunked Prefill' in the supported features page.

## How was this patch tested?

- Verified the new URL resolves correctly
- Documentation change only

Closes #4217
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
