### PR TITLE
[Bugfix] #6868 Prevent negative prompt-token metric increments for GLM5

### DIFF
--- a/tests/ut/patch/platform/test_patch_metrics_prompt_token_stats.py
+++ b/tests/ut/patch/platform/test_patch_metrics_prompt_token_stats.py
@@ -1,0 +1,89 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from vllm.v1.metrics.stats import PromptTokenStats
+
+import vllm_ascend.patch.platform.patch_metrics_prompt_token_stats  # noqa: F401
+from tests.ut.base import TestBase
+
+
+class TestPatchMetricsPromptTokenStats(TestBase):
+
+    def test_clamp_external_tokens_to_non_negative_sources(self):
+        stats = PromptTokenStats()
+
+        stats.update_from_output(
+            num_cached_tokens=1,
+            num_external_computed_tokens=3,
+            prompt_len=2,
+        )
+
+        self.assertGreaterEqual(stats.get_by_source("local_compute"), 0)
+        self.assertGreaterEqual(stats.get_by_source("local_cache_hit"), 0)
+        self.assertGreaterEqual(stats.get_by_source("external_kv_transfer"), 0)
+
+    def test_clamp_cached_tokens_not_exceed_prompt_len(self):
+        stats = PromptTokenStats()
+
+        stats.update_from_output(
+            num_cached_tokens=5,
+            num_external_computed_tokens=0,
+            prompt_len=2,
+        )
+
+        self.assertEqual(stats.total, 2)
+        self.assertGreaterEqual(stats.get_by_source("local_compute"), 0)
+
+    def test_negative_inputs_are_clamped_to_zero(self):
+        stats = PromptTokenStats()
+
+        stats.update_from_output(
+            num_cached_tokens=-1,
+            num_external_computed_tokens=-3,
+            prompt_len=-2,
+        )
+
+        self.assertEqual(stats.total, 0)
+        self.assertEqual(stats.get_by_source("local_compute"), 0)
+        self.assertEqual(stats.get_by_source("local_cache_hit"), 0)
+        self.assertEqual(stats.get_by_source("external_kv_transfer"), 0)
+
+    def test_counters_monotonic_across_multiple_updates(self):
+        stats = PromptTokenStats()
+
+        stats.update_from_output(
+            num_cached_tokens=1,
+            num_external_computed_tokens=1,
+            prompt_len=3,
+        )
+
+        total_after_first = stats.total
+        local_compute_after_first = stats.get_by_source("local_compute")
+        local_cache_hit_after_first = stats.get_by_source("local_cache_hit")
+        external_transfer_after_first = stats.get_by_source("external_kv_transfer")
+
+        stats.update_from_output(
+            num_cached_tokens=-5,
+            num_external_computed_tokens=-7,
+            prompt_len=-9,
+        )
+
+        self.assertGreaterEqual(stats.total, total_after_first)
+        self.assertGreaterEqual(stats.get_by_source("local_compute"), local_compute_after_first)
+        self.assertGreaterEqual(stats.get_by_source("local_cache_hit"), local_cache_hit_after_first)
+        self.assertGreaterEqual(
+            stats.get_by_source("external_kv_transfer"),
+            external_transfer_after_first,
+        )

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -107,6 +107,17 @@
 #    Future Plan:
 #       remove this patch once upstream no longer requires these global symbols or
 #       provides a backend-safe initialization path.
+# ** 7. File: platform/patch_metrics_prompt_token_stats.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.metrics.stats.PromptTokenStats.update_from_output`
+#    Why:
+#       Invalid prompt-token breakdown values may lead to negative increments in Prometheus Counter.
+#    How：
+#       Normalize prompt/cached/external token stats to valid ranges before updating metrics.
+#    Related PR (if no, explain why):
+#       No, this is a compatibility guard for current upstream behavior.
+#    Future Plan:
+#       Remove this patch when upstream metrics path guarantees non-negative per-source counters.
 #
 # * Worker Patch:
 # ===============

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -19,6 +19,7 @@ import os
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_fusion_matcher_compat_ops  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
+import vllm_ascend.patch.platform.patch_metrics_prompt_token_stats  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":

--- a/vllm_ascend/patch/platform/patch_metrics_prompt_token_stats.py
+++ b/vllm_ascend/patch/platform/patch_metrics_prompt_token_stats.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+
+from vllm.logger import init_logger
+from vllm.v1.metrics.stats import PromptTokenStats
+
+logger = init_logger(__name__)
+
+_original_update_from_output = PromptTokenStats.update_from_output
+_warned_invalid_prompt_token_stats = False
+_warn_lock = threading.Lock()
+
+
+def _patched_update_from_output(
+    self,
+    num_cached_tokens: int,
+    num_external_computed_tokens: int,
+    prompt_len: int,
+) -> None:
+    safe_prompt_len = max(prompt_len, 0)
+    safe_cached_tokens = max(0, min(num_cached_tokens, safe_prompt_len))
+    # ``num_external_computed_tokens`` is a subset of cached tokens and must
+    # never exceed the normalized cached-token count.
+    max_external_tokens = safe_cached_tokens
+    safe_external_tokens = max(0, min(num_external_computed_tokens, max_external_tokens))
+
+    global _warned_invalid_prompt_token_stats
+    has_invalid_token_stats = (
+        safe_prompt_len != prompt_len
+        or safe_cached_tokens != num_cached_tokens
+        or safe_external_tokens != num_external_computed_tokens
+    )
+    if has_invalid_token_stats and not _warned_invalid_prompt_token_stats:
+        with _warn_lock:
+            if not _warned_invalid_prompt_token_stats:
+                logger.warning(
+                    "Detected invalid prompt token stats: prompt_len=%d, num_cached_tokens=%d, "
+                    "num_external_computed_tokens=%d; normalized to prompt_len=%d, num_cached_tokens=%d, "
+                    "num_external_computed_tokens=%d",
+                    prompt_len,
+                    num_cached_tokens,
+                    num_external_computed_tokens,
+                    safe_prompt_len,
+                    safe_cached_tokens,
+                    safe_external_tokens,
+                )
+                _warned_invalid_prompt_token_stats = True
+
+    _original_update_from_output(
+        self,
+        safe_cached_tokens,
+        safe_external_tokens,
+        safe_prompt_len,
+    )
+
+
+PromptTokenStats.update_from_output = _patched_update_from_output


### PR DESCRIPTION
## What\n- Add a platform patch for llm.v1.metrics.stats.PromptTokenStats.update_from_output to normalize invalid token-stat inputs.\n- Clamp prompt_len, 
um_cached_tokens, and 
um_external_computed_tokens into valid ranges before stats accumulation.\n- Keep metric source counters non-negative so Prometheus Counter.inc() never receives negative values.\n- Add unit tests covering invalid external-token and cached-token-overflow cases.\n\n## Why\nIssue #6868 reports server crash on GLM5 metrics path:\nValueError: Counters can only be incremented by non-negative amounts.\n\nThe crash is triggered when prompt token breakdown values become inconsistent and produce negative per-source increments. This patch adds a defensive normalization layer in vllm-ascend patching path, preventing runtime crashes while preserving expected metric invariants.\n\n## Validation\n- uff check vllm_ascend/patch/platform/patch_metrics_prompt_token_stats.py tests/ut/patch/platform/test_patch_metrics_prompt_token_stats.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py\n- Unit test file added: 	ests/ut/patch/platform/test_patch_metrics_prompt_token_stats.py\n\n## Note\nTargeted pytest execution is blocked in this environment due to missing runtime dependency (	orch).\n\nCloses #6868
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
