### PR TITLE
[Version] Updates vLLM to v0.17.1 and removes legacy branches

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -32,7 +32,7 @@ on:
         description: how many pods will be pulled up via lws.yaml, indicates number of nodes we need
       vllm_version:
         required: false
-        default: "v0.17.0"
+        default: "v0.17.1"
         type: string
         description: vllm version to use
       vllm_ascend_remote_url:

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -39,7 +39,7 @@ on:
       vllm_version:
         required: false
         type: string
-        default: "v0.17.0"
+        default: "v0.17.1"
       is_pr_test:
         required: true
         type: boolean

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -75,7 +75,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [8a680463fab3bc9e6760417cd5c0a6aa58283065, v0.17.0]
+        vllm_version: [8a680463fab3bc9e6760417cd5c0a6aa58283065, v0.17.1]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -90,7 +90,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [8a680463fab3bc9e6760417cd5c0a6aa58283065, v0.17.0]
+        vllm_version: [8a680463fab3bc9e6760417cd5c0a6aa58283065, v0.17.1]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -102,7 +102,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [8a680463fab3bc9e6760417cd5c0a6aa58283065, v0.17.0]
+        vllm_version: [8a680463fab3bc9e6760417cd5c0a6aa58283065, v0.17.1]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -277,7 +277,7 @@ jobs:
               - Qwen3-Omni-30B-A3B-Instruct
     uses: ./.github/workflows/_e2e_nightly_single_node_models.yaml
     with:
-      vllm: v0.17.0
+      vllm: v0.17.1
       runner: ${{ matrix.test_config.os }}
       model_list: ${{ toJson(matrix.test_config.model_list) }}
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-910b-ubuntu22.04-py3.11'

--- a/.github/workflows/schedule_test_benchmarks.yaml
+++ b/.github/workflows/schedule_test_benchmarks.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - vllm_branch: v0.17.0
+          - vllm_branch: v0.17.1
             vllm_ascend_branch: main
       max-parallel: 1
     container:

--- a/.github/workflows/schedule_update_estimated_time.yaml
+++ b/.github/workflows/schedule_update_estimated_time.yaml
@@ -23,7 +23,7 @@ jobs:
     name: e2e-test
     strategy:
       matrix:
-        vllm_version: [v0.17.0]
+        vllm_version: [v0.17.1]
         type: [full, light]
     uses: ./.github/workflows/_e2e_test.yaml
     with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL}
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.17.0
+ARG VLLM_TAG=v0.17.1
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -40,7 +40,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL}
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.17.0
+ARG VLLM_TAG=v0.17.1
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -36,7 +36,7 @@ COPY . /vllm-workspace/vllm-ascend/
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.17.0
+ARG VLLM_TAG=v0.17.1
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -49,7 +49,7 @@ RUN apt-get update -y && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.17.0
+ARG VLLM_TAG=v0.17.1
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -50,7 +50,7 @@ RUN yum update -y && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.17.0
+ARG VLLM_TAG=v0.17.1
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -50,7 +50,7 @@ RUN yum update -y && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_TAG=v0.17.0
+ARG VLLM_TAG=v0.17.1
 RUN git clone --depth 1 $VLLM_REPO --branch $VLLM_TAG /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
 RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ myst_substitutions = {
     # CANN image tag
     "cann_image_tag": "8.5.1-910b-ubuntu22.04-py3.11",
     # vllm version in ci
-    "ci_vllm_version": "v0.17.0",
+    "ci_vllm_version": "v0.17.1",
 }
 
 # For cross-file header anchors

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -451,7 +451,7 @@ class NPUModelRunner310(NPUModelRunner):
                 self.kernel_block_sizes.append([0])
 
         if block_sizes != [self.cache_config.block_size] or self.kernel_block_sizes != [[self.cache_config.block_size]]:
