### PR TITLE
[Bugfix] Fix DualChunkRotaryEmbedding hardcoded CUDA device for Ascend NPU

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -450,6 +450,25 @@
 #    Future Plan:
 #       Remove this patch when upstream adds a backend dispatch path for q/k norm.
 #
+# ** 20. File: worker/patch_dual_chunk_rope.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.layers.rotary_embedding.dual_chunk_rope.DualChunkRotaryEmbedding.__init__`
+#    Why:
+#       DualChunkRotaryEmbedding.__init__ in upstream vLLM hardcodes
+#       `torch.device(f"cuda:{torch.cuda.current_device()}")`, which raises
+#       `AssertionError: Torch not compiled with CUDA enabled` on Ascend NPU.
+#       This breaks any model that uses Dual Chunk Attention (e.g. Qwen2.5-7B-Instruct-1M).
+#       (vllm-ascend issue #4309)
+#    How：
+#       Monkey-patch `__init__` to replace the hardcoded CUDA device lookup
+#       with `torch.device(current_platform.device_name)` so that the rotary
+#       cache is allocated on the correct device regardless of backend.
+#    Related PR (if no, explain why):
+#       Pending upstream fix in vLLM.
+#    Future Plan:
+#       Remove this patch once upstream vLLM replaces the hardcoded CUDA
+#       device with a platform-aware alternative.
+#
 # ** 19. File: worker/patch_qwen3_5.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.qwen3_5.Qwen3_5GatedDeltaNet._forward_core`

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -42,3 +42,4 @@ import vllm_ascend.patch.worker.patch_kimi_k25  # noqa
 import vllm_ascend.patch.worker.patch_draft_quarot  # noqa
 import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
+import vllm_ascend.patch.worker.patch_dual_chunk_rope  # noqa

--- a/vllm_ascend/patch/worker/patch_dual_chunk_rope.py
+++ b/vllm_ascend/patch/worker/patch_dual_chunk_rope.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from vllm.model_executor.layers.rotary_embedding.dual_chunk_rope import (
+    DualChunkRotaryEmbedding,
+)
+from vllm.platforms import current_platform
+
+
+def _dual_chunk_rope_init(
+    self,
+    head_size: int,
+    rotary_dim: int,
+    max_position_embeddings: int,
+    base: float,
+    is_neox_style: bool,
+    dtype: torch.dtype,
+    chunk_size: int,
+    local_size: int,
+) -> None:
+    # Call nn.Module.__init__ directly to avoid the CUDA device lookup in
+    # the original DualChunkRotaryEmbedding.__init__.
+    torch.nn.Module.__init__(self)
+    self.head_size = head_size
+    self.rotary_dim = rotary_dim
+    self.max_position_embeddings = max_position_embeddings
+    self.base = base
+    self.is_neox_style = is_neox_style
+    self.chunk_size = chunk_size
+    self.local_size = local_size
+    self.dtype = dtype
+    # Use current_platform.device_name instead of the hardcoded
+    # "cuda:<N>" string so that this works on Ascend NPU and any other
+    # non-CUDA backend.  (Fixes vllm-ascend issue #4309.)
+    self.device = torch.device(current_platform.device_name)
+    (q_cache, qc_cache, k_cache, qc_no_clamp_cache, q_inter_cache) = (
+        self._compute_cos_sin_cache()
+    )
+
+    self.register_buffer("cos_sin_q_cache", q_cache, persistent=False)
+    self.register_buffer("cos_sin_qc_cache", qc_cache, persistent=False)
+    self.register_buffer("cos_sin_k_cache", k_cache, persistent=False)
+    self.register_buffer(
+        "cos_sin_qc_no_clamp_cache", qc_no_clamp_cache, persistent=False
+    )
+    self.register_buffer("cos_sin_q_inter_cache", q_inter_cache, persistent=False)
+
+
+# Patch DualChunkRotaryEmbedding.__init__ to replace the hardcoded
+# `torch.device(f"cuda:{torch.cuda.current_device()}")` with a
+# platform-aware device string so that Qwen2.5-7B-Instruct-1M (and any
+# other model that uses DualChunkAttention) can run on Ascend NPU.
+# TODO: Remove this patch when upstream vLLM fixes the hardcoded CUDA
+# device in dual_chunk_rope.py.
+DualChunkRotaryEmbedding.__init__ = _dual_chunk_rope_init


### PR DESCRIPTION
## Summary
- Add monkey-patch for `DualChunkRotaryEmbedding.__init__` to replace hardcoded `torch.cuda.current_device()` with `current_platform.device_name`
- Register patch in `patch/worker/__init__.py` and document in `patch/__init__.py`

Upstream vLLM's `DualChunkRotaryEmbedding` hardcodes `torch.device(f"cuda:{torch.cuda.current_device()}")`, which raises `AssertionError: Torch not compiled with CUDA enabled` on Ascend NPU. This breaks models using Dual Chunk Attention (e.g. Qwen2.5-7B-Instruct-1M).

Fixes #4309
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
