### PR TITLE
[Feat]skip lightning indexer for the first 2048 preceding tokens

### DIFF
--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -198,10 +198,12 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
+        common_attn_metadata.seq_lens = torch.Tensor(
+            [100]*common_attn_metadata.num_reqs)
         common_attn_metadata.query_start_loc = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
         common_attn_metadata.query_start_loc_cpu = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
         common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
         common_attn_metadata.positions = torch.randn(100)
@@ -256,10 +258,12 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
+        common_attn_metadata.seq_lens = torch.Tensor(
+            [100]*common_attn_metadata.num_reqs)
         common_attn_metadata.query_start_loc = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
         common_attn_metadata.query_start_loc_cpu = torch.tensor(
-            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
         common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
         common_attn_metadata.positions = torch.randn(100)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -30,6 +30,8 @@ from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,
     enable_cp,
+    get_index_of_skipped_queries_numpy,
+    get_li_skip_indices,
     maybe_save_kv_layer_to_connector,
     trans_rope_weight,
     transdata,
@@ -53,6 +55,7 @@ from vllm_ascend.utils import (
     enable_dsa_cp,
     enable_dsa_cp_with_layer_shard,
     enable_dsa_cp_with_o_proj_tp,
+    enable_lightning_indexer_skip,
     get_weight_prefetch_method,
     maybe_trans_nz,
 )
@@ -63,6 +66,8 @@ if TYPE_CHECKING:
 
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
+
+SPARSE_COUNT = 2048
 
 
 class AscendSFABackend(AttentionBackend):
@@ -144,11 +149,17 @@ class AscendSFAMetadata:
     # chunked prefill by default if no attn_states passed
     attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill
     dsa_cp_context: DSACPContext | None = None
+    li_reorder_indices: torch.Tensor | None = None
     reshape_cache_event: torch.npu.Event = None
     sfa_cp_metadata: AscendPCPMetadata | None = None
+    num_actual_seqs: int = 0
+    top_k_indices_skip_li_query: torch.Tensor | None = None
     num_decodes: int = 0
     num_decode_tokens: int = 0
     num_prefills: int = 0
+
+    num_of_non_skip_tokens: int = 1
+    skip: bool = False
 
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -200,6 +211,10 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         self.actual_seq_lengths_query = torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device)
         self.actual_seq_lengths_key = torch.empty_like(self.actual_seq_lengths_query)
 
+        self.enable_lightning_indexer_skip = enable_lightning_indexer_skip()
+        self.index_of_skipped_queries = None
+        self.num_actual_seqs = max_num_reqs
+
     @staticmethod
     def determine_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
         return ascend_chunked_prefill_workspace_size(vllm_config)
@@ -236,15 +251,79 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         seq_lens = common_attn_metadata.seq_lens[:num_reqs]
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu[:num_reqs]
 
+        query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
+        tokens = query_start_loc[1:] - query_start_loc[:-1]
+
         cos, sin = get_cos_and_sin_mla(input_positions, True)
 
+        # ====================================================================
+        # Step 1: lightning_indexer_skip
+        # Reorder the batch: non-skip tokens first, skip tokens appended as
+        # separate requests at the end. Updates cum_query_lens, seq_lens,
+        # block_table, slot_mapping, cos, sin.
+        # ====================================================================
+        num_of_non_skip_tokens = 0
+        skip = False
+        top_k_indices_of_skipped_queries_numpy = None
+        li_reorder_indices = None
+        if self.enable_lightning_indexer_skip:
+            (li_reorder_indices, li_cum_query_lens, li_seq_lens, li_skipped_query_mask, num_of_non_skip_tokens) = (
+                get_li_skip_indices(seq_lens - tokens, tokens)
+            )
+
+            if li_reorder_indices is not None:
+                skip = True
+                li_reorder_indices = (
+                    torch.from_numpy(li_reorder_indices)
+                    .pin_memory()
+                    .to(dtype=torch.int32, device=self.device, non_blocking=True)
+                )
+                li_cum_query_lens = (
+                    torch.from_numpy(li_cum_query_lens)
+                    .pin_memory()
+                    .to(dtype=torch.int32, device=self.device, non_blocking=True)
+                )
+                li_seq_lens = (
+                    torch.from_numpy(li_seq_lens)
+                    .pin_memory()
+                    .to(dtype=torch.int32, device=self.device, non_blocking=True)
+                )
+                li_skipped_query_mask = (
+                    torch.from_numpy(li_skipped_query_mask)
+                    .pin_memory()
+                    .to(dtype=torch.bool, device=self.device, non_blocking=True)
+                )
+                input_positions_pad = torch.zeros_like(input_positions)
+                input_positions_pad[:num_actual_tokens] = torch.index_select(input_positions, 0, li_reorder_indices)
+                slot_mapping_pad = torch.zeros_like(slot_mapping)
+                slot_mapping_pad[:num_actual_tokens] = torch.index_select(slot_mapping, 0, li_reorder_indices)
+
+                cum_query_lens = li_cum_query_lens
+                seq_lens = li_seq_lens
+                block_table = torch.cat([block_table, block_table[li_skipped_query_mask]], dim=0)
+                slot_mapping = slot_mapping_pad
+                input_positions = input_positions_pad
+                cos, sin = get_cos_and_sin_mla(input_positions, True)
+
+        # ====================================================================
+        # Step 2: dsa_cp
+        # Split tokens evenly across TP devices, recompute per-device
+        # actual_seq_lengths_query and actual_seq_lengths_key.
+        # When combined with lightning_indexer_skip, operates on the
+        # already-reordered cum_query_lens/seq_lens and uses skip-aware
+        # key_lens computation.
+        # ====================================================================
         dsa_cp_context = None
         if self.enable_dsa_cp:
+            num_of_non_skip_tokens = 0
+            num_segs = cum_query_lens.shape[0]
+
             global_tp_size = get_tp_group().world_size
             num_tokens = num_input_tokens
             num_tokens_pad = _round_up(num_tokens, global_tp_size)
             num_tokens_per_device = num_tokens_pad // global_tp_size
             local_start = get_tp_group().rank_in_group * num_tokens_per_device
+
             local_end_with_pad = local_start + num_tokens_per_device
             local_end = min(local_end_with_pad, num_actual_tokens)
 
@@ -278,10 +357,13 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                     got {slot_mapping.shape[0]} and {num_tokens_pad}"
             )
 
-            actual_seq_lengths_query = self.actual_seq_lengths_query
-            actual_seq_lengths_key = self.actual_seq_lengths_key
+            if skip:
+                actual_seq_lengths_query = cum_query_lens
+                actual_seq_lengths_key = seq_lens
+            else:
+                actual_seq_lengths_query = self.actual_seq_lengths_query
+                actual_seq_lengths_key = self.actual_seq_lengths_key
 
-            num_segs = cum_query_lens.shape[0]
             last_token = 0
             cum = 0
             for i in range(0, num_segs):
@@ -293,6 +375,9 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 req_local_end = min(global_end, local_end_with_pad)
                 num_local_tokens = req_local_end - req_local_start
 
+                if i < num_reqs and num_local_tokens > 0:
+                    num_of_non_skip_tokens += num_local_tokens
+
                 if num_local_tokens > 0:
                     cum += num_local_tokens
                     actual_seq_lengths_query[i] = cum
@@ -303,8 +388,8 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                     actual_seq_lengths_query[i] = cum
                     actual_seq_lengths_key[i] = 0
 
-            actual_seq_lengths_query = actual_seq_lengths_query[:num_reqs]
-            actual_seq_lengths_key = actual_seq_lengths_key[:num_reqs]
+            actual_seq_lengths_query = actual_seq_lengths_query[:num_segs]
+            actual_seq_lengths_key = actual_seq_lengths_key[:num_segs]
 
             dsa_cp_context = DSACPContext(
                 num_tokens=num_tokens,
@@ -316,6 +401,26 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
             )
