### PR TITLE
[Feat] Remove block_size = 128 limitation

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1066,16 +1066,16 @@ def refresh_block_size(vllm_config):
     if not scheduler_config or not model_config:
         return
 
-    # TODO(MengqingCao): Remove the model_type check, after resolving the hidden error in get_kv_cache_groups.
-    if model_config.hf_text_config.model_type != "qwen3_next" and cache_config.block_size != 128:
-        if cache_config.enable_prefix_caching or scheduler_config.enable_chunked_prefill:
-            logger.info("Block size is set to 128 if prefix cache or chunked prefill is enabled.")
-            cache_config.block_size = 128
+    # # TODO(MengqingCao): Remove the model_type check, after resolving the hidden error in get_kv_cache_groups.
+    # if model_config.hf_text_config.model_type != "qwen3_next" and cache_config.block_size != 128:
+    #     if cache_config.enable_prefix_caching or scheduler_config.enable_chunked_prefill:
+    #         logger.info("Block size is set to 128 if prefix cache or chunked prefill is enabled.")
+    #         cache_config.block_size = 128
 
 
 def dispose_layer(layer: Any):
     for attr_name in dir(layer):
-        attr_value = getattr(layer, attr_name)
+        attr_value = getattr(layer, attr_name)ß
         if isinstance(attr_value, torch.Tensor):
             dispose_tensor(attr_value)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Improve prefix cache hit rate
### Does this PR introduce _any_ user-facing change?

Set `--block-size 16` in the configuration.

### How was this patch tested?
None
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
