### PR TITLE
fix: handle partial rotary embedding for GLM-4 models

### DIFF
--- a/tests/ut/ops/test_rotary_embedding.py
+++ b/tests/ut/ops/test_rotary_embedding.py
@@ -80,6 +80,7 @@ class TestRopeForwardOot(unittest.TestCase):
         # Mock self object for rope_forward_oot
         self.mock_self = MagicMock()
         self.mock_self.head_size = self.head_size
+        self.mock_self.rotary_dim = self.head_size  # Add rotary_dim for partial rope support
         self.mock_self.cos_sin_cache = self.cos_sin_cache
         self.mock_self.is_neox_style = True
         self.mock_self.forward_native.return_value = (self.query, self.key)
@@ -178,6 +179,54 @@ class TestRopeForwardOot(unittest.TestCase):
         # Check that neox_style=False was passed to the NPU function
         args, kwargs = mock_npu_rotary.call_args
         self.assertFalse(args[-1])
+
+    @patch('vllm_ascend.ops.rotary_embedding.get_ascend_config')
+    @patch('vllm_ascend.ops.rotary_embedding.custom_rotary_embedding_enabled',
+           return_value=False)
+    @patch('torch_npu._npu_rotary_embedding')
+    def test_rope_forward_oot_partial_rotary(self, mock_npu_rotary,
+                                             mock_custom_enabled,
+                                             mock_get_ascend_config):
+        """Test partial rotary embedding when rotary_dim < head_size.
+
+        This is needed for models like GLM-4 where only part of the head
+        dimensions use rotary position embeddings (e.g., head_size=128,
+        rotary_dim=64).
+        """
+        mock_config = MagicMock()
+        mock_config.torchair_graph_config.enabled = False
+        mock_get_ascend_config.return_value = mock_config
+
+        # Setup for partial rotary: head_size=128, rotary_dim=64
+        head_size = 128
+        rotary_dim = 64
+        num_heads = 2
+        num_tokens = 4
+
+        # Create mock with partial rotary configuration
+        mock_self_partial = MagicMock()
+        mock_self_partial.head_size = head_size
+        mock_self_partial.rotary_dim = rotary_dim
+        mock_self_partial.cos_sin_cache = torch.randn(1024, rotary_dim,
+                                                      dtype=torch.float16)
+        mock_self_partial.is_neox_style = True
+
+        positions = torch.tensor([0, 1, 2, 3])
+        query = torch.randn(num_tokens, num_heads * head_size,
+                            dtype=torch.float16)
+        key = torch.randn(num_tokens, num_heads * head_size,
+                          dtype=torch.float16)
+
+        result_q, result_k = rope_forward_oot(mock_self_partial, positions,
+                                              query, key)
+
+        # Verify output shapes match input shapes
+        self.assertEqual(result_q.shape, query.shape)
+        self.assertEqual(result_k.shape, key.shape)
+
+        # Verify NPU kernel was called with rotary_dim, not head_size
+        args, kwargs = mock_npu_rotary.call_args
+        self.assertEqual(args[3], rotary_dim)
 
 
 class MockRopeModule:

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -72,18 +72,51 @@ def rope_forward_oot(
         raise NotImplementedError(
             "Batched rotary embedding is currently not supported on NPU.")
     else:
-        # TODO: Remove the contiguous in the future.
-        query = query.contiguous().view(query.shape[0], -1)
-        key = key.contiguous().view(key.shape[0], -1)
-        torch_npu._npu_rotary_embedding(
-            positions,
-            query,
-            key,
-            self.head_size,
-            self.cos_sin_cache,
-            neox_style,
-        )
-    return query.view(query_shape), key.view(key_shape)
+        # Handle partial rotary embedding (rotary_dim < head_size)
+        # This is needed for models like GLM-4 where only part of the
+        # head dimensions use rotary position embeddings.
+        if self.rotary_dim < self.head_size:
+            num_tokens = query.shape[0]
+            query = query.view(num_tokens, -1, self.head_size)
+            key = key.view(num_tokens, -1, self.head_size)
+            # Split into rotary and pass-through parts
+            q_rot = query[..., :self.rotary_dim]
+            q_pass = query[..., self.rotary_dim:]
+            k_rot = key[..., :self.rotary_dim]
+            k_pass = key[..., self.rotary_dim:]
+            # Flatten rotary parts for NPU kernel
+            q_rot = q_rot.contiguous().view(num_tokens, -1)
+            k_rot = k_rot.contiguous().view(num_tokens, -1)
+            # Apply rotary embedding only to the rotary part
+            torch_npu._npu_rotary_embedding(
+                positions,
+                q_rot,
+                k_rot,
+                self.rotary_dim,
+                self.cos_sin_cache,
+                neox_style,
+            )
+            # Reshape and concatenate with pass-through parts
+            q_rot = q_rot.view(num_tokens, -1, self.rotary_dim)
+            k_rot = k_rot.view(num_tokens, -1, self.rotary_dim)
+            query = torch.cat((q_rot, q_pass), dim=-1).reshape(query_shape)
+            key = torch.cat((k_rot, k_pass), dim=-1).reshape(key_shape)
+        else:
+            # Full rotary embedding (rotary_dim == head_size)
+            # TODO: Remove the contiguous in the future.
+            query = query.contiguous().view(query.shape[0], -1)
+            key = key.contiguous().view(key.shape[0], -1)
+            torch_npu._npu_rotary_embedding(
+                positions,
+                query,
+                key,
+                self.head_size,
+                self.cos_sin_cache,
+                neox_style,
+            )
+            query = query.view(query_shape)
+            key = key.view(key_shape)
+    return query, key
 
 
 def native_rope_deepseek_forward(self,


### PR DESCRIPTION
## Summary

Fix GLM-4 models (e.g., `ZhipuAI/glm-4-9b-chat-hf`) failing to start with `RopeOperation setup failed!` error on Ascend NPU.

### Problem

- GLM-4 models use partial rotary embedding where `rotary_dim=64` but `head_size=128`
- The NPU rotary embedding kernel was receiving `head_size` (128) instead of `rotary_dim` (64)
- This caused the kernel to fail with: `RopeOperation_0 Wrong rotaryCoeff: 128`
- Error occurred during `profile_run()` → `_dummy_run()` when initializing KV caches

### Solution

When `rotary_dim < head_size`:
1. Split query/key tensors into rotary (`[:rotary_dim]`) and pass-through (`[rotary_dim:]`) parts
2. Apply rotary embedding only to the rotary part with correct `rotary_dim` dimension
3. Concatenate the rotated and pass-through parts back together

### Key Changes

| File | Change |
|------|--------|
| `vllm_ascend/ops/rotary_embedding.py` | Handle `rotary_dim < head_size` case in `rope_forward_oot()` |
| `tests/ut/ops/test_rotary_embedding.py` | Add unit test for partial rotary embedding |

## Test plan

- [ ] Verify GLM-4 model starts successfully: `vllm serve ZhipuAI/glm-4-9b-chat-hf --trust-remote-code`
- [ ] Run existing unit tests: `pytest tests/ut/ops/test_rotary_embedding.py`
- [ ] Verify no regression on models with `rotary_dim == head_size`

Fixes #2255
Related: #309, #2258, #6060

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
