### PR TITLE
[Lint] fix typos error in epd_load_balance_proxy_layerwise_server_example.py

### DIFF
--- a/examples/epd_disaggregated/epd_load_balance_proxy_layerwise_server_example.py
+++ b/examples/epd_disaggregated/epd_load_balance_proxy_layerwise_server_example.py
@@ -196,7 +196,7 @@ class ProxyState:
     def abort_pd_request(self, server_idx: int, request_id):
         self.pds[server_idx].aborted_requests.add(request_id)
 
-    def aquire_aborted_pd_requests(self, server_idx: int):
+    def acquire_aborted_pd_requests(self, server_idx: int):
         aborted_requests = self.pds[server_idx].aborted_requests.copy()
         self.pds[server_idx].aborted_requests.clear()
         return aborted_requests
@@ -204,7 +204,7 @@ class ProxyState:
     def abort_prefiller_request(self, server_idx: int, request_id):
         self.prefillers[server_idx].aborted_requests.add(request_id)
 
-    def aquire_aborted_prefiller_requests(self, server_idx: int):
+    def acquire_aborted_prefiller_requests(self, server_idx: int):
         aborted_requests = self.prefillers[server_idx].aborted_requests.copy()
         self.prefillers[server_idx].aborted_requests.clear()
         return aborted_requests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
his PR fixes a typo in two function names in the `epd_load_balance_proxy_layerwise_server_example.py` example script. The function names `aquire_aborted_pd_requests` and `aquire_aborted_prefiller_requests` were misspelled and have been corrected to `acquire_aborted_pd_requests` and `acquire_aborted_prefiller_requests` respectively. This improves code readability and correctness.

### Does this PR introduce _any_ user-facing change?

No. This is a change to an example script and fixes a typo in internal function names.

### How was this patch tested?

This is a minor typo fix in an example script and does not affect core functionality. The change is straightforward and doesn't require new tests.
Merge info
Review required
At least 1 approving review is required by reviewers with write access.


Some checks haven't completed yet
2 pending, 1 in progress, 3 successful checks


pending checks
[docs/readthedocs.org:vllm-ascend](https://app.readthedocs.org/projects/vllm-ascend/builds/31772308/)
docs/readthedocs.org:vllm-ascendWaiting for status to be reported — Read the Docs build is in progress!
[docs/readthedocs.org:vllm-ascend-cn](https://app.readthedocs.org/projects/vllm-ascend-cn/builds/31772307/)
docs/readthedocs.org:vllm-ascend-cnWaiting for status to be reported — Read the Docs build is in progress!
in progress checks
Loading
[E2E-Light / lint / pre-commit (pull_request)](https://github.com/vllm-project/vllm-ascend/actions/runs/22993939077/job/66761291103?pr=7199)
E2E-Light / lint / pre-commit (pull_request)Started 1 minute ago — This check has started...
successful checks
[DCO](https://github.com/vllm-project/vllm-ascend/pull/7199/checks?check_run_id=66761286488)
DCOSuccessful in 1s — DCO
Required
[E2E-Light / changes (pull_request)](https://github.com/vllm-project/vllm-ascend/actions/runs/22993939077/job/66761291010?pr=7199)
E2E-Light / changes (pull_request)Successful in 32s
[PR Create / PR create action (pull_request_target)](https://github.com/vllm-project/vllm-ascend/actions/runs/22993938154/job/66761288144?pr=7199)
PR Create / PR create action (pull_request_target)Successful in 14s
Merging is blocked
At least 1 approving review is required by reviewers with write access.
Still in progress?
@Ronald1995


Add a comment
Comment
> ### What this PR does / why we need it?
> ### Does this PR introduce _any_ user-facing change?
> ### How was this patch tested?


Remember, contributions to this repository should follow its [contributing guidelines](https://github.com/vllm-project/vllm-ascend/blob/21fea86b08edf4a016749a0d637d18cf7017dd2a/CONTRIBUTING.md) and [code of conduct](https://github.com/vllm-project/vllm-ascend/blob/21fea86b08edf4a016749a0d637d18cf7017dd2a/CODE_OF_CONDUCT.md).
 ProTip! Add comments to specific lines under [Files changed](https://github.com/vllm-project/vllm-ascend/pull/7199/files).
Reviewers
@[wangxiyuan](https://github.com/wangxiyuan)
wangxiyuan
1 more reviewer
@gemini-code-assist
[gemini-code-assist[bot]](https://github.com/apps/gemini-code-assist)

At least 1 approving review is required to merge this pull request.

Still in progress?
Assignees
No one assigned
Labels
None yet
Projects
None yet
Milestone
No milestone
Development
Successfully merging this pull request may close these issues.

None yet


Notifications
Customize
You’re receiving notifications because you authored the thread.
1 participant
@Ronald1995
Allow edits and access to secrets by maintainers
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
no
### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
