### PR TITLE
[CI] Image build from cache

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -28,10 +28,18 @@ on:
             description: 'Quay password for pushing images'
             required: false
 
+env:
+  QUAY_REPO: quay.io/ascend/vllm-ascend
+  CACHE_REPO: ghcr.io/vllm-project/vllm-ascend
+
 jobs:
   build-push-digest:
     name: build
     runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
+      contents: read
+
     strategy:
       matrix:
         include:
@@ -42,6 +50,7 @@ jobs:
             runner: ubuntu-22.04-arm
             tag: arm64
     steps:
+
     - uses: actions/checkout@v6
       if: ${{ github.event_name != 'workflow_dispatch' }}
       with:
@@ -76,6 +85,22 @@ jobs:
         driver: docker-container
         use: true
 
+    - name: Login to GitHub Container Registry (for cache)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Compute cache tag
+      id: cache-tag
+      run: |
+        if [ -n "${{ inputs.suffix }}" ]; then
+          echo "value=buildcache-${{ inputs.suffix }}-${{ matrix.tag }}" >> $GITHUB_OUTPUT
+        else
+          echo "value=buildcache-${{ matrix.tag }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Build and push
       uses: docker/build-push-action@v7
       id: build
@@ -86,10 +111,15 @@ jobs:
         file: ${{ inputs.dockerfile || 'Dockerfile' }}
         # only trigger when tag, branch/main push
         push: ${{ inputs.should_push }}
-        outputs: type=image,name=quay.io/ascend/vllm-ascend,push-by-digest=true,name-canonical=true,push=${{ inputs.should_push }}
+        outputs: type=image,name=${{ env.QUAY_REPO }},push-by-digest=true,name-canonical=true,push=${{ inputs.should_push }}
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
         provenance: false
+        # To speed up the build, we use registry cache. The cache tag is determined by the suffix and architecture, and shared across different workflow runs.
+        # For example, the cache tag for arm64 image with suffix "openeuler" will be "buildcache-openeuler-arm64".
+        # When a new image is built and pushed, the cache will also be updated in the registry, so that next build can benefit from it.
+        cache-from: type=registry,ref=${{ env.CACHE_REPO }}:${{ steps.cache-tag.outputs.value }}
+        cache-to: ${{ inputs.should_push && format('type=registry,ref={0}:{1},mode=max', env.CACHE_REPO, steps.cache-tag.outputs.value) || '' }}
 
     - name: Export digest
       run: |
@@ -131,6 +161,10 @@ jobs:
       - name: Prepare suffix
         id: suffix
         run: |
+          # Prepend '-' to suffix so Docker metadata action can append it directly
+          # to the tag (e.g. suffix=310p-openeuler → SUFFIX=-310p-openeuler,
+          # resulting in tags like main-310p-openeuler).
+          # Leave SUFFIX empty when no suffix is provided (plain tags like main).
           if [ -n "${{ inputs.suffix }}" ]; then
             echo "SUFFIX=-${{ inputs.suffix }}" >> $GITHUB_ENV
           else
@@ -143,16 +177,23 @@ jobs:
         with:
           # TODO(yikun): add more hub image and a note on release policy for container image
           images: |
-            quay.io/ascend/vllm-ascend
-          # Note for test case
+            ${{ env.QUAY_REPO }}
+          # Three trigger scenarios and resulting image tags:
           # https://github.com/marketplace/actions/docker-metadata-action#typeref
