### PR TITLE
[Docs][310P] Clarify supported image versions

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -194,6 +194,8 @@ Supported images as following.
 | vllm-ascend:<image-tag>-310p | Atlas 300I | Ubuntu |
 | vllm-ascend:<image-tag>-310p-openeuler | Atlas 300I | openEuler |
 
+Atlas 300I image support is available from `v0.14.0rc1-310p` onward. If you need 310P MoE, W8A8, or weightNZ support, use `v0.15.0rc1-310p` or later.
+
 :::{dropdown} Click here to see "Build from Dockerfile"
 or build IMAGE from **source code**:
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -3,6 +3,7 @@
 ```{note}
 1. This Atlas 300I series is currently experimental. In future versions, there may be behavioral changes related to model coverage and performance improvement.
 2. Currently, the 310I series only supports eager mode and the float16 data type.
+3. Docker images for Atlas 300I support are available from `v0.14.0rc1-310p` onward. MoE, W8A8, and weightNZ support require `v0.15.0rc1-310p` or later.
 ```
 
 ## Run vLLM on Atlas 300I Series
@@ -12,7 +13,7 @@ Run docker container:
 ```{code-block} bash
    :substitutions:
 # Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:v0.10.0rc1-310p
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
 docker run --rm \
 --name vllm-ascend \
 --shm-size=1g \
@@ -36,6 +37,8 @@ docker run --rm \
 -p 8000:8000 \
 -it $IMAGE bash
 ```
+
+If you need the minimum supported 310P image explicitly, start from `quay.io/ascend/vllm-ascend:v0.14.0rc1-310p`. For newer 310P features such as MoE, W8A8, and weightNZ, use `v0.15.0rc1-310p` or later.
 
 Set up environment variables:
 


### PR DESCRIPTION
## Summary`n- document the minimum Docker image version that supports Atlas 300I (310P)`n- clarify that MoE, W8A8, and weightNZ features require newer 310P images`n- replace the stale hard-coded 310P image tag in the hardware tutorial`n`nCloses #6309
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
