### PR TITLE
[CI] Fix ds32 EP and dual nodes nightly run params

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/multi_node_config.py
+++ b/tests/e2e/nightly/multi_node/scripts/multi_node_config.py
@@ -182,13 +182,15 @@ class MultiNodeConfig:
         npu_per_node: int,
         envs: dict,
         disaggregated_prefill: dict | None,
-        benchmark_cases: list[dict],
+        perf_cmd: dict[str, Any] | None,
+        acc_cmd: dict[str, Any] | None,
     ):
         self.model = model
         self.test_name = test_name
         self.nodes = nodes
         self.npu_per_node = npu_per_node
-        self.benchmark_cases = benchmark_cases
+        self.perf_cmd = perf_cmd
+        self.acc_cmd = acc_cmd
 
         self.cur_index = self._resolve_cur_index()
         self.cur_node = self.nodes[self.cur_index]
@@ -279,7 +281,8 @@ class MultiNodeConfigLoader:
             npu_per_node=config.get("npu_per_node", 16),
             envs=config.get("env_common", {}),
             disaggregated_prefill=config.get("disaggregated_prefill"),
-            benchmark_cases=list(benchmarks.values()),
+            perf_cmd=benchmarks.get("perf"),
+            acc_cmd=benchmarks.get("acc"),
         )
 
     @classmethod
@@ -332,8 +335,6 @@ class MultiNodeConfigLoader:
     @staticmethod
     def _parse_benchmarks(cfg: dict) -> dict:
         benchmarks = cfg.get("benchmarks") or {}
-        for name, case in benchmarks.items():
-            case["case_name"] = name
         return benchmarks
 
     @staticmethod

--- a/tests/e2e/nightly/multi_node/scripts/test_multi_node.py
+++ b/tests/e2e/nightly/multi_node/scripts/test_multi_node.py
@@ -290,7 +290,7 @@ async def test_multi_node() -> None:
                 results = run_aisbench_cases(
                     model=config.model,
                     port=port,
-                    aisbench_cases=config.benchmark_cases,
+                    aisbench_cases=aisbench_cases,
                     host_ip=host,
                 )
                 _save_benchmark_results_json(config, results)

--- a/tools/aisbench.py
+++ b/tools/aisbench.py
@@ -103,7 +103,7 @@ class AisbenchRunner:
     def _init_dataset_conf(self):
         if self.task_type == "accuracy":
             dataset_name = os.path.basename(self.dataset_path)
-            dataset_rename = self.DATASET_RENAME.get(dataset_name, dataset_name)
+            dataset_rename = self.DATASET_RENAME.get(dataset_name, "")
             dst_dir = os.path.join(DATASET_DIR, dataset_rename)
             command = ["cp", "-r", self.dataset_path, dst_dir]
             subprocess.call(command)
@@ -226,25 +226,15 @@ class AisbenchRunner:
 def run_aisbench_cases(model, port, aisbench_cases, server_args="", host_ip="localhost"):
     aisbench_results = []
     aisbench_errors = []
-    total = sum(1 for c in aisbench_cases if c)
-    idx = 0
     for aisbench_case in aisbench_cases:
         if not aisbench_case:
             continue
-        idx += 1
-        case_name = aisbench_case.get("case_name", "unknown")
-        case_type = aisbench_case.get("case_type", "unknown")
-        logging.info("=" * 60)
-        logging.info("[%d/%d] Starting benchmark: %s (type=%s)", idx, total, case_name, case_type)
-        logging.info("=" * 60)
         try:
             with AisbenchRunner(model=model, port=port, host_ip=host_ip, aisbench_config=aisbench_case) as aisbench:
                 aisbench_results.append(aisbench.result)
-            logging.info("[%d/%d] Finished benchmark: %s", idx, total, case_name)
         except Exception as e:
             aisbench_results.append("")
             aisbench_errors.append([aisbench_case, e])
-            logging.error("[%d/%d] Benchmark failed: %s, reason: %s", idx, total, case_name, e)
             print(e)
     for failed_case, error_info in aisbench_errors:
         error_msg = f"The following aisbench case failed: {failed_case}, reason is {error_info}"
@@ -295,27 +285,15 @@ def maybe_download_from_modelscope(
     # downloading the same model weights at the same time.
     with get_lock(model, download_dir):
         if not os.path.exists(model):
-            kwargs = dict(
+            model_path = snapshot_download(
                 model_id=model,
                 repo_type=repo_type,
                 cache_dir=download_dir,
+                local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
                 revision=revision,
                 ignore_file_pattern=ignore_patterns,
                 allow_patterns=allow_patterns,
             )
-            if huggingface_hub.constants.HF_HUB_OFFLINE:
-                # Try local cache first; if not found, fall back to download.
-                try:
-                    model_path = snapshot_download(**kwargs, local_files_only=True)
-                except Exception:
-                    logging.warning(
-                        "HF_HUB_OFFLINE is set but '%s' was not found in local cache. "
-                        "Falling back to online download.",
-                        model,
-                    )
-                    model_path = snapshot_download(**kwargs, local_files_only=False)
-            else:
-                model_path = snapshot_download(**kwargs, local_files_only=False)
         else:
             model_path = model
     return model_path


### PR DESCRIPTION
### What this PR does / why we need it?

The nightly configs for DeepSeek-V3_2-W8A8-EP and DeepSeek-V3_2-W8A8-A3-dual-nodes are updated with corrected run parameters and baselines based on actual test results:

- HCCL_BUFFSIZE: 1024 → 256
- --max-num-batched-tokens: 16384 → 32560
- --max-model-len: 68000 → 90000 (A3 dual-node config)
- --gpu-memory-utilization: 0.95 → 0.90 (P/D decode configs)
- batch_size and baseline values corrected for perf_short and accuracy cases
- EP config split perf into perf_short_warmup, perf_long_warmup, perf_short, perf_long for more granular measurement

The aime2025 case will be moved to a separate YAML config file.

### Does this PR introduce _any_ user-facing change?

No. All changes are internal to the nightly CI test infrastructure and tooling. No public API, documentation, or runtime behavior is affected.

### How was this patch tested?

have tested here https://github.com/vllm-project/vllm-ascend/actions/runs/23786978617/job/69312680849?pr=7119
https://github.com/vllm-project/vllm-ascend/actions/runs/24222505363/job/70716884885?pr=7119

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d