### PR TITLE
[BugFix]Fix CI errors “ascend_transport.so: cannot open shared object file: No such file or directory”

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -9,20 +9,18 @@ class GlobalTE:
         self.register_buffer_lock = threading.Lock()
 
     def get_transfer_engine(self, hostname: str, device_name: str | None):
-        try:
-            from mooncake.engine import TransferEngine  # type: ignore
-        except ImportError as e:
-            raise ImportError(
-                "Please install mooncake by following the instructions at "
-                "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
-                "to run vLLM with MooncakeConnector."
-            ) from e
         if self.transfer_engine is None:
             with self.transfer_engine_lock:
                 # Double-Checked Locking
                 if self.transfer_engine is None:
-                    if TransferEngine is None:
-                        raise RuntimeError("mooncake is not available")
+                    try:
+                        from mooncake.engine import TransferEngine  # type: ignore
+                    except ImportError as e:
+                        raise ImportError(
+                            "Please install mooncake by following the instructions at "
+                            "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
+                            "to run vLLM with MooncakeConnector."
+                        ) from e
                     self.transfer_engine = TransferEngine()
                     device_name = device_name if device_name is not None else ""
                     ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", "ascend", device_name)


### PR DESCRIPTION
### What this PR does / why we need it?
Conditional Import for Mooncake: The import of mooncake.engine.TransferEngine was moved into a try-except block within the GlobalTE class's constructor. This ensures that mooncake is only imported when needed and provides a clear error message with installation instructions if it's missing.
### Does this PR introduce _any_ user-facing change?
The error message "ascend_transport.so: cannot open shared object file: No such file or directory" in the CI is fixed to ensure the normal running of the CI.
### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
