### PR TITLE
[Bugfix] Fix PP>=3 KV cache init KeyError when using Ray executor (Issue #6678)

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -108,6 +108,27 @@
 #       remove this patch once upstream no longer requires these global symbols or
 #       provides a backend-safe initialization path.
 #
+# ** 7. File: platform/patch_worker_base.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.worker.worker_base.WorkerWrapperBase.adjust_rank`
+#    Why:
+#       When using Ray executor with pipeline parallelism (PP >= 3), the upstream
+#       `WorkerWrapperBase.adjust_rank()` method updates `rpc_rank` but leaves
+#       `global_rank` stale. During `initialize_from_config`, each worker selects
+#       `kv_cache_configs[self.global_rank]` to get its per-worker KV cache config.
+#       With stale `global_rank`, workers in non-first PP stages pick the wrong
+#       config (e.g., a PP rank 2 worker gets the PP rank 0 config containing
+#       layers 0-22), causing a KeyError when the layer names in the config are
+#       looked up in the worker's `static_forward_context`.
+#    How：
+#       Monkey-patch `adjust_rank` to also update `self.global_rank` whenever
+#       `self.rpc_rank` is updated.
+#    Related PR (if no, explain why):
+#       Upstream issue: https://github.com/vllm-project/vllm/issues/30128
+#       Upstream PR: https://github.com/vllm-project/vllm/pull/33700
+#    Future Plan:
+#       Remove this patch when vLLM merges PR #33700.
+#
 # * Worker Patch:
 # ===============
 #

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -20,6 +20,7 @@ import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_fusion_matcher_compat_ops  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
+import vllm_ascend.patch.platform.patch_worker_base  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_worker_base.py
+++ b/vllm_ascend/patch/platform/patch_worker_base.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This patch fixes an upstream vLLM bug where `WorkerWrapperBase.adjust_rank()`
+# updates `rpc_rank` but not `global_rank`, causing workers to select the wrong
+# `kv_cache_config` during initialization when using Ray executor with
+# pipeline parallelism (PP >= 3).
+#
+# Upstream issue: https://github.com/vllm-project/vllm/issues/30128
+# Upstream PR: https://github.com/vllm-project/vllm/pull/33700
+
+from vllm.v1.worker.worker_base import WorkerWrapperBase
+
+
+def _patched_adjust_rank(self, rank_mapping: dict[int, int]) -> None:
+    """
+    Adjust both rpc_rank and global_rank based on the given mapping.
+
+    This fixes a bug in the upstream vLLM where only rpc_rank was updated
+    but global_rank was left stale. When the Ray executor remaps worker
+    ranks during pipeline parallel initialization, global_rank must also
+    be updated so that `initialize_from_config` can correctly select the
+    per-worker KVCacheConfig from the global list using self.global_rank.
+
+    Without this fix, workers receive the wrong PP stage's kv_cache_config,
+    causing a KeyError in get_layers_from_vllm_config because the layer
+    names in the config don't exist in the worker's static_forward_context.
+    """
+    if self.rpc_rank in rank_mapping:
+        self.global_rank = self.rpc_rank = rank_mapping[self.rpc_rank]
+
+
+WorkerWrapperBase.adjust_rank = _patched_adjust_rank


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #6678

When using `--distributed-executor-backend ray` with `--pipeline-parallel-size >= 3`, the engine fails to initialize with:

\\\
KeyError: 'model.layers.0.self_attn.attn'
\\\

**Root Cause:**

The upstream \WorkerWrapperBase.adjust_rank()\ in \llm/v1/worker/worker_base.py\ updates \pc_rank\ but leaves \global_rank\ stale.

When the Ray executor remaps worker ranks during pipeline parallel initialization via \^Gdjust_rank(rank_mapping)\, only \pc_rank\ is updated. However, \initialize_from_config()\ uses \kv_cache_configs[self.global_rank]\ to select the per-worker KV cache config from the global list.

With stale \global_rank\, workers in non-first PP stages pick the wrong config. For example, a PP rank 2 worker (which should handle layers 46-68) incorrectly gets the PP rank 0 config (containing layers 0-22), causing the \KeyError\ when those layer names cannot be found in the worker's \static_forward_context\.

This is confirmed as upstream vLLM bug https://github.com/vllm-project/vllm/issues/30128, with fix in PR https://github.com/vllm-project/vllm/pull/33700.

**Fix:**

Monkey-patch \WorkerWrapperBase.adjust_rank\ to also update \self.global_rank\:

\\\python
# Before (upstream bug):
def adjust_rank(self, rank_mapping):
    if self.rpc_rank in rank_mapping:
        self.rpc_rank = rank_mapping[self.rpc_rank]

# After (patched):
def adjust_rank(self, rank_mapping):
    if self.rpc_rank in rank_mapping:
        self.global_rank = self.rpc_rank = rank_mapping[self.rpc_rank]
\\\

## Does this PR introduce any user-facing change?

No, this is a bug fix that makes Ray executor with PP >= 3 work correctly. No API or behavior changes.

## How was this patch tested?

- This patch directly addresses the error seen in issue #6678 (PP=4 with 4 nodes x 8 NPUs using Ray executor)
- The root cause is confirmed by upstream vLLM issue #30128 with independent verification by multiple users
- The fix is identical to upstream PR #33700
- CI testing will verify correctness.
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
