### PR TITLE
[Bugfix][Platform] Fix CPU binding parsing on localized npu-smi output

### DIFF
--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -59,6 +59,14 @@ class TestDeviceInfo(unittest.TestCase):
         self.assertEqual(len(running_npus), 1)
 
     @patch('vllm_ascend.cpu_binding.execute_command')
+    def test_get_running_npus_with_non_english_header(self, mock_execute_command):
+        mock_execute_command.return_value = (
+            "| NPU Chip | 进程 ID |\n| 1 0 | 1236 | vllm | 56000 |", 0
+        )
+        running_npus = self.device_info.get_running_npus()
+        self.assertEqual(running_npus, [1])
+
+    @patch('vllm_ascend.cpu_binding.execute_command')
     def test_parse_topo_affinity(self, mock_execute_command):
         mock_execute_command.return_value = (
             "NPU0 X HCCS HCCS HCCS HCCS HCCS HCCS HCCS 0-3", 0)

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -92,27 +92,27 @@ class DeviceInfo:
 
     def get_running_npus(self) -> list[int]:
         npu_message, _ = execute_command(["npu-smi", "info"])
-        in_proc_section = False
         running_npu_set = set()
         for line in npu_message.splitlines():
             line = line.strip()
-            if line.startswith("| NPU") and "Process id" in line:
-                in_proc_section = True
+            if not line.startswith("|"):
                 continue
-            if not in_proc_section:
+            parts = [p.strip() for p in line.strip("|").split("|")]
+            if len(parts) < 2:
                 continue
-            if line.startswith("| "):
-                parts = [p.strip() for p in line.strip("|").split("|")]
-                if len(parts) < 2:
-                    continue
-                npu_id = parts[0].split()[0]
-                chip_id = parts[0].split()[1]
-                if not npu_id.isdigit() or not chip_id.isdigit():
-                    continue
-                chip_logic_id = self.npu_map_info.get(npu_id, {}).get(chip_id)
-                if not chip_logic_id or not chip_logic_id.isdigit():
-                    raise RuntimeError("Failed to get correct chip_logic_id from command 'npu-smi info -m'.")
-                running_npu_set.add(int(chip_logic_id))
+            # Process section headers can be localized (e.g. Chinese), but the process
+            # table rows are stable: "| <npu_id> <chip_id> | <pid> | ... |".
+            npu_chip = parts[0].split()
+            if len(npu_chip) < 2:
+                continue
+            npu_id, chip_id = npu_chip[0], npu_chip[1]
+            pid = parts[1].split()[0] if parts[1] else ""
+            if not (npu_id.isdigit() and chip_id.isdigit() and pid.isdigit()):
+                continue
+            chip_logic_id = self.npu_map_info.get(npu_id, {}).get(chip_id)
+            if not chip_logic_id or not chip_logic_id.isdigit():
+                raise RuntimeError("Failed to get correct chip_logic_id from command 'npu-smi info -m'.")
+            running_npu_set.add(int(chip_logic_id))
         if ASCEND_RT_VISIBLE_DEVICES:
             devices_str = ASCEND_RT_VISIBLE_DEVICES
             devices_list = [int(x) for x in devices_str.split(",")]


### PR DESCRIPTION
### What this PR does / why we need it?
- Fix CPU binding failing on systems where `npu-smi info` process table headers are localized (e.g. Chinese OS language).
- Parse process rows by their stable table structure instead of relying on the English header substring "Process id".

Fixes #6992.

### Does this PR introduce _any_ user-facing change?
- Yes. CPU binding no longer depends on English `npu-smi` output.

### How was this patch tested?
- Added UT: `tests/ut/device_allocator/test_cpu_binding.py::test_get_running_npus_with_non_english_header`.
- (Local) Syntax check: `python -m compileall vllm_ascend/cpu_binding.py tests/ut/device_allocator/test_cpu_binding.py`.

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
