### PR TITLE
[Bugfix][Worker] Disable prefix caching for pooling models to fix embedding inconsistency

### DIFF
--- a/tests/e2e/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/singlecard/pooling/test_embedding.py
@@ -57,31 +57,32 @@ def test_embed_models_correctness(model: str):
     )
 
 
-def test_embedding_duplicate_queries_consistency():
+@pytest.mark.parametrize("enforce_eager", [True, False])
+def test_embedding_duplicate_queries_consistency(enforce_eager: bool):
     """Regression test for https://github.com/vllm-project/vllm-ascend/issues/5725
 
-    Verifies that repeated identical queries produce consistent embeddings.
-    Previously, prefix caching caused the second computation of the same
+    Verifies that repeated identical queries produce consistent embeddings
+    across both eager and graph execution paths. Previously, enabling prefix
+    caching for pooling models caused the second computation of the same
     query to return incorrect embeddings (cosine similarity ~0.58 instead
     of ~1.0).
     """
     query = 'What is the capital of China?'
-    # Send the same query twice to trigger prefix cache hit on the second one
-    queries = [query, query]
 
     model_name = snapshot_download("Qwen/Qwen3-Embedding-0.6B")
     with VllmRunner(
             model_name,
             runner="pooling",
             max_model_len=None,
-            enforce_eager=True,
+            enable_prefix_caching=True,
+            enforce_eager=enforce_eager,
     ) as vllm_runner:
-        vllm_outputs = vllm_runner.embed(queries)
+        first_output = vllm_runner.embed([query])[0]
+        second_output = vllm_runner.embed([query])[0]
 
-    # The two embeddings for the same query must be identical
     check_embeddings_close(
-        embeddings_0_lst=[vllm_outputs[0]],
-        embeddings_1_lst=[vllm_outputs[1]],
+        embeddings_0_lst=[first_output],
+        embeddings_1_lst=[second_output],
         name_0="first_call",
         name_1="second_call",
         tol=1e-3,

--- a/tests/e2e/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/singlecard/pooling/test_embedding.py
@@ -24,27 +24,27 @@ from tests.e2e.utils import check_embeddings_close
 
 MODELS = [
     "Qwen/Qwen3-Embedding-0.6B",  # lasttoken
-    "intfloat/multilingual-e5-small"  # mean_tokens
+    "intfloat/multilingual-e5-small",  # mean_tokens
 ]
 
 
 @pytest.mark.parametrize("model", MODELS)
 def test_embed_models_correctness(model: str):
-    queries = ['What is the capital of China?', 'Explain gravity']
+    queries = ["What is the capital of China?", "Explain gravity"]
 
     model_name = snapshot_download(model)
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            max_model_len=None,
-            cudagraph_capture_sizes=[4],
+        model_name,
+        runner="pooling",
+        max_model_len=None,
+        cudagraph_capture_sizes=[4],
     ) as vllm_runner:
         vllm_outputs = vllm_runner.embed(queries)
 
     with HfRunner(
-            model_name,
-            dtype="float32",
-            is_sentence_transformer=True,
+        model_name,
+        dtype="float32",
+        is_sentence_transformer=True,
     ) as hf_runner:
         hf_outputs = hf_runner.encode(queries)
 
