### PR TITLE
[Bugfix] fix TransposeKvCacheByBlock op error report in plog

### DIFF
--- a/csrc/transpose_kv_cache_by_block/op_host/transpose_kv_cache_by_block_def.cpp
+++ b/csrc/transpose_kv_cache_by_block/op_host/transpose_kv_cache_by_block_def.cpp
@@ -17,9 +17,9 @@ public:
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("blockIDs")
             .ParamType(REQUIRED)
-            .DataTypeList({ge::DT_INT64})
-            .FormatList({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Attr("blockSize").Int();
         this->Attr("headNum").Int();
         this->Attr("headDim").Int();


### PR DESCRIPTION
### What this PR does / why we need it?

As issue #7201 reported, there are some TransposeKvCacheByBlock operation related ERRORs in plog when vllm launching, though it doesn't influence the running of vllm, but ERRORs will be very confused in debug, this PR fixed the problem as suggested.

### Does this PR introduce _any_ user-facing change?
no.

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
