### PR TITLE
[Doc] Clarify unsupported DeepSeek-R1 MTP mix quantization

### DIFF
--- a/docs/source/user_guide/feature_guide/Multi_Token_Prediction.md
+++ b/docs/source/user_guide/feature_guide/Multi_Token_Prediction.md
@@ -112,3 +112,4 @@ if self.speculative_config:
 
 - Due to the fact that only a single layer of weights is exposed in DeepSeek's MTP, the accuracy and performance are not effectively guaranteed in scenarios where MTP > 1 (especially MTP ≥ 3). Moreover, due to current operator limitations, MTP supports a maximum of 15.
 - In the fullgraph mode with MTP > 1, the capture size of each ACLGraph must be an integer multiple of (num_speculative_tokens + 1).
+- For DeepSeek-R1 quantized deployment, vLLM Ascend currently supports `W8A8 + MTP float quantization` only. MTP mix quantization is not supported yet. If you are converting the model with ModelSlim, make sure the MTP part uses float quantization before enabling MTP serving.

--- a/docs/source/user_guide/feature_guide/quantization.md
+++ b/docs/source/user_guide/feature_guide/quantization.md
@@ -10,6 +10,12 @@ Model quantization is a technique that reduces model size and computational over
 > See <https://www.modelscope.cn/models/vllm-ascend/Kimi-K2-Instruct-W8A8>.
 > Before you quantize a model, ensure sufficient RAM is available.
 
+:::{warning}
+For DeepSeek-R1 MTP deployment, vLLM Ascend currently supports `W8A8 + MTP float quantization` only.
+The default MTP mix quantization configuration in some ModelSlim examples is not supported yet and may cause engine startup failures with unclear runtime errors.
+When preparing a DeepSeek-R1 quantized model for MTP serving, use float quantization for the MTP part instead of mix quantization.
+:::
+
 ## Quantization Tools
 
 vLLM Ascend supports models quantized by two main tools: `ModelSlim` and `LLM-Compressor`.


### PR DESCRIPTION
## Summary
- add a warning in the quantization guide that DeepSeek-R1 MTP deployment currently supports only W8A8 + MTP float quantization
- document the same limitation in the MTP guide with an explicit workaround for ModelSlim users

Closes #2771
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
