### PR TITLE
Fix incorrect environment variable name

### DIFF
--- a/docs/source/user_guide/feature_guide/lmcache_ascend_deployment.md
+++ b/docs/source/user_guide/feature_guide/lmcache_ascend_deployment.md
@@ -35,7 +35,6 @@ docker run -it \
     -p 8000:8000 \
     -p 8001:8001 \
     --name lmcache-ascend-dev \
-    -e ASCEND_VISIBLE_DEVICES=${DEVICE_LIST} \
     -e ASCEND_RT_VISIBLE_DEVICES=${DEVICE_LIST} \
     -e ASCEND_TOTAL_MEMORY_GB=32 \
     -e VLLM_TARGET_DEVICE=npu \


### PR DESCRIPTION
Remove duplicate and incorrectly named ASCEND_VISIBLE_DEVICES environment variable. The correct variable is ASCEND_RT_VISIBLE_DEVICES.

Fixes #5568

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
