### PR TITLE
[Doc] fix DSV3.1 PD configs

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -554,8 +554,8 @@ vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
   --kv-transfer-config \
   '{"kv_connector": "MooncakeConnectorV1",
   "kv_role": "kv_consumer",
-  "kv_port": "30300",
-  "engine_id": "3",
+  "kv_port": "30200",
+  "engine_id": "2",
   "kv_connector_extra_config": {
             "prefill": {
                     "dp_size": 2,


### PR DESCRIPTION
### What this PR does / why we need it?
Modify the `kv_port` and  `engine_id` config of DeepSeek-V3.1/R1 in the 2P1D scenario

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
