### PR TITLE
[WIP][PD] Implement multi-queue parallel KV cache transfer

### DIFF
--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -276,9 +276,146 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
             offset=test_req["offset"],
             tp_num_need_pulls=test_req["tp_num_need_pulls"],
             all_task_done=test_req["all_task_done"])
-        queued = self.thread.request_queue.get_nowait()
+        # Verify task is routed to the correct queue
+        remote_rank_key = ("localhost", 6666)
+        self.assertIn(remote_rank_key, self.thread.remote_rank_to_queue)
+        queue_id = self.thread.remote_rank_to_queue[remote_rank_key]
+        self.assertIn(queue_id, self.thread.task_queues)
+        queued = self.thread.task_queues[queue_id].get_nowait()
         self.assertEqual(queued["request_id"], "req1")
         self.assertEqual(queued["remote_host"], "localhost")
+
+    def test_add_request_routes_same_remote_rank_to_same_queue(self):
+        """Test that tasks with same remote_rank go to the same queue."""
+        # Add two requests for the same remote rank
+        self.thread.add_request(
+            request_id="req1",
+            local_block_ids=[1],
+            remote_block_ids=[1],
+            remote_engine_id="remote_engine",
+            remote_host="host1",
+            remote_handshake_port=1000,
+            offset=0,
+            tp_num_need_pulls=1,
+            all_task_done=False)
+        self.thread.add_request(
+            request_id="req2",
+            local_block_ids=[2],
+            remote_block_ids=[2],
+            remote_engine_id="remote_engine",
+            remote_host="host1",
+            remote_handshake_port=1000,
+            offset=0,
+            tp_num_need_pulls=1,
+            all_task_done=False)
+
+        # Both should go to the same queue
+        queue_id = self.thread.remote_rank_to_queue[("host1", 1000)]
+        self.assertEqual(self.thread.task_queues[queue_id].qsize(), 2)
+
+    def test_load_balancing_under_max_workers(self):
+        """Test that different remote_ranks get different queues when under max_workers."""
+        # Add requests for 3 different remote ranks
+        self.thread.add_request(
+            request_id="req1",
+            local_block_ids=[1],
+            remote_block_ids=[1],
+            remote_engine_id="remote_engine",
+            remote_host="host1",
+            remote_handshake_port=1000,
+            offset=0,
+            tp_num_need_pulls=1,
+            all_task_done=False)
+        self.thread.add_request(
+            request_id="req2",
+            local_block_ids=[2],
+            remote_block_ids=[2],
+            remote_engine_id="remote_engine",
+            remote_host="host2",
+            remote_handshake_port=2000,
+            offset=0,
+            tp_num_need_pulls=1,
+            all_task_done=False)
+        self.thread.add_request(
+            request_id="req3",
+            local_block_ids=[3],
+            remote_block_ids=[3],
+            remote_engine_id="remote_engine",
+            remote_host="host3",
+            remote_handshake_port=3000,
+            offset=0,
+            tp_num_need_pulls=1,
+            all_task_done=False)
+
+        # Each remote rank should get a different queue (load balancing)
+        queue_ids = [
+            self.thread.remote_rank_to_queue[("host1", 1000)],
+            self.thread.remote_rank_to_queue[("host2", 2000)],
+            self.thread.remote_rank_to_queue[("host3", 3000)],
+        ]
+        # All queue_ids should be unique
+        self.assertEqual(len(set(queue_ids)), 3)
+        # Each queue should have load 1
+        for qid in queue_ids:
+            self.assertEqual(self.thread.queue_loads[qid], 1)
+
+    def test_all_queues_pre_created(self):
+        """Test that all queues are pre-created in __init__."""
+        # All queues should be pre-created
+        self.assertEqual(len(self.thread.task_queues), self.thread.max_workers)
+        for i in range(self.thread.max_workers):
+            self.assertIn(i, self.thread.task_queues)
+            self.assertIsInstance(self.thread.task_queues[i], queue.Queue)
+        # queue_loads should be initialized to 0
+        self.assertEqual(len(self.thread.queue_loads), self.thread.max_workers)
+        for load in self.thread.queue_loads.values():
+            self.assertEqual(load, 0)
+
+    def test_load_balancing_exceeds_max_workers(self):
+        """Test load balancing when remote_ranks exceed max_workers."""
+        # Set a small max_workers for testing
+        self.thread.max_workers = 2
+        self.thread.task_queues = {i: queue.Queue() for i in range(2)}
+        self.thread.queue_loads = {i: 0 for i in range(2)}
+
+        # Add requests for 4 different remote ranks
+        for i in range(4):
+            self.thread.add_request(
+                request_id=f"req{i}",
+                local_block_ids=[i],
+                remote_block_ids=[i],
+                remote_engine_id="remote_engine",
+                remote_host=f"host{i}",
+                remote_handshake_port=1000 * (i + 1),
+                offset=0,
+                tp_num_need_pulls=1,
+                all_task_done=False)
+
+        # With load balancing: first 2 go to queue 0,1; next 2 go to queue 0,1 again
+        # Each queue should have 2 remote_ranks
+        self.assertEqual(self.thread.queue_loads[0], 2)
+        self.assertEqual(self.thread.queue_loads[1], 2)
+
+    def test_mapping_consistency(self):
+        """Test that same remote_rank always maps to same queue."""
+        # Add multiple requests for the same remote rank
+        for i in range(3):
+            self.thread.add_request(
+                request_id=f"req{i}",
+                local_block_ids=[i],
+                remote_block_ids=[i],
+                remote_engine_id="remote_engine",
+                remote_host="host1",
+                remote_handshake_port=1000,
+                offset=0,
+                tp_num_need_pulls=1,
+                all_task_done=False)
+
+        # All should map to the same queue
+        queue_id = self.thread.remote_rank_to_queue[("host1", 1000)]
+        self.assertEqual(self.thread.task_queues[queue_id].qsize(), 3)
+        # Load should still be 1 (one remote_rank mapped)
+        self.assertEqual(self.thread.queue_loads[queue_id], 1)
 
     @patch.object(KVCacheTaskTracker, 'get_and_clear_finished_requests')
     def test_get_finished_requests(self, mock_tracker):
