### PR TITLE
[310P][Bugfix]: fix ngram graph replay accuracy error

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -582,10 +582,10 @@ class NPUModelRunner(GPUModelRunner):
                 ],
                 dtype=np.int32,
             )
-        self._build_attn_state(num_reqs, num_scheduled_tokens, num_valid_tokens)
+        attn_state = self._build_attn_state(num_reqs, num_scheduled_tokens, num_valid_tokens)
 
         # Determine if it's a splitfuse batch
-        with_prefill = self.attn_state not in [AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding]
+        with_prefill = attn_state not in [AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding]
         self.with_prefill = with_prefill
 
         # Get positions.
@@ -857,6 +857,8 @@ class NPUModelRunner(GPUModelRunner):
             self.attn_state = AscendAttentionState.ChunkedPrefill  # type: ignore
         else:
             self.attn_state = attn_state  # type: ignore
+
+        return attn_state
 
     def _calc_spec_decode_metadata(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?
On the 310P device, when running ACLGraph together with the n-gram speculative decoding algorithm, both graph capture and graph replay require `uniform_decode_query_len` and do not depend on `attention_state`. This leads to a rather interesting and unexpected issue on 310P: during decode-only, execution does **not** enter the graph, while in the split-fuse state (that is, the chunked prefill state), it instead enters graph execution directly.

The issue can be resolved by forcibly setting `uniform_decode_query_len` to `1`, so that 310P captures only the decode-only graph, and replay is then controlled through `attention_state`.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
本地测试+profiling验证

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