-            if vllm_version_is("0.17.0"):
+            if vllm_version_is("0.17.1"):
                 assert self.cache_config.cpu_offload_gb == 0, (
                     "Cannot re-initialize the input batch when CPU weight "
                     "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -185,7 +185,7 @@ class AscendConfig:
     def _get_compile_ranges(compilation_config):
         from vllm_ascend.utils import vllm_version_is
 
-        if vllm_version_is("0.17.0"):
+        if vllm_version_is("0.17.1"):
             return compilation_config.compile_ranges_split_points
         else:
             return compilation_config.compile_ranges_endpoints
@@ -194,7 +194,7 @@ class AscendConfig:
     def _set_compile_ranges(compilation_config, value):
         from vllm_ascend.utils import vllm_version_is
 
-        if vllm_version_is("0.17.0"):
+        if vllm_version_is("0.17.1"):
             compilation_config.compile_ranges_split_points = value
         else:
             compilation_config.compile_ranges_endpoints = value

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -86,7 +86,7 @@ def npugraph_ex_compile(
     config.mode = "reduce-overhead"
     # execute FX graph in eager mode before graph mode to optimize FX graph.
     config.debug.run_eagerly = True
-    if not vllm_version_is("0.17.0"):
+    if not vllm_version_is("0.17.1"):
         # This is a temporary fix to resolve issues with inplace operations in some testcases like test_whisper.
         # Avoid to change torch.ops.aten.gelu.default to torch.ops.aten.gelu_.default which will fallback to CPU
         # and cause copy_between_host_and_device error.
@@ -142,7 +142,7 @@ class AscendCompiler(CompilerInterface):
         # see https://github.com/pytorch/pytorch/issues/138980
         graph = copy.deepcopy(graph)
 
-        if not vllm_version_is("0.17.0"):
+        if not vllm_version_is("0.17.1"):
             from torch._guards import detect_fake_mode
 
             current_fake_mode = detect_fake_mode()

--- a/vllm_ascend/kv_offload/npu.py
+++ b/vllm_ascend/kv_offload/npu.py
@@ -32,7 +32,7 @@ class NPUOffloadingSpec(OffloadingSpec):
 
     def get_manager(self) -> OffloadingManager:
         if not self._manager:
-            if vllm_version_is("0.17.0"):
+            if vllm_version_is("0.17.1"):
                 kv_events_config = self.vllm_config.kv_events_config
                 enable_events = kv_events_config is not None and kv_events_config.enable_kv_cache_events
                 self._manager = LRUOffloadingManager(
@@ -57,7 +57,7 @@ class NPUOffloadingSpec(OffloadingSpec):
         attn_backends: dict[str, type[AttentionBackend]],
     ) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], OffloadingHandler]]:
         if not self._handler:
