### PR TITLE
[Doc] Replace deprecated full_cuda_graph with cudagraph_mode in Qwen2.5-Omni

### DIFF
--- a/docs/source/tutorials/models/Qwen2.5-Omni.md
+++ b/docs/source/tutorials/models/Qwen2.5-Omni.md
@@ -82,7 +82,7 @@ vllm serve "${MODEL_PATH}" \
 --served-model-name Qwen-Omni \
 --allowed-local-media-path ${LOCAL_MEDIA_PATH} \
 --trust-remote-code \
---compilation-config '{"full_cuda_graph": 1}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --no-enable-prefix-caching
 ```
 
@@ -113,7 +113,7 @@ vllm serve ${MODEL_PATH}\
 --served-model-name Qwen-Omni \
 --allowed-local-media-path ${LOCAL_MEDIA_PATH} \
 --trust-remote-code \
---compilation-config {"full_cuda_graph": 1} \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
 --data-parallel-size ${DP_SIZE} \
 --no-enable-prefix-caching
 ```


### PR DESCRIPTION
## Summary
- Replace `full_cuda_graph: 1` with `cudagraph_mode: FULL_DECODE_ONLY` in both single-NPU and multi-NPU examples
- `full_cuda_graph` is deprecated and falls back to `NONE` on NPU

Fixes #4696
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
