### PR TITLE
Revert "[CI] fix skiped e2e test when upgrade vllm version  (#6654)"

### DIFF
--- a/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
+++ b/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
@@ -129,6 +129,7 @@ def _run_worker_process(
         torch.npu.reset_peak_memory_stats()
 
 
+@pytest.mark.skip(reason="fix me")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [4, 36])
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})


### PR DESCRIPTION
This reverts commit f6db47f1038cf14d6c6f7eb4780be3c839c7656b.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
