### PR TITLE
[Bugfix] Add `profile_prefix` param to worker `profile()` method

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -580,7 +580,7 @@ class NPUWorker(WorkerBase):
                     torch_npu.profiler.ProfilerActivity.CPU,
                     torch_npu.profiler.ProfilerActivity.NPU,
                 ],
-                with_stack=True,
+                with_stack=False,
                 profile_memory=profiler_config.torch_profiler_with_memory,
                 # NOTE: torch_npu.profiler.with_modules is equivalent to torch.profiler.with_stack.
                 # The with_stack option in torch_npu.profiler introduces significant time overhead.


### PR DESCRIPTION
### What this PR does / why we need it?

When profiling, I get an error:

```bash
typeerror: npuworker.profile() takes from 1 to 2 positional arguments but 3 were given
```

To fix this bug, we need to receive the param `profile_prefix` passed from vllm.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
