### PR TITLE
[Docs][Mooncake] Clarify global_segment_size guidance

### DIFF
--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -197,7 +197,11 @@ The template for the mooncake.json file is as follows:
 | protocol              | ascend              | Ascend proprietary protocol    |
 | use_ascend_direct     | true                | Enable direct hardware access  |
 | master_server_address | 90.90.100.188:50088(for example) | Master server address|
-| global_segment_size   | 107374182400    | Size per segment (100 GB)      |
+| global_segment_size   | 107374182400    | Size per segment (100 GB). If Mooncake initialization is unstable in your environment, lower this value first.      |
+
+:::{note}
+`global_segment_size` affects the amount of memory registered to Mooncake per card. Oversized values may trigger intermittent initialization failures on some environments. If you hit initialization issues, lower `global_segment_size` first and tune upward gradually.
+:::
 
 ## vLLM Instance Deployment
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -114,7 +114,7 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
 **protocol:** Must be set to 'Ascend' on the NPU.
 **device_name**: ""
 **master_server_address**: Configured with the IP and port of the master service.  
-**global_segment_size**: Registered memory size per card to the KV Pool.
+**global_segment_size**: Registered memory size per card to the KV Pool. Start with a conservative value such as `1GB` and increase it gradually only if needed. If Mooncake initialization fails intermittently, reduce `global_segment_size` first and retry.
 
 #### 2.Start mooncake_master
 


### PR DESCRIPTION
## Summary`n- clarify what `global_segment_size` controls in Mooncake configuration`n- document that oversized values can make initialization unstable in some environments`n- add a simple workaround: lower the value first and tune upward gradually`n`nCloses #4795
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
