### PR TITLE
fix: retry cmake build serially after parallel failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,7 @@ class cmake_build_ext(build_ext):
         ]
         try:
             subprocess.check_call(["cmake", *build_args], cwd=self.build_temp)
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             if num_jobs <= 1:
                 raise
             logger.warning(
@@ -388,8 +388,10 @@ class cmake_build_ext(build_ext):
             ]
             try:
                 subprocess.check_call(["cmake", *serial_build_args], cwd=self.build_temp)
-            except OSError as e:
-                raise RuntimeError(f"Build library failed: {e}")
+            except subprocess.CalledProcessError as serial_e:
+                raise serial_e from e
+            except OSError as serial_e:
+                raise RuntimeError(f"Build library failed: {serial_e}") from e
         except OSError as e:
             raise RuntimeError(f"Build library failed: {e}")
         # Install the libraries


### PR DESCRIPTION
Retry the CMake extension build with -j=1 when the initial parallel build fails. This mitigates installation failures like issue #3847 on A2 environments where high job counts can trip GNU make/LTO jobserver errors during linking.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