+        if self.enable_lightning_indexer_skip and self.enable_dsa_cp:
+            top_k_indices_of_skipped_queries_numpy = get_index_of_skipped_queries_numpy(
+                actual_seq_lengths_query, actual_seq_lengths_key, num_reqs, SPARSE_COUNT
+            )
+        if self.enable_lightning_indexer_skip:
+            if self.enable_dsa_cp:
+                top_k_indices_of_skipped_queries_numpy = get_index_of_skipped_queries_numpy(
+                    actual_seq_lengths_query, actual_seq_lengths_key, num_reqs, SPARSE_COUNT
+                )
+            else:
+                top_k_indices_of_skipped_queries_numpy = get_index_of_skipped_queries_numpy(
+                    cum_query_lens, seq_lens, num_reqs, SPARSE_COUNT
+                )
+        top_k_indices_of_skipped_queries_numpy = (
+            torch.from_numpy(top_k_indices_of_skipped_queries_numpy)
+            .pin_memory()
+            .to(dtype=torch.int32, device=self.device, non_blocking=True)
+            if top_k_indices_of_skipped_queries_numpy is not None
+            else None
+        )
 
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
@@ -331,6 +436,11 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             dsa_cp_context=dsa_cp_context,
+            li_reorder_indices=li_reorder_indices,
+            num_actual_seqs=num_reqs,
+            top_k_indices_skip_li_query=top_k_indices_of_skipped_queries_numpy,
+            num_of_non_skip_tokens=num_of_non_skip_tokens,
+            skip=skip,
         )
 
     def build_for_graph_capture(
@@ -438,6 +548,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         if self.use_sparse_c8_indexer:
             self.c8_k_cache_dtype = torch.int8
             self.c8_k_scale_cache_dtype = torch.float16
+        self.enable_lightning_indexer_skip = enable_lightning_indexer_skip()
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
@@ -925,37 +1036,69 @@ class AscendSFAImpl(MLAAttentionImpl):
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
     ):
-        weights, _ = self.weights_proj(x)
-
-        q_li, _ = self.wq_b(q_c)  # [b,s,1536] @ [1536,64*128] = [b,s,64*128]
-        q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
-        if HAS_TRITON:
-            q_li = rope_forward_triton_siso(
-                q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
-            )
+        # =========================
+        # step1: determine token range
+        # =========================
+        if attn_metadata.skip:
+            num_of_non_skip_tokens = attn_metadata.num_of_non_skip_tokens
+            if num_of_non_skip_tokens > 0:
+                x = x[:num_of_non_skip_tokens]
+                q_c = q_c[:num_of_non_skip_tokens]
+                cos = cos[:num_of_non_skip_tokens]
+                sin = sin[:num_of_non_skip_tokens]
         else:
-            q_li_pe, q_li_nope = torch.split(
-                q_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
-            )  # [b,s,64,64+64]
+            num_of_non_skip_tokens = x.shape[0]
 
-            q_li_pe = q_li_pe.unsqueeze(2)
-            q_li_pe = torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
-            q_li_pe = q_li_pe.squeeze(2)
-            q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)  # [b*s,64,128]
+        # =========================
+        # step2: compute weights + q_li
+        # =========================
+        if num_of_non_skip_tokens > 0:
+            weights, _ = self.weights_proj(x)
+            q_li, _ = self.wq_b(q_c)  # [b,s,1536] @ [1536,64*128] = [b,s,64*128]
+            q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
+            # rope
+            if HAS_TRITON:
+                q_li = rope_forward_triton_siso(
+                    q_li,
+                    cos,
+                    sin,
+                    rope_dim=self.qk_rope_head_dim,
+                    is_neox_style=self.is_rope_neox_style,
+                )
+            else:
+                q_li_pe, q_li_nope = torch.split(
+                    q_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
+                )  # [b,s,64,64+64]
 
-        if self.use_sparse_c8_indexer:
-            q_li_shape_ori = q_li.shape
-            q_li = q_li @ AscendSFAImpl.q_hadamard
-            q_li, q_li_scale = torch_npu.npu_dynamic_quant(q_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
-            q_li_scale = q_li_scale.to(self.c8_k_scale_cache_dtype)
+                q_li_pe = q_li_pe.unsqueeze(2)
+                q_li_pe = torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
+                q_li_pe = q_li_pe.squeeze(2)
+                q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)  # [b*s,64,128]
 
+            if self.use_sparse_c8_indexer:
+                q_li_shape_ori = q_li.shape
+                q_li = q_li @ AscendSFAImpl.q_hadamard
+                q_li, q_li_scale = torch_npu.npu_dynamic_quant(
+                    q_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype
+                )
+                q_li_scale = q_li_scale.to(self.c8_k_scale_cache_dtype)
+
+        # =========================
+        # step3: run lightning indexer
+        # =========================
         # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
         # So two branches are maintained temporarily.
         # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
-        if self.use_sparse_c8_indexer:
+        if attn_metadata.skip and num_of_non_skip_tokens == 0:
+            top_k_indices_no_skip_li_query = torch.empty(
+                (0, 1, SPARSE_COUNT),
+                device=x.device,
+                dtype=torch.int32,
+            )
+        elif self.use_sparse_c8_indexer:
             assert len(kv_cache) == 4
             weights = weights.to(torch.float16)
