### PR TITLE
fix: add memory pre-check for attention mask generation

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -19,7 +19,7 @@ locale = "en"
 extend-ignore-identifiers-re = [".*Unc.*", ".*_thw",
     ".*UE8M0.*", ".*(UE4M3|ue4m3).*", ".*eles.*", ".*fo.*", ".*ba.*",
     ".*ot.*", ".*[Tt]h[rR].*"]
-extend-ignore-words-re = ["CANN", "cann","ND","alog","nd","BA","datas","ful","udo",]
+extend-ignore-words-re = ["CANN", "cann","ND","alog","nd","BA","datas","ful","udo","TBE","tbe",]
 extend-ignore-re = []
 
 [default.extend-identifiers]

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -15,11 +15,19 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import logging
+
 import torch
 import torch_npu
 
+from vllm_ascend.attention.attention_mask import (
+    _check_attn_mask_memory,
+    _estimate_attn_mask_memory,
+)
 from vllm_ascend.attention.attention_v1 import AscendMetadata
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, nd_to_nz_2d, nd_to_nz_spec
+
+logger = logging.getLogger(__name__)
 
 
 class AttentionMaskBuilder310:
@@ -54,6 +62,9 @@ class AttentionMaskBuilder310:
         Returns:
             torch.Tensor: A float16 tensor representing the causal mask.
         """
+        # Check memory requirement before allocating tensors
+        _check_attn_mask_memory(max_seq_len, torch.float16)
+
         tril = torch.ones((max_seq_len, max_seq_len), dtype=torch.bool, device=device).tril_()
         upper = ~tril
         mask = torch.zeros((max_seq_len, max_seq_len), dtype=torch.float16, device=device)
@@ -149,6 +160,12 @@ class AttentionMaskBuilder310:
             torch.Tensor: The cached causal mask in ACL_FORMAT_FRACTAL_NZ.
         """
         if self.attn_mask_cache is None:
+            estimated_memory = _estimate_attn_mask_memory(max_seq_len, torch.float16)
+            logger.debug(
+                "Generating 310P causal attention mask: max_seq_len=%d, estimated_memory=%.2f MB",
+                max_seq_len,
+                estimated_memory / (1024 * 1024),
+            )
             attn_mask = self.gen_causal_additive_mask(max_seq_len, self.device)
             self.attn_mask_cache = torch_npu.npu_format_cast(nd_to_nz_2d(attn_mask), ACL_FORMAT_FRACTAL_NZ)
         return self.attn_mask_cache

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -12,14 +12,120 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import os
+
 import torch
 from vllm.distributed import get_pcp_group
 
 from vllm_ascend.platform import ModelConfig
 from vllm_ascend.utils import singleton
 
+logger = logging.getLogger(__name__)
+
+# Default maximum attention mask size (in bytes): 16GB
+# This can be configured via VLLM_ASCEND_MAX_ATTN_MASK_MEMORY environment variable
+DEFAULT_MAX_ATTN_MASK_MEMORY_GB = 16
+
+# Warning threshold: warn when attention mask memory exceeds this value (in GB)
+ATTN_MASK_MEMORY_WARNING_THRESHOLD_GB = 4
+
+
+def _get_max_attn_mask_memory_bytes() -> int:
+    """Get the maximum allowed attention mask memory from environment variable.
+
+    Returns:
+        Maximum allowed memory in bytes.
+    """
+    env_value = os.environ.get("VLLM_ASCEND_MAX_ATTN_MASK_MEMORY")
+    if env_value is not None:
+        try:
+            max_memory_gb = float(env_value)
+            if max_memory_gb <= 0:
+                logger.warning(
+                    "VLLM_ASCEND_MAX_ATTN_MASK_MEMORY must be positive, using default value: %d GB",
+                    DEFAULT_MAX_ATTN_MASK_MEMORY_GB,
+                )
+                max_memory_gb = DEFAULT_MAX_ATTN_MASK_MEMORY_GB
+            return int(max_memory_gb * 1024 * 1024 * 1024)
+        except ValueError:
+            logger.warning(
+                "Invalid VLLM_ASCEND_MAX_ATTN_MASK_MEMORY value: '%s', using default value: %d GB",
+                env_value,
+                DEFAULT_MAX_ATTN_MASK_MEMORY_GB,
+            )
+    return DEFAULT_MAX_ATTN_MASK_MEMORY_GB * 1024 * 1024 * 1024
+
+
+def _estimate_attn_mask_memory(max_seq_len: int, dtype: torch.dtype) -> int:
+    """Estimate the memory required for attention mask tensor.
+
+    Args:
+        max_seq_len: Maximum sequence length.
+        dtype: Data type of the attention mask.
+
+    Returns:
+        Estimated memory in bytes.
+    """
+    element_size = torch.tensor([], dtype=dtype).element_size()
+    # Attention mask shape is (max_seq_len, max_seq_len)
+    num_elements = max_seq_len * max_seq_len
+    return num_elements * element_size
+
+
+def _check_attn_mask_memory(max_seq_len: int, dtype: torch.dtype) -> None:
+    """Check if the attention mask memory requirement is within limits.
+
+    This function estimates the memory required for the attention mask and
+    compares it against the configured maximum. If the estimated memory
+    exceeds the limit, a RuntimeError is raised with a clear error message.
+
+    Args:
+        max_seq_len: Maximum sequence length.
+        dtype: Data type of the attention mask.
+
+    Raises:
+        RuntimeError: If estimated memory exceeds the configured maximum.
+    """
+    estimated_memory = _estimate_attn_mask_memory(max_seq_len, dtype)
+    max_allowed_memory = _get_max_attn_mask_memory_bytes()
+
+    estimated_memory_gb = estimated_memory / (1024 * 1024 * 1024)
+    max_allowed_memory_gb = max_allowed_memory / (1024 * 1024 * 1024)
+
+    # Log warning if memory usage is high but within limits
+    if estimated_memory_gb > ATTN_MASK_MEMORY_WARNING_THRESHOLD_GB:
+        logger.warning(
+            "Attention mask for max_seq_len=%d with dtype=%s requires %.2f GB memory. "
+            "This may cause performance issues or OOM errors on devices with limited memory. "
+            "Consider reducing max_model_len or setting VLLM_ASCEND_MAX_ATTN_MASK_MEMORY "
+            "environment variable to adjust the limit.",
+            max_seq_len,
+            dtype,
+            estimated_memory_gb,
+        )
+
+    if estimated_memory > max_allowed_memory:
+        raise RuntimeError(
+            f"Attention mask memory requirement ({estimated_memory_gb:.2f} GB) exceeds "
+            f"the maximum allowed limit ({max_allowed_memory_gb:.2f} GB). "
+            f"The attention mask has shape ({max_seq_len}, {max_seq_len}) with dtype={dtype}, "
+            f"which requires O(max_model_len^2) memory.\n\n"
+            f"Possible solutions:\n"
+            f"  1. Reduce max_model_len to a smaller value (e.g., --max-model-len 4096)\n"
+            f"  2. Increase the memory limit by setting environment variable:\n"
+            f"     export VLLM_ASCEND_MAX_ATTN_MASK_MEMORY=<memory_in_gb>\n"
+            f"  3. Use a device with more memory\n\n"
+            f"Note: This error prevents a potential TBE subprocess crash that would "
+            f"otherwise produce an unclear error message like "
+            f"'TBE Subprocess[task_distribute] raise error[], main process disappeared!'"
+        )
+
 
 def _generate_attn_mask(max_seq_len, dtype):
