### PR TITLE
[Bugfix] Handle thinking API parameter for GLM models

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm_thinking_mode.py
+++ b/tests/ut/patch/platform/test_patch_glm_thinking_mode.py
@@ -34,7 +34,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Lightweight stubs for vllm types that we cannot import in a plain unit-test
 # context without a full vllm installation.
@@ -50,7 +49,7 @@ class _FakeChatParams:
     chat_template_kwargs: dict[str, Any] = field(default_factory=dict)
     extra_field: str | None = None
 
-    def model_copy(self, update: dict[str, Any] | None = None) -> "_FakeChatParams":
+    def model_copy(self, update: dict[str, Any] | None = None) -> _FakeChatParams:
         """Minimal ``BaseModel.model_copy`` compatible helper for tests."""
         return replace(self, **(update or {}))
 

--- a/tests/ut/patch/platform/test_patch_glm_thinking_mode.py
+++ b/tests/ut/patch/platform/test_patch_glm_thinking_mode.py
@@ -1,0 +1,297 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for :mod:`vllm_ascend.patch.platform.patch_glm_thinking_mode`.
+
+Tests focus on the monkey-patched ``ChatCompletionRequest.build_chat_params``
+method, specifically the mapping:
+
+* ``thinking: {type: "disabled"}`` -> ``enable_thinking: False`` injected into
+  ``chat_template_kwargs``.
+* ``thinking: {type: "enabled"}`` -> ``enable_thinking: True`` injected.
+* No ``thinking`` field -> original ``chat_template_kwargs`` returned unchanged.
+* ``enable_thinking`` already set in ``chat_template_kwargs`` -> not overridden.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass, field, replace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs for vllm types that we cannot import in a plain unit-test
+# context without a full vllm installation.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeChatParams:
+    """Minimal stand-in for ``vllm.renderers.ChatParams``."""
+
+    chat_template: str | None = None
+    chat_template_content_format: str = "auto"
+    chat_template_kwargs: dict[str, Any] = field(default_factory=dict)
+    extra_field: str | None = None
+
+    def model_copy(self, update: dict[str, Any] | None = None) -> "_FakeChatParams":
+        """Minimal ``BaseModel.model_copy`` compatible helper for tests."""
+        return replace(self, **(update or {}))
+
+
+def _merge_kwargs(
+    defaults: dict[str, Any] | None,
+    overrides: dict[str, Any] | None,
+    *,
+    unset_values: tuple[object, ...] = (None, "auto"),
+) -> dict[str, Any]:
+    """Replica of ``vllm.renderers.merge_kwargs`` for offline tests."""
+    if defaults is None:
+        defaults = {}
+    if overrides is None:
+        overrides = {}
+    return defaults | {k: v for k, v in overrides.items() if v not in unset_values}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(
+    thinking: Any | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    chat_template: str | None = None,
+    model_extra: dict[str, Any] | None = None,
+    pydantic_extra: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Create a ``MagicMock`` that mimics ``ChatCompletionRequest``."""
+    request = MagicMock()
+    default_extra = {} if thinking is None else {"thinking": thinking}
+    request.model_extra = default_extra if model_extra is None else model_extra
+    request.__pydantic_extra__ = pydantic_extra
+    request.chat_template = chat_template
+    request.chat_template_kwargs = chat_template_kwargs
+    return request
+
+
+def _make_original_result(
+    chat_template_kwargs: dict[str, Any] | None = None,
+    chat_template: str | None = None,
+    extra_field: str | None = None,
+) -> _FakeChatParams:
+    return _FakeChatParams(
+        chat_template=chat_template,
+        chat_template_content_format="auto",
+        chat_template_kwargs=chat_template_kwargs or {},
+        extra_field=extra_field,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch the heavy-weight vllm module imports *before* importing our patch.
+# ---------------------------------------------------------------------------
+
+_fake_chat_completion_protocol = MagicMock()
+
+# ``ChatCompletionRequest`` will be replaced after we import the patch module.
+_fake_chat_completion_cls = MagicMock()
+_fake_chat_completion_protocol.ChatCompletionRequest = _fake_chat_completion_cls
+
+_fake_renderers = MagicMock()
+_fake_renderers.ChatParams = _FakeChatParams
+_fake_renderers.merge_kwargs = _merge_kwargs
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _patch_vllm_imports():
+    """Inject lightweight stubs so the patch module can be imported."""
+    with patch.dict(
+        sys.modules,
+        {
+            "vllm": MagicMock(),
+            "vllm.renderers": _fake_renderers,
+            "vllm.entrypoints": MagicMock(),
+            "vllm.entrypoints.openai": MagicMock(),
+            "vllm.entrypoints.openai.chat_completion": MagicMock(),
+            "vllm.entrypoints.openai.chat_completion.protocol": _fake_chat_completion_protocol,
+        },
+    ):
+        module_name = "vllm_ascend.patch.platform.patch_glm_thinking_mode"
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        module = importlib.import_module(module_name)
+        yield module
+
+
+# ---------------------------------------------------------------------------
+# Utility: extract the patched function from the module
+# ---------------------------------------------------------------------------
+
+
+def _get_patched_fn():
+    """Return the current patched function from the module."""
+    module_name = "vllm_ascend.patch.platform.patch_glm_thinking_mode"
+    mod = sys.modules[module_name]
+    return mod._patched_build_chat_params
+
+
+def _call_patched(
+    thinking: Any | None = None,
+    existing_kwargs: dict[str, Any] | None = None,
+    chat_template: str | None = None,
+    model_extra: dict[str, Any] | None = None,
+    pydantic_extra: dict[str, Any] | None = None,
+    extra_field: str | None = None,
+):
+    """Exercise the patched function end-to-end with mocked collaborators."""
+    original_result = _make_original_result(
+        chat_template_kwargs=existing_kwargs,
+        chat_template=chat_template,
+        extra_field=extra_field,
+    )
+
+    patched_fn = _get_patched_fn()
+    module = sys.modules["vllm_ascend.patch.platform.patch_glm_thinking_mode"]
+    original_original = module._original_build_chat_params
+    module._original_build_chat_params = MagicMock(return_value=original_result)
+
+    try:
+        request = _make_request(
+            thinking=thinking,
+            chat_template_kwargs=existing_kwargs,
+            chat_template=chat_template,
+            model_extra=model_extra,
+            pydantic_extra=pydantic_extra,
+        )
+        return patched_fn(request, None, "auto")
+    finally:
+        module._original_build_chat_params = original_original
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGlmThinkingModeDisabled:
+    """``thinking: {type: "disabled"}`` -> ``enable_thinking: False``."""
+
+    def test_enable_thinking_false_injected(self):
+        result = _call_patched(thinking={"type": "disabled"})
+        assert isinstance(result, _FakeChatParams)
+        assert result.chat_template_kwargs.get("enable_thinking") is False
+
+    def test_existing_kwargs_preserved(self):
+        result = _call_patched(
+            thinking={"type": "disabled"},
+            existing_kwargs={"foo": "bar"},
+        )
+        assert result.chat_template_kwargs.get("foo") == "bar"
+        assert result.chat_template_kwargs.get("enable_thinking") is False
+
+    def test_enable_thinking_not_overridden_when_already_set(self):
+        """A user-supplied ``enable_thinking`` in ``chat_template_kwargs`` wins."""
+        result = _call_patched(
+            thinking={"type": "disabled"},
+            existing_kwargs={"enable_thinking": True},
+        )
+        assert result.chat_template_kwargs.get("enable_thinking") is True
+
+    def test_falls_back_to_pydantic_extra(self):
+        result = _call_patched(
+            thinking=None,
+            model_extra=None,
+            pydantic_extra={"thinking": {"type": "disabled"}},
+        )
+        assert result.chat_template_kwargs.get("enable_thinking") is False
+
+    def test_preserves_other_chat_params_fields(self):
+        result = _call_patched(
+            thinking={"type": "disabled"},
+            extra_field="keep-me",
+        )
+        assert result.extra_field == "keep-me"
+
+
+class TestGlmThinkingModeEnabled:
+    """``thinking: {type: "enabled"}`` -> ``enable_thinking: True``."""
+
+    def test_enable_thinking_true_injected(self):
+        result = _call_patched(thinking={"type": "enabled"})
+        assert result.chat_template_kwargs.get("enable_thinking") is True
+
+    def test_enable_thinking_not_overridden_when_already_false(self):
+        """``chat_template_kwargs`` takes precedence."""
+        result = _call_patched(
+            thinking={"type": "enabled"},
+            existing_kwargs={"enable_thinking": False},
+        )
+        assert result.chat_template_kwargs.get("enable_thinking") is False
+
+
+class TestGlmThinkingModeAbsent:
+    """When no ``thinking`` field is present, result must be unchanged."""
+
+    def test_no_thinking_field(self):
+        original = _make_original_result(chat_template_kwargs={"a": 1})
+        module = sys.modules["vllm_ascend.patch.platform.patch_glm_thinking_mode"]
+        original_original = module._original_build_chat_params
+        module._original_build_chat_params = MagicMock(return_value=original)
+        patched_fn = _get_patched_fn()
+        try:
+            request = _make_request(thinking=None)
+            result = patched_fn(request, None, "auto")
+        finally:
+            module._original_build_chat_params = original_original
+
+        assert result is original
+
+    def test_thinking_is_not_dict(self):
+        """Non-dict ``thinking`` values are ignored."""
+        original = _make_original_result(chat_template_kwargs={"a": 1})
+        module = sys.modules["vllm_ascend.patch.platform.patch_glm_thinking_mode"]
+        original_original = module._original_build_chat_params
+        module._original_build_chat_params = MagicMock(return_value=original)
+        patched_fn = _get_patched_fn()
+        try:
+            request = _make_request(thinking="disabled")
+            result = patched_fn(request, None, "auto")
+        finally:
+            module._original_build_chat_params = original_original
+
+        assert result is original
+
+
+class TestGlmThinkingModeUnknownType:
+    """Unknown ``thinking.type`` values leave the result unchanged."""
+
+    def test_unknown_type_returns_original(self):
+        original = _make_original_result()
+        module = sys.modules["vllm_ascend.patch.platform.patch_glm_thinking_mode"]
+        original_original = module._original_build_chat_params
+        module._original_build_chat_params = MagicMock(return_value=original)
+        patched_fn = _get_patched_fn()
+        try:
+            request = _make_request(thinking={"type": "auto"})
+            result = patched_fn(request, None, "auto")
+        finally:
+            module._original_build_chat_params = original_original
+
+        assert result is original

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -107,6 +107,27 @@
 #    Future Plan:
 #       remove this patch once upstream no longer requires these global symbols or
 #       provides a backend-safe initialization path.
+# ** 7. File: platform/patch_glm_thinking_mode.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionRequest.build_chat_params`
+#    Why:
+#       When caller sets `"thinking": {"type": "disabled"}` in the Chat Completion API request,
+#       vLLM silently ignores the field because it is an undeclared extra-field on the Pydantic
+#       model.  Without forwarding it to the chat template, GLM-5 (and similar GLM models) still
+#       generate a full `<think>…reasoning…</think>` block.  The `<think>` special token is then
+#       filtered by `skip_special_tokens=True`, while the `</think>` text and all reasoning
+#       content remain visible in the API response `content` field – violating the non-thinking
+#       contract.
+#    How：
+#       Monkey-patch `build_chat_params` to extract the `thinking` extra-field value and inject
+#       the corresponding `enable_thinking` boolean into `chat_template_kwargs`.  A user-supplied
+#       `enable_thinking` in `chat_template_kwargs` always takes precedence.
+#    Related PR (if no, explain why):
+#       This is a GLM-specific mapping between the OpenAI `thinking` parameter and the GLM chat
+#       template's `enable_thinking` kwarg.  Upstream vLLM does not have this mapping.
+#    Future Plan:
+#       Push a generic `thinking` -> `enable_thinking` translation upstream to vLLM so that the
+#       patch can be removed.
 #
 # * Worker Patch:
 # ===============

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,6 +18,7 @@ import os
 
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_fusion_matcher_compat_ops  # noqa
+import vllm_ascend.patch.platform.patch_glm_thinking_mode  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 

--- a/vllm_ascend/patch/platform/patch_glm_thinking_mode.py
+++ b/vllm_ascend/patch/platform/patch_glm_thinking_mode.py
@@ -47,8 +47,7 @@ always respected and takes precedence over the ``thinking`` field.
 from dataclasses import is_dataclass, replace
 from typing import Any
 
-from vllm.entrypoints.openai.chat_completion.protocol import \
-    ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.renderers import ChatParams, merge_kwargs
 
 _original_build_chat_params = ChatCompletionRequest.build_chat_params

--- a/vllm_ascend/patch/platform/patch_glm_thinking_mode.py
+++ b/vllm_ascend/patch/platform/patch_glm_thinking_mode.py
@@ -76,9 +76,7 @@ def _patched_build_chat_params(
     ``chat_template_kwargs`` so that GLM-family models honour the requested
     thinking mode when rendering their chat template.
     """
-    original_result: ChatParams = _original_build_chat_params(
-        self, default_template, default_template_content_format
-    )
+    original_result: ChatParams = _original_build_chat_params(self, default_template, default_template_content_format)
 
     # ``thinking`` is an extra (non-declared) field on the Pydantic model.
     # With ``model_config = ConfigDict(extra="allow")`` Pydantic v2 may store

--- a/vllm_ascend/patch/platform/patch_glm_thinking_mode.py
+++ b/vllm_ascend/patch/platform/patch_glm_thinking_mode.py
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Patch for handling the ``thinking`` API parameter for GLM models.
+
+When a GLM-series model (GLM-4.5, GLM-5, etc.) is deployed, users can
+control the thinking mode through the ``thinking`` field in the
+Chat Completion API request::
+
+    "thinking": {"type": "disabled"}   # non-thinking mode
+    "thinking": {"type": "enabled"}    # thinking mode (default)
+
+Without this patch the ``thinking`` field is silently ignored because
+``ChatCompletionRequest.build_chat_params`` only processes known Pydantic
+fields. As a result:
+
+1. GLM5 still generates a full ``<think>reasoning</think>answer`` block.
+2. The ``<think>`` start token is filtered out by
+   ``skip_special_tokens=True``.
+3. The ``</think>`` token and reasoning content remain visible in
+   ``content``, violating the user's intent.
+
+This patch maps:
+
+* ``thinking: {type: "disabled"}`` -> ``enable_thinking: False`` in
+  ``chat_template_kwargs`` so that the GLM chat template generates no
+  ``<think>`` block.
+* ``thinking: {type: "enabled"}`` -> ``enable_thinking: True`` in
+  ``chat_template_kwargs`` (explicit opt-in).
+
+A user-supplied ``enable_thinking`` inside ``chat_template_kwargs`` is
+always respected and takes precedence over the ``thinking`` field.
+"""
+
+from dataclasses import is_dataclass, replace
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.protocol import \
+    ChatCompletionRequest
+from vllm.renderers import ChatParams, merge_kwargs
+
+_original_build_chat_params = ChatCompletionRequest.build_chat_params
+
+
+def _get_request_extra(request: "ChatCompletionRequest") -> dict[str, Any]:
+    """Merge extra request fields from the available Pydantic accessors."""
+    merged_extra: dict[str, Any] = {}
+    pydantic_extra = getattr(request, "__pydantic_extra__", None)
+    model_extra = getattr(request, "model_extra", None)
+    if isinstance(pydantic_extra, dict):
+        merged_extra.update(pydantic_extra)
+    if isinstance(model_extra, dict):
+        merged_extra.update(model_extra)
+    return merged_extra
+
+
+def _patched_build_chat_params(
+    self: "ChatCompletionRequest",
+    default_template: "str | None",
+    default_template_content_format: Any,
+) -> "ChatParams":
+    """Patched :meth:`ChatCompletionRequest.build_chat_params`.
+
+    Maps the ``thinking`` API extra-field to ``enable_thinking`` inside
+    ``chat_template_kwargs`` so that GLM-family models honour the requested
+    thinking mode when rendering their chat template.
+    """
+    original_result: ChatParams = _original_build_chat_params(
+        self, default_template, default_template_content_format
+    )
+
+    # ``thinking`` is an extra (non-declared) field on the Pydantic model.
+    # With ``model_config = ConfigDict(extra="allow")`` Pydantic v2 may store
+    # extra fields in ``model_extra`` or ``__pydantic_extra__`` depending on
+    # how the request object was constructed.
+    request_extra = _get_request_extra(self)
+    thinking = request_extra.get("thinking")
+
+    if not isinstance(thinking, dict):
+        # ``thinking`` was not provided or is not a recognised format.
+        return original_result
+
+    thinking_type = thinking.get("type")
+    if thinking_type == "disabled":
+        enable_thinking = False
+    elif thinking_type == "enabled":
+        enable_thinking = True
+    else:
+        # Unknown thinking type; leave the original result unchanged.
+        return original_result
+
+    # Respect an explicitly set ``enable_thinking`` from ``chat_template_kwargs``
+    # (user always wins).
+    existing_kwargs: dict[str, Any] = original_result.chat_template_kwargs or {}
+    if "enable_thinking" in existing_kwargs:
+        return original_result
+
+    updated_kwargs = merge_kwargs(
+        existing_kwargs,
+        {"enable_thinking": enable_thinking},
+    )
+
+    model_copy = getattr(original_result, "model_copy", None)
+    if callable(model_copy):
+        return model_copy(update={"chat_template_kwargs": updated_kwargs})
+
+    if is_dataclass(original_result):
+        return replace(original_result, chat_template_kwargs=updated_kwargs)
+
+    return ChatParams(
+        chat_template=original_result.chat_template,
+        chat_template_content_format=original_result.chat_template_content_format,
+        chat_template_kwargs=updated_kwargs,
+    )
+
+
+# Apply the monkey-patch.
+ChatCompletionRequest.build_chat_params = _patched_build_chat_params  # type: ignore[method-assign]


### PR DESCRIPTION
## What this PR does / why we need it?

Fixes #6772.

When a user sends `thinking: {type: disabled}` (or `enabled`) in the Chat Completion API request targeting a GLM-series model (GLM-4.5, GLM-5, etc.), the parameter was silently ignored.

**Root cause:**

1. `ChatCompletionRequest` has no declared `thinking` field; pydantic's `extra='allow'` stores unknown fields in `model_extra` with a warning.
2. `ChatCompletionRequest.build_chat_params()` only processes declared fields, so `enable_thinking` was never forwarded to the GLM chat template.
3. The GLM chat template defaults to thinking mode, so it always generated `<think>[reasoning]</think>answer`.
4. `skip_special_tokens=True` filtered the `<think>` start token (it is a special token) but **not** `</think>` (a normal text token with id 154827), so the closing tag and full reasoning leaked into `content` while `reasoning_content` remained `null`.

**Fix:**

Monkey-patch `ChatCompletionRequest.build_chat_params` in a new platform patch (`vllm_ascend/patch/platform/patch_glm_thinking_mode.py`) to:

| Request field | Injected into `chat_template_kwargs` |
|---|---|
| `thinking: {type: disabled}` | `enable_thinking: False` |
| `thinking: {type: enabled}` | `enable_thinking: True` |
| anything else | no change |

A user-supplied `enable_thinking` already present in `chat_template_kwargs` always takes precedence and is never overridden.

## Does this PR introduce any user-facing change?

Yes. After this fix:
- `thinking: {type: disabled}` suppresses the `<think>...</think>` block; the response `content` contains only the final answer.
- `thinking: {type: enabled}` (default) behaves as before – the model reasons and the client receives `reasoning_content` + `content`.

## How was this patch tested?

Unit tests added in `tests/ut/patch/platform/test_patch_glm_thinking_mode.py`:

- `test_thinking_disabled_injects_enable_thinking_false`
- `test_thinking_enabled_injects_enable_thinking_true`
- `test_existing_kwargs_preserved`
- `test_enable_thinking_not_overridden_when_already_set`
- `test_enable_thinking_not_overridden_when_already_false`
- `test_no_thinking_field`
- `test_thinking_is_not_dict`
- `test_unknown_type_returns_original`

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
