### PR TITLE
[Bugfix] Handle non-2D tensor in npu_weight_quant_batchmatmul

### DIFF
--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -132,12 +132,19 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = None,
     ) -> torch.Tensor:
-        return torch_npu.npu_weight_quant_batchmatmul(
+        original_shape = x.shape
+        is_3d = x.dim() == 3
+        if is_3d:
+            x = x.reshape(-1, x.shape[-1])
+        output = torch_npu.npu_weight_quant_batchmatmul(
             x,
             layer.weight,
             antiquant_scale=layer.weight_scale_second.to(x.dtype),
             antiquant_group_size=self.group_size,
         )
+        if is_3d:
+            output = output.reshape(original_shape[0], original_shape[1], -1)
+        return output
 
     def process_weights_after_loading(self, layer: torch.nn.Module):
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()

--- a/vllm_ascend/quantization/methods/w8a16.py
+++ b/vllm_ascend/quantization/methods/w8a16.py
@@ -62,6 +62,10 @@ class AscendW8A16LinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
+        original_shape = x.shape
+        is_3d = x.dim() == 3
+        if is_3d:
+            x = x.reshape(-1, x.shape[-1])
         output = torch_npu.npu_weight_quant_batchmatmul(
             x=x,
             weight=layer.weight,
@@ -69,6 +73,8 @@ class AscendW8A16LinearMethod(AscendLinearScheme):
             antiquant_offset=layer.weight_offset,
             bias=bias,
         )
+        if is_3d:
+            output = output.reshape(original_shape[0], original_shape[1], -1)
         return output
 
     def process_weights_after_loading(self, layer):


### PR DESCRIPTION
## Summary
- Fix the issue where npu_weight_quant_batchmatmul requires 2D input tensor
- Added conversion for non-2D tensors (3D) to 2D before the operation
- Reshape back to original shape after the operation

## Related Issue
- Fixes #3210

## Testing
- Unit tests pass
- Tested with quantized models that have 3D input tensors
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
