### PR TITLE
[CI] add scheduled stale issue management

### DIFF
--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -8,9 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-      contents: write
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
### What this PR does / why we need it?

1. issue with "resolved", 7 days stale, 14 days closed after stale with `stale` and `resolved` label.
2. issue with "awaiting-feedback", 7 days stale, 14 days closed after stale with `stale` and `awaiting-feedback` label.

Change items:
- Add a scheduled stale-management workflow to process resolved and awaiting-feedback issues independently.
- Automatically mark inactive issues as stale , post tailored reminder messages, and close issues after a grace period.
- Remove source labels when issues become active again, and disable PR stale handling so the automation remains issue-scoped.

### Does this PR introduce _any_ user-facing change?
- No API or runtime behavior changes.
- This PR only updates GitHub issue automation (labeling and stale management workflow).

### How was this patch tested?
- Test locally

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