@@ -371,7 +508,6 @@ class TestCoreFunctionality(unittest.TestCase):
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
             prefill_pp_layer_partition=None)
-        self.thread.request_queue = self.mock_queue
         self.test_req = {
             "request_id": "req1",
             "local_block_ids": [1, 2],
@@ -397,7 +533,7 @@ class TestCoreFunctionality(unittest.TestCase):
         mock_transfer.return_value = None
         mock_send.return_value = None
 
-        self.thread._handle_request(self.test_req)
+        self.thread._handle_request(self.test_req, self.mock_queue)
 
         mock_transfer.assert_called_once_with(self.test_req)
         mock_send.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
@@ -531,10 +667,25 @@ class TestMainThreadLoop(unittest.TestCase):
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
             prefill_pp_layer_partition=None)
-        self.thread.request_queue = queue.Queue()
 
-    @patch.object(KVCacheRecvingThread, '_handle_request')
-    def test_run_loop_normal(self, mock_handle):
+    @patch.object(KVCacheRecvingThread, '_worker_loop')
+    def test_run_starts_multiple_workers(self, mock_worker_loop):
+        """Test that run() starts multiple worker threads."""
+        mock_worker_loop.return_value = None
+
+        self.thread.run()
+
+        # Verify ready_event is set
+        self.assertTrue(self.thread.ready_event.is_set())
+
+        # Verify correct number of worker threads started
+        self.assertEqual(len(self.thread.workers), self.thread.max_workers)
+
+        # Verify worker_loop was called for each worker
+        self.assertEqual(mock_worker_loop.call_count, self.thread.max_workers)
+
+    def test_worker_loop_processes_tasks(self):
+        """Test that worker_loop processes tasks from its queue."""
         test_request = {
             "request_id": "req1",
             "local_block_ids": [1, 2],
@@ -548,16 +699,28 @@ class TestMainThreadLoop(unittest.TestCase):
             "all_task_done": False
         }
 
