### PR TITLE
docs: align CANN version requirements across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ By using vLLM Ascend plugin, popular open-source models, including Transformer-l
 - OS: Linux
 - Software:
     - Python >= 3.10, < 3.12
-    - CANN == 8.5.0 (Ascend HDK version refers to [here](https://www.hiascend.com/document/detail/zh/canncommercial/83RC2/releasenote/releasenote_0000.html))
+    - CANN == 8.5.1 (Ascend HDK version refers to [here](https://www.hiascend.com/document/detail/zh/canncommercial/83RC1/releasenote/releasenote_0000.html))
     - PyTorch == 2.9.0, torch-npu == 2.9.0
     - vLLM (the same version as vllm-ascend)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -47,7 +47,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 - 操作系统：Linux
 - 软件：
     - Python >= 3.10, < 3.12
-    - CANN == 8.5.0 (Ascend HDK 版本参考[这里](https://www.hiascend.com/document/detail/zh/canncommercial/83RC2/releasenote/releasenote_0000.html))
+    - CANN == 8.5.1 (Ascend HDK 版本参考[这里](https://www.hiascend.com/document/detail/zh/canncommercial/83RC1/releasenote/releasenote_0000.html))
     - PyTorch == 2.9.0, torch-npu == 2.9.0
     - vLLM (与vllm-ascend版本一致)
 


### PR DESCRIPTION
## Summary

Fix inconsistency between README and installation documentation regarding CANN version requirements.

## Changes

- Update README.md: CANN 8.5.0 → 8.5.1
- Update README.zh.md: CANN 8.5.0 → 8.5.1
- Update documentation link from 83RC2 to 83RC1 to match installation.md

## Testing

- Verified CANN 8.5.1 is used consistently across all Dockerfiles and CI workflows
- Verified documentation is now consistent

Fixes vllm-project/vllm-ascend#3349
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