-          # 1. branch job publish per main/*-dev branch commits
-          # 2. main and dev pull_request is build only, so the tag pr-N-openeuler is fine
-          # 3. only pep440 matched tag will be published:
-          #    - v0.7.1 --> v0.7.1-openeuler
-          #    - pre/post/dev: v0.7.1rc1-openeuler/v0.7.1rc1-openeuler/v0.7.1rc1.dev1-openeuler/v0.7.1.post1-openeuler, no latest
-          #      which follow the rule from vLLM with prefix v
-          # TODO(yikun): the post release might be considered as latest release
+          #
+          # 1. Push tag (on: push tags: v*) → type=pep440
+          #    Only pep440-compliant tags are published:
+          #    - v0.16.0rc1       --> vllm-ascend:v0.16.0rc1[-suffix]
+          #    Non-pep440 tags are ignored.
+          #
+          # 2. Schedule (on: schedule) → type=schedule,pattern=main
+          #    Triggered by cron, always produces a fixed tag:
+          #    - (any schedule run) --> vllm-ascend:main[-suffix]
+          #
+          # 3. Manual (on: workflow_dispatch) → type=raw,value=inputs.workflow_dispatch_tag
+          #    Tag is determined by the user-selected input at dispatch time:
+          #    - inputs.tag=main       --> vllm-ascend:main[-suffix]
+          #    - inputs.tag=v0.16.0rc1 --> vllm-ascend:v0.16.0rc1[-suffix]
           tags: |
             type=pep440,pattern={{raw}},suffix=${{ env.SUFFIX }}
             type=schedule,pattern=main,suffix=${{ env.SUFFIX }}
@@ -172,7 +213,7 @@ jobs:
 
       - name: Merge and push multi-arch image
         env:
