### PR TITLE
[Bugfix] Handle empty logits tensor in _apply_top_k_top_p_pytorch

### DIFF
--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -101,6 +101,13 @@ def _apply_top_k_top_p_pytorch(
     if p is None and k is None:
         return logits
 
+    # During chunked prefill, there may be scheduling steps where no tokens
+    # need sampling, resulting in an empty logits tensor (batch_size == 0).
+    # All subsequent sort/gather/cumsum/mask operations produce degenerate
+    # tensors and crash at indexing (e.g. top_p_mask[:, -1]).
+    if logits.shape[0] == 0:
+        return logits
+
     probs = logits.softmax(dim=-1)
     probs_sort, _ = probs.sort(dim=-1, descending=False)
 


### PR DESCRIPTION
## Summary
- Add early return when `logits.shape[0] == 0` in `_apply_top_k_top_p_pytorch`
- During chunked prefill, scheduling steps with no tokens to sample produce empty logits tensors
- Without this guard, `sort`/`gather`/`cumsum` produce degenerate tensors and crash at `top_p_mask[:, -1]` indexing

Fixes #1133
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
