### PR TITLE
Add Qwen3_5 to model list

### DIFF
--- a/.github/workflows/misc/model_list.json
+++ b/.github/workflows/misc/model_list.json
@@ -102,6 +102,8 @@
       "Qwen/Qwen3-VL-30B-A3B-Instruct",
       "Qwen/Qwen3-VL-32B-Instruct",
       "Qwen/Qwen3-VL-8B-Instruct",
+      "Qwen/Qwen3.5-27B",
+      "Qwen/Qwen3.5-35B-A3B",
       "RedHatAI/Qwen3-32B-speculator.eagle3",
       "RedHatAI/Qwen3-8B-speculator.eagle3",
       "Shanghai_AI_Laboratory/internlm--chat-7b",


### PR DESCRIPTION
### What this PR does / why we need it?
The pr aims to add new models like Qwen3.5-35B-A3B/Qwen3.5-27B to model list for testing.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
