### PR TITLE
[CI] Add PAT_TOKEN when checkout

### DIFF
--- a/.github/workflows/schedule_update_estimated_time.yaml
+++ b/.github/workflows/schedule_update_estimated_time.yaml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * 1'  # Every Monday at 02:00 UTC
   workflow_dispatch:
-  pull_request:
-    branches:
-      - 'main'
-    paths:
-      - '.github/workflows/schedule_update_estimated_time.yaml'
 
 permissions:
   contents: write
@@ -92,7 +87,6 @@ jobs:
           fi
 
       - name: Create pull request
-        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |


### PR DESCRIPTION
### What this PR does / why we need it?
When we checkout the fork repo and wanna to submit push to the fork repo, the pat_token is needed
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4497431df654e46fb1fb5e64bf8611e762ae5d87
