### PR TITLE
[CI] add Kimi-K2.5 weights download

### DIFF
--- a/.github/workflows/misc/model_list.json
+++ b/.github/workflows/misc/model_list.json
@@ -17,6 +17,7 @@
       "DevQuasar/deepseek-ai.DeepSeek-V3.2-BF16",
       "Eco-Tech/DeepSeek-V3.1-w8a8-mtp-QuaRot",
       "Eco-Tech/Qwen3-30B-A3B-w8a8",
+      "Eco-Tech/Kimi-K2.5-W4A8",
       "Howeee/Qwen2.5-1.5B-apeach",
       "IntervitensInc/pangu-pro-moe-model",
       "IntervitensInc/pangu-pro-moe-modelt",


### PR DESCRIPTION
### What this PR does / why we need it?
Add Kimi-K2.5 weights download.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4497431df654e46fb1fb5e64bf8611e762ae5d87
