### PR TITLE
[Main2Main] Upgrade vLLM to 0305

### DIFF
--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7
+          VLLM_COMMIT=5b3ba94ab4bd9da739bcc27cdd05505467fa499e
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7
+ARG VLLM_COMMIT=5b3ba94ab4bd9da739bcc27cdd05505467fa499e
 RUN git clone $VLLM_REPO /vllm-workspace/vllm && \
     cd /vllm-workspace/vllm && \
     git checkout $VLLM_COMMIT

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7, v0.16.0]
+        vllm_version: [5b3ba94ab4bd9da739bcc27cdd05505467fa499e, v0.16.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7
+      vllm: 5b3ba94ab4bd9da739bcc27cdd05505467fa499e
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -89,7 +89,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7, v0.16.0]
+        vllm_version: [5b3ba94ab4bd9da739bcc27cdd05505467fa499e, v0.16.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -101,7 +101,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7, v0.16.0]
+        vllm_version: [5b3ba94ab4bd9da739bcc27cdd05505467fa499e, v0.16.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7]
+        vllm_version: [5b3ba94ab4bd9da739bcc27cdd05505467fa499e]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_update_estimated_time.yaml
+++ b/.github/workflows/schedule_update_estimated_time.yaml
@@ -18,7 +18,7 @@ jobs:
     name: e2e-test
     strategy:
       matrix:
-        vllm_version: [e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7]
+        vllm_version: [5b3ba94ab4bd9da739bcc27cdd05505467fa499e]
         type: [full, light]
     uses: ./.github/workflows/_e2e_test.yaml
     with:

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -57,7 +57,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
 |-------------|--------------|------------------|-------------|--------------------|
-|     main    | e2b31243c092e9f4ade5ffe4bf9a5d5ddae06ca7, v0.16.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+|     main    | 5b3ba94ab4bd9da739bcc27cdd05505467fa499e, v0.16.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
 
 ## Release cadence
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2341,6 +2341,7 @@ class NPUModelRunner(GPUModelRunner):
                 aclgraph_runtime_mode=cudagraph_runtime_mode,
                 batch_descriptor=batch_desc,
                 model_instance=self.model,
+                skip_compiled=is_profile,
             ):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
@@ -2396,12 +2397,23 @@ class NPUModelRunner(GPUModelRunner):
         ) in {MoECommType.MC2, MoECommType.FUSED_MC2}:
             self._dummy_run(mc2_tokens_capacity, with_prefill=True, is_profile=True)
         origin_max_num_tokens = self.max_num_tokens
+        origin_compilation_mode = self.compilation_config.mode
+        origin_cudagraph_mode = self.compilation_config.cudagraph_mode
         # in the pcp scenario, the split sequence needs to be used for profile run
         # TODO: after the vllm pcp function is launched, this logic needs to be brought up to the community
         if self.pcp_size > 1:
             self.max_num_tokens = math.ceil(self.max_num_tokens / (self.pcp_size * 2)) * 2
-        super().profile_run()
-        self.max_num_tokens = origin_max_num_tokens
+        # NOTE: profiling is only used to estimate memory. On Ascend, entering
+        # the compile / graph path here can create FakeTensorMode mismatches
+        # before the real warmup stage.
+        self.compilation_config.mode = CompilationMode.NONE
+        self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        try:
+            super().profile_run()
+        finally:
+            self.compilation_config.mode = origin_compilation_mode
+            self.compilation_config.cudagraph_mode = origin_cudagraph_mode
+            self.max_num_tokens = origin_max_num_tokens
 
     def eplb_warmup(self):
         if self.dynamic_eplb and not self.is_eplb_warmuped:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -111,9 +111,7 @@ def npu_memory_profiling(
     result.non_torch_increase = diff_from_create.non_torch_memory
     result.profile_time = diff_profile.timestamp
 
-    result.non_kv_cache_memory = (
-        result.non_torch_increase + result.torch_peak_increase + result.weights_memory
-    )
+    result.non_kv_cache_memory = result.non_torch_increase + result.torch_peak_increase + result.weights_memory
 
 
 class NPUWorker(WorkerBase):


### PR DESCRIPTION
### What this PR does / why we need it?
break:
- https://github.com/vllm-project/vllm/pull/30681
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
