### PR TITLE
[BugFix] Fix VLLM_ASCEND_ENABLE_FUSED_MC2 not activating for ModelSlim-quantized models

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -228,6 +228,14 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
         "moe_quantize",
         getattr(vllm_config.model_config.hf_text_config, "quantize", None),
     )
+    if quant_type is None and vllm_config.quant_config is not None:
+        quant_desc = getattr(vllm_config.quant_config, "quant_description", {})
+        expert_types = [
+            val.lower() for key, val in quant_desc.items()
+            if "experts" in key and isinstance(val, str)
+        ]
+        if expert_types and all(t == "w8a8_dynamic" for t in expert_types):
+            quant_type = "w8a8_dynamic"
 
     if not vllm_config.parallel_config.enable_expert_parallel or get_ep_group().world_size == 1:
         moe_comm_type = MoECommType.ALLGATHER


### PR DESCRIPTION
ModelSlim quantized models do not write moe_quantize/quantize fields to config.json, causing quant_type to be None and silently disabling the FUSED_MC2 path. Add fallback that reads the actual MoE quant type from ModelSlim's quant_description instead of hardcoding w8a8_dynamic.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.16.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