-        self.thread.request_queue.put(test_request)
-        self.thread.request_queue.put(None)
+        # Queue already pre-created in __init__, add a task to queue 0
+        queue_id = 0
+        self.thread.task_queues[queue_id].put(test_request)
+        # Add None to signal shutdown after processing the task
+        self.thread.task_queues[queue_id].put(None)
 
-        self.thread.start()
-        time.sleep(0.1)
-        self.thread.join(timeout=1.0)
+        with patch.object(self.thread, '_handle_request') as mock_handle:
+            self.thread._worker_loop(queue_id)
 
-        self.assertTrue(self.thread.ready_event.is_set())
-        mock_handle.assert_called_once_with(test_request)
-        self.assertTrue(self.thread.request_queue.empty())
+            # Verify task was processed
+            mock_handle.assert_called_once()
+            self.assertTrue(self.thread.task_queues[queue_id].empty())
+
+    def test_shutdown_sends_none_to_all_queues(self):
+        """Test that shutdown sends None to all queues."""
+        self.thread.shutdown()
+
+        # Verify each queue has a None signal
+        for qid, q in self.thread.task_queues.items():
+            self.assertEqual(q.qsize(), 1)
+            item = q.get_nowait()
+            self.assertIsNone(item)
 
 
 class MockVllmConfig:
@@ -574,6 +737,7 @@ class MockVllmConfig:
         self.parallel_config.data_parallel_size_local = 1
         self.parallel_config.pipeline_parallel_size = 1
         self.parallel_config.data_parallel_rank_local = 0
+        self.parallel_config.prefill_context_parallel_size = 1
         self.model_config.get_num_layers_by_block_type = MagicMock(
             return_value=32)
         self.cache_config.block_size = 16

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -378,9 +378,7 @@ class KVCacheRecvingThread(threading.Thread):
 
         # Pre-create all queues upfront to avoid synchronization overhead
         # Each worker thread handles one queue
-        self.task_queues: dict[int, queue.Queue[Any]] = {
-            i: queue.Queue() for i in range(self.max_workers)
-        }
+        self.task_queues: dict[int, queue.Queue[Any]] = {i: queue.Queue() for i in range(self.max_workers)}
         # (remote_host, remote_handshake_port) -> queue_id
         self.remote_rank_to_queue: dict[tuple[str, int], int] = {}
         # Track number of remote_ranks mapped to each queue for load balancing

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -11,7 +11,6 @@ import threading
 import time
 from collections import OrderedDict, defaultdict, deque
 from collections.abc import Iterator
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -334,9 +333,6 @@ class KVCacheRecvingThread(threading.Thread):
         # TODO(jianzs): find a better way to detect MLA.
         self.use_mla = len(block_len) == 2
 
-        self.request_queue: queue.Queue[Any] = queue.Queue()
-        self.executor = ThreadPoolExecutor(max_workers=32)
-
         self.task_tracker = KVCacheTaskTracker()
 
         self.encoder = msgspec.msgpack.Encoder()
@@ -369,6 +365,85 @@ class KVCacheRecvingThread(threading.Thread):
                 self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
         self.proc_not_transfer_request: dict[str, bool] = {}
 
