### PR TITLE
[Misc] Download on both hk and guiyang region

### DIFF
--- a/.github/workflows/labled_download_model.yaml
+++ b/.github/workflows/labled_download_model.yaml
@@ -19,7 +19,10 @@ jobs:
   download-models:
     if: contains(github.event.pull_request.labels.*.name, 'model-download')
     name: Download models from ModelScope
-    runs-on: linux-aarch64-a2b3-0
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [linux-aarch64-a2b3-0, linux-aarch64-a3-0]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-cpu
 

--- a/.github/workflows/misc/model_list.json
+++ b/.github/workflows/misc/model_list.json
@@ -144,7 +144,6 @@
       "mistralai/Mistral-7B-Instruct-v0.1",
       "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
       "mlx-community/DeepSeek-V3-3bit-bf16",
-      "moonshotai/..__temp",
       "moonshotai/Kimi-K2-Thinking",
       "moonshotai/Kimi-Linear-48B-A3B-Instruct",
       "neuralmagic/Qwen2.5-3B-quantized.w8a8",


### PR DESCRIPTION
### What this PR does / why we need it?
Since the PVC files for Guiyang and Hong Kong are not shared, we need to trigger the download of both regions simultaneously when downloading the model to ensure that the models in all regions are synchronized.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
