### PR TITLE
docs: specify Python version requirement >= 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "vllm-ascend"
+requires-python = ">=3.10"
+
 [build-system]
 # Should be mirrored in requirements.txt
 requires = [


### PR DESCRIPTION
## Summary

Explicitly specify Python >= 3.10 as a requirement in setup configuration to prevent installation issues on Python 3.9.

## Changes

- Add `[project]` section with `requires-python = ">=3.10"` to pyproject.toml

## Testing

- Verified TOML syntax is valid
- Confirms Python 3.10+ requirement is now specified in both setup.py and pyproject.toml

Fixes vllm-project/vllm-ascend#3657
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