@@ -67,15 +67,15 @@ def test_embedding_duplicate_queries_consistency(enforce_eager: bool):
     query to return incorrect embeddings (cosine similarity ~0.58 instead
     of ~1.0).
     """
-    query = 'What is the capital of China?'
+    query = "What is the capital of China?"
 
     model_name = snapshot_download("Qwen/Qwen3-Embedding-0.6B")
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            max_model_len=None,
-            enable_prefix_caching=True,
-            enforce_eager=enforce_eager,
+        model_name,
+        runner="pooling",
+        max_model_len=None,
+        enable_prefix_caching=True,
+        enforce_eager=enforce_eager,
     ) as vllm_runner:
         first_output = vllm_runner.embed([query])[0]
         second_output = vllm_runner.embed([query])[0]
@@ -90,27 +90,27 @@ def test_embedding_duplicate_queries_consistency(enforce_eager: bool):
 
 
 def test_bge_m3_correctness():
-    queries = ['What is the capital of China?', 'Explain gravity']
+    queries = ["What is the capital of China?", "Explain gravity"]
 
     model_name = snapshot_download("BAAI/bge-m3")
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            cudagraph_capture_sizes=[4],
+        model_name,
+        runner="pooling",
+        cudagraph_capture_sizes=[4],
     ) as vllm_aclgraph_runner:
         vllm_aclgraph_outputs = vllm_aclgraph_runner.embed(queries)
 
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            enforce_eager=True,
+        model_name,
+        runner="pooling",
+        enforce_eager=True,
     ) as vllm_runner:
         vllm_eager_outputs = vllm_runner.embed(queries)
 
     with HfRunner(
-            model_name,
-            dtype="float32",
-            is_sentence_transformer=True,
+        model_name,
+        dtype="float32",
+        is_sentence_transformer=True,
     ) as hf_runner:
         hf_outputs = hf_runner.encode(queries)
 

--- a/tests/e2e/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/singlecard/pooling/test_embedding.py
@@ -57,6 +57,37 @@ def test_embed_models_correctness(model: str):
     )
 
 
+def test_embedding_duplicate_queries_consistency():
+    """Regression test for https://github.com/vllm-project/vllm-ascend/issues/5725
+
+    Verifies that repeated identical queries produce consistent embeddings.
+    Previously, prefix caching caused the second computation of the same
+    query to return incorrect embeddings (cosine similarity ~0.58 instead
+    of ~1.0).
+    """
+    query = 'What is the capital of China?'
+    # Send the same query twice to trigger prefix cache hit on the second one
+    queries = [query, query]
+
+    model_name = snapshot_download("Qwen/Qwen3-Embedding-0.6B")
+    with VllmRunner(
+            model_name,
+            runner="pooling",
+            max_model_len=None,
+            enforce_eager=True,
+    ) as vllm_runner:
+        vllm_outputs = vllm_runner.embed(queries)
+
+    # The two embeddings for the same query must be identical
+    check_embeddings_close(
+        embeddings_0_lst=[vllm_outputs[0]],
+        embeddings_1_lst=[vllm_outputs[1]],
+        name_0="first_call",
+        name_1="second_call",
+        tol=1e-3,
+    )
+
+
 def test_bge_m3_correctness():
     queries = ['What is the capital of China?', 'Explain gravity']
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -222,8 +222,7 @@ class NPUModelRunner(GPUModelRunner):
         if vllm_config.model_config.runner_type == "pooling":
             if vllm_config.cache_config.enable_prefix_caching:
                 logger.warning(
-                    "Prefix caching is not supported for pooling models. "
-                    "Disabling prefix caching automatically."
+                    "Prefix caching is not supported for pooling models. Disabling prefix caching automatically."
                 )
                 vllm_config.cache_config.enable_prefix_caching = False
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -213,6 +213,20 @@ class ExecuteModelState(NamedTuple):
 
 class NPUModelRunner(GPUModelRunner):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        # Disable prefix caching for pooling models to avoid embedding
+        # inconsistency. When prefix cache hits, the model only forward-passes
+        # new (non-cached) tokens, producing partial hidden_states. The pooler
+        # (e.g., LastTokenPooler) then incorrectly uses these partial states,
+        # resulting in wrong embeddings on subsequent identical queries.
+        # See: https://github.com/vllm-project/vllm-ascend/issues/5725
+        if vllm_config.model_config.runner_type == "pooling":
+            if vllm_config.cache_config.enable_prefix_caching:
+                logger.warning(
+                    "Prefix caching is not supported for pooling models. "
+                    "Disabling prefix caching automatically."
+                )
+                vllm_config.cache_config.enable_prefix_caching = False
+
         # TODO(qcs): These manual pad and unpad for GPUModelRunner are
         # used to expand some buffers, which need to be reverted after
         # the following PR is merged:

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -49,10 +49,7 @@ def _disable_prefix_caching_for_pooling_models(vllm_config: VllmConfig) -> None:
     if vllm_config.model_config.runner_type != "pooling":
         return
     if vllm_config.cache_config.enable_prefix_caching:
-        logger.warning(
-            "Prefix caching is not supported for pooling models. "
-            "Disabling prefix caching automatically."
-        )
+        logger.warning("Prefix caching is not supported for pooling models. Disabling prefix caching automatically.")
         vllm_config.cache_config.enable_prefix_caching = False
 
 

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -44,10 +44,23 @@ from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
 logger = init_logger(__name__)
 
 
+def _disable_prefix_caching_for_pooling_models(vllm_config: VllmConfig) -> None:
+    """Disable prefix caching for pooling workloads to avoid partial-state reuse."""
+    if vllm_config.model_config.runner_type != "pooling":
+        return
+    if vllm_config.cache_config.enable_prefix_caching:
+        logger.warning(
+            "Prefix caching is not supported for pooling models. "
+            "Disabling prefix caching automatically."
+        )
+        vllm_config.cache_config.enable_prefix_caching = False
+
+
 class NPUModelRunner(GPUModelRunner):
     """Model runner for Ascend NPUs."""
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        _disable_prefix_caching_for_pooling_models(vllm_config)
         with torch_cuda_wrapper():
             super().__init__(vllm_config, device)
 


### PR DESCRIPTION
## What this PR does / why we need it?

When prefix caching is enabled (which is the default for LAST pooling models like Qwen3-Embedding-0.6B), repeated embedding queries hit the cache. The model then only forward-passes new (non-cached) tokens, producing partial hidden_states. The pooler (e.g., \LastTokenPooler\) incorrectly uses these partial states, resulting in wrong embeddings with cosine similarity dropping from ~0.999 to ~0.58 on subsequent identical queries.

This fix disables prefix caching for all pooling models in \NPUModelRunner.__init__\ with a warning message.

**Root Cause Analysis:**
1. Upstream vLLM's \is_prefix_caching_supported\ returns \True\ for causal attention + LAST pooling models
2. When prefix cache hits, \_prepare_inputs\ only prepares new tokens (skipping cached ones)
3. \_pool\ receives \hidden_states[:num_scheduled_tokens]\ which only contains partial representations
4. \LastTokenPooler\ takes the last token from these partial states - this token lacks full context from the cached prefix tokens
5. Result: embeddings are inconsistent between first call (full forward pass) and subsequent calls (partial forward pass)

Closes https://github.com/vllm-project/vllm-ascend/issues/5725

## Does this PR introduce _any_ user-facing change?

Yes. Prefix caching is now automatically disabled for pooling models (embedding, scoring, classification) with a warning log. This ensures embedding consistency at the cost of not benefiting from prefix cache speedup for pooling workloads.

## How was this patch tested?

- Added regression test \	est_embedding_duplicate_queries_consistency\ that sends the same query twice and verifies the embeddings are consistent (cosine similarity >= 0.999)
- Existing embedding tests continue to pass

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