-          IMAGE: quay.io/ascend/vllm-ascend
+          IMAGE: ${{ env.QUAY_REPO }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           DIGESTS=$(printf "$IMAGE@sha256:%s " $(ls ${{ runner.temp }}/digests))

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -36,6 +36,10 @@ on:
           - v0.14.0rc1
           - v0.13.0rc3
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   image_build:
     name: Image Build and Push

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,34 +19,32 @@ FROM quay.io/ascend/cann:8.5.1-910b-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_TAG="v0.3.8.post1"
-ARG SOC_VERSION="ascend910b1"
-
-# Define environments
-ENV DEBIAN_FRONTEND=noninteractive
-ENV SOC_VERSION=$SOC_VERSION \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
 
 WORKDIR /workspace
 
-COPY . /vllm-workspace/vllm-ascend/
+COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
-# Install Mooncake dependencies
+# Install clang-15 (for triton-ascend) and Mooncake
 RUN apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake libnuma-dev libjemalloc2 && \
+    apt-get install -y git vim wget net-tools gcc g++ cmake libnuma-dev libjemalloc2 clang-15 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
-    cp /vllm-workspace/vllm-ascend/tools/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
+    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
     cd /vllm-workspace/Mooncake && bash mooncake_installer.sh -y && \
     ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:$LD_LIBRARY_PATH && \
     mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
     make -j$(nproc) && make install && \
-    rm -fr /vllm-workspace/Mooncake/build && \
+    rm -rf /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip config set global.index-url ${PIP_INDEX_URL}
+# Install modelscope (for fast download) and ray (for multinode)
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip cache purge
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
@@ -58,8 +56,13 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+ARG SOC_VERSION="ascend910b1"
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SOC_VERSION=$SOC_VERSION \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+COPY . /vllm-workspace/vllm-ascend/
+
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -69,18 +72,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
-# Install clang-15 (for triton-ascend)
-RUN apt-get update -y && \
-    apt-get -y install clang-15 && \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install modelscope (for fast download) and ray (for multinode)
-RUN python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
-    python3 -m pip cache purge
-
+# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -18,25 +18,18 @@
 FROM quay.io/ascend/cann:8.5.1-310p-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG SOC_VERSION="ascend310p1"
 
-# Define environments
-ENV DEBIAN_FRONTEND=noninteractive
-ENV SOC_VERSION=$SOC_VERSION \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
-    
+WORKDIR /workspace
 
 RUN apt-get update -y && \
     apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake libnuma-dev libjemalloc2 && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /workspace
-
-COPY . /vllm-workspace/vllm-ascend/
-
-RUN pip config set global.index-url ${PIP_INDEX_URL}
+# Install modelscope (for fast download) and ray (for multinode)
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip cache purge
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
@@ -48,8 +41,13 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+ARG SOC_VERSION="ascend310p1"
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SOC_VERSION=$SOC_VERSION \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+COPY . /vllm-workspace/vllm-ascend/
+
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -59,10 +57,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
-# Install modelscope (for fast download) and ray (for multinode)
-RUN python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
-    python3 -m pip cache purge
-
+# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -18,21 +18,17 @@
 FROM quay.io/ascend/cann:8.5.1-310p-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-ARG SOC_VERSION="ascend310p1"
 
-ENV SOC_VERSION=$SOC_VERSION \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+WORKDIR /workspace
 
 RUN yum update -y && \
     yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl-devel jemalloc && \
     rm -rf /var/cache/yum
 
-RUN pip config set global.index-url ${PIP_INDEX_URL}
-
-WORKDIR /workspace
-
-COPY . /vllm-workspace/vllm-ascend/
+# Install modelscope (for fast download) and ray (for multinode)
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip cache purge
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
@@ -44,7 +40,12 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+ARG SOC_VERSION="ascend310p1"
+ENV SOC_VERSION=$SOC_VERSION \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+COPY . /vllm-workspace/vllm-ascend/
+
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -53,10 +54,6 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install -v triton-ascend==3.2.0 && \
-    python3 -m pip cache purge
-
-# Install modelscope (for fast download) and ray (for multinode)
-RUN python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -19,24 +19,20 @@ FROM quay.io/ascend/cann:8.5.1-a3-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_TAG=v0.3.8.post1
-ARG SOC_VERSION="ascend910_9391"
 
-COPY . /vllm-workspace/vllm-ascend/
-# Define environments
+COPY ./tools/mooncake_installer.sh /vllm-workspace/
+
 ENV DEBIAN_FRONTEND=noninteractive
-ENV SOC_VERSION=$SOC_VERSION \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
-
-RUN pip config set global.index-url ${PIP_INDEX_URL}
 
 WORKDIR /workspace
 
-# Install Mooncake dependencies
+# Install clang-15 (for triton-ascend) and Mooncake
 RUN apt-get update -y && \
-    apt-get install -y git vim wget net-tools gcc g++ cmake libnuma-dev libjemalloc2 && \
+    apt-get install -y git vim wget net-tools gcc g++ cmake libnuma-dev libjemalloc2 clang-15 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
-    cp /vllm-workspace/vllm-ascend/tools/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
+    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
     cd /vllm-workspace/Mooncake && bash mooncake_installer.sh -y && \
     ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
@@ -46,6 +42,11 @@ RUN apt-get update -y && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
+
+# Install modelscope (for fast download) and ray (for multinode)
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip cache purge
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
@@ -57,8 +58,13 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+ARG SOC_VERSION="ascend910_9391"
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SOC_VERSION=$SOC_VERSION \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+COPY . /vllm-workspace/vllm-ascend/
+
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -68,18 +74,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
-# Install clang-15 (for triton-ascend)
-RUN apt-get update -y && \
-    apt-get -y install clang-15 && \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install modelscope (for fast download) and ray (for multinode)
-RUN python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
-    python3 -m pip cache purge
-
+# Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -19,24 +19,18 @@ FROM quay.io/ascend/cann:8.5.1-a3-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_TAG="v0.3.8.post1"
-ARG SOC_VERSION="ascend910_9391"
-
-ENV SOC_VERSION=$SOC_VERSION \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
-
-RUN pip config set global.index-url ${PIP_INDEX_URL}
 
 WORKDIR /workspace
 
-COPY . /vllm-workspace/vllm-ascend/
+COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
 SHELL ["/bin/bash", "-c"]
 
+# Install clang (for triton-ascend) and Mooncake
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl-devel jemalloc && \
+    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl-devel jemalloc clang && \
     git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
-    cp /vllm-workspace/vllm-ascend/tools/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
+    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
     ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:$LD_LIBRARY_PATH && \
@@ -48,6 +42,11 @@ RUN yum update -y && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 
+# Install modelscope (for fast download) and ray (for multinode)
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip cache purge
+
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.18.0
@@ -58,7 +57,12 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+ARG SOC_VERSION="ascend910_9391"
+ENV SOC_VERSION=$SOC_VERSION \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+COPY . /vllm-workspace/vllm-ascend/
+
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -67,15 +71,6 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install -v triton-ascend==3.2.0 && \
-    python3 -m pip cache purge
-
-# Install clang (for triton-ascend)
-RUN yum update -y && \
-    yum install -y clang && \
-    rm -rf /var/cache/yum/*
-
-# Install modelscope (for fast download) and ray (for multinode)
-RUN python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -19,24 +19,18 @@ FROM quay.io/ascend/cann:8.5.1-910b-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_TAG="v0.3.8.post1"
-ARG SOC_VERSION="ascend910b1"
-
-ENV SOC_VERSION=$SOC_VERSION \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
-
-RUN pip config set global.index-url ${PIP_INDEX_URL}
 
 WORKDIR /workspace
 
-COPY . /vllm-workspace/vllm-ascend/
+COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
 SHELL ["/bin/bash", "-c"]
 
+# Install clang (for triton-ascend) and Mooncake
 RUN yum update -y && \
-    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl-devel jemalloc && \
+    yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl-devel jemalloc clang && \
     git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /vllm-workspace/Mooncake && \
-    cp /vllm-workspace/vllm-ascend/tools/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
+    mv /vllm-workspace/mooncake_installer.sh /vllm-workspace/Mooncake/ && \
     ARCH=$(uname -m) && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:$LD_LIBRARY_PATH && \
@@ -48,6 +42,11 @@ RUN yum update -y && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 
+# Install modelscope (for fast download) and ray (for multinode)
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
+    python3 -m pip cache purge
+
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.18.0
@@ -58,7 +57,12 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+ARG SOC_VERSION="ascend910b1"
+ENV SOC_VERSION=$SOC_VERSION \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+COPY . /vllm-workspace/vllm-ascend/
+
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
@@ -67,15 +71,6 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install -v triton-ascend==3.2.0 && \
-    python3 -m pip cache purge
-
-# Install clang (for triton-ascend)
-RUN yum update -y && \
-    yum install -y clang && \
-    rm -rf /var/cache/yum/*
-
-# Install modelscope (for fast download) and ray (for multinode)
-RUN python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc


### PR DESCRIPTION
## What

Introduce Docker registry cache (`cache-from`/`cache-to`) backed by
GitHub Container Registry (ghcr.io) to accelerate scheduled and
manual image builds.

### Workflow changes
- Add `cache_repo` input (default: `ghcr.io/vllm-project/vllm-ascend`)
  to both `_schedule_image_build.yaml` and
  `schedule_image_build_and_push.yaml`, letting callers choose where
  cache layers are stored.
- Add GHCR login step and `packages: write` permission so the runner
  can push cache manifests.
- Derive a per-arch, per-suffix cache tag at build time
  (e.g. `buildcache-openeuler-arm64`) so caches never collide across
  matrix variants.

### Dockerfile layer-order optimisation
Reorder layers in all Dockerfiles so the slow, rarely-changing steps
(system packages, Mooncake, vLLM core) appear before the fast-changing
`COPY . /vllm-workspace/vllm-ascend/` step. This maximises cache-hit
rate: rebuilding vllm-ascend from source no longer invalidates the
upstream dependency layers.

### Additional Dockerfile tweaks:
- Pre-install `clang-15` (required by triton-ascend) in the same
  apt layer as other system deps.
- Pre-install `modelscope` and `ray` before the vllm-ascend install
  so those layers are also cached.
- Switch vLLM clone from `--depth 1` to `--filter=blob:none` to avoid
  re-downloading on branch checkouts.
- Move `ARG SOC_VERSION` / `ENV` declarations immediately before
  `COPY .` to avoid early cache invalidation.

## How does this patch tested
see https://github.com/Potabk/vllm-ascend-fork/actions/runs/23038468201 in my personal repo


## Next steps

Extend `workflow_dispatch` inputs to support optional ARM + Ubuntu
build variants for nightly testing, while reusing the cache mechanism
introduced here (same `cache_repo` / cache-tag convention).
