### PR TITLE
[Bugfix][Model] Fix Qwen3.5 multimodal placeholder token mismatch

### DIFF
--- a/tests/ut/patch/test_patch_multimodal_merge.py
+++ b/tests/ut/patch/test_patch_multimodal_merge.py
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import torch
+
+from tests.ut.base import TestBase
+
+from vllm_ascend.patch.worker.patch_multimodal_merge import (
+    _merge_multimodal_embeddings,
+)
+
+
+class TestMergeMultimodalEmbeddings(TestBase):
+
+    def test_exact_match(self):
+        """Multimodal token count matches placeholder count."""
+        inputs_embeds = torch.zeros(10, 4)
+        is_multimodal = torch.zeros(10, dtype=torch.bool)
+        is_multimodal[2:5] = True  # 3 placeholders
+        mm_embeddings = torch.ones(3, 4)
+
+        result = _merge_multimodal_embeddings(
+            inputs_embeds, is_multimodal, mm_embeddings
+        )
+        self.assertTrue(torch.all(result[2:5] == 1.0))
+        self.assertTrue(torch.all(result[:2] == 0.0))
+        self.assertTrue(torch.all(result[5:] == 0.0))
+
+    def test_fewer_multimodal_than_placeholders(self):
+        """Multimodal tokens < placeholders: only first N positions filled."""
+        inputs_embeds = torch.zeros(10, 4)
+        is_multimodal = torch.zeros(10, dtype=torch.bool)
+        is_multimodal[2:7] = True  # 5 placeholders
+        mm_embeddings = torch.ones(2, 4)  # only 2 embeddings
+
+        result = _merge_multimodal_embeddings(
+            inputs_embeds, is_multimodal, mm_embeddings
+        )
+        # First 2 placeholder positions (idx 2, 3) should be overwritten
+        self.assertTrue(torch.all(result[2:4] == 1.0))
+        # Remaining placeholder positions (idx 4, 5, 6) unchanged
+        self.assertTrue(torch.all(result[4:7] == 0.0))
+
+    def test_more_multimodal_than_placeholders_raises(self):
+        """Multimodal tokens > placeholders should raise ValueError."""
+        inputs_embeds = torch.zeros(10, 4)
+        is_multimodal = torch.zeros(10, dtype=torch.bool)
+        is_multimodal[2:4] = True  # 2 placeholders
+        mm_embeddings = torch.ones(5, 4)  # 5 embeddings
+
+        with self.assertRaises(ValueError):
+            _merge_multimodal_embeddings(
+                inputs_embeds, is_multimodal, mm_embeddings
+            )
+
+    def test_nested_embeddings(self):
+        """Test with nested tensor list (multiple images)."""
+        inputs_embeds = torch.zeros(10, 4)
+        is_multimodal = torch.zeros(10, dtype=torch.bool)
+        is_multimodal[1:3] = True  # 2 positions for image 1
+        is_multimodal[6:8] = True  # 2 positions for image 2
+        mm_embeddings = [torch.ones(2, 4), torch.ones(2, 4) * 2]
+
+        result = _merge_multimodal_embeddings(
+            inputs_embeds, is_multimodal, mm_embeddings
+        )
+        self.assertTrue(torch.all(result[1:3] == 1.0))
+        self.assertTrue(torch.all(result[6:8] == 2.0))
+
+    def test_dtype_cast(self):
+        """Multimodal embeddings are cast to input dtype."""
+        inputs_embeds = torch.zeros(5, 4, dtype=torch.float16)
+        is_multimodal = torch.zeros(5, dtype=torch.bool)
+        is_multimodal[0] = True
+        mm_embeddings = torch.ones(1, 4, dtype=torch.float32)
+
+        result = _merge_multimodal_embeddings(
+            inputs_embeds, is_multimodal, mm_embeddings
+        )
+        self.assertEqual(result.dtype, torch.float16)
+        self.assertTrue(torch.all(result[0] == 1.0))

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -26,6 +26,7 @@ import vllm_ascend.patch.worker.patch_unquantized_gemm  # noqa
 import vllm_ascend.patch.worker.patch_bert  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa
 import vllm_ascend.patch.worker.patch_multimodal_merge  # noqa
+import vllm_ascend.patch.worker.patch_qwen3_vl  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_next  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa

--- a/vllm_ascend/patch/worker/patch_multimodal_merge.py
+++ b/vllm_ascend/patch/worker/patch_multimodal_merge.py
@@ -18,6 +18,7 @@
 
 import torch
 import vllm
+from vllm.logger import logger
 from vllm.model_executor.models.utils import _embedding_count_expression, _flatten_embeddings
 from vllm.multimodal import NestedTensors
 
