### PR TITLE
VL w8a8 model type modify

### DIFF
--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -55,7 +55,7 @@ QUANT_MODEL_PREFIX_MAPPINGS: dict[str, dict[str, str]] = {
         "language_model.lm_head.": "lm_head.",
         "language_model.model.": "model.language_model.",
     },
-    "qwen3_vl_text": {
+    "qwen3_vl": {
         "visual.": "model.visual.",
         "language_model.lm_head.": "lm_head.",
         "language_model.model.": "model.language_model.",


### PR DESCRIPTION
### What this PR does / why we need it?

To adapt to the model type of the qwen3-vl w8a8 model.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Deploy a model of Qwen3-VL-8B-W8A8 with vLLM serve.

vllm serve /xxxxx/Qwen3-VL-32B-Instruct-W8A8 \
--host 0.0.0.0 \
--port 10012 \
--served-model-name qwen3vl \
--tensor-parallel-size 2 \
--max-model-len 20000 \
--max-num-batched-tokens 20000 \
--trust-remote-code \
--enable-prefix-caching \
--gpu-memory-utilization 0.8 \
--allowed-local-media-path / \
--media-io-kwargs '{"video":{"num_frames":5}}' \
--additional-config='{"enable_cpu_binding":true}' \
--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,32,64,80,96,128]}' \
--async-scheduling \
--mm-processor-cache-gb 0 \
--quantization ascend
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
