### PR TITLE
[Bugfix] Support ModelSlim variant config filenames

### DIFF
--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -53,7 +53,11 @@ class TestAscendModelSlimConfig(TestBase):
 
     def test_get_config_filenames(self):
         filenames = AscendModelSlimConfig.get_config_filenames()
-        self.assertEqual(filenames, ["quant_model_description.json"])
+        # base name should always come first
+        self.assertEqual(filenames[0], "quant_model_description.json")
+        # make sure the w8a8 dynamic one is in the list (fixes #6931)
+        self.assertIn("quant_model_description_w8a8_dynamic.json", filenames)
+        self.assertTrue(len(filenames) >= 2)
 
     def test_from_config(self):
         config = AscendModelSlimConfig.from_config(self.sample_config)

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -450,7 +450,17 @@ class AscendModelSlimConfig(QuantizationConfig):
 
     @classmethod
     def get_config_filenames(cls) -> list[str]:
-        return ["quant_model_description.json"]
+        # ModelSlim uses different config filenames for each quant method
+        # (e.g. w8a8_dynamic, w4a16, etc.), so we need to check all of them.
+        return [
+            "quant_model_description.json",
+            "quant_model_description_w8a8_dynamic.json",
+            "quant_model_description_w8a8.json",
+            "quant_model_description_w4a8.json",
+            "quant_model_description_w8a8sc.json",
+            "quant_model_description_w4a16.json",
+            "quant_model_description_w8a16.json",
+        ]
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "AscendModelSlimConfig":


### PR DESCRIPTION
## Summary

- `AscendModelSlimConfig.get_config_filenames()` previously only returned `["quant_model_description.json"]`, but ModelSlim generates different config filenames depending on the quantization method (e.g. `quant_model_description_w8a8_dynamic.json` for W8A8 dynamic). This caused a "Cannot find the config file for ascend" error when loading those models.
- Expanded the return list to include all known ModelSlim config filename variants (`w8a8_dynamic`, `w8a8`, `w4a8`, `w8a8sc`, `w4a16`, `w8a16`), following the same multi-filename pattern that AWQ and other vLLM quantization configs already use.
- Updated the unit test to verify the new behavior.

Closes #6931

## Test plan

- [x] Verified Python syntax for both modified files
- [x] Simulated the test assertions locally (all 6 checks pass)
- [x] Confirmed the approach matches vLLM's established pattern (AWQ returns multiple filenames too)
- [ ] Run `pytest tests/ut/quantization/test_modelslim_config.py` in CI
- [ ] Verify on Ascend hardware with a ModelSlim w8a8 quantized model (e.g. deepseek-r1-0528-w8a8)