### PR TITLE
[CI]Fix resource exhausted in building vllm-ascend in container, cause container always use cgroup to limit the cpu cores.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ WORKDIR /workspace
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
+COPY ./tools/get_cpu_count.sh /vllm-workspace/
+
 # Install clang-15 (for triton-ascend) and Mooncake
 RUN apt-get update -y && \
     apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 clang-15 && \
@@ -36,7 +38,7 @@ RUN apt-get update -y && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:$LD_LIBRARY_PATH && \
     mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
-    make -j$(nproc) && make install && \
+    make -j$(/vllm-workspace/get_cpu_count.sh) && make install && \
     rm -rf /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -22,6 +22,8 @@ ARG MOONCAKE_TAG=v0.3.8.post1
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
+COPY ./tools/get_cpu_count.sh /vllm-workspace/
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspace
@@ -38,7 +40,7 @@ RUN apt-get update -y && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:$LD_LIBRARY_PATH && \
     mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
-    make -j$(nproc) && make install && \
+    make -j$(/vllm-workspace/get_cpu_count.sh) && make install && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -24,6 +24,8 @@ WORKDIR /workspace
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
+COPY ./tools/get_cpu_count.sh /vllm-workspace/
+
 SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
@@ -38,7 +40,7 @@ RUN yum update -y && \
     cd /vllm-workspace/Mooncake && \
     bash mooncake_installer.sh -y && \
     mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
-    make -j$(nproc) && make install && \
+    make -j$(/vllm-workspace/get_cpu_count.sh) && make install && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -24,6 +24,8 @@ WORKDIR /workspace
 
 COPY ./tools/mooncake_installer.sh /vllm-workspace/
 
+COPY ./tools/get_cpu_count.sh /vllm-workspace/
+
 SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
@@ -38,7 +40,7 @@ RUN yum update -y && \
     cd /vllm-workspace/Mooncake && \
     bash mooncake_installer.sh -y && \
     mkdir -p build && cd build && cmake .. -DUSE_ASCEND_DIRECT=ON && \
