### PR TITLE
[Feat][Platform] Add PR_SET_PDEATHSIG guard to prevent orphaned NPU worker processes

### DIFF
--- a/tests/e2e/singlecard/test_server_restart_after_abnormal_exit.py
+++ b/tests/e2e/singlecard/test_server_restart_after_abnormal_exit.py
@@ -1,0 +1,220 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Test server restart after abnormal exit with PDEATHSIG guard.
+
+Verifies that:
+1. Server can be killed abnormally (SIGKILL or SIGTERM)
+2. NPU resources are properly released (verified by successful restart)
+3. Server can be restarted and serve requests normally
+
+VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD is enabled by default, so this test
+validates the out-of-the-box behaviour.
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psutil
+import pytest
+
+
+MODEL_PATH = os.getenv("VLLM_TEST_MODEL_PATH", "")
+HOST = "127.0.0.1"
+PORT = 8199
+
+
+def _wait_port_closed(host: str, port: int, timeout_s: float) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            sock = socket.socket()
+            sock.settimeout(1)
+            sock.connect((host, port))
+            sock.close()
+            time.sleep(0.5)
+        except (OSError, socket.error):
+            return True
+    return False
+
+
+def _wait_port_open(host: str, port: int, timeout_s: float) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            sock = socket.socket()
+            sock.settimeout(1)
+            sock.connect((host, port))
+            sock.close()
+            return True
+        except (OSError, socket.error):
+            time.sleep(1)
+    return False
+
+
+def _start_server(env_overrides: dict | None = None) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+    env["VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD"] = "1"
+    env["VLLM_PLUGINS"] = "ascend"
+    if env_overrides:
+        env.update(env_overrides)
+
+    cmd = [
+        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", MODEL_PATH,
+        "--port", str(PORT),
+        "--host", "0.0.0.0",
+        "--dtype", "bfloat16",
+        "--max-model-len", "4096",
+        "--max-num-seqs", "32",
+        "--served-model-name", "test_model",
+        "--tensor-parallel-size", "1",
+        "--gpu-memory-utilization", "0.8",
+        "--enforce-eager",
+    ]
+    return subprocess.Popen(cmd, env=env, stdout=sys.stdout, stderr=sys.stderr)
+
+
+def _find_descendant_pids(root_pid: int) -> list[int]:
+    """Return all descendant PIDs of the given process (recursive)."""
+    try:
+        parent = psutil.Process(root_pid)
+        return [c.pid for c in parent.children(recursive=True)]
+    except psutil.NoSuchProcess:
+        return []
+
+
+@pytest.mark.skipif(
+    not MODEL_PATH or not Path(MODEL_PATH).exists(),
+    reason="Set VLLM_TEST_MODEL_PATH to a valid local model directory",
+)
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="PR_SET_PDEATHSIG is only supported on Linux",
+)
+@pytest.mark.parametrize("kill_signal", [signal.SIGKILL, signal.SIGTERM])
+def test_server_restart_after_abnormal_exit(kill_signal: int):
+    """Kill -> verify cleanup -> restart -> verify healthy."""
+
+    if _wait_port_open(HOST, PORT, timeout_s=1.0):
+        pytest.skip(f"Port {PORT} is already in use")
+
+    # --- Round 1: start, verify, kill ---
+    proc = _start_server()
+    try:
+        assert _wait_port_open(HOST, PORT, timeout_s=300), \
+            "Server did not start in time"
+
+        child_pids = _find_descendant_pids(proc.pid)
+        all_pids = [proc.pid] + child_pids
+
+        signal_name = signal.Signals(kill_signal).name
+        print(f"\n[Test] Killing server (pid={proc.pid}) with {signal_name}, "
+              f"known descendants: {child_pids}")
+
+        os.kill(proc.pid, kill_signal)
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    # Wait for port to close and all descendants to exit
+    assert _wait_port_closed(HOST, PORT, timeout_s=30), \
+        f"Port {PORT} should be closed after server death"
+
+    # Give the kernel a moment to deliver SIGKILL via pdeathsig
+    time.sleep(3)
+
+    still_alive = [p for p in all_pids if psutil.pid_exists(p)]
+    if still_alive:
+        print(f"[WARN] Descendants still alive after kill: {still_alive}")
+
+    # Extra buffer for NPU driver cleanup
+    time.sleep(5)
+
+    # --- Round 2: restart and verify ---
+    print("\n[Test] Restarting server …")
+    proc2 = _start_server()
+    try:
+        assert _wait_port_open(HOST, PORT, timeout_s=300), \
+            "Server did not restart – NPU resources may not have been released"
+        print(f"\n[Test] PASS – Server restarted after {signal.Signals(kill_signal).name}")
+    finally:
+        proc2.terminate()
+        try:
+            proc2.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc2.kill()
+            proc2.wait()
+        _wait_port_closed(HOST, PORT, timeout_s=15)
+
+
+@pytest.mark.skipif(
+    not MODEL_PATH or not Path(MODEL_PATH).exists(),
+    reason="Set VLLM_TEST_MODEL_PATH to a valid local model directory",
+)
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="PR_SET_PDEATHSIG is only supported on Linux",
+)
+def test_no_orphan_processes_after_sigkill():
+    """After SIGKILL on the main process, no descendant should survive."""
+
+    if _wait_port_open(HOST, PORT, timeout_s=1.0):
+        pytest.skip(f"Port {PORT} is already in use")
+
+    proc = _start_server()
+    try:
+        assert _wait_port_open(HOST, PORT, timeout_s=300), \
+            "Server did not start in time"
+
+        child_pids = _find_descendant_pids(proc.pid)
+        print(f"\n[Test] Server pid={proc.pid}, descendants={child_pids}")
+
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+    # Allow pdeathsig + atexit cleanup to propagate
+    time.sleep(8)
+
+    survivors = [pid for pid in child_pids if psutil.pid_exists(pid)]
+    if survivors:
+        print(f"[FAIL] Orphan processes detected: {survivors}")
+        for pid in survivors:
+            try:
+                p = psutil.Process(pid)
+                print(f"  pid={pid} name={p.name()} status={p.status()}")
+                os.kill(pid, signal.SIGKILL)
+            except (psutil.NoSuchProcess, OSError):
+                pass
+
+    assert not survivors, (
+        f"Orphan processes found after SIGKILL: {survivors}. "
+        "PDEATHSIG guard or atexit cleanup may have failed."
+    )

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -117,6 +117,12 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))
     ),