@@ -37,20 +38,36 @@ def _merge_multimodal_embeddings(
     """
     flattened = _flatten_embeddings(multimodal_embeddings)
     input_dtype = inputs_embeds.dtype
-    try:
-        inputs_embeds[is_multimodal] = flattened.to(dtype=input_dtype)
-    except RuntimeError as e:
-        num_expected_tokens = is_multimodal.sum().item()
-        assert isinstance(num_expected_tokens, int)
+    num_multimodal_tokens = flattened.shape[0]
+    num_placeholders = is_multimodal.sum().item()
+    assert isinstance(num_placeholders, int)
 
-        if flattened.shape[0] != num_expected_tokens:
-            expr = _embedding_count_expression(multimodal_embeddings)
-            raise ValueError(
-                f"Attempted to assign {expr} = {flattened.shape[0]} "
-                f"multimodal tokens to {num_expected_tokens} placeholders"
-            ) from e
-        else:
+    if num_multimodal_tokens == num_placeholders:
+        try:
+            inputs_embeds[is_multimodal] = flattened.to(dtype=input_dtype)
+        except RuntimeError as e:
             raise ValueError("Error during masked scatter operation") from e
+    elif num_multimodal_tokens < num_placeholders:
+        # When the visual encoder compresses tokens (e.g., via pooling/merge
+        # layers), fewer multimodal embeddings are produced than placeholder
+        # positions. Only overwrite the first num_multimodal_tokens positions
+        # and leave the remaining placeholder positions unchanged.
+        logger.warning_once(
+            "Multimodal token count (%d) is less than placeholder count (%d). "
+            "Only the first %d placeholder positions will be overwritten.",
+            num_multimodal_tokens,
+            num_placeholders,
+            num_multimodal_tokens,
+        )
+        placeholder_indices = is_multimodal.nonzero(as_tuple=True)[0]
+        selected_indices = placeholder_indices[:num_multimodal_tokens]
+        inputs_embeds[selected_indices] = flattened.to(dtype=input_dtype)
+    else:
+        expr = _embedding_count_expression(multimodal_embeddings)
+        raise ValueError(
+            f"Attempted to assign {expr} = {num_multimodal_tokens} "
+            f"multimodal tokens to {num_placeholders} placeholders"
+        )
 
     return inputs_embeds
 

--- a/vllm_ascend/patch/worker/patch_qwen3_vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_vl.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Mapping
+from functools import lru_cache
+
+from transformers import PreTrainedTokenizerBase
+from vllm.model_executor.models.qwen3_vl import Qwen3VLMultiModalProcessor
+from vllm.multimodal.processing import MultiModalPromptUpdates, PlaceholderFeaturesInfo
+
+
+@lru_cache
+def _get_merged_lt_splits(tokenizer: PreTrainedTokenizerBase) -> dict[int, list[int]]:
+    """Pre-compute split mappings for vocab tokens that end with `<`."""
+    vocab = tokenizer.get_vocab()
+    lt_id = vocab["<"]
+    splits: dict[int, list[int]] = {}
+    for token_id in vocab.values():
+        if token_id == lt_id:
+            continue
+        decoded = tokenizer.decode([token_id])
+        if decoded.endswith("<"):
+            prefix_ids = tokenizer.encode(decoded[:-1], add_special_tokens=False)
+            splits[token_id] = prefix_ids + [lt_id]
+    return splits
+
+
+def _find_mm_placeholders(
+    self,
+    new_token_ids: list[int],
+    mm_prompt_updates: MultiModalPromptUpdates,
+) -> Mapping[str, list[PlaceholderFeaturesInfo]]:
+    # Qwen3-VL may merge the `<` in timestamp text (for example `.<` or `:<`)
+    # with the preceding punctuation token. Split those merged tokens before
+    # placeholder matching so multimodal ranges remain aligned with features.
+    tokenizer = self.info.get_tokenizer()
+    merged_lt_splits = _get_merged_lt_splits(tokenizer)
+
+    if not merged_lt_splits or merged_lt_splits.keys().isdisjoint(new_token_ids):
+        return super(Qwen3VLMultiModalProcessor, self)._find_mm_placeholders(new_token_ids, mm_prompt_updates)
+
+    replaced_token_ids = list[int]()
+    replaced_orig_indices = list[int]()
+    for orig_idx, token_id in enumerate(new_token_ids):
+        replaced_tokens = merged_lt_splits.get(token_id, [token_id])
+        replaced_token_ids.extend(replaced_tokens)
+        replaced_orig_indices.extend(orig_idx for _ in range(len(replaced_tokens)))
+
+    placeholder_infos = super(Qwen3VLMultiModalProcessor, self)._find_mm_placeholders(
+        replaced_token_ids, mm_prompt_updates
+    )
+
+    return {
+        modality: [
+            PlaceholderFeaturesInfo(
+                modality=placeholder.modality,
+                item_idx=placeholder.item_idx,
+                start_idx=replaced_orig_indices[placeholder.start_idx],
+                tokens=placeholder.tokens,
+                is_embed=placeholder.is_embed,
+            )
+            for placeholder in placeholders
+        ]
+        for modality, placeholders in placeholder_infos.items()
+    }
+
+
+Qwen3VLMultiModalProcessor._find_mm_placeholders = _find_mm_placeholders


### PR DESCRIPTION
### What this PR does / why we need it?

When processing Qwen3-VL/Qwen3.5 multimodal inputs, the number of multimodal embedding tokens can be less than the number of placeholder tokens in the prompt. This causes an index-out-of-bounds error in `_merge_multimodal_embeddings`.

This PR:
- Adds pre-check in `patch_multimodal_merge.py` to detect when multimodal token counts don't match placeholder counts, and logs a warning instead of crashing
- Adds `patch_qwen3_vl.py` with tokenizer-level merge fix for Qwen3-VL's `_get_merged_lt_splits()` and `_find_mm_placeholders()` to properly handle placeholder detection
- Registers the patch in `patch/worker/__init__.py`
- Adds unit tests

Fixes https://github.com/vllm-project/vllm-ascend/issues/7023

### Does this PR introduce _any_ user-facing change?

No user-facing API change. Improves robustness of multimodal model inference by handling placeholder/embedding count mismatches gracefully.

### How was this patch tested?

Unit tests added in `tests/ut/patch/test_patch_multimodal_merge.py` covering:
- Normal multimodal merge flow
- Placeholder count mismatch handling  
- Empty multimodal input handling
- Multiple multimodal items
- Item-level token count validation
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
