### PR TITLE
fix: bypass flash_attn import in AscendApplyRotaryEmb

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.rotary_embedding import (
     RotaryEmbedding,
     YaRNScalingRotaryEmbedding,
 )
+from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 from vllm.triton_utils import HAS_TRITON
 
@@ -556,11 +557,14 @@ class AscendApplyRotaryEmb(ApplyRotaryEmb):
         is_neox_style: bool = True,
         enable_fp32_compute: bool = False,
     ) -> None:
-        super().__init__(
-            enforce_enable=enforce_enable,
-            is_neox_style=is_neox_style,
-            enable_fp32_compute=enable_fp32_compute,
-        )
+        # Bypass ApplyRotaryEmb.__init__ to avoid flash_attn import which is
+        # not available on Ascend NPU. Directly call CustomOp.__init__ and
+        # manually set the required attributes.
+        # See: https://github.com/vllm-project/vllm-ascend/issues/6555
+        CustomOp.__init__(self, enforce_enable=enforce_enable)
+        self.is_neox_style = is_neox_style
+        self.enable_fp32_compute = enable_fp32_compute
+        self.apply_rotary_emb_flash_attn = None
 
     def forward_oot(
         self,


### PR DESCRIPTION
## Summary
Fix `ModuleNotFoundError: No module named 'flash_attn.ops'` error when loading VL models on Ascend NPU.

### Problem
- When loading Qwen3-VL models with `--attention_backend flash` parameter, the `ApplyRotaryEmb.__init__()` attempts to detect and import `flash_attn` library
- On Ascend NPU, `flash_attn` is not available (it's designed for NVIDIA CUDA GPUs only)
- This causes the error: `ModuleNotFoundError: No module named 'flash_attn.ops'; 'flash_attn' is not a package`

### Root Cause Analysis
The error occurs because:
1. `ApplyRotaryEmb.__init__()` in vllm uses `find_spec("flash_attn")` to detect the library
2. In some Ascend environments, an incomplete `flash_attn` module may exist (e.g., a stub file), causing `find_spec` to return non-None
3. The subsequent import `from flash_attn.ops.triton.rotary import apply_rotary` fails

### Solution
Bypass `ApplyRotaryEmb.__init__()` in `AscendApplyRotaryEmb` by:
- Directly calling `CustomOp.__init__()` instead of `super().__init__()`
- Manually setting the required attributes (`is_neox_style`, `enable_fp32_compute`, `apply_rotary_emb_flash_attn`)
- This avoids the flash_attn import while maintaining full functionality using `torch_npu.npu_rotary_mul`

### Key Changes
| File | Change |
|------|--------|
| `vllm_ascend/ops/rotary_embedding.py` | Bypass parent `__init__` to avoid flash_attn import |

## Test plan
- [ ] Verify the fix resolves issue #6555
- [ ] Run existing VL model tests on Ascend NPU
- [ ] Verify `AscendApplyRotaryEmb.forward_oot()` still works correctly

Fixes #6555

Made with [Cursor](https://cursor.com)
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
