### PR TITLE
Fix CPU binding for non-English OS by setting LANG=C

### DIFF
--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -37,7 +37,10 @@ def is_arm_cpu() -> bool:
 
 
 def execute_command(cmd: list[str]) -> tuple[str, int]:
-    with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
+    # Set LANG=C to ensure consistent English output regardless of OS language
+    env = os.environ.copy()
+    env["LANG"] = "C"
+    with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env) as p:
         out, _ = p.communicate(timeout=1000)
     return out.decode(), p.returncode
 


### PR DESCRIPTION
Set the LANG environment variable to 'C' in execute_command() to ensure consistent English output from system commands like 'ps', regardless of the OS language settings. This fixes parsing failures on Chinese and other non-English language systems.

Fixes #6992

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
