### PR TITLE
[Triton][Sampler]add penalty-related triton kernel for better performance of penalties

### DIFF
--- a/vllm_ascend/ops/triton/bincount.py
+++ b/vllm_ascend/ops/triton/bincount.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit
+def token_bin_counts_and_mask_kernel(
+    tokens_ptr,
+    tokens_batch_stride,
+    tokens_seq_stride,
+    batch_size,
+    seq_len,
+    vocab_size,
+    bin_counts_ptr,
+    counts_batch_stride,
+    counts_vocab_stride,
+    BIG_CORE_NUM: tl.constexpr,
+    BIG_ROW_BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    SMALL_ROW_BLOCK_SIZE = BIG_ROW_BLOCK_SIZE - 1
+    if pid < BIG_CORE_NUM:
+        row_block_size = BIG_ROW_BLOCK_SIZE
+        row_start_idx = pid * BIG_ROW_BLOCK_SIZE
+    else:
+        row_block_size = SMALL_ROW_BLOCK_SIZE
+        row_start_idx = BIG_CORE_NUM * BIG_ROW_BLOCK_SIZE + (pid - BIG_CORE_NUM) * SMALL_ROW_BLOCK_SIZE
+
+    row_end_idx = min(row_start_idx + row_block_size, batch_size)
+    for batch_idx in range(row_start_idx, row_end_idx):
+        batch_tokens_start = tokens_ptr + batch_idx * tokens_batch_stride
+        batch_counts_start = bin_counts_ptr + batch_idx * counts_batch_stride
+
+        for pos in range(seq_len):
+            token = tl.load(batch_tokens_start + pos * tokens_seq_stride)
+            if token >= 0 and token < vocab_size:
+                count_ptr = batch_counts_start + token * counts_vocab_stride
+                # Each (batch_idx, token) pair is only written by one program.
+                old = tl.load(count_ptr)
+                tl.store(count_ptr, old + 1)
+
+
+def get_token_bin_counts_and_mask_triton(
+    tokens: torch.Tensor,
+    vocab_size: int,
+    num_seqs: int | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    core_num = get_vectorcore_num()
+    n_rows, n_cols = tokens.shape
+    if num_seqs is not None and num_seqs > 0:
+        assert n_rows == num_seqs, (
+            "tokens rows must match num_seqs to avoid silently skipping rows: "
+            f"tokens.shape[0]={n_rows}, num_seqs={num_seqs}"
+        )
+        n_rows = num_seqs
+
+    bin_counts = torch.zeros((n_rows, vocab_size), dtype=torch.int32, device=tokens.device)
+    if not tokens.is_contiguous():
+        tokens = tokens.contiguous()
+    if not bin_counts.is_contiguous():
+        bin_counts = bin_counts.contiguous()
+
+    big_row_block_size = triton.cdiv(n_rows, core_num)
+    # cdiv guarantees big_row_block_size * core_num >= n_rows.
+    # big_core_num cores handle big_row_block_size rows each;
+    # the remaining cores handle (big_row_block_size - 1) rows each.
+    big_core_num = max(
+        0,
+        min(
+            core_num - (big_row_block_size * core_num - n_rows),
+            core_num,
+        ),
+    )
+    grid = (min(n_rows, core_num),)
+
+    token_bin_counts_and_mask_kernel[grid](
+        tokens,
+        tokens.stride(0),
+        tokens.stride(1),
+        n_rows,
+        n_cols,
+        vocab_size,
+        bin_counts,
+        bin_counts.stride(0),
+        bin_counts.stride(1),
+        BIG_CORE_NUM=big_core_num,
+        BIG_ROW_BLOCK_SIZE=big_row_block_size,
+    )
+    return bin_counts, bin_counts > 0

--- a/vllm_ascend/ops/triton/penalty.py
+++ b/vllm_ascend/ops/triton/penalty.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.bincount import get_token_bin_counts_and_mask_triton
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit
+def apply_all_penalties_kernel(
+    logits_ptr,
+    prompt_mask_ptr,
+    output_mask_ptr,
+    output_bin_counts_ptr,
+    repetition_penalties_ptr,
+    frequency_penalties_ptr,
+    presence_penalties_ptr,
+    num_seqs,
+    vocab_size,
+    stride_logits_seq,
+    stride_logits_vocab,
+    stride_prompt_mask_seq,
+    stride_prompt_mask_vocab,
+    stride_output_mask_seq,
+    stride_output_mask_vocab,
+    stride_bin_counts_seq,
+    stride_bin_counts_vocab,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+    seqs_per_program = (num_seqs + num_programs - 1) // num_programs
+
+    start_seq = pid * seqs_per_program
+    end_seq = tl.minimum(start_seq + seqs_per_program, num_seqs)
+
+    for seq_idx in range(start_seq, end_seq):
+        repetition_penalty = tl.load(repetition_penalties_ptr + seq_idx)
+        frequency_penalty = tl.load(frequency_penalties_ptr + seq_idx)
+        presence_penalty = tl.load(presence_penalties_ptr + seq_idx)
+
+        for vocab_start in range(0, vocab_size, BLOCK_SIZE):
+            vocab_offsets = vocab_start + tl.arange(0, BLOCK_SIZE)
+            mask = vocab_offsets < vocab_size
+
+            logits_offset = seq_idx * stride_logits_seq + vocab_offsets * stride_logits_vocab
+            prompt_mask_offset = seq_idx * stride_prompt_mask_seq + vocab_offsets * stride_prompt_mask_vocab
+            output_mask_offset = seq_idx * stride_output_mask_seq + vocab_offsets * stride_output_mask_vocab
+            counts_offset = seq_idx * stride_bin_counts_seq + vocab_offsets * stride_bin_counts_vocab
+
+            logits = tl.load(logits_ptr + logits_offset, mask=mask, other=0.0)
+            prompt_mask_val = tl.load(prompt_mask_ptr + prompt_mask_offset, mask=mask, other=False)
+            output_mask_val = tl.load(output_mask_ptr + output_mask_offset, mask=mask, other=False)
+            output_bin_counts = tl.load(output_bin_counts_ptr + counts_offset, mask=mask, other=0).to(tl.float32)
+
+            need_repetition_penalty = (prompt_mask_val | output_mask_val).to(tl.int1)
+            penalty_factor = tl.where(need_repetition_penalty, repetition_penalty, 1.0)
+            scaling = tl.where((logits > 0.0).to(tl.int1), 1.0 / penalty_factor, penalty_factor)
+            updated = logits * scaling
+
+            updated -= frequency_penalty * output_bin_counts
+            updated -= presence_penalty * output_mask_val.to(tl.float32)
+            tl.store(logits_ptr + logits_offset, updated, mask=mask)
+
+
+def apply_penalties_triton(
+    logits: torch.Tensor,
+    prompt_tokens_tensor: torch.Tensor,
+    output_tokens_tensor: torch.Tensor,
+    presence_penalties: torch.Tensor,
+    frequency_penalties: torch.Tensor,
+    repetition_penalties: torch.Tensor,
+) -> torch.Tensor:
+    num_seqs, vocab_size = logits.shape
+    _, prompt_mask = get_token_bin_counts_and_mask_triton(prompt_tokens_tensor, vocab_size, num_seqs)
+    output_bin_counts, output_mask = get_token_bin_counts_and_mask_triton(
+        output_tokens_tensor,
+        vocab_size,
+        num_seqs,
+    )
+    _apply_all_penalties_triton(
+        logits,
+        prompt_mask,
+        output_mask,
+        output_bin_counts,
+        repetition_penalties,
+        frequency_penalties,
+        presence_penalties,
+    )
+    return logits
+
+
+def _apply_all_penalties_triton(
+    logits: torch.Tensor,
+    prompt_mask: torch.Tensor,
+    output_mask: torch.Tensor,
+    output_bin_counts: torch.Tensor,
+    repetition_penalties: torch.Tensor,
+    frequency_penalties: torch.Tensor,
+    presence_penalties: torch.Tensor,
+) -> None:
+    num_seqs, vocab_size = logits.shape
+    grid = (min(num_seqs, get_vectorcore_num()), 1, 1)
+
+    apply_all_penalties_kernel[grid](
+        logits,
+        prompt_mask,
+        output_mask,
+        output_bin_counts,
+        repetition_penalties,
+        frequency_penalties,
+        presence_penalties,
+        num_seqs,
+        vocab_size,
+        logits.stride(0),
+        logits.stride(1),
+        prompt_mask.stride(0),
+        prompt_mask.stride(1),
+        output_mask.stride(0),
+        output_mask.stride(1),
+        output_bin_counts.stride(0),
+        output_bin_counts.stride(1),
+        BLOCK_SIZE=2048,
+    )

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -1,8 +1,13 @@
 import torch
+from vllm.triton_utils import HAS_TRITON
+from vllm.utils.platform_utils import is_pin_memory_available
+from vllm.utils.torch_utils import make_tensor_with_pad
+from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ops.triton.penalty import apply_penalties_triton
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream, npu_stream_switch
 
 DEFAULT_LOGPROBS_MODE = "raw_logprobs"
@@ -34,6 +39,44 @@ def random_sample(
     return probs.div_(q).argmax(dim=-1).view(-1)
 
 
+def apply_all_penalties(
+    logits: torch.Tensor,
+    prompt_token_ids: torch.Tensor,
+    presence_penalties: torch.Tensor,
+    frequency_penalties: torch.Tensor,
+    repetition_penalties: torch.Tensor,
+    output_token_ids: list[list[int]],
+) -> torch.Tensor:
+    _, vocab_size = logits.shape
+    output_tokens_t = _convert_to_tensors(output_token_ids, vocab_size, logits.device)
+
+    return apply_penalties_triton(
+        logits,
+        prompt_token_ids,
+        output_tokens_t,
+        presence_penalties,
+        frequency_penalties,
+        repetition_penalties,
+    )
+
+
+def _convert_to_tensors(
+    output_token_ids: list[list[int]],
+    vocab_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    output_tokens_tensor = make_tensor_with_pad(
+        output_token_ids,
+        # Use the value of vocab_size as a pad since we don't have a
+        # token_id of this value.
+        pad=vocab_size,
+        device="cpu",
+        dtype=torch.int64,
+        pin_memory=is_pin_memory_available(),
+    )
+    return output_tokens_tensor.to(device, non_blocking=True)
+
+
 class AscendSampler(Sampler):
     def __init__(self, logprobs_mode=DEFAULT_LOGPROBS_MODE):
         # TODO: support logprobs_mode in vllm-ascend
@@ -58,6 +101,28 @@ class AscendSampler(Sampler):
                     q[i].exponential_(generator=generator)
             self.async_exponential_event.record()
         self.set_q_event(q, self.async_exponential_event)
+
+    def apply_penalties(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        output_token_ids: list[list[int]],
+    ) -> torch.Tensor:
+        if sampling_metadata.no_penalties:
+            return logits
+
+        if not HAS_TRITON:
+            return super().apply_penalties(logits, sampling_metadata, output_token_ids)
+
+        assert sampling_metadata.prompt_token_ids is not None
+        return apply_all_penalties(
+            logits,
+            sampling_metadata.prompt_token_ids,
+            sampling_metadata.presence_penalties,
+            sampling_metadata.frequency_penalties,
+            sampling_metadata.repetition_penalties,
+            output_token_ids,
+        )
 
 
 class AscendTopKTopPSampler(TopKTopPSampler):


### PR DESCRIPTION
### What this PR does / why we need it?
Implement `get_token_bin_count` and `apply_penalties` with triton kernels. It can significantly reduce latency of sampling process with penalties.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
E2E testing with Qwen3-480B (accuracy and perforamnce, update later)

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