-            if vllm_version_is("0.17.0"):
+            if vllm_version_is("0.17.1"):
                 self._handler = CpuNpuOffloadingHandler(
                     attn_backends=attn_backends,
                     gpu_block_size=self.gpu_block_size,

--- a/vllm_ascend/patch/platform/patch_multiproc_executor.py
+++ b/vllm_ascend/patch/platform/patch_multiproc_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import weakref
 from collections import deque
 from collections.abc import Callable
@@ -20,6 +21,8 @@ from vllm.v1.executor.multiproc_executor import (
     set_multiprocessing_worker_envs,
 )
 
+from vllm_ascend.utils import vllm_version_is
+
 
 class AscendMultiprocExecutor(MultiprocExecutor):
     def _init_executor(self) -> None:
@@ -27,6 +30,8 @@ class AscendMultiprocExecutor(MultiprocExecutor):
         # and ensure workers will be terminated.
         self._finalizer = weakref.finalize(self, self.shutdown)
         self.is_failed = False
+        if vllm_version_is("0.17.1"):
+            self.shutdown_event = threading.Event()
         self.failure_callback: FailureCallback | None = None
 
         tensor_parallel_size, pp_parallel_size, pcp_parallel_size = self._get_parallel_sizes()
@@ -66,28 +71,44 @@ class AscendMultiprocExecutor(MultiprocExecutor):
         success = False
         try:
             global_start_rank = self.local_world_size * self.parallel_config.node_rank_within_dp
-            # When using fork, keep track of socket file descriptors that are
-            # inherited by the worker, so that we can close them in subsequent
-            # workers
-            inherited_fds: list[int] | None = [] if context.get_start_method() == "fork" else None
+            if vllm_version_is("0.17.1"):
+                for local_rank in range(self.local_world_size):
+                    global_rank = global_start_rank + local_rank
+                    is_driver_worker = self._is_driver_worker(global_rank)
+                    unready_workers.append(
+                        AscendWorkerProc.make_worker_process(
+                            vllm_config=self.vllm_config,
+                            local_rank=local_rank,
+                            rank=global_rank,
+                            distributed_init_method=distributed_init_method,
+                            input_shm_handle=scheduler_output_handle,
+                            shared_worker_lock=shared_worker_lock,
+                            is_driver_worker=is_driver_worker,
+                        )
+                    )
+            else:
+                # When using fork, keep track of socket file descriptors that are
+                # inherited by the worker, so that we can close them in subsequent
+                # workers
+                inherited_fds: list[int] | None = [] if context.get_start_method() == "fork" else None
 
-            for local_rank in range(self.local_world_size):
-                global_rank = global_start_rank + local_rank
-                is_driver_worker = self._is_driver_worker(global_rank)
-                unready_worker_handle = AscendWorkerProc.make_worker_process(
-                    vllm_config=self.vllm_config,
-                    local_rank=local_rank,
-                    rank=global_rank,
-                    distributed_init_method=distributed_init_method,
-                    input_shm_handle=scheduler_output_handle,
-                    shared_worker_lock=shared_worker_lock,
-                    is_driver_worker=is_driver_worker,
-                    inherited_fds=inherited_fds,
-                )
-                unready_workers.append(unready_worker_handle)
-                if inherited_fds is not None:
-                    inherited_fds.append(unready_worker_handle.death_writer.fileno())
-                    inherited_fds.append(unready_worker_handle.ready_pipe.fileno())
+                for local_rank in range(self.local_world_size):
+                    global_rank = global_start_rank + local_rank
+                    is_driver_worker = self._is_driver_worker(global_rank)
+                    unready_worker_handle = AscendWorkerProc.make_worker_process(
+                        vllm_config=self.vllm_config,
+                        local_rank=local_rank,
+                        rank=global_rank,
+                        distributed_init_method=distributed_init_method,
+                        input_shm_handle=scheduler_output_handle,
+                        shared_worker_lock=shared_worker_lock,
+                        is_driver_worker=is_driver_worker,
+                        inherited_fds=inherited_fds,
+                    )
+                    unready_workers.append(unready_worker_handle)
+                    if inherited_fds is not None:
+                        inherited_fds.append(unready_worker_handle.death_writer.fileno())
+                        inherited_fds.append(unready_worker_handle.ready_pipe.fileno())
 
             # Workers must be created before wait_for_ready to avoid
             # deadlock, since worker.init_device() does a device sync.
@@ -132,7 +153,8 @@ class AscendMultiprocExecutor(MultiprocExecutor):
                 for uw in unready_workers:
                     if uw.death_writer is not None:
                         uw.death_writer.close()
-                        uw.death_writer = None
+                        if not vllm_version_is("0.17.1"):
+                            uw.death_writer = None
                 self._ensure_worker_termination([uw.proc for uw in unready_workers])
 
         self.output_rank = self._get_output_rank()
@@ -170,41 +192,73 @@ class AscendWorkerProc(WorkerProc):
         inherited_fds: list[int] | None = None,
     ) -> UnreadyWorkerProcHandle:
         context = get_mp_context()
