### PR TITLE
[Docs][Models] Replace stale NPU allocator examples

### DIFF
--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -104,12 +104,12 @@ Setup environment variables:
 # Load model from ModelScope to speed up download
 export VLLM_USE_MODELSCOPE=True
 
-# Set `max_split_size_mb` to reduce memory fragmentation and avoid out of memory
-export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256
+# Use virtual memory to reduce fragmentation under long-running workloads
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 ```
 
 :::{note}
-`max_split_size_mb` prevents the native allocator from splitting blocks larger than this size (in MB). This can reduce fragmentation and may allow some borderline workloads to complete without running out of memory. You can find more details [<u>here</u>](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/800alpha003/apiref/envref/envref_07_0061.html).
+`expandable_segments:True` enables the virtual memory mode recommended by current vLLM Ascend docs to reduce fragmentation during long-running multimodal workloads. You can find more details [<u>here</u>](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/800alpha003/apiref/envref/envref_07_0061.html).
 :::
 
 ## Deployment

--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -37,8 +37,8 @@ Set up environment variables:
 # Load model from ModelScope to speed up download
 export VLLM_USE_MODELSCOPE=True
 
-# Set `max_split_size_mb` to reduce memory fragmentation and avoid out of memory
-export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256
+# Use virtual memory to reduce fragmentation under long-running workloads
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 ```
 
 ### Online Inference on Multi-NPU

--- a/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
@@ -61,12 +61,12 @@ Setup environment variables:
 # Load model from ModelScope to speed up download
 export VLLM_USE_MODELSCOPE=True
 
-# Set `max_split_size_mb` to reduce memory fragmentation and avoid out of memory
-export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256
+# Use virtual memory to reduce fragmentation under long-running workloads
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 ```
 
 :::{note}
-`max_split_size_mb` prevents the native allocator from splitting blocks larger than this size (in MB). This can reduce fragmentation and may allow some borderline workloads to complete without running out of memory. You can find more details [<u>here</u>](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/800alpha003/apiref/envref/envref_07_0061.html).
+`expandable_segments:True` enables the virtual memory mode recommended by current vLLM Ascend docs to reduce fragmentation during long-running multimodal workloads. You can find more details [<u>here</u>](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/800alpha003/apiref/envref/envref_07_0061.html).
 :::
 
 ## Deployment


### PR DESCRIPTION
## Summary`n- replace stale `max_split_size_mb:256` examples in affected model tutorials`n- switch to `expandable_segments:True`, which matches the current recommended memory fragmentation guidance for long-running workloads`n`nCloses #4246
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
