### PR TITLE
[Bugfix] Fixed permission issues with the automatic PR submission workflow

### DIFF
--- a/.github/workflows/schedule_update_estimated_time.yaml
+++ b/.github/workflows/schedule_update_estimated_time.yaml
@@ -47,7 +47,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ env.FORK_OWNER }}/vllm-ascend
-          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download all timing artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### What this PR does / why we need it?
Auto submit a pull request via https://github.com/vllm-ascend-ci/vllm-ascend, the workflow looks like:
1. get a new config.yaml via run e2e tests
2. push the changed `config.yaml` to a new branch of https://github.com/vllm-ascend-ci/vllm-ascend
3. submit a pull request to vllm-ascend via gh cli
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
