### PR TITLE
[Feature] Remove block_size = 128 limitation

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1208,12 +1208,6 @@ def refresh_block_size(vllm_config):
         # logic rather than the generic platform default.
         return
 
-    if cache_config.block_size != 128:
-        if cache_config.enable_prefix_caching or scheduler_config.enable_chunked_prefill:
-            logger.info("Block size is set to 128 if prefix cache or chunked prefill is enabled.")
-            cache_config.block_size = 128
-            return
-
     ascend_config = get_ascend_config()
     if ascend_config.xlite_graph_config.enabled and cache_config.block_size > 128:
         logger.warning("Setting block size to 128 for xlite compatibility.")


### PR DESCRIPTION
### What this PR does / why we need it?
Improve prefix cache hit rate
### Does this PR introduce _any_ user-facing change?

Set `--block-size 16` in the configuration.

### How was this patch tested?
None
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/15d76f74e2fdb12a95ea00f0ca283acf6219a2b7
