### PR TITLE
[Bugfix] Fix device None error in PyHcclCommunicator for training scenarios

### DIFF
--- a/vllm_ascend/distributed/device_communicators/pyhccl.py
+++ b/vllm_ascend/distributed/device_communicators/pyhccl.py
@@ -87,6 +87,8 @@ class PyHcclCommunicator:
 
         logger.info("vLLM is using pyhccl")
 
+        if device is None:
+            device = torch.npu.current_device()
         if isinstance(device, int):
             device = torch.device(f"npu:{device}")
         elif isinstance(device, str):


### PR DESCRIPTION
## Summary
- Fix the issue where device is None in PyHcclCommunicator causing AssertionError during training
- Added fallback to use current NPU device when device is None

## Related Issue
- Fixes #3255

## Testing
- Unit tests pass
- Manual testing in training scenarios
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
