### PR TITLE
fix: add qwen3 dense model to packed_modules_model_mapping

### DIFF
--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -102,6 +102,17 @@ QUANT_MODEL_PREFIX_MAPPINGS: dict[str, dict[str, str]] = {
 # key: model_type
 # value: dict of fused module name -> list of original module names
 packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
+    "qwen3": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    },
     "qwen3_moe": {
         "qkv_proj": [
             "q_proj",


### PR DESCRIPTION
## Summary

Add missing `qwen3` (Qwen3 Dense) model type to the `packed_modules_model_mapping` dictionary, enabling proper W8A8 per-token quantization support for Qwen3 dense models.

### Problem

- W8A8 per-token quantized Qwen3 dense models generate garbled output in vLLM-Ascend
- The same quantized model works correctly with Transformers
- QwQ-W8A8 per-token works fine, only Qwen3 dense models are affected

### Root Cause

The `packed_modules_model_mapping` in `modelslim_config.py` was missing the `qwen3` model type entry. This caused quantization parameters (`weight_scale`, `weight_offset`) to not be correctly mapped to fused layers during weight loading.

### Solution

Add `qwen3` entry to `packed_modules_model_mapping` with the correct mapping:
- `qkv_proj`: [q_proj, k_proj, v_proj]
- `gate_up_proj`: [gate_proj, up_proj]

This mapping matches the `packed_modules_mapping` defined in vLLM's `Qwen3ForCausalLM` class.

### Key Changes

| File | Change |
|------|--------|
| `vllm_ascend/quantization/modelslim_config.py` | Add `qwen3` to `packed_modules_model_mapping` |

## Test plan

- [ ] Verify W8A8 per-token quantized Qwen3 dense model inference produces coherent output
- [ ] Run existing quantization unit tests
- [ ] Test with `vllm serve --quantization ascend` on Qwen3-32B-W8A8 per-token model

Fixes #2318