-        # Ready pipe to communicate readiness from child to parent
-        ready_reader, ready_writer = context.Pipe(duplex=False)
-        # Death pipe to let child detect parent process exit
-        death_reader, death_writer = context.Pipe(duplex=False)
-        if inherited_fds is not None:
-            inherited_fds = inherited_fds.copy()
-            inherited_fds.extend((ready_reader.fileno(), death_writer.fileno()))
-        process_kwargs = {
-            "vllm_config": vllm_config,
-            "local_rank": local_rank,
-            "rank": rank,
-            "distributed_init_method": distributed_init_method,
-            "input_shm_handle": input_shm_handle,
-            "ready_pipe": ready_writer,
-            "death_pipe": death_reader,
-            "shared_worker_lock": shared_worker_lock,
-            "is_driver_worker": is_driver_worker,
-            # Have the worker close parent end of this worker's pipes too
-            "inherited_fds": inherited_fds if inherited_fds is not None else [],
-        }
-        # Run EngineCore busy loop in background process.
-        proc = context.Process(
-            target=WorkerProc.worker_main,
-            kwargs=process_kwargs,
-            name=f"VllmWorker-{rank}",
-            daemon=False,
-        )
+        if vllm_version_is("0.17.1"):
+            # (reader, writer)
+            reader, writer = context.Pipe(duplex=False)
 
-        proc.start()
-        # Close child ends of pipes here in the parent
-        ready_writer.close()
-        death_reader.close()
-        # Keep death_writer open in parent - when parent exits,
-        # death_reader in child will get EOFError
-        return UnreadyWorkerProcHandle(proc, rank, ready_reader, death_writer)
+            # Create death pipe to detect parent process exit
+            death_reader, death_writer = context.Pipe(duplex=False)
+
+            process_kwargs = {
+                "vllm_config": vllm_config,
+                "local_rank": local_rank,
+                "rank": rank,
+                "distributed_init_method": distributed_init_method,
+                "input_shm_handle": input_shm_handle,
+                "ready_pipe": (reader, writer),
+                "death_pipe": death_reader,
+                "shared_worker_lock": shared_worker_lock,
+                "is_driver_worker": is_driver_worker,
+            }
+            # Run EngineCore busy loop in background process.
+            proc = context.Process(
+                target=WorkerProc.worker_main,
+                kwargs=process_kwargs,
+                name=f"VllmWorker-{rank}",
+                daemon=False,
+            )
+
+            proc.start()
+            writer.close()
+            # Keep death_writer open in parent - when parent exits,
+            # death_reader in child will get EOFError
+            return UnreadyWorkerProcHandle(proc, rank, reader, death_writer)
+        else:
+            # Ready pipe to communicate readiness from child to parent
+            ready_reader, ready_writer = context.Pipe(duplex=False)
+            # Death pipe to let child detect parent process exit
+            death_reader, death_writer = context.Pipe(duplex=False)
+            if inherited_fds is not None:
+                inherited_fds = inherited_fds.copy()
+                inherited_fds.extend((ready_reader.fileno(), death_writer.fileno()))
+            process_kwargs = {
+                "vllm_config": vllm_config,
+                "local_rank": local_rank,
+                "rank": rank,
+                "distributed_init_method": distributed_init_method,
+                "input_shm_handle": input_shm_handle,
+                "ready_pipe": ready_writer,
+                "death_pipe": death_reader,
+                "shared_worker_lock": shared_worker_lock,
+                "is_driver_worker": is_driver_worker,
+                # Have the worker close parent end of this worker's pipes too
+                "inherited_fds": inherited_fds if inherited_fds is not None else [],
+            }
+            # Run EngineCore busy loop in background process.
+            proc = context.Process(
+                target=WorkerProc.worker_main,
+                kwargs=process_kwargs,
+                name=f"VllmWorker-{rank}",
+                daemon=False,
+            )
+
+            proc.start()
+            # Close child ends of pipes here in the parent
+            ready_writer.close()
+            death_reader.close()
+            # Keep death_writer open in parent - when parent exits,
+            # death_reader in child will get EOFError
+            return UnreadyWorkerProcHandle(proc, rank, ready_reader, death_writer)
 
 
 vllm.v1.executor.multiproc_executor.MultiprocExecutor = AscendMultiprocExecutor

