### PR TITLE
[Bugfix] Set default multiprocessing method to spawn for NPU

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -30,6 +30,9 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
+# NPU does not support fork, use spawn for multiprocessing
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
 from vllm_ascend.ascend_config import init_ascend_config
 
 # isort: off


### PR DESCRIPTION
## Summary
- Fix the tensor parallel error on Ascend 910C
- Set default VLLM_WORKER_MULTIPROC_METHOD to spawn since NPU does not support fork
- This prevents the RuntimeError: Cannot re-initialize NPU in forked subprocess

## Related Issue
- Fixes #3133

## Testing
- Tested with tensor parallel configurations on Ascend 910C
- Existing tests pass with spawn method
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
