### PR TITLE
[Bugfix][Examples] Fix proxy retry for list chat content + SSE header

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -131,6 +131,12 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
 
+from vllm_ascend.openai_proxy_utils import (
+    append_text_to_chat_content,
+    append_text_to_prompt,
+    streaming_response_kwargs,
+)
+
 try:
     from vllm.logger import init_logger
 
@@ -788,9 +794,9 @@ async def _handle_completions(api: str, request: Request):
                             retry = True
                             retry_count += 1
                             if chat_flag:
-                                messages[0]["content"] = origin_prompt + generated_token
+                                messages[0]["content"] = append_text_to_chat_content(origin_prompt, generated_token)
                             else:
-                                req_data["prompt"] = origin_prompt + generated_token
+                                req_data["prompt"] = append_text_to_prompt(origin_prompt, generated_token)
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
                             instance_info = await _handle_select_instance(api, req_data, tmp_request_length)
@@ -814,9 +820,7 @@ async def _handle_completions(api: str, request: Request):
             # After streaming done, release tokens
             proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
 
-        # Determine the correct media type based on stream flag
-        media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
-        return StreamingResponse(generate_stream(), media_type=media_type)
+        return StreamingResponse(generate_stream(), **streaming_response_kwargs(stream_flag))
     except Exception as e:
         import traceback
 

--- a/tests/ut/test_openai_proxy_utils.py
+++ b/tests/ut/test_openai_proxy_utils.py
@@ -1,0 +1,54 @@
+import unittest
+
+from starlette.responses import StreamingResponse
+
+from vllm_ascend.openai_proxy_utils import (
+    append_text_to_chat_content,
+    append_text_to_prompt,
+    streaming_response_kwargs,
+)
+
+
+class TestAppendTextToPrompt(unittest.TestCase):
+
+    def test_append_to_str(self):
+        self.assertEqual(append_text_to_prompt("hello", " world"), "hello world")
+
+    def test_append_to_list_of_str(self):
+        self.assertEqual(append_text_to_prompt(["hello"], " world"), ["hello world"])
+
+    def test_append_to_empty_list(self):
+        self.assertEqual(append_text_to_prompt([], "x"), ["x"])
+
+
+class TestAppendTextToChatContent(unittest.TestCase):
+
+    def test_append_to_str(self):
+        self.assertEqual(append_text_to_chat_content("hello", " world"), "hello world")
+
+    def test_append_to_list_of_text_parts(self):
+        content = [{"type": "text", "text": "hello"}]
+        updated = append_text_to_chat_content(content, " world")
+        self.assertEqual(updated, [{"type": "text", "text": "hello world"}])
+        self.assertEqual(content, [{"type": "text", "text": "hello"}])
+
+    def test_append_to_list_ending_with_non_text_part(self):
+        content = [{"type": "image_url", "image_url": "https://example.com/a.png"}]
+        updated = append_text_to_chat_content(content, "hello")
+        self.assertEqual(content, [{"type": "image_url", "image_url": "https://example.com/a.png"}])
+        self.assertEqual(updated[-1], {"type": "text", "text": "hello"})
+
+    def test_append_to_list_ending_with_str(self):
+        self.assertEqual(append_text_to_chat_content(["hello"], " world"), ["hello world"])
+
+
+class TestStreamingResponseKwargs(unittest.TestCase):
+
+    def test_streaming_response_sets_exact_sse_content_type(self):
+        response = StreamingResponse(iter([b"data: ok\n\n"]), **streaming_response_kwargs(True))
+        self.assertEqual(response.headers["content-type"], "text/event-stream")
+
+    def test_non_streaming_response_uses_json_media_type(self):
+        response = StreamingResponse(iter([b"{}"]), **streaming_response_kwargs(False))
+        self.assertEqual(response.headers["content-type"], "application/json")
+

--- a/vllm_ascend/openai_proxy_utils.py
+++ b/vllm_ascend/openai_proxy_utils.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def append_text_to_prompt(prompt: Any, text: str) -> Any:
+    """Append generated text to an OpenAI-compatible `prompt` field.
+
+    The OpenAI `/v1/completions` API allows `prompt` to be a string or a list.
+    This helper performs a best-effort append while preserving the input type.
+    """
+    if not text:
+        return prompt
+    if prompt is None:
+        return text
+    if isinstance(prompt, str):
+        return prompt + text
+    if isinstance(prompt, list):
+        if not prompt:
+            return [text]
+        new_prompt = list(prompt)
+        last = new_prompt[-1]
+        if isinstance(last, str):
+            new_prompt[-1] = last + text
+            return new_prompt
+        new_prompt[-1] = str(last) + text
+        return new_prompt
+    return str(prompt) + text
+
+
+def append_text_to_chat_content(content: Any, text: str) -> Any:
+    """Append generated text to an OpenAI-compatible chat message `content`.
+
+    The OpenAI `/v1/chat/completions` API supports `content` as either a string
+    or a list of content parts (e.g. `[{\"type\": \"text\", \"text\": \"...\"}]`).
+    """
+    if not text:
+        return content
+    if content is None:
+        return text
+    if isinstance(content, str):
+        return content + text
+    if isinstance(content, list):
+        if not content:
+            return [{"type": "text", "text": text}]
+        new_content = list(content)
+        last = new_content[-1]
+        if isinstance(last, str):
+            new_content[-1] = last + text
+            return new_content
+        if isinstance(last, dict):
+            if last.get("type") == "text" and isinstance(last.get("text"), str):
+                updated_last = dict(last)
+                updated_last["text"] = updated_last["text"] + text
+                new_content[-1] = updated_last
+                return new_content
+        new_content.append({"type": "text", "text": text})
+        return new_content
+    if isinstance(content, dict):
+        if content.get("type") == "text" and isinstance(content.get("text"), str):
+            updated = dict(content)
+            updated["text"] = updated["text"] + text
+            return updated
+    return str(content) + text
+
+
+def streaming_response_kwargs(stream: bool) -> dict[str, Any]:
+    """Return kwargs for FastAPI/Starlette StreamingResponse.
+
+    For streaming responses, set an explicit `Content-Type: text/event-stream`
+    header (without charset) to satisfy strict SSE checkers and to avoid
+    Starlette's automatic `; charset=...` injection.
+    """
+    if stream:
+        return {"headers": {"content-type": "text/event-stream"}}
+    return {"media_type": "application/json"}
+


### PR DESCRIPTION
### What this PR does / why we need it?
- Fix `examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py` crashing on recompute retries when `/v1/chat/completions` sends list-style `messages[0].content` (OpenAI content parts). The previous code attempted `list + str`.
- For streaming responses, set an explicit `Content-Type: text/event-stream` header (without charset) for strict SSE validators.

Fixes #6495. Fixes #6294.
Related: #5367.

### Does this PR introduce _any_ user-facing change?
- Yes. The proxy example no longer crashes for list-style chat content, and streaming responses return `text/event-stream`.

### How was this patch tested?
- Added UT: `tests/ut/test_openai_proxy_utils.py`.
- (Local) `python -m unittest tests/ut/test_openai_proxy_utils.py -v`.

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