+        # Multi-queue architecture for parallel KV transfer
+        # Default max_workers = prefill total ranks (tp * pp * dp * pcp)
+        default_max_workers = (
+            vllm_config.parallel_config.tensor_parallel_size
+            * vllm_config.parallel_config.pipeline_parallel_size
+            * vllm_config.parallel_config.data_parallel_size_local
+            * vllm_config.parallel_config.prefill_context_parallel_size
+        )
+        self.max_workers = int(os.getenv("VLLM_ASCEND_KV_RECV_WORKERS", default_max_workers))
+        logger.info("KVCacheRecvingThread max_workers: %d", self.max_workers)
+
+        # Pre-create all queues upfront to avoid synchronization overhead
+        # Each worker thread handles one queue
+        self.task_queues: dict[int, queue.Queue[Any]] = {
+            i: queue.Queue() for i in range(self.max_workers)
+        }
+        # (remote_host, remote_handshake_port) -> queue_id
+        self.remote_rank_to_queue: dict[tuple[str, int], int] = {}
+        # Track number of remote_ranks mapped to each queue for load balancing
+        self.queue_loads: dict[int, int] = {i: 0 for i in range(self.max_workers)}
+        self.remote_rank_lock = threading.Lock()
+
+        # Worker threads
+        self.workers: list[threading.Thread] = []
+
+    def shutdown(self):
+        """Shutdown all worker threads gracefully.
+
+        Sends None to each queue as a shutdown signal.
+        Workers will exit after processing pending tasks.
+        """
+        for q in self.task_queues.values():
+            q.put(None)
+
+    def _get_or_create_queue_id(self, remote_host: str, remote_handshake_port: int) -> int:
+        """Get the queue ID for a given remote rank using load balancing.
+
+        Strategy:
+        - All queues are pre-created in __init__
+        - New remote_rank is assigned to the queue with the lowest load
+        - This ensures: when remote_ranks < max_workers, each gets its own queue
+        - When remote_ranks >= max_workers, load is balanced across queues
+
+        Args:
+            remote_host: The remote host address
+            remote_handshake_port: The remote handshake port
+
+        Returns:
+            The queue_id that should handle tasks for this remote_rank
+        """
+        remote_rank_key = (remote_host, remote_handshake_port)
+
+        # Fast path: already mapped
+        if remote_rank_key in self.remote_rank_to_queue:
+            return self.remote_rank_to_queue[remote_rank_key]
+
+        with self.remote_rank_lock:
+            # Double check after acquiring lock
+            if remote_rank_key in self.remote_rank_to_queue:
+                return self.remote_rank_to_queue[remote_rank_key]
+
+            # Find the queue with minimum load
+            min_load = min(self.queue_loads.values())
+            candidates = [qid for qid, load in self.queue_loads.items() if load == min_load]
+            # Choose the first candidate (smallest queue_id among ties)
+            queue_id = candidates[0]
+
+            # Update mapping and load
+            self.remote_rank_to_queue[remote_rank_key] = queue_id
+            self.queue_loads[queue_id] += 1
+            logger.debug(
+                "Mapped remote rank %s:%d to queue %d (load: %d)",
+                remote_host,
+                remote_handshake_port,
+                queue_id,
+                self.queue_loads[queue_id],
+            )
+            return queue_id
+
     def add_request(
         self,
         request_id: str,
@@ -383,25 +458,36 @@ class KVCacheRecvingThread(threading.Thread):
         remote_port_send_num: dict[int, RemotePortInfo] | None = None,
         all_task_done: bool = False,
     ):
-        """Add a new request to the queue for processing."""
+        """Add a new request to the appropriate queue for processing.
+
+        Tasks are routed to queues based on (remote_host, remote_handshake_port).
+        Same remote rank tasks go to the same queue (serial execution).
+        Different remote rank tasks go to different queues (parallel execution).
+        """
         if remote_port_send_num is None:
             remote_port_send_num = {}
