### PR TITLE
[main][bugfix] Fixed the problem that eagle3 will crash in FULL_DECODE_ONLY

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -559,6 +559,8 @@ class SpecDecodeBaseProposer(EagleProposer):
                 common_attn_metadata.num_reqs = num_reqs_padded
                 common_attn_metadata.query_start_loc = self.runner.query_start_loc.gpu[: num_reqs_padded + 1]
                 common_attn_metadata.query_start_loc_cpu = self.runner.query_start_loc.cpu[: num_reqs_padded + 1]
+                common_attn_metadata.seq_lens = self.runner.seq_lens.gpu[:num_reqs_padded]
+                common_attn_metadata.seq_lens_cpu = self.runner.seq_lens.cpu[:num_reqs_padded]
         else:
             num_input_tokens = num_tokens
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -745,11 +745,11 @@ class NPUModelRunner(GPUModelRunner):
             self.gdn_query_start_loc.copy_to_gpu()
 
         self.seq_lens.np[:num_reqs] = self.input_batch.num_computed_tokens_cpu[:num_reqs] + num_scheduled_tokens
+        self.seq_lens.cpu[num_reqs:].fill_(0)
         self.seq_lens.copy_to_gpu()
 
         # Fill unused with -1. Needed for reshape_and_cache in attention_cp
         self.query_start_loc.gpu[num_reqs + 1 :].fill_(-1)
-        self.seq_lens.gpu[num_reqs:].fill_(0)
 
         # Copy the tensors to the NPU.
         self._prepare_input_ids(scheduler_output, total_num_scheduled_tokens, cu_num_tokens)


### PR DESCRIPTION
### What this PR does / why we need it?

Two problems have been solved in this pr.

These problems occur in the `FULL_DECODE_ONLY` mode that `num_tokens` should be padded to some value in `cudagraph_capture_sizes`.

1. We found the length of `seq_lens_list` in drafter's `attn_metadata` is 1 shorter than expected. It will raise a kernel exception to make vllm crash.
  e.g., `num_reqs` = 3, `cudagraph_capture_sizes` = [20], `actual_seq_lengths_q` is padded well to [4, 8, 12, 20]. But `seq_lens_list` = [5742, 4700, 7996], it is not padded.

3. Though the length of `seq_lens_list` in target's `attn_metadata` is the same as expected in `FULL_DECODE_ONLY`, some data are corrupted at the end of the list.
  e.g., `num_reqs` = 3, `cudagraph_capture_sizes` = [20], `actual_seq_lengths_q` is padded well to [4, 8, 12, 20]. But `seq_lens_list` = [5742, 4700, 7996, 5738], it has corrupted at the end of the list.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

The codes to reproduce:

```python
if __name__ == '__main__':
    prompts = [
        "2.Who are you?" * 1100,
        "Who are you?" * 1100,
        "2.Who are you?1" * 1100,
        "Who are you?2" * 1100,
        "2.Who are you?3" * 1100,
        "Who are you?4" * 1100,
        "2.Who are you?5" * 1100,
        "Who are you?6" * 1100,
    ]

    sampling_params = SamplingParams(temperature=0.0, top_p=0.95, top_k=40, max_tokens=300)
    llm = LLM(
        model="/home/some-model/Qwen3-30B-A3B",

        max_num_seqs=16,
        
        max_num_batched_tokens=10240,
        tensor_parallel_size=4,
        distributed_executor_backend="mp",
        gpu_memory_utilization=0.9,
        async_scheduling=True,
        disable_log_stats=False,
        speculative_config={
            "model": "/home/some-model/Qwen3-a3B_eagle3",
            "disable_padded_drafter_batch": False,
            "method": "eagle3",
            "num_speculative_tokens": 3,
        },
        
        compilation_config={
            "cudagraph_mode": "FULL_DECODE_ONLY",
            "cudagraph_num_of_warmups": 1,
        },

        max_model_len=10240, 
        enable_prefix_caching=False,
    )

    outputs = llm.generate(prompts, sampling_params)
```

The program will crash, exception is shown as below:

```text
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] WorkerProc hit an exception.
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] Traceback (most recent call last):
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/vllm-workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 875, in worker_busy_loop
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     output = func(*args, **kwargs)
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]              ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/vllm-workspace/vllm/vllm/v1/worker/worker_base.py", line 365, in execute_model
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     return self.worker.execute_model(scheduler_output)
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/worker.py", line 406, in execute_model
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     return func(*args, **kwargs)
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 1368, in execute_model
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     hidden_states = self._model_forward(
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]                     ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 1794, in _model_forward
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     hidden_states = self.model(
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]                     ^^^^^^^^^^^
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/vllm-workspace/vllm-ascend/vllm_ascend/compilation/acl_graph.py", line 201, in __call__
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     torch.npu.current_stream().synchronize()
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch_npu/npu/streams.py", line 85, in synchronize
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]     super(Stream, self).synchronize()
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] RuntimeError: synchronize:build/CMakeFiles/torch_npu.dir/compiler_depend.ts:361 NPU function error: c10_npu::acl::AclrtSynchronizeStreamWithTimeout(stream()), error code is 507015
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] [ERROR] 2026-03-16-11:36:26 (PID:94519, Device:2, RankID:-1) ERR00100 PTA call acl api failed
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] [Error]: The aicore execution is abnormal. 
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880]         Rectify the fault based on the error information in the ascend log.
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] EE9999: Inner Error!
(EngineCore_DP0 pid=94497) (Worker pid=94519) (Worker_TP2 pid=94519) ERROR 03-16 11:36:26 [multiproc_executor.py:880] EE9999[PID: 94519] 2026-03-16-11:36:26.650.466 (EE9999):  rtStreamSynchronizeWithTimeout execution failed, reason=aicore exception[FUNC:FuncErrorReason][FILE:error_message_manage.cc][LINE:61]
```

After changes in this pr:

The result of codes is shown:

```text
--------------------------------------------------
total_num_output_tokens: 2400
num_drafts: 675
num_draft_tokens: 2025
num_accepted_tokens: 1722
mean acceptance length: 3.55
--------------------------------------------------
acceptance at token 0: 0.85
acceptance at token 1: 0.85
acceptance at token 2: 0.85
acceptance at token 3: 0.00
acceptance at token 4: 0.00
acceptance at token 5: 0.00
```

Unfortunately, the data for `ci` is too short to reproduce the crash.

If we increase the data length of `ci` by 1000 times, it will only reproduce with a very low probability.

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8b6325758cce5f9c36d38f2462edbd368b97a07c
