### PR TITLE
[Feat][Worker] Enable V1 usage stats reporting on Ascend

### DIFF
--- a/tests/ut/test_usage_stats.py
+++ b/tests/ut/test_usage_stats.py
@@ -1,0 +1,58 @@
+import sys
+import types
+import unittest
+
+from vllm_ascend.usage_stats import maybe_report_v1_usage_stats
+
+
+class TestMaybeReportV1UsageStats(unittest.TestCase):
+
+    def setUp(self):
+        self._saved_modules = dict(sys.modules)
+
+    def tearDown(self):
+        sys.modules.clear()
+        sys.modules.update(self._saved_modules)
+
+    def test_noop_when_vllm_v1_utils_missing(self):
+        sys.modules.pop("vllm", None)
+        sys.modules.pop("vllm.v1", None)
+        sys.modules.pop("vllm.v1.utils", None)
+        maybe_report_v1_usage_stats(object())
+
+    def test_calls_report_usage_stats_when_available(self):
+        calls = []
+
+        vllm_mod = types.ModuleType("vllm")
+        v1_mod = types.ModuleType("vllm.v1")
+        utils_mod = types.ModuleType("vllm.v1.utils")
+
+        def report_usage_stats(vllm_config):
+            calls.append(vllm_config)
+
+        utils_mod.report_usage_stats = report_usage_stats
+
+        sys.modules["vllm"] = vllm_mod
+        sys.modules["vllm.v1"] = v1_mod
+        sys.modules["vllm.v1.utils"] = utils_mod
+
+        cfg = object()
+        maybe_report_v1_usage_stats(cfg)
+        self.assertEqual(calls, [cfg])
+
+    def test_swallows_report_usage_stats_errors(self):
+        vllm_mod = types.ModuleType("vllm")
+        v1_mod = types.ModuleType("vllm.v1")
+        utils_mod = types.ModuleType("vllm.v1.utils")
+
+        def report_usage_stats(_):
+            raise RuntimeError("boom")
+
+        utils_mod.report_usage_stats = report_usage_stats
+
+        sys.modules["vllm"] = vllm_mod
+        sys.modules["vllm.v1"] = v1_mod
+        sys.modules["vllm.v1.utils"] = utils_mod
+
+        maybe_report_v1_usage_stats(object())
+

--- a/vllm_ascend/usage_stats.py
+++ b/vllm_ascend/usage_stats.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_report_v1_usage_stats(vllm_config: Any) -> None:
+    """Report vLLM V1 usage stats if the feature is available.
+
+    vLLM reports anonymized usage statistics by default (users can opt out
+    following upstream documentation). vLLM Ascend should behave consistently
+    with upstream V1 workers by reporting once on rank0 during initialization.
+
+    This helper is intentionally best-effort and must never crash the worker.
+    """
+    try:
+        from vllm.v1.utils import report_usage_stats  # type: ignore
+    except Exception:
+        return
+
+    try:
+        report_usage_stats(vllm_config)
+    except Exception as e:
+        logger.debug("Failed to report v1 usage stats: %s", e)
+

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -52,6 +52,7 @@ from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+from vllm_ascend.usage_stats import maybe_report_v1_usage_stats
 from vllm_ascend.utils import (
     AscendDeviceType,
     check_ascend_device_type,
@@ -320,6 +321,9 @@ class NPUWorker(WorkerBase):
             self.model_runner = NPUModelRunnerV2(self.vllm_config, self.device)
         else:
             self.model_runner = NPUModelRunner(self.vllm_config, self.device)
+
+        if self.rank == 0:
+            maybe_report_v1_usage_stats(self.vllm_config)
 
     @torch.inference_mode()
     def determine_available_memory(self) -> int:


### PR DESCRIPTION
### What this PR does / why we need it?
- Call upstream vLLM V1 `report_usage_stats` from the Ascend V1 worker (rank0) to align with GPU/TPU workers.
- Keep the behavior best-effort so usage stats reporting cannot crash worker init.

Fixes #1053.

### Does this PR introduce _any_ user-facing change?
- Yes. When usage stats are enabled upstream, vLLM Ascend V1 will now report once during initialization on rank0.

### How was this patch tested?
- Added UT: `tests/ut/test_usage_stats.py`.
- (Local) `python -m unittest tests/ut/test_usage_stats.py -v`.

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
