### PR TITLE
[DOC] add enable mlapo to deepseek 3.2 doc 

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -684,6 +684,7 @@ Before you start, please
         export TASK_QUEUE_ENABLE=1
 
         export ASCEND_RT_VISIBLE_DEVICES=$1
+        export VLLM_ASCEND_ENABLE_MLAPO=1
 
 
         vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
@@ -761,6 +762,7 @@ Before you start, please
         export TASK_QUEUE_ENABLE=1
 
         export ASCEND_RT_VISIBLE_DEVICES=$1
+        export VLLM_ASCEND_ENABLE_MLAPO=1
 
 
         vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \


### PR DESCRIPTION
### What this PR does / why we need it?                                                                                                                                                                     
 
Adds the `VLLM_ASCEND_ENABLE_MLAPO=1` environment variable to the DeepSeek-V3.2 documentation examples.                
                                                                  
###  Does this PR introduce any user-facing change?

 No (documentation-only update).

###  How was this patch tested?

  Documentation-only change, no testing required.
- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