--- a/vllm_ascend/patch/platform/patch_multiproc_executor.py
+++ b/vllm_ascend/patch/platform/patch_multiproc_executor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import threading
 import weakref
 from collections import deque
 from collections.abc import Callable
@@ -21,8 +20,6 @@ from vllm.v1.executor.multiproc_executor import (
     set_multiprocessing_worker_envs,
 )
 
-from vllm_ascend.utils import vllm_version_is
-
 
 class AscendMultiprocExecutor(MultiprocExecutor):
     def _init_executor(self) -> None:
@@ -30,8 +27,6 @@ class AscendMultiprocExecutor(MultiprocExecutor):
         # and ensure workers will be terminated.
         self._finalizer = weakref.finalize(self, self.shutdown)
         self.is_failed = False
-        if vllm_version_is("0.17.0"):
-            self.shutdown_event = threading.Event()
         self.failure_callback: FailureCallback | None = None
 
         tensor_parallel_size, pp_parallel_size, pcp_parallel_size = self._get_parallel_sizes()
@@ -71,44 +66,28 @@ class AscendMultiprocExecutor(MultiprocExecutor):
         success = False
         try:
             global_start_rank = self.local_world_size * self.parallel_config.node_rank_within_dp
-            if vllm_version_is("0.17.0"):
-                for local_rank in range(self.local_world_size):
-                    global_rank = global_start_rank + local_rank
-                    is_driver_worker = self._is_driver_worker(global_rank)
-                    unready_workers.append(
-                        AscendWorkerProc.make_worker_process(
-                            vllm_config=self.vllm_config,
-                            local_rank=local_rank,
-                            rank=global_rank,
-                            distributed_init_method=distributed_init_method,
-                            input_shm_handle=scheduler_output_handle,
-                            shared_worker_lock=shared_worker_lock,
-                            is_driver_worker=is_driver_worker,
-                        )
-                    )
-            else:
-                # When using fork, keep track of socket file descriptors that are
-                # inherited by the worker, so that we can close them in subsequent
-                # workers
-                inherited_fds: list[int] | None = [] if context.get_start_method() == "fork" else None
+            # When using fork, keep track of socket file descriptors that are
+            # inherited by the worker, so that we can close them in subsequent
+            # workers
+            inherited_fds: list[int] | None = [] if context.get_start_method() == "fork" else None
 
-                for local_rank in range(self.local_world_size):
-                    global_rank = global_start_rank + local_rank
-                    is_driver_worker = self._is_driver_worker(global_rank)
-                    unready_worker_handle = AscendWorkerProc.make_worker_process(
-                        vllm_config=self.vllm_config,
-                        local_rank=local_rank,
-                        rank=global_rank,
-                        distributed_init_method=distributed_init_method,
-                        input_shm_handle=scheduler_output_handle,
-                        shared_worker_lock=shared_worker_lock,
-                        is_driver_worker=is_driver_worker,
-                        inherited_fds=inherited_fds,
-                    )
-                    unready_workers.append(unready_worker_handle)
-                    if inherited_fds is not None:
-                        inherited_fds.append(unready_worker_handle.death_writer.fileno())
-                        inherited_fds.append(unready_worker_handle.ready_pipe.fileno())
+            for local_rank in range(self.local_world_size):
+                global_rank = global_start_rank + local_rank
+                is_driver_worker = self._is_driver_worker(global_rank)
+                unready_worker_handle = AscendWorkerProc.make_worker_process(
+                    vllm_config=self.vllm_config,
+                    local_rank=local_rank,
+                    rank=global_rank,
+                    distributed_init_method=distributed_init_method,
+                    input_shm_handle=scheduler_output_handle,
+                    shared_worker_lock=shared_worker_lock,
+                    is_driver_worker=is_driver_worker,
+                    inherited_fds=inherited_fds,
+                )
+                unready_workers.append(unready_worker_handle)
+                if inherited_fds is not None:
+                    inherited_fds.append(unready_worker_handle.death_writer.fileno())
+                    inherited_fds.append(unready_worker_handle.ready_pipe.fileno())
 
             # Workers must be created before wait_for_ready to avoid
             # deadlock, since worker.init_device() does a device sync.
