### PR TITLE
fix(metrics): ensure num_computed_tokens is monotonic to prevent nega…

### DIFF
--- a/vllm_ascend/core/scheduler.py
+++ b/vllm_ascend/core/scheduler.py
@@ -469,6 +469,8 @@ class AscendScheduler(Scheduler):
         scheduler_output: SchedulerOutput,
         model_runner_output: ModelRunnerOutput,
     ) -> EngineCoreOutputs:
+        prev_num_computed = {req.request_id: req.num_computed_tokens
+                             for req in self.running}
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
 
         # NOTE(woosuk): As len(self.running) can be up to 1K or more, the below
@@ -483,5 +485,10 @@ class AscendScheduler(Scheduler):
             if req_id in self.scheduled_req_ids:
                 self.scheduled_req_ids.remove(req_id)
 
-        return super().update_from_output(scheduler_output,
-                                          model_runner_output)
+        result = super().update_from_output(scheduler_output,
+                                            model_runner_output)
+        for request in self.running:
+            prev = prev_num_computed.get(request.request_id)
+            if prev is not None and request.num_computed_tokens < prev:
+                request.num_computed_tokens = prev
+        return result


### PR DESCRIPTION
…tive counter increments

The AsyncLLM output_handler fails when Prometheus counters are incremented by negative amounts. This can happen if num_computed_tokens decreases between iterations (e.g., due to speculative decoding rejection or prefix cache adjustments). This commit ensures num_computed_tokens is monotonic in AscendScheduler.update_from_output to prevent such crashes.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
