### PR TITLE
[bugfix] fix unzip file path for fia operator

### DIFF
--- a/tools/install_flash_infer_attention_score_ops_a2.sh
+++ b/tools/install_flash_infer_attention_score_ops_a2.sh
@@ -22,10 +22,9 @@ set -euo pipefail
 trap 'echo "Error on line $LINENO: command \`$BASH_COMMAND\` failed with exit code $?" >&2' ERR
 
 cd /vllm-workspace
-mkdir -p fused_infer_attention_score_a2_$(uname -i)
 # download fused_infer_attention_score related source files
 wget https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/cann-8.5.1/fused_infer_attention_score_a2_$(uname -i).tar.gz
-tar -zxvf ./fused_infer_attention_score_a2_$(uname -i).tar.gz -C ./fused_infer_attention_score_a2_$(uname -i)
+tar -zxvf ./fused_infer_attention_score_a2_$(uname -i).tar.gz
 
 # replace fused_infer_attention_score operation files
 cd $ASCEND_TOOLKIT_HOME/opp/built-in/op_impl/ai_core/tbe/kernel/ascend910b/ops_transformer

--- a/tools/install_flash_infer_attention_score_ops_a3.sh
+++ b/tools/install_flash_infer_attention_score_ops_a3.sh
@@ -21,10 +21,9 @@ set -euo pipefail
 trap 'echo "Error on line $LINENO: command \`$BASH_COMMAND\` failed with exit code $?" >&2' ERR
 
 cd /vllm-workspace
-mkdir -p fused_infer_attention_score_a3_$(uname -i)
 # download fused_infer_attention_score related source files
 wget https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/cann-8.5.1/fused_infer_attention_score_a3_$(uname -i).tar.gz
-tar -zxvf ./fused_infer_attention_score_a3_$(uname -i).tar.gz -C ./fused_infer_attention_score_a3_$(uname -i)
+tar -zxvf ./fused_infer_attention_score_a3_$(uname -i).tar.gz
 
 # replace fused_infer_attention_score operation files
 cd $ASCEND_TOOLKIT_HOME/opp/built-in/op_impl/ai_core/tbe/kernel/ascend910_93/ops_transformer


### PR DESCRIPTION
### What this PR does / why we need it?

The decompression path of the FIA operator package is incorrect, and unnecessary folders have been created during modification.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
Run the script and ensure that the files are replaced correctly.

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
