### PR TITLE
Clarify 310P image support and availability

### DIFF
--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -5,14 +5,27 @@
 2. Currently, the 310I series only supports eager mode and the float16 data type.
 ```
 
+## Supported Images
+
+310P images are published alongside each release. You can find all available 310P images at [quay.io/ascend/vllm-ascend](https://quay.io/repository/ascend/vllm-ascend?tab=tags) by looking for tags ending with `-310p` or `-310p-openeuler`.
+
+Image naming convention:
+- `vllm-ascend:<version>-310p` - Ubuntu-based image for Atlas 300I
+- `vllm-ascend:<version>-310p-openeuler` - openEuler-based image for Atlas 300I
+
+```{warning}
+Not all release versions include 310P images. Please check the quay.io repository for available 310P tags before use.
+```
+
 ## Run vLLM on Atlas 300I Series
 
 Run docker container:
 
 ```{code-block} bash
    :substitutions:
-# Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:v0.10.0rc1-310p
+# Check quay.io/ascend/vllm-ascend for available 310P image tags
+# Example: quay.io/ascend/vllm-ascend:v0.16.0rc1-310p (if available)
+export IMAGE=quay.io/ascend/vllm-ascend:<version>-310p
 docker run --rm \
 --name vllm-ascend \
 --shm-size=1g \


### PR DESCRIPTION
Add documentation section explaining 310P image naming convention and availability. Direct users to check quay.io for available 310P tags since not all releases include 310P images. Update example to use generic version placeholder.

Fixes #6309

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
