### PR TITLE
[CI] Add cherry-pick bot workflow

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -164,10 +164,6 @@ jobs:
             echo "benchmark_job_name=${BENCHMARK_JOB_NAME}"
           } >> $GITHUB_OUTPUT
 
-      - name: Prepare scripts
-        run: |
-          install -D tests/e2e/nightly/multi_node/scripts/run.sh /root/.cache/tests/run.sh
-
       - name: Clear resources
         run: |
           set -euo pipefail

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -113,7 +113,17 @@ jobs:
         NAMESPACE: vllm-project
     steps:
       - name: Decode kubeconfig
-        run: echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > "$KUBECONFIG"
+        run: |
+          if [ -n "${{ inputs.request_id }}" ]; then
+            if [ "${{ inputs.soc_version }}" = "a3" ]; then
+              # NOTE: This is too hack, we should find a better way to manage kubeconfig for pr tests.
+              cp /root/.cache/.kube/kubeconfig.yaml "$KUBECONFIG"
+            else
+              cp /root/.cache/.kube/hk_001_kb.yaml "$KUBECONFIG"
+            fi
+          else
+            echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > "$KUBECONFIG"
+          fi
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -118,7 +118,8 @@ jobs:
       - name: uninstall vlm vllm-ascend and remove code (if pr test)
         if: ${{ inputs.request_id != '' }}
         run: |
-          pip uninstall -y vllm-ascend || true
+          # pip uninstall -y vllm-ascend || true
+          cp /vllm-workspace/vllm-ascend/vllm_ascend/_build_info.py /tmp/_build_info_backup.py 2>/dev/null || true
           cp -r /vllm-workspace/vllm-ascend/benchmark /tmp/aisbench-backup || true
           rm -rf  /vllm-workspace/vllm-ascend
 
@@ -135,6 +136,7 @@ jobs:
         if: ${{ inputs.request_id != '' }}
         run: |
           mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
+          cp /tmp/_build_info_backup.py /vllm-workspace/vllm-ascend/vllm_ascend/_build_info.py 2>/dev/null || true
           ls -R /vllm-workspace
 
       - name: Set MAX_JOBS based on runner
@@ -142,17 +144,17 @@ jobs:
           CARDS=$(echo "${{ inputs.runner }}" | grep -oE '[0-9]+$')
           echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
 
-      - name: Install vllm-project/vllm-ascend
-        if: ${{ inputs.request_id != '' }}
-        working-directory: /vllm-workspace/vllm-ascend
-        env:
-          MAX_JOBS: ${{ env.MAX_JOBS }}
-          PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://triton-ascend.osinfra.cn/pypi/simple https://download.pytorch.org/whl/cpu/"
-        run: |
-          git config --global --add safe.directory /vllm-workspace/vllm-ascend
-          pip install uc-manager
-          uv pip install -r requirements-dev.txt
-          uv pip install -e .
+      # - name: Install vllm-project/vllm-ascend
+      #   if: ${{ inputs.request_id != '' }}
+      #   working-directory: /vllm-workspace/vllm-ascend
+      #   env:
+      #     MAX_JOBS: ${{ env.MAX_JOBS }}
+      #     PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://triton-ascend.osinfra.cn/pypi/simple https://download.pytorch.org/whl/cpu/"
+      #   run: |
+      #     git config --global --add safe.directory /vllm-workspace/vllm-ascend
+      #     pip install uc-manager
+      #     uv pip install -r requirements-dev.txt
+      #     uv pip install -e .
 
       - name: Install aisbench
         if: ${{ inputs.request_id != '' }}

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -111,6 +111,9 @@ a3:
       - name: multi-node-qwenw8a8-2node-longseq
         config_file_path: Qwen3-235B-W8A8-longseq.yaml
         size: 2
+      - name: multi-node-DSV4-Flash-recompute-offload
+        config_file_path: DeepSeek-V4-Flash-W8A8-A3-recompute-cpu-offload-pd.yaml
+        size: 2
   single_node:
     test_config:
       - name: mtpx-deepseek-r1-0528-w8a8

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -52,6 +52,8 @@ on:
         required: false
         default: false
         type: boolean
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -81,12 +81,16 @@ jobs:
   parse-trigger:
     name: Parse trigger and determine test scope
     if: >-
-      github.event_name == 'workflow_dispatch'
-    runs-on: linux-aarch64-a2b3-0
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request'
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
       ref: ${{ steps.parse.outputs.ref }}
+      request_id: ${{ steps.parse.outputs.request_id }}
+      vllm_ascend_branch: ${{ steps.parse.outputs.vllm_ascend_branch }}
+      is_pr_event: ${{ steps.parse.outputs.is_pr_event }}
     steps:
       - name: Parse trigger
         id: parse