+    # If set, child processes will receive SIGKILL when their parent dies,
+    # ensuring NPU resources are released after abnormal exits (e.g. SIGKILL).
+    # Uses Linux PR_SET_PDEATHSIG mechanism. Enabled by default on Linux.
+    "VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD", "1"))
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -14,11 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_mamba_config  # noqa
+import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
-
-if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
-    import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -604,6 +604,12 @@ class BalanceDPEngineCoreProc(DPEngineCoreProc):
 
 def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
     """Launch EngineCore busy loop in background process."""
+    # This function replaces the default run_engine_core (which is wrapped
+    # by patch_multiproc_executor.py). We must call pdeathsig here because
+    # our replacement discards that wrapper.
+    from vllm_ascend.utils import maybe_set_pdeathsig
+
+    maybe_set_pdeathsig()
 
     # Signal handler used for graceful termination.
     # SystemExit exception is only raised once to allow this and worker

--- a/vllm_ascend/patch/platform/patch_multiproc_executor.py
+++ b/vllm_ascend/patch/platform/patch_multiproc_executor.py
@@ -1,3 +1,22 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import atexit
+import os
 import threading
 import weakref
 from collections import deque
@@ -8,8 +27,10 @@ import vllm.v1.executor.multiproc_executor
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
+from vllm.logger import init_logger
 from vllm.utils.network_utils import get_distributed_init_method, get_loopback_ip, get_open_port
