### PR TITLE
[Bugfix] Fix Qwen3.5 weight loading error by registering `AscendUnquantizedLinearMethod`

### DIFF
--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -49,7 +49,7 @@ if not vllm_version_is("0.16.0"):
 if not vllm_version_is("0.16.0"):
 
     @register_weight_loader_v2_supported_method
-    class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
+    class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):  # type: ignore[no-redef]
         """Linear method without quantization"""
 
         def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -58,7 +58,7 @@ if not vllm_version_is("0.16.0"):
                 layer.weight.data = maybe_trans_nz(layer.weight.data)
 else:
 
-    class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
+    class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):  # type: ignore[no-redef]
         """Linear method without quantization"""
 
         def process_weights_after_loading(self, layer: torch.nn.Module) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?

Currently, run Qwen3.5 will get a weight loading error:

```bash
...
ERROR 03-04 07:43:12 [multiproc_executor.py:783]   File "/vllm-workspace/vllm/vllm/model_executor/models/qwen3_5.py", line 430, in load_weights
ERROR 03-04 07:43:12 [multiproc_executor.py:783]     weight_loader(param, loaded_weight, shard_id)
ERROR 03-04 07:43:12 [multiproc_executor.py:783]   File "/vllm-workspace/vllm/vllm/model_executor/layers/linear.py", line 743, in weight_loader
ERROR 03-04 07:43:12 [multiproc_executor.py:783]     raise NotImplementedError(
ERROR 03-04 07:43:12 [multiproc_executor.py:783] NotImplementedError: Shard id with multiple indices is not supported in weight_loader, please use weight_loader_v2 instead.
```

This is because `AscendUnquantizedLinearMethod` is not contained in the `WEIGHT_LOADER_V2_SUPPORTED` in vllm.

Thus, we register `AscendUnquantizedLinearMethod` into `WEIGHT_LOADER_V2_SUPPORTED` to fix the bug.

This PR relies on https://github.com/vllm-project/vllm/pull/35981.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

```bash
vllm serve /root/.cache/modelscope/hub/models/Qwen/Qwen3___5-4B \
-tp 2 \
--reasoning-parser qwen3 \
--max_model_len 4096 \
--language-model-only \
--enforce-eager \
--gpu-memory-utilization 0.5
```

Output:

```
{"id":"chatcmpl-b5078af45294a53e","object":"chat.completion","created":1772610011,"model":"/root/.cache/modelscope/hub/models/Qwen/Qwen3___5-4B","choices":[{"index":0,"message":{"role":"assistant","content":"Here's a thinking process that leads to the suggested answer about the future of AI:\n\n1.  **Deconstruct the Request:**\n    *   **Topic:** Future of AI (Artificial Intelligence).\n    *   **Nature of Question:** Open-ended, speculative, broad, requires balancing optimism/possibilities with realism/risks.\n    *   **Goal:** Provide a comprehensive, nuanced, and informative overview without making unfounded predictions.\n\n2.  **Initial Brainstorm","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":28,"total_tokens":128,"completion_tokens":100,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_p
```

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