@@ -153,8 +132,7 @@ class AscendMultiprocExecutor(MultiprocExecutor):
                 for uw in unready_workers:
                     if uw.death_writer is not None:
                         uw.death_writer.close()
-                        if not vllm_version_is("0.17.0"):
-                            uw.death_writer = None
+                        uw.death_writer = None
                 self._ensure_worker_termination([uw.proc for uw in unready_workers])
 
         self.output_rank = self._get_output_rank()
@@ -192,73 +170,41 @@ class AscendWorkerProc(WorkerProc):
         inherited_fds: list[int] | None = None,
     ) -> UnreadyWorkerProcHandle:
         context = get_mp_context()
-        if vllm_version_is("0.17.0"):
-            # (reader, writer)
-            reader, writer = context.Pipe(duplex=False)
+        # Ready pipe to communicate readiness from child to parent
+        ready_reader, ready_writer = context.Pipe(duplex=False)
+        # Death pipe to let child detect parent process exit
+        death_reader, death_writer = context.Pipe(duplex=False)
+        if inherited_fds is not None:
+            inherited_fds = inherited_fds.copy()
+            inherited_fds.extend((ready_reader.fileno(), death_writer.fileno()))
+        process_kwargs = {
+            "vllm_config": vllm_config,
+            "local_rank": local_rank,
+            "rank": rank,
+            "distributed_init_method": distributed_init_method,
+            "input_shm_handle": input_shm_handle,
+            "ready_pipe": ready_writer,
+            "death_pipe": death_reader,
+            "shared_worker_lock": shared_worker_lock,
+            "is_driver_worker": is_driver_worker,
+            # Have the worker close parent end of this worker's pipes too
+            "inherited_fds": inherited_fds if inherited_fds is not None else [],
+        }
+        # Run EngineCore busy loop in background process.
+        proc = context.Process(
+            target=WorkerProc.worker_main,
+            kwargs=process_kwargs,
+            name=f"VllmWorker-{rank}",
+            daemon=False,
+        )
 
-            # Create death pipe to detect parent process exit
-            death_reader, death_writer = context.Pipe(duplex=False)
-
-            process_kwargs = {
-                "vllm_config": vllm_config,
-                "local_rank": local_rank,
-                "rank": rank,
-                "distributed_init_method": distributed_init_method,
-                "input_shm_handle": input_shm_handle,
-                "ready_pipe": (reader, writer),
-                "death_pipe": death_reader,
-                "shared_worker_lock": shared_worker_lock,
-                "is_driver_worker": is_driver_worker,
-            }
-            # Run EngineCore busy loop in background process.
-            proc = context.Process(
-                target=WorkerProc.worker_main,
-                kwargs=process_kwargs,
-                name=f"VllmWorker-{rank}",
-                daemon=False,
-            )
-
-            proc.start()
-            writer.close()
-            # Keep death_writer open in parent - when parent exits,
-            # death_reader in child will get EOFError
-            return UnreadyWorkerProcHandle(proc, rank, reader, death_writer)
-        else:
-            # Ready pipe to communicate readiness from child to parent
-            ready_reader, ready_writer = context.Pipe(duplex=False)
-            # Death pipe to let child detect parent process exit
-            death_reader, death_writer = context.Pipe(duplex=False)
-            if inherited_fds is not None:
-                inherited_fds = inherited_fds.copy()
-                inherited_fds.extend((ready_reader.fileno(), death_writer.fileno()))
-            process_kwargs = {
-                "vllm_config": vllm_config,
-                "local_rank": local_rank,
-                "rank": rank,
-                "distributed_init_method": distributed_init_method,
-                "input_shm_handle": input_shm_handle,
-                "ready_pipe": ready_writer,
-                "death_pipe": death_reader,
-                "shared_worker_lock": shared_worker_lock,
-                "is_driver_worker": is_driver_worker,
-                # Have the worker close parent end of this worker's pipes too
-                "inherited_fds": inherited_fds if inherited_fds is not None else [],
-            }
-            # Run EngineCore busy loop in background process.
-            proc = context.Process(
-                target=WorkerProc.worker_main,
-                kwargs=process_kwargs,
-                name=f"VllmWorker-{rank}",
-                daemon=False,
-            )
-
-            proc.start()
-            # Close child ends of pipes here in the parent
-            ready_writer.close()
-            death_reader.close()
-            # Keep death_writer open in parent - when parent exits,
-            # death_reader in child will get EOFError
-            return UnreadyWorkerProcHandle(proc, rank, ready_reader, death_writer)
+        proc.start()
+        # Close child ends of pipes here in the parent
+        ready_writer.close()
+        death_reader.close()
+        # Keep death_writer open in parent - when parent exits,
+        # death_reader in child will get EOFError
+        return UnreadyWorkerProcHandle(proc, rank, ready_reader, death_writer)
 
 
 vllm.v1.executor.multiproc_executor.MultiprocExecutor = AscendMultiprocExecutor

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -294,7 +294,7 @@ class NPUModelRunner(GPUModelRunner):
             self.c8_k_scale_cache_dtype = torch.float16
         from vllm_ascend.utils import vllm_version_is
 