-        logger.debug(f"Adding request {request_id} to the queue.")
-        self.request_queue.put(
-            {
-                "request_id": request_id,
-                "local_block_ids": local_block_ids,
-                "remote_block_ids": remote_block_ids,
-                "remote_engine_id": remote_engine_id,
-                "remote_request_id": remote_request_id,
-                "remote_host": remote_host,
-                "remote_handshake_port": remote_handshake_port,
-                "offset": offset,
-                "tp_num_need_pulls": tp_num_need_pulls,
-                "remote_port_send_num": remote_port_send_num,
-                "all_task_done": all_task_done,
-            }
+        logger.debug(
+            "Adding request %s to queue for remote rank %s:%d",
+            request_id,
+            remote_host,
+            remote_handshake_port,
         )
+
+        queue_id = self._get_or_create_queue_id(remote_host, remote_handshake_port)
+        task_data = {
+            "request_id": request_id,
+            "local_block_ids": local_block_ids,
+            "remote_block_ids": remote_block_ids,
+            "remote_engine_id": remote_engine_id,
+            "remote_request_id": remote_request_id,
+            "remote_host": remote_host,
+            "remote_handshake_port": remote_handshake_port,
+            "offset": offset,
+            "tp_num_need_pulls": tp_num_need_pulls,
+            "remote_port_send_num": remote_port_send_num,
+            "all_task_done": all_task_done,
+        }
+        self.task_queues[queue_id].put(task_data)
 
     def get_and_clear_finished_requests(self) -> set[str]:
         """
@@ -412,20 +498,58 @@ class KVCacheRecvingThread(threading.Thread):
         return self.task_tracker.get_and_clear_finished_requests()
 
     def run(self):
-        """Run the thread to handle KV cache transfer requests."""
-        self.ready_event.set()
-        while True:
-            try:
-                request_data = self.request_queue.get()
-                if request_data is None:
-                    logger.warning("Received a None request!")
-                    self.request_queue.task_done()
-                    continue
-                self._handle_request(request_data)
-            except Exception as e:
-                logger.error(f"Error in KVCacheTransferThread: {e}")
+        """Run the thread to start all worker threads for KV cache transfer.
 
-    def _handle_request(self, req_meta: dict[str, Any]):
+        Each worker thread handles one queue. Tasks in the same queue are
+        processed serially (same remote rank), while different queues are
+        processed in parallel (different remote ranks).
+        """
+        self.ready_event.set()
+
+        # Start worker threads
+        for i in range(self.max_workers):
+            worker = threading.Thread(
+                target=self._worker_loop,
+                args=(i,),
+                daemon=True,
+                name=f"KVCacheRecvWorker-{i}",
+            )
+            worker.start()
+            self.workers.append(worker)
+
+        logger.info(
+            "Started %d KV cache receive workers for parallel transfer",
+            self.max_workers,
+        )
+
+    def _worker_loop(self, queue_id: int):
+        """Worker loop for processing tasks from a specific queue.
+
+        Args:
+            queue_id: The ID of the queue this worker is responsible for.
+
+        Note:
+            All queues are pre-created in __init__, so this worker can
+            immediately start processing tasks from its assigned queue.
+            Worker blocks indefinitely on q.get() until a task arrives,
+            achieving zero CPU overhead when idle.
+            Worker exits when it receives None as a shutdown signal.
+        """
+        q = self.task_queues[queue_id]
+        while True:
+            request_data = q.get()  # Block indefinitely, no timeout
+
+            if request_data is None:
+                # None is the shutdown signal
+                q.task_done()
+                break
+
+            try:
+                self._handle_request(request_data, q)
+            except Exception as e:
+                logger.error("Worker %d error: %s", queue_id, e, exc_info=True)
+
+    def _handle_request(self, req_meta: dict[str, Any], q: queue.Queue):
         request_id = req_meta["request_id"]
         remote_request_id = req_meta["remote_request_id"]
         remote_host = req_meta["remote_host"]
@@ -446,7 +570,7 @@ class KVCacheRecvingThread(threading.Thread):
                     self.task_tracker.update_done_task_count(request_id)
                 if request_id in self.proc_not_transfer_request:
                     del self.proc_not_transfer_request[request_id]
-            self.request_queue.task_done()
+            q.task_done()
             # Always send the done signal to the remote host to ensure proper
             # resource cleanup. Failing to do so may cause a memory leak on the
             # remote host.


### PR DESCRIPTION
### What this PR does / why we need it?
## Summary    
                                                                                                                                      
This PR implements a multi-queue architecture for KVCacheRecvingThread to enable parallel KV cache transfer across different remote ranks, significantly improving transfer throughput in PD disaggregation scenarios. 

 ## Background

In the original design, all KV cache transfer tasks were queued in a single queue and processed by a single worker thread sequentially. This design couldn't leverage the parallelism between different remote ranks, resulting in suboptimal transfer throughput.

## Before
Single Queue Architecture, all tasks processed one by one, regardless of remote rank. Tasks targeting different remote ranks could be processed in parallel, but the single-queue design forces sequential execution.

## After: Multi-Queue Architecture

  RP = Remote Rank (identified by remote_host:remote_handshake_port)
  ✓ Same RP tasks: Serial execution (same queue)
  ✓ Different RP tasks: Parallel execution (different queues)


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
