### PR TITLE
[Refactor] Replace npu_ring_mla with FIA in mla_cp prefill

### DIFF
--- a/tests/e2e/multicard/4-cards/long_sequence/test_accuracy.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_accuracy.py
@@ -22,7 +22,7 @@ Run `pytest tests/e2e/multicard/long_sequence/test_accuracy.py`.
 
 import pytest
 
-from tests.e2e.conftest import VllmRunner
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.model_utils import check_outputs_equal
 
 MODELS = [
@@ -212,36 +212,53 @@ def test_accuracy_pcp_only(max_tokens: int, ) -> None:
     )
 
 
+@wait_until_npu_memory_free(target_free_percentage=0.6)
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [10])
 def test_models_long_sequence_cp_kv_interleave_size_output_between_tp_and_cp(
     model: str,
     max_tokens: int,
 ) -> None:
-    prompts = [
-        "The president of the United States is", "The capital of France is"
-    ]
+    prompts = ["The president of the United States is"]
 
+    GOLDEN_TEXT_DS = 'The president of the United States is a man who has been elected to the highest office'
+    GOLDEN_TOKENS_DS = [100000, 549, 6847, 280, 254, 4794, 5110, 317, 245, 668, 779, 643, 803, 19136, 276, 254, 7492, 4995]
+
+    GOLDEN_TEXT_QWEN = 'The president of the United States is the head of state and head of government of the'
+    GOLDEN_TOKENS_QWEN = [785, 4767, 315, 279, 3639, 4180, 374, 279, 1968, 315, 1584, 323, 1968, 315, 3033, 315, 279]
+
+    GOLDEN_DS = [(GOLDEN_TOKENS_DS,GOLDEN_TEXT_DS)]
+    GOLDEN_QWEN = [(GOLDEN_TOKENS_QWEN,GOLDEN_TEXT_QWEN)]
+    
     common_kwargs = {
         "max_model_len": 1024,
     }
 
     if model == "vllm-ascend/DeepSeek-V2-Lite-W8A8":
         cp_kwargs = {
-            "tensor_parallel_size": 2,
-            "decode_context_parallel_size": 2,
+            "tensor_parallel_size": 1,
+            "decode_context_parallel_size": 1,
             "prefill_context_parallel_size": 2,
             "enable_expert_parallel": True,
             "cp_kv_cache_interleave_size": 128,
             "enforce_eager": True,
             "quantization": "ascend",
         }
-        tp_kwargs = {
-            "tensor_parallel_size": 4,
-            "enable_expert_parallel": True,
-            "enforce_eager": True,
-            "quantization": "ascend",
-        }
+
+        cp_full_kwargs = {}
+        cp_full_kwargs.update(common_kwargs)  # type: ignore
+        cp_full_kwargs.update(cp_kwargs)  # type: ignore
+
+        with VllmRunner(model, **cp_full_kwargs) as runner:  # type: ignore
+            vllm_context_parallel_outputs = runner.generate_greedy(
+                prompts, max_tokens)
+
+        check_outputs_equal(
+            outputs_0_lst=GOLDEN_DS,
+            outputs_1_lst=vllm_context_parallel_outputs,
+            name_0="GOLDEN_DS",
+            name_1="vllm_context_parallel_outputs",
+        )
 
     else:
         cp_kwargs = {
@@ -249,33 +266,20 @@ def test_models_long_sequence_cp_kv_interleave_size_output_between_tp_and_cp(
             "decode_context_parallel_size": 1,
             "prefill_context_parallel_size": 2,
             "cp_kv_cache_interleave_size": 128,
-            "compilation_config": {
-                "cudagraph_mode": "FULL_DECODE_ONLY",
-                "cudagraph_capture_sizes": [4, 8, 24, 48, 60]
-            },
-        }
-        tp_kwargs = {
-            "tensor_parallel_size": 2,
             "enforce_eager": True,
         }
 
-    cp_full_kwargs = {}
-    cp_full_kwargs.update(common_kwargs)  # type: ignore
-    cp_full_kwargs.update(cp_kwargs)  # type: ignore
+        cp_full_kwargs = {}
+        cp_full_kwargs.update(common_kwargs)  # type: ignore
+        cp_full_kwargs.update(cp_kwargs)  # type: ignore
 
-    tp_full_kwargs = {}
-    tp_full_kwargs.update(common_kwargs)  # type: ignore
-    tp_full_kwargs.update(tp_kwargs)  # type: ignore
-    with VllmRunner(model, **cp_full_kwargs) as runner:  # type: ignore
-        vllm_context_parallel_outputs = runner.generate_greedy(
-            prompts, max_tokens)
+        with VllmRunner(model, **cp_full_kwargs) as runner:  # type: ignore
+            vllm_context_parallel_outputs = runner.generate_greedy(
+                prompts, max_tokens)
 
-    with VllmRunner(model, **tp_full_kwargs) as runner:  # type: ignore
-        vllm_eager_outputs = runner.generate_greedy(prompts, max_tokens)
-
-    check_outputs_equal(
-        outputs_0_lst=vllm_eager_outputs,
-        outputs_1_lst=vllm_context_parallel_outputs,
-        name_0="vllm_eager_outputs",
-        name_1="vllm_context_parallel_outputs",
+        check_outputs_equal(
+            outputs_0_lst=GOLDEN_QWEN,
+            outputs_1_lst=vllm_context_parallel_outputs,
+            name_0="GOLDEN_QWEN",
+            name_1="vllm_context_parallel_outputs",
     )

--- a/tests/ut/attention/test_attention_cp.py
+++ b/tests/ut/attention/test_attention_cp.py
@@ -426,9 +426,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.assertEqual(attn_lse.shape, (96, 8, 1))
 
     @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch(
-        'vllm_ascend.attention.context_parallel.attention_cp.AscendAttentionCPImpl._update_out_and_lse'
-    )
+    @patch('vllm_ascend.attention.context_parallel.attention_cp._update_out_and_lse')
     def test_attention_with_nomask_and_mask_chunk(
             self, mock_update_out_and_lse,
             mock_npu_fused_infer_attention_score):
@@ -474,9 +472,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.assertIsNotNone(attn_lse)
 
     @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    @patch(
-        'vllm_ascend.attention.context_parallel.attention_cp.AscendAttentionCPImpl._npu_attn_out_lse_update'
-    )
+    @patch('vllm_ascend.attention.context_parallel.attention_cp._npu_attn_out_lse_update')
     def test_attention_with_nomask_and_mask_nochunk(
             self, mock_npu_attn_out_lse_update,
             mock_npu_fused_infer_attention_score):
@@ -522,9 +518,7 @@ class TestUpdateNpuAttnOutLse(TestBase):
         self.assertIsNotNone(output)
         self.assertEqual(attn_lse, None)
 
-    @patch(
-        'vllm_ascend.attention.context_parallel.attention_cp.AscendAttentionCPImpl._npu_attn_out_lse_update'
-    )
+    @patch('vllm_ascend.attention.context_parallel.attention_cp._npu_attn_out_lse_update')
     def test_update_chunk_attn_out_lse_with_current_attn_out_lse(
             self, mock_npu_attn_out_lse_update):
         # Mock input data

--- a/tests/ut/attention/test_attention_cp.py
+++ b/tests/ut/attention/test_attention_cp.py
@@ -9,7 +9,9 @@ from vllm_ascend.attention.attention_v1 import AscendMetadata
 from vllm_ascend.attention.context_parallel.attention_cp import \
     AscendAttentionCPImpl
 from vllm_ascend.attention.context_parallel.common_cp import (
-    AscendMetadataForPrefill, AscendPCPMetadata)
+    AscendMetadataForPrefill, AscendPCPMetadata,_npu_attention_update,
+    _npu_attn_out_lse_update,_out_lse_reshape,
+    _process_attn_out_lse,_update_out_and_lse)
 
 
 class TestAscendAttentionCPImpl(TestBase):
@@ -546,57 +548,14 @@ class TestUpdateNpuAttnOutLse(TestBase):
             attn_output_full_chunk, attn_lse_full_chunk, prefill_query,
             attn_metadata)
         # Assert the method call
-        self.impl._npu_attn_out_lse_update.assert_called_once()
+        mock_npu_attn_out_lse_update.assert_called_once()
         # test pcp_size = 1
         self.impl.pcp_size = 1
         self.impl._update_chunk_attn_out_lse_with_current_attn_out_lse(
             current_attn_output_prefill, current_attn_lse_prefill,
             attn_output_full_chunk, attn_lse_full_chunk, prefill_query,
             attn_metadata)
