### PR TITLE
[Bugfix] Fix server start failure when long weight loading

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -76,6 +76,7 @@ jobs:
       UV_INDEX_STRATEGY: unsafe-best-match
       UV_NO_CACHE: 1
       UV_SYSTEM_PYTHON: 1
+      VLLM_ENGINE_READY_TIMEOUT_S: 1800
     steps:
       - name: Check npu and CANN info
         run: |


### PR DESCRIPTION
### What this PR does / why we need it?
When loading large models (e.g., 163 shards), weight loading can exceed the default 600s timeout. Engine startup timeout with the error:
```shell
TimeoutError: Timed out waiting for engines to send initial message on input socket.
```
We should increase the `VLLM_ENGINE_READY_TIMEOUT_S ` to avoid it
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
