### PR TITLE
[310P] Support pooling runner for embedding and reranking models

### DIFF
--- a/tests/ut/_310p/attention/test_attention_mask_310.py
+++ b/tests/ut/_310p/attention/test_attention_mask_310.py
@@ -26,11 +26,15 @@ class TestAttentionMaskBuilder310(TestBase):
         self.max_seqlen = 4096
         self.attention_mask_builder = AttentionMaskBuilder310(torch.device("cpu"), self.max_seqlen)
 
-    def test_get_attention_mask_310_for_pooling_model(self):
+    @patch("torch_npu.npu_format_cast")
+    def test_get_attention_mask_310_for_pooling_model(self, mock_format_cast):
+        mock_format_cast.side_effect = lambda x, y: x
         model_config = MagicMock()
         model_config.runner_type = "pooling"
-        with self.assertRaises(NotImplementedError):
-            self.attention_mask_builder.get_attention_mask(model_config)
+        attn_mask = self.attention_mask_builder.get_attention_mask(model_config)
+        self.assertEqual(attn_mask.shape, (1, self.max_seqlen // 16, self.max_seqlen, 16))
+        # Encoder mask should be all zeros (no causal masking)
+        self.assertEqual(attn_mask.sum().item(), 0.0)
 
     @patch("torch_npu.npu_format_cast")
     def test_get_attention_mask_310(self, mock_format_cast):

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -118,22 +118,41 @@ class AttentionMaskBuilder310:
         """
         Retrieves the appropriate attention mask based on the model configuration.
 
-        It explicitly checks for 'pooling' runner types which are not supported
-        on 310P hardware.
+        For pooling/embedding models, returns a non-causal (all-zeros) encoder
+        mask. For other models, returns the standard causal mask.
 
         Args:
             model_config: Configuration object containing runner details.
 
         Returns:
-            torch.Tensor: The causal attention mask.
-
-        Raises:
-            NotImplementedError: If the runner_type is 'pooling'.
+            torch.Tensor: The attention mask in ACL_FORMAT_FRACTAL_NZ.
         """
         if getattr(model_config, "runner_type", None) == "pooling":
-            # TODO: pooling model will be supported soon.
-            raise NotImplementedError("310P does not support runner_type='pooling'")
+            return self._get_encoder_mask(self.max_seqlen)
         return self._get_causal_mask(self.max_seqlen)
+
+    def _get_encoder_mask(self, max_seq_len: int) -> torch.Tensor:
+        """Non-causal attention mask for pooling/embedding models.
+
+        Returns an all-zeros mask (no future-token masking) converted to
+        the FRACTAL_NZ format required by 310P NPU kernels.
+
+        Args:
+            max_seq_len (int): The required sequence length.
+
+        Returns:
+            torch.Tensor: The cached encoder mask in ACL_FORMAT_FRACTAL_NZ.
+        """
+        if not hasattr(self, '_encoder_mask_cache') or self._encoder_mask_cache is None:
+            attn_mask = torch.zeros(
+                (max_seq_len, max_seq_len),
+                dtype=torch.float16,
+                device=self.device,
+            )
+            self._encoder_mask_cache = torch_npu.npu_format_cast(
+                nd_to_nz_2d(attn_mask), ACL_FORMAT_FRACTAL_NZ
+            )
+        return self._encoder_mask_cache
 
     def _get_causal_mask(self, max_seq_len: int) -> torch.Tensor:
         """


### PR DESCRIPTION
**Yes, I donated this PR with my Claude Max sub, you can love or hate slop, or someone can finally make this card worth a damn for the consumer**

The 310P attention backend blocked runner_type='pooling' with a NotImplementedError stub. The parent 910 backend already has full pooling support via _forward_encoder_attention() which uses npu_fusion_attention with sparse_mode=0 (no mask needed). The only fix required is returning a valid encoder mask from get_attention_mask() instead of throwing, since the mask must exist in the metadata struct even though it is unused during pooling forward passes.

Add _get_encoder_mask() that returns a cached all-zeros mask in FRACTAL_NZ format, and update the unit test to assert success.

### What this PR does / why we need it?

The 310P attention backend explicitly blocks `runner_type='pooling'` with a `NotImplementedError` stub in `AttentionMaskBuilder310.get_attention_mask()`. This prevents running embedding and reranking models (e.g. Qwen3-VL-Embedding, Qwen3-VL-Reranker) on 310P hardware, even though the underlying infrastructure already supports it.

**Why it works with a minimal change:**

The execution flow for pooling models is:

1. `AscendAttentionMetadataBuilder.build()` (attention_v1.py:293) calls `self.attn_mask_builder.get_attention_mask(model_config)` → **310P throws here**
2. The mask is stored in `attn_metadata.attn_mask`
3. The parent's `forward()` (attention_v1.py:985) checks `attn_metadata.model_runner_type == "pooling"` and calls `_forward_encoder_attention()`
4. `_forward_encoder_attention()` (attention_v1.py:883-894) uses `torch_npu.npu_fusion_attention()` with `sparse_mode=0` — **the mask is not consumed during the pooling forward pass**

So the 310P backend only needs to stop throwing and return a structurally valid mask. The parent class `AscendAttentionBackendImpl` already has the full pooling branch, and the 310P subclass (`AscendAttentionBackendImpl310`) inherits it without override.

**Changes:**

- **`vllm_ascend/_310p/attention/attention_mask.py`**: Replace `NotImplementedError` with a new `_get_encoder_mask()` method that returns a cached all-zeros mask in `ACL_FORMAT_FRACTAL_NZ` format. Follows the same caching pattern as `_get_causal_mask()`.
- **`tests/ut/_310p/attention/test_attention_mask_310.py`**: Update `test_get_attention_mask_310_for_pooling_model` to assert the encoder mask is returned with the correct shape and all-zero values, instead of asserting `NotImplementedError`.

No changes to `attention_v1.py` — the inherited `forward()` and `_forward_encoder_attention()` work as-is on 310P since both `npu_fusion_attention` and `_npu_flash_attention` are available on this hardware.

### Does this PR introduce _any_ user-facing change?

Yes. Users can now serve pooling/embedding/reranking models on Ascend 310P hardware using `--runner pooling`. Previously this raised `NotImplementedError`.

### How was this patch tested?

**Unit test:**

```bash
python -m pytest tests/ut/_310p/attention/test_attention_mask_310.py::TestAttentionMaskBuilder310::test_get_attention_mask_310_for_pooling_model -v
```

The updated test mocks `torch_npu.npu_format_cast`, creates a model config with `runner_type = "pooling"`, and asserts:
- The returned mask has the expected FRACTAL_NZ shape `(1, max_seqlen // 16, max_seqlen, 16)`
- All values are zero (no causal masking)

**Integration test on 310P hardware:**

```bash
# Reranker
vllm serve Qwen/Qwen3-Reranker-0.6B \
  --task score \
  --hf-overrides '{"architectures": ["Qwen3ForSequenceClassification"], "is_original_qwen3_reranker": true}'

curl http://localhost:8000/v1/score \
  -d '{"model":"Qwen/Qwen3-Reranker-0.6B","text_1":"what is a cat?","text_2":"A cat is a small furry animal."}'

# Embedding
vllm serve Qwen/Qwen3-Embedding-0.6B \
  --task embed

curl http://localhost:8000/v1/embeddings \
  -d '{"model":"Qwen/Qwen3-Embedding-0.6B","input":"hello world"}'
```
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
