### PR TITLE
[Feat][Worker] Allow eager prefill with decode ACL graph mode

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -82,14 +82,15 @@ class TestAscendConfig(TestBase):
         test_vllm_config.additional_config = {
             "ascend_compilation_config": {
                 "enable_npugraph_ex": True,
-                "enable_static_kernel": True
+                "enable_static_kernel": True,
+                "prefill_use_eager": True,
             },
-            "refresh": True
+            "refresh": True,
         }
-        ascend_compilation_config = init_ascend_config(
-            test_vllm_config).ascend_compilation_config
+        ascend_compilation_config = init_ascend_config(test_vllm_config).ascend_compilation_config
         self.assertTrue(ascend_compilation_config.enable_npugraph_ex)
         self.assertTrue(ascend_compilation_config.enable_static_kernel)
+        self.assertTrue(ascend_compilation_config.prefill_use_eager)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from vllm.config import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
+
+from tests.ut.base import TestBase
+
+
+class TestNPUModelRunner(TestBase):
+    def _make_runner(self, prefill_use_eager: bool):
+        from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+        runner = object.__new__(NPUModelRunner)
+        runner._pad_for_sequence_parallelism = lambda num_tokens: num_tokens
+        runner.input_batch = MagicMock()
+        runner.input_batch.num_computed_tokens_cpu = np.array([0, 0], dtype=np.int32)
+        runner.input_batch.lora_id_to_lora_request = {}
+        runner.speculative_config = None
+        runner.uniform_decode_query_len = 1
+        runner.model_config = MagicMock()
+        runner.model_config.is_encoder_decoder = False
+        runner.parallel_config = MagicMock()
+        runner.parallel_config.data_parallel_rank = 0
+        runner.vllm_config = MagicMock()
+        runner.vllm_config.parallel_config = MagicMock()
+        runner.vllm_config.parallel_config.data_parallel_size = 1
+        runner.vllm_config.parallel_config.tensor_parallel_size = 1
+        runner.vllm_config.observability_config = MagicMock()
+        runner.vllm_config.observability_config.cudagraph_metrics = False
+        runner.ascend_config = MagicMock()
+        runner.ascend_config.ascend_compilation_config.prefill_use_eager = prefill_use_eager
+        runner.cudagraph_dispatcher = MagicMock()
+        runner.cudagraph_dispatcher.dispatch.return_value = (
+            CUDAGraphMode.FULL,
+            BatchDescriptor(num_tokens=2, num_reqs=2, uniform=True),
+        )
+        return runner
+
+    @patch("vllm_ascend.worker.model_runner_v1.enable_sp", return_value=False)
+    def test_determine_batch_execution_with_prefill_aclgraph(self, _mock_enable_sp):
+        runner = self._make_runner(prefill_use_eager=False)
+
+        cudagraph_mode, batch_descriptor, _, _, _ = runner._determine_batch_execution_and_padding(
+            num_tokens=2,
+            num_reqs=2,
+            num_scheduled_tokens_np=np.array([1, 1], dtype=np.int32),
+            max_num_scheduled_tokens=1,
+            use_cascade_attn=False,
+        )
+
+        self.assertEqual(cudagraph_mode, CUDAGraphMode.FULL)
+        self.assertEqual(batch_descriptor, BatchDescriptor(num_tokens=2, num_reqs=2, uniform=True))
+        runner.cudagraph_dispatcher.dispatch.assert_called_once()
+
+    @patch("vllm_ascend.worker.model_runner_v1.enable_sp", return_value=False)
+    def test_determine_batch_execution_forces_eager_prefill(self, _mock_enable_sp):
+        runner = self._make_runner(prefill_use_eager=True)
+
+        cudagraph_mode, batch_descriptor, _, _, _ = runner._determine_batch_execution_and_padding(
+            num_tokens=2,
+            num_reqs=2,
+            num_scheduled_tokens_np=np.array([1, 1], dtype=np.int32),
+            max_num_scheduled_tokens=1,
+            use_cascade_attn=False,
+        )
+
+        self.assertEqual(cudagraph_mode, CUDAGraphMode.NONE)
+        self.assertEqual(batch_descriptor, BatchDescriptor(num_tokens=2))
+        runner.cudagraph_dispatcher.dispatch.assert_not_called()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -265,6 +265,7 @@ class AscendCompilationConfig:
         fuse_norm_quant: bool = True,
         fuse_qknorm_rope: bool = True,
         fuse_allreduce_rms: bool = False,
