### PR TITLE
Document profiler configuration options for torch profiler

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
+++ b/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
@@ -28,7 +28,23 @@ Two performance collection solutions are provided below: Ascend PyTorch Profiler
 
 ### 0. Installation and Configuration
 
-No additional packages need to be installed; it can be enabled through command-line configuration. Currently, vLLM enables **python stack** by default, which can significantly inflate the collected performance data. If you do not wish to collect **python stack**, you can disable it using `torch_profiler_with_stack=false`.
+No additional packages need to be installed; it can be enabled through command-line configuration.
+
+#### Profiler Configuration Options
+
+The `--profiler-config` parameter accepts a JSON object with the following options:
+
+| Parameter | Description | Default |
+|:----------|:------------|:--------|
+| `profiler` | Profiler type. Use `"torch"` for Ascend PyTorch Profiler. | `"torch"` |
+| `torch_profiler_dir` | Directory path to save profiling data. **Required** when using torch profiler. | - |
+| `torch_profiler_with_stack` | Whether to record Python stack trace for each operator. Enabling this provides more detailed call stack information but significantly increases profiling data size. | `true` |
+| `torch_profiler_with_memory` | Whether to record memory allocation and deallocation information. Useful for debugging memory issues but increases overhead. | `false` |
+
+```{note}
+- When `torch_profiler_with_stack=true` (default), the collected performance data can be significantly larger. If you only need operator timing information without call stacks, set `torch_profiler_with_stack=false` to reduce data size.
+- The `torch_profiler_with_memory` option is useful for debugging memory-related issues but may impact performance during profiling.
+```
 
 ### 1. Preparation for Collection
 


### PR DESCRIPTION
Add detailed documentation table explaining all profiler configuration options including:
- torch_profiler_dir: Directory to save profiling data
- torch_profiler_with_stack: Python stack trace recording
- torch_profiler_with_memory: Memory allocation tracking

This addresses the missing documentation for additional config options introduced in PR #5928.

Fixes #6903

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
