### PR TITLE
fix: DP + ACLGraph hang with single request (#3128)

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -418,6 +418,9 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 self.cudagraph_batch_sizes = []
 
+        # FIX for Issue #3128: Validate cudagraph_capture_sizes for DP scenarios
+        self._validate_cudagraph_config_for_dp()
+
     @property
     def use_cp(self) -> bool:
         return self.pcp_size * self.dcp_size > 1
@@ -503,6 +506,41 @@ class NPUModelRunner(GPUModelRunner):
         # requires MC2 or recompute-based scheduler is enabled.
         return decode_must_use_mc2 and (prefill_must_use_mc2 or self.ascend_config.recompute_scheduler_enable)
 
+
+    def _validate_cudagraph_config_for_dp(self):
+        """
+        Validate and warn about problematic cudagraph_capture_sizes configurations
+        when using Data Parallel (DP).
+
+        Issue #3128: Single-request hangs with dp+tp+aclgraph when capture_sizes
+        includes small batch sizes (e.g., 1) that cause synchronization issues.
+        """
+        if self.dp_size <= 1:
+            return
+
+        if not hasattr(self, 'cudagraph_batch_sizes') or not self.cudagraph_batch_sizes:
+            return
+
+        # Check if capture_sizes includes 1 (single batch)
+        if 1 in self.cudagraph_batch_sizes:
+            logger.warning(
+                "[Issue #3128 Fix] Detected cudagraph_capture_sizes includes 1 "
+                "with DP size %d. This may cause single-request hangs. "
+                "Consider removing 1 from capture_sizes or use eager mode fallback.",
+                self.dp_size
+            )
+
+        # Check if capture_sizes has gaps that might cause issues
+        sorted_sizes = sorted(self.cudagraph_batch_sizes)
+        if len(sorted_sizes) >= 2:
+            # If there's a large gap between smallest and next size
+            if sorted_sizes[1] > sorted_sizes[0] * 2 and sorted_sizes[0] <= 2:
+                logger.warning(
+                    "[Issue #3128 Fix] Large gap in cudagraph_capture_sizes: %s. "
+                    "This may cause batch size mismatch issues with DP.",
+                    sorted_sizes
+                )
+
     def _sync_metadata_across_dp(
         self, num_tokens: int, with_prefill: bool = False, is_draft_model: bool = False
     ) -> tuple[int, torch.Tensor | None, bool]:
@@ -518,6 +556,13 @@ class NPUModelRunner(GPUModelRunner):
         if self._skip_all_reduce_across_dp_group(is_draft_model):
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, with_prefill
+
+        # FIX for Issue #3128: Add barrier before sync when using ACLGraph
+        # This ensures all DP ranks are at the same point before communication
+        if self.use_aclgraph and self.dp_size > 1:
+            torch.npu.synchronize()
+            if dist.is_initialized():
+                dist.barrier(group=get_dp_group().device_group)
 
         # Sync num_tokens, with_prefill across dp ranks
         num_tokens_tensor = torch.tensor(


### PR DESCRIPTION
## Summary

Fix Issue #3128: Qwen3-235B dp8tp2+aclgraph hangs on single request while multi-concurrency works fine.

## Problem

When running Qwen3-235B with DP8+TP2+ACLGraph configuration, single inference requests hang during in-flight replay, then report RPC timeout. Multi-concurrent requests work normally.

## Root Cause

When using DP + ACLGraph with cudagraph_capture_sizes containing small batch sizes (e.g., 1), graph mode synchronization conflicts with DP communication, causing deadlock.

## Changes

- Add `_validate_cudagraph_config_for_dp()` to detect problematic configurations
- Add barrier synchronization in `_sync_metadata_across_dp()` for ACLGraph scenarios
- Add warning logs for potentially problematic capture sizes

## Testing

- Verified validation logic works correctly
- Tested with DP + ACLGraph scenarios

Fixes #3128
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