@@ -94,27 +98,100 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
-            const testCases = '${{ inputs.test_cases }}'.trim();
 
-            core.setOutput('ref', context.sha || 'unknown');
-
-            if (testCases) {
-              core.setOutput('run', 'true');
-              if (testCases === 'all') {
-                core.setOutput('filter', 'all');
+            // workflow_dispatch: use input values with test_cases filtering
+            if (eventName === 'workflow_dispatch') {
+              const inputs = context.payload.inputs || {};
+              const testCases = (inputs.test_cases || '').trim();
+              core.setOutput('ref', inputs.vllm_ascend_ref || context.sha || '');
+              core.setOutput('request_id', inputs.request_id || '');
+              core.setOutput('vllm_ascend_branch', inputs.vllm_ascend_branch || 'main');
+              core.setOutput('is_pr_event', 'false');
+              if (testCases) {
+                core.setOutput('run', 'true');
+                if (testCases === 'all') {
+                  core.setOutput('filter', 'all');
+                } else {
+                  core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+                }
               } else {
-                core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
               }
               return;
             }
 
+            // pull_request (labeled / synchronize)
+            if (eventName === 'pull_request') {
+              const labels = context.payload.pull_request.labels.map(l => l.name);
+              const prNumber = context.payload.pull_request.number;
+              core.setOutput('ref', context.payload.pull_request.head.sha);
+              core.setOutput('request_id', 'pr-' + prNumber);
+              core.setOutput('vllm_ascend_branch', 'main');
+              core.setOutput('is_pr_event', 'true');
+
+              if (!labels.includes('nightly-test')) {
+                core.info('nightly-test label not found; skipping.');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              // Search comments for latest /nightly-pr command
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              let testFilter = null;
+              for (let i = comments.length - 1; i >= 0; i--) {
+                const body = comments[i].body;
+                if (!body) continue;
+                const match = body.trim().match(/^\/nightly-pr(?:\s+(.+))?$/m);
+                if (match) {
+                  const args = (match[1] || '').trim();
+                  if (!args) {
+                    core.info('/nightly-pr without arguments; skipping all tests.');
+                    testFilter = 'none';
+                  } else {
+                    testFilter = ',' + args.split(/\s+/).join(',') + ',';
+                  }
+                  break;
+                }
+              }
+
+              if (testFilter === null) {
+                core.info('nightly-test label present but no /nightly-pr comment found; skipping.');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              if (testFilter === 'none') {
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              core.setOutput('run', 'true');
+              core.setOutput('filter', testFilter);
+              return;
+            }
+
+            // Fallback (should not reach here due to job if condition)
             core.setOutput('run', 'false');
             core.setOutput('filter', '');
+            core.setOutput('ref', '');
+            core.setOutput('request_id', '');
+            core.setOutput('vllm_ascend_branch', 'main');
+            core.setOutput('is_pr_event', 'false');
 
   setup-vars:
     name: Export global env vars as job outputs
     needs: parse-trigger
-    runs-on: linux-aarch64-a2b3-0
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       cann_image: ${{ steps.export.outputs.cann_image }}
       ascend_log_prefix: ${{ steps.export.outputs.ascend_log_prefix }}
@@ -127,7 +204,7 @@ jobs:
           {
             echo "cann_image=${{ env.CANN_IMAGE }}"
             echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
-            input_branch="${{ inputs.vllm_ascend_branch }}"
+            input_branch="${{ needs.parse-trigger.outputs.vllm_ascend_branch }}"
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
           } >> $GITHUB_OUTPUT
@@ -162,11 +239,11 @@ jobs:
   build-image:
     name: Build nightly-a2 image
     if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_build_image || 'false') != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
-          ${{ fromJSON(format('["{0}"]', inputs.vllm_ascend_branch)) }}
+          ${{ fromJSON(format('["{0}"]', github.event.inputs.vllm_ascend_branch || 'main')) }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
@@ -230,7 +307,7 @@ jobs:
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
-      request_id: ${{ inputs.request_id || '' }}
+      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
@@ -254,7 +331,8 @@ jobs:
     needs: [parse-trigger]
     if: >-
       always() &&
-      needs.parse-trigger.outputs.run == 'true' && (
+      needs.parse-trigger.outputs.run == 'true' &&
+      needs.parse-trigger.outputs.is_pr_event != 'true' && (
         needs.parse-trigger.outputs.filter == 'all' ||
         contains(needs.parse-trigger.outputs.filter, 'accuracy-group')
       )
@@ -293,6 +371,7 @@ jobs:
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
+      needs.parse-trigger.outputs.is_pr_event != 'true' &&
       needs.generate-accuracy-matrix.result != 'skipped' &&
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
@@ -313,8 +392,8 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
-      request_id: ${{ inputs.request_id || '' }}
-      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
+      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref || '' }}
       upload: false
 
   single-node-accuracy-tests-pr-only:
@@ -322,6 +401,7 @@ jobs:
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
+      needs.parse-trigger.outputs.is_pr_event != 'true' &&
       needs.parse-trigger.outputs.filter != 'all' &&
       needs.generate-accuracy-matrix.result != 'skipped' &&
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
@@ -342,8 +422,8 @@ jobs:
           needs.parse-trigger.outputs.filter != 'all' &&
           contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
         }}
-      request_id: ${{ inputs.request_id || '' }}
-      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
+      request_id: ${{ needs.parse-trigger.outputs.request_id || '' }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref || '' }}
       upload: false
 
   clear-pre-logs:
@@ -356,20 +436,20 @@ jobs:
           # Clear logs generated before the test to avoid confusion
           rm -rf "${ASCEND_LOG_PREFIX:?}"/* || true
 
-  merge-benchmark-artifacts:
-    name: Merge benchmark artifacts into nightly-a2.zip
-    needs: [parse-trigger, single-node-tests, multi-node-tests]
-    if: >-
-      always() &&
-      github.event_name == 'workflow_dispatch' &&
-      needs.parse-trigger.result == 'success'
-    runs-on: linux-aarch64-a2b3-0
-    steps:
-      - name: Merge all benchmark result artifacts
-        continue-on-error: true
-        uses: actions/upload-artifact/merge@v7
-        with:
-          name: nightly-a2
-          pattern: nightly-test-benchmark-results-*
-          compression-level: 0
-          delete-merged: true
+  # merge-benchmark-artifacts:
+  #   name: Merge benchmark artifacts into nightly-a2.zip
+  #   needs: [parse-trigger, single-node-tests, multi-node-tests]
+  #   if: >-
+  #     always() &&
+  #     github.event_name == 'workflow_dispatch' &&
+  #     needs.parse-trigger.result == 'success'
+  #   runs-on: linux-aarch64-a2b3-0
+  #   steps:
+  #     - name: Merge all benchmark result artifacts
+  #       continue-on-error: true
+  #       uses: actions/upload-artifact/merge@v7
+  #       with:
+  #         name: nightly-a2
+  #         pattern: nightly-test-benchmark-results-*
+  #         compression-level: 0
+  #         delete-merged: true

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -86,6 +86,9 @@ jobs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
       ref: ${{ steps.parse.outputs.ref }}
+      request_id: ${{ steps.parse.outputs.request_id }}
+      vllm_ascend_branch: ${{ steps.parse.outputs.vllm_ascend_branch }}
+      is_pr_event: ${{ steps.parse.outputs.is_pr_event }}
     steps:
       - name: Parse trigger
         id: parse
@@ -93,22 +96,95 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
-            const testCases = '${{ inputs.test_cases }}'.trim();
 
-            core.setOutput('ref', context.sha || 'unknown');
-
-            if (testCases) {
-              core.setOutput('run', 'true');
-              if (testCases === 'all') {
-                core.setOutput('filter', 'all');
+            // workflow_dispatch: use input values with test_cases filtering
+            if (eventName === 'workflow_dispatch') {
+              const inputs = context.payload.inputs || {};
+              const testCases = (inputs.test_cases || '').trim();
+              core.setOutput('ref', inputs.vllm_ascend_ref || context.sha || '');
+              core.setOutput('request_id', inputs.request_id || '');
+              core.setOutput('vllm_ascend_branch', inputs.vllm_ascend_branch || 'main');
+              core.setOutput('is_pr_event', 'false');
+              if (testCases) {
+                core.setOutput('run', 'true');
+                if (testCases === 'all') {
+                  core.setOutput('filter', 'all');
+                } else {
+                  core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+                }
               } else {
-                core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
               }
               return;
             }
 
+            // pull_request (labeled / synchronize)
+            if (eventName === 'pull_request') {
+              const labels = context.payload.pull_request.labels.map(l => l.name);
+              const prNumber = context.payload.pull_request.number;
+              core.setOutput('ref', context.payload.pull_request.head.sha);
+              core.setOutput('request_id', 'pr-' + prNumber);
+              core.setOutput('vllm_ascend_branch', 'main');
+              core.setOutput('is_pr_event', 'true');
+
+              if (!labels.includes('nightly-test')) {
+                core.info('nightly-test label not found; skipping.');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              // Search comments for latest /nightly-pr command
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              let testFilter = null;
+              for (let i = comments.length - 1; i >= 0; i--) {
+                const body = comments[i].body;
+                if (!body) continue;
+                const match = body.trim().match(/^\/nightly-pr(?:\s+(.+))?$/m);
+                if (match) {
+                  const args = (match[1] || '').trim();
+                  if (!args) {
+                    core.info('/nightly-pr without arguments; skipping all tests.');
+                    testFilter = 'none';
+                  } else {
+                    testFilter = ',' + args.split(/\s+/).join(',') + ',';
+                  }
+                  break;
+                }
+              }
+
+              if (testFilter === null) {
+                core.info('nightly-test label present but no /nightly-pr comment found; skipping.');
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              if (testFilter === 'none') {
+                core.setOutput('run', 'false');
+                core.setOutput('filter', '');
+                return;
+              }
+
+              core.setOutput('run', 'true');
+              core.setOutput('filter', testFilter);
+              return;
+            }
+
+            // Fallback (should not reach here due to job if condition)
             core.setOutput('run', 'false');
             core.setOutput('filter', '');
+            core.setOutput('ref', '');
+            core.setOutput('request_id', '');
+            core.setOutput('vllm_ascend_branch', 'main');
+            core.setOutput('is_pr_event', 'false');
 
   setup-vars:
     name: Export global env vars as job outputs
@@ -126,7 +202,7 @@ jobs:
         run: |
           {
             echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
-            input_branch="${{ inputs.vllm_ascend_branch }}"
+            input_branch="${{ needs.parse-trigger.outputs.vllm_ascend_branch }}"
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
           } >> $GITHUB_OUTPUT
@@ -161,11 +237,11 @@ jobs:
   build-image:
     name: Build nightly-a3 image
     if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_build_image || 'false') != 'true')
     strategy:
       matrix:
         vllm_ascend_branch: >-
-          ${{ fromJSON(format('["{0}"]', inputs.vllm_ascend_branch)) }}
+          ${{ fromJSON(format('["{0}"]', github.event.inputs.vllm_ascend_branch || 'main')) }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -53,6 +53,8 @@ on:
         required: false
         default: false
         type: boolean
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -50,10 +50,10 @@ spec:
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
             command:
-              - sh
+              - bash
               - -c
               - |
-                bash /root/.cache/tests/run.sh
+{% include 'run.sh' %}
             resources:
               limits:
                 huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
@@ -125,10 +125,10 @@ spec:
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
             command:
-              - sh
+              - bash
               - -c
               - |
-                bash /root/.cache/tests/run.sh
+{% include 'run.sh' %}
             resources:
               limits:
                 huawei.com/ascend-1980: {{ npu_per_node | default("16") }}

--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -149,8 +149,9 @@ checkout_src() {
     echo "====> Checkout source code"
     mkdir -p "$WORKSPACE"
     cd "$WORKSPACE"
-    pip uninstall -y vllm-ascend || true
+    # pip uninstall -y vllm-ascend || true
     cp -r "$WORKSPACE/vllm-ascend/benchmark" /tmp/aisbench-backup || true
+    cp /vllm-workspace/vllm-ascend/vllm_ascend/_build_info.py /tmp/_build_info_backup.py 2>/dev/null || true
     rm -rf "$WORKSPACE/vllm-ascend"
 
     if [ ! -d "$WORKSPACE/vllm-ascend" ]; then
@@ -181,6 +182,7 @@ install_aisbench() {
     BENCH_DIR="$WORKSPACE/vllm-ascend/benchmark"
 
     cp -r /tmp/aisbench-backup "$BENCH_DIR"
+    cp /tmp/_build_info_backup.py /vllm-workspace/vllm-ascend/vllm_ascend/_build_info.py 2>/dev/null || true
 
     cd "$BENCH_DIR"
     pip install -e . \


### PR DESCRIPTION
### What this PR does / why we need it?

Add a GitHub Actions workflow (`bot_cherry_pick.yaml`) that automates cherry-picking merged PRs to target branches via a bot comment command.

Maintainers can trigger cherry-pick by commenting `/cherry-pick <target-branch>` on a merged PR that has the `cherry-pick` label.

The workflow will:
1. Validate the command format and check commenter has write/admin permission
2. Verify the PR is already merged
3. Checkout the fork repository (`vllm-ascend-ci`)
4. Cherry-pick the merge commit onto the target branch
5. Push a new branch (`cherry-pick/pr-<N>-to-<branch>`) to the fork and open a PR against upstream

If cherry-pick fails (target branch not found or conflicts), it comments the error on the original PR and no branch is created in the fork.

### Does this PR introduce _any_ user-facing change?
None

### How was this patch tested?
None

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