+        prefill_use_eager: bool = False,
         **kwargs,
     ):
         """
@@ -289,6 +290,11 @@ class AscendCompilationConfig:
                 Default: True
             fuse_allreduce_rms (bool): Whether to enable allreduce and addrmsnorm fusion optimization.
                 Default: False
+            prefill_use_eager (bool): Whether to bypass ACL graph dispatch for
+                batches that still contain prefill requests. This is useful
+                when `cudagraph_mode=FULL_DECODE_ONLY` is enabled but prefill
+                batches with `query_len == 1` should stay in eager mode.
+                Default: False
             **kwargs: Additional optional parameters for forward compatibility and configuration extension.
         """
         self.fuse_norm_quant = fuse_norm_quant
@@ -296,6 +302,7 @@ class AscendCompilationConfig:
         self.fuse_allreduce_rms = fuse_allreduce_rms
         self.enable_npugraph_ex = enable_npugraph_ex
         self.enable_static_kernel = enable_static_kernel
+        self.prefill_use_eager = prefill_use_eager
         self.fuse_muls_add = kwargs.get("fuse_muls_add", True)
         if self.enable_static_kernel:
             assert self.enable_npugraph_ex, "Static kernel generation requires npugraph_ex to be enabled."

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1811,6 +1811,7 @@ class NPUModelRunner(GPUModelRunner):
     ) -> tuple[CUDAGraphMode, BatchDescriptor, bool, torch.Tensor | None, CUDAGraphStat | None]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+        force_eager_prefill = self.ascend_config.ascend_compilation_config.prefill_use_eager and not is_all_decode
         uniform_decode = (
             (
                 (is_all_decode if self.speculative_config else True)
@@ -1827,7 +1828,7 @@ class NPUModelRunner(GPUModelRunner):
 
         # ruff: noqa: E731
         def dispatch_cudagraph(num_tokens, disable_full=False, valid_modes=None):
-            if force_eager:
+            if force_eager or force_eager_prefill:
                 return (CUDAGraphMode.NONE, BatchDescriptor(num_tokens_padded))
 
             if vllm_version_is("0.16.0"):


### PR DESCRIPTION
### What this PR does / why we need it?

This patch adds an Ascend-side `ascend_compilation_config.prefill_use_eager` switch so batches that still contain prefill requests can stay in eager mode even when decode ACL graph mode is enabled.

The immediate motivation is issue #6189: with `cudagraph_mode=FULL_DECODE_ONLY`, batches with `query_len == 1` can still be dispatched onto the decode ACL graph path although they are not pure decode batches. That makes it hard to keep prefill and decode on different runtime paths for latency-sensitive workloads such as Qwen3-Omni ASR.

This PR keeps the existing decode graph behavior unchanged and only bypasses ACL graph dispatch when:
- `ascend_compilation_config.prefill_use_eager=True`
- the current batch is not `all_decode`

It also adds unit coverage for:
- parsing the new additional-config knob
- model-runner dispatch behavior with and without eager-prefill enabled

Fixes #6189

### Does this PR introduce _any_ user-facing change?

Yes. Users can now set `additional_config={"ascend_compilation_config": {"prefill_use_eager": true}}` to keep prefill-containing batches in eager mode while preserving the existing decode ACL graph path.

### How was this patch tested?

- `ruff format vllm_ascend/ascend_config.py vllm_ascend/worker/model_runner_v1.py tests/ut/test_ascend_config.py tests/ut/worker/test_model_runner_v1.py`
- `ruff check vllm_ascend/ascend_config.py vllm_ascend/worker/model_runner_v1.py tests/ut/test_ascend_config.py tests/ut/worker/test_model_runner_v1.py`
- Added regression tests in:
  - `tests/ut/test_ascend_config.py`
  - `tests/ut/worker/test_model_runner_v1.py`
- Full local `pytest` execution was not possible in the current environment because `torch_npu` is not installed, so the new tests still need CI/NPU validation.

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