-from vllm.utils.system_utils import get_mp_context
+from vllm.utils.system_utils import get_mp_context, kill_process_tree
+from vllm.v1.engine.core import EngineCoreProc
 from vllm.v1.executor.abstract import FailureCallback
 from vllm.v1.executor.multiproc_executor import (
     FutureWrapper,
@@ -19,6 +40,21 @@ from vllm.v1.executor.multiproc_executor import (
     set_multiprocessing_worker_envs,
 )
 
+from vllm_ascend.utils import maybe_set_pdeathsig
+
+logger = init_logger(__name__)
+
+
+def _cleanup_worker_pids(worker_pids: list[int]) -> None:
+    """atexit handler: forcibly clean up any surviving worker process trees."""
+    for pid in worker_pids:
+        try:
+            os.kill(pid, 0)  # check if alive
+        except OSError:
+            continue
+        logger.debug("atexit: cleaning up surviving worker pid %d", pid)
+        kill_process_tree(pid)
+
 
 class AscendMultiprocExecutor(MultiprocExecutor):
     def _init_executor(self) -> None:
@@ -27,6 +63,7 @@ class AscendMultiprocExecutor(MultiprocExecutor):
         self._finalizer = weakref.finalize(self, self.shutdown)
         self.is_failed = False
         self.shutdown_event = threading.Event()
+        self._worker_pids: list[int] = []
         self.failure_callback: FailureCallback | None = None
 
         tensor_parallel_size, pp_parallel_size, pcp_parallel_size = self._get_parallel_sizes()
@@ -86,6 +123,12 @@ class AscendMultiprocExecutor(MultiprocExecutor):
 
             # Wait for all local workers to be ready.
             self.workers = AscendWorkerProc.wait_for_ready(unready_workers)
+
+            # Record worker PIDs and register atexit cleanup as a last resort
+            # for multi-card scenarios where intermediate processes may orphan
+            # NPU driver subprocesses.
+            self._worker_pids = [uw.proc.pid for uw in unready_workers if uw.proc.pid is not None]
+            atexit.register(_cleanup_worker_pids, self._worker_pids)
 
             # Start background thread to monitor worker health if not in headless mode.
             if self.monitor_workers:
@@ -150,6 +193,20 @@ class AscendMultiprocExecutor(MultiprocExecutor):
 
 class AscendWorkerProc(WorkerProc):
     @staticmethod
+    def _worker_main_with_pdeathsig(*args, **kwargs):
+        """Wrapper that arms PR_SET_PDEATHSIG before entering the busy loop.
+
+        Also creates a new process group so that NPU driver subprocesses
+        (e.g. HCCL) spawned by this worker belong to a killable group.
+        """
+        try:
+            os.setpgrp()
+        except OSError:
+            pass
+        maybe_set_pdeathsig()
+        WorkerProc.worker_main(*args, **kwargs)
+
+    @staticmethod
     def make_worker_process(
         vllm_config: VllmConfig,
         local_rank: int,
@@ -177,9 +234,9 @@ class AscendWorkerProc(WorkerProc):
             "shared_worker_lock": shared_worker_lock,
             "is_driver_worker": is_driver_worker,
         }
-        # Run EngineCore busy loop in background process.
+        # Run worker busy loop in background process.
         proc = context.Process(
-            target=WorkerProc.worker_main,
+            target=AscendWorkerProc._worker_main_with_pdeathsig,
             kwargs=process_kwargs,
             name=f"VllmWorker-{rank}",
             daemon=False,
@@ -191,5 +248,23 @@ class AscendWorkerProc(WorkerProc):
         # death_reader in child will get EOFError
         return UnreadyWorkerProcHandle(proc, rank, reader, death_writer)
 
+
+# --- Patch EngineCoreProc.run_engine_core to arm pdeathsig ---
+# The EngineCore runs in a spawned process and is the primary holder of
+# NPU resources. We wrap its entry point so that pdeathsig is armed
+# before any NPU initialization happens.
+# NOTE: patch_balance_schedule.py may overwrite this with its own
+# run_engine_core that already contains maybe_set_pdeathsig(), so both
+# the default and balance-scheduling paths are covered.
+
+_original_run_engine_core = EngineCoreProc.run_engine_core
+
+
+def _run_engine_core_with_pdeathsig(*args, **kwargs):
+    maybe_set_pdeathsig()
+    _original_run_engine_core(*args, **kwargs)
+
+
+EngineCoreProc.run_engine_core = staticmethod(_run_engine_core_with_pdeathsig)
 
 vllm.v1.executor.multiproc_executor.MultiprocExecutor = AscendMultiprocExecutor

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -20,9 +20,12 @@
 from __future__ import annotations
 
 import atexit
+import ctypes
 import functools
 import math
 import os
+import signal
+import sys
 from contextlib import nullcontext
 from enum import Enum
 from functools import lru_cache
@@ -42,6 +45,48 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 else:
     VllmConfig = None
+
+
+def maybe_set_pdeathsig(sig: int = signal.SIGKILL) -> None:
+    """Set PR_SET_PDEATHSIG so this process dies when its parent exits.
+
+    This is a Linux-only kernel mechanism. When the parent process exits
+    (for any reason, including SIGKILL), the kernel delivers ``sig`` to
+    this process. Combined with the userspace death_pipe already present
+    in vLLM's MultiprocExecutor, it provides a robust two-layer guard
+    that prevents orphaned worker processes from holding NPU resources.
+
+    Controlled by VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD (default: enabled).
+    """
+    if not envs_ascend.VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD:
+        return
+    if not sys.platform.startswith("linux"):
+        logger.warning_once(
+            "VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD is set, but "
+            "PR_SET_PDEATHSIG is only supported on Linux."
+        )
+        return
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        PR_SET_PDEATHSIG = 1
+        res = libc.prctl(
+            ctypes.c_int(PR_SET_PDEATHSIG),
+            ctypes.c_ulong(int(sig)),
+            ctypes.c_ulong(0),
+            ctypes.c_ulong(0),
+            ctypes.c_ulong(0),
+        )
+        if res != 0:
+            err = ctypes.get_errno()
+            raise OSError(err, os.strerror(err))
+        logger.debug(
+            "PR_SET_PDEATHSIG set to %s for pid %d",
+            sig.name if isinstance(sig, signal.Signals) else sig,
+            os.getpid(),
+        )
+    except Exception as exc:
+        logger.warning("Failed to set PR_SET_PDEATHSIG: %s", exc)
+
 
 COMPILATION_PASS_KEY = "graph_fusion_manager"
 ASCEND_QUANTIZATION_METHOD = "ascend"


### PR DESCRIPTION

### What this PR does / why we need it?

When the vLLM API server is terminated abnormally (e.g. `SIGKILL`, OOM kill, or
crash), child processes holding NPU resources may survive as orphans, preventing
subsequent server restarts because the NPU device remains occupied.

This PR adds a three-layer defense mechanism to ensure NPU resources are always
released:

1. **PR_SET_PDEATHSIG (kernel-level)**: Each spawned EngineCore/Worker process
   calls `prctl(PR_SET_PDEATHSIG, SIGKILL)`, so the kernel auto-delivers
   SIGKILL when its parent exits — even if the parent is killed with SIGKILL.
2. **Process group isolation (`os.setpgrp`)**: Workers create a new process
   group, ensuring NPU driver subprocesses (e.g. HCCL) belong to a killable
   group rather than the parent's group.
3. **atexit handler**: The executor registers a fallback that walks the process
   tree and kills any surviving workers during normal shutdown.

This is controlled by `VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD` (default: enabled).

**Changes:**
- `vllm_ascend/envs.py`: Add `VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD` env var
- `vllm_ascend/utils.py`: Add `maybe_set_pdeathsig()` utility function
- `vllm_ascend/patch/platform/patch_multiproc_executor.py`: Inject pdeathsig
  into Worker and EngineCore entry points; add atexit process-tree cleanup
- `vllm_ascend/patch/platform/patch_balance_schedule.py`: Add pdeathsig call
  in the balance-scheduling code path (which replaces the default wrapper)
- `vllm_ascend/patch/platform/__init__.py`: Unconditionally load
  `patch_multiproc_executor` so the guard is always active

### Does this PR introduce _any_ user-facing change?

Yes. A new environment variable `VLLM_ASCEND_ENABLE_PDEATHSIG_GUARD` is
introduced (default: `1` / enabled). Users can set it to `0` to disable
the guard if needed. When enabled, orphaned worker processes are automatically
cleaned up after abnormal server exits, so users no longer need to manually
kill residual processes before restarting.

### How was this patch tested?

New E2E test added: `tests/e2e/singlecard/test_server_restart_after_abnormal_exit.py`

**Test cases:**
- `test_no_orphan_processes_after_sigkill`: Starts server, sends SIGKILL to
  main process, verifies all descendant processes are cleaned up within 10s
- `test_server_restart_after_abnormal_exit[SIGKILL]`: Kills server with
  SIGKILL, then verifies a new server can start successfully (NPU released)
- `test_server_restart_after_abnormal_exit[SIGTERM]`: Same flow with SIGTERM

**Manual verification:**
- Single-card (TP=1): All 3 tests passed ✅
- 2-card (TP=2): SIGKILL main process → 4 descendants (EngineCore, Worker_TP0,
  Worker_TP1, resource_tracker) all cleaned up, server restarted successfully ✅

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