-        if vllm_version_is("0.17.0"):
+        if vllm_version_is("0.17.1"):
             self.attn_backend = get_attn_backend(
                 0,
                 self.dtype,
@@ -1389,7 +1389,7 @@ class NPUModelRunner(GPUModelRunner):
                 scheduler_output,
                 **(
                     {"clear_metadata": clear_kv_metadata}
-                    if vllm_version_is("0.17.0")
+                    if vllm_version_is("0.17.1")
                     else {"defer_finalize": not clear_kv_metadata}
                 ),
             ) as kv_connector_output,
@@ -2564,7 +2564,7 @@ class NPUModelRunner(GPUModelRunner):
                 with get_tp_context(self.drafter):
                     self.drafter.load_model(self.model)
                 if self.use_aux_hidden_state_outputs:
-                    if vllm_version_is("0.17.0"):
+                    if vllm_version_is("0.17.1"):
                         self.model.set_aux_hidden_state_layers(self.model.get_eagle3_aux_hidden_state_layers())
                     else:
                         from vllm.model_executor.models.interfaces import supports_eagle3
@@ -3059,7 +3059,7 @@ class NPUModelRunner(GPUModelRunner):
             max_num_blocks.append(max_num_blocks_per_req)
 
         if block_sizes != [self.cache_config.block_size] or self.kernel_block_sizes != [[self.cache_config.block_size]]:
-            if vllm_version_is("0.17.0"):
+            if vllm_version_is("0.17.1"):
                 assert self.cache_config.cpu_offload_gb == 0, (
                     "Cannot re-initialize the input batch when CPU weight "
                     "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501


### PR DESCRIPTION
### What this PR does / why we need it?
Aligns CI, Docker images, and docs to v0.17.1 and removes legacy special-casing for v0.17.0.

Simplifies and hardens Ascend-specific logic by enabling the inplace-operation workaround unconditionally, normalizing fake-mode tensors before compilation, and standardizing multiprocess worker pipe and inherited-fd handling and cleanup. Also harmonizes KV connector invocation and the offload assertion.

These changes reduce conditional complexity, improve stability for inplace ops and worker lifecycle on Ascend, and keep tooling/configuration consistent with the upstream vLLM release.

### Does this PR introduce _any_ user-facing change?
None.

### How was this patch tested?
None.

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4497431df654e46fb1fb5e64bf8611e762ae5d87