-            topk_indices = torch.ops._C_ascend.npu_lightning_indexer_quant(
+            top_k_indices_no_skip_li_query = torch.ops._C_ascend.npu_lightning_indexer_quant(
                 query=q_li.view(q_li_shape_ori),
                 key=kv_cache[2],
                 weights=weights,
@@ -968,36 +1111,46 @@ class AscendSFAImpl(MLAAttentionImpl):
                 key_quant_mode=0,
                 layout_query="TND",
                 layout_key="PA_BSND",
-                sparse_count=2048,
+                sparse_count=SPARSE_COUNT,
                 sparse_mode=3,
             )
         elif self.use_torch_npu_lightning_indexer:
-            topk_indices, _ = torch_npu.npu_lightning_indexer(
+            top_k_indices_no_skip_li_query, _ = torch_npu.npu_lightning_indexer(
                 query=q_li,
                 key=kv_cache[2],
                 weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
+                actual_seq_lengths_query=actual_seq_lengths_query[: attn_metadata.num_actual_seqs],
+                actual_seq_lengths_key=actual_seq_lengths_key[: attn_metadata.num_actual_seqs],
+                block_table=attn_metadata.block_table[: attn_metadata.num_actual_seqs],
                 layout_query="TND",
                 layout_key="PA_BSND",
-                sparse_count=2048,
+                sparse_count=SPARSE_COUNT,
                 sparse_mode=3,
             )
         else:
-            topk_indices = torch.ops._C_ascend.npu_lightning_indexer(
+            top_k_indices_no_skip_li_query = torch.ops._C_ascend.npu_lightning_indexer(
                 query=q_li,
                 key=kv_cache[2],
                 weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
+                actual_seq_lengths_query=actual_seq_lengths_query[: attn_metadata.num_actual_seqs],
+                actual_seq_lengths_key=actual_seq_lengths_key[: attn_metadata.num_actual_seqs],
+                block_table=attn_metadata.block_table[: attn_metadata.num_actual_seqs],
                 layout_query="TND",
                 layout_key="PA_BSND",
-                sparse_count=2048,
+                sparse_count=SPARSE_COUNT,
                 sparse_mode=3,
             )
-        return topk_indices
+
+        # concat skipped sequences
+        if attn_metadata.num_actual_seqs != actual_seq_lengths_key.shape[0]:
+            top_k_indices = torch.cat(
+                [top_k_indices_no_skip_li_query, attn_metadata.top_k_indices_skip_li_query],
+                dim=0,
+            )
+        else:
+            top_k_indices = top_k_indices_no_skip_li_query
+
+        return top_k_indices
 
     def _execute_sparse_flash_attention_process(
         self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
@@ -1211,6 +1364,26 @@ class AscendSFAImpl(MLAAttentionImpl):
             actual_seq_lengths_query=actual_seq_lengths_query,
             actual_seq_lengths_key=actual_seq_lengths_key,
         )
+
+        # dsa_cp mode: ql_nope/q_pe have num_tokens_per_device positions (including
+        # pad), but the skip path in indexer_select_post_process may produce fewer
+        # rows (only covering real tokens). Pad topk_indices with -1 so that its
+        # first dimension matches the query tensors — the pad positions are masked
+        # out by actual_seq_lengths_query anyway.
+        if topk_indices.shape[0] < ql_nope.shape[0]:
+            pad_count = ql_nope.shape[0] - topk_indices.shape[0]
+            topk_indices = torch.cat(
+                [
+                    topk_indices,
+                    torch.full(
+                        (pad_count, topk_indices.shape[1], topk_indices.shape[2]),
+                        -1,
+                        device=topk_indices.device,
+                        dtype=topk_indices.dtype,
+                    ),
+                ],
+                dim=0,
+            )
 
         attn_output = self._execute_sparse_flash_attention_process(
             ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 from vllm.config import VllmConfig, get_current_vllm_config
@@ -331,3 +332,134 @@ def enabling_mlapo(vllm_config: VllmConfig) -> bool:
         and not vllm_config.kv_transfer_config.is_kv_producer
     )
     return bool(envs.VLLM_ASCEND_ENABLE_MLAPO and is_decode_instance)
+
+
+def to_numpy(x):
+    if isinstance(x, torch.Tensor):
+        return x.cpu().numpy()
+    return x
+
+
+def get_li_skip_indices(num_comptuted_tokens, query_lens):
+    num_comptuted_tokens = to_numpy(num_comptuted_tokens).astype(np.int32)
+    query_lens = to_numpy(query_lens).astype(np.int32)
+    skip_threhold = 2048
+
+    # calculate num of tokens need skip for each request
+    num_comptuted_tokens = num_comptuted_tokens[: len(query_lens)]
+    num_skip_tokens = np.maximum(skip_threhold - num_comptuted_tokens, 0)
+    skip_query_lens = np.minimum(num_skip_tokens, query_lens)
+    # if no request is skipped, return None
+    if np.sum(skip_query_lens) == 0:
+        return None, None, None, None, None
+
+    # calculate query lens for non-skip part
+    no_skip_query_lens = np.maximum(query_lens - skip_query_lens, 0)
+    num_of_non_skip_tokens = int(np.sum(no_skip_query_lens))
+
+    # mask the block table need copy
+    li_skipped_mask = query_lens - no_skip_query_lens > 0
+
+    # (1) combine no-skip and skip part query lens
+    # (2) put skip part at the end
+    # (3) for skip-part, only select request with len > 0
+    # (4) cumsum of query len
+    li_cum_query_lens = np.cumsum(np.concatenate([no_skip_query_lens, skip_query_lens[skip_query_lens != 0]]))
+
+    # (1) for no-skip part of a request:
+    #  seq_len  = skip_query_len + no_skip_query_len + num_computed_tokens
+    #           = query_len + num_computed_tokens
+    # (2) for skip part of a request:
+    #  seq_len = skip_query_len + num_computed_tokens
+    # (3) for skip-part, only select request with len > 0
+    # (4) combine skip and no-skip parts as seq_lens
+
+    li_seq_lens = np.concatenate(
+        [
+            query_lens + num_comptuted_tokens,
+            skip_query_lens[skip_query_lens != 0] + num_comptuted_tokens[skip_query_lens != 0],
+        ]
+    )
+
+    # calculate li skip reorder indices
+    q_cal_part_indices = np.array([], dtype=np.int32)
+    q_skip_indices = np.array([], dtype=np.int32)
+
+    seq_offset = np.cumsum(np.insert(query_lens[:-1], 0, 0))
+
+    for req_idx in range(len(query_lens)):
+        full_indices = np.arange(query_lens[req_idx])
+
+        keep_indices = full_indices[full_indices >= num_skip_tokens[req_idx]] + seq_offset[req_idx]
+        skip_indices = full_indices[full_indices < num_skip_tokens[req_idx]] + seq_offset[req_idx]
+
+        q_cal_part_indices = np.concatenate([q_cal_part_indices, keep_indices])
+        q_skip_indices = np.concatenate([q_skip_indices, skip_indices])
+
+    indices = np.concatenate([q_cal_part_indices, q_skip_indices]).astype(np.int32)
+
+    return (indices, li_cum_query_lens, li_seq_lens, li_skipped_mask, num_of_non_skip_tokens)
+
+
+def get_index_of_skipped_queries_numpy(actual_seq_lengths_query, actual_seq_lengths_key, num_actual_seqs, sparse_count):
+    actual_seq_lengths_query = to_numpy(actual_seq_lengths_query)
+    actual_seq_lengths_key = to_numpy(actual_seq_lengths_key)
+    num_actual_seqs = to_numpy(num_actual_seqs)
+
+    # 2. calculate each seq's length
+    actual_query_lens = np.diff(actual_seq_lengths_query, prepend=0)
+
+    # 3. get skipped sequences
+    skipped_q_lens = actual_query_lens[num_actual_seqs:]
+    skipped_k_total_lens = actual_seq_lengths_key[num_actual_seqs:]
+
+    num_tokens: int = np.sum(skipped_q_lens)
+    if num_tokens == 0:
+        return np.full((0, 1, sparse_count), -1, dtype=np.int32)
+
+    # 4. generate token ids in each sequence (0, 1, 2...)
+    # e.g. for seq_lens = [2, 3], generate [0, 1, 0, 1, 2]
+    repeat_offsets = np.cumsum(np.concatenate(([0], skipped_q_lens[:-1])))
+    token_within_seq_idx = np.arange(num_tokens) - np.repeat(repeat_offsets, skipped_q_lens)
+
+    # 5. calculate each token's key length
+    # logic：base_k (total_k - q_len) + token_id + 1
+    base_k_lens = skipped_k_total_lens - skipped_q_lens
+    repeated_base_k_lens = np.repeat(base_k_lens, skipped_q_lens)
+    curr_key_lengths = repeated_base_k_lens + token_within_seq_idx + 1  # shape: (num_tokens,)
+
+    # 6. generate Top-K indices matrices
+    # base indexing [0, 1, 2, ..., sparse_count-1]
+    col_indices = np.arange(sparse_count, dtype=np.int32)
+
+    # generate mask (num_tokens, 1) < (sparse_count)
+    mask = col_indices < curr_key_lengths[:, np.newaxis]
+
+    # generate Top-K indices matrices
+    res = np.where(mask, col_indices, -1)
+
+    # 7. adjust shape (num_tokens, 1, sparse_count)
+    top_k_indices_of_skipped_queries = res[:, np.newaxis, :].astype(np.int32)
+
+    return top_k_indices_of_skipped_queries
+
+
+def maybe_pad_and_reorder_inputs(input_ids, positions, reorder_indices):
+    input_ids_reorder = torch.index_select(input_ids, 0, reorder_indices)
+    positions_reorder = torch.index_select(positions, 0, reorder_indices)
+
+    input_actual_length = input_ids_reorder.size(0)
+    input_ids_reorder_pad = torch.zeros_like(input_ids)
+    input_ids_reorder_pad[:input_actual_length] = input_ids_reorder
+
+    positions_reorder_pad = torch.zeros_like(input_ids)
+    positions_reorder_pad[:input_actual_length] = positions_reorder
+
+    input_ids = input_ids_reorder_pad
+    positions = positions_reorder_pad
+
+    return input_ids_reorder_pad, positions_reorder_pad
+
+
+def hidden_states_reorder(hidden_states, reorder_indices):
+    return torch.index_select(hidden_states, 0, reorder_indices.to(torch.float32).argsort().to(torch.int32))

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1278,3 +1278,19 @@ def parse_layer_idx(prefix: str) -> int | None:
     """Extract the layer index from a module prefix string like 'model.layers.0.self_attn'."""
     match = re.search(r"layers\.(\d+)", prefix)
     return int(match.group(1)) if match else None
+
+
+# TODO: Temporarily use enable_skip_li to enable skipping lightning indexer for first 2048 token of ds32.
+@lru_cache(maxsize=1)
+def enable_lightning_indexer_skip() -> bool:
+    from vllm.config import get_current_vllm_config
+
+    vllm_config = get_current_vllm_config()
+    has_index_topk = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
+        vllm_config.model_config.hf_text_config, "index_topk"
+    )
+    return bool(
+        has_index_topk
+        and vllm_config.additional_config.get("enable_lightning_indexer_skip", True)
+        and vllm_config.model_config.enforce_eager
+    )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -91,7 +91,12 @@ from vllm.v1.worker.utils import AttentionGroup
 # yapf: enable
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, using_paged_attention
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    hidden_states_reorder,
+    maybe_pad_and_reorder_inputs,
+    using_paged_attention,
+)
 
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -1279,7 +1284,6 @@ class NPUModelRunner(GPUModelRunner):
 
                 use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
                 ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
-
                 if (
                     cudagraph_mode == CUDAGraphMode.FULL
                     or (enable_sp() and not self.model_config.use_mla)
@@ -1385,9 +1389,24 @@ class NPUModelRunner(GPUModelRunner):
                 ),
             ) as kv_connector_output,
         ):
+            key = "model.layers.0.self_attn.attn"
+            li_reorder_indices = None
+            if isinstance(attn_metadata, dict):
+                attn = attn_metadata.get(key)
+                if attn is not None:
+                    li_reorder_indices = getattr(attn, "li_reorder_indices", None)
+
+            li_skip = li_reorder_indices is not None
+            if li_skip:
+                input_ids, positions = maybe_pad_and_reorder_inputs(
+                    input_ids, positions, li_reorder_indices
+                )
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
+            if li_skip:
+                hidden_states = hidden_states_reorder(
+                    hidden_states, li_reorder_indices)
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:


### PR DESCRIPTION

### What this PR does / why we need it?
Skip first 2048 tokens for lighting indexer to avoid redundant computation

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4497431df654e46fb1fb5e64bf8611e762ae5d87
### precision test with DeepSeek V3.2
The markdown format results is as below:
| dataset | version | metric | mode | vllm-api-stream-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | 7cd45e | accuracy | gen | 95.75 |