+    # Check memory requirement before allocating tensors
+    _check_attn_mask_memory(max_seq_len, dtype)
+
     # Construct lower triangle matrix.
     mask_flag = torch.ones((max_seq_len, max_seq_len), dtype=torch.bool).tril_()
     # Create upper triangle matrix used to mark mask positions.
@@ -44,6 +150,13 @@ class AttentionMaskBuilder:
 
     def get_attn_mask(self, max_seq_len: int, dtype: torch.dtype):
         if self.attn_mask_cache is None or max_seq_len > self._seq_len_cached:
+            estimated_memory = _estimate_attn_mask_memory(max_seq_len, dtype)
+            logger.debug(
+                "Generating attention mask: max_seq_len=%d, dtype=%s, estimated_memory=%.2f MB",
+                max_seq_len,
+                dtype,
+                estimated_memory / (1024 * 1024),
+            )
             self.attn_mask_cache = _generate_attn_mask(max_seq_len, dtype)
             self._seq_len_cached = max_seq_len
         assert self.attn_mask_cache is not None, "Something is wrong in generate_attn_mask."


### PR DESCRIPTION
## Summary
Add memory pre-check and configurable limits for attention mask generation to prevent unclear TBE subprocess crashes when `max_model_len` is too large.

### Problem
- When `max_model_len` is very large (e.g., 128K), `_generate_attn_mask()` creates a tensor of shape `(max_seq_len, max_seq_len)`, requiring O(max_model_len²) memory
- For 128K context length with float16, this requires ~32GB memory
- This causes TBE subprocess crashes with unclear error messages: `[ERROR] TBE Subprocess[task_distribute] raise error[], main process disappeared!`
- Python's try-except cannot catch these low-level TBE errors

### Solution
- Add memory estimation before allocating attention mask tensors
- Add configurable memory limit via `VLLM_ASCEND_MAX_ATTN_MASK_MEMORY` environment variable (default: 16GB)
- Raise clear `RuntimeError` with helpful suggestions when the estimated memory exceeds the limit
- Add warning logs when memory usage exceeds 4GB threshold
- Add debug logs showing estimated memory for each mask generation

### Key Changes
| File | Change |
|------|--------|
| `vllm_ascend/attention/attention_mask.py` | Add memory check functions and integrate into `_generate_attn_mask()` and `get_attn_mask()` |
| `vllm_ascend/_310p/attention/attention_mask.py` | Reuse memory check functions from main module |

### Example Error Message (after this fix)
```
RuntimeError: Attention mask memory requirement (32.00 GB) exceeds the maximum allowed limit (16.00 GB). 
The attention mask has shape (131072, 131072) with dtype=torch.float16, which requires O(max_model_len^2) memory.

Possible solutions:
  1. Reduce max_model_len to a smaller value (e.g., --max-model-len 4096)
  2. Increase the memory limit by setting environment variable:
     export VLLM_ASCEND_MAX_ATTN_MASK_MEMORY=<memory_in_gb>
  3. Use a device with more memory

Note: This error prevents a potential TBE subprocess crash that would otherwise produce an unclear error message like 'TBE Subprocess[task_distribute] raise error[], main process disappeared!'
```

## Test plan
- [ ] Verify the fix raises clear error when max_model_len is too large
- [ ] Verify warning logs are emitted when memory usage exceeds 4GB
- [ ] Verify VLLM_ASCEND_MAX_ATTN_MASK_MEMORY environment variable works correctly
- [ ] Run existing attention mask tests

Fixes #2694
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