-        self.assertEqual(self.impl._npu_attn_out_lse_update.call_count, 2)
-
-    @patch('torch_npu.npu_attention_update')
-    def test_npu_attn_out_lse_update(self, mock_npu_attention_update):
-        # Mock input data
-        attn_lse_mask = torch.randn(8, 128, 1)
-        attn_lse_nomask = torch.randn(8, 128, 1)
-        attn_out_mask = torch.randn(8, 128, 128)
-        attn_out_nomask = torch.randn(8, 128, 128)
-
-        # Mock output
-        mock_npu_attention_update.return_value = (torch.randn(8 * 128,
-                                                              128), None)
-
-        # Call the method under test
-        output = self.impl._npu_attn_out_lse_update(attn_lse_mask,
-                                                    attn_lse_nomask,
-                                                    attn_out_mask,
-                                                    attn_out_nomask)
-
-        # Assert the method call
-        self.assertIsInstance(output, torch.Tensor)
-        self.assertEqual(output.shape, (8, 128, 128))
-
-        mock_npu_attention_update.assert_called_once()
-
-    def test_update_out_and_lse(self):
-        # Mock input data
-        out_list = torch.randn(3, 2, 4,
-                               8)  # [N, batch_size, num_heads, head_size]
-        lse_list = torch.randn(3, 2, 4, 1)  # [N, batch_size, num_heads, 1]
-
-        # Call the method under test
-        out_final, lse_final = self.impl._update_out_and_lse(
-            out_list, lse_list)
-
-        # Assert the method call
-        self.assertEqual(out_final.shape,
-                         (2, 4, 8))  # [batch_size, num_heads, head_size]
-        self.assertEqual(lse_final.shape,
-                         (2, 4, 1))  # [batch_size, num_heads, 1]
-
-        self.assertIsInstance(out_final, torch.Tensor)
-        self.assertIsInstance(lse_final, torch.Tensor)
+        self.assertEqual(mock_npu_attn_out_lse_update.call_count, 2)
 
     @patch_distributed_groups(dcp_size=2, pcp_size=3)
     def test_update_chunk_attn_out_lse_dcp2_pcp3(self, mock_all_to_all_single,

--- a/tests/ut/attention/test_common_cp.py
+++ b/tests/ut/attention/test_common_cp.py
@@ -1,0 +1,150 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import torch
+
+from vllm_ascend.attention.context_parallel.common_cp import (
+    _npu_attention_update,
+    _npu_attn_out_lse_update,
+    _update_out_and_lse,
+    _out_lse_reshape
+)
+
+class TestCommonCP(unittest.TestCase):
+
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size')
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_dcp_group')
+    @patch('torch.distributed.all_to_all_single')
+    def test_process_attn_out_lse_complex(self, 
+                                        mock_all2all, 
+                                        mock_get_dcp_group, 
+                                        mock_get_dcp_size, 
+                                        mock_get_pcp_group):
+        from vllm_ascend.attention.context_parallel.common_cp import _process_attn_out_lse
+
+        pcp_size = 2
+        dcp_size = 2
+        mock_get_pcp_group.return_value.world_size = pcp_size
+        mock_get_dcp_size.return_value = dcp_size
+        
+        mock_group = MagicMock()
+        mock_get_dcp_group.return_value.device_group = mock_group
+
+        bs, num_heads, head_dim = 4, 8, 64
+        attn_output = torch.randn(bs, num_heads, head_dim, dtype=torch.float16)
+        softmax_lse = torch.randn(bs, num_heads, 1, dtype=torch.float16)
+
+        def fake_all_gather(tensor, dim=0):
+            return torch.cat([tensor, tensor], dim=dim)
+        mock_get_pcp_group.return_value.all_gather = fake_all_gather
+
+        output = _process_attn_out_lse(attn_output, softmax_lse)
+
+        self.assertEqual(output.dtype, torch.float32)
+
+        # [4, 8, 64] + [4, 8, 1] -> [4, 8, 65] (Cat)
+        # DCP All2All -> [4, 8, 65]
+        # PCP AllGather (dim=0, size=2) -> [8, 8, 65]
+        expected_shape = (bs * pcp_size, num_heads, head_dim + 1)
+        self.assertEqual(output.shape, expected_shape)
+
+        mock_all2all.assert_called_once()
+        called_args = mock_all2all.call_args
+        self.assertEqual(called_args.kwargs['group'], mock_group)
+
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size')
+    def test_process_attn_out_lse_simple(self, mock_get_dcp_size, mock_get_pcp_group):
+        from vllm_ascend.attention.context_parallel.common_cp import _process_attn_out_lse
+        
+        mock_get_pcp_group.return_value.world_size = 1
+        mock_get_dcp_size.return_value = 1
+        
+        attn_output = torch.randn(2, 4, 16)
+        softmax_lse = torch.randn(2, 4, 1)
+        
+        output = _process_attn_out_lse(attn_output, softmax_lse)
+        
+        # concat: [2, 4, 16+1]
+        self.assertEqual(output.shape, (2, 4, 17))
+
+    @patch('torch_npu.npu_attention_update')
+    def test_npu_attn_out_lse_update(self, mock_npu_attention_update):
+        # Mock input data
+        attn_lse_mask = torch.randn(8, 128, 1)
+        attn_lse_nomask = torch.randn(8, 128, 1)
+        attn_out_mask = torch.randn(8, 128, 128)
+        attn_out_nomask = torch.randn(8, 128, 128)
+
+        mock_npu_attention_update.return_value = (
+            torch.randn(8 * 128, 128), 
+            None
+        )
+
+        # Call the method under test
+        output = _npu_attn_out_lse_update(
+            attn_lse_mask,
+            attn_lse_nomask,
+            attn_out_mask,
+            attn_out_nomask
+        )
+
+        # Assertions
+        self.assertIsInstance(output, torch.Tensor)
+        self.assertEqual(output.shape, (8, 128, 128))
+        mock_npu_attention_update.assert_called_once()
+
+    def test_update_out_and_lse(self):
+        # Mock input data: [N, batch, heads, head_size/1]
+        out_list = torch.randn(3, 2, 4, 8)
+        lse_list = torch.randn(3, 2, 4, 1)
+
+        # Call the method under test
+        out_final, lse_final = _update_out_and_lse(out_list, lse_list)
+
+        # Assert shapes
+        self.assertEqual(out_final.shape, (2, 4, 8))
+        self.assertEqual(lse_final.shape, (2, 4, 1))
+        self.assertIsInstance(out_final, torch.Tensor)
+        self.assertIsInstance(lse_final, torch.Tensor)
+
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_pcp_group')
+    @patch('vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size')
+    @patch('torch_npu.npu_attention_update')
+    def test_npu_attention_update(self, mock_npu_update, mock_get_dcp, mock_get_pcp):
+        pcp_size = 2
+        dcp_size = 2
+        mock_get_pcp.return_value.world_size = pcp_size
+        mock_get_dcp.return_value = dcp_size
+        
+        head_size = 64
+        S, H = 4, 8 # Sequence and Heads per segment
+        
+        attn_out_lse = torch.randn(pcp_size * S, dcp_size * H, head_size + 1)
+        
+        # mock NPU op return (N=PCP*DCP=4, S*H=32) -> [4*32, 64]
+        mock_npu_update.return_value = (torch.randn(pcp_size * dcp_size * S * H, head_size), None)
+        
+        # test
+        result = _npu_attention_update(head_size, attn_out_lse)
+        
+        self.assertEqual(result.shape, (pcp_size * dcp_size * S, H, head_size))
+        mock_npu_update.assert_called_once()
+
+    def test_out_lse_reshape(self):
+        # Mock input data
+        out_list = torch.randn(3, 2, 4,
+                               8)  # [N, batch_size, num_heads, head_size]
+        lse_list = torch.randn(3, 2, 4, 1)  # [N, batch_size, num_heads, 1]
+
+        # Call the method under test
+        out_final, lse_final = _update_out_and_lse(out_list, lse_list)
+
+        # Assert the method call
+        self.assertEqual(out_final.shape,
+                         (2, 4, 8))  # [batch_size, num_heads, head_size]
+        self.assertEqual(lse_final.shape,
+                         (2, 4, 1))  # [batch_size, num_heads, 1]
+
+        self.assertIsInstance(out_final, torch.Tensor)
+        self.assertIsInstance(lse_final, torch.Tensor)

--- a/tests/ut/attention/test_mla_cp.py
+++ b/tests/ut/attention/test_mla_cp.py
@@ -792,7 +792,7 @@ class TestAscendMLAImpl(TestBase):
             self.impl.pcp_size = 1
             assert out.shape == (NUM_TOKENS, num_heads, self.impl.kv_lora_rank)
 
-    @patch('torch_npu.atb.npu_ring_mla')
+    @patch('torch.ops.npu.npu_fused_infer_attention_score')
     def test_attention_with_mask_and_nomask_with_dcp_pcp(
             self, mock_npu_ring_mla):
         num_heads = self.impl.num_heads
@@ -909,7 +909,7 @@ class TestAscendMLAImpl(TestBase):
             self.impl.dcp_size = 1
             self.impl.pcp_size = 1
 
-    @patch('torch_npu.atb.npu_ring_mla')
+    @patch('torch.ops.npu.npu_fused_infer_attention_score')
     def test_forward_prefill_cp_with_dcp_pcp(self, mock_npu_ring_mla):
 
         def mock_attention_with_nomask_and_mask(
@@ -917,7 +917,8 @@ class TestAscendMLAImpl(TestBase):
                 k_pe: torch.Tensor, value: torch.Tensor,
                 kv_mask_idx: torch.Tensor, kv_nomask_idx: torch.Tensor,
                 attn_mask_seqlens: torch.Tensor,
-                attn_nomask_seqlens: torch.Tensor, mask: torch.Tensor):
+                attn_nomask_seqlens: torch.Tensor, mask: torch.Tensor,
+                attn_metadata):
             mock_output = torch.randn(q_nope.shape[0],
                                       self.impl.num_heads,
                                       self.impl.v_head_dim,

--- a/tests/ut/attention/test_mla_cp.py
+++ b/tests/ut/attention/test_mla_cp.py
@@ -782,7 +782,6 @@ class TestAscendMLAImpl(TestBase):
 
             mock_dcp.world_size = self.impl.dcp_size
             mock_dcp_group = MagicMock()
-            # mock_dcp_group.world_size = self.impl.dcp_size
             mock_get_dcp_group.return_value = mock_dcp_group
             attn_out_lse = torch.randn(self.impl.pcp_size * NUM_TOKENS,
                                        self.impl.dcp_size * num_heads,
@@ -791,61 +790,51 @@ class TestAscendMLAImpl(TestBase):
             self.impl.dcp_size = 1
             self.impl.pcp_size = 1
             assert out.shape == (NUM_TOKENS, num_heads, self.impl.kv_lora_rank)
-
+    
     @patch('torch.ops.npu.npu_fused_infer_attention_score')
+    @patch('vllm_ascend.attention.context_parallel.mla_cp._npu_attn_out_lse_update')
     def test_attention_with_mask_and_nomask_with_dcp_pcp(
-            self, mock_npu_ring_mla):
+            self, mock_npu_attn_update, mock_npu_fia):
         num_heads = self.impl.num_heads
         v_head_dim = self.impl.v_head_dim
         qk_nope_head_dim = self.impl.qk_nope_head_dim
         qk_rope_head_dim = self.impl.qk_rope_head_dim
 
-        def mock_npu_ring_mla_effect(q_nope, q_rope, k_nope, k_rope, value,
-                                     mask, seqlen, head_num, kv_head_num,
-                                     pre_out, prev_lse, qk_scale, kernel_type,
-                                     mask_type, input_layout, calc_type,
-                                     output, softmax_lse):
+        def mock_npu_fia_effect(*args, **kwargs):
+            q_nope = args[0]
+            q_tokens = q_nope.shape[0]
+            out = torch.randn(q_tokens, num_heads, v_head_dim, dtype=torch.float16)
+            lse = torch.randn(q_tokens, num_heads, 1, dtype=torch.float32)
+            return out, lse
+        mock_npu_fia.side_effect = mock_npu_fia_effect
 
-            return torch.randn(q_nope.shape[0], value.shape[1],
-                               value.shape[-1])
-
-        mock_npu_ring_mla.side_effect = mock_npu_ring_mla_effect
-        test_cases = [([8], 2, 2), ([8], 2, 1), ([8], 1, 2), ([8], 2, 2),
-                      ([8, 12], 2, 2)]
+        def mock_update_effect(lse_mask, lse_nomask, out_mask, out_nomask):
+            return torch.randn_like(out_mask)
+        mock_npu_attn_update.side_effect = mock_update_effect
+        
+        test_cases = [([8], 2, 2), ([8, 12], 2, 2)] 
         for test_case in test_cases:
             scheduled_tokens, pcp_size, dcp_size = test_case
-            nums_tokens_per_rank = []
-            for num_tokens in scheduled_tokens:
-                assert num_tokens % (2 * pcp_size) == 0
-                nums_tokens_per_rank.append(num_tokens // pcp_size)
-            seq_len_q, seq_len_k = sum(nums_tokens_per_rank), sum(
-                scheduled_tokens)
-            q_nope = torch.randn(seq_len_q,
-                                 num_heads,
-                                 qk_nope_head_dim,
-                                 dtype=torch.float16)
-            q_pe = torch.randn(seq_len_q,
-                               num_heads,
-                               qk_rope_head_dim,
-                               dtype=torch.float16)
-            k_nope = torch.randn(seq_len_k,
-                                 num_heads,
-                                 qk_nope_head_dim,
-                                 dtype=torch.float16)
-            k_pe = torch.randn(seq_len_k,
-                               num_heads,
-                               qk_rope_head_dim,
-                               dtype=torch.float16)
-            value = torch.randn(seq_len_k,
-                                num_heads,
-                                v_head_dim,
-                                dtype=torch.float16)
+            nums_tokens_per_rank = [num // pcp_size for num in scheduled_tokens]
+            seq_len_q, seq_len_k = sum(nums_tokens_per_rank), sum(scheduled_tokens)
+            
+            q_nope = torch.randn(seq_len_q, num_heads, qk_nope_head_dim, dtype=torch.float16)
+            q_pe = torch.randn(seq_len_q, num_heads, qk_rope_head_dim, dtype=torch.float16)
+            k_nope = torch.randn(seq_len_k, num_heads, qk_nope_head_dim, dtype=torch.float16)
+            k_pe = torch.randn(seq_len_k, num_heads, qk_rope_head_dim, dtype=torch.float16)
+            value = torch.randn(seq_len_k, num_heads, v_head_dim, dtype=torch.float16)
             mask = torch.triu(torch.ones(10, 10, dtype=torch.float16), 1)
+
+            attn_metadata = MagicMock()
+            attn_metadata.prefill = MagicMock()
+            attn_metadata.prefill.chunked_context = None
+
             for rank in range(pcp_size):
-                q_head_idx, q_tail_idx, kv_with_q_head_nomask_idx, kv_with_q_head_mask_idx, kv_with_q_tail_nomask_idx, \
-                    kv_with_q_tail_mask_idx, chunk_seqlens, kv_with_q_head_nomask_seqlens, kv_with_q_tail_nomask_seqlens = get_pcp_split_info(
-                    rank, pcp_size, nums_tokens_per_rank)
-                kv_with_q_head_nomask_idx = [kv_with_q_head_nomask_idx]
+                info = get_pcp_split_info(rank, pcp_size, nums_tokens_per_rank)
+                q_head_idx, _, kv_with_q_head_nomask_idx, kv_with_q_head_mask_idx = info[:4]
+                chunk_seqlens = info[6]
+                kv_with_q_head_nomask_seqlens = info[7]
+
                 output_head, lse_head = self.impl._attention_with_mask_and_nomask(
                     q_nope=torch.index_select(q_nope, 0, q_head_idx),
                     q_pe=torch.index_select(q_pe, 0, q_head_idx),
@@ -854,172 +843,90 @@ class TestAscendMLAImpl(TestBase):
                     value=value,
                     kv_mask_idx=kv_with_q_head_mask_idx,
                     kv_nomask_idx=kv_with_q_head_nomask_idx,
-                    attn_mask_seqlens=torch.tensor(
-                        [chunk_seqlens, chunk_seqlens], dtype=torch.int32),
-                    attn_nomask_seqlens=[kv_with_q_head_nomask_seqlens],
-                    mask=mask)
-                self.assertEqual(output_head.shape,
-                                 (q_head_idx.shape[0], num_heads, v_head_dim))
-                self.assertEqual(lse_head.shape,
-                                 (num_heads, q_head_idx.shape[0]))
-                self.assertEqual(mock_npu_ring_mla.call_count,
-                                 1 + (len(kv_with_q_head_nomask_idx[0]) != 0))
-                mock_npu_ring_mla.reset_mock()
-                kv_with_q_tail_nomask_idx = [kv_with_q_tail_nomask_idx]
-                output_tail, lse_tail = self.impl._attention_with_mask_and_nomask(
-                    q_nope=torch.index_select(q_nope, 0, q_tail_idx),
-                    q_pe=torch.index_select(q_pe, 0, q_tail_idx),
+                    attn_mask_seqlens=torch.tensor([chunk_seqlens, chunk_seqlens], dtype=torch.int32),
+                    attn_nomask_seqlens=torch.tensor([kv_with_q_head_nomask_seqlens], dtype=torch.int32),
+                    mask=mask,
+                    attn_metadata=attn_metadata
+                )
+
+                self.assertEqual(output_head.shape, (q_head_idx.shape[0], num_heads, v_head_dim))
+                if lse_head is not None:
+                    self.assertEqual(lse_head.shape, (q_head_idx.shape[0], num_heads, 1))
+                else:
+                    self.assertIsNone(lse_head)
+
+                mock_npu_fia.reset_mock()
+                mock_npu_attn_update.reset_mock()
+    
+    @patch('torch.ops.npu.npu_fused_infer_attention_score')
+    @patch('vllm_ascend.attention.context_parallel.mla_cp._npu_attn_out_lse_update')
+    @patch('vllm_ascend.attention.context_parallel.mla_cp._update_out_and_lse')
+    def test_attention_with_mask_and_nomask_trigger_chunked(
+            self, mock_update_out_lse, mock_npu_attn_update, mock_npu_fia):
+        
+        num_heads = self.impl.num_heads
+        v_head_dim = self.impl.v_head_dim
+        qk_nope_head_dim = self.impl.qk_nope_head_dim
+        qk_rope_head_dim = self.impl.qk_rope_head_dim
+
+        def mock_npu_fia_effect(*args, **kwargs):
+            q_tokens = args[0].shape[0]
+            out = torch.randn(q_tokens, num_heads, v_head_dim, dtype=torch.float16)
+            lse = torch.randn(q_tokens, num_heads, 1, dtype=torch.float32)
+            return out, lse
+        mock_npu_fia.side_effect = mock_npu_fia_effect
+
+        def mock_chunked_update_effect(outs, lses):
+            return outs[0], lses[0] 
+        mock_update_out_lse.side_effect = mock_chunked_update_effect
+
+        test_cases = [([8], 2, 2)] 
+        for test_case in test_cases:
+            scheduled_tokens, pcp_size, dcp_size = test_case
+            nums_tokens_per_rank = [num // pcp_size for num in scheduled_tokens]
+            
+            q_nope = torch.randn(sum(nums_tokens_per_rank), num_heads, qk_nope_head_dim, dtype=torch.float16)
+            q_pe = torch.randn(sum(nums_tokens_per_rank), num_heads, qk_rope_head_dim, dtype=torch.float16)
+            k_nope = torch.randn(sum(scheduled_tokens), num_heads, qk_nope_head_dim, dtype=torch.float16)
+            k_pe = torch.randn(sum(scheduled_tokens), num_heads, qk_rope_head_dim, dtype=torch.float16)
+            value = torch.randn(sum(scheduled_tokens), num_heads, v_head_dim, dtype=torch.float16)
+            mask = torch.ones(10, 10, dtype=torch.float16)
+
+            attn_metadata = MagicMock()
+            attn_metadata.prefill = MagicMock()
+            attn_metadata.prefill.chunked_context = "TRIGGER_CHUNKED"
+            update_called_at_least_once = False
+
+            for rank in range(pcp_size):
+                info = get_pcp_split_info(rank, pcp_size, nums_tokens_per_rank)
+                q_head_idx, _, kv_with_q_head_nomask_idx, kv_with_q_head_mask_idx = info[:4]
+                chunk_seqlens = info[6]
+                kv_with_q_head_nomask_seqlens = info[7]
+
+                output_head, lse_head = self.impl._attention_with_mask_and_nomask(
+                    q_nope=torch.index_select(q_nope, 0, q_head_idx),
+                    q_pe=torch.index_select(q_pe, 0, q_head_idx),
                     k_nope=k_nope,
                     k_pe=k_pe,
                     value=value,
-                    kv_mask_idx=kv_with_q_tail_mask_idx,
-                    kv_nomask_idx=kv_with_q_tail_nomask_idx,
-                    attn_mask_seqlens=torch.tensor(
-                        [chunk_seqlens, chunk_seqlens], dtype=torch.int32),
-                    attn_nomask_seqlens=[kv_with_q_tail_nomask_seqlens],
-                    mask=mask)
+                    kv_mask_idx=kv_with_q_head_mask_idx,
+                    kv_nomask_idx=kv_with_q_head_nomask_idx,
+                    attn_mask_seqlens=torch.tensor([chunk_seqlens, chunk_seqlens], dtype=torch.int32),
+                    attn_nomask_seqlens=torch.tensor([kv_with_q_head_nomask_seqlens], dtype=torch.int32),
+                    mask=mask,
+                    attn_metadata=attn_metadata
+                )
 
-                self.assertEqual(output_tail.shape,
-                                 (q_tail_idx.shape[0], num_heads, v_head_dim))
-                self.assertEqual(lse_tail.shape,
-                                 (num_heads, q_tail_idx.shape[0]))
-                self.assertEqual(mock_npu_ring_mla.call_count,
-                                 1 + (len(kv_with_q_tail_nomask_idx[0]) != 0))
-                mock_npu_ring_mla.reset_mock()
+                if kv_with_q_head_nomask_idx is not None and kv_with_q_head_nomask_idx.numel() > 0:
+                    self.assertTrue(mock_update_out_lse.called, f"Rank {rank} should have called update")
+                    update_called_at_least_once = True
+                    self.assertIsNotNone(lse_head)
+                else:
+                    self.assertIsNotNone(lse_head)
 
-    @patch_distributed_groups(dcp_size=2, pcp_size=2)
-    def test_process_attn_out_lse_with_dcp_pcp(self, mock_all_to_all, mock_dcp,
-                                               mock_pcp):
-        B, H, D = 4, self.impl.num_heads, self.impl.v_head_dim  # total: [4, 4, 8]
-        test_cases = [(1, 1), (1, 2), (2, 1), (2, 2), (4, 4)]
-        for test_case in test_cases:
-            self.impl.dcp_size = test_case[0]
-            self.impl.pcp_size = test_case[1]
-            mock_dcp.world_size = test_case[0]
-            mock_pcp.world_size = test_case[1]
-            # Inputs
-            attn_output = torch.randn(B, H, D)
-            softmax_lse = torch.randn(B, H, 1)
-            decode_meta = MagicMock()
+                self.assertEqual(output_head.shape, (q_head_idx.shape[0], num_heads, v_head_dim))
 
-            result = _process_attn_out_lse(attn_output, softmax_lse)
-            # [PCP * S, DCP * H, D + 1]
-            self.assertIsInstance(result, torch.Tensor)
-            assert result.shape == (B * self.impl.pcp_size, H, D + 1)
-            self.impl.dcp_size = 1
-            self.impl.pcp_size = 1
-
-    @patch('torch.ops.npu.npu_fused_infer_attention_score')
-    def test_forward_prefill_cp_with_dcp_pcp(self, mock_npu_ring_mla):
-
-        def mock_attention_with_nomask_and_mask(
-                q_nope: torch.Tensor, q_pe: torch.Tensor, k_nope: torch.Tensor,
-                k_pe: torch.Tensor, value: torch.Tensor,
-                kv_mask_idx: torch.Tensor, kv_nomask_idx: torch.Tensor,
-                attn_mask_seqlens: torch.Tensor,
-                attn_nomask_seqlens: torch.Tensor, mask: torch.Tensor,
-                attn_metadata):
-            mock_output = torch.randn(q_nope.shape[0],
-                                      self.impl.num_heads,
-                                      self.impl.v_head_dim,
-                                      dtype=k_pe.dtype,
-                                      device=k_pe.device)
-            mock_lse = torch.randn(self.impl.num_heads,
-                                   q_pe.shape[0],
-                                   dtype=torch.float32,
-                                   device=k_pe.device)
-            return mock_output, mock_lse
-
-        def mock_compute_prefill_context(q_nope, q_pe, kv_c_and_k_pe_cache,
-                                         rope_dim, attn_metadata,
-                                         prefix_output, prefix_lse):
-            mock_output = torch.randn_like(prefix_output)
-            mock_lse = torch.randn_like(prefix_lse)
-            return mock_output, mock_lse
-
-        def mock_npu_ring_mla_effect(q_nope, q_rope, k_nope, k_rope, value,
-                                     mask, seqlen, head_num, kv_head_num,
-                                     pre_out, prev_lse, qk_scale, kernel_type,
-                                     mask_type, input_layout, calc_type,
-                                     output, softmax_lse):
-            return torch.randn(q_nope.shape[0], value.shape[1],
-                               value.shape[-1])
-
-        self.impl._attention_with_mask_and_nomask = MagicMock()
-        self.impl._attention_with_mask_and_nomask.side_effect = mock_attention_with_nomask_and_mask
-        self.impl._compute_prefill_context = MagicMock()
-        self.impl._compute_prefill_context.side_effect = mock_compute_prefill_context
-        mock_npu_ring_mla.side_effect = mock_npu_ring_mla_effect
-        block_num = 10
-        block_size = 32
-        kv_c_and_k_pe_cache = (torch.randn(block_num,
-                                           block_size,
-                                           1,
-                                           self.impl.q_lora_rank,
-                                           dtype=torch.float16),
-                               torch.randn(block_num,
-                                           block_size,
-                                           1,
-                                           self.impl.qk_rope_head_dim,
-                                           dtype=torch.float16))
-        test_cases = [([8], 2, 2), ([8], 2, 1), ([8], 1, 2), ([8], 2, 2),
-                      ([8, 16], 2, 2)]
-        for test_case in test_cases:
-            scheduled_tokens, pcp_size, dcp_size = test_case
-            nums_tokens_per_rank = []
-            for num_tokens in scheduled_tokens:
-                assert num_tokens % (
-                    2 * pcp_size) == 0  # padded head&tail compute balance
-                nums_tokens_per_rank.append(num_tokens // pcp_size)
-            seq_len_q, seq_len_k = sum(nums_tokens_per_rank), sum(
-                scheduled_tokens)
-
-            q_nope = torch.randn(seq_len_q,
-                                 self.impl.num_heads,
-                                 self.impl.qk_nope_head_dim,
-                                 dtype=torch.float16)
-            q_pe = torch.randn(seq_len_q,
-                               self.impl.num_heads,
-                               self.impl.qk_rope_head_dim,
-                               dtype=torch.float16)
-            k_nope = torch.randn(seq_len_k,
-                                 self.impl.num_heads,
-                                 self.impl.qk_nope_head_dim,
-                                 dtype=torch.float16)
-            k_pe = torch.randn(seq_len_k,
-                               self.impl.num_heads,
-                               self.impl.qk_rope_head_dim,
-                               dtype=torch.float16)
-            value = torch.randn(seq_len_k,
-                                self.impl.num_heads,
-                                self.impl.v_head_dim,
-                                dtype=torch.float16)
-            # only test one rank
-            for rank in range(pcp_size):
-                q_head_idx, q_tail_idx, kv_with_q_head_nomask_idx, kv_with_q_head_mask_idx, kv_with_q_tail_nomask_idx, \
-                    kv_with_q_tail_mask_idx, chunk_seqlens, kv_with_q_head_nomask_seqlens, kv_with_q_tail_nomask_seqlens = get_pcp_split_info(
-                    rank, pcp_size, nums_tokens_per_rank)
-                attn_metadata = MagicMock()
-                attn_metadata.prefill = MagicMock()
-                attn_metadata.prefill.pcp_metadata.q_head_idx = q_head_idx
-                attn_metadata.prefill.pcp_metadata.q_tail_idx = q_tail_idx
-                attn_metadata.prefill.pcp_metadata.q_full_idx = torch.cat([
-                    attn_metadata.prefill.pcp_metadata.q_head_idx,
-                    attn_metadata.prefill.pcp_metadata.q_tail_idx
-                ])
-                attn_metadata.prefill.pcp_metadata.kv_with_q_head_nomask_idx = kv_with_q_head_nomask_idx
-
-                attn_metadata.prefill.pcp_metadata.kv_with_q_head_mask_idx = kv_with_q_head_mask_idx
-                attn_metadata.prefill.pcp_metadata.kv_with_q_tail_nomask_idx = kv_with_q_tail_nomask_idx
-                attn_metadata.prefill.pcp_metadata.kv_with_q_tail_mask_idx = kv_with_q_tail_mask_idx
-                attn_metadata.prefill.pcp_metadata.attn_mask_seqlens = torch.tensor(
-                    [chunk_seqlens, chunk_seqlens], dtype=torch.int32)
-                attn_metadata.prefill.pcp_metadata.head_attn_nomask_seqlens = kv_with_q_head_nomask_seqlens
-                attn_metadata.prefill.pcp_metadata.tail_attn_nomask_seqlens = kv_with_q_tail_nomask_seqlens
-
-                output = self.impl._forward_prefill(q_nope, q_pe, k_nope, k_pe,
-                                                    value, kv_c_and_k_pe_cache,
-                                                    attn_metadata)
-                self.assertEqual(
-                    output.shape,
-                    (seq_len_q, self.impl.num_heads * self.impl.v_head_dim))
+                mock_npu_fia.reset_mock()
+                mock_update_out_lse.reset_mock()
+            
+            self.assertTrue(update_called_at_least_once, "Test case data did not trigger nomask branch at all!")

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -138,13 +138,14 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
         assert num_computed_tokens_of_pcp_dcp is not None
         chunked_context_metadata = None
         attn_mask_seqlens = common_long_seq_metadata.attn_mask_seqlens
+        attn_chunk_seqlens = common_long_seq_metadata.attn_chunk_seqlens
         if num_prefills > 0:
             query_lens = query_lens[num_decodes:]
             context_lens_cpu = num_computed_tokens_cpu[num_decodes:num_reqs]
             max_context_len_cpu = context_lens_cpu.max().item()
             if self.chunked_prefill_enabled and max_context_len_cpu > 0:
                 if self.pcp_size > 1 and common_long_seq_metadata.pcp_use_hybrid_attn:
-                    query_lens = attn_mask_seqlens[0] * 2
+                    query_lens = attn_chunk_seqlens * 2
                 local_context_lens_allranks = (
                     torch.tensor(num_computed_tokens_of_pcp_dcp)[self.num_decodes_flatten :]
                     .to(self.device)

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -41,7 +41,9 @@ from vllm_ascend.attention.context_parallel.common_cp import (
     AscendMetadataForPrefill,
     AscendPCPMetadata,
     _npu_attention_update,
+    _npu_attn_out_lse_update,
     _process_attn_out_lse,
+    _update_out_and_lse,
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -184,10 +186,6 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
                 )
             head_attn_nomask_seqlens = common_long_seq_metadata.head_attn_nomask_seqlens
             tail_attn_nomask_seqlens = common_long_seq_metadata.tail_attn_nomask_seqlens
-            if self.pcp_size > 1:
-                attn_mask_seqlens = torch.cumsum(attn_mask_seqlens[0], dim=0).tolist()
-                head_attn_nomask_seqlens = torch.cumsum(head_attn_nomask_seqlens[1], dim=0).tolist()
-                tail_attn_nomask_seqlens = torch.cumsum(tail_attn_nomask_seqlens[1], dim=0).tolist()
 
             pcp_metadata = AscendPCPMetadata(
                 q_head_idx=common_long_seq_metadata.q_head_idx_tensor,
@@ -414,32 +412,15 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         attn_lse = attn_lse_mask
         if k_nomask is not None:
             if attn_metadata.prefill is not None and attn_metadata.prefill.chunked_context is None:
-                output = self._npu_attn_out_lse_update(attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask)
+                output = _npu_attn_out_lse_update(attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask)
                 attn_lse = None
             else:
-                output, attn_lse = self._update_out_and_lse(
+                output, attn_lse = _update_out_and_lse(
                     torch.stack([attn_out_nomask, attn_out_mask], dim=0),
                     torch.stack([attn_lse_nomask, attn_lse_mask], dim=0),
                 )
 
         return output, attn_lse
-
-    def _npu_attn_out_lse_update(self, attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask):
-        T = attn_out_mask.shape[0]
-        N = attn_out_mask.shape[1]
-        D = attn_out_mask.shape[2]
-        attn_out_mask, attn_lse_mask = self._out_lse_reshape(attn_out_mask, attn_lse_mask)
-        attn_out_nomask, attn_lse_nomask = self._out_lse_reshape(attn_out_nomask, attn_lse_nomask)
-        attn_out_mask = attn_out_mask.to(torch.float32)
-        attn_out_nomask = attn_out_nomask.to(torch.float32)
-        attn_lse_mask = attn_lse_mask.to(torch.float32)
-        attn_lse_nomask = attn_lse_nomask.to(torch.float32)
-        attn_output = [attn_out_nomask, attn_out_mask]
-        attn_lse = [attn_lse_nomask, attn_lse_mask]
-        update_type = 0
-        output, _ = torch_npu.npu_attention_update(attn_lse, attn_output, update_type)
-        output = output.view(T, N, D)
-        return output
 
     def _forward_prefill_cp(
         self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, attn_metadata: AscendMetadata
@@ -522,11 +503,6 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
             attn_lse = torch.index_select(torch.cat(lses, dim=0), 0, q_full_idx)
         return output, attn_lse
 
-    def _out_lse_reshape(self, attn_out: torch.Tensor, attn_lse: torch.Tensor) -> torch.Tensor:
-        attn_out = attn_out.contiguous().view(attn_out.shape[0] * attn_out.shape[1], attn_out.shape[2])
-        attn_lse = attn_lse.contiguous().view(attn_lse.shape[0] * attn_lse.shape[1] * attn_lse.shape[2])
-        return attn_out, attn_lse
-
     def _forward_decode_pcp_dcp(self, query: torch.Tensor, attn_metadata: AscendMetadata) -> torch.Tensor:
         assert self.key_cache is not None
         assert self.value_cache is not None
@@ -605,19 +581,6 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         attn_out = _npu_attention_update(self.head_size, attn_out_lse)
         return attn_out
 
-    def _update_out_and_lse(self, out_list: torch.Tensor, lse_list: torch.Tensor) -> torch.Tensor:
-        """LSE_final = log(sum(exp(LSE_i))), O_final = sum(exp(LSE_i - LSE_final) * O_i)
-        Args:
-            out_list: shape = [N, batch_size, num_heads, head_size]
-            lse_list: shape = [N, batch_size, num_heads, 1]
-        Returns:
-            out_final: shape = [batch_size, num_heads, head_size]
-            lse_final: shape = [batch_size, num_heads, 1]
-        """
-        lse_final = torch.logsumexp(lse_list, dim=0, keepdim=False)
-        out_final = torch.sum(torch.exp(lse_list - lse_final) * out_list, dim=0)
-        return out_final, lse_final
-
     def _update_chunk_attn_out_lse_with_current_attn_out_lse(
         self,
         current_attn_output_prefill,
@@ -648,7 +611,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         attn_output_full_chunk = attn_output_full_chunk[filtered_indices, :, :]
         attn_lse_full_chunk = attn_lse_full_chunk[filtered_indices, :, :]
 
-        attn_output_filtered = self._npu_attn_out_lse_update(
+        attn_output_filtered = _npu_attn_out_lse_update(
             attn_lse_prefill_filtered, attn_lse_full_chunk, attn_output_prefill_filtered, attn_output_full_chunk
         )
 
@@ -885,7 +848,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         x = x.view(-1, S, H, D_plus_1)
         # Split out lse
         attn_out_allgather, attn_lse_allgather = torch.split(x, [D, 1], dim=-1)  # [N, S, H, D], [N, S, H, 1]
-        context_output, context_lse = self._update_out_and_lse(attn_out_allgather, attn_lse_allgather)
+        context_output, context_lse = _update_out_and_lse(attn_out_allgather, attn_lse_allgather)
         return context_output, context_lse
 
     def forward_impl(

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -148,3 +148,41 @@ def _npu_attention_update(head_size, attn_out_lse: torch.Tensor) -> torch.Tensor
     attn_out, _ = torch_npu.npu_attention_update(lse_list, out_list, 0)
     attn_out = attn_out.view(-1, H, D)
     return attn_out
+
+
+def _npu_attn_out_lse_update(attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask):
+    T = attn_out_mask.shape[0]
+    N = attn_out_mask.shape[1]
+    D = attn_out_mask.shape[2]
+    attn_out_mask, attn_lse_mask = _out_lse_reshape(attn_out_mask, attn_lse_mask)
+    attn_out_nomask, attn_lse_nomask = _out_lse_reshape(attn_out_nomask, attn_lse_nomask)
+    attn_out_mask = attn_out_mask.to(torch.float32)
+    attn_out_nomask = attn_out_nomask.to(torch.float32)
+    attn_lse_mask = attn_lse_mask.to(torch.float32)
+    attn_lse_nomask = attn_lse_nomask.to(torch.float32)
+    attn_output = [attn_out_nomask, attn_out_mask]
+    attn_lse = [attn_lse_nomask, attn_lse_mask]
+    update_type = 0
+    output, _ = torch_npu.npu_attention_update(attn_lse, attn_output, update_type)
+    output = output.view(T, N, D)
+    return output
+
+
+def _out_lse_reshape(attn_out: torch.Tensor, attn_lse: torch.Tensor) -> torch.Tensor:
+    attn_out = attn_out.contiguous().view(attn_out.shape[0] * attn_out.shape[1], attn_out.shape[2])
+    attn_lse = attn_lse.contiguous().view(attn_lse.shape[0] * attn_lse.shape[1] * attn_lse.shape[2])
+    return attn_out, attn_lse
+
+
+def _update_out_and_lse(out_list: torch.Tensor, lse_list: torch.Tensor) -> torch.Tensor:
+    """LSE_final = log(sum(exp(LSE_i))), O_final = sum(exp(LSE_i - LSE_final) * O_i)
+    Args:
+        out_list: shape = [N, batch_size, num_heads, head_size]
+        lse_list: shape = [N, batch_size, num_heads, 1]
+    Returns:
+        out_final: shape = [batch_size, num_heads, head_size]
+        lse_final: shape = [batch_size, num_heads, 1]
+    """
+    lse_final = torch.logsumexp(lse_list, dim=0, keepdim=False)
+    out_final = torch.sum(torch.exp(lse_list - lse_final) * out_list, dim=0)
+    return out_final, lse_final

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -35,7 +35,9 @@ from vllm_ascend.attention.context_parallel.common_cp import (
     AscendPCPMetadata,
     CPChunkedContextMetadata,
     _npu_attention_update,
+    _npu_attn_out_lse_update,
     _process_attn_out_lse,
+    _update_out_and_lse,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, update_graph_params_workspaces
@@ -278,10 +280,6 @@ class AscendMlaCPImpl(AscendMLAImpl):
             **kwargs,
         )
 
-        # npu_ring_mla needs bfloat16 512x512 mask, different from FIA's int8 2048x2048 mask
-        # TODO: Remove this when mla_cp.py also migrates to FIA
-        self._ring_mla_mask_builder = AttentionMaskBuilder(torch.device("npu"))
-
         self.pcp_size = get_pcp_group().world_size
         self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
         self.pcp_group = get_pcp_group().device_group if self.pcp_size > 1 else None
@@ -480,6 +478,7 @@ class AscendMlaCPImpl(AscendMLAImpl):
         assert attn_metadata.prefill is not None
         assert attn_metadata.prefill.pcp_metadata is not None
         num_tokens = q_nope.size(0)
+        prefill_meta = attn_metadata.prefill
         # Use precomputed indices from the metadata (already converted to tensors and on device)
         q_head_idx = attn_metadata.prefill.pcp_metadata.q_head_idx
         q_tail_idx = attn_metadata.prefill.pcp_metadata.q_tail_idx
@@ -490,9 +489,16 @@ class AscendMlaCPImpl(AscendMLAImpl):
         attn_mask_seqlens = attn_metadata.prefill.pcp_metadata.attn_mask_seqlens
         head_attn_nomask_seqlens = attn_metadata.prefill.pcp_metadata.head_attn_nomask_seqlens
         tail_attn_nomask_seqlens = attn_metadata.prefill.pcp_metadata.tail_attn_nomask_seqlens
-        # Use ring_mla-specific mask (bfloat16, 512x512)
-        # TODO: Remove this when mla_cp.py migrates to FIA
-        ring_mla_mask = self._ring_mla_mask_builder.get_mla_mask(self.vllm_config.model_config.dtype)
+
+        # FIA with TND layout only supports bfloat16, convert if needed
+        original_dtype = q_nope.dtype
+        need_dtype_convert = original_dtype != torch.bfloat16
+        if need_dtype_convert:
+            q_nope = q_nope.to(torch.bfloat16)
+            q_pe = q_pe.to(torch.bfloat16)
+            k_nope = k_nope.to(torch.bfloat16)
+            k_pe = k_pe.to(torch.bfloat16)
+            value = value.to(torch.bfloat16)
 
         output_head, lse_head = self._attention_with_mask_and_nomask(
             q_nope=torch.index_select(q_nope, 0, q_head_idx),
@@ -504,7 +510,8 @@ class AscendMlaCPImpl(AscendMLAImpl):
             kv_nomask_idx=kv_with_q_head_nomask_idx,
             attn_mask_seqlens=attn_mask_seqlens,
             attn_nomask_seqlens=head_attn_nomask_seqlens,
-            mask=ring_mla_mask,
+            mask=prefill_meta.attn_mask,
+            attn_metadata=attn_metadata,
         )
 
         output_tail, lse_tail = self._attention_with_mask_and_nomask(
@@ -517,18 +524,25 @@ class AscendMlaCPImpl(AscendMLAImpl):
             kv_nomask_idx=kv_with_q_tail_nomask_idx,
             attn_mask_seqlens=attn_mask_seqlens,
             attn_nomask_seqlens=tail_attn_nomask_seqlens,
-            mask=ring_mla_mask,
+            mask=prefill_meta.attn_mask,
+            attn_metadata=attn_metadata,
         )
 
         q_full_idx = attn_metadata.prefill.pcp_metadata.q_full_idx
         attn_output = torch.index_select(torch.cat([output_head, output_tail], dim=0), 0, q_full_idx)
-        attn_lse = torch.index_select(torch.cat([lse_head, lse_tail], dim=1), 1, q_full_idx)
+        attn_lse = None
+        if attn_metadata.prefill is not None and attn_metadata.prefill.chunked_context is not None:
+            attn_lse = torch.index_select(torch.cat([lse_head, lse_tail], dim=0), 0, q_full_idx)
 
         output, _ = self._compute_prefill_context(
             q_nope, q_pe, kv_c_and_k_pe_cache, self.qk_rope_head_dim, attn_metadata, attn_output, attn_lse
         )
 
         output = output.reshape([num_tokens, self.num_heads * self.v_head_dim])
+
+        # Convert back to original dtype if needed
+        if need_dtype_convert:
+            output = output.to(original_dtype)
 
         return output
 
@@ -540,69 +554,76 @@ class AscendMlaCPImpl(AscendMLAImpl):
         k_pe: torch.Tensor,
         value: torch.Tensor,
         kv_mask_idx: torch.Tensor,
-        kv_nomask_idx: list[torch.Tensor],
+        kv_nomask_idx: torch.Tensor,
         attn_mask_seqlens: torch.Tensor,
-        attn_nomask_seqlens: list[torch.Tensor],
+        attn_nomask_seqlens: torch.Tensor,
         mask: torch.Tensor,
+        attn_metadata,
     ):
-        attn_output = torch.empty(
-            q_nope.shape[0], self.num_heads, self.v_head_dim, dtype=k_pe.dtype, device=k_pe.device
-        )
-        attn_lse = torch.empty(self.num_heads, q_pe.shape[0], dtype=torch.float32, device=k_pe.device)
-        # mask
+        # nomask Attention
+        if kv_nomask_idx is not None and kv_nomask_idx.numel() > 0:
+            k_nope_nomask = torch.index_select(k_nope, 0, kv_nomask_idx)
+            value_nomask = torch.index_select(value, 0, kv_nomask_idx)
+            k_pe_nomask = torch.index_select(k_pe, 0, kv_nomask_idx)
+
+            attn_out_nomask, attn_lse_nomask = torch.ops.npu.npu_fused_infer_attention_score(
+                q_nope,
+                k_nope_nomask,
+                value_nomask,
+                query_rope=q_pe,
+                key_rope=k_pe_nomask,
+                num_heads=self.num_heads,
+                num_key_value_heads=self.num_heads,
+                input_layout="TND",
+                atten_mask=None,
+                scale=self.scale,
+                sparse_mode=0,
+                antiquant_mode=0,
+                antiquant_scale=None,
+                softmax_lse_flag=True,
+                actual_seq_lengths_kv=attn_nomask_seqlens,
+                actual_seq_lengths=attn_mask_seqlens,
+            )
+
+        # mask Attention
         k_nope_mask = torch.index_select(k_nope, 0, kv_mask_idx)
         value_mask = torch.index_select(value, 0, kv_mask_idx)
         k_pe_mask = torch.index_select(k_pe, 0, kv_mask_idx)
-        torch_npu.atb.npu_ring_mla(
-            q_nope=q_nope,
-            q_rope=q_pe,
-            k_nope=k_nope_mask,
-            k_rope=k_pe_mask,
-            value=value_mask,
-            mask=mask,
-            seqlen=attn_mask_seqlens,
-            head_num=self.num_heads,
-            kv_head_num=self.num_heads,
-            pre_out=None,
-            prev_lse=None,
-            qk_scale=self.scale,
-            kernel_type="kernel_type_high_precision",
-            mask_type="mask_type_triu",
-            input_layout="type_bsnd",
-            calc_type="calc_type_first_ring",
-            output=attn_output,
-            softmax_lse=attn_lse,
+
+        attn_out_mask, attn_lse_mask = torch.ops.npu.npu_fused_infer_attention_score(
+            q_nope,
+            k_nope_mask,
+            value_mask,
+            query_rope=q_pe,
+            key_rope=k_pe_mask,
+            num_heads=self.num_heads,
+            num_key_value_heads=self.num_heads,
+            input_layout="TND",
+            atten_mask=mask,
+            scale=self.scale,
+            sparse_mode=3,
+            antiquant_mode=0,
+            antiquant_scale=None,
+            softmax_lse_flag=True,
+            actual_seq_lengths_kv=attn_mask_seqlens,
+            actual_seq_lengths=attn_mask_seqlens,
         )
 
-        # nomask
-        if not kv_nomask_idx or len(kv_nomask_idx[0]) == 0:
-            return attn_output, attn_lse
+        # update
+        output = attn_out_mask
+        attn_lse = attn_lse_mask
 
-        for kv_nomask_idx_split, attn_nomask_seqlens_split in zip(kv_nomask_idx, attn_nomask_seqlens):
-            k_nope_nomask = torch.index_select(k_nope, 0, kv_nomask_idx_split)
-            value_nomask = torch.index_select(value, 0, kv_nomask_idx_split)
-            k_pe_nomask = torch.index_select(k_pe, 0, kv_nomask_idx_split)
-            torch_npu.atb.npu_ring_mla(
-                q_nope=q_nope,
-                q_rope=q_pe,
-                k_nope=k_nope_nomask,
-                k_rope=k_pe_nomask,
-                value=value_nomask,
-                mask=mask,
-                seqlen=attn_nomask_seqlens_split,
-                head_num=self.num_heads,
-                kv_head_num=self.num_heads,
-                pre_out=attn_output,
-                prev_lse=attn_lse,
-                qk_scale=self.scale,
-                kernel_type="kernel_type_high_precision",
-                mask_type="no_mask",
-                input_layout="type_bsnd",
-                calc_type="calc_type_default",
-                output=attn_output,
-                softmax_lse=attn_lse,
-            )
-        return attn_output, attn_lse
+        if kv_nomask_idx is not None and kv_nomask_idx.numel() > 0:
+            if attn_metadata.prefill is not None and attn_metadata.prefill.chunked_context is None:
+                output = _npu_attn_out_lse_update(attn_lse_mask, attn_lse_nomask, attn_out_mask, attn_out_nomask)
+                attn_lse = None
+            else:
+                output, attn_lse = _update_out_and_lse(
+                    torch.stack([attn_out_nomask, attn_out_mask], dim=0),
+                    torch.stack([attn_lse_nomask, attn_lse_mask], dim=0),
+                )
+
+        return output, attn_lse
 
     def _forward_decode(
         self,

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -30,7 +30,6 @@ from vllm_ascend.attention.mla_v1 import (
 # isort: on
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.context_parallel.common_cp import (
     AscendPCPMetadata,
     CPChunkedContextMetadata,

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -490,16 +490,6 @@ class AscendMlaCPImpl(AscendMLAImpl):
         head_attn_nomask_seqlens = attn_metadata.prefill.pcp_metadata.head_attn_nomask_seqlens
         tail_attn_nomask_seqlens = attn_metadata.prefill.pcp_metadata.tail_attn_nomask_seqlens
 
-        # FIA with TND layout only supports bfloat16, convert if needed
-        original_dtype = q_nope.dtype
-        need_dtype_convert = original_dtype != torch.bfloat16
-        if need_dtype_convert:
-            q_nope = q_nope.to(torch.bfloat16)
-            q_pe = q_pe.to(torch.bfloat16)
-            k_nope = k_nope.to(torch.bfloat16)
-            k_pe = k_pe.to(torch.bfloat16)
-            value = value.to(torch.bfloat16)
-
         output_head, lse_head = self._attention_with_mask_and_nomask(
             q_nope=torch.index_select(q_nope, 0, q_head_idx),
             q_pe=torch.index_select(q_pe, 0, q_head_idx),
@@ -540,10 +530,6 @@ class AscendMlaCPImpl(AscendMLAImpl):
 
         output = output.reshape([num_tokens, self.num_heads * self.v_head_dim])
 
-        # Convert back to original dtype if needed
-        if need_dtype_convert:
-            output = output.to(original_dtype)
-
         return output
 
     def _attention_with_mask_and_nomask(
@@ -555,8 +541,8 @@ class AscendMlaCPImpl(AscendMLAImpl):
         value: torch.Tensor,
         kv_mask_idx: torch.Tensor,
         kv_nomask_idx: torch.Tensor,
-        attn_mask_seqlens: torch.Tensor,
-        attn_nomask_seqlens: torch.Tensor,
+        attn_mask_seqlens: list[int],
+        attn_nomask_seqlens: list[int],
         mask: torch.Tensor,
         attn_metadata,
     ):

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -126,6 +126,12 @@ class AscendPrefillContextParallelMetadata:
     # the number of scheduled tokens on the current rank before padding
     total_num_scheduled_tokens: int = 0
 
+    # Because the sequence shard in linear attention layers does not include padding, 
+    # the full attention layers cannot obtain the correct query_lens with pcp pad for 
+    # chunked prefill calculation. Therefore, this value needs to be passed to the backend. 
+    # TODO:To be refactored.
+    attn_chunk_seqlens: torch.Tensor = None
+
 
 @dataclass
 class AscendCommonAttentionMetadata(CommonAttentionMetadata):

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -126,9 +126,9 @@ class AscendPrefillContextParallelMetadata:
     # the number of scheduled tokens on the current rank before padding
     total_num_scheduled_tokens: int = 0
 
-    # Because the sequence shard in linear attention layers does not include padding, 
-    # the full attention layers cannot obtain the correct query_lens with pcp pad for 
-    # chunked prefill calculation. Therefore, this value needs to be passed to the backend. 
+    # Because the sequence shard in linear attention layers does not include padding,
+    # the full attention layers cannot obtain the correct query_lens with pcp pad for
+    # chunked prefill calculation. Therefore, this value needs to be passed to the backend.
     # TODO:To be refactored.
     attn_chunk_seqlens: torch.Tensor = None
 

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -905,25 +905,13 @@ class PCPManager:
                     tensor_npu = self._list_to_tensor(value, self.device)
                     self.kv_idx_names[key] = tensor_npu
 
-                attn_mask_seqlens = torch.tensor([chunk_seqlens, chunk_seqlens], dtype=torch.int32)
-                head_attn_nomask_seqlens = torch.tensor(
-                    [chunk_seqlens, kv_with_q_head_nomask_seqlens], dtype=torch.int32
-                )
-                tail_attn_nomask_seqlens = torch.tensor(
-                    [chunk_seqlens, kv_with_q_tail_nomask_seqlens], dtype=torch.int32
-                )
-                if self.vllm_config.model_config.use_mla:
-                    (
-                        split_q_head_nomask_idx_tensor_list,
-                        split_q_tail_nomask_idx_tensor_list,
-                        head_attn_nomask_seqlens_list,
-                        tail_attn_nomask_seqlens_list,
-                    ) = self._split_nomask_idx_tensor_list(
-                        split_with_q_head_nomask_idx_reqs,
-                        split_kv_with_q_tail_nomask_idx_reqs,
-                        head_attn_nomask_seqlens,
-                        chunk_seqlens,
-                    )
+                attn_mask_seqlens = torch.cumsum(torch.tensor(chunk_seqlens, dtype=torch.int32), dim=0).tolist()
+                head_attn_nomask_seqlens = torch.cumsum(
+                    torch.tensor(kv_with_q_head_nomask_seqlens, dtype=torch.int32), dim=0
+                ).tolist()
+                tail_attn_nomask_seqlens = torch.cumsum(
+                    torch.tensor(kv_with_q_tail_nomask_seqlens, dtype=torch.int32), dim=0
+                ).tolist()
 
                 self.extra_long_seq_kwargs = {
                     "attn_mask_seqlens": attn_mask_seqlens,
@@ -959,11 +947,6 @@ class PCPManager:
                 long_seq_metadata.attn_mask_seqlens = self.extra_long_seq_kwargs["attn_mask_seqlens"]
                 long_seq_metadata.head_attn_nomask_seqlens = self.extra_long_seq_kwargs["head_attn_nomask_seqlens"]
                 long_seq_metadata.tail_attn_nomask_seqlens = self.extra_long_seq_kwargs["tail_attn_nomask_seqlens"]
-                if self.vllm_config.model_config.use_mla:
-                    long_seq_metadata.kv_with_q_head_nomask_idx_tensor = split_q_head_nomask_idx_tensor_list
-                    long_seq_metadata.kv_with_q_tail_nomask_idx_tensor = split_q_tail_nomask_idx_tensor_list
-                    long_seq_metadata.head_attn_nomask_seqlens = head_attn_nomask_seqlens_list
-                    long_seq_metadata.tail_attn_nomask_seqlens = tail_attn_nomask_seqlens_list
 
         self.long_seq_metadata = long_seq_metadata
         return long_seq_metadata, block_table_tensor

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -905,6 +905,7 @@ class PCPManager:
                     tensor_npu = self._list_to_tensor(value, self.device)
                     self.kv_idx_names[key] = tensor_npu
 
+                attn_chunk_seqlens = torch.tensor(chunk_seqlens, dtype=torch.int32)
                 attn_mask_seqlens = torch.cumsum(torch.tensor(chunk_seqlens, dtype=torch.int32), dim=0).tolist()
                 head_attn_nomask_seqlens = torch.cumsum(
                     torch.tensor(kv_with_q_head_nomask_seqlens, dtype=torch.int32), dim=0
@@ -947,6 +948,7 @@ class PCPManager:
                 long_seq_metadata.attn_mask_seqlens = self.extra_long_seq_kwargs["attn_mask_seqlens"]
                 long_seq_metadata.head_attn_nomask_seqlens = self.extra_long_seq_kwargs["head_attn_nomask_seqlens"]
                 long_seq_metadata.tail_attn_nomask_seqlens = self.extra_long_seq_kwargs["tail_attn_nomask_seqlens"]
+                long_seq_metadata.attn_chunk_seqlens = attn_chunk_seqlens
 
         self.long_seq_metadata = long_seq_metadata
         return long_seq_metadata, block_table_tensor


### PR DESCRIPTION
### What this PR does / why we need it?
**Refactor: Replace npu_ring_mla with FIA in mla_cp prefill**

This PR refactors the MLA (Multi-Layer Attention) prefill  for CP (context parallel) implementation by replacing **npu_ring_mla** with **npu_fused_infer_attention_score (FIA)** operator, unifying the attention backend with the standard attention implementation.

**Key changes:**

**Core prefill refactoring (`mla_cp.py`)**

Replace npu_ring_mla with npu_fused_infer_attention_score in `_forward_prefill `
Use TND layout with `softmax_lse_flag=True` for prefill attention
Extract common functions use both by` mla_cp.py` and `attention_cp.py` to `common_cp.py`

**Why we need it:**

Backend unification: Aligns MLA prefill with standard attention implementation (`attention_cp.py`)
Better chunked context support: FIA +` npu_attention_update` provides native LSE-based output merging
Future compatibility: Prepares for eventual `npu_ring_mla` removal across the codebase

### Does this PR introduce _any_ user-facing change?
No. This is a pure refactoring with no functional changes - same behavior, unified backend.

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7

gsm8k acc after use fia
<img width="1217" height="179" alt="1" src="https://github.com/user-attachments/assets/480a1800-aa8e-4c08-9cba-23eddd6c37bf" />

- Co-author by: Wang Xiaochao wangxiaochao6@hisilicon.com
