### PR TITLE
[Bugfix][v0.16.0] fallback to profile preifx to empty str when running on v0.16.0

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -58,6 +58,7 @@ from vllm_ascend.utils import (
     enable_sp,
     get_ascend_device_type,
     register_ascend_customop,
+    vllm_version_is,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
@@ -526,10 +527,13 @@ class NPUWorker(WorkerBase):
             )
 
         if is_start:
-            from vllm.distributed.utils import get_worker_rank_suffix
+            if vllm_version_is("0.16.0"):
+                trace_name = ""
+            else:
+                from vllm.distributed.utils import get_worker_rank_suffix
 
-            rank_suffix = get_worker_rank_suffix(global_rank=self.rank)
-            trace_name = f"{profile_prefix}_{rank_suffix}" if profile_prefix else rank_suffix
+                rank_suffix = get_worker_rank_suffix(global_rank=self.rank)
+                trace_name = f"{profile_prefix}_{rank_suffix}" if profile_prefix else rank_suffix
 
             if self.profiler is None:
                 self.profiler = self._create_profiler(trace_name)


### PR DESCRIPTION
### What this PR does / why we need it?
- https://github.com/vllm-project/vllm-ascend/pull/6968 support `profile_prefix` in profile, which will call `get_worker_rank_suffix` from vllm：https://github.com/vllm-project/vllm-ascend/issues/7124
- However, vLLM v0.16.0 does not have `get_worker_rank_suffix` in `vllm.distributed.utils`
- Skip  `get_worker_rank_suffix` and fallback prefix to empty str when running on v0.16.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
import time

from vllm import LLM, SamplingParams

prompts = ["Hello, my name is", "The future of AI is"]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)

def main():
    llm = LLM(
        model="Qwen/Qwen3-0.6B",
        trust_remote_code=True,
        quantization="ascend",
        max_model_len=256,
        gpu_memory_utilization=0.3,  # Reduce for shared NPU
        profiler_config={
            "profiler": "torch",
            "torch_profiler_dir": "./vllm_profile_offline",
        },
    )

    # Test profile_prefix (upstream Python API supports this)
    llm.start_profile()

    outputs = llm.generate(prompts, sampling_params)

    llm.stop_profile()

if __name__ == "__main__":
    main()
```
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