-    make -j$(nproc) && make install && \
+    make -j$(/vllm-workspace/get_cpu_count.sh) && make install && \
     rm -fr /vllm-workspace/Mooncake/build && \
     rm -rf /var/cache/yum/*
 

--- a/csrc/build.sh
+++ b/csrc/build.sh
@@ -1329,7 +1329,7 @@ else
 fi
 
 function get_cpu_num() {
-    CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2))
+    CPU_NUM=$(($($CURRENT_DIR/../tools/get_cpu_count.sh)*2))
     if [ -n "${OPS_CPU_NUMBER}" ]; then
         if [[ "${OPS_CPU_NUMBER}" =~ ^[0-9]+$ ]]; then
             CPU_NUM="${OPS_CPU_NUMBER}"

--- a/csrc/cmake/scripts/prepare.sh
+++ b/csrc/cmake/scripts/prepare.sh
@@ -9,7 +9,12 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2))
+# Get CPU count using the common script (handles container environments correctly)
+SCRIPT_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
+VLLM_ASCEND_ROOT=$(dirname $(dirname $(dirname ${SCRIPT_DIR})))
+CPU_NUM=$(${VLLM_ASCEND_ROOT}/tools/get_cpu_count.sh)
+# Double the CPU count for parallel builds
+CPU_NUM=$((CPU_NUM * 2))
 JOB_NUM="-j${CPU_NUM}"
 
 while [[ $# -gt 0 ]]; do

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,49 @@ ROOT_DIR = os.path.dirname(__file__)
 logger = logging.getLogger(__name__)
 
 
+def get_container_cpu_count() -> int:
+    """Get the number of CPUs available in the current environment.
+
+    This function correctly handles container environments where nproc or
+    os.cpu_count() may return the host's CPU count instead of the container's
+    limit. It reads from cgroups to get the actual CPU limit.
+    """
+    # Try cgroup v2 first (most reliable for containers)
+    cpu_max_path = "/sys/fs/cgroup/cpu.max"
+    if os.path.exists(cpu_max_path):
+        try:
+            with open(cpu_max_path) as f:
+                content = f.read().strip()
+                quota, period = content.split()
+                if quota != "max":
+                    return max(1, int(int(quota) / int(period)))
+        except (OSError, ValueError):
+            pass
+
+    # Try cgroup v1
+    quota_path = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+    period_path = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+    if os.path.exists(quota_path) and os.path.exists(period_path):
+        try:
+            with open(quota_path) as f:
+                quota = int(f.read().strip())
+            with open(period_path) as f:
+                period = int(f.read().strip())
+            if quota > 0:  # quota <= 0 means unlimited
+                return max(1, int(quota / period))
+        except (OSError, ValueError):
+            pass
+
+    # Fallback: try sched_getaffinity
+    try:
+        return len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        pass
+
+    # Final fallback: os.cpu_count()
+    return os.cpu_count() or 1
+
+
 def check_or_set_default_env(cmake_args, env_name, env_variable, default_path=""):
     if env_variable is None:
         logging.warning(
@@ -243,12 +286,8 @@ class cmake_build_ext(build_ext):
             num_jobs = int(num_jobs)
             logger.info("Using MAX_JOBS=%d as the number of jobs.", num_jobs)
         else:
-            try:
-                # os.sched_getaffinity() isn't universally available, so fall
-                #  back to os.cpu_count() if we get an error here.
-                num_jobs = len(os.sched_getaffinity(0))
-            except AttributeError:
-                num_jobs = os.cpu_count()
+            # Use cgroup-aware CPU count to handle container environments
+            num_jobs = get_container_cpu_count()
         num_jobs = max(1, num_jobs)
 
         return num_jobs

--- a/tools/get_cpu_count.sh
+++ b/tools/get_cpu_count.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+# This script outputs the number of CPUs available in the current environment.
+# It correctly handles container environments where nproc may return host CPU count.
+
+# Function to get CPU count from cgroups v2
+get_cpu_count_cgroup_v2() {
+    local cpu_max_path="/sys/fs/cgroup/cpu.max"
+    if [ -f "$cpu_max_path" ]; then
+        local content quota period
+        content=$(cat "$cpu_max_path")
+        quota=$(echo "$content" | awk '{print $1}')
+        period=$(echo "$content" | awk '{print $2}')
+        if [ "$quota" = "max" ]; then
+            return 1  # Fallback to system CPU count
+        fi
+        echo $(( quota / period ))
+        return 0
+    fi
+    return 1
+}
+
+# Function to get CPU count from cgroups v1
+get_cpu_count_cgroup_v1() {
+    local quota_path="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+    local period_path="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+    if [ -f "$quota_path" ] && [ -f "$period_path" ]; then
+        local quota period
+        quota=$(cat "$quota_path")
+        period=$(cat "$period_path")
+        if [ "$quota" -le 0 ] 2>/dev/null; then
+            return 1  # quota <= 0 means unlimited, fallback
+        fi
+        echo $(( quota / period ))
+        return 0
+    fi
+    return 1
+}
+
+# Function to get CPU count from CPU affinity
+get_cpu_count_affinity() {
+    if command -v nproc &> /dev/null; then
+        # Try sched_getaffinity-based approach using python
+        if command -v python3 &> /dev/null; then
+            local count
+            count=$(python3 -c "import os; print(len(os.sched_getaffinity(0)))" 2>/dev/null)
+            if [ -n "$count" ] && [ "$count" -gt 0 ]; then
+                echo "$count"
+                return 0
+            fi
+        fi
+    fi
+    return 1
+}
+
+# Function to get CPU count from /proc/self/status
+get_cpu_count_proc_status() {
+    local status_path="/proc/self/status"
+    if [ -f "$status_path" ]; then
+        local cpus_allowed
+        cpus_allowed=$(grep "Cpus_allowed:" "$status_path" 2>/dev/null | awk '{print $2}')
+        if [ -n "$cpus_allowed" ]; then
+            # Convert hex mask to binary and count 1s
+            local hex_mask count
+            hex_mask=$(echo "$cpus_allowed" | tr -d ',')
+            if command -v python3 &> /dev/null; then
+                count=$(python3 -c "print(bin(int('$hex_mask', 16)).count('1'))" 2>/dev/null)
+                if [ -n "$count" ] && [ "$count" -gt 0 ]; then
+                    echo "$count"
+                    return 0
+                fi
+            fi
+        fi
+    fi
+    return 1
+}
+
+# Get system default CPU count
+get_system_cpu_count() {
+    if [ -f /proc/cpuinfo ]; then
+        grep -c "^processor" /proc/cpuinfo
+    elif command -v nproc &> /dev/null; then
+        nproc
+    elif command -v sysctl &> /dev/null; then
+        sysctl -n hw.ncpu 2>/dev/null || echo 1
+    else
+        echo 1
+    fi
+}
+
+# Main function to get available CPU count
+get_cpu_count() {
+    local cpu_count
+
+    # Try cgroups v2 first (most reliable for containers)
+    cpu_count=$(get_cpu_count_cgroup_v2)
+    if [ $? -eq 0 ] && [ -n "$cpu_count" ] && [ "$cpu_count" -gt 0 ]; then
+        echo "$cpu_count"
+        return 0
+    fi
+
+    # Try cgroups v1
+    cpu_count=$(get_cpu_count_cgroup_v1)
+    if [ $? -eq 0 ] && [ -n "$cpu_count" ] && [ "$cpu_count" -gt 0 ]; then
+        echo "$cpu_count"
+        return 0
+    fi
+
+    # Try CPU affinity
+    cpu_count=$(get_cpu_count_affinity)
+    if [ $? -eq 0 ] && [ -n "$cpu_count" ] && [ "$cpu_count" -gt 0 ]; then
+        echo "$cpu_count"
+        return 0
+    fi
+
+    # Try /proc/self/status
+    cpu_count=$(get_cpu_count_proc_status)
+    if [ $? -eq 0 ] && [ -n "$cpu_count" ] && [ "$cpu_count" -gt 0 ]; then
+        echo "$cpu_count"
+        return 0
+    fi
+
+    # Fallback to system CPU count
+    get_system_cpu_count
+}
+
+# Output the CPU count
+get_cpu_count

--- a/tools/mooncake_installer.sh
+++ b/tools/mooncake_installer.sh
@@ -32,6 +32,10 @@ GITHUB_PROXY=${GITHUB_PROXY:-"https://github.com"}
 GOVER=1.23.8
 YALANTINGLIBS_VERSION=0.5.6
 
+# Get CPU count (handles container environments correctly)
+SCRIPT_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
+CPU_NUM=$(${SCRIPT_DIR}/get_cpu_count.sh)
+
 # Function to print section headers
 print_section() {
     echo -e "\n${BLUE}=== $1 ===${NC}"
@@ -179,7 +183,7 @@ elif command -v yum &> /dev/null; then
     rm -rf build
     mkdir -p build && cd build
     cmake ..
-    make -j$(nproc)
+    make -j${CPU_NUM}
     make install
     cd "${REPO_ROOT}"
 else
@@ -239,8 +243,8 @@ echo "Configuring yalantinglibs..."
 cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF
 check_success "Failed to configure yalantinglibs"
 
-echo "Building yalantinglibs (using $(nproc) cores)..."
-cmake --build . -j$(nproc)
+echo "Building yalantinglibs (using ${CPU_NUM} cores)..."
+cmake --build . -j${CPU_NUM}
 check_success "Failed to build yalantinglibs"
 
 echo "Installing yalantinglibs..."


### PR DESCRIPTION

### What this PR does / why we need it?
Fix resource exhausted in building vllm-ascend in container, cause container always use cgroup to limit the cpu cores.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
