### PR TITLE
[CI]Style: Convert `test/` to ruff format(Batch #8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,18 +77,6 @@ exclude = [
     "tests/ut/device_allocator/",
     "tests/ut/distributed/",
     "tests/ut/eplb/",
-
-    "tests/ut/ops/",
-    "tests/ut/patch/",
-    "tests/ut/quantization/",
-    "tests/ut/sample/",
-
-    "tests/ut/spec_decode/",
-    "tests/ut/test_ascend_config.py",
-    "tests/ut/test_envs.py",
-    "tests/ut/test_platform.py",
-    "tests/ut/test_utils.py",
-    "tests/ut/worker/",
 ]
 
 [tool.ruff.lint]

--- a/tests/ut/ops/test_activation.py
+++ b/tests/ut/ops/test_activation.py
@@ -20,7 +20,6 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul
 
-from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.utils import is_310p as is_310p_hw
 
 
@@ -53,8 +52,7 @@ def test_QuickGELU_forward(mock_gelu, dummy_tensor, default_vllm_config):
 
 
 @pytest.mark.skipif(is_310p_hw(), reason="non_310P device unittest case.")
-@patch("vllm_ascend.ops.activation.get_weight_prefetch_method",
-       return_value=MagicMock())
+@patch("vllm_ascend.ops.activation.get_weight_prefetch_method", return_value=MagicMock())
 @patch("torch_npu.npu_swiglu", side_effect=lambda x: x + 1)
 def test_SiluAndMul_forward(
     mock_swiglu,

--- a/tests/ut/ops/test_comm_utils.py
+++ b/tests/ut/ops/test_comm_utils.py
@@ -21,12 +21,13 @@ from pytest_mock import MockerFixture
 
 from tests.ut.base import PytestBase
 from vllm_ascend.ops.fused_moe.comm_utils import (
-    _gather_along_first_dim, async_all_to_all,
-    gather_from_sequence_parallel_region)
+    _gather_along_first_dim,
+    async_all_to_all,
+    gather_from_sequence_parallel_region,
+)
 
 
 class TestDistributedCommunication(PytestBase):
-
     @pytest.fixture(autouse=True)
     def context(self, mocker: MockerFixture):
         mocker.patch("torch.npu.current_device", return_value="cpu")
@@ -36,63 +37,52 @@ class TestDistributedCommunication(PytestBase):
 
     @pytest.mark.parametrize(
         "input_tensor, output_split_sizes, input_split_sizes",
-        [(torch.randn(8, 16), [2, 2, 2, 2], [2, 2, 2, 2]),
-         (torch.randn(16, 32), None, None)])
-    def test_async_all_to_all(self, input_tensor, output_split_sizes,
-                              input_split_sizes, mocker: MockerFixture):
+        [(torch.randn(8, 16), [2, 2, 2, 2], [2, 2, 2, 2]), (torch.randn(16, 32), None, None)],
+    )
+    def test_async_all_to_all(self, input_tensor, output_split_sizes, input_split_sizes, mocker: MockerFixture):
         """Test async_all_to_all"""
         mock_group = mocker.MagicMock()
-        mocker.patch("torch.distributed.all_to_all_single",
-                     return_value=mocker.MagicMock())
+        mocker.patch("torch.distributed.all_to_all_single", return_value=mocker.MagicMock())
 
-        _, a2a_out, handle = async_all_to_all(input_tensor, output_split_sizes,
-                                              input_split_sizes, mock_group)
+        _, a2a_out, handle = async_all_to_all(input_tensor, output_split_sizes, input_split_sizes, mock_group)
 
         # Check if the output tensor is created properly
         if output_split_sizes is None:
             assert a2a_out.shape == input_tensor.shape
         else:
             total_output_size = sum(output_split_sizes)
-            expected_shape = [total_output_size] + list(
-                input_tensor.size())[1:]
+            expected_shape = [total_output_size] + list(input_tensor.size())[1:]
             assert a2a_out.shape == torch.Size(expected_shape)
 
         # Ensure handle is returned from async operation
         assert handle is not None
         assert isinstance(handle, mocker.MagicMock)
 
-    @pytest.mark.parametrize("world_size, test_tensor, expected",
-                             [(1, torch.randn(8, 16), (8, 16)),
-                              (4, torch.randn(8, 16), (32, 16))])
-    def test_gather_along_first_dim(self, test_tensor, expected, world_size,
-                                    mocker: MockerFixture):
+    @pytest.mark.parametrize(
+        "world_size, test_tensor, expected", [(1, torch.randn(8, 16), (8, 16)), (4, torch.randn(8, 16), (32, 16))]
+    )
+    def test_gather_along_first_dim(self, test_tensor, expected, world_size, mocker: MockerFixture):
         """Test _gather_along_first_dim"""
-        mocker.patch("torch.distributed.get_world_size",
-                     return_value=world_size)
+        mocker.patch("torch.distributed.get_world_size", return_value=world_size)
 
         result = _gather_along_first_dim(test_tensor, mocker.MagicMock())
 
         assert result.shape == expected
 
-    @pytest.mark.parametrize("input_tensor, output_split_sizes",
-                             [(torch.randn(8, 16), None),
-                              (torch.randn(8, 16), [2, 2, 2, 2])])
-    def test_gather_from_sequence_parallel_region(self, input_tensor,
-                                                  output_split_sizes,
-                                                  mocker: MockerFixture):
+    @pytest.mark.parametrize(
+        "input_tensor, output_split_sizes", [(torch.randn(8, 16), None), (torch.randn(8, 16), [2, 2, 2, 2])]
+    )
+    def test_gather_from_sequence_parallel_region(self, input_tensor, output_split_sizes, mocker: MockerFixture):
         """Test gather_from_sequence_parallel_region"""
         mock_group = mocker.MagicMock()
 
-        result = gather_from_sequence_parallel_region(input_tensor, mock_group,
-                                                      output_split_sizes)
+        result = gather_from_sequence_parallel_region(input_tensor, mock_group, output_split_sizes)
 
         # If output_split_sizes is not provided, result should have expanded first dimension by world size
         if output_split_sizes is None:
-            expected_shape = [input_tensor.shape[0] * 4] + list(
-                input_tensor.shape[1:])
+            expected_shape = [input_tensor.shape[0] * 4] + list(input_tensor.shape[1:])
             assert result.shape == torch.Size(expected_shape)
         else:
             # If output_split_sizes is provided, result shape is dictated by sum of output_split_sizes
-            expected_shape = [sum(output_split_sizes)] + list(
-                input_tensor.shape[1:])
+            expected_shape = [sum(output_split_sizes)] + list(input_tensor.shape[1:])
             assert result.shape == torch.Size(expected_shape)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -120,8 +120,7 @@ def setup_vllm_config_mock(mocker: MockerFixture):
     mock_vllm_config.scheduler_config = MagicMock(max_num_seqs=4)
     mock_vllm_config.model_config.max_model_len = 2048
 
-    mocker.patch('vllm_ascend.ops.fused_moe.fused_moe.get_current_vllm_config',
-                 return_value=mock_vllm_config)
+    mocker.patch("vllm_ascend.ops.fused_moe.fused_moe.get_current_vllm_config", return_value=mock_vllm_config)
 
 
 @pytest.fixture
@@ -148,94 +147,76 @@ def mock_dist_env(mocker: MockerFixture):
     mock_moe_comm_method.finalize.side_effect = mock_finalize
     dp_metadata = MagicMock(num_tokens_across_dp_cpu=[5, 5])
     mock_weight_prefetch_method = MagicMock()
-    mock_forward_context_obj = MagicMock(moe_comm_method=mock_moe_comm_method,
-                                         moe_comm_type=MoECommType.MC2,
-                                         max_tokens_across_dp=10,
-                                         dp_metadata=dp_metadata,
-                                         mc2_mask=torch.zeros(
-                                             16, dtype=torch.bool),
-                                         padded_num_tokens=16,
-                                         with_quant=False)
+    mock_forward_context_obj = MagicMock(
+        moe_comm_method=mock_moe_comm_method,
+        moe_comm_type=MoECommType.MC2,
+        max_tokens_across_dp=10,
+        dp_metadata=dp_metadata,
+        mc2_mask=torch.zeros(16, dtype=torch.bool),
+        padded_num_tokens=16,
+        with_quant=False,
+    )
 
-    with patch('torch.distributed.get_rank', return_value=0), \
-        patch('torch.distributed.get_world_size', return_value=4), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.get_ep_group', return_value=mock_ep_and_mc2_group(mocker)), \
-        patch('vllm_ascend.ops.fused_moe.token_dispatcher.get_ep_group', return_value=mock_ep_and_mc2_group(mocker)), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.get_mc2_group', return_value=mock_ep_and_mc2_group(mocker)), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.get_tp_group', return_value=mock_dp_and_tp_group(mocker)), \
-        patch('vllm.distributed.parallel_state.get_tp_group', return_value=mock_dp_and_tp_group(mocker)), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.get_dp_group', return_value=mock_dp_and_tp_group(mocker)), \
-        patch('vllm.model_executor.layers.fused_moe.layer.get_dp_group', return_value=mock_dp_and_tp_group(mocker)), \
-        patch('vllm.model_executor.layers.fused_moe.config.get_dp_group',
-            return_value=mock_dp_and_tp_group(mocker)), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.get_ascend_config',
-            return_value=MagicMock(
-                enable_multistream_moe=False,
-                expert_map_path=None
-            )), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.init_eplb_config',
-            return_value=(torch.tensor([0, 1, 2, -1, -1, -1, -1, -1]), None, 0)), \
-        patch('vllm_ascend.ops.fused_moe.fused_moe.get_forward_context',
-            return_value=mock_forward_context_obj), \
-        patch('vllm_ascend.ascend_forward_context.get_forward_context',
-            return_value=mock_forward_context_obj), \
-        patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3), \
-        patch('vllm_ascend.ops.fused_moe.moe_comm_method.MC2CommImpl._get_token_dispatcher',
-              return_value=None), \
-        patch('vllm_ascend.ops.fused_moe.moe_comm_method.AlltoAllCommImpl._get_token_dispatcher',
-              return_value=None), \
-        patch('vllm_ascend.ops.fused_moe.moe_comm_method.AllGatherCommImpl._get_token_dispatcher',
-              return_value=None), \
-        patch('vllm_ascend.ops.fused_moe.experts_selector.get_weight_prefetch_method',
-              return_value=mock_weight_prefetch_method):
-
+    with (
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_world_size", return_value=4),
+        patch("vllm_ascend.ops.fused_moe.fused_moe.get_ep_group", return_value=mock_ep_and_mc2_group(mocker)),
+        patch("vllm_ascend.ops.fused_moe.token_dispatcher.get_ep_group", return_value=mock_ep_and_mc2_group(mocker)),
+        patch("vllm_ascend.ops.fused_moe.fused_moe.get_mc2_group", return_value=mock_ep_and_mc2_group(mocker)),
+        patch("vllm_ascend.ops.fused_moe.fused_moe.get_tp_group", return_value=mock_dp_and_tp_group(mocker)),
+        patch("vllm.distributed.parallel_state.get_tp_group", return_value=mock_dp_and_tp_group(mocker)),
+        patch("vllm_ascend.ops.fused_moe.fused_moe.get_dp_group", return_value=mock_dp_and_tp_group(mocker)),
+        patch("vllm.model_executor.layers.fused_moe.layer.get_dp_group", return_value=mock_dp_and_tp_group(mocker)),
+        patch("vllm.model_executor.layers.fused_moe.config.get_dp_group", return_value=mock_dp_and_tp_group(mocker)),
+        patch(
+            "vllm_ascend.ops.fused_moe.fused_moe.get_ascend_config",
+            return_value=MagicMock(enable_multistream_moe=False, expert_map_path=None),
+        ),
+        patch(
+            "vllm_ascend.ops.fused_moe.fused_moe.init_eplb_config",
+            return_value=(torch.tensor([0, 1, 2, -1, -1, -1, -1, -1]), None, 0),
+        ),
+        patch("vllm_ascend.ops.fused_moe.fused_moe.get_forward_context", return_value=mock_forward_context_obj),
+        patch("vllm_ascend.ascend_forward_context.get_forward_context", return_value=mock_forward_context_obj),
+        patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3),
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.MC2CommImpl._get_token_dispatcher", return_value=None),
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.AlltoAllCommImpl._get_token_dispatcher", return_value=None),
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.AllGatherCommImpl._get_token_dispatcher", return_value=None),
+        patch(
+            "vllm_ascend.ops.fused_moe.experts_selector.get_weight_prefetch_method",
+            return_value=mock_weight_prefetch_method,
+        ),
+    ):
         yield {
-            'mock_forward_context_obj': mock_forward_context_obj,
-            'mock_moe_comm_method': mock_moe_comm_method,
+            "mock_forward_context_obj": mock_forward_context_obj,
+            "mock_moe_comm_method": mock_moe_comm_method,
         }
 
 
 @pytest.fixture
 def mock_moe_env(mocker: MockerFixture):
-
-    with patch('torch_npu.npu_moe_gating_top_k', return_value=(
-            torch.randn(8, 2),
-            torch.randint(0, 8, (8, 2)),
-            None
-        )), \
-        patch('torch_npu.npu_moe_init_routing', return_value=(
-                torch.randn(8, 2),
-                torch.randint(0, 8, (8, 2)),
-                torch.tensor([0, 1, 2, 4, 6, 2, 7, 1])
-        )), \
-        patch("torch_npu.npu_moe_compute_expert_tokens", return_value=(
-                torch.randn(8, 2)
-        )), \
-        patch("torch_npu.npu_moe_distribute_dispatch", return_value=(
-                torch.randn(16, 2)
-        )), \
-        patch("torch_npu.npu_moe_distribute_combine", return_value=(
-                torch.randn(16, 2)
-        )), \
-        patch("torch_npu.npu_grouped_matmul", return_value=(
-                [torch.randn(16, 2)]
-        )), \
-        patch("torch_npu.npu_swiglu", return_value=(
-                torch.randn(16, 2)
-        )), \
-        patch("torch_npu.npu_moe_gating_top_k_softmax", return_value=(
-                torch.randn(8, 2),
-                torch.randint(0, 8, (8, 2)),
-                torch.tensor([0, 1, 2, 4, 6, 2, 7, 1])
-        )), \
-        patch("torch_npu.npu_moe_finalize_routing", return_value=(
-                torch.randn(16, 2)
-        )):
-        if hasattr(torch_npu, 'npu_moe_distribute_dispatch_v2'):
-            with patch("torch_npu.npu_moe_distribute_dispatch_v2", return_value=(
-                torch.randn(16, 2))), \
-                patch("torch_npu.npu_moe_distribute_combine_v2", return_value=(
-                torch.randn(16, 2))):
+    with (
+        patch("torch_npu.npu_moe_gating_top_k", return_value=(torch.randn(8, 2), torch.randint(0, 8, (8, 2)), None)),
+        patch(
+            "torch_npu.npu_moe_init_routing",
+            return_value=(torch.randn(8, 2), torch.randint(0, 8, (8, 2)), torch.tensor([0, 1, 2, 4, 6, 2, 7, 1])),
+        ),
+        patch("torch_npu.npu_moe_compute_expert_tokens", return_value=(torch.randn(8, 2))),
+        patch("torch_npu.npu_moe_distribute_dispatch", return_value=(torch.randn(16, 2))),
+        patch("torch_npu.npu_moe_distribute_combine", return_value=(torch.randn(16, 2))),
+        patch("torch_npu.npu_grouped_matmul", return_value=([torch.randn(16, 2)])),
+        patch("torch_npu.npu_swiglu", return_value=(torch.randn(16, 2))),
+        patch(
+            "torch_npu.npu_moe_gating_top_k_softmax",
+            return_value=(torch.randn(8, 2), torch.randint(0, 8, (8, 2)), torch.tensor([0, 1, 2, 4, 6, 2, 7, 1])),
+        ),
+        patch("torch_npu.npu_moe_finalize_routing", return_value=(torch.randn(16, 2))),
+    ):
+        if hasattr(torch_npu, "npu_moe_distribute_dispatch_v2"):
+            with (
+                patch("torch_npu.npu_moe_distribute_dispatch_v2", return_value=(torch.randn(16, 2))),
+                patch("torch_npu.npu_moe_distribute_combine_v2", return_value=(torch.randn(16, 2))),
+            ):
                 yield
         else:
             yield
@@ -243,12 +224,7 @@ def mock_moe_env(mocker: MockerFixture):
 
 @pytest.fixture
 def default_moe_config():
-    return {
-        'num_experts': 8,
-        'top_k': 2,
-        'hidden_size': 512,
-        'intermediate_size': 1024
-    }
+    return {"num_experts": 8, "top_k": 2, "hidden_size": 512, "intermediate_size": 1024}
 
 
 @pytest.fixture
@@ -277,22 +253,17 @@ class MockData(TypedDict):
 
 
 class MockQuantMethod(nn.Module):
-
     def __init__(self, shared_experts, num_tokens):
         super().__init__()
         if shared_experts:
-            self.apply = MagicMock(return_value=(torch.randn(num_tokens, 32),
-                                                 torch.randn(num_tokens, 10)))
+            self.apply = MagicMock(return_value=(torch.randn(num_tokens, 32), torch.randn(num_tokens, 10)))
         else:
             self.apply = MagicMock(return_value=(torch.randn(num_tokens, 32)))
 
 
 class TestExpertsSelector:
-
     @pytest.mark.parametrize("global_num_experts", [256, 128])
-    def test_select_experts(self, mock_dist_env, mock_moe_env,
-                            global_num_experts):
-
+    def test_select_experts(self, mock_dist_env, mock_moe_env, global_num_experts):
         x = torch.randn(8, 2)
         router_logits = torch.randn(8, 2)
         topk_weights, topk_ids = select_experts(
@@ -306,19 +277,19 @@ class TestExpertsSelector:
             custom_routing_function=None,
             scoring_func="softmax",
             e_score_correction_bias=None,
-            global_num_experts=global_num_experts)
+            global_num_experts=global_num_experts,
+        )
 
         assert topk_weights.shape == (8, 2)
         assert topk_ids.shape == (8, 2)
 
 
 class TestCumsumGroupList(TestBase):
-
     def setUp(self):
         self.active_num = 8
         self.expert_num = 128
-        self.experts = torch.zeros((self.expert_num, ), dtype=torch.int64)
-        self.experts[:self.active_num] = 1
+        self.experts = torch.zeros((self.expert_num,), dtype=torch.int64)
+        self.experts[: self.active_num] = 1
         self.experts = self.experts[torch.randperm(self.expert_num)]
         self.group_list = self.experts.cumsum(dim=0)
 
@@ -336,58 +307,48 @@ class TestCumsumGroupList(TestBase):
 
     def test_cumsum_group_list_with_type_2(self):
         tokens = torch.arange(self.expert_num, dtype=torch.int64)
-        group_list = torch.cat([
-            tokens.reshape(self.expert_num, 1),
-            self.experts.reshape(self.expert_num, 1)
-        ],
-                               dim=1)
+        group_list = torch.cat([tokens.reshape(self.expert_num, 1), self.experts.reshape(self.expert_num, 1)], dim=1)
         group_list_type = 2
-        result = cumsum_group_list(group_list,
-                                   group_list_type,
-                                   0,
-                                   active_num=self.active_num,
-                                   expert_num=self.expert_num)
+        result = cumsum_group_list(
+            group_list, group_list_type, 0, active_num=self.active_num, expert_num=self.expert_num
+        )
         self.assertTrue(torch.equal(result, self.group_list))
 
 
 class TestUnifiedApplyMLP(TestBase):
-
-    @patch('vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method',
-           return_value=MagicMock())
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch('vllm_ascend.utils.get_ascend_device_type',
-           return_value=AscendDeviceType.A3)
-    @patch('torch_npu.npu_grouped_matmul')
-    @patch('torch_npu.npu_dynamic_quant')
-    @patch('torch_npu.npu_dequant_swiglu_quant')
-    def test_unified_apply_mlp_with_quantization_mc2(self, mock_npu_dequant,
-                                                     mock_npu_dynamic_quant,
-                                                     mock_npu_grouped_matmul,
-                                                     mock_soc_version,
-                                                     mock_get_forward_context,
-                                                     mock_get_weight_prefetch_method):
-
+    @patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method", return_value=MagicMock())
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    @patch("torch_npu.npu_dequant_swiglu_quant")
+    def test_unified_apply_mlp_with_quantization_mc2(
+        self,
+        mock_npu_dequant,
+        mock_npu_dynamic_quant,
+        mock_npu_grouped_matmul,
+        mock_soc_version,
+        mock_get_forward_context,
+        mock_get_weight_prefetch_method,
+    ):
         mock_forward_context = MagicMock()
         mock_forward_context.moe_comm_type = MoECommType.MC2
         mock_get_forward_context.return_value = mock_forward_context
 
-        mock_npu_dynamic_quant.return_value = (torch.randint(-128,
-                                                             127, (10, 20),
-                                                             dtype=torch.int8),
-                                               torch.rand(10,
-                                                          1,
-                                                          dtype=torch.float32))
+        mock_npu_dynamic_quant.return_value = (
+            torch.randint(-128, 127, (10, 20), dtype=torch.int8),
+            torch.rand(10, 1, dtype=torch.float32),
+        )
 
-        mock_npu_grouped_matmul.side_effect = [[
-            torch.randint(-2147483648, 2147483647, (10, 40), dtype=torch.int32)
-        ], [torch.randn(10, 20, dtype=torch.bfloat16)]]
+        mock_npu_grouped_matmul.side_effect = [
+            [torch.randint(-2147483648, 2147483647, (10, 40), dtype=torch.int32)],
+            [torch.randn(10, 20, dtype=torch.bfloat16)],
+        ]
 
-        mock_npu_dequant.return_value = (torch.randn(10,
-                                                     40,
-                                                     dtype=torch.bfloat16),
-                                         torch.randn(10,
-                                                     1,
-                                                     dtype=torch.float32))
+        mock_npu_dequant.return_value = (
+            torch.randn(10, 40, dtype=torch.bfloat16),
+            torch.randn(10, 1, dtype=torch.float32),
+        )
 
         hidden_states = torch.randn(10, 20, dtype=torch.bfloat16)
         w1 = torch.randint(-128, 127, (5, 20, 40), dtype=torch.int8)
@@ -396,15 +357,17 @@ class TestUnifiedApplyMLP(TestBase):
         w2_scale = torch.randn(5, 20, dtype=torch.bfloat16)
         group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
 
-        result = unified_apply_mlp(mlp_compute_input=build_mlp_compute_input_fixture(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            group_list=group_list,
-            with_quant=True,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-        ))
+        result = unified_apply_mlp(
+            mlp_compute_input=build_mlp_compute_input_fixture(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                group_list=group_list,
+                with_quant=True,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+            )
+        )
 
         mock_get_forward_context.assert_called()
 
@@ -416,19 +379,17 @@ class TestUnifiedApplyMLP(TestBase):
 
         self.assertEqual(result.dtype, torch.bfloat16)
 
-    @patch('vllm_ascend.utils.get_ascend_device_type',
-           return_value=AscendDeviceType.A3)
-    @patch('torch_npu.npu_grouped_matmul')
-    @patch('torch_npu.npu_swiglu')
-    @patch('torch_npu.npu_dynamic_quant')
-    def test_unified_apply_mlp_without_quantization(self,
-                                                    mock_npu_dynamic_quant,
-                                                    mock_npu_swiglu,
-                                                    mock_npu_grouped_matmul,
-                                                    mock_soc_version):
-        mock_npu_grouped_matmul.side_effect = [[
-            torch.randn(10, 40, dtype=torch.float16)
-        ], [torch.randn(10, 20, dtype=torch.float16)]]
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_swiglu")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_unified_apply_mlp_without_quantization(
+        self, mock_npu_dynamic_quant, mock_npu_swiglu, mock_npu_grouped_matmul, mock_soc_version
+    ):
+        mock_npu_grouped_matmul.side_effect = [
+            [torch.randn(10, 40, dtype=torch.float16)],
+            [torch.randn(10, 20, dtype=torch.float16)],
+        ]
         mock_npu_swiglu.return_value = torch.randn(10, 40, dtype=torch.float16)
         mock_npu_dynamic_quant.return_value = (MagicMock(), MagicMock())
 
@@ -438,14 +399,16 @@ class TestUnifiedApplyMLP(TestBase):
         group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
         topk_scales = torch.randn(10, 1, dtype=torch.float16)
 
-        result = unified_apply_mlp(mlp_compute_input=build_mlp_compute_input_fixture(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            group_list=group_list,
-            with_quant=False,
-            topk_scales=topk_scales,
-        ))
+        result = unified_apply_mlp(
+            mlp_compute_input=build_mlp_compute_input_fixture(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                group_list=group_list,
+                with_quant=False,
+                topk_scales=topk_scales,
+            )
+        )
 
         self.assertEqual(mock_npu_grouped_matmul.call_count, 2)
         mock_npu_swiglu.assert_called_once()
@@ -453,37 +416,36 @@ class TestUnifiedApplyMLP(TestBase):
         self.assertEqual(result.shape, hidden_states.shape)
         self.assertEqual(result.dtype, torch.float16)
 
-    @patch('vllm_ascend.ops.fused_moe.moe_mlp.HAS_TRITON', False)
-    @patch('vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method',
-           return_value=MagicMock())
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch('torch_npu.npu_grouped_matmul')
-    @patch('torch_npu.npu_swiglu')
-    @patch('torch_npu.npu_dynamic_quant')
+    @patch("vllm_ascend.ops.fused_moe.moe_mlp.HAS_TRITON", False)
+    @patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method", return_value=MagicMock())
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_swiglu")
+    @patch("torch_npu.npu_dynamic_quant")
     def test_unified_apply_mlp_with_quantization_and_dynamic_scale(
-            self, mock_npu_dynamic_quant, mock_npu_swiglu,
-            mock_npu_grouped_matmul, mock_get_forward_context,
-            mock_get_weight_prefetch_method):
-
+        self,
+        mock_npu_dynamic_quant,
+        mock_npu_swiglu,
+        mock_npu_grouped_matmul,
+        mock_get_forward_context,
+        mock_get_weight_prefetch_method,
+    ):
         mock_forward_context = MagicMock()
         mock_forward_context.with_quant = True
         mock_forward_context.fused_moe_state = "NOT_MC2"
         mock_get_forward_context.return_value = mock_forward_context
 
-        mock_npu_grouped_matmul.side_effect = [[
-            torch.randn(10, 40, dtype=torch.bfloat16)
-        ], [torch.randn(10, 20, dtype=torch.bfloat16)]]
+        mock_npu_grouped_matmul.side_effect = [
+            [torch.randn(10, 40, dtype=torch.bfloat16)],
+            [torch.randn(10, 20, dtype=torch.bfloat16)],
+        ]
 
-        mock_npu_swiglu.return_value = torch.randn(10,
-                                                   40,
-                                                   dtype=torch.bfloat16)
+        mock_npu_swiglu.return_value = torch.randn(10, 40, dtype=torch.bfloat16)
 
-        mock_npu_dynamic_quant.return_value = (torch.randint(-128,
-                                                             127, (10, 40),
-                                                             dtype=torch.int8),
-                                               torch.rand(10,
-                                                          1,
-                                                          dtype=torch.float32))
+        mock_npu_dynamic_quant.return_value = (
+            torch.randint(-128, 127, (10, 40), dtype=torch.int8),
+            torch.rand(10, 1, dtype=torch.float32),
+        )
 
         hidden_states = torch.randn(10, 20, dtype=torch.bfloat16)
         hidden_states_shape = hidden_states.shape
@@ -496,18 +458,20 @@ class TestUnifiedApplyMLP(TestBase):
         group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
         provided_dynamic_scale = torch.rand(10, 1, dtype=torch.float32)
 
-        result = unified_apply_mlp(mlp_compute_input=build_mlp_compute_input_fixture(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            group_list=group_list,
-            with_quant=True,
-            dynamic_scale=provided_dynamic_scale,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            w1_scale_bias=w1_scale_bias,
-            w2_scale_bias=w2_scale_bias,
-        ))
+        result = unified_apply_mlp(
+            mlp_compute_input=build_mlp_compute_input_fixture(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                group_list=group_list,
+                with_quant=True,
+                dynamic_scale=provided_dynamic_scale,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                w1_scale_bias=w1_scale_bias,
+                w2_scale_bias=w2_scale_bias,
+            )
+        )
 
         mock_get_forward_context.assert_called()
 
@@ -518,18 +482,16 @@ class TestUnifiedApplyMLP(TestBase):
         self.assertEqual(result.shape, hidden_states_shape)
         self.assertEqual(result.dtype, torch.bfloat16)
 
-    @patch('vllm_ascend.utils.get_ascend_device_type',
-           return_value=AscendDeviceType._310P)
-    @patch('torch_npu.npu_grouped_matmul')
-    @patch('torch_npu.npu_swiglu')
-    @patch('torch_npu.npu_dynamic_quant')
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType._310P)
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_swiglu")
+    @patch("torch_npu.npu_dynamic_quant")
     def test_unified_apply_mlp_without_quantization_310p(
-            self, mock_npu_dynamic_quant, mock_npu_swiglu,
-            mock_npu_grouped_matmul, mock_soc_version):
+        self, mock_npu_dynamic_quant, mock_npu_swiglu, mock_npu_grouped_matmul, mock_soc_version
+    ):
         mock_gmm1_out = torch.randn(10, 40, dtype=torch.float16)
         mock_gmm2_out = torch.randn(10, 20, dtype=torch.float16)
-        mock_npu_grouped_matmul.side_effect = [[mock_gmm1_out],
-                                               [mock_gmm2_out]]
+        mock_npu_grouped_matmul.side_effect = [[mock_gmm1_out], [mock_gmm2_out]]
 
         mock_npu_swiglu.return_value = torch.randn(10, 40, dtype=torch.float16)
 
@@ -541,14 +503,16 @@ class TestUnifiedApplyMLP(TestBase):
         group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
         topk_scales = torch.randn(10, 1, dtype=torch.float16)
 
-        result = unified_apply_mlp(mlp_compute_input=build_mlp_compute_input_fixture(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            group_list=group_list,
-            with_quant=False,
-            topk_scales=topk_scales,
-        ))
+        result = unified_apply_mlp(
+            mlp_compute_input=build_mlp_compute_input_fixture(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                group_list=group_list,
+                with_quant=False,
+                topk_scales=topk_scales,
+            )
+        )
 
         self.assertEqual(mock_npu_grouped_matmul.call_count, 2)
         mock_npu_swiglu.assert_called_once()
@@ -556,41 +520,37 @@ class TestUnifiedApplyMLP(TestBase):
         self.assertEqual(result.shape, hidden_states.shape)
         self.assertEqual(result.dtype, torch.float16)
 
-    @patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method",
-           return_value=MagicMock())
+    @patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method", return_value=MagicMock())
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_grouped_matmul")
     @patch("torch_npu.npu_swiglu")
     @patch("torch_npu.npu_grouped_matmul_swiglu_quant")
     @patch("torch_npu.npu_dynamic_quant")
     def test_unified_apply_mlp_with_quantization_and_fusion_mlp(
-            self, mock_npu_dynamic_quant, mock_npu_grouped_matmul_swiglu_quant,
-            mock_npu_swiglu, mock_npu_grouped_matmul,
-            mock_get_forward_context,
-            mock_get_weight_prefetch_method):
-
+        self,
+        mock_npu_dynamic_quant,
+        mock_npu_grouped_matmul_swiglu_quant,
+        mock_npu_swiglu,
+        mock_npu_grouped_matmul,
+        mock_get_forward_context,
+        mock_get_weight_prefetch_method,
+    ):
         mock_forward_context = MagicMock()
         mock_forward_context.with_quant = True
         mock_forward_context.fused_moe_state = "NOT_MC2"
         mock_get_forward_context.return_value = mock_forward_context
 
-        mock_npu_grouped_matmul_swiglu_quant.return_value = (torch.randint(
-            -128, 127, (10, 40),
-            dtype=torch.int8), torch.rand(
-                10, 1,
-                dtype=torch.float32), torch.rand(10, 1, dtype=torch.float32))
-        mock_npu_grouped_matmul.side_effect = [[
-            torch.randn(10, 20, dtype=torch.bfloat16)
-        ]]
-        mock_npu_swiglu.return_value = torch.randn(10,
-                                                   40,
-                                                   dtype=torch.bfloat16)
-        mock_npu_dynamic_quant.return_value = (torch.randint(-128,
-                                                             127, (10, 40),
-                                                             dtype=torch.int8),
-                                               torch.rand(10,
-                                                          1,
-                                                          dtype=torch.float32))
+        mock_npu_grouped_matmul_swiglu_quant.return_value = (
+            torch.randint(-128, 127, (10, 40), dtype=torch.int8),
+            torch.rand(10, 1, dtype=torch.float32),
+            torch.rand(10, 1, dtype=torch.float32),
+        )
+        mock_npu_grouped_matmul.side_effect = [[torch.randn(10, 20, dtype=torch.bfloat16)]]
+        mock_npu_swiglu.return_value = torch.randn(10, 40, dtype=torch.bfloat16)
+        mock_npu_dynamic_quant.return_value = (
+            torch.randint(-128, 127, (10, 40), dtype=torch.int8),
+            torch.rand(10, 1, dtype=torch.float32),
+        )
 
         hidden_states = torch.randn(10, 20, dtype=torch.bfloat16)
         hidden_states_shape = hidden_states.shape
@@ -603,19 +563,21 @@ class TestUnifiedApplyMLP(TestBase):
         group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
         provided_dynamic_scale = torch.rand(10, 1, dtype=torch.float32)
 
-        result = unified_apply_mlp(mlp_compute_input=build_mlp_compute_input_fixture(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            group_list=group_list,
-            with_quant=True,
-            dynamic_scale=provided_dynamic_scale,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            w1_scale_bias=w1_scale_bias,
-            w2_scale_bias=w2_scale_bias,
-            fusion=True,
-        ))
+        result = unified_apply_mlp(
+            mlp_compute_input=build_mlp_compute_input_fixture(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                group_list=group_list,
+                with_quant=True,
+                dynamic_scale=provided_dynamic_scale,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                w1_scale_bias=w1_scale_bias,
+                w2_scale_bias=w2_scale_bias,
+                fusion=True,
+            )
+        )
 
         mock_get_forward_context.assert_called()
         mock_npu_grouped_matmul.assert_called_once()

--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -176,9 +176,7 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
             {
                 "world_size": world_size,
                 "rank_in_group": 0,
-                "all_gather": lambda self, value, dim: _GatherResult(
-                    [_DummyTensor("g0"), _DummyTensor("g1")]
-                ),
+                "all_gather": lambda self, value, dim: _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")]),
             },
         )()
 

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -9,14 +9,15 @@ from vllm import config
 from tests.ut.base import TestBase
 from vllm_ascend import ascend_config
 from vllm_ascend.distributed import parallel_state
-from vllm_ascend.ops.linear import (AscendMergedColumnParallelLinear,
-                                    AscendReplicatedLinear,
-                                    AscendRowParallelLinear,
-                                    AscendUnquantizedLinearMethod)
+from vllm_ascend.ops.linear import (
+    AscendMergedColumnParallelLinear,
+    AscendReplicatedLinear,
+    AscendRowParallelLinear,
+    AscendUnquantizedLinearMethod,
+)
 
 
 class BaseLinearTest(unittest.TestCase):
-
     def setUp(self):
         self.mock_group = mock.MagicMock()
         self.mock_group.world_size = 2
@@ -30,20 +31,16 @@ class BaseLinearTest(unittest.TestCase):
         self.mock_ascend_config.finegrained_tp_config.mlp_tensor_parallel_size = 2
 
         self.patches = [
-            patch("vllm_ascend.ascend_config.get_ascend_config",
-                  return_value=self.mock_ascend_config),
-            patch("vllm_ascend.distributed.parallel_state.get_otp_group",
-                  return_value=self.mock_group),
-            patch("vllm_ascend.distributed.parallel_state.get_mlp_tp_group",
-                  return_value=self.mock_group),
-            patch("vllm_ascend.ops.linear_op.get_tp_group",
-                  return_value=self.mock_group),
+            patch("vllm_ascend.ascend_config.get_ascend_config", return_value=self.mock_ascend_config),
+            patch("vllm_ascend.distributed.parallel_state.get_otp_group", return_value=self.mock_group),
+            patch("vllm_ascend.distributed.parallel_state.get_mlp_tp_group", return_value=self.mock_group),
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=self.mock_group),
             patch(
                 "vllm.distributed.parallel_state.get_tp_group",
                 return_value=self.mock_group,
             ),
             patch("vllm_ascend.utils.mlp_tp_enable", return_value=True),
-            patch("vllm_ascend.utils.oproj_tp_enable", return_value=True)
+            patch("vllm_ascend.utils.oproj_tp_enable", return_value=True),
         ]
 
         for p in self.patches:
@@ -55,7 +52,6 @@ class BaseLinearTest(unittest.TestCase):
 
 
 class TestAscendUnquantizedLinearMethod(TestBase):
-
     def setUp(self):
         self.method = AscendUnquantizedLinearMethod()
         self.layer = mock.MagicMock()
@@ -82,11 +78,8 @@ class TestAscendUnquantizedLinearMethod(TestBase):
 
 
 class TestAscendRowParallelLinear(BaseLinearTest):
-
-    @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method",
-           return_value=MagicMock())
+    @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method", return_value=MagicMock())
     def test_mlp_optimize(self, mock_get_weight_prefetch_method):
-
         ascend_config._ASCEND_CONFIG = MagicMock()
         ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.mlp_tensor_parallel_size = 2
@@ -102,10 +95,8 @@ class TestAscendRowParallelLinear(BaseLinearTest):
         input_tensor = torch.randn(16, 8)
         linear(input_tensor)
 
-    @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method",
-           return_value=MagicMock())
+    @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method", return_value=MagicMock())
     def test_oproj_tp(self, mock_get_weight_prefetch_method):
-
         config._current_vllm_config = MagicMock()
 
         ascend_config._ASCEND_CONFIG = MagicMock()
@@ -125,9 +116,7 @@ class TestAscendRowParallelLinear(BaseLinearTest):
 
 
 class TestAscendMergedColumnParallelLinear(BaseLinearTest):
-
     def test_merged_mlp_tp_init(self):
-
         ascend_config._ASCEND_CONFIG = MagicMock()
         ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.mlp_tensor_parallel_size = 2
@@ -142,23 +131,20 @@ class TestAscendMergedColumnParallelLinear(BaseLinearTest):
 
 
 class TestAscendReplicatedLinear(BaseLinearTest):
-
     def test_init_disable_tp(self):
         linear = AscendReplicatedLinear(
             input_size=16,
             output_size=8,
         )
-        self.assertTrue(
-            isinstance(linear.quant_method, AscendUnquantizedLinearMethod))
+        self.assertTrue(isinstance(linear.quant_method, AscendUnquantizedLinearMethod))
 
     def test_init_without_disable_tp(self):
         linear = AscendReplicatedLinear(
             input_size=16,
             output_size=8,
         )
-        self.assertTrue(
-            isinstance(linear.quant_method, AscendUnquantizedLinearMethod))
+        self.assertTrue(isinstance(linear.quant_method, AscendUnquantizedLinearMethod))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -11,7 +11,6 @@ from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention, IndexerWrapper
 
 
 class TestIndexerWrapper(TestBase):
-
     def test_initialization(self):
         mock_indexer = MagicMock()
         mock_indexer.n_head = 64
@@ -49,7 +48,6 @@ class TestIndexerWrapper(TestBase):
 
 
 class TestAscendMultiHeadLatentAttention(TestBase):
-
     def setUp(self):
         self.hidden_size = 4096
         self.num_heads = 32
@@ -80,8 +78,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
     @patch("vllm_ascend.ops.mla.get_current_vllm_config")
     @patch("vllm_ascend.ops.mla.get_ascend_config")
     @patch("vllm_ascend.ops.mla.get_tensor_model_parallel_world_size")
-    def test_initialization(self, mock_tp_size, mock_ascend_config,
-                            mock_get_vllm_config):
+    def test_initialization(self, mock_tp_size, mock_ascend_config, mock_get_vllm_config):
         # Create a proper mock for MLAAttention that has the required attributes
         mock_mla_attn = MagicMock()
         mock_mla_attn.process_weights_after_loading = MagicMock()
@@ -92,8 +89,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
             mock_tp_size.return_value = 2
             mock_ascend_config.return_value.enable_shared_expert_dp = True
             mock_vllm_config = MagicMock(spec=VllmConfig)
-            mock_vllm_config.model_config.hf_text_config = MagicMock(
-                num_hidden_layers=32, first_k_dense_replace=True)
+            mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)
             mock_get_vllm_config.return_value = mock_vllm_config
             mock_vllm_config.compilation_config = CompilationConfig()
 
@@ -121,15 +117,20 @@ class TestAscendMultiHeadLatentAttention(TestBase):
     @patch("vllm_ascend.ops.mla.get_ascend_config")
     @patch("vllm_ascend.ops.mla.get_tensor_model_parallel_world_size")
     @patch("vllm_ascend.ops.mla.get_forward_context")
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    def test_forward(self, mock_get_forward_context_2, mock_get_forward_context, mock_tp_size,
-                     mock_ascend_config, mock_get_vllm_config,
-                     mock_mla_forward,):
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_forward(
+        self,
+        mock_get_forward_context_2,
+        mock_get_forward_context,
+        mock_tp_size,
+        mock_ascend_config,
+        mock_get_vllm_config,
+        mock_mla_forward,
+    ):
         mock_tp_size.return_value = 1
         mock_ascend_config.return_value.enable_shared_expert_dp = False
         mock_vllm_config = MagicMock(spec=VllmConfig)
-        mock_vllm_config.model_config.hf_text_config = MagicMock(
-            num_hidden_layers=32, first_k_dense_replace=False)
+        mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=False)
         mock_get_vllm_config.return_value = mock_vllm_config
         mock_vllm_config.compilation_config = CompilationConfig()
 

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -22,7 +22,6 @@ from vllm_ascend.quantization.methods.base import QuantType
 
 
 class TestMoECommMethod(TestBase):
-
     def setUp(self):
         # Mock FusedMoEConfig
         self.moe_config = MagicMock(spec=FusedMoEConfig)
@@ -37,16 +36,10 @@ class TestMoECommMethod(TestBase):
         self.moe_config.dp_group = MagicMock()
         self.moe_config.global_redundant_expert_num = 0
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather"
-    )
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAllGather"
-    )
-    def test_all_gather_comm_impl(self, mock_token_dispatcher,
-                                  mock_prepare_finalize,
-                                  mock_get_forward_context):
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAllGather")
+    def test_all_gather_comm_impl(self, mock_token_dispatcher, mock_prepare_finalize, mock_get_forward_context):
         # Mock forward context
         mock_context = MagicMock()
         mock_context.moe_comm_method = "all_gather"
@@ -58,7 +51,8 @@ class TestMoECommMethod(TestBase):
             hidden_states=torch.randn(4, 8),
             router_logits=torch.randn(4, 2),
             mc2_mask=None,
-            padded_hidden_states_shape=None)
+            padded_hidden_states_shape=None,
+        )
         mock_pf_instance.finalize.return_value = torch.randn(4, 8)
         mock_prepare_finalize.return_value = mock_pf_instance
 
@@ -77,21 +71,16 @@ class TestMoECommMethod(TestBase):
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(
-            hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
 
         # Test finalize method
-        comm_impl.finalize(h_out,
-                           reduce_results=True,
-                           padded_hidden_states_shape=padded_hidden_states_shape)
+        comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
         mock_pf_instance.finalize.assert_called_once_with(h_out, True, None)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithMC2")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithMC2")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithMC2")
-    def test_mc2_comm_impl(self, mock_token_dispatcher, mock_prepare_finalize,
-                           mock_get_forward_context):
+    def test_mc2_comm_impl(self, mock_token_dispatcher, mock_prepare_finalize, mock_get_forward_context):
         # Mock forward context
         mock_context = MagicMock()
         mock_context.moe_comm_method = "mc2"
@@ -103,7 +92,8 @@ class TestMoECommMethod(TestBase):
             hidden_states=torch.randn(4, 8),
             router_logits=torch.randn(4, 2),
             mc2_mask=torch.tensor([1, 0, 1, 0]),
-            padded_hidden_states_shape=None)
+            padded_hidden_states_shape=None,
+        )
         mock_pf_instance.finalize.return_value = torch.randn(4, 8)
         mock_prepare_finalize.return_value = mock_pf_instance
 
@@ -122,25 +112,16 @@ class TestMoECommMethod(TestBase):
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(
-            hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
 
         # Test finalize method
-        comm_impl.finalize(h_out,
-                           reduce_results=True,
-                           padded_hidden_states_shape=padded_hidden_states_shape)
+        comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
         mock_pf_instance.finalize.assert_called_once_with(h_out, True, None)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAll2All"
-    )
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAll2AllV"
-    )
-    def test_alltoall_comm_impl(self, mock_token_dispatcher,
-                                mock_prepare_finalize,
-                                mock_get_forward_context):
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAll2All")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAll2AllV")
+    def test_alltoall_comm_impl(self, mock_token_dispatcher, mock_prepare_finalize, mock_get_forward_context):
         # Mock forward context
         mock_context = MagicMock()
         mock_context.moe_comm_method = "alltoall"
@@ -152,7 +133,8 @@ class TestMoECommMethod(TestBase):
             hidden_states=torch.randn(4, 8),
             router_logits=torch.randn(4, 2),
             mc2_mask=None,
-            padded_hidden_states_shape=None)
+            padded_hidden_states_shape=None,
+        )
         mock_pf_instance.finalize.return_value = torch.randn(4, 8)
         mock_prepare_finalize.return_value = mock_pf_instance
 
@@ -169,21 +151,16 @@ class TestMoECommMethod(TestBase):
         _ = comm_impl.prepare(hidden_states, router_logits)
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(
-            hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather"
-    )
-    @patch(
-        "vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAllGather"
-    )
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAllGather")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.unified_apply_mlp")
     @patch("torch.npu.current_stream", MagicMock())
-    def test_fused_experts_method(self, mock_unified_apply_mlp,
-                                  mock_token_dispatcher, mock_prepare_finalize,
-                                  mock_get_forward_context):
+    def test_fused_experts_method(
+        self, mock_unified_apply_mlp, mock_token_dispatcher, mock_prepare_finalize, mock_get_forward_context
+    ):
         # Mock forward context
         mock_context = MagicMock()
         mock_context.moe_comm_method = "all_gather"
@@ -195,7 +172,8 @@ class TestMoECommMethod(TestBase):
             hidden_states=torch.randn(4, 8),
             router_logits=torch.randn(4, 2),
             mc2_mask=None,
-            padded_hidden_states_shape=None)
+            padded_hidden_states_shape=None,
+        )
         mock_pf_instance.finalize.return_value = torch.randn(4, 8)
         mock_prepare_finalize.return_value = mock_pf_instance
 
@@ -210,7 +188,8 @@ class TestMoECommMethod(TestBase):
                 topk_weights=dispatch_topk_weights,
                 expanded_row_idx=torch.arange(8, dtype=torch.int32),
                 restore_shape=torch.Size([4, 8]),
-            ))
+            ),
+        )
         mock_td_instance.token_combine.return_value = torch.randn(4, 8)
         mock_token_dispatcher.return_value = mock_td_instance
 
@@ -232,25 +211,27 @@ class TestMoECommMethod(TestBase):
         w1 = w1.contiguous()
         w2 = w2.contiguous()
 
-        result = comm_impl.fused_experts(fused_experts_input=MoEFusedExpertsInput(
-            hidden_states=hidden_states,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            weights=MoEWeights(
-                w1=[w1],
-                w2=[w2],
-            ),
-            routing=MoERoutingParams(
-                expert_map=None,
-                global_redundant_expert_num=0,
-                mc2_mask=None,
-                apply_router_weight_on_input=False,
-            ),
-            activation="silu",
-            need_trans=False,
-            dynamic_eplb=False,
-            quant=MoEQuantParams(),
-        ))
+        result = comm_impl.fused_experts(
+            fused_experts_input=MoEFusedExpertsInput(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                weights=MoEWeights(
+                    w1=[w1],
+                    w2=[w2],
+                ),
+                routing=MoERoutingParams(
+                    expert_map=None,
+                    global_redundant_expert_num=0,
+                    mc2_mask=None,
+                    apply_router_weight_on_input=False,
+                ),
+                activation="silu",
+                need_trans=False,
+                dynamic_eplb=False,
+                quant=MoEQuantParams(),
+            )
+        )
 
         # Verify result shape
         self.assertEqual(result.routed_out.shape, (4, 8))

--- a/tests/ut/ops/test_moe_runtime_args.py
+++ b/tests/ut/ops/test_moe_runtime_args.py
@@ -166,17 +166,19 @@ class TestMoERuntimeArgs(unittest.TestCase):
 
     def test_build_fused_experts_input_requires_primitive_mxfp_params_for_mxfp_quant(self):
         for quant_type in (QuantType.MXFP8, QuantType.MXFP4):
-            with self.subTest(quant_type=quant_type):
-                with self.assertRaisesRegex(ValueError, "primitive MXFP params are required"):
-                    build_fused_experts_input(
-                        hidden_states=torch.randn(2, 8),
-                        topk_weights=torch.randn(2, 2),
-                        topk_ids=torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
-                        w1=torch.randn(2, 8, 16),
-                        w2=torch.randn(2, 16, 8),
-                        quant_type=quant_type,
-                        dynamic_eplb=False,
-                    )
+            with (
+                self.subTest(quant_type=quant_type),
+                self.assertRaisesRegex(ValueError, "primitive MXFP params are required"),
+            ):
+                build_fused_experts_input(
+                    hidden_states=torch.randn(2, 8),
+                    topk_weights=torch.randn(2, 2),
+                    topk_ids=torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
+                    w1=torch.randn(2, 8, 16),
+                    w2=torch.randn(2, 16, 8),
+                    quant_type=quant_type,
+                    dynamic_eplb=False,
+                )
 
     def test_build_mlp_compute_input_derives_fusion_and_preserves_mxfp_params(self):
         for quant_type, expected_fusion in ((QuantType.MXFP8, True), (QuantType.MXFP4, False)):

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -5,12 +5,13 @@ import torch
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ops.fused_moe.prepare_finalize import (
-    PrepareAndFinalizeWithAll2All, PrepareAndFinalizeWithAllGather,
-    PrepareAndFinalizeWithMC2)
+    PrepareAndFinalizeWithAll2All,
+    PrepareAndFinalizeWithAllGather,
+    PrepareAndFinalizeWithMC2,
+)
 
 
 class TestPrepareAndFinalize(unittest.TestCase):
-
     def setUp(self):
         # Mock FusedMoEConfig
         fake_stream = MagicMock()
@@ -26,15 +27,10 @@ class TestPrepareAndFinalize(unittest.TestCase):
         self.moe_config.dp_group = MagicMock()
         self.moe_config.original_num_experts = 8
 
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size",
-        return_value=1)
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank",
-        return_value=0)
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    def test_mc2_prepare_finalize(self, mock_get_forward_context, mock_tp_rank,
-                                  mock_tp_size):
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=1)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank", return_value=0)
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_mc2_prepare_finalize(self, mock_get_forward_context, mock_tp_rank, mock_tp_size):
         mock_context = MagicMock()
         mock_context.mc2_mask = torch.tensor([1, 0, 1])
         mock_context.padded_num_tokens = 4
@@ -58,22 +54,14 @@ class TestPrepareAndFinalize(unittest.TestCase):
         self.assertEqual(padded_hidden_states_shape, torch.Size([4, 8]))
 
         # Finalize
-        result = layer.finalize(h_out,
-                                reduce_results=False,
-                                padded_hidden_states_shape=padded_hidden_states_shape)
+        result = layer.finalize(h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape)
         self.assertEqual(result.shape[0], 3)
 
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size",
-        return_value=2)
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank",
-        return_value=0)
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=2)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank", return_value=0)
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch.distributed.all_gather")
-    def test_mc2_tp_split_allgather(self, mock_all_gather,
-                                    mock_get_forward_context, mock_tp_rank,
-                                    mock_tp_size):
+    def test_mc2_tp_split_allgather(self, mock_all_gather, mock_get_forward_context, mock_tp_rank, mock_tp_size):
         mock_context = MagicMock()
         mock_context.mc2_mask = torch.tensor([1, 0, 1, 0])
         mock_context.padded_num_tokens = 4
@@ -84,13 +72,9 @@ class TestPrepareAndFinalize(unittest.TestCase):
         router_logits = torch.randn(4, 2)
 
         prepare_output = layer.prepare(
-            hidden_states,
-            router_logits,
-            enable_shared_expert_dp=False,
-            replace_allreduce=False)
+            hidden_states, router_logits, enable_shared_expert_dp=False, replace_allreduce=False
+        )
         h_out = prepare_output.hidden_states
-        r_out = prepare_output.router_logits
-        mask = prepare_output.mc2_mask
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # With TP=2, should split into 2 parts
@@ -104,23 +88,16 @@ class TestPrepareAndFinalize(unittest.TestCase):
 
         mock_all_gather.side_effect = mock_all_gather_func
 
-        layer.split_hidden_states = [
-            torch.zeros_like(h_out),
-            torch.zeros_like(h_out)
-        ]
-        final_result = layer.finalize(h_out,
-                                      reduce_results=False,
-                                      padded_hidden_states_shape=padded_hidden_states_shape)
+        layer.split_hidden_states = [torch.zeros_like(h_out), torch.zeros_like(h_out)]
+        final_result = layer.finalize(
+            h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape
+        )
 
         # Should concat back to original size
         self.assertEqual(final_result.shape[0], 4)
 
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size",
-        return_value=1)
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank",
-        return_value=0)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=1)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank", return_value=0)
     def test_all2all_prepare_finalize(self, mock_tp_rank, mock_tp_size):
         layer = PrepareAndFinalizeWithAll2All(self.moe_config)
         hidden_states = torch.randn(3, 8)
@@ -128,38 +105,27 @@ class TestPrepareAndFinalize(unittest.TestCase):
 
         prepare_output = layer.prepare(hidden_states, router_logits)
         h_out = prepare_output.hidden_states
-        r_out = prepare_output.router_logits
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Pad to tp_size=1, so no change
         self.assertEqual(h_out.shape[0], 3)
         self.assertEqual(padded_hidden_states_shape, torch.Size([3, 8]))
 
-        result = layer.finalize(h_out,
-                                reduce_results=False,
-                                padded_hidden_states_shape=padded_hidden_states_shape)
+        result = layer.finalize(h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape)
         self.assertEqual(result.shape[0], 3)
 
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size",
-        return_value=2)
-    @patch(
-        "vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank",
-        return_value=0)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=2)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_rank", return_value=0)
     @patch("torch.distributed.all_gather")
-    def test_all2all_tp_split_allgather(self, mock_all_gather, mock_tp_rank,
-                                        mock_tp_size):
+    def test_all2all_tp_split_allgather(self, mock_all_gather, mock_tp_rank, mock_tp_size):
         layer = PrepareAndFinalizeWithAll2All(self.moe_config)
         hidden_states = torch.randn(2, 8)
         router_logits = torch.randn(2, 2)
 
         prepare_output = layer.prepare(
-            hidden_states,
-            router_logits,
-            enable_shared_expert_dp=False,
-            replace_allreduce=False)
+            hidden_states, router_logits, enable_shared_expert_dp=False, replace_allreduce=False
+        )
         h_out = prepare_output.hidden_states
-        r_out = prepare_output.router_logits
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Split due to TP=2
@@ -173,27 +139,21 @@ class TestPrepareAndFinalize(unittest.TestCase):
 
         mock_all_gather.side_effect = mock_all_gather_func
 
-        layer.split_hidden_states = [
-            torch.zeros_like(h_out),
-            torch.zeros_like(h_out)
-        ]
-        final_result = layer.finalize(h_out,
-                                      reduce_results=False,
-                                      padded_hidden_states_shape=padded_hidden_states_shape)
+        layer.split_hidden_states = [torch.zeros_like(h_out), torch.zeros_like(h_out)]
+        final_result = layer.finalize(
+            h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape
+        )
 
         # Should concat back
         self.assertEqual(final_result.shape[0], 2)
 
     @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_dp_group")
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.enable_sp",
-           return_value=False)
-    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.enable_sp_by_pass",
-        return_value=False)
-    def test_allgather_prepare_finalize(self, mock_enable_sp_by_pass,
-                                        mock_enable_sp,
-                                        mock_get_forward_context,
-                                        mock_get_dp_group):
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.enable_sp", return_value=False)
+    @patch("vllm_ascend.ops.fused_moe.prepare_finalize.enable_sp_by_pass", return_value=False)
+    def test_allgather_prepare_finalize(
+        self, mock_enable_sp_by_pass, mock_enable_sp, mock_get_forward_context, mock_get_dp_group
+    ):
         # Mock forward context
         mock_context = MagicMock()
         mock_context.max_tokens_across_dp = 6
@@ -235,9 +195,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
             return tensor[:3]
 
         mock_dp_group.reduce_scatter = mock_reduce_scatter_func
-        result = layer.finalize(h_out,
-                                reduce_results=False,
-                                padded_hidden_states_shape=padded_hidden_states_shape)
+        result = layer.finalize(h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape)
 
         self.assertEqual(result.shape[0], 3)
 

--- a/tests/ut/ops/test_rotary_embedding.py
+++ b/tests/ut/ops/test_rotary_embedding.py
@@ -15,13 +15,13 @@
 
 
 import inspect
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
-from unittest.mock import MagicMock, patch, PropertyMock
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding, YaRNScalingRotaryEmbedding
 
-from vllm.model_executor.layers.rotary_embedding import (YaRNScalingRotaryEmbedding, RotaryEmbedding)
-from vllm_ascend.ops.rotary_embedding import (AscendYaRNRotaryEmbedding, AscendRotaryEmbedding)
-
+from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, AscendYaRNRotaryEmbedding
 
 HEAD_SIZE = 64
 ROTARY_DIM = 64
@@ -46,7 +46,7 @@ def check_parent_init_signature_has_not_changed(parent_func, child_func):
     child_sig = inspect.signature(child_func)
     child_params = set(child_sig.parameters) - {"self"}
 
-    added   = parent_params - child_params
+    added = parent_params - child_params
     removed = child_params - parent_params
 
     assert not added, (
@@ -95,9 +95,7 @@ def make_embedding(patch_init_side_effects):
             emb.is_neox_style = is_neox_style
             emb.cos_sin_cache = torch.zeros(MAX_POS, ROTARY_DIM)
             # Call __init__ to exercise our code path
-            AscendRotaryEmbedding.__init__(
-                emb, HEAD_SIZE, ROTARY_DIM, MAX_POS, BASE, is_neox_style, DTYPE
-            )
+            AscendRotaryEmbedding.__init__(emb, HEAD_SIZE, ROTARY_DIM, MAX_POS, BASE, is_neox_style, DTYPE)
         return emb
 
     return _factory
@@ -109,6 +107,7 @@ def make_yarn_embedding(patch_init_side_effects):
     Factory for AscendYaRNRotaryEmbedding with parent __init__ suppressed.
     patch_init_side_effects is the same autouse fixture as before.
     """
+
     def _factory(is_neox_style: bool = True):
         with patch("vllm_ascend.ops.rotary_embedding.YaRNScalingRotaryEmbedding.__init__") as mock_parent_init:
             mock_parent_init.return_value = None
@@ -135,7 +134,6 @@ def make_yarn_embedding(patch_init_side_effects):
 
 
 class TestAscendEmbeddingForwardOOT:
-
     @patch("torch.ops.vllm.npu_rotary_embedding")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_basic_call_delegates_to_npu_op(self, mock_get_forward_context, mock_npu_op, make_embedding):
@@ -152,8 +150,13 @@ class TestAscendEmbeddingForwardOOT:
         result = emb.forward_oot(positions, query, key)
 
         mock_npu_op.assert_called_once_with(
-            positions, query, key, emb.cos_sin_cache,
-            HEAD_SIZE, ROTARY_DIM, emb.is_neox_style,
+            positions,
+            query,
+            key,
+            emb.cos_sin_cache,
+            HEAD_SIZE,
+            ROTARY_DIM,
+            emb.is_neox_style,
         )
         assert result is expected_output
 
@@ -233,17 +236,26 @@ class TestAscendEmbeddingForwardOOT:
         # npu op should receive the gathered positions, not the originals
         assert mock_npu_op.call_args[0][0] is gathered_positions
 
-    @pytest.mark.parametrize("is_draft_model,flash_comm,use_mtp", [
-        (False, True,  True),   # not draft
-        (True,  False, True),   # flash_comm disabled
-        (True,  True,  False),  # use_mtp disabled
-    ])
+    @pytest.mark.parametrize(
+        "is_draft_model,flash_comm,use_mtp",
+        [
+            (False, True, True),  # not draft
+            (True, False, True),  # flash_comm disabled
+            (True, True, False),  # use_mtp disabled
+        ],
+    )
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
     @patch("torch.ops.vllm.npu_rotary_embedding")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_gather_unpad_skipped_unless_all_conditions_met(
-        self, mock_get_forward_context, mock_npu_op, mock_gather,
-        is_draft_model, flash_comm, use_mtp, make_embedding,
+        self,
+        mock_get_forward_context,
+        mock_npu_op,
+        mock_gather,
+        is_draft_model,
+        flash_comm,
+        use_mtp,
+        make_embedding,
     ):
         """gather/unpad must NOT fire if any one of the three conditions is False."""
         mock_get_forward_context.return_value = MagicMock()
@@ -259,21 +271,17 @@ class TestAscendEmbeddingForwardOOT:
         mock_gather.assert_not_called()
         # Original positions tensor is passed through untouched
         assert mock_npu_op.call_args[0][0] is positions
-    
+
     def test_parent_init_signature_has_not_changed(self):
         """
         Fail loudly if RotaryEmbedding.__init__ adds, removes, or
         renames parameters, so a developer knows to update AscendRotaryEmbedding
         accordingly.
         """
-        check_parent_init_signature_has_not_changed(
-            RotaryEmbedding.__init__,
-            AscendRotaryEmbedding.__init__
-        )
+        check_parent_init_signature_has_not_changed(RotaryEmbedding.__init__, AscendRotaryEmbedding.__init__)
 
 
 class TestAscendYaRNRotaryEmbeddingForwardOOT:
-
     @patch("vllm_ascend.ops.rotary_embedding.AscendRotaryEmbedding.forward_oot")
     def test_delegates_to_ascend_rotary_forward_oot(self, mock_delegate, make_yarn_embedding):
         """forward_oot must delegate to AscendRotaryEmbedding.forward_oot."""
@@ -335,6 +343,5 @@ class TestAscendYaRNRotaryEmbeddingForwardOOT:
         accordingly.
         """
         check_parent_init_signature_has_not_changed(
-            YaRNScalingRotaryEmbedding.__init__,
-            AscendYaRNRotaryEmbedding.__init__
+            YaRNScalingRotaryEmbedding.__init__, AscendYaRNRotaryEmbedding.__init__
         )

--- a/tests/ut/ops/test_token_dispatcher.py
+++ b/tests/ut/ops/test_token_dispatcher.py
@@ -30,6 +30,7 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoERoutingParams,
     MoETokenDispatchInput,
 )
+
 from vllm_ascend.ops.fused_moe.token_dispatcher import (  # isort: skip
     AscendDeviceType,
     TokenDispatcherWithAll2AllV,
@@ -78,11 +79,8 @@ def build_token_dispatch_input_fixture(
 
 
 class TestTokenDispatcherWithMC2(TestBase):
-
     def setUp(self):
-        self.config_patcher = patch(
-            'vllm_ascend.ops.fused_moe.token_dispatcher.get_current_vllm_config'
-        )
+        self.config_patcher = patch("vllm_ascend.ops.fused_moe.token_dispatcher.get_current_vllm_config")
         self.mock_get_config = self.config_patcher.start()
 
         mock_config = MagicMock()
@@ -102,26 +100,25 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.mc2_group.rank_in_group = 0
         self.mc2_group.world_size = 8
         self.mc2_group_patch = patch(
-            "vllm_ascend.ops.fused_moe.token_dispatcher.get_mc2_group",
-            return_value=self.mc2_group)
+            "vllm_ascend.ops.fused_moe.token_dispatcher.get_mc2_group", return_value=self.mc2_group
+        )
         self.mc2_group_patch.start()
 
-        self.rank_group_patch = patch("torch.distributed.get_rank",
-                                      return_value=0)
+        self.rank_group_patch = patch("torch.distributed.get_rank", return_value=0)
         self.rank_group_patch.start()
 
         # Mock get_forward_context().mc2_mask
         self.forward_context = MagicMock()
         self.forward_context.mc2_mask = torch.tensor([1, 0, 1])
         self.forward_context_patch = patch(
-            "vllm.forward_context.get_forward_context",
-            return_value=self.forward_context)
+            "vllm.forward_context.get_forward_context", return_value=self.forward_context
+        )
         self.forward_context_patch.start()
 
         # Mock get_ascend_device_type()
         self.ascend_soc_version_patch = patch(
-            "vllm_ascend.ops.fused_moe.token_dispatcher.get_ascend_device_type",
-            return_value=AscendDeviceType.A3)
+            "vllm_ascend.ops.fused_moe.token_dispatcher.get_ascend_device_type", return_value=AscendDeviceType.A3
+        )
         self.ascend_soc_version_patch.start()
 
         kwargs = {"with_quant": False, "top_k": 8, "num_experts": 128}
@@ -163,9 +160,9 @@ class TestTokenDispatcherWithMC2(TestBase):
         topk_ids = torch.randint(0, 8, (10, 1))
         expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
 
-        with patch("torch_npu.npu_moe_distribute_dispatch_v2",
-                   return_value=(torch.randn(10, 128), ) * 5 +
-                   (None, None)) as mock_dispatch:
+        with patch(
+            "torch_npu.npu_moe_distribute_dispatch_v2", return_value=(torch.randn(10, 128),) * 5 + (None, None)
+        ) as mock_dispatch:
             token_dispatch_input = build_token_dispatch_input_fixture(
                 hidden_states=hidden_states,
                 topk_weights=topk_weights,
@@ -200,8 +197,7 @@ class TestTokenDispatcherWithMC2(TestBase):
         self.dispatcher.need_extra_args = True
         self.dispatcher.enable_dispatch_v2 = True
         self.dispatcher.moe_expert_num = len(expert_map)
-        kwargs = self.dispatcher.get_combine_mc_kwargs(hidden_states,
-                                                       combine_metadata)
+        kwargs = self.dispatcher.get_combine_mc_kwargs(hidden_states, combine_metadata)
         self.assertIn("tp_send_counts", kwargs)
 
     def test_get_dispatch_mc2_kwargs_with_mxfp8_quant(self):
@@ -267,7 +263,6 @@ class TestTokenDispatcherWithMC2(TestBase):
 
 
 class TestTokenDispatcherWithAllGather(TestBase):
-
     def setUp(self):
         # Mock dependencies
         kwargs = {
@@ -281,27 +276,23 @@ class TestTokenDispatcherWithAllGather(TestBase):
         self.dispatcher = TokenDispatcherWithAllGather(**kwargs)
 
         # Mock NPU functions
-        self.patcher_npu_moe_init_routing_custom = patch(
-            'torch.ops._C_ascend.npu_moe_init_routing_custom')
-        self.mock_npu_moe_init_routing_custom = self.patcher_npu_moe_init_routing_custom.start(
-        )
+        self.patcher_npu_moe_init_routing_custom = patch("torch.ops._C_ascend.npu_moe_init_routing_custom")
+        self.mock_npu_moe_init_routing_custom = self.patcher_npu_moe_init_routing_custom.start()
         self.mock_npu_moe_init_routing_custom.return_value = (
             torch.randn(6, 128),  # sorted_hidden_states
             torch.tensor([0, 1, 2, 3, 4, 5]),  # expanded_row_idx
             torch.tensor([0, 1, 0, 1, 0, 1]),  # expanded_expert_idx
-            torch.tensor([0, 1, 0, 1, 0, 1]))
-        self.patcher_npu_moe_token_unpermute = patch(
-            'torch_npu.npu_moe_token_unpermute')
-        self.mock_npu_moe_token_unpermute = self.patcher_npu_moe_token_unpermute.start(
+            torch.tensor([0, 1, 0, 1, 0, 1]),
         )
+        self.patcher_npu_moe_token_unpermute = patch("torch_npu.npu_moe_token_unpermute")
+        self.mock_npu_moe_token_unpermute = self.patcher_npu_moe_token_unpermute.start()
         self.mock_npu_moe_token_unpermute.return_value = torch.randn(6, 128)
 
     def tearDown(self):
         self.patcher_npu_moe_init_routing_custom.stop()
         self.patcher_npu_moe_token_unpermute.stop()
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_without_expert_map(self):
         hidden_states = torch.randn(3, 128)
         topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [0.5, 0.5]])
@@ -321,8 +312,7 @@ class TestTokenDispatcherWithAllGather(TestBase):
         self.assertEqual(results.group_list_type, 1)
         self.assertIsInstance(results.combine_metadata, MoEAllGatherCombineMetadata)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_with_expert_map(self):
         self.dispatcher.expert_map = torch.tensor([0, 1, 2, 3])
         hidden_states = torch.randn(3, 128)
@@ -343,8 +333,7 @@ class TestTokenDispatcherWithAllGather(TestBase):
         self.assertEqual(results.group_list_type, 1)
         self.assertIsInstance(results.combine_metadata, MoEAllGatherCombineMetadata)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_without_quant(self):
         kwargs = {
             "apply_router_weight_on_input": False,
@@ -368,8 +357,7 @@ class TestTokenDispatcherWithAllGather(TestBase):
 
         self.assertEqual(results.group_list_type, 1)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_with_quant(self):
         kwargs = {
             "apply_router_weight_on_input": False,
@@ -397,8 +385,7 @@ class TestTokenDispatcherWithAllGather(TestBase):
         self.assertIsNotNone(results.dynamic_scale)
         self.assertEqual(results.group_list_type, 1)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_combine_with_expert_map(self):
         hidden_states = torch.randn(6, 128)
         combine_metadata = MoEAllGatherCombineMetadata(
@@ -409,8 +396,7 @@ class TestTokenDispatcherWithAllGather(TestBase):
         final_hidden_states = self.dispatcher.token_combine(hidden_states, combine_metadata)
         self.assertEqual(final_hidden_states.shape, (6, 128))
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_combine_without_expert_map(self):
         hidden_states = torch.randn(6, 128)
         combine_metadata = MoEAllGatherCombineMetadata(
@@ -422,8 +408,7 @@ class TestTokenDispatcherWithAllGather(TestBase):
         self.mock_npu_moe_token_unpermute.assert_called_once()
         self.assertEqual(final_hidden_states.shape, (6, 128))
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_with_router_weight(self):
         hidden_states = torch.randn(3, 128)
         topk_weights = torch.tensor([[0.7], [0.6], [0.5]])  # topk=1
@@ -441,21 +426,13 @@ class TestTokenDispatcherWithAllGather(TestBase):
 
 
 class TestTokenDispatcherWithAll2AllV(TestBase):
-
     def setUp(self):
         # Patch properties
-        patcher1 = patch.object(TokenDispatcherWithAll2AllV,
-                                'ep_group',
-                                new_callable=PropertyMock,
-                                return_value=MagicMock())
-        patcher2 = patch.object(TokenDispatcherWithAll2AllV,
-                                'ep_rank',
-                                new_callable=PropertyMock,
-                                return_value=0)
-        patcher3 = patch.object(TokenDispatcherWithAll2AllV,
-                                'ep_size',
-                                new_callable=PropertyMock,
-                                return_value=2)
+        patcher1 = patch.object(
+            TokenDispatcherWithAll2AllV, "ep_group", new_callable=PropertyMock, return_value=MagicMock()
+        )
+        patcher2 = patch.object(TokenDispatcherWithAll2AllV, "ep_rank", new_callable=PropertyMock, return_value=0)
+        patcher3 = patch.object(TokenDispatcherWithAll2AllV, "ep_size", new_callable=PropertyMock, return_value=2)
 
         self.addCleanup(patcher1.stop)
         self.addCleanup(patcher2.stop)
@@ -466,83 +443,76 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.mock_ep_size_prop = patcher3.start()
 
         # Mock torch_npu.npu_moe_token_permute
-        patcher4 = patch('torch_npu.npu_moe_token_permute')
+        patcher4 = patch("torch_npu.npu_moe_token_permute")
         self.mock_npu_moe_token_permute = patcher4.start()
         self.addCleanup(patcher4.stop)
-        self.mock_npu_moe_token_permute.return_value = (torch.randn(16, 16),
-                                                        torch.arange(16))
+        self.mock_npu_moe_token_permute.return_value = (torch.randn(16, 16), torch.arange(16))
 
         # Mock torch_npu.npu_moe_token_unpermute
-        patcher5 = patch('torch_npu.npu_moe_token_unpermute')
+        patcher5 = patch("torch_npu.npu_moe_token_unpermute")
         self.mock_npu_moe_token_unpermute = patcher5.start()
         self.addCleanup(patcher5.stop)
         self.mock_npu_moe_token_unpermute.return_value = torch.randn(8, 16)
 
         # Mock async_all_to_all
-        patcher6 = patch(
-            'vllm_ascend.ops.fused_moe.comm_utils.async_all_to_all')
+        patcher6 = patch("vllm_ascend.ops.fused_moe.comm_utils.async_all_to_all")
         self.mock_async_all_to_all = patcher6.start()
         self.addCleanup(patcher6.stop)
-        self.mock_async_all_to_all.return_value = (None, torch.randn(16, 16),
-                                                   MagicMock())
+        self.mock_async_all_to_all.return_value = (None, torch.randn(16, 16), MagicMock())
 
         # Mock gather_from_sequence_parallel_region
-        patcher7 = patch(
-            'vllm_ascend.ops.fused_moe.token_dispatcher.gather_from_sequence_parallel_region'
-        )
+        patcher7 = patch("vllm_ascend.ops.fused_moe.token_dispatcher.gather_from_sequence_parallel_region")
         self.mock_gather_from_sequence_parallel_region = patcher7.start()
         self.addCleanup(patcher7.stop)
         self.mock_gather_from_sequence_parallel_region.return_value = torch.tensor(
-            [[2, 2, 2, 2], [2, 2, 2, 2]], dtype=torch.int64)
+            [[2, 2, 2, 2], [2, 2, 2, 2]], dtype=torch.int64
+        )
 
         # Mock torch.histc
-        patcher8 = patch('torch.histc')
+        patcher8 = patch("torch.histc")
         self.mock_histc = patcher8.start()
         self.addCleanup(patcher8.stop)
-        self.mock_histc.return_value = torch.tensor([2, 2, 2, 2],
-                                                    dtype=torch.int64)
+        self.mock_histc.return_value = torch.tensor([2, 2, 2, 2], dtype=torch.int64)
 
         # Mock torch.npu.current_device
-        patcher9 = patch('torch.npu.current_device')
+        patcher9 = patch("torch.npu.current_device")
         self.mock_current_device = patcher9.start()
         self.addCleanup(patcher9.stop)
-        self.mock_current_device.return_value = 'cpu'
+        self.mock_current_device.return_value = "cpu"
 
         # Mock torch_npu.npu_dynamic_quant
-        patcher10 = patch('torch_npu.npu_dynamic_quant')
+        patcher10 = patch("torch_npu.npu_dynamic_quant")
         self.mock_npu_dynamic_quant = patcher10.start()
         self.addCleanup(patcher10.stop)
-        self.mock_npu_dynamic_quant.return_value = (torch.randn(16, 16),
-                                                    torch.randn(16))
+        self.mock_npu_dynamic_quant.return_value = (torch.randn(16, 16), torch.randn(16))
 
         # Mock torch.ops._C_ascend.npu_moe_init_routing_custom
-        patcher11 = patch('torch.ops._C_ascend.npu_moe_init_routing_custom')
+        patcher11 = patch("torch.ops._C_ascend.npu_moe_init_routing_custom")
         self.mock_npu_moe_init_routing_custom = patcher11.start()
         self.addCleanup(patcher11.stop)
-        self.mock_npu_moe_init_routing_custom.return_value = (torch.randn(
-            16, 16), torch.arange(16), None, torch.randn(16))
+        self.mock_npu_moe_init_routing_custom.return_value = (
+            torch.randn(16, 16),
+            torch.arange(16),
+            None,
+            torch.randn(16),
+        )
 
         # Mock torch.repeat_interleave
-        patcher12 = patch('torch.repeat_interleave')
+        patcher12 = patch("torch.repeat_interleave")
         self.mock_repeat_interleave = patcher12.start()
         self.addCleanup(patcher12.stop)
         self.mock_repeat_interleave.return_value = torch.arange(16)
 
-        self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2,
-                                                      num_experts=4,
-                                                      num_local_experts=2,
-                                                      with_quant=False)
+        self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2, num_experts=4, num_local_experts=2, with_quant=False)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch(self):
         hidden_states = torch.randn(8, 16)
         topk_weights = torch.rand(8, 4)
         topk_ids = torch.randint(0, 4, (8, 2)).long()
         expert_map = torch.tensor([0, 1, 2, 3])
 
-        self.dispatcher.expert_ids_per_ep_rank = torch.tensor(
-            [0, 1], dtype=torch.int32)
+        self.dispatcher.expert_ids_per_ep_rank = torch.tensor([0, 1], dtype=torch.int32)
         self.dispatcher.local_expert_indices = [0, 1]
 
         token_dispatch_input = build_token_dispatch_input_fixture(
@@ -558,8 +528,7 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.assertEqual(result.group_list_type, 1)
         self.assertIsInstance(result.combine_metadata, MoEAllToAllCombineMetadata)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_combine(self):
         hidden_states = torch.randn(16, 16)
         combine_metadata = MoEAllToAllCombineMetadata(
@@ -571,28 +540,23 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
             hidden_shape=torch.Size([8, 16]),
             hidden_shape_before_permute=torch.Size([8, 16]),
         )
-        self.dispatcher.expert_ids_per_ep_rank = torch.tensor(
-            [0, 1], dtype=torch.int32)
+        self.dispatcher.expert_ids_per_ep_rank = torch.tensor([0, 1], dtype=torch.int32)
         self.dispatcher.local_expert_indices = [0, 1]
 
         output = self.dispatcher.token_combine(hidden_states, combine_metadata)
         self.assertIsNotNone(output)
         self.assertEqual(output.shape, (8, 16))
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_with_quant(self):
-        self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2,
-                                                      num_experts=4,
-                                                      num_local_experts=2)
+        self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2, num_experts=4, num_local_experts=2)
 
         hidden_states = torch.randn(8, 16)
         topk_weights = torch.rand(8, 4)
         topk_ids = torch.randint(0, 4, (8, 2)).long()
         expert_map = torch.tensor([0, 1, 2, 3])
 
-        self.dispatcher.expert_ids_per_ep_rank = torch.tensor(
-            [0, 1], dtype=torch.int32)
+        self.dispatcher.expert_ids_per_ep_rank = torch.tensor([0, 1], dtype=torch.int32)
         self.dispatcher.local_expert_indices = [0, 1]
 
         token_dispatch_input = build_token_dispatch_input_fixture(
@@ -610,23 +574,18 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.assertEqual(result.group_list_type, 1)
         self.assertIsInstance(result.combine_metadata, MoEAllToAllCombineMetadata)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_dispatch_with_quant_no_active_tokens(self):
-        self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2,
-                                                      num_experts=4,
-                                                      num_local_experts=2)
+        self.dispatcher = TokenDispatcherWithAll2AllV(top_k=2, num_experts=4, num_local_experts=2)
 
-        self.mock_repeat_interleave.return_value = torch.tensor(
-            [], dtype=torch.long)
+        self.mock_repeat_interleave.return_value = torch.tensor([], dtype=torch.long)
 
         hidden_states = torch.randn(8, 16)
         topk_weights = torch.rand(8, 4)
         topk_ids = torch.randint(0, 4, (8, 2)).long()
         expert_map = torch.tensor([0, 1, 2, 3])
 
-        self.dispatcher.expert_ids_per_ep_rank = torch.tensor(
-            [0, 1], dtype=torch.int32)
+        self.dispatcher.expert_ids_per_ep_rank = torch.tensor([0, 1], dtype=torch.int32)
         self.dispatcher.local_expert_indices = [0, 1]
 
         token_dispatch_input = build_token_dispatch_input_fixture(

--- a/tests/ut/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/ops/test_vocab_parallel_embedding.py
@@ -21,13 +21,15 @@ import torch
 
 from vllm_ascend.distributed import parallel_state
 from vllm_ascend.ops.vocab_parallel_embedding import (
-    AscendLogitsProcessor, AscendParallelLMHead, AscendVocabParallelEmbedding)
+    AscendLogitsProcessor,
+    AscendParallelLMHead,
+    AscendVocabParallelEmbedding,
+)
 
 VOCAB_PARALLEL_EMBEDDING_TEST_NUM_RANDOM_SEEDS = 128
 
 
 class TestCustomVocabParallelEmbedding(unittest.TestCase):
-
     def setUp(self):
         self.num_embeddings = 50
         self.embedding_dim = 10
@@ -48,10 +50,8 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         self.mock_ascend_config.finegrained_tp_config.embedding_tensor_parallel_size = 2
 
         self.patches = [
-            patch("vllm_ascend.utils.get_ascend_config",
-                  return_value=self.mock_ascend_config),
-            patch("vllm_ascend.distributed.parallel_state.get_lmhead_tp_group",
-                  return_value=self.mock_group),
+            patch("vllm_ascend.utils.get_ascend_config", return_value=self.mock_ascend_config),
+            patch("vllm_ascend.distributed.parallel_state.get_lmhead_tp_group", return_value=self.mock_group),
             patch(
                 "vllm.distributed.parallel_state.get_tp_group",
                 return_value=self.mock_group,
@@ -66,12 +66,16 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         mock_group = MagicMock()
         mock_group.world_size = 2
         mock_group.rank_in_group = 0
-        with patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=mock_group), \
-            patch("vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0), \
-            patch("vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_world_size", return_value=2), \
-            patch("vllm.model_executor.layers.vocab_parallel_embedding.pad_vocab_size", side_effect=lambda x, y: x + y), \
-            patch("vllm.model_executor.layers.vocab_parallel_embedding.divide", side_effect=lambda x, y: x // y):
-
+        with (
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=mock_group),
+            patch("vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0),
+            patch(
+                "vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_world_size",
+                return_value=2,
+            ),
+            patch("vllm.model_executor.layers.vocab_parallel_embedding.pad_vocab_size", side_effect=lambda x, y: x + y),
+            patch("vllm.model_executor.layers.vocab_parallel_embedding.divide", side_effect=lambda x, y: x // y),
+        ):
             # Create an instance of VocabParallelEmbedding
             layer = AscendVocabParallelEmbedding(
                 num_embeddings=self.num_embeddings,
@@ -79,7 +83,8 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
                 org_num_embeddings=self.org_num_embeddings,
                 padding_size=self.padding_size,
                 quant_config=None,  # Mock quantization config
-                prefix="")
+                prefix="",
+            )
 
             layer.shard_indices = MagicMock()
             layer.shard_indices.org_vocab_start_index = 10
@@ -90,8 +95,8 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
 
             # Mock the quantization method
             layer.quant_method.embedding = MagicMock(
-                side_effect=lambda _, x: torch.randn(x.shape[0], self.
-                                                     embedding_dim))
+                side_effect=lambda _, x: torch.randn(x.shape[0], self.embedding_dim)
+            )
             return layer
 
     def test_get_masked_input_and_mask(self):
@@ -106,17 +111,16 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
             org_vocab_end_index=20,
             num_org_vocab_padding=5,
             added_vocab_start_index=30,
-            added_vocab_end_index=40)
+            added_vocab_end_index=40,
+        )
 
         expected_mask = torch.tensor([True, False, True, False, True])
-        self.assertTrue(
-            torch.equal(mask, expected_mask),
-            f"Mask mismatch. Expected {expected_mask}, got {mask}")
+        self.assertTrue(torch.equal(mask, expected_mask), f"Mask mismatch. Expected {expected_mask}, got {mask}")
 
         expected_masked = torch.tensor([0, 5, 0, 20, 0])
         self.assertTrue(
             torch.equal(masked_input, expected_masked),
-            f"Masked input mismatch. Expected {expected_masked}, got {masked_input}"
+            f"Masked input mismatch. Expected {expected_masked}, got {masked_input}",
         )
 
     def test_forward_with_tp_size_1(self):
@@ -124,18 +128,15 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         # Create a fresh mock embedding with tp_size=1
         layer = self._create_layer()
         layer.tp_size = 1
-        layer.quant_method.embedding = MagicMock(
-            return_value=torch.randn(3, layer.embedding_dim))
+        layer.quant_method.embedding = MagicMock(return_value=torch.randn(3, layer.embedding_dim))
 
         input_ = torch.tensor([1, 2, 3])
 
-        with patch("torch.ops.vllm.maybe_pad_and_reduce",
-                   side_effect=lambda x: x) as mock_reduce_tp1:
+        with patch("torch.ops.vllm.maybe_pad_and_reduce", side_effect=lambda x: x) as mock_reduce_tp1:
             output = layer.forward(input_)
 
         # Should just pass through without masking
-        layer.quant_method.embedding.assert_called_once_with(
-            layer, input_.long())
+        layer.quant_method.embedding.assert_called_once_with(layer, input_.long())
         self.assertEqual(output.shape, (3, layer.embedding_dim))
 
         # Verify all_reduce was called once
@@ -147,8 +148,7 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
 
         input_ = torch.tensor([15, 35])  # one org vocab, one added vocab
 
-        with patch("torch.ops.vllm.maybe_pad_and_reduce",
-                   side_effect=lambda x: x) as mock_reduce_tp:
+        with patch("torch.ops.vllm.maybe_pad_and_reduce", side_effect=lambda x: x) as mock_reduce_tp:
             # Call the forward method
             output = layer.forward(input_)
 
@@ -169,12 +169,10 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         input_ = torch.tensor([5, 15, 25, 35, 45])  # includes invalid cases
         # Create predictable mock output
         mock_output = torch.randn(5, self.embedding_dim)
-        layer.quant_method.embedding = MagicMock(
-            return_value=mock_output.clone())
+        layer.quant_method.embedding = MagicMock(return_value=mock_output.clone())
 
         # Patch tensor_model_parallel_all_reduce to mock its behavior
-        with patch("torch.ops.vllm.maybe_pad_and_reduce",
-                   side_effect=lambda x: x):
+        with patch("torch.ops.vllm.maybe_pad_and_reduce", side_effect=lambda x: x):
             # Call the forward method
             output = layer.forward(input_)
         # Check that invalid positions (0, 2, 4) were zeroed out
@@ -198,24 +196,22 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
 
         for input_, expected_shape in test_cases:
             with self.subTest(input=input_):
-                with patch("torch.ops.vllm.maybe_pad_and_reduce",
-                           side_effect=lambda x: x):
+                with patch("torch.ops.vllm.maybe_pad_and_reduce", side_effect=lambda x: x):
                     # Call the forward method
                     output = layer.forward(input_)
                 self.assertEqual(output.shape, expected_shape)
 
 
 class TestAscendLogitsProcessor(unittest.TestCase):
-
     def setUp(self):
         self.mock_vllm_config = MagicMock()
         self.mock_vllm_config.compilation_config.custom_ops = ["all"]
 
         from vllm.config.vllm import set_current_vllm_config
+
         set_current_vllm_config(self.mock_vllm_config)
 
-        self.config_patch = patch("vllm.config.vllm.get_current_vllm_config",
-                                  return_value=self.mock_vllm_config)
+        self.config_patch = patch("vllm.config.vllm.get_current_vllm_config", return_value=self.mock_vllm_config)
         self.config_patch.start()
         self.vocab_size = 50
         self.num_embeddings = 50
@@ -228,22 +224,19 @@ class TestAscendLogitsProcessor(unittest.TestCase):
         self.mock_group.rank_in_group = 0
         self.mock_ascend_config = MagicMock()
         self.mock_quant_method = MagicMock()
-        self.mock_quant_method.apply = MagicMock(
-            return_value=torch.randn(1, self.vocab_size))
+        self.mock_quant_method.apply = MagicMock(return_value=torch.randn(1, self.vocab_size))
         self.patches = [
-            patch("vllm_ascend.ascend_config.get_ascend_config",
-                  return_value=self.mock_ascend_config),
-            patch(
-                "vllm_ascend.ops.vocab_parallel_embedding.get_lmhead_tp_group",
-                return_value=self.mock_group),
-            patch("vllm_ascend.ops.vocab_parallel_embedding.lmhead_tp_enable",
-                  return_value=True),
+            patch("vllm_ascend.ascend_config.get_ascend_config", return_value=self.mock_ascend_config),
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_lmhead_tp_group", return_value=self.mock_group),
+            patch("vllm_ascend.ops.vocab_parallel_embedding.lmhead_tp_enable", return_value=True),
             patch(
                 "vllm_ascend.ops.vocab_parallel_embedding.get_lmhead_tp_group.all_to_all",
-                return_value=torch.randn(1, self.vocab_size)),
+                return_value=torch.randn(1, self.vocab_size),
+            ),
             patch(
                 "vllm_ascend.ops.vocab_parallel_embedding.get_lmhead_tp_group.all_gather",
-                return_value=torch.randn(1, self.vocab_size))
+                return_value=torch.randn(1, self.vocab_size),
+            ),
         ]
 
         for p in self.patches:
@@ -259,9 +252,9 @@ class TestAscendLogitsProcessor(unittest.TestCase):
 
     def test_get_logits(self):
         processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
-        lmhead = AscendParallelLMHead(num_embeddings=self.num_embeddings,
-                                      embedding_dim=self.embedding_dim,
-                                      prefix="lm_head")
+        lmhead = AscendParallelLMHead(
+            num_embeddings=self.num_embeddings, embedding_dim=self.embedding_dim, prefix="lm_head"
+        )
         lmhead.quant_method = self.mock_quant_method
         lmhead.quant_method.apply = self.mock_quant_method.apply
         hidden_state = torch.randn(1, self.org_num_embeddings)

--- a/tests/ut/patch/worker/patch_common/test_hccl_pg_registry.py
+++ b/tests/ut/patch/worker/patch_common/test_hccl_pg_registry.py
@@ -14,12 +14,12 @@
 #
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager
-from importlib.util import module_from_spec, spec_from_file_location
 from dataclasses import dataclass
 from datetime import timedelta
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-import sys
 from typing import Any
 from unittest.mock import MagicMock
 

--- a/tests/ut/patch/worker/patch_common/test_patch_distributed.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_distributed.py
@@ -14,18 +14,17 @@
 #
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-import sys
 from typing import Any
 from unittest.mock import MagicMock, call
 
 import pytest
-
 
 _WORKTREE_ROOT = Path(__file__).resolve().parents[5]
 _PATCH_MODULE_PATH = _WORKTREE_ROOT / "vllm_ascend/patch/worker/patch_distributed.py"
@@ -89,9 +88,7 @@ def _load_patch_distributed_module():
     non_group_member = object()
     new_group_calls: list[dict[str, object]] = []
     destroy_process_group = MagicMock()
-    destroy_distributed_environment = MagicMock(
-        name="destroy_distributed_environment"
-    )
+    destroy_distributed_environment = MagicMock(name="destroy_distributed_environment")
     get_rank = MagicMock(return_value=0)
     current_device = MagicMock(return_value="npu:0")
     communicator_instances: list[object] = []
@@ -105,11 +102,13 @@ def _load_patch_distributed_module():
 
     def new_group(ranks, backend, pg_options=None):
         backend_name = str(backend)
-        new_group_calls.append({
-            "ranks": tuple(ranks),
-            "backend": backend_name,
-            "pg_options": pg_options,
-        })
+        new_group_calls.append(
+            {
+                "ranks": tuple(ranks),
+                "backend": backend_name,
+                "pg_options": pg_options,
+            }
+        )
         if get_rank() not in ranks:
             return non_group_member
         handle = FakeProcessGroup(
@@ -151,37 +150,25 @@ def _load_patch_distributed_module():
     parallel_state_module.GroupCoordinator = BaseGroupCoordinator
     parallel_state_module._get_unique_name = _get_unique_name
     parallel_state_module._register_group = MagicMock()
-    parallel_state_module.destroy_distributed_environment = (
-        destroy_distributed_environment
-    )
+    parallel_state_module.destroy_distributed_environment = destroy_distributed_environment
 
-    shm_broadcast_module: Any = ModuleType(
-        "vllm.distributed.device_communicators.shm_broadcast"
-    )
+    shm_broadcast_module: Any = ModuleType("vllm.distributed.device_communicators.shm_broadcast")
 
     class MessageQueue:
-        create_from_process_group = MagicMock(
-            side_effect=lambda group, *_: SimpleNamespace(group=group)
-        )
+        create_from_process_group = MagicMock(side_effect=lambda group, *_: SimpleNamespace(group=group))
 
     shm_broadcast_module.MessageQueue = MessageQueue
 
     vllm_distributed.parallel_state = parallel_state_module
-    vllm_distributed.destroy_distributed_environment = (
-        destroy_distributed_environment
-    )
+    vllm_distributed.destroy_distributed_environment = destroy_distributed_environment
     vllm_module.distributed = vllm_distributed
 
     vllm_ascend_module: Any = ModuleType("vllm_ascend")
     vllm_ascend_patch: Any = ModuleType("vllm_ascend.patch")
     vllm_ascend_patch_worker: Any = ModuleType("vllm_ascend.patch.worker")
     vllm_ascend_distributed: Any = ModuleType("vllm_ascend.distributed")
-    vllm_ascend_device_communicators: Any = ModuleType(
-        "vllm_ascend.distributed.device_communicators"
-    )
-    npu_communicator_module: Any = ModuleType(
-        "vllm_ascend.distributed.device_communicators.npu_communicator"
-    )
+    vllm_ascend_device_communicators: Any = ModuleType("vllm_ascend.distributed.device_communicators")
+    npu_communicator_module: Any = ModuleType("vllm_ascend.distributed.device_communicators.npu_communicator")
     utils_module: Any = ModuleType("vllm_ascend.utils")
 
     class FakeNPUCommunicator:
@@ -211,12 +198,8 @@ def _load_patch_distributed_module():
         "vllm_ascend.patch": vllm_ascend_patch,
         "vllm_ascend.patch.worker": vllm_ascend_patch_worker,
         "vllm_ascend.distributed": vllm_ascend_distributed,
-        "vllm_ascend.distributed.device_communicators": (
-            vllm_ascend_device_communicators
-        ),
-        "vllm_ascend.distributed.device_communicators.npu_communicator": (
-            npu_communicator_module
-        ),
+        "vllm_ascend.distributed.device_communicators": (vllm_ascend_device_communicators),
+        "vllm_ascend.distributed.device_communicators.npu_communicator": (npu_communicator_module),
         "vllm_ascend.utils": utils_module,
     }
 
@@ -293,10 +276,7 @@ def _calls_with_backend(module_env, backend: str) -> list[dict[str, object]]:
 
 
 def test_group_coordinator_is_patched(module_env):
-    assert (
-        module_env.parallel_state_module.GroupCoordinator
-        is module_env.module.GroupCoordinatorPatch
-    )
+    assert module_env.parallel_state_module.GroupCoordinator is module_env.module.GroupCoordinatorPatch
 
 
 def test_same_hccl_group_reuses_device_pg_once(module_env):
@@ -316,8 +296,8 @@ def test_same_hccl_group_reuses_device_pg_once(module_env):
 
 
 def test_same_hccl_group_reuses_with_realistic_options_object(module_env):
-    module_env.utils_module.create_hccl_pg_options.return_value = (
-        RealisticFakeHcclOptions(hccl_config={"hccl_buffer_size": 200})
+    module_env.utils_module.create_hccl_pg_options.return_value = RealisticFakeHcclOptions(
+        hccl_config={"hccl_buffer_size": 200}
     )
 
     first = _make_group(module_env, backend="hccl", group_name="tp")
@@ -352,18 +332,14 @@ def test_mc2_stays_isolated_from_ep_even_when_pg_options_match(module_env):
 
 
 def test_dynamic_eplb_stays_separate_from_ep_when_pg_options_differ(module_env):
-    default_hccl_pg_options = (
-        module_env.utils_module.create_hccl_pg_options.return_value
-    )
+    default_hccl_pg_options = module_env.utils_module.create_hccl_pg_options.return_value
 
     def fake_create_hccl_pg_options(group_name: str):
         if group_name == "dynamic_eplb":
             return {"hccl_config": {"hccl_buffer_size": 512}}
         return default_hccl_pg_options
 
-    module_env.utils_module.create_hccl_pg_options.side_effect = (
-        fake_create_hccl_pg_options
-    )
+    module_env.utils_module.create_hccl_pg_options.side_effect = fake_create_hccl_pg_options
 
     first = _make_group(module_env, group_name="ep")
     second = _make_group(module_env, group_name="dynamic_eplb")
@@ -457,9 +433,7 @@ def test_failed_device_communicator_init_releases_all_keys_in_reverse_order(
 ):
     release_mock = MagicMock(wraps=module_env.module._HCCL_PG_REGISTRY.release)
     module_env.module._HCCL_PG_REGISTRY.release = release_mock
-    module_env.module.NPUCommunicator = MagicMock(
-        side_effect=RuntimeError("communicator failed")
-    )
+    module_env.module.NPUCommunicator = MagicMock(side_effect=RuntimeError("communicator failed"))
 
     key_a = module_env.registry_module.make_hccl_pg_key(
         [0, 1],

--- a/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
@@ -6,13 +6,13 @@ from typing import cast
 
 import pytest
 import torch
-
-import vllm_ascend.patch.worker.patch_gdn_attn as patch_gdn_attn
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.fla.ops import index as _fla_index
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import MambaSpec
+
+import vllm_ascend.patch.worker.patch_gdn_attn as patch_gdn_attn
 from vllm_ascend.ops.gdn import (
     get_non_spec_causal_conv1d_host_args,
     get_non_spec_chunked_prefill_meta,
@@ -21,8 +21,14 @@ from vllm_ascend.ops.gdn import (
 from vllm_ascend.ops.triton.fla import utils as fla_utils
 from vllm_ascend.ops.triton.fla.utils import (
     prepare_chunk_indices as runtime_prepare_chunk_indices,
+)
+from vllm_ascend.ops.triton.fla.utils import (
     prepare_chunk_offsets as runtime_prepare_chunk_offsets,
+)
+from vllm_ascend.ops.triton.fla.utils import (
     prepare_final_chunk_indices as runtime_prepare_final_chunk_indices,
+)
+from vllm_ascend.ops.triton.fla.utils import (
     prepare_update_chunk_offsets as runtime_prepare_update_chunk_offsets,
 )
 
@@ -70,10 +76,7 @@ def create_common_attn_metadata(
     seq_lens = torch.tensor(batch_spec.seq_lens, dtype=torch.int32, device=device)
     seq_lens_cpu = seq_lens.cpu()
     max_seq_len = int(seq_lens_cpu.max())
-    context_lens = [
-        batch_spec.seq_lens[i] - batch_spec.query_lens[i]
-        for i in range(batch_spec.batch_size)
-    ]
+    context_lens = [batch_spec.seq_lens[i] - batch_spec.query_lens[i] for i in range(batch_spec.batch_size)]
     num_computed_tokens_cpu = torch.tensor(context_lens, dtype=torch.int32)
     max_blocks = (max(batch_spec.seq_lens) + block_size - 1) // block_size
     block_table_tensor = torch.arange(
@@ -300,6 +303,7 @@ def test_non_spec_prefill_fallback_meta_matches_original_inputs_and_runtime_help
         fallback_meta.chunk,
         attn_metadata.non_spec_query_start_loc,
     )
+
 
 def test_build_non_spec_causal_conv1d_host_meta_avoids_seq_lens_cpu_fallback():
     class GuardSeqLens:

--- a/tests/ut/patch/worker/patch_common/test_patch_routed_experts_capturer.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_routed_experts_capturer.py
@@ -1,18 +1,14 @@
-from unittest.mock import patch, MagicMock
 import uuid
+from unittest.mock import MagicMock, patch
 
 import torch
+from vllm.platforms import current_platform
 
 from tests.ut.base import TestBase
 from vllm_ascend.patch.worker.patch_routed_experts_capturer import RoutedExpertsCapturer
-from vllm.config import ModelConfig, VllmConfig
-from vllm.config.parallel import ParallelConfig
-from transformers import PretrainedConfig
-from vllm.platforms import current_platform
 
 
 class MockVllmConfig:
-
     def __init__(self):
         self.model_config = MagicMock()
         self.model_config.hf_text_config.num_hidden_layers = 1
@@ -23,7 +19,6 @@ class MockVllmConfig:
 
 
 class TestPatchRoutedExpertsCapturer(TestBase):
-
     def setUp(self):
         RoutedExpertsCapturer.create()
         self.capturer = RoutedExpertsCapturer.get_instance()
@@ -34,7 +29,7 @@ class TestPatchRoutedExpertsCapturer(TestBase):
         max_num_kv_tokens = 1
         with patch(
             target="vllm_ascend.patch.worker.patch_routed_experts_capturer.get_tensor_model_parallel_rank",
-            return_value=True
+            return_value=True,
         ):
             current_platform.device_name = "cpu"
             self.capturer.init_buffer(
@@ -48,7 +43,7 @@ class TestPatchRoutedExpertsCapturer(TestBase):
                     max_num_batched_tokens,
                     self.vllm_config.model_config.hf_text_config.num_hidden_layers,
                     self.vllm_config.model_config.hf_text_config.num_experts_per_tok,
-                )
+                ),
             )
             self.assertEqual(self.capturer._device_buffer.dtype, torch.int32)
             self.assertEqual(self.capturer._device_buffer.device.type, current_platform.device_name)

--- a/tests/ut/quantization/test_kv_c8.py
+++ b/tests/ut/quantization/test_kv_c8.py
@@ -1,7 +1,8 @@
 import unittest
+from unittest.mock import MagicMock, Mock, patch
+
 import torch
 import torch.nn as nn
-from unittest.mock import MagicMock, Mock, patch
 
 from tests.ut.base import TestBase
 
@@ -13,15 +14,12 @@ class TestWeightLoader(unittest.TestCase):
         """Set up test environment before each test"""
         # Import the module under test
         from vllm_ascend.quantization.methods.kv_c8 import _fa_quant_weight_loader as weight_loader
+
         self.weight_loader = weight_loader
 
         # Mock distributed functions
-        self.tp_rank_patch = patch(
-            "vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_rank"
-        )
-        self.tp_size_patch = patch(
-            "vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_world_size"
-        )
+        self.tp_rank_patch = patch("vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_rank")
+        self.tp_size_patch = patch("vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_world_size")
         self.mock_tp_rank = self.tp_rank_patch.start()
         self.mock_tp_size = self.tp_size_patch.start()
 
@@ -63,7 +61,7 @@ class TestWeightLoader(unittest.TestCase):
         loaded_weight = torch.ones(8, 5)  # Full weight (8,5)
 
         # Mock narrow to track the call
-        with patch.object(loaded_weight, 'narrow', wraps=loaded_weight.narrow) as mock_narrow:
+        with patch.object(loaded_weight, "narrow", wraps=loaded_weight.narrow) as mock_narrow:
             self.weight_loader(param, loaded_weight)
 
             # Verify narrow was called correctly: narrow(dim=0, start=0, length=2)
@@ -81,7 +79,7 @@ class TestWeightLoader(unittest.TestCase):
         param = torch.zeros(2, 5)
         loaded_weight = torch.ones(8, 5)
 
-        with patch.object(loaded_weight, 'narrow', wraps=loaded_weight.narrow) as mock_narrow:
+        with patch.object(loaded_weight, "narrow", wraps=loaded_weight.narrow) as mock_narrow:
             self.weight_loader(param, loaded_weight)
 
             # Verify narrow was called correctly: start = shard_size * rank = 2 * 2 = 4
@@ -98,7 +96,7 @@ class TestWeightLoader(unittest.TestCase):
         param = torch.zeros(2, 5)
         loaded_weight = torch.ones(8, 5)
 
-        with patch.object(loaded_weight, 'narrow', wraps=loaded_weight.narrow) as mock_narrow:
+        with patch.object(loaded_weight, "narrow", wraps=loaded_weight.narrow) as mock_narrow:
             self.weight_loader(param, loaded_weight)
 
             # Verify narrow was called correctly: start = 2 * 3 = 6
@@ -115,7 +113,7 @@ class TestWeightLoader(unittest.TestCase):
         loaded_weight = torch.ones(4, 4)  # Different shape after sharding
 
         # Mock narrow to return tensor with wrong shape
-        with patch.object(loaded_weight, 'narrow', return_value=torch.ones(2, 4)):
+        with patch.object(loaded_weight, "narrow", return_value=torch.ones(2, 4)):
             with self.assertRaises(AssertionError) as context:
                 self.weight_loader(param, loaded_weight)
 
@@ -157,6 +155,7 @@ class TestAscendFAQuantAttentionMethodInit(unittest.TestCase):
 
         # Import the class after patching
         from vllm_ascend.quantization.methods.kv_c8 import AscendFAQuantAttentionMethod
+
         self.method_class = AscendFAQuantAttentionMethod
 
     def tearDown(self):
@@ -219,6 +218,7 @@ class TestAscendFAQuantAttentionMethodCreateWeights(unittest.TestCase):
 
         # Import the class
         from vllm_ascend.quantization.methods.kv_c8 import AscendFAQuantAttentionMethod
+
         self.method_class = AscendFAQuantAttentionMethod
 
         # Mock torch functions
@@ -289,8 +289,8 @@ class TestAscendFAQuantAttentionMethodCreateWeights(unittest.TestCase):
 
         # Create real tensors for testing
         def create_tensor(*args, **kwargs):
-            size = args[0] if args else kwargs.get('size', (1,))
-            dtype = kwargs.get('dtype', torch.float32)
+            size = args[0] if args else kwargs.get("size", (1,))
+            dtype = kwargs.get("dtype", torch.float32)
             return torch.zeros(*size, dtype=dtype)
 
         with patch("torch.empty", side_effect=create_tensor):
@@ -334,6 +334,7 @@ class TestAscendFAQuantAttentionMethodProcessWeights(unittest.TestCase):
 
         # Import the class
         from vllm_ascend.quantization.methods.kv_c8 import AscendFAQuantAttentionMethod
+
         self.method_class = AscendFAQuantAttentionMethod
 
         # Create method instance with real layer
@@ -387,12 +388,8 @@ class TestIntegration(unittest.TestCase):
         self.mock_get_config.return_value = self.mock_config
 
         # Mock distributed functions
-        self.tp_rank_patch = patch(
-            "vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_rank"
-        )
-        self.tp_size_patch = patch(
-            "vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_world_size"
-        )
+        self.tp_rank_patch = patch("vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_rank")
+        self.tp_size_patch = patch("vllm_ascend.quantization.methods.kv_c8.get_tensor_model_parallel_world_size")
         self.mock_tp_rank = self.tp_rank_patch.start()
         self.mock_tp_size = self.tp_size_patch.start()
 
@@ -471,6 +468,7 @@ class TestC8KVScaleWeightLoader(TestBase):
 
     def setUp(self):
         from vllm_ascend.quantization.methods.kv_c8 import _c8_kv_scale_weight_loader
+
         self.loader = _c8_kv_scale_weight_loader
 
     def test_shape_match_copies_value(self):
@@ -504,6 +502,7 @@ class TestAscendC8KVCacheAttentionMethod(TestBase):
 
     def _make_method(self):
         from vllm_ascend.quantization.methods.kv_c8 import AscendC8KVCacheAttentionMethod
+
         return AscendC8KVCacheAttentionMethod(quant_description={}, prefix="model.layers.0.self_attn.attn")
 
     def _make_layer_with_impl(self):
@@ -539,6 +538,7 @@ class TestAscendC8KVCacheAttentionMethod(TestBase):
 
     def test_create_weights_assigns_weight_loader(self):
         from vllm_ascend.quantization.methods.kv_c8 import _c8_kv_scale_weight_loader
+
         method = self._make_method()
         layer = self._make_layer_with_impl()
         method.create_weights(layer)
@@ -571,6 +571,7 @@ class TestAscendC8AttentionBackendImplScales(TestBase):
 
     def _make_impl(self, num_kv_heads=4, head_size=8):
         from vllm_ascend.attention.attention_v1 import AscendC8AttentionBackendImpl
+
         impl = object.__new__(AscendC8AttentionBackendImpl)
         impl.num_heads = num_kv_heads
         impl.num_kv_heads = num_kv_heads
@@ -651,9 +652,13 @@ class TestAscendC8AttentionBackendImplScales(TestBase):
         layer = nn.Module()
         scale_val = torch.full((num_kv_heads * head_size,), 2.0, dtype=torch.float32)
         layer.k_cache_scale = nn.Parameter(scale_val.clone(), requires_grad=False)
-        layer.k_cache_offset = nn.Parameter(torch.zeros(num_kv_heads * head_size, dtype=torch.float32), requires_grad=False)
+        layer.k_cache_offset = nn.Parameter(
+            torch.zeros(num_kv_heads * head_size, dtype=torch.float32), requires_grad=False
+        )
         layer.v_cache_scale = nn.Parameter(scale_val.clone(), requires_grad=False)
-        layer.v_cache_offset = nn.Parameter(torch.zeros(num_kv_heads * head_size, dtype=torch.float32), requires_grad=False)
+        layer.v_cache_offset = nn.Parameter(
+            torch.zeros(num_kv_heads * head_size, dtype=torch.float32), requires_grad=False
+        )
         impl._prepare_c8_scales(layer, torch.device("cpu"))
         key = torch.full((1, num_kv_heads, head_size), 4.0, dtype=torch.bfloat16)
         value = torch.full((1, num_kv_heads, head_size), 4.0, dtype=torch.bfloat16)

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.linear import LinearBase
@@ -15,12 +17,8 @@ from vllm_ascend.quantization.modelslim_config import (
 )
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
 
-from vllm.model_executor.layers.attention import Attention
-from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
-
 
 class TestAscendModelSlimConfig(TestBase):
-
     def setUp(self):
         self.sample_config = {
             "weight": "INT8",
@@ -38,16 +36,14 @@ class TestAscendModelSlimConfig(TestBase):
         self.ascend_config.packed_modules_mapping = None
 
     def test_init(self):
-        self.assertEqual(self.ascend_config.quant_description,
-                         self.sample_config)
+        self.assertEqual(self.ascend_config.quant_description, self.sample_config)
 
     def test_repr(self):
         repr_str = repr(self.ascend_config)
         self.assertTrue(repr_str.startswith("AscendModelSlimConfig:\n"))
 
     def test_get_name(self):
-        self.assertEqual(AscendModelSlimConfig.get_name(),
-                         ASCEND_QUANTIZATION_METHOD)
+        self.assertEqual(AscendModelSlimConfig.get_name(), ASCEND_QUANTIZATION_METHOD)
 
     def test_get_supported_act_dtypes(self):
         supported_dtypes = AscendModelSlimConfig.get_supported_act_dtypes()
@@ -66,15 +62,14 @@ class TestAscendModelSlimConfig(TestBase):
         self.assertIsInstance(config, AscendModelSlimConfig)
         self.assertEqual(config.quant_description, self.sample_config)
 
-    @patch('torch.npu.is_available')
+    @patch("torch.npu.is_available")
     def test_override_quantization_method(self, mock_is_available):
         # Test when NPU is available
         mock_is_available.return_value = True
         result = AscendModelSlimConfig.override_quantization_method(None, None)
         self.assertIsNone(result)
         hf_quant_cfg = {"quant_method": ""}
-        result = AscendModelSlimConfig.override_quantization_method(
-            hf_quant_cfg, None)
+        result = AscendModelSlimConfig.override_quantization_method(hf_quant_cfg, None)
         self.assertEqual(result, "ascend")
 
         # Test when NPU is not available
@@ -82,8 +77,7 @@ class TestAscendModelSlimConfig(TestBase):
         result = AscendModelSlimConfig.override_quantization_method(None, None)
         self.assertIsNone(result)
         hf_quant_cfg = {"quant_method": ""}
-        result = AscendModelSlimConfig.override_quantization_method(
-            hf_quant_cfg, None)
+        result = AscendModelSlimConfig.override_quantization_method(hf_quant_cfg, None)
         self.assertIsNone(result)
 
     def test_get_quant_method_for_linear(self):
@@ -91,20 +85,23 @@ class TestAscendModelSlimConfig(TestBase):
         mock_config.model_config.hf_config.model_type = None
         linear_layer = MagicMock(spec=LinearBase)
         # Test skipped layer
-        with patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config), \
-            patch.object(self.ascend_config, \
-                          'is_layer_skipped_ascend',
-                          return_value=True):
+        with (
+            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config),
+            patch.object(self.ascend_config, "is_layer_skipped_ascend", return_value=True),
+        ):
             method = self.ascend_config.get_quant_method(linear_layer, ".attn")
             self.assertIsInstance(method, AscendUnquantizedLinearMethod)
 
         # Test quantized layer
         mock_scheme = MagicMock()
-        with patch.object(self.ascend_config, 'is_layer_skipped_ascend', return_value=False), \
-            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config), \
-            patch("vllm_ascend.quantization.modelslim_config.create_scheme_for_layer", return_value=mock_scheme), \
-            patch('vllm_ascend.quantization.method_adapters.AscendLinearMethod', return_value=MagicMock()) as mock_ascend_linear:
-
+        with (
+            patch.object(self.ascend_config, "is_layer_skipped_ascend", return_value=False),
+            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config),
+            patch("vllm_ascend.quantization.modelslim_config.create_scheme_for_layer", return_value=mock_scheme),
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()
+            ) as mock_ascend_linear,
+        ):
             method = self.ascend_config.get_quant_method(linear_layer, ".attn")
             self.assertIs(method, mock_ascend_linear.return_value)
             mock_ascend_linear.assert_called_once_with(mock_scheme)
@@ -114,16 +111,17 @@ class TestAscendModelSlimConfig(TestBase):
         mock_config = MagicMock()
         mock_config.model_config.hf_config.model_type = None
         mock_scheme = MagicMock()
-        with patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config), \
-            patch("vllm_ascend.quantization.modelslim_config.create_scheme_for_layer", return_value=mock_scheme), \
-            patch('vllm_ascend.quantization.method_adapters.AscendKVCacheMethod', \
-                   return_value=MagicMock()) as mock_ascend_kvcache:
+        with (
+            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config),
+            patch("vllm_ascend.quantization.modelslim_config.create_scheme_for_layer", return_value=mock_scheme),
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendKVCacheMethod", return_value=MagicMock()
+            ) as mock_ascend_kvcache,
+        ):
             # Test with fa_quant_type
-            method = self.ascend_config.get_quant_method(
-                attention_layer, ".attn")
+            method = self.ascend_config.get_quant_method(attention_layer, ".attn")
             self.assertIs(method, None)
-            method = self.ascend_config.get_quant_method(
-                attention_layer, "layers.1.attn")
+            method = self.ascend_config.get_quant_method(attention_layer, "layers.1.attn")
             self.assertIs(method, mock_ascend_kvcache.return_value)
 
     def test_get_quant_method_for_c8_kv_cache_attention(self):
@@ -131,12 +129,17 @@ class TestAscendModelSlimConfig(TestBase):
         attention_layer = MagicMock(spec=AttentionLayerBase)
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.hf_config.model_type = None
-        with patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_vllm_config), \
-            patch("vllm_ascend.quantization.method_adapters.AscendKVCacheMethod", return_value=MagicMock()) as mock_kvcache:
+        with (
+            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_vllm_config),
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendKVCacheMethod", return_value=MagicMock()
+            ) as mock_kvcache,
+        ):
             method = c8_config.get_quant_method(attention_layer, "model.layers.0.self_attn.attn")
             self.assertIs(method, mock_kvcache.return_value)
             args, _ = mock_kvcache.call_args
             from vllm_ascend.quantization.methods.kv_c8 import AscendC8KVCacheAttentionMethod
+
             self.assertIsInstance(args[0], AscendC8KVCacheAttentionMethod)
 
     def test_get_quant_method_for_fused_moe(self):
@@ -147,21 +150,27 @@ class TestAscendModelSlimConfig(TestBase):
         mock_config.model_config.hf_config.model_type = None
 
         # Test skipped layer
-        with patch.object(self.ascend_config, 'is_layer_skipped_ascend', return_value=True), \
-            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config), \
-            patch('vllm_ascend.ops.fused_moe.fused_moe.AscendUnquantizedFusedMoEMethod', return_value=MagicMock()) as mock_ascend_moe:
-            method = self.ascend_config.get_quant_method(
-                fused_moe_layer, "moe_layer")
+        with (
+            patch.object(self.ascend_config, "is_layer_skipped_ascend", return_value=True),
+            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config),
+            patch(
+                "vllm_ascend.ops.fused_moe.fused_moe.AscendUnquantizedFusedMoEMethod", return_value=MagicMock()
+            ) as mock_ascend_moe,
+        ):
+            method = self.ascend_config.get_quant_method(fused_moe_layer, "moe_layer")
             self.assertIs(method, mock_ascend_moe.return_value)
 
         # Test quantized layer
         mock_scheme = MagicMock()
-        with patch.object(self.ascend_config, 'is_layer_skipped_ascend', return_value=False), \
-            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config), \
-            patch("vllm_ascend.quantization.modelslim_config.create_scheme_for_layer", return_value=mock_scheme), \
-            patch('vllm_ascend.quantization.method_adapters.AscendFusedMoEMethod', return_value=MagicMock()) as mock_ascend_moe:
-            method = self.ascend_config.get_quant_method(
-                fused_moe_layer, "moe_layer")
+        with (
+            patch.object(self.ascend_config, "is_layer_skipped_ascend", return_value=False),
+            patch("vllm_ascend.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config),
+            patch("vllm_ascend.quantization.modelslim_config.create_scheme_for_layer", return_value=mock_scheme),
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendFusedMoEMethod", return_value=MagicMock()
+            ) as mock_ascend_moe,
+        ):
+            method = self.ascend_config.get_quant_method(fused_moe_layer, "moe_layer")
             self.assertIs(method, mock_ascend_moe.return_value)
 
     def test_is_layer_skipped_ascend(self):
@@ -173,9 +182,7 @@ class TestAscendModelSlimConfig(TestBase):
 
         # Test fused layer
         fused_mapping = {"fused_layer": ["shard1", "shard2"]}
-        self.assertTrue(
-            self.ascend_config.is_layer_skipped_ascend("fused_layer",
-                                                       fused_mapping))
+        self.assertTrue(self.ascend_config.is_layer_skipped_ascend("fused_layer", fused_mapping))
 
         # Test inconsistent fused layer shards
         bad_config = {"shard1.weight": "FLOAT", "shard2.weight": "INT8"}
@@ -196,8 +203,7 @@ class TestAscendModelSlimConfig(TestBase):
         self.assertTrue(len(self.ascend_config.quant_description) > 0)
         self.ascend_config.maybe_update_config("/some/model/path")
         # quant_description should remain unchanged
-        self.assertEqual(self.ascend_config.quant_description,
-                         self.sample_config)
+        self.assertEqual(self.ascend_config.quant_description, self.sample_config)
 
     def test_maybe_update_config_loads_from_file(self):
         config = AscendModelSlimConfig()
@@ -255,8 +261,7 @@ class TestAscendModelSlimConfig(TestBase):
         }
         config._apply_extra_quant_adaptations()
         self.assertIn("model.layers.0.weight", config.quant_description)
-        self.assertEqual(config.quant_description["model.layers.0.weight"],
-                         "INT8")
+        self.assertEqual(config.quant_description["model.layers.0.weight"], "INT8")
 
     def test_apply_extra_quant_adaptations_weight_packed(self):
         config = AscendModelSlimConfig()
@@ -265,5 +270,4 @@ class TestAscendModelSlimConfig(TestBase):
         }
         config._apply_extra_quant_adaptations()
         self.assertIn("model.layers.0.weight", config.quant_description)
-        self.assertEqual(config.quant_description["model.layers.0.weight"],
-                         "INT8")
+        self.assertEqual(config.quant_description["model.layers.0.weight"], "INT8")

--- a/tests/ut/quantization/test_quant_utils.py
+++ b/tests/ut/quantization/test_quant_utils.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tests.ut.base import TestBase
@@ -14,7 +13,6 @@ from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_MET
 
 
 class TestDetectQuantizationMethod(TestBase):
-
     def test_returns_none_for_non_existent_path(self):
         result = detect_quantization_method("/non/existent/path")
         self.assertIsNone(result)
@@ -32,11 +30,7 @@ class TestDetectQuantizationMethod(TestBase):
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = os.path.join(tmpdir, "config.json")
             with open(config_path, "w") as f:
-                json.dump({
-                    "quantization_config": {
-                        "quant_method": "compressed-tensors"
-                    }
-                }, f)
+                json.dump({"quantization_config": {"quant_method": "compressed-tensors"}}, f)
 
             result = detect_quantization_method(tmpdir)
             self.assertEqual(result, COMPRESSED_TENSORS_METHOD)
@@ -50,11 +44,7 @@ class TestDetectQuantizationMethod(TestBase):
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = os.path.join(tmpdir, "config.json")
             with open(config_path, "w") as f:
-                json.dump({
-                    "quantization_config": {
-                        "quant_method": "gptq"
-                    }
-                }, f)
+                json.dump({"quantization_config": {"quant_method": "gptq"}}, f)
 
             result = detect_quantization_method(tmpdir)
             self.assertIsNone(result)
@@ -87,86 +77,66 @@ class TestDetectQuantizationMethod(TestBase):
 
             config_path = os.path.join(tmpdir, "config.json")
             with open(config_path, "w") as f:
-                json.dump({
-                    "quantization_config": {
-                        "quant_method": "compressed-tensors"
-                    }
-                }, f)
+                json.dump({"quantization_config": {"quant_method": "compressed-tensors"}}, f)
 
             result = detect_quantization_method(tmpdir)
             self.assertEqual(result, ASCEND_QUANTIZATION_METHOD)
 
 
 class TestMaybeAutoDetectQuantization(TestBase):
-
-    def _make_vllm_config(self, model_path="/fake/model",
-                           quantization=None, revision=None):
+    def _make_vllm_config(self, model_path="/fake/model", quantization=None, revision=None):
         vllm_config = MagicMock()
         vllm_config.model_config.model = model_path
         vllm_config.model_config.quantization = quantization
         vllm_config.model_config.revision = revision
         return vllm_config
 
-    @patch("vllm_ascend.quantization.utils.detect_quantization_method",
-           return_value=None)
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=None)
     def test_no_detection_does_nothing(self, mock_detect):
         vllm_config = self._make_vllm_config()
         maybe_auto_detect_quantization(vllm_config)
         self.assertIsNone(vllm_config.model_config.quantization)
 
-    @patch("vllm_ascend.quantization.utils.detect_quantization_method",
-           return_value=ASCEND_QUANTIZATION_METHOD)
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
     def test_user_specified_same_method_no_change(self, mock_detect):
-        vllm_config = self._make_vllm_config(
-            quantization=ASCEND_QUANTIZATION_METHOD)
+        vllm_config = self._make_vllm_config(quantization=ASCEND_QUANTIZATION_METHOD)
         maybe_auto_detect_quantization(vllm_config)
-        self.assertEqual(vllm_config.model_config.quantization,
-                         ASCEND_QUANTIZATION_METHOD)
+        self.assertEqual(vllm_config.model_config.quantization, ASCEND_QUANTIZATION_METHOD)
 
-    @patch("vllm.config.VllmConfig._get_quantization_config",
-           return_value=MagicMock())
-    @patch("vllm_ascend.quantization.utils.detect_quantization_method",
-           return_value=ASCEND_QUANTIZATION_METHOD)
-    def test_auto_detect_sets_quantization_and_logs_info(
-            self, mock_detect, mock_get_quant_config):
+    @patch("vllm.config.VllmConfig._get_quantization_config", return_value=MagicMock())
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
+    def test_auto_detect_sets_quantization_and_logs_info(self, mock_detect, mock_get_quant_config):
         """When no --quantization is specified but ModelSlim config is found,
         the method should auto-set quantization and emit an INFO log."""
-        vllm_config = self._make_vllm_config(
-            model_path="/fake/quant_model", quantization=None)
+        vllm_config = self._make_vllm_config(model_path="/fake/quant_model", quantization=None)
 
         with patch("vllm_ascend.quantization.utils.logger") as mock_logger:
             maybe_auto_detect_quantization(vllm_config)
 
-        self.assertEqual(vllm_config.model_config.quantization,
-                         ASCEND_QUANTIZATION_METHOD)
+        self.assertEqual(vllm_config.model_config.quantization, ASCEND_QUANTIZATION_METHOD)
         mock_logger.info.assert_called_once()
         call_args = mock_logger.info.call_args[0]
         self.assertIn("Auto-detected quantization method", call_args[0])
         self.assertIn(ASCEND_QUANTIZATION_METHOD, call_args)
         self.assertIn("/fake/quant_model", call_args)
 
-    @patch("vllm_ascend.quantization.utils.detect_quantization_method",
-           return_value=ASCEND_QUANTIZATION_METHOD)
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
     def test_user_mismatch_logs_warning(self, mock_detect):
         """When user specifies a different method than auto-detected,
         a WARNING should be emitted and user's choice should be respected."""
-        vllm_config = self._make_vllm_config(
-            model_path="/fake/quant_model",
-            quantization=COMPRESSED_TENSORS_METHOD)
+        vllm_config = self._make_vllm_config(model_path="/fake/quant_model", quantization=COMPRESSED_TENSORS_METHOD)
 
         with patch("vllm_ascend.quantization.utils.logger") as mock_logger:
             maybe_auto_detect_quantization(vllm_config)
 
-        self.assertEqual(vllm_config.model_config.quantization,
-                         COMPRESSED_TENSORS_METHOD)
+        self.assertEqual(vllm_config.model_config.quantization, COMPRESSED_TENSORS_METHOD)
         mock_logger.warning.assert_called_once()
         call_args = mock_logger.warning.call_args[0]
         self.assertIn("Auto-detected quantization method", call_args[0])
         self.assertIn(ASCEND_QUANTIZATION_METHOD, call_args)
         self.assertIn(COMPRESSED_TENSORS_METHOD, call_args)
 
-    @patch("vllm_ascend.quantization.utils.detect_quantization_method",
-           return_value=None)
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=None)
     def test_no_detection_emits_no_log(self, mock_detect):
         """When no quantization is detected, no log should be emitted."""
         vllm_config = self._make_vllm_config(quantization=None)
@@ -178,13 +148,10 @@ class TestMaybeAutoDetectQuantization(TestBase):
         mock_logger.warning.assert_not_called()
         self.assertIsNone(vllm_config.model_config.quantization)
 
-    @patch("vllm.config.VllmConfig._get_quantization_config",
-           return_value=MagicMock())
-    @patch("vllm_ascend.quantization.utils.detect_quantization_method",
-           return_value=ASCEND_QUANTIZATION_METHOD)
+    @patch("vllm.config.VllmConfig._get_quantization_config", return_value=MagicMock())
+    @patch("vllm_ascend.quantization.utils.detect_quantization_method", return_value=ASCEND_QUANTIZATION_METHOD)
     def test_passes_revision_to_detect(self, mock_detect, mock_get_quant):
         """Verify that model revision is forwarded to detect_quantization_method."""
-        vllm_config = self._make_vllm_config(
-            model_path="org/model-name", revision="v1.0", quantization=None)
+        vllm_config = self._make_vllm_config(model_path="org/model-name", revision="v1.0", quantization=None)
         maybe_auto_detect_quantization(vllm_config)
         mock_detect.assert_called_once_with("org/model-name", revision="v1.0")

--- a/tests/ut/quantization/test_w4a16.py
+++ b/tests/ut/quantization/test_w4a16.py
@@ -8,7 +8,6 @@ from vllm_ascend.quantization.methods.w4a16 import AscendW4A16FusedMoEMethod, pa
 
 
 class TestUnpackFromInt32(TestBase):
-
     def test_unpack_from_int32_packed_dim_1(self):
         weight = torch.tensor([[305419896, -1420531520]], dtype=torch.int32)
         shape = torch.Size([1, 8])
@@ -40,13 +39,9 @@ class TestUnpackFromInt32(TestBase):
 
 
 class TestPackToInt32(TestBase):
-
-    @patch(
-        "vllm_ascend.quantization.methods.w4a16.torch_npu.npu_convert_weight_to_int4pack"
-    )
+    @patch("vllm_ascend.quantization.methods.w4a16.torch_npu.npu_convert_weight_to_int4pack")
     def test_pack_to_int32_int8(self, mock_npu_convert_weight_to_int4pack):
-        mock_npu_convert_weight_to_int4pack.return_value = torch.zeros(
-            (2, 4), dtype=torch.int32)
+        mock_npu_convert_weight_to_int4pack.return_value = torch.zeros((2, 4), dtype=torch.int32)
 
         weight = torch.zeros((2, 8, 16), dtype=torch.int8)
         result = pack_to_int32(weight)
@@ -56,11 +51,8 @@ class TestPackToInt32(TestBase):
 
         self.assertEqual(result.shape, torch.Size([2, 8, 4]))
 
-    @patch(
-        "vllm_ascend.quantization.methods.w4a16.torch_npu.npu_convert_weight_to_int4pack"
-    )
+    @patch("vllm_ascend.quantization.methods.w4a16.torch_npu.npu_convert_weight_to_int4pack")
     def test_pack_to_int32_int32(self, mock_npu_convert_weight_to_int4pack):
-
         def mock_convert_weight(weight):
             return weight
 
@@ -106,9 +98,11 @@ class TestAscendW4A16FusedMoEMethod(TestBase):
         mock_get_ascend_config.return_value = mock_ascend_config
 
         mock_vllm_config = Mock()
-        mock_vllm_config.quant_config = Mock(quant_description={
-            "group_size": self.group_size,
-        })
+        mock_vllm_config.quant_config = Mock(
+            quant_description={
+                "group_size": self.group_size,
+            }
+        )
         mock_get_current_vllm_config.return_value = mock_vllm_config
 
         self.quant_method = AscendW4A16FusedMoEMethod()
@@ -121,108 +115,84 @@ class TestAscendW4A16FusedMoEMethod(TestBase):
         self.assertFalse(self.quant_method.dynamic_eplb)
 
     def test_get_weight(self):
-        param_dict = self.quant_method.get_weight(self.experts,
-                                                  self.input_size,
-                                                  self.output_size,
-                                                  torch.bfloat16)
+        param_dict = self.quant_method.get_weight(self.experts, self.input_size, self.output_size, torch.bfloat16)
 
         self.assertEqual(param_dict["w13_weight_packed"].dtype, torch.int32)
-        expected_w13_shape = (self.experts, 2 * self.input_size,
-                              self.output_size //
-                              self.quant_method.pack_factor)
-        self.assertEqual(param_dict["w13_weight_packed"].shape,
-                         expected_w13_shape)
+        expected_w13_shape = (self.experts, 2 * self.input_size, self.output_size // self.quant_method.pack_factor)
+        self.assertEqual(param_dict["w13_weight_packed"].shape, expected_w13_shape)
 
         self.assertEqual(param_dict["w2_weight_packed"].dtype, torch.int32)
-        expected_w2_shape = (self.experts, self.output_size,
-                             self.input_size // self.quant_method.pack_factor)
-        self.assertEqual(param_dict["w2_weight_packed"].shape,
-                         expected_w2_shape)
+        expected_w2_shape = (self.experts, self.output_size, self.input_size // self.quant_method.pack_factor)
+        self.assertEqual(param_dict["w2_weight_packed"].shape, expected_w2_shape)
 
     def test_get_dynamic_quant_param(self):
         param_dict = self.quant_method.get_dynamic_quant_param(
-            self.experts, self.input_size, self.output_size, torch.bfloat16)
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
 
         self.assertEqual(param_dict["w13_weight_scale"].dtype, torch.bfloat16)
-        expected_w13_scale_shape = (self.experts, 2 * self.input_size,
-                                    self.output_size // self.group_size)
-        self.assertEqual(param_dict["w13_weight_scale"].shape,
-                         expected_w13_scale_shape)
+        expected_w13_scale_shape = (self.experts, 2 * self.input_size, self.output_size // self.group_size)
+        self.assertEqual(param_dict["w13_weight_scale"].shape, expected_w13_scale_shape)
 
         self.assertEqual(param_dict["w2_weight_scale"].dtype, torch.bfloat16)
-        expected_w2_scale_shape = (self.experts, self.output_size,
-                                   self.input_size // self.group_size)
-        self.assertEqual(param_dict["w2_weight_scale"].shape,
-                         expected_w2_scale_shape)
+        expected_w2_scale_shape = (self.experts, self.output_size, self.input_size // self.group_size)
+        self.assertEqual(param_dict["w2_weight_scale"].shape, expected_w2_scale_shape)
 
         self.assertEqual(param_dict["w13_weight_shape"].dtype, torch.int32)
-        self.assertEqual(param_dict["w13_weight_shape"].shape,
-                         (self.experts, 2))
+        self.assertEqual(param_dict["w13_weight_shape"].shape, (self.experts, 2))
 
         self.assertEqual(param_dict["w2_weight_shape"].dtype, torch.int32)
-        self.assertEqual(param_dict["w2_weight_shape"].shape,
-                         (self.experts, 2))
+        self.assertEqual(param_dict["w2_weight_shape"].shape, (self.experts, 2))
 
         self.assertEqual(param_dict["w13_weight_offset"].dtype, torch.bfloat16)
-        self.assertEqual(param_dict["w13_weight_offset"].shape,
-                         expected_w13_scale_shape)
+        self.assertEqual(param_dict["w13_weight_offset"].shape, expected_w13_scale_shape)
 
         self.assertEqual(param_dict["w2_weight_offset"].dtype, torch.bfloat16)
-        self.assertEqual(param_dict["w2_weight_offset"].shape,
-                         expected_w2_scale_shape)
+        self.assertEqual(param_dict["w2_weight_offset"].shape, expected_w2_scale_shape)
 
     def build_layer(self):
         """Build a mock layer for testing"""
         layer = torch.nn.Module()
 
-        w13_shape = (self.experts, 2 * self.input_size,
-                     self.output_size // self.quant_method.pack_factor)
-        w2_shape = (self.experts, self.output_size,
-                    self.input_size // self.quant_method.pack_factor)
+        w13_shape = (self.experts, 2 * self.input_size, self.output_size // self.quant_method.pack_factor)
+        w2_shape = (self.experts, self.output_size, self.input_size // self.quant_method.pack_factor)
 
-        layer.w13_weight_packed = torch.nn.Parameter(torch.randint(
-            -100, 100, w13_shape, dtype=torch.int32),
-                                                     requires_grad=False)
-        layer.w2_weight_packed = torch.nn.Parameter(torch.randint(
-            -100, 100, w2_shape, dtype=torch.int32),
-                                                    requires_grad=False)
+        layer.w13_weight_packed = torch.nn.Parameter(
+            torch.randint(-100, 100, w13_shape, dtype=torch.int32), requires_grad=False
+        )
+        layer.w2_weight_packed = torch.nn.Parameter(
+            torch.randint(-100, 100, w2_shape, dtype=torch.int32), requires_grad=False
+        )
 
-        w13_scale_shape = (self.experts, 2 * self.input_size,
-                           self.output_size // self.group_size)
-        w2_scale_shape = (self.experts, self.output_size,
-                          self.input_size // self.group_size)
+        w13_scale_shape = (self.experts, 2 * self.input_size, self.output_size // self.group_size)
+        w2_scale_shape = (self.experts, self.output_size, self.input_size // self.group_size)
 
-        layer.w13_weight_scale = torch.nn.Parameter(torch.ones(
-            w13_scale_shape, dtype=torch.bfloat16),
-                                                    requires_grad=False)
-        layer.w2_weight_scale = torch.nn.Parameter(torch.ones(
-            w2_scale_shape, dtype=torch.bfloat16),
-                                                   requires_grad=False)
+        layer.w13_weight_scale = torch.nn.Parameter(
+            torch.ones(w13_scale_shape, dtype=torch.bfloat16), requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            torch.ones(w2_scale_shape, dtype=torch.bfloat16), requires_grad=False
+        )
 
-        layer.w13_weight_offset = torch.nn.Parameter(torch.zeros(
-            w13_scale_shape, dtype=torch.bfloat16),
-                                                     requires_grad=False)
-        layer.w2_weight_offset = torch.nn.Parameter(torch.zeros(
-            w2_scale_shape, dtype=torch.bfloat16),
-                                                    requires_grad=False)
+        layer.w13_weight_offset = torch.nn.Parameter(
+            torch.zeros(w13_scale_shape, dtype=torch.bfloat16), requires_grad=False
+        )
+        layer.w2_weight_offset = torch.nn.Parameter(
+            torch.zeros(w2_scale_shape, dtype=torch.bfloat16), requires_grad=False
+        )
 
-        layer.w13_weight_shape = torch.nn.Parameter(torch.tensor(
-            [[2 * self.input_size, self.output_size]] * self.experts,
-            dtype=torch.int32),
-                                                    requires_grad=False)
-        layer.w2_weight_shape = torch.nn.Parameter(torch.tensor(
-            [[self.output_size, self.input_size]] * self.experts,
-            dtype=torch.int32),
-                                                   requires_grad=False)
+        layer.w13_weight_shape = torch.nn.Parameter(
+            torch.tensor([[2 * self.input_size, self.output_size]] * self.experts, dtype=torch.int32),
+            requires_grad=False,
+        )
+        layer.w2_weight_shape = torch.nn.Parameter(
+            torch.tensor([[self.output_size, self.input_size]] * self.experts, dtype=torch.int32), requires_grad=False
+        )
 
         return layer
 
-    @patch(
-        "vllm_ascend.quantization.methods.w4a16.torch_npu.npu_convert_weight_to_int4pack"
-    )
-    def test_process_weights_after_loading_with_transpose(
-            self, mock_npu_convert_weight_to_int4pack):
-
+    @patch("vllm_ascend.quantization.methods.w4a16.torch_npu.npu_convert_weight_to_int4pack")
+    def test_process_weights_after_loading_with_transpose(self, mock_npu_convert_weight_to_int4pack):
         def mock_convert_weight(weight):
             new_shape = list(weight.shape)
             new_shape[-1] = new_shape[-1] // 8
@@ -235,19 +205,13 @@ class TestAscendW4A16FusedMoEMethod(TestBase):
 
         self.quant_method.process_weights_after_loading(layer)
 
-        self.assertEqual(layer.w13_weight_packed.data.shape,
-                         torch.Size([8, 128, 8]))
-        self.assertEqual(layer.w2_weight_packed.data.shape,
-                         torch.Size([8, 32, 16]))
+        self.assertEqual(layer.w13_weight_packed.data.shape, torch.Size([8, 128, 8]))
+        self.assertEqual(layer.w2_weight_packed.data.shape, torch.Size([8, 32, 16]))
 
-        self.assertEqual(layer.w13_weight_scale.data.shape,
-                         torch.Size([8, 4, 64]))
-        self.assertEqual(layer.w2_weight_scale.data.shape,
-                         torch.Size([8, 1, 128]))
-        self.assertEqual(layer.w13_weight_offset.data.shape,
-                         torch.Size([8, 4, 64]))
-        self.assertEqual(layer.w2_weight_offset.data.shape,
-                         torch.Size([8, 1, 128]))
+        self.assertEqual(layer.w13_weight_scale.data.shape, torch.Size([8, 4, 64]))
+        self.assertEqual(layer.w2_weight_scale.data.shape, torch.Size([8, 1, 128]))
+        self.assertEqual(layer.w13_weight_offset.data.shape, torch.Size([8, 4, 64]))
+        self.assertEqual(layer.w2_weight_offset.data.shape, torch.Size([8, 1, 128]))
 
         self.assertTrue(layer.w13_weight_scale.data.is_contiguous())
         self.assertTrue(layer.w2_weight_scale.data.is_contiguous())
@@ -263,10 +227,8 @@ class TestAscendW4A16FusedMoEMethod(TestBase):
 
         self.quant_method.process_weights_after_loading(layer)
 
-        self.assertTrue(
-            torch.equal(layer.w13_weight_packed.data, original_w13_data))
-        self.assertTrue(
-            torch.equal(layer.w2_weight_packed.data, original_w2_data))
+        self.assertTrue(torch.equal(layer.w13_weight_packed.data, original_w13_data))
+        self.assertTrue(torch.equal(layer.w2_weight_packed.data, original_w2_data))
 
     @patch("vllm_ascend.quantization.methods.w4a16._EXTRA_CTX")
     @patch("vllm_ascend.quantization.methods.w4a16.select_experts")

--- a/tests/ut/quantization/test_w4a4_flatquant_dynamic.py
+++ b/tests/ut/quantization/test_w4a4_flatquant_dynamic.py
@@ -5,8 +5,10 @@ import torch
 import torch.nn as nn
 
 from vllm_ascend.quantization.methods.w4a4_flatquant import (
-    AscendW4A4FlatQuantDynamicLinearMethod, get_decompose_dim,
-    pack_int4_weights)
+    AscendW4A4FlatQuantDynamicLinearMethod,
+    get_decompose_dim,
+    pack_int4_weights,
+)
 
 
 class TestW4A4FlatQuantDynamic(unittest.TestCase):
@@ -33,20 +35,17 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         self.assertEqual(get_decompose_dim(100), (10, 10))
         self.assertEqual(get_decompose_dim(99), (9, 11))
 
-    @patch('vllm_ascend.quantization.methods.w4a4_flatquant.torch_npu')
+    @patch("vllm_ascend.quantization.methods.w4a4_flatquant.torch_npu")
     def test_pack_int4_weights_npu_success(self, mock_torch_npu):
         """
         Tests weight packing using the mocked NPU kernel.
         """
         weight_tensor = torch.randn(self.output_size, self.input_size)
-        mock_packed_tensor = torch.randint(
-            0,
-            100, (self.output_size, self.input_size // 8),
-            dtype=torch.int32)
+        mock_packed_tensor = torch.randint(0, 100, (self.output_size, self.input_size // 8), dtype=torch.int32)
         mock_npu_tensor = MagicMock()
         mock_npu_tensor.to.return_value = mock_packed_tensor
         mock_torch_npu.npu_convert_weight_to_int4pack.return_value = mock_npu_tensor
-        with patch('torch.Tensor.npu', return_value=weight_tensor):
+        with patch("torch.Tensor.npu", return_value=weight_tensor):
             result = pack_int4_weights(weight_tensor)
 
         mock_torch_npu.npu_convert_weight_to_int4pack.assert_called_once()
@@ -57,14 +56,11 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
 
     def test_get_weight(self):
         """Tests the get_weight static method for correct output."""
-        params = self.method.get_weight(self.input_size, self.output_size,
-                                        self.params_dtype)
+        params = self.method.get_weight(self.input_size, self.output_size, self.params_dtype)
         self.assertIn("weight", params)
-        self.assertEqual(params["weight"].shape,
-                         (self.output_size, self.input_size))
+        self.assertEqual(params["weight"].shape, (self.output_size, self.input_size))
         self.assertEqual(params["weight"].dtype, torch.int8)
-        self.assertEqual(AscendW4A4FlatQuantDynamicLinearMethod.input_size,
-                         self.input_size)
+        self.assertEqual(AscendW4A4FlatQuantDynamicLinearMethod.input_size, self.input_size)
 
     def test_get_weight_value_error(self):
         """Tests that get_weight raises ValueError for invalid input_size."""
@@ -73,8 +69,7 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
 
     def test_get_pertensor_param(self):
         """Tests the get_pertensor_param static method."""
-        self.method.get_weight(self.input_size, self.output_size,
-                               self.params_dtype)
+        self.method.get_weight(self.input_size, self.output_size, self.params_dtype)
         params = self.method.get_pertensor_param(self.params_dtype)
         left_dim, right_dim = get_decompose_dim(self.input_size)
         self.assertIn("left_trans", params)
@@ -82,14 +77,13 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         self.assertIn("clip_ratio", params)
         self.assertEqual(params["left_trans"].shape, (left_dim, left_dim))
         self.assertEqual(params["right_trans"].shape, (right_dim, right_dim))
-        self.assertEqual(params["clip_ratio"].shape, (1, ))
+        self.assertEqual(params["clip_ratio"].shape, (1,))
         self.assertEqual(params["left_trans"].dtype, self.params_dtype)
         self.assertEqual(params["clip_ratio"].dtype, torch.float32)
 
     def test_get_perchannel_param(self):
         """Tests the get_perchannel_param static method."""
-        params = self.method.get_perchannel_param(self.output_size,
-                                                  self.params_dtype)
+        params = self.method.get_perchannel_param(self.output_size, self.params_dtype)
         self.assertIn("weight_scale", params)
         self.assertIn("weight_offset", params)
         self.assertEqual(params["weight_scale"].shape, (self.output_size, 1))
@@ -99,9 +93,7 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
 
     def test_get_pergroup_param(self):
         """Tests the get_pergroup_param method."""
-        params = self.method.get_pergroup_param(self.input_size,
-                                                self.output_size,
-                                                self.params_dtype)
+        params = self.method.get_pergroup_param(self.input_size, self.output_size, self.params_dtype)
         self.assertEqual(params, {})
 
     def _prepare_apply_mocks_and_layer(self, batch_size):
@@ -111,57 +103,42 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         layer.left_trans = torch.randn(m, m, dtype=self.params_dtype)
         layer.right_trans = torch.randn(n, n, dtype=self.params_dtype)
         layer.aclnn_clip_ratio = 0.95
-        layer.weight_packed = torch.randint(
-            -8, 7, (self.output_size, self.input_size // 8), dtype=torch.int32)
-        layer.weight_scale = torch.randn(self.output_size,
-                                         1,
-                                         dtype=torch.float32)
+        layer.weight_packed = torch.randint(-8, 7, (self.output_size, self.input_size // 8), dtype=torch.int32)
+        layer.weight_scale = torch.randn(self.output_size, 1, dtype=torch.float32)
         x = torch.randn(batch_size, self.input_size, dtype=self.params_dtype)
         return layer, x, m, n
 
-    @patch('vllm_ascend.quantization.methods.w4a4_flatquant.torch_npu')
+    @patch("vllm_ascend.quantization.methods.w4a4_flatquant.torch_npu")
     def test_apply_small_batch(self, mock_torch_npu):
         """Tests the apply method with a batch size smaller than MAX_BATCH_SIZE."""
         batch_size = 128
         layer, x, m, n = self._prepare_apply_mocks_and_layer(batch_size)
-        mock_quant_x = torch.randint(0,
-                                     255, (batch_size, self.input_size // 8),
-                                     dtype=torch.int32)
+        mock_quant_x = torch.randint(0, 255, (batch_size, self.input_size // 8), dtype=torch.int32)
         mock_act_scale = torch.randn(batch_size, 1, dtype=torch.float32)
-        mock_torch_npu.npu_kronecker_quant.return_value = (mock_quant_x.view(
-            batch_size, m, n // 8), mock_act_scale)
-        mock_output = torch.randn(batch_size,
-                                  self.output_size,
-                                  dtype=self.params_dtype)
+        mock_torch_npu.npu_kronecker_quant.return_value = (mock_quant_x.view(batch_size, m, n // 8), mock_act_scale)
+        mock_output = torch.randn(batch_size, self.output_size, dtype=self.params_dtype)
         mock_torch_npu.npu_quant_matmul.return_value = mock_output
         bias = torch.randn(self.output_size, dtype=self.params_dtype)
         output = self.method.apply(layer, x, bias=bias)
         mock_torch_npu.npu_kronecker_quant.assert_called_once()
         mock_torch_npu.npu_quant_matmul.assert_called_once()
-        self.assertTrue(
-            torch.allclose(output, mock_output + bias.to(self.params_dtype)))
+        self.assertTrue(torch.allclose(output, mock_output + bias.to(self.params_dtype)))
         self.assertEqual(output.shape, (batch_size, self.output_size))
 
-    @patch(
-        'vllm_ascend.quantization.methods.w4a4_flatquant.KRONECKER_QUANT_MAX_BATCH_SIZE',
-        10)
-    @patch('vllm_ascend.quantization.methods.w4a4_flatquant.torch_npu')
+    @patch("vllm_ascend.quantization.methods.w4a4_flatquant.KRONECKER_QUANT_MAX_BATCH_SIZE", 10)
+    @patch("vllm_ascend.quantization.methods.w4a4_flatquant.torch_npu")
     def test_apply_large_batch(self, mock_torch_npu):
         """Tests the apply method with a batch size larger than MAX_BATCH_SIZE."""
         batch_size = 25
         layer, x, m, n = self._prepare_apply_mocks_and_layer(batch_size)
-        mock_quant_x = torch.randint(0,
-                                     255, (batch_size, self.input_size // 8),
-                                     dtype=torch.int32)
+        mock_quant_x = torch.randint(0, 255, (batch_size, self.input_size // 8), dtype=torch.int32)
         mock_act_scale = torch.randn(batch_size, 1, dtype=torch.float32)
         mock_torch_npu.npu_kronecker_quant.side_effect = [
             (mock_quant_x[:10].view(10, m, n // 8), mock_act_scale[:10]),
             (mock_quant_x[10:20].view(10, m, n // 8), mock_act_scale[10:20]),
             (mock_quant_x[20:].view(5, m, n // 8), mock_act_scale[20:]),
         ]
-        mock_output = torch.randn(batch_size,
-                                  self.output_size,
-                                  dtype=self.params_dtype)
+        mock_output = torch.randn(batch_size, self.output_size, dtype=self.params_dtype)
         mock_torch_npu.npu_quant_matmul.return_value = mock_output
         output = self.method.apply(layer, x, bias=None)
         self.assertEqual(mock_torch_npu.npu_kronecker_quant.call_count, 3)
@@ -174,35 +151,25 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         layer, x, _, _ = self._prepare_apply_mocks_and_layer(16)
         layer.left_trans = torch.randn(20, 20)
         layer.right_trans = torch.randn(30, 30)  # 20 * 30 != 768
-        with self.assertRaisesRegex(
-                ValueError, "FlatQuant transform matrices dimension mismatch"):
+        with self.assertRaisesRegex(ValueError, "FlatQuant transform matrices dimension mismatch"):
             self.method.apply(layer, x)
 
-    @patch('vllm_ascend.quantization.methods.w4a4_flatquant.pack_int4_weights')
+    @patch("vllm_ascend.quantization.methods.w4a4_flatquant.pack_int4_weights")
     def test_process_weights_after_loading(self, mock_pack_weights):
         """Tests weight processing after loading, without transpose."""
         layer = nn.Module()
-        layer.weight = torch.randint(-8,
-                                     7, (self.output_size, self.input_size),
-                                     dtype=torch.int8)
-        layer.weight_scale = torch.randn(self.output_size,
-                                         1,
-                                         dtype=torch.bfloat16)
-        layer.weight_offset = torch.randn(self.output_size,
-                                          1,
-                                          dtype=torch.bfloat16)
+        layer.weight = torch.randint(-8, 7, (self.output_size, self.input_size), dtype=torch.int8)
+        layer.weight_scale = torch.randn(self.output_size, 1, dtype=torch.bfloat16)
+        layer.weight_offset = torch.randn(self.output_size, 1, dtype=torch.bfloat16)
         layer.left_trans = torch.randn(24, 24)
         layer.right_trans = torch.randn(32, 32)
         layer.clip_ratio = torch.tensor([0.9])
-        mock_packed = torch.randint(0,
-                                    100,
-                                    (self.output_size, self.input_size // 8),
-                                    dtype=torch.int32)
+        mock_packed = torch.randint(0, 100, (self.output_size, self.input_size // 8), dtype=torch.int32)
         mock_pack_weights.return_value = mock_packed
         self.method.process_weights_after_loading(layer)
         mock_pack_weights.assert_called_once()
-        self.assertFalse(hasattr(layer, 'weight'))
-        self.assertTrue(hasattr(layer, 'weight_packed'))
+        self.assertFalse(hasattr(layer, "weight"))
+        self.assertTrue(hasattr(layer, "weight_packed"))
         self.assertTrue(torch.equal(layer.weight_packed.data, mock_packed))
         self.assertEqual(layer.weight_scale.dtype, torch.float32)
         self.assertEqual(layer.weight_offset.dtype, torch.float32)
@@ -212,5 +179,5 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         self.assertTrue(layer.left_trans.is_contiguous())
 
 
-if __name__ == '__main__':
-    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+if __name__ == "__main__":
+    unittest.main(argv=["first-arg-is-ignored"], exit=False)

--- a/tests/ut/quantization/test_w4a8_dynamic.py
+++ b/tests/ut/quantization/test_w4a8_dynamic.py
@@ -3,22 +3,19 @@ from unittest.mock import Mock, patch
 import torch
 
 from tests.ut.base import TestBase
-from vllm_ascend.quantization.methods.w4a8 import (
-    AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod)
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
 
 
 class TestAscendW4A8DynamicLinearMethod(TestBase):
-
-    @patch('vllm.distributed.get_tensor_model_parallel_world_size')
-    @patch('vllm_ascend.quantization.methods.w4a8.get_current_vllm_config')
+    @patch("vllm.distributed.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
     def setUp(self, mock_get_current_vllm_config, mock_get_tp_world_size):
         mock_get_tp_world_size.return_value = 1
         mock_vllm_config = Mock()
-        mock_vllm_config.quant_config = Mock(
-            quant_description={"group_size": 256})
-        mock_vllm_config.scheduler_config = Mock(max_num_batched_tokens=2048,
-                                                 max_model_len=2048,
-                                                 enable_chunked_prefill=False)
+        mock_vllm_config.quant_config = Mock(quant_description={"group_size": 256})
+        mock_vllm_config.scheduler_config = Mock(
+            max_num_batched_tokens=2048, max_model_len=2048, enable_chunked_prefill=False
+        )
         mock_get_current_vllm_config.return_value = mock_vllm_config
         self.method = AscendW4A8DynamicLinearMethod()
         self.method.group_size = 8
@@ -47,76 +44,49 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         self.assertEqual(params["weight_offset_second"].shape, (32, 1))
         # new quant version weight
         self.method.new_quant_version = True
-        params = self.method.get_pergroup_param(8,
-                                                32,
-                                                torch.bfloat16,
-                                                layer_type="column")
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="column")
         self.assertEqual(params["scale_bias"].dtype, torch.float32)
         self.assertEqual(params["scale_bias"].shape, (32, 1))
-        params = self.method.get_pergroup_param(8,
-                                                32,
-                                                torch.bfloat16,
-                                                layer_type="row")
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="row")
         self.assertEqual(params["scale_bias"].dtype, torch.float32)
         self.assertEqual(params["scale_bias"].shape, (32, 16))
 
-    @patch('torch_npu.npu_convert_weight_to_int4pack')
-    @patch('torch.Tensor.npu')
+    @patch("torch_npu.npu_convert_weight_to_int4pack")
+    @patch("torch.Tensor.npu")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading(self, mock_format_cast, mock_npu,
-                                           mock_npu_convert_weight):
-        mock_npu.side_effect = lambda: torch.zeros(
-            (1, 32), dtype=torch.float32)
-        mock_npu_convert_weight.return_value = torch.zeros((32, 4),
-                                                           dtype=torch.int32)
+    def test_process_weights_after_loading(self, mock_format_cast, mock_npu, mock_npu_convert_weight):
+        mock_npu.side_effect = lambda: torch.zeros((1, 32), dtype=torch.float32)
+        mock_npu_convert_weight.return_value = torch.zeros((32, 4), dtype=torch.int32)
         # old quant version weight
         layer = torch.nn.Module()
-        layer.weight = torch.nn.Parameter(torch.zeros((32, 8),
-                                                      dtype=torch.int8),
-                                          requires_grad=False)
-        layer.weight_scale = torch.nn.Parameter(torch.ones(
-            (32, 1), dtype=torch.float32),
-                                                requires_grad=False)
-        layer.weight_offset = torch.nn.Parameter(torch.empty_like(
-            layer.weight_scale.data),
-                                                 requires_grad=False)
-        layer.weight_scale_second = torch.nn.Parameter(torch.ones(
-            (32, 1), dtype=torch.float32),
-                                                       requires_grad=False)
-        layer.weight_offset_second = torch.nn.Parameter(torch.empty_like(
-            layer.weight_scale_second.data),
-                                                        requires_grad=False)
-        mock_format_cast.return_value = layer.weight.data.transpose(
-            0, 1).contiguous()
+        layer.weight = torch.nn.Parameter(torch.zeros((32, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty_like(layer.weight_scale.data), requires_grad=False)
+        layer.weight_scale_second = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset_second = torch.nn.Parameter(
+            torch.empty_like(layer.weight_scale_second.data), requires_grad=False
+        )
+        mock_format_cast.return_value = layer.weight.data.transpose(0, 1).contiguous()
         self.method.process_weights_after_loading(layer)
         self.assertTrue(hasattr(layer, "weight_scale_bias"))
-        self.assertEqual(layer.weight_scale_bias.data.shape, (32, ))
+        self.assertEqual(layer.weight_scale_bias.data.shape, (32,))
         self.assertEqual(layer.weight_scale_bias.data.dtype, torch.float32)
         # new quant version weight
         self.method.new_quant_version = True
         new_layer = torch.nn.Module()
-        new_layer.weight = torch.nn.Parameter(torch.zeros((16, 8),
-                                                          dtype=torch.int8),
-                                              requires_grad=False)
-        new_layer.weight_scale = torch.nn.Parameter(torch.ones(
-            (32, 1), dtype=torch.float32),
-                                                    requires_grad=False)
-        new_layer.weight_offset = torch.nn.Parameter(torch.empty_like(
-            new_layer.weight_scale.data),
-                                                     requires_grad=False)
-        new_layer.weight_scale_second = torch.nn.Parameter(torch.ones(
-            (32, 1), dtype=torch.float32),
-                                                           requires_grad=False)
+        new_layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        new_layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        new_layer.weight_offset = torch.nn.Parameter(torch.empty_like(new_layer.weight_scale.data), requires_grad=False)
+        new_layer.weight_scale_second = torch.nn.Parameter(
+            torch.ones((32, 1), dtype=torch.float32), requires_grad=False
+        )
         new_layer.weight_offset_second = torch.nn.Parameter(
-            torch.empty_like(new_layer.weight_scale_second.data),
-            requires_grad=False)
-        new_layer.scale_bias = torch.nn.Parameter(torch.zeros(
-            (32, 1), dtype=torch.float32),
-                                                  requires_grad=False)
-        mock_format_cast.return_value = new_layer.weight.data.transpose(
-            0, 1).contiguous()
+            torch.empty_like(new_layer.weight_scale_second.data), requires_grad=False
+        )
+        new_layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+        mock_format_cast.return_value = new_layer.weight.data.transpose(0, 1).contiguous()
         self.method.process_weights_after_loading(new_layer)
-        self.assertEqual(new_layer.scale_bias.data.shape, (32, ))
+        self.assertEqual(new_layer.scale_bias.data.shape, (32,))
         self.assertTrue(hasattr(new_layer, "weight_scale_second"))
         self.assertEqual(new_layer.weight_scale_second.data.shape, (1, 32))
 
@@ -127,149 +97,134 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
     output_size = 56
     group_size = 2
 
-    @patch('vllm_ascend.quantization.methods.w4a8.get_ascend_config')
-    @patch('vllm_ascend.quantization.methods.w4a8.get_current_vllm_config')
-    @patch('vllm_ascend.quantization.methods.w4a8.get_ep_group')
-    @patch('vllm_ascend.quantization.methods.w4a8.get_mc2_group')
-    @patch('torch.distributed.get_rank', return_value=0)
-    def setUp(self, mock_get_rank, mock_get_mc2_group, mock_get_ep_group,
-              get_current_vllm_config, mock_get_ascend_config):
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ep_group")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_mc2_group")
+    @patch("torch.distributed.get_rank", return_value=0)
+    def setUp(
+        self, mock_get_rank, mock_get_mc2_group, mock_get_ep_group, get_current_vllm_config, mock_get_ascend_config
+    ):
         # Mock ascend config
         mock_ascend_config = Mock()
         mock_ascend_config.eplb_config.dynamic_eplb = False
         mock_get_ascend_config.return_value = mock_ascend_config
 
         mock_vllm_config = Mock()
-        mock_vllm_config.quant_config = Mock(quant_description={
-            "group_size": self.group_size,
-            "version": "0.0.0"
-        })
+        mock_vllm_config.quant_config = Mock(quant_description={"group_size": self.group_size, "version": "0.0.0"})
         mock_vllm_config.parallel_config = Mock(enable_expert_parallel=True)
-        mock_vllm_config.scheduler_config = Mock(max_num_batched_tokens=2048,
-                                                 max_model_len=2048,
-                                                 enable_chunked_prefill=False)
+        mock_vllm_config.scheduler_config = Mock(
+            max_num_batched_tokens=2048, max_model_len=2048, enable_chunked_prefill=False
+        )
         get_current_vllm_config.return_value = mock_vllm_config
         self.quant_method = AscendW4A8DynamicFusedMoEMethod()
 
     def test_get_weight(self):
         # old quant version w4a8 weight
-        param_dict = self.quant_method.get_weight(self.experts,
-                                                  self.input_size,
-                                                  self.output_size,
-                                                  torch.bfloat16)
+        param_dict = self.quant_method.get_weight(self.experts, self.input_size, self.output_size, torch.bfloat16)
         self.assertEqual(param_dict["w13_weight"].dtype, torch.int8)
-        self.assertEqual(param_dict["w13_weight"].shape,
-                         (self.experts, 2 * self.input_size, self.output_size))
+        self.assertEqual(param_dict["w13_weight"].shape, (self.experts, 2 * self.input_size, self.output_size))
         # new quant version weight
         self.quant_method.new_quant_version = True
-        param_dict = self.quant_method.get_weight(self.experts,
-                                                  self.input_size,
-                                                  self.output_size,
-                                                  torch.bfloat16)
+        param_dict = self.quant_method.get_weight(self.experts, self.input_size, self.output_size, torch.bfloat16)
         self.assertEqual(param_dict["w13_weight"].dtype, torch.int8)
-        self.assertEqual(param_dict["w13_weight"].shape,
-                         (self.experts, self.input_size, self.output_size))
+        self.assertEqual(param_dict["w13_weight"].shape, (self.experts, self.input_size, self.output_size))
 
     def test_get_dynamic_quant_param(self):
         # old quant version weight
         param_dict = self.quant_method.get_dynamic_quant_param(
-            self.experts, self.input_size, self.output_size, torch.bfloat16)
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
         self.assertEqual(param_dict["w13_weight_scale"].dtype, torch.float32)
-        self.assertEqual(param_dict["w13_weight_scale"].shape,
-                         (self.experts, 2 * self.input_size, 1))
-        self.assertEqual(param_dict["w13_weight_scale_second"].dtype,
-                         torch.float32)
-        self.assertEqual(param_dict["w13_weight_scale_second"].shape,
-                         (self.experts, 2 * self.input_size,
-                          self.output_size // self.group_size))
+        self.assertEqual(param_dict["w13_weight_scale"].shape, (self.experts, 2 * self.input_size, 1))
+        self.assertEqual(param_dict["w13_weight_scale_second"].dtype, torch.float32)
+        self.assertEqual(
+            param_dict["w13_weight_scale_second"].shape,
+            (self.experts, 2 * self.input_size, self.output_size // self.group_size),
+        )
         self.assertEqual(param_dict["w2_weight_scale"].dtype, torch.float32)
-        self.assertEqual(param_dict["w2_weight_scale"].shape,
-                         (self.experts, self.output_size, 1))
-        self.assertEqual(param_dict["w2_weight_scale_second"].dtype,
-                         torch.float32)
-        self.assertEqual(param_dict["w2_weight_scale_second"].shape,
-                         (self.experts, self.output_size,
-                          self.input_size // self.group_size))
+        self.assertEqual(param_dict["w2_weight_scale"].shape, (self.experts, self.output_size, 1))
+        self.assertEqual(param_dict["w2_weight_scale_second"].dtype, torch.float32)
+        self.assertEqual(
+            param_dict["w2_weight_scale_second"].shape,
+            (self.experts, self.output_size, self.input_size // self.group_size),
+        )
         # new quant version weight
         self.quant_method.new_quant_version = True
         param_dict = self.quant_method.get_dynamic_quant_param(
-            self.experts, self.input_size, self.output_size, torch.bfloat16)
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
         self.assertEqual(param_dict["w2_scale_bias"].dtype, torch.float32)
         self.assertEqual(
-            param_dict["w2_scale_bias"].shape,
-            (self.experts, self.output_size, 16 // self.quant_method.tp_size))
+            param_dict["w2_scale_bias"].shape, (self.experts, self.output_size, 16 // self.quant_method.tp_size)
+        )
         # per-channel weight
         self.quant_method.is_per_channel_weight = True
         param_dict = self.quant_method.get_dynamic_quant_param(
-            self.experts, self.input_size, self.output_size, torch.bfloat16)
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
         pergroup_param = [
-            "w13_weight_scale_second", "w13_weight_offset_second",
-            "w2_weight_scale_second", "w2_weight_offset_second"
+            "w13_weight_scale_second",
+            "w13_weight_offset_second",
+            "w2_weight_scale_second",
+            "w2_weight_offset_second",
         ]
         is_contains = any(key in param_dict for key in pergroup_param)
         self.assertFalse(is_contains)
 
-    def build_layer(self,
-                    is_new_quant_version=True,
-                    is_per_channel_weight=False):
+    def build_layer(self, is_new_quant_version=True, is_per_channel_weight=False):
         layer = torch.nn.Module()
         if is_new_quant_version:
-            layer.w13_weight = torch.nn.Parameter(torch.zeros(
-                (self.experts, self.input_size, self.output_size),
-                dtype=torch.int8),
-                                                  requires_grad=False)
-            layer.w2_weight = torch.nn.Parameter(torch.zeros(
-                (self.experts, self.output_size // 2, self.input_size),
-                dtype=torch.int8),
-                                                 requires_grad=False)
-            w13_scale_bias = torch.zeros(
-                (self.experts, 2 * self.input_size, 1), dtype=torch.float32)
-            layer.w13_scale_bias = torch.nn.Parameter(w13_scale_bias,
-                                                      requires_grad=False)
-            w2_scale_bias = torch.zeros((self.experts, self.output_size,
-                                         16 // self.quant_method.tp_size),
-                                        dtype=torch.float32)
-            layer.w2_scale_bias = torch.nn.Parameter(w2_scale_bias,
-                                                     requires_grad=False)
+            layer.w13_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, self.input_size, self.output_size), dtype=torch.int8), requires_grad=False
+            )
+            layer.w2_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, self.output_size // 2, self.input_size), dtype=torch.int8),
+                requires_grad=False,
+            )
+            w13_scale_bias = torch.zeros((self.experts, 2 * self.input_size, 1), dtype=torch.float32)
+            layer.w13_scale_bias = torch.nn.Parameter(w13_scale_bias, requires_grad=False)
+            w2_scale_bias = torch.zeros(
+                (self.experts, self.output_size, 16 // self.quant_method.tp_size), dtype=torch.float32
+            )
+            layer.w2_scale_bias = torch.nn.Parameter(w2_scale_bias, requires_grad=False)
         else:
-            layer.w13_weight = torch.nn.Parameter(torch.zeros(
-                (self.experts, 2 * self.input_size, self.output_size),
-                dtype=torch.int8),
-                                                  requires_grad=False)
-            layer.w2_weight = torch.nn.Parameter(torch.zeros(
-                (self.experts, self.output_size, self.input_size),
-                dtype=torch.int8),
-                                                 requires_grad=False)
-        layer.w13_weight_scale = torch.nn.Parameter(torch.ones(
-            (self.experts, 2 * self.input_size, 1), dtype=torch.float32),
-                                                    requires_grad=False)
-        layer.w2_weight_scale = torch.nn.Parameter(torch.ones(
-            (self.experts, self.output_size, 1), dtype=torch.float32),
-                                                   requires_grad=False)
+            layer.w13_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, 2 * self.input_size, self.output_size), dtype=torch.int8),
+                requires_grad=False,
+            )
+            layer.w2_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, self.output_size, self.input_size), dtype=torch.int8), requires_grad=False
+            )
+        layer.w13_weight_scale = torch.nn.Parameter(
+            torch.ones((self.experts, 2 * self.input_size, 1), dtype=torch.float32), requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            torch.ones((self.experts, self.output_size, 1), dtype=torch.float32), requires_grad=False
+        )
         if not is_per_channel_weight:
             layer.w13_weight_scale_second = torch.nn.Parameter(
-                torch.ones((self.experts, 2 * self.input_size,
-                            self.output_size // self.group_size),
-                           dtype=torch.float32),
-                requires_grad=False)
+                torch.ones(
+                    (self.experts, 2 * self.input_size, self.output_size // self.group_size), dtype=torch.float32
+                ),
+                requires_grad=False,
+            )
             layer.w13_weight_offset_second = torch.nn.Parameter(
-                torch.empty_like(layer.w13_weight_scale_second.data),
-                requires_grad=False)
+                torch.empty_like(layer.w13_weight_scale_second.data), requires_grad=False
+            )
             layer.w2_weight_scale_second = torch.nn.Parameter(
-                torch.ones((self.experts, self.output_size,
-                            self.input_size // self.group_size),
-                           dtype=torch.float32),
-                requires_grad=False)
+                torch.ones((self.experts, self.output_size, self.input_size // self.group_size), dtype=torch.float32),
+                requires_grad=False,
+            )
             layer.w2_weight_offset_second = torch.nn.Parameter(
-                torch.empty_like(layer.w2_weight_scale_second.data),
-                requires_grad=False)
+                torch.empty_like(layer.w2_weight_scale_second.data), requires_grad=False
+            )
         return layer
 
-    @patch('torch_npu.npu_format_cast')
-    @patch('torch_npu.npu_quantize')
-    @patch('torch.Tensor.npu')
-    def test_process_weights_after_loading(self, mock_npu, mock_npu_quantize,
-                                           mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    @patch("torch_npu.npu_quantize")
+    @patch("torch.Tensor.npu")
+    def test_process_weights_after_loading(self, mock_npu, mock_npu_quantize, mock_npu_format_cast):
         mock_npu.return_value = torch.Tensor()
         mock_npu_quantize.return_value = torch.Tensor()
 
@@ -281,26 +236,20 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         layer = self.build_layer(is_new_quant_version=False)
         self.quant_method.process_weights_after_loading(layer)
         self.assertTrue(hasattr(layer, "w13_scale_bias"))
-        self.assertEqual(layer.w13_scale_bias.data.shape,
-                         (self.experts, 2 * self.input_size))
+        self.assertEqual(layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
         self.assertEqual(layer.w13_scale_bias.data.dtype, torch.float32)
         self.assertTrue(hasattr(layer, "w2_scale_bias"))
-        self.assertEqual(layer.w2_scale_bias.data.shape,
-                         (self.experts, self.output_size))
+        self.assertEqual(layer.w2_scale_bias.data.shape, (self.experts, self.output_size))
         self.assertEqual(layer.w2_scale_bias.data.dtype, torch.float32)
         # new quant version weight
         self.quant_method.new_quant_version = True
         new_layer = self.build_layer(is_new_quant_version=True)
         self.quant_method.process_weights_after_loading(new_layer)
-        self.assertEqual(new_layer.w13_scale_bias.data.shape,
-                         (self.experts, 2 * self.input_size))
-        self.assertEqual(new_layer.w2_scale_bias.data.shape,
-                         (self.experts, self.output_size))
+        self.assertEqual(new_layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(new_layer.w2_scale_bias.data.shape, (self.experts, self.output_size))
         self.assertFalse(hasattr(new_layer, "w13_weight_scale_second"))
         # per-channel weight
         self.quant_method.is_per_channel_weight = True
-        per_channel_layer = self.build_layer(is_new_quant_version=True,
-                                             is_per_channel_weight=True)
+        per_channel_layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
         self.quant_method.process_weights_after_loading(per_channel_layer)
-        self.assertEqual(new_layer.w13_scale_bias.data.shape,
-                         (self.experts, 2 * self.input_size))
+        self.assertEqual(new_layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))

--- a/tests/ut/quantization/test_w8a16.py
+++ b/tests/ut/quantization/test_w8a16.py
@@ -8,14 +8,13 @@ from vllm_ascend.quantization.methods.w8a16 import AscendW8A16LinearMethod
 
 
 class TestAscendW8A16LinearMethod(TestBase):
-
     def setUp(self):
         self.method = AscendW8A16LinearMethod()
 
     def test_get_weight(self):
         weight = self.method.get_weight(10, 20)
-        self.assertEqual(weight['weight'].dtype, torch.int8)
-        self.assertEqual(weight['weight'].shape, (20, 10))
+        self.assertEqual(weight["weight"].dtype, torch.int8)
+        self.assertEqual(weight["weight"].shape, (20, 10))
 
     @patch("torch_npu.npu_weight_quant_batchmatmul")
     def test_apply_with_x_is_int8(self, mock_npu_weight_quant_batchmatmul):
@@ -35,57 +34,48 @@ class TestAscendW8A16LinearMethod(TestBase):
         self.assertTrue(torch.equal(output, expected_y_output))
 
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
-    @patch('torch_npu.npu_format_cast')
-    def test_process_weights_after_loading_with_nz0(self,
-                                                    mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz0(self, mock_npu_format_cast):
         layer = MagicMock()
-        layer.weight.data = torch.randint(-127,
-                                          128, (128, 256),
-                                          dtype=torch.int8)
+        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
         layer.weight_scale.data = torch.randn(128, 1)
         layer.weight_offset.data = torch.randn(128, 1)
 
         mock_npu_format_cast.return_value = MagicMock
         self.method.process_weights_after_loading(layer)
 
-        self.assertEqual(layer.weight_scale.data.shape, (128, ))
-        self.assertEqual(layer.weight_offset.data.shape, (128, ))
+        self.assertEqual(layer.weight_scale.data.shape, (128,))
+        self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_not_called()
 
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"})
-    @patch('torch_npu.npu_format_cast')
-    def test_process_weights_after_loading_with_nz1(self,
-                                                    mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz1(self, mock_npu_format_cast):
         layer = MagicMock()
 
-        layer.weight.data = torch.randint(-127,
-                                          128, (128, 256),
-                                          dtype=torch.int8)
+        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
         layer.weight_scale.data = torch.randn(128, 1)
         layer.weight_offset.data = torch.randn(128, 1)
 
         mock_npu_format_cast.return_value = MagicMock
         self.method.process_weights_after_loading(layer)
 
-        self.assertEqual(layer.weight_scale.data.shape, (128, ))
-        self.assertEqual(layer.weight_offset.data.shape, (128, ))
+        self.assertEqual(layer.weight_scale.data.shape, (128,))
+        self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()
 
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"})
-    @patch('torch_npu.npu_format_cast')
-    def test_process_weights_after_loading_with_nz2(self,
-                                                    mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz2(self, mock_npu_format_cast):
         layer = MagicMock()
 
-        layer.weight.data = torch.randint(-127,
-                                          128, (128, 256),
-                                          dtype=torch.int8)
+        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
         layer.weight_scale.data = torch.randn(128, 1)
         layer.weight_offset.data = torch.randn(128, 1)
 
         mock_npu_format_cast.return_value = MagicMock
         self.method.process_weights_after_loading(layer)
 
-        self.assertEqual(layer.weight_scale.data.shape, (128, ))
-        self.assertEqual(layer.weight_offset.data.shape, (128, ))
+        self.assertEqual(layer.weight_scale.data.shape, (128,))
+        self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()

--- a/tests/ut/quantization/test_w8a8.py
+++ b/tests/ut/quantization/test_w8a8.py
@@ -9,41 +9,37 @@ from vllm_ascend.utils import AscendDeviceType
 
 
 class TestAscendW8A8LinearMethod(TestBase):
-
     def setUp(self):
         self.method = AscendW8A8LinearMethod()
 
     def test_get_weight(self):
         weight = self.method.get_weight(10, 20)
-        self.assertEqual(weight['weight'].dtype, torch.int8)
-        self.assertEqual(weight['weight'].shape, (20, 10))
+        self.assertEqual(weight["weight"].dtype, torch.int8)
+        self.assertEqual(weight["weight"].shape, (20, 10))
 
     def test_get_pertensor_param(self):
         params = self.method.get_pertensor_param(torch.bfloat16)
-        self.assertEqual(params['input_scale'].dtype, torch.bfloat16)
-        self.assertEqual(params['input_offset'].dtype, torch.int8)
-        self.assertEqual(params['input_scale'].shape, (1, ))
-        self.assertEqual(params['input_offset'].shape, (1, ))
+        self.assertEqual(params["input_scale"].dtype, torch.bfloat16)
+        self.assertEqual(params["input_offset"].dtype, torch.int8)
+        self.assertEqual(params["input_scale"].shape, (1,))
+        self.assertEqual(params["input_offset"].shape, (1,))
 
     def test_get_perchannel_param(self):
         params = self.method.get_perchannel_param(10, torch.bfloat16)
 
-        self.assertEqual(params['quant_bias'].dtype, torch.int32)
-        self.assertEqual(params['deq_scale'].dtype, torch.float32)
-        self.assertEqual(params['weight_scale'].dtype, torch.bfloat16)
-        self.assertEqual(params['weight_offset'].dtype, torch.bfloat16)
-        self.assertEqual(params['quant_bias'].shape, (10, ))
-        self.assertEqual(params['deq_scale'].shape, (10, ))
-        self.assertEqual(params['weight_scale'].shape, (10, 1))
-        self.assertEqual(params['weight_offset'].shape, (10, 1))
+        self.assertEqual(params["quant_bias"].dtype, torch.int32)
+        self.assertEqual(params["deq_scale"].dtype, torch.float32)
+        self.assertEqual(params["weight_scale"].dtype, torch.bfloat16)
+        self.assertEqual(params["weight_offset"].dtype, torch.bfloat16)
+        self.assertEqual(params["quant_bias"].shape, (10,))
+        self.assertEqual(params["deq_scale"].shape, (10,))
+        self.assertEqual(params["weight_scale"].shape, (10, 1))
+        self.assertEqual(params["weight_offset"].shape, (10, 1))
 
-    @patch(
-        "vllm_ascend.quantization.methods.w8a8_static.get_weight_prefetch_method"
-    )
+    @patch("vllm_ascend.quantization.methods.w8a8_static.get_weight_prefetch_method")
     @patch("torch.ops.vllm.quantize")
     @patch("torch_npu.npu_quant_matmul")
-    def test_apply_with_x_not_int8(self, mock_npu_quant_matmul, mock_quantize,
-                                   mock_get_weight_prefetch_method):
+    def test_apply_with_x_not_int8(self, mock_npu_quant_matmul, mock_quantize, mock_get_weight_prefetch_method):
         layer = MagicMock()
         layer.aclnn_input_scale = 0.1
         layer.aclnn_input_offset = 0.2
@@ -54,10 +50,7 @@ class TestAscendW8A8LinearMethod(TestBase):
 
         x = torch.randn(32, 128)
         bias = torch.randn(256)
-        mock_quantize.return_value = torch.randint(-128,
-                                                   127,
-                                                   x.shape,
-                                                   dtype=torch.int8)
+        mock_quantize.return_value = torch.randint(-128, 127, x.shape, dtype=torch.int8)
 
         expected_y_output = torch.randn(32, 256)
         mock_npu_quant_matmul.return_value = expected_y_output
@@ -85,11 +78,9 @@ class TestAscendW8A8LinearMethod(TestBase):
         expected_y_output += bias
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch('vllm_ascend.utils.get_ascend_device_type',
-           return_value=AscendDeviceType._310P)
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType._310P)
     @patch("torch_npu.npu_quant_matmul")
-    def test_apply_with_x_is_310p(self, mock_npu_quant_matmul,
-                                  mock_soc_version):
+    def test_apply_with_x_is_310p(self, mock_npu_quant_matmul, mock_soc_version):
         layer = MagicMock()
         layer.aclnn_input_scale = 0.1
         layer.aclnn_input_offset = 0.2
@@ -107,14 +98,11 @@ class TestAscendW8A8LinearMethod(TestBase):
         self.assertTrue(torch.equal(output, expected_y_output))
 
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
-    @patch('torch_npu.npu_format_cast')
-    def test_process_weights_after_loading_with_nz0(self,
-                                                    mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz0(self, mock_npu_format_cast):
         layer = MagicMock()
 
-        layer.weight.data = torch.randint(-127,
-                                          128, (128, 256),
-                                          dtype=torch.int8)
+        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
         layer.input_scale.data = torch.tensor([0.1])
         layer.input_offset.data = torch.tensor([0])
         layer.deq_scale = torch.tensor([0.5])
@@ -125,25 +113,21 @@ class TestAscendW8A8LinearMethod(TestBase):
         self.method.process_weights_after_loading(layer)
 
         expected_offset = torch.tensor([0]).repeat(256).to(torch.int8)
-        self.assertTrue(
-            torch.equal(layer.aclnn_input_offset.data, expected_offset))
+        self.assertTrue(torch.equal(layer.aclnn_input_offset.data, expected_offset))
         self.assertFalse(layer.aclnn_input_offset.requires_grad)
 
         self.assertFalse(layer.deq_scale.requires_grad)
 
-        self.assertEqual(layer.weight_scale.data.shape, (128, ))
-        self.assertEqual(layer.weight_offset.data.shape, (128, ))
+        self.assertEqual(layer.weight_scale.data.shape, (128,))
+        self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_not_called()
 
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"})
-    @patch('torch_npu.npu_format_cast')
-    def test_process_weights_after_loading_with_nz1(self,
-                                                    mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz1(self, mock_npu_format_cast):
         layer = MagicMock()
 
-        layer.weight.data = torch.randint(-127,
-                                          128, (128, 256),
-                                          dtype=torch.int8)
+        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
         layer.input_scale.data = torch.tensor([0.1])
         layer.input_offset.data = torch.tensor([0])
         layer.deq_scale = torch.tensor([0.5])
@@ -154,25 +138,21 @@ class TestAscendW8A8LinearMethod(TestBase):
         self.method.process_weights_after_loading(layer)
 
         expected_offset = torch.tensor([0]).repeat(256).to(torch.int8)
-        self.assertTrue(
-            torch.equal(layer.aclnn_input_offset.data, expected_offset))
+        self.assertTrue(torch.equal(layer.aclnn_input_offset.data, expected_offset))
         self.assertFalse(layer.aclnn_input_offset.requires_grad)
 
         self.assertFalse(layer.deq_scale.requires_grad)
 
-        self.assertEqual(layer.weight_scale.data.shape, (128, ))
-        self.assertEqual(layer.weight_offset.data.shape, (128, ))
+        self.assertEqual(layer.weight_scale.data.shape, (128,))
+        self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()
 
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"})
-    @patch('torch_npu.npu_format_cast')
-    def test_process_weights_after_loading_with_nz2(self,
-                                                    mock_npu_format_cast):
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_nz2(self, mock_npu_format_cast):
         layer = MagicMock()
 
-        layer.weight.data = torch.randint(-127,
-                                          128, (128, 256),
-                                          dtype=torch.int8)
+        layer.weight.data = torch.randint(-127, 128, (128, 256), dtype=torch.int8)
         layer.input_scale.data = torch.tensor([0.1])
         layer.input_offset.data = torch.tensor([0])
         layer.deq_scale = torch.tensor([0.5])
@@ -183,12 +163,11 @@ class TestAscendW8A8LinearMethod(TestBase):
         self.method.process_weights_after_loading(layer)
 
         expected_offset = torch.tensor([0]).repeat(256).to(torch.int8)
-        self.assertTrue(
-            torch.equal(layer.aclnn_input_offset.data, expected_offset))
+        self.assertTrue(torch.equal(layer.aclnn_input_offset.data, expected_offset))
         self.assertFalse(layer.aclnn_input_offset.requires_grad)
 
         self.assertFalse(layer.deq_scale.requires_grad)
 
-        self.assertEqual(layer.weight_scale.data.shape, (128, ))
-        self.assertEqual(layer.weight_offset.data.shape, (128, ))
+        self.assertEqual(layer.weight_scale.data.shape, (128,))
+        self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()

--- a/tests/ut/quantization/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/test_w8a8_dynamic.py
@@ -16,18 +16,15 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_mc2_group")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ep_group")
-    def setUp(self, mock_get_ep_group, mock_get_ascend_config,
-              mock_get_mc2_group, mock_get_rank):
+    def setUp(self, mock_get_ep_group, mock_get_ascend_config, mock_get_mc2_group, mock_get_rank):
         with patch(
-                'vllm_ascend.quantization.methods.w8a8_dynamic.get_current_vllm_config'
+            "vllm_ascend.quantization.methods.w8a8_dynamic.get_current_vllm_config"
         ) as mock_get_current_vllm_config:
             mock_vllm_config = Mock()
-            mock_vllm_config.quant_config = Mock(
-                quant_description={"group_size": 256})
+            mock_vllm_config.quant_config = Mock(quant_description={"group_size": 256})
             mock_vllm_config.scheduler_config = Mock(
-                max_num_batched_tokens=2048,
-                max_model_len=2048,
-                enable_chunked_prefill=False)
+                max_num_batched_tokens=2048, max_model_len=2048, enable_chunked_prefill=False
+            )
             mock_get_current_vllm_config.return_value = mock_vllm_config
             mock_ep_group = Mock()
             mock_get_ep_group.return_value = mock_ep_group
@@ -44,60 +41,43 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
             self.quant_method = AscendW8A8DynamicFusedMoEMethod()
 
     def test_get_weight(self):
-        param_dict = self.quant_method.get_weight(self.num_experts,
-                                                  self.intermediate_size,
-                                                  self.hidden_size,
-                                                  torch.bfloat16)
+        param_dict = self.quant_method.get_weight(
+            self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16
+        )
         self.assertEqual(param_dict["w13_weight"].dtype, torch.int8)
         self.assertEqual(
-            param_dict["w13_weight"].shape,
-            (self.num_experts, 2 * self.intermediate_size, self.hidden_size))
+            param_dict["w13_weight"].shape, (self.num_experts, 2 * self.intermediate_size, self.hidden_size)
+        )
 
     def test_get_dynamic_quant_param(self):
         param_dict = self.quant_method.get_dynamic_quant_param(
-            self.num_experts, self.intermediate_size, self.hidden_size,
-            torch.bfloat16)
+            self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16
+        )
         self.assertEqual(param_dict["w13_weight_scale"].dtype, torch.bfloat16)
-        self.assertEqual(param_dict["w13_weight_scale"].shape,
-                         (self.num_experts, 2 * self.intermediate_size, 1))
+        self.assertEqual(param_dict["w13_weight_scale"].shape, (self.num_experts, 2 * self.intermediate_size, 1))
 
     def build_layer(self):
         layer = torch.nn.Module()
-        layer.w13_weight = torch.nn.Parameter(torch.empty(
-            self.num_experts,
-            2 * self.intermediate_size,
-            self.hidden_size,
-            dtype=torch.int8),
-                                              requires_grad=False)
-        layer.w2_weight = torch.nn.Parameter(torch.empty(
-            self.num_experts,
-            self.hidden_size,
-            self.intermediate_size,
-            dtype=torch.int8),
-                                             requires_grad=False)
-        w13_weight_scale = torch.zeros(
-            (self.num_experts, 2 * self.intermediate_size, 1),
-            dtype=torch.float32)
-        layer.w13_weight_scale = torch.nn.Parameter(w13_weight_scale,
-                                                    requires_grad=False)
-        w13_weight_offset = torch.zeros(
-            (self.num_experts, 2 * self.intermediate_size, 1),
-            dtype=torch.float32)
-        layer.w13_weight_offset = torch.nn.Parameter(w13_weight_offset,
-                                                     requires_grad=False)
-        w2_weight_scale = torch.zeros((self.num_experts, self.hidden_size, 1),
-                                      dtype=torch.float32)
-        layer.w2_weight_scale = torch.nn.Parameter(w2_weight_scale,
-                                                   requires_grad=False)
-        w2_weight_offset = torch.zeros((self.num_experts, self.hidden_size, 1),
-                                       dtype=torch.float32)
-        layer.w2_weight_offset = torch.nn.Parameter(w2_weight_offset,
-                                                    requires_grad=False)
+        layer.w13_weight = torch.nn.Parameter(
+            torch.empty(self.num_experts, 2 * self.intermediate_size, self.hidden_size, dtype=torch.int8),
+            requires_grad=False,
+        )
+        layer.w2_weight = torch.nn.Parameter(
+            torch.empty(self.num_experts, self.hidden_size, self.intermediate_size, dtype=torch.int8),
+            requires_grad=False,
+        )
+        w13_weight_scale = torch.zeros((self.num_experts, 2 * self.intermediate_size, 1), dtype=torch.float32)
+        layer.w13_weight_scale = torch.nn.Parameter(w13_weight_scale, requires_grad=False)
+        w13_weight_offset = torch.zeros((self.num_experts, 2 * self.intermediate_size, 1), dtype=torch.float32)
+        layer.w13_weight_offset = torch.nn.Parameter(w13_weight_offset, requires_grad=False)
+        w2_weight_scale = torch.zeros((self.num_experts, self.hidden_size, 1), dtype=torch.float32)
+        layer.w2_weight_scale = torch.nn.Parameter(w2_weight_scale, requires_grad=False)
+        w2_weight_offset = torch.zeros((self.num_experts, self.hidden_size, 1), dtype=torch.float32)
+        layer.w2_weight_offset = torch.nn.Parameter(w2_weight_offset, requires_grad=False)
         return layer
 
-    @patch('torch_npu.npu_format_cast')
+    @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading(self, mock_npu_format_cast):
-
         def func_by_args(weight, num_format):
             return weight
 

--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -18,10 +18,14 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend.sample.rejection_sampler import (
-    expand_batch_to_tokens, expand_pytorch, rejection_greedy_sample_pytorch,
-    rejection_random_sample_pytorch, sample_recovered_tokens_pytorch,
-    rejection_random_sample_block_verify_pytorch, 
-    sample_recovered_tokens_blockwise_pytorch)
+    expand_batch_to_tokens,
+    expand_pytorch,
+    rejection_greedy_sample_pytorch,
+    rejection_random_sample_block_verify_pytorch,
+    rejection_random_sample_pytorch,
+    sample_recovered_tokens_blockwise_pytorch,
+    sample_recovered_tokens_pytorch,
+)
 
 # Global constants
 PLACEHOLDER_TOKEN_ID = -1
@@ -30,27 +34,24 @@ MAX_SPEC_LEN = 8  # Used as MAX_NUM_TOKENS in expand_batch_to_tokens
 
 
 def mock_pin_memory(original_func):
-
     def func_wo_pin_memory(*args, **kwargs):
-        if kwargs.get('pin_memory', False):
-            kwargs['pin_memory'] = False
+        if kwargs.get("pin_memory", False):
+            kwargs["pin_memory"] = False
         return original_func(*args, **kwargs)
 
     return func_wo_pin_memory
 
 
 class TestAscendRejectionSampler(TestBase):
-
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_rejection_greedy_sample_pytorch(self):
         """Test greedy rejection sampling: stop when draft doesn't match, otherwise append bonus token"""
         batch_size = 2
         max_spec_len = 2
-        output_token_ids = torch.full((batch_size, max_spec_len + 1),
-                                      PLACEHOLDER_TOKEN_ID)
+        output_token_ids = torch.full((batch_size, max_spec_len + 1), PLACEHOLDER_TOKEN_ID)
 
         cu_num_draft_tokens = torch.tensor([2, 4])
         num_draft_tokens = [2, 2]
@@ -76,29 +77,32 @@ class TestAscendRejectionSampler(TestBase):
         assert output_token_ids[1, 0].item() == 20
         assert output_token_ids[1, 2].item() == PLACEHOLDER_TOKEN_ID
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_rejection_random_sample_pytorch(self):
         """Test random rejection sampling: accept based on uniform probability"""
         batch_size = 2
         max_spec_len = 3
-        output_token_ids = torch.full((batch_size, max_spec_len + 1),
-                                      PLACEHOLDER_TOKEN_ID)
+        output_token_ids = torch.full((batch_size, max_spec_len + 1), PLACEHOLDER_TOKEN_ID)
 
         cu_num_draft_tokens = torch.tensor([2, 1])
         draft_token_ids = torch.tensor([1, 0, 2])
-        draft_probs = torch.tensor([
-            [0.0, 0.6, 0.0, 0.4],  # vocab_size=4
-            [0.1, 0.2, 0.3, 0.4],
-            [0.5, 0.5, 0.0, 0.0],
-        ])
-        target_probs = torch.tensor([
-            [0.0, 0.8, 0.0, 0.2],
-            [0.2, 0.1, 0.3, 0.4],
-            [0.9, 0.1, 0.0, 0.0],
-        ])
+        draft_probs = torch.tensor(
+            [
+                [0.0, 0.6, 0.0, 0.4],  # vocab_size=4
+                [0.1, 0.2, 0.3, 0.4],
+                [0.5, 0.5, 0.0, 0.0],
+            ]
+        )
+        target_probs = torch.tensor(
+            [
+                [0.0, 0.8, 0.0, 0.2],
+                [0.2, 0.1, 0.3, 0.4],
+                [0.9, 0.1, 0.0, 0.0],
+            ]
+        )
         bonus_token_ids = torch.tensor([[100], [200]])
         recovered_token_ids = torch.tensor([1, 2, 3])
         uniform_probs = torch.tensor([0.7, 0.6, 0.5])
@@ -124,10 +128,10 @@ class TestAscendRejectionSampler(TestBase):
         assert output_token_ids[0, 1].item() == 0
         assert output_token_ids[0, 2].item() == 100
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_expand_pytorch(self):
         """Test expand_pytorch functionality"""
         input_ptr = torch.tensor([10, 20, 30], dtype=torch.int32)
@@ -146,34 +150,36 @@ class TestAscendRejectionSampler(TestBase):
         expected = torch.tensor([10, 10, 20, 20, 20, 30, 30])
         assert torch.equal(output_ptr, expected)
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_expand_batch_to_tokens(self):
         """Test expand_batch_to_tokens wrapper"""
         x = torch.tensor([10, 20, 30])
         cu_num_tokens = torch.tensor([2, 5, 7])
         num_tokens = 7
         # Test PyTorch path
-        with patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False):
-            with patch("vllm_ascend.sample.rejection_sampler.expand_pytorch"
-                       ) as mock_pytorch:
-                expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
-                mock_pytorch.assert_called_once()
-                args = mock_pytorch.call_args[0]
-                assert (args[1] == x).all()
-                assert (args[2] == cu_num_tokens).all()
+        with (
+            patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False),
+            patch("vllm_ascend.sample.rejection_sampler.expand_pytorch") as mock_pytorch,
+        ):
+            expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
+            mock_pytorch.assert_called_once()
+            args = mock_pytorch.call_args[0]
+            assert (args[1] == x).all()
+            assert (args[2] == cu_num_tokens).all()
 
         # Test Triton kernel path
-        with patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", True):
-            with patch("vllm_ascend.sample.rejection_sampler.expand_triton"
-                       ) as mock_triton:
-                expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
-                mock_triton.assert_called_once()
-                call_args = mock_triton.call_args[0]
-                assert (call_args[2] == x).all()
-                assert (call_args[3] == cu_num_tokens).all()
+        with (
+            patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", True),
+            patch("vllm_ascend.sample.rejection_sampler.expand_triton") as mock_triton,
+        ):
+            expand_batch_to_tokens(x, cu_num_tokens, num_tokens)
+            mock_triton.assert_called_once()
+            call_args = mock_triton.call_args[0]
+            assert (call_args[2] == x).all()
+            assert (call_args[3] == cu_num_tokens).all()
 
         # Run actual function
         with patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False):
@@ -181,24 +187,28 @@ class TestAscendRejectionSampler(TestBase):
             expected = torch.tensor([10, 10, 20, 20, 20, 30, 30])
             assert torch.equal(result, expected)
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_sample_recovered_tokens_pytorch_ngram(self):
         """Test recovered token sampling under n-gram mode"""
         output_token_ids = torch.empty(2, dtype=torch.int32)
         cu_num_draft_tokens = torch.tensor([1, 2])
         draft_token_ids = torch.tensor([1, 2])
         draft_probs = None
-        target_probs = torch.tensor([
-            [0.1, 0.2, 0.7],
-            [0.3, 0.3, 0.4],
-        ])
-        q = torch.tensor([
-            [0.1, 0.2, 0.7],
-            [0.5, 0.4, 0.1],
-        ])
+        target_probs = torch.tensor(
+            [
+                [0.1, 0.2, 0.7],
+                [0.3, 0.3, 0.4],
+            ]
+        )
+        q = torch.tensor(
+            [
+                [0.1, 0.2, 0.7],
+                [0.5, 0.4, 0.1],
+            ]
+        )
         vocab_size = 3
 
         sample_recovered_tokens_pytorch(
@@ -215,29 +225,32 @@ class TestAscendRejectionSampler(TestBase):
         assert output_token_ids[0].item() == 0
         assert output_token_ids[1].item() == 1
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_rejection_random_sample_block_verify_pytorch(self):
         """Test random rejection sampling for block verify: accept based on uniform probability"""
         batch_size = 2
         max_spec_len = 3
-        output_token_ids = torch.full((batch_size, max_spec_len + 1),
-                                      PLACEHOLDER_TOKEN_ID)
+        output_token_ids = torch.full((batch_size, max_spec_len + 1), PLACEHOLDER_TOKEN_ID)
 
         cu_num_draft_tokens = torch.tensor([2, 1])
         draft_token_ids = torch.tensor([1, 0, 2])
-        draft_probs = torch.tensor([
-            [0.0, 0.6, 0.0, 0.4],
-            [0.1, 0.2, 0.3, 0.4],
-            [0.5, 0.5, 0.0, 0.0],
-        ])
-        target_probs = torch.tensor([
-            [0.0, 0.8, 0.0, 0.2],
-            [0.2, 0.1, 0.3, 0.4],
-            [0.9, 0.1, 0.0, 0.0],
-        ])
+        draft_probs = torch.tensor(
+            [
+                [0.0, 0.6, 0.0, 0.4],
+                [0.1, 0.2, 0.3, 0.4],
+                [0.5, 0.5, 0.0, 0.0],
+            ]
+        )
+        target_probs = torch.tensor(
+            [
+                [0.0, 0.8, 0.0, 0.2],
+                [0.2, 0.1, 0.3, 0.4],
+                [0.9, 0.1, 0.0, 0.0],
+            ]
+        )
         bonus_token_ids = torch.tensor([[100], [200]])
         recovered_token_ids = torch.tensor([1, 2, 3])
         uniform_probs = torch.tensor([0.7, 0.6, 0.5])
@@ -263,24 +276,28 @@ class TestAscendRejectionSampler(TestBase):
         assert output_token_ids[0, 1].item() == 0
         assert output_token_ids[0, 2].item() == 100
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_sample_recovered_tokens_blockwise_pytorch_ngram(self):
         """Test recovered token sampling for blockwise speculative decoding with n-gram."""
         output_token_ids = torch.empty(2, dtype=torch.int32)
         cu_num_draft_tokens = torch.tensor([1, 2])
         draft_token_ids = torch.tensor([1, 2])
         draft_probs = None
-        target_probs = torch.tensor([
-            [0.1, 0.2, 0.7],
-            [0.3, 0.3, 0.4],
-        ])
-        q = torch.tensor([
-            [0.1, 0.2, 0.7],
-            [0.5, 0.4, 0.1],
-        ])
+        target_probs = torch.tensor(
+            [
+                [0.1, 0.2, 0.7],
+                [0.3, 0.3, 0.4],
+            ]
+        )
+        q = torch.tensor(
+            [
+                [0.1, 0.2, 0.7],
+                [0.5, 0.4, 0.1],
+            ]
+        )
         vocab_size = 3
 
         sample_recovered_tokens_blockwise_pytorch(
@@ -297,27 +314,33 @@ class TestAscendRejectionSampler(TestBase):
         assert output_token_ids[0].item() == 0
         assert output_token_ids[1].item() == 1
 
-    @patch('torch.arange', new=mock_pin_memory(torch.arange))
-    @patch('torch.ones', new=mock_pin_memory(torch.ones))
-    @patch('torch.full', new=mock_pin_memory(torch.full))
-    @patch('torch.tensor', new=mock_pin_memory(torch.tensor))
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_sample_recovered_tokens_blockwise_pytorch(self):
         """Test recovered token sampling for blockwise speculative decoding."""
         output_token_ids = torch.empty(2, dtype=torch.int32)
         cu_num_draft_tokens = torch.tensor([1, 2])
         draft_token_ids = torch.tensor([0, 1])
-        draft_probs = torch.tensor([
-            [0.6, 0.1, 0.3],
-            [0.2, 0.7, 0.1],
-        ])
-        target_probs = torch.tensor([
-            [0.8, 0.1, 0.1],
-            [0.3, 0.6, 0.1],
-        ])
-        q = torch.tensor([
-            [0.5, 0.3, 0.2],
-            [0.1, 0.8, 0.1],
-        ])
+        draft_probs = torch.tensor(
+            [
+                [0.6, 0.1, 0.3],
+                [0.2, 0.7, 0.1],
+            ]
+        )
+        target_probs = torch.tensor(
+            [
+                [0.8, 0.1, 0.1],
+                [0.3, 0.6, 0.1],
+            ]
+        )
+        q = torch.tensor(
+            [
+                [0.5, 0.3, 0.2],
+                [0.1, 0.8, 0.1],
+            ]
+        )
         vocab_size = 3
 
         sample_recovered_tokens_blockwise_pytorch(

--- a/tests/ut/sample/test_sampler.py
+++ b/tests/ut/sample/test_sampler.py
@@ -3,9 +3,8 @@ from vllm_ascend.sample.sampler import AscendSampler, AscendTopKTopPSampler
 
 
 class TestAscendSampler(TestBase):
-
     def test_init_with_raw_logprobs(self):
         sampler = AscendSampler(logprobs_mode="raw_logprobs")
         self.assertEqual(sampler.logprobs_mode, "raw_logprobs")
-        self.assertTrue(hasattr(sampler, 'topk_topp_sampler'))
+        self.assertTrue(hasattr(sampler, "topk_topp_sampler"))
         self.assertIsInstance(sampler.topk_topp_sampler, AscendTopKTopPSampler)

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1,11 +1,13 @@
-from unittest.mock import MagicMock, patch
 import unittest
-import pytest
+from unittest.mock import MagicMock, patch
+
 import numpy as np
+import pytest
 import torch
 from vllm.config import CacheConfig, CompilationMode, CUDAGraphMode, VllmConfig, set_current_vllm_config
-from vllm.forward_context import BatchDescriptor, get_forward_context
+from vllm.forward_context import BatchDescriptor
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -139,6 +141,7 @@ class TestEagleProposerInitialization(TestBase):
             self.assertTrue(proposer.use_cuda_graph)
             expected_max_num_tokens = proposer.max_num_tokens
             self.assertEqual(proposer.hidden_states.shape, (expected_max_num_tokens, 2048))
+
 
 @unittest.skip("Skip due to the changes in #7153, fix me later")
 class TestEagleProposerLoadModel(TestBase):
@@ -343,9 +346,10 @@ class TestEagleProposerDummyRun(TestBase):
         set_current_vllm_config(None)
 
     # cpu does not support parallel-group, let alone `sp`
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context",
-           **{"return_value.flash_comm_v1_enabled": False})
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch(
+        "vllm_ascend.spec_decode.eagle_proposer.get_forward_context", **{"return_value.flash_comm_v1_enabled": False}
+    )
     @patch("vllm_ascend.spec_decode.eagle_proposer.set_ascend_forward_context")
     def test_dummy_run_basic(self, mock_context, mock_get_context, mock_get_context_2):
         num_tokens = 32
@@ -359,9 +363,10 @@ class TestEagleProposerDummyRun(TestBase):
             self.assertTrue(self.proposer._runnable.call_count == 1)
 
     # cpu does not support parallel-group, let alone `sp`
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
-    @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context",
-           **{"return_value.flash_comm_v1_enabled": False})
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch(
+        "vllm_ascend.spec_decode.eagle_proposer.get_forward_context", **{"return_value.flash_comm_v1_enabled": False}
+    )
     @patch("vllm_ascend.spec_decode.eagle_proposer.set_ascend_forward_context")
     def test_dummy_run_with_prefill(self, mock_context, mock_get_context, mock_get_context_2):
         mock_context.return_value.__enter__.return_value = None
@@ -371,12 +376,13 @@ class TestEagleProposerDummyRun(TestBase):
             self.proposer.dummy_run(num_tokens=64, with_prefill=True, num_reqs=4)
             self.assertTrue(self.proposer._runnable.call_count == 1)
 
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.spec_decode.eagle_proposer.update_full_graph_params")
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context")
     @patch("vllm_ascend.spec_decode.eagle_proposer.set_ascend_forward_context")
-    def test_dummy_run_in_graph_capture(self, mock_context, mock_get_context,
-                                        mock_update_full_graph_params, mock_get_context_2):
+    def test_dummy_run_in_graph_capture(
+        self, mock_context, mock_get_context, mock_update_full_graph_params, mock_get_context_2
+    ):
         last_use_cuda_graph = self.proposer.use_cuda_graph
         mock_return_context = MagicMock()
         mock_return_context.cudagraph_runtime_mode = CUDAGraphMode.FULL
@@ -393,13 +399,14 @@ class TestEagleProposerDummyRun(TestBase):
             self.assertTrue(self.proposer._runnable.call_count == 1)
             mock_update_full_graph_params.assert_not_called()
             self.proposer.use_cuda_graph = last_use_cuda_graph
-    
-    @patch('vllm_ascend.ascend_forward_context.get_forward_context')
+
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.spec_decode.eagle_proposer.update_full_graph_params")
     @patch("vllm_ascend.spec_decode.eagle_proposer.get_forward_context")
     @patch("vllm_ascend.spec_decode.eagle_proposer.set_ascend_forward_context")
-    def test_dummy_run_in_graph_run(self, mock_context, mock_get_context,
-                                    mock_update_full_graph_params, mock_get_context_2):
+    def test_dummy_run_in_graph_run(
+        self, mock_context, mock_get_context, mock_update_full_graph_params, mock_get_context_2
+    ):
         last_use_cuda_graph = self.proposer.use_cuda_graph
         mock_return_context = MagicMock()
         mock_return_context.cudagraph_runtime_mode = CUDAGraphMode.FULL
@@ -490,7 +497,7 @@ class TestEagleProposerHelperMethods(TestBase):
             self.assertEqual(indices.tolist(), [1, 2, 4])
 
 
-class TestEagleProposerPropose():
+class TestEagleProposerPropose:
     @pytest.fixture(autouse=True)
     def setUp_and_tearDown(self):
         self.vllm_config = MagicMock(spec=VllmConfig)
@@ -544,9 +551,7 @@ class TestEagleProposerPropose():
         self.mock_dp_group.start()
 
         # Mock sp
-        self.mock_enable_sp = patch(
-            "vllm_ascend.utils.enable_sp", return_value=False
-        )
+        self.mock_enable_sp = patch("vllm_ascend.utils.enable_sp", return_value=False)
         self.mock_enable_sp.start()
 
         # Set the current vllm config
@@ -562,52 +567,171 @@ class TestEagleProposerPropose():
         # Clear the current vllm config
         set_current_vllm_config(None)
 
-    # config: prefill and decode, Qwen3-8B, tp1, enforce_eager, no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
+    # config: prefill and decode, Qwen3-8B, tp1, enforce_eager,
+    # no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
     @pytest.mark.parametrize(
-        'flag_prefill_decode, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,' \
-        'num_actual_tokens, max_query_len, max_seq_len, block_table_tensor,' \
-        'slot_mapping, causal, logits_indices_padded, num_logits_indices,' \
-        'encoder_seq_lens, encoder_seq_lens_cpu, dcp_local_seq_lens,' \
-        'dcp_local_seq_lens_cpu, _seq_lens_cpu, _num_computed_tokens_cpu,' \
-        '_num_computed_tokens_cache, seq_lens_cpu, num_computed_tokens_cpu,' \
-        'decode_token_per_req, actual_seq_lengths_q, positions, attn_state,' \
-        'graph_pad_size, num_input_tokens, prefill_context_parallel_metadata',
+        "flag_prefill_decode, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,"
+        "num_actual_tokens, max_query_len, max_seq_len, block_table_tensor,"
+        "slot_mapping, causal, logits_indices_padded, num_logits_indices,"
+        "encoder_seq_lens, encoder_seq_lens_cpu, dcp_local_seq_lens,"
+        "dcp_local_seq_lens_cpu, _seq_lens_cpu, _num_computed_tokens_cpu,"
+        "_num_computed_tokens_cache, seq_lens_cpu, num_computed_tokens_cpu,"
+        "decode_token_per_req, actual_seq_lengths_q, positions, attn_state,"
+        "graph_pad_size, num_input_tokens, prefill_context_parallel_metadata",
         [
             (
-                "prefill", torch.tensor([ 0, 13], device=torch.device("cpu"), dtype=torch.int32), torch.tensor([ 0, 13], dtype=torch.int32), 
-                torch.tensor([13], device=torch.device("cpu"), dtype=torch.int32), 1, 13, 13, 13,
+                "prefill",
+                torch.tensor([0, 13], device=torch.device("cpu"), dtype=torch.int32),
+                torch.tensor([0, 13], dtype=torch.int32),
+                torch.tensor([13], device=torch.device("cpu"), dtype=torch.int32),
+                1,
+                13,
+                13,
+                13,
                 torch.eye(256, device=torch.device("cpu"), dtype=torch.int32)[0].unsqueeze(0),
-                torch.tensor([128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140], device=torch.device("cpu"), dtype=torch.int32),
-                True, None, None, None, None, None, None, None, None, None, torch.tensor([13], dtype=torch.int32), torch.tensor([0], dtype=torch.int32), 4, [],
+                torch.tensor(
+                    [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140],
+                    device=torch.device("cpu"),
+                    dtype=torch.int32,
+                ),
+                True,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                torch.tensor([13], dtype=torch.int32),
+                torch.tensor([0], dtype=torch.int32),
+                4,
+                [],
                 torch.cat([torch.arange(13), torch.zeros(8704 - 13)]),
-                AscendAttentionState.PrefillNoCache, -1, 13, None
+                AscendAttentionState.PrefillNoCache,
+                -1,
+                13,
+                None,
             ),
             (
-                "decode", torch.tensor([ 0, 4, 8, 12], device=torch.device("cpu"), dtype=torch.int32), torch.tensor([ 0, 4, 8, 12], dtype=torch.int32), 
-                torch.tensor([21, 17, 17], device=torch.device("cpu"), dtype=torch.int32), 3, 12, 4, 0,
-                torch.cat([torch.eye(256, device="cpu", dtype=torch.int32)[0].unsqueeze(0)*i for i in [1,2,3]], dim=0),
-                torch.tensor([145, 146, 147, 148, 269, 270, 271, 272, 397, 398, 399, 400], device=torch.device("cpu"), dtype=torch.int32),
-                True, None, None, None, None, None, None, None, None, None, torch.tensor([21, 17, 17], dtype=torch.int32), torch.tensor([17, 13, 13], dtype=torch.int32), 4, [],
-                torch.cat([torch.tensor([17, 18, 19, 20, 13, 14, 15, 16, 13, 14, 15, 16, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]), torch.zeros(8704 - 30)]),
-                AscendAttentionState.ChunkedPrefill, -1, 12, None
+                "decode",
+                torch.tensor([0, 4, 8, 12], device=torch.device("cpu"), dtype=torch.int32),
+                torch.tensor([0, 4, 8, 12], dtype=torch.int32),
+                torch.tensor([21, 17, 17], device=torch.device("cpu"), dtype=torch.int32),
+                3,
+                12,
+                4,
+                0,
+                torch.cat(
+                    [torch.eye(256, device="cpu", dtype=torch.int32)[0].unsqueeze(0) * i for i in [1, 2, 3]], dim=0
+                ),
+                torch.tensor(
+                    [145, 146, 147, 148, 269, 270, 271, 272, 397, 398, 399, 400],
+                    device=torch.device("cpu"),
+                    dtype=torch.int32,
+                ),
+                True,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                torch.tensor([21, 17, 17], dtype=torch.int32),
+                torch.tensor([17, 13, 13], dtype=torch.int32),
+                4,
+                [],
+                torch.cat(
+                    [
+                        torch.tensor(
+                            [
+                                17,
+                                18,
+                                19,
+                                20,
+                                13,
+                                14,
+                                15,
+                                16,
+                                13,
+                                14,
+                                15,
+                                16,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                            ]
+                        ),
+                        torch.zeros(8704 - 30),
+                    ]
+                ),
+                AscendAttentionState.ChunkedPrefill,
+                -1,
+                12,
+                None,
             ),
-        ]
+        ],
     )
-    # config: prefill and decode, Qwen3-30B, tp2, ep_enable, enforce_eager, no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
-    @pytest.mark.parametrize('model_type', ['qwen_dense','qwen_moe', 'deepseek'])
-    @patch('vllm_ascend.spec_decode.eagle_proposer.AscendEagleProposer.get_model')
-    def test_propose(self, mock_get_model, model_type, flag_prefill_decode, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,
-                     num_actual_tokens, max_query_len, max_seq_len, block_table_tensor,
-                     slot_mapping, causal, logits_indices_padded, num_logits_indices,
-                     encoder_seq_lens, encoder_seq_lens_cpu, dcp_local_seq_lens,
-                     dcp_local_seq_lens_cpu, _seq_lens_cpu, _num_computed_tokens_cpu,
-                     _num_computed_tokens_cache, seq_lens_cpu, num_computed_tokens_cpu,
-                     decode_token_per_req, actual_seq_lengths_q, positions, attn_state,
-                     graph_pad_size, num_input_tokens, prefill_context_parallel_metadata
-                    ):
+    # config: prefill and decode, Qwen3-30B, tp2, ep_enable, enforce_eager,
+    # no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
+    @pytest.mark.parametrize("model_type", ["qwen_dense", "qwen_moe", "deepseek"])
+    @patch("vllm_ascend.spec_decode.eagle_proposer.AscendEagleProposer.get_model")
+    def test_propose(
+        self,
+        mock_get_model,
+        model_type,
+        flag_prefill_decode,
+        query_start_loc,
+        query_start_loc_cpu,
+        seq_lens,
+        num_reqs,
+        num_actual_tokens,
+        max_query_len,
+        max_seq_len,
+        block_table_tensor,
+        slot_mapping,
+        causal,
+        logits_indices_padded,
+        num_logits_indices,
+        encoder_seq_lens,
+        encoder_seq_lens_cpu,
+        dcp_local_seq_lens,
+        dcp_local_seq_lens_cpu,
+        _seq_lens_cpu,
+        _num_computed_tokens_cpu,
+        _num_computed_tokens_cache,
+        seq_lens_cpu,
+        num_computed_tokens_cpu,
+        decode_token_per_req,
+        actual_seq_lengths_q,
+        positions,
+        attn_state,
+        graph_pad_size,
+        num_input_tokens,
+        prefill_context_parallel_metadata,
+    ):
         # mock and adjust functions and var in propose
-        if model_type == 'deepseek':
-            self.proposer.method = 'mtp'
+        if model_type == "deepseek":
+            self.proposer.method = "mtp"
             if not self.is_decode(flag_prefill_decode):
                 num_actual_tokens = 9
         self.runner._sync_metadata_across_dp.return_value = (num_actual_tokens, None, False)
@@ -616,7 +740,7 @@ class TestEagleProposerPropose():
         self.proposer.model.combine_hidden_states.return_value = custom_combined_hidden_states
         mock_get_model.return_value = self.proposer.model
         self.proposer.hidden_size = 4096
-        if model_type == 'deepseek':
+        if model_type == "deepseek":
             self.proposer.hidden_states = torch.zeros(8192, 7168, device=self.device, dtype=torch.bfloat16)
         else:
             self.proposer.hidden_states = torch.zeros(8192, 4096, device=self.device, dtype=torch.bfloat16)
@@ -626,7 +750,7 @@ class TestEagleProposerPropose():
         mock_builder.build.return_value = mock_attn_metadata
         mock_attn_group.get_metadata_builder.return_value = mock_builder
         self.proposer.draft_attn_groups = [mock_attn_group]
-        self.proposer.attn_layer_names = ['model.layers.36.self_attn.attn']
+        self.proposer.attn_layer_names = ["model.layers.36.self_attn.attn"]
         self.proposer.kernel_block_size = 128
         self.proposer._runnable = MagicMock()
         self.proposer._runnable.return_value = [0, 0, 0]
@@ -640,66 +764,149 @@ class TestEagleProposerPropose():
             return res_common, res_attn
 
         # create common_attn_metadata
-        mock_common_attn_metadata= MagicMock()
+        mock_common_attn_metadata = MagicMock()
         if not self.is_decode(flag_prefill_decode):
             mock_common_attn_metadata.batch_size.return_value = 1
-            if model_type == 'qwen_moe':
+            if model_type == "qwen_moe":
                 _seq_lens_cpu = torch.tensor([13], dtype=torch.int32)
-            if model_type == 'deepseek':
+            if model_type == "deepseek":
                 query_start_loc = torch.tensor([0, 9], device=torch.device("cpu"), dtype=torch.int32)
                 query_start_loc_cpu = torch.tensor([0, 9], device=torch.device("cpu"), dtype=torch.int32)
                 seq_lens = torch.tensor([9], device=torch.device("cpu"), dtype=torch.int32)
                 max_query_len = 9
                 max_seq_len = 9
-                slot_mapping = torch.tensor([128, 129, 130, 131, 132, 133, 134, 135, 136], device=torch.device("cpu"), dtype=torch.int32)
+                slot_mapping = torch.tensor(
+                    [128, 129, 130, 131, 132, 133, 134, 135, 136], device=torch.device("cpu"), dtype=torch.int32
+                )
                 _seq_lens_cpu = torch.tensor([9], dtype=torch.int32)
                 seq_lens_cpu = torch.tensor([9], dtype=torch.int32)
                 positions = torch.cat([torch.arange(9), torch.zeros(8704 - 9)])
                 num_input_tokens = 9
         if self.is_decode(flag_prefill_decode):
             mock_common_attn_metadata.batch_size.return_value = 3
-            if model_type == 'qwen_moe':
+            if model_type == "qwen_moe":
                 seq_lens = torch.tensor([19, 17, 17], device=torch.device("cpu"), dtype=torch.int32)
-                slot_mapping = torch.tensor([143, 144, 145, 146, 269, 270, 271, 272, 397, 398, 399, 400], device=torch.device("cpu"), dtype=torch.int32)
+                slot_mapping = torch.tensor(
+                    [143, 144, 145, 146, 269, 270, 271, 272, 397, 398, 399, 400],
+                    device=torch.device("cpu"),
+                    dtype=torch.int32,
+                )
                 seq_lens_cpu = torch.tensor([19, 17, 17], dtype=torch.int32)
                 num_computed_tokens_cpu = torch.tensor([15, 13, 13], dtype=torch.int32)
-                positions = torch.cat([torch.tensor([15, 16, 17, 18, 13, 14, 15, 16, 13, 14, 15, 16, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]), torch.zeros(8704 - 30)])
-            if model_type == 'deepseek':
+                positions = torch.cat(
+                    [
+                        torch.tensor(
+                            [
+                                15,
+                                16,
+                                17,
+                                18,
+                                13,
+                                14,
+                                15,
+                                16,
+                                13,
+                                14,
+                                15,
+                                16,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12,
+                            ]
+                        ),
+                        torch.zeros(8704 - 30),
+                    ]
+                )
+            if model_type == "deepseek":
                 seq_lens = torch.tensor([14, 13, 14], device=torch.device("cpu"), dtype=torch.int32)
-                slot_mapping = torch.tensor([138, 139, 140, 141, 265, 266, 267, 268, 394, 395, 396, 397], device=torch.device("cpu"), dtype=torch.int32)
+                slot_mapping = torch.tensor(
+                    [138, 139, 140, 141, 265, 266, 267, 268, 394, 395, 396, 397],
+                    device=torch.device("cpu"),
+                    dtype=torch.int32,
+                )
                 seq_lens_cpu = torch.tensor([14, 13, 14], dtype=torch.int32)
                 num_computed_tokens_cpu = torch.tensor([10, 9, 10], dtype=torch.int32)
-                positions = torch.cat([torch.tensor([10, 11, 12, 13, 9, 10, 11, 12, 10, 11, 12, 13, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), torch.zeros(8704 - 23)])
+                positions = torch.cat(
+                    [
+                        torch.tensor([10, 11, 12, 13, 9, 10, 11, 12, 10, 11, 12, 13, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                        torch.zeros(8704 - 23),
+                    ]
+                )
                 attn_state = AscendAttentionState.SpecDecoding
-        self.value_mock_common_attn_metadata(mock_common_attn_metadata, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,
-                                        num_actual_tokens, max_query_len, max_seq_len, block_table_tensor,
-                                        slot_mapping, causal, logits_indices_padded, num_logits_indices,
-                                        encoder_seq_lens, encoder_seq_lens_cpu, dcp_local_seq_lens,
-                                        dcp_local_seq_lens_cpu, _seq_lens_cpu, _num_computed_tokens_cpu,
-                                        _num_computed_tokens_cache, seq_lens_cpu, num_computed_tokens_cpu,
-                                        decode_token_per_req, actual_seq_lengths_q, positions, attn_state,
-                                        graph_pad_size, num_input_tokens, prefill_context_parallel_metadata
-                                        )
-        
+        self.value_mock_common_attn_metadata(
+            mock_common_attn_metadata,
+            query_start_loc,
+            query_start_loc_cpu,
+            seq_lens,
+            num_reqs,
+            num_actual_tokens,
+            max_query_len,
+            max_seq_len,
+            block_table_tensor,
+            slot_mapping,
+            causal,
+            logits_indices_padded,
+            num_logits_indices,
+            encoder_seq_lens,
+            encoder_seq_lens_cpu,
+            dcp_local_seq_lens,
+            dcp_local_seq_lens_cpu,
+            _seq_lens_cpu,
+            _num_computed_tokens_cpu,
+            _num_computed_tokens_cache,
+            seq_lens_cpu,
+            num_computed_tokens_cpu,
+            decode_token_per_req,
+            actual_seq_lengths_q,
+            positions,
+            attn_state,
+            graph_pad_size,
+            num_input_tokens,
+            prefill_context_parallel_metadata,
+        )
+
         # create other parameters
         if not self.is_decode(flag_prefill_decode):
-            if model_type == 'qwen_dense' or model_type == 'qwen_moe':
-                target_token_ids = torch.tensor([151644, 872, 198, 5501, 7512, 14678, 51765, 30, 151645, 198, 151644, 77091, 198], device=self.device, dtype=torch.int32)
+            if model_type == "qwen_dense" or model_type == "qwen_moe":
+                target_token_ids = torch.tensor(
+                    [151644, 872, 198, 5501, 7512, 14678, 51765, 30, 151645, 198, 151644, 77091, 198],
+                    device=self.device,
+                    dtype=torch.int32,
+                )
                 target_positions = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], device=self.device)
                 next_token_ids = torch.tensor([151667], device=self.device, dtype=torch.int32)
-                req_scheduled_tokens = {'0-8222703c': 13}
-            if model_type == 'deepseek':
-                target_token_ids = torch.tensor([ 0, 0, 128803, 12473, 9734, 19991, 50096, 33, 128804], device=self.device, dtype=torch.int32)
+                req_scheduled_tokens = {"0-8222703c": 13}
+            if model_type == "deepseek":
+                target_token_ids = torch.tensor(
+                    [0, 0, 128803, 12473, 9734, 19991, 50096, 33, 128804], device=self.device, dtype=torch.int32
+                )
                 target_positions = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8], device=self.device)
                 target_hidden_states = torch.zeros(num_actual_tokens, 7168, device=self.device, dtype=torch.bfloat16)
                 next_token_ids = torch.tensor([128798], device=self.device, dtype=torch.int32)
-                req_scheduled_tokens = {'0-b4ed8210': 9}
-            if model_type == 'qwen_dense':
+                req_scheduled_tokens = {"0-b4ed8210": 9}
+            if model_type == "qwen_dense":
                 target_hidden_states = torch.zeros(num_actual_tokens, 12288, device=self.device, dtype=torch.bfloat16)
-            if model_type == 'qwen_moe':
+            if model_type == "qwen_moe":
                 target_hidden_states = torch.zeros(num_actual_tokens, 6144, device=self.device, dtype=torch.bfloat16)
             token_indices_to_sample = None
-            target_model_batch_desc = BatchDescriptor(num_tokens=num_actual_tokens, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0)
+            target_model_batch_desc = BatchDescriptor(
+                num_tokens=num_actual_tokens, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0
+            )
             mock_sampling_metadata = MagicMock()
             mm_embed_inputs = None
             long_seq_metadata = None
@@ -710,57 +917,109 @@ class TestEagleProposerPropose():
             num_rejected_tokens_gpu = None
 
         if self.is_decode(flag_prefill_decode):
-            if model_type == 'qwen_dense':
-                target_token_ids = torch.tensor([279, 1196, 374, 8014, 151667, 198, 32313, 11, 151667, 198, 32313, 11], device=self.device, dtype=torch.int32)
+            if model_type == "qwen_dense":
+                target_token_ids = torch.tensor(
+                    [279, 1196, 374, 8014, 151667, 198, 32313, 11, 151667, 198, 32313, 11],
+                    device=self.device,
+                    dtype=torch.int32,
+                )
                 target_positions = torch.tensor([17, 18, 19, 20, 13, 14, 15, 16, 13, 14, 15, 16], device=self.device)
                 target_hidden_states = torch.zeros(num_actual_tokens, 12288, device=self.device, dtype=torch.bfloat16)
                 next_token_ids = torch.tensor([4588, 279, 279], device=self.device, dtype=torch.int32)
                 token_indices_to_sample = torch.tensor([1, 7, 11], device=self.device, dtype=torch.int32)
                 num_rejected_tokens_gpu = torch.tensor([2, 0, 0], device=self.device, dtype=torch.int32)
-            if model_type == 'qwen_moe':
-                target_token_ids = torch.tensor([32313, 2776, 198, 198, 151667, 198, 198, 198, 151667, 198, 198, 198], device=self.device, dtype=torch.int32)
+            if model_type == "qwen_moe":
+                target_token_ids = torch.tensor(
+                    [32313, 2776, 198, 198, 151667, 198, 198, 198, 151667, 198, 198, 198],
+                    device=self.device,
+                    dtype=torch.int32,
+                )
                 target_positions = torch.tensor([15, 16, 17, 18, 13, 14, 15, 16, 13, 14, 15, 16], device=self.device)
                 target_hidden_states = torch.zeros(num_actual_tokens, 6144, device=self.device, dtype=torch.bfloat16)
                 next_token_ids = torch.tensor([11, 32313, 32313], device=self.device, dtype=torch.int32)
                 token_indices_to_sample = torch.tensor([0, 5, 9], device=self.device, dtype=torch.int32)
                 num_rejected_tokens_gpu = torch.tensor([3, 2, 2], device=self.device, dtype=torch.int32)
-            if model_type == 'deepseek':
-                target_token_ids = torch.tensor([201, 33001, 14, 832, 128798, 271, 5, 128798, 128798, 271, 5, 128798], device=self.device, dtype=torch.int32)
+            if model_type == "deepseek":
+                target_token_ids = torch.tensor(
+                    [201, 33001, 14, 832, 128798, 271, 5, 128798, 128798, 271, 5, 128798],
+                    device=self.device,
+                    dtype=torch.int32,
+                )
                 target_positions = torch.tensor([10, 11, 12, 13, 9, 10, 11, 12, 10, 11, 12, 13], device=self.device)
                 target_hidden_states = torch.zeros(num_actual_tokens, 7168, device=self.device, dtype=torch.bfloat16)
                 next_token_ids = torch.tensor([270, 128799, 201], device=self.device, dtype=torch.int32)
                 token_indices_to_sample = torch.tensor([2, 5, 8], device=self.device, dtype=torch.int32)
                 num_rejected_tokens_gpu = torch.tensor([1, 2, 3], device=self.device, dtype=torch.int32)
-            target_model_batch_desc = BatchDescriptor(num_tokens=num_actual_tokens, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0)
+            target_model_batch_desc = BatchDescriptor(
+                num_tokens=num_actual_tokens, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0
+            )
             mock_sampling_metadata = MagicMock()
             mm_embed_inputs = None
-            req_scheduled_tokens = {'0-b69afbe5': 4, '1-b60368b9': 4, '2-82281e95': 4}
+            req_scheduled_tokens = {"0-b69afbe5": 4, "1-b60368b9": 4, "2-82281e95": 4}
             long_seq_metadata = None
             num_prefill_reqs = 0
             num_decode_reqs = 0
             scheduler_output = MagicMock()
             num_scheduled_tokens = num_actual_tokens
 
-        #run
-        with patch.object(self.proposer, 'attn_update_stack_num_spec_norm', side_effect=side_effect):
-            with set_current_vllm_config(self.vllm_config):
-                self.proposer._propose(target_token_ids, target_positions, target_hidden_states, next_token_ids,
-                                    token_indices_to_sample, mock_common_attn_metadata, target_model_batch_desc, mock_sampling_metadata,
-                                    mm_embed_inputs, req_scheduled_tokens, long_seq_metadata, num_prefill_reqs, num_decode_reqs,
-                                    scheduler_output, num_scheduled_tokens, num_rejected_tokens_gpu,
-                                    )
-                self.assert_value_common_attn_metadata(captured_common_attn_metadata, flag_prefill_decode, model_type)
+        # run
+        with (
+            patch.object(self.proposer, "attn_update_stack_num_spec_norm", side_effect=side_effect),
+            set_current_vllm_config(self.vllm_config),
+        ):
+            self.proposer._propose(
+                target_token_ids,
+                target_positions,
+                target_hidden_states,
+                next_token_ids,
+                token_indices_to_sample,
+                mock_common_attn_metadata,
+                target_model_batch_desc,
+                mock_sampling_metadata,
+                mm_embed_inputs,
+                req_scheduled_tokens,
+                long_seq_metadata,
+                num_prefill_reqs,
+                num_decode_reqs,
+                scheduler_output,
+                num_scheduled_tokens,
+                num_rejected_tokens_gpu,
+            )
+            self.assert_value_common_attn_metadata(captured_common_attn_metadata, flag_prefill_decode, model_type)
 
     # give common_attn_metadata value
-    def value_mock_common_attn_metadata(self, mock_common_attn_metadata, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,
-                                        num_actual_tokens, max_query_len, max_seq_len, block_table_tensor,
-                                        slot_mapping, causal, logits_indices_padded, num_logits_indices,
-                                        encoder_seq_lens, encoder_seq_lens_cpu, dcp_local_seq_lens,
-                                        dcp_local_seq_lens_cpu, _seq_lens_cpu, _num_computed_tokens_cpu,
-                                        _num_computed_tokens_cache, seq_lens_cpu, num_computed_tokens_cpu,
-                                        decode_token_per_req, actual_seq_lengths_q, positions, attn_state,
-                                        graph_pad_size, num_input_tokens, prefill_context_parallel_metadata
-                                        ):
+    def value_mock_common_attn_metadata(
+        self,
+        mock_common_attn_metadata,
+        query_start_loc,
+        query_start_loc_cpu,
+        seq_lens,
+        num_reqs,
+        num_actual_tokens,
+        max_query_len,
+        max_seq_len,
+        block_table_tensor,
+        slot_mapping,
+        causal,
+        logits_indices_padded,
+        num_logits_indices,
+        encoder_seq_lens,
+        encoder_seq_lens_cpu,
+        dcp_local_seq_lens,
+        dcp_local_seq_lens_cpu,
+        _seq_lens_cpu,
+        _num_computed_tokens_cpu,
+        _num_computed_tokens_cache,
+        seq_lens_cpu,
+        num_computed_tokens_cpu,
+        decode_token_per_req,
+        actual_seq_lengths_q,
+        positions,
+        attn_state,
+        graph_pad_size,
+        num_input_tokens,
+        prefill_context_parallel_metadata,
+    ):
         mock_common_attn_metadata.query_start_loc = query_start_loc
         mock_common_attn_metadata.query_start_loc_cpu = query_start_loc_cpu
         mock_common_attn_metadata.seq_lens = seq_lens
@@ -798,26 +1057,40 @@ class TestEagleProposerPropose():
             assert captured_common_attn_metadata.num_reqs == 1
             assert captured_common_attn_metadata.num_actual_tokens == 1
             assert captured_common_attn_metadata.max_query_len == 1
-            assert torch.equal(captured_common_attn_metadata.block_table_tensor, torch.eye(256, dtype=torch.int32)[0].unsqueeze(0))
+            assert torch.equal(
+                captured_common_attn_metadata.block_table_tensor, torch.eye(256, dtype=torch.int32)[0].unsqueeze(0)
+            )
             assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([2]))
-            if model_type == 'qwen_moe':
+            if model_type == "qwen_moe":
                 assert captured_common_attn_metadata._seq_lens_cpu == torch.tensor([15])
-            if model_type == 'qwen_dense':
-                assert captured_common_attn_metadata._seq_lens_cpu == None
-            if model_type == 'deepseek':
+            if model_type == "qwen_dense":
+                assert captured_common_attn_metadata._seq_lens_cpu is None
+            if model_type == "deepseek":
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([11]))
                 assert captured_common_attn_metadata.max_seq_len == 9
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([138]), torch.full((8703,), -1)]))
+                assert torch.equal(
+                    captured_common_attn_metadata.slot_mapping,
+                    torch.cat([torch.tensor([138]), torch.full((8703,), -1)]),
+                )
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([11]))
                 assert captured_common_attn_metadata._seq_lens_cpu == torch.tensor([11])
-                assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([10, 1, 2, 3, 4, 5, 6, 7, 8] + [0]*(8704-9), dtype=torch.int64))
+                assert torch.equal(
+                    captured_common_attn_metadata.positions,
+                    torch.tensor([10, 1, 2, 3, 4, 5, 6, 7, 8] + [0] * (8704 - 9), dtype=torch.int64),
+                )
                 assert captured_common_attn_metadata.num_input_tokens == 9
-            if model_type == 'qwen_dense' or model_type == 'qwen_moe':
+            if model_type == "qwen_dense" or model_type == "qwen_moe":
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([15]))
                 assert captured_common_attn_metadata.max_seq_len == 13
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([142]), torch.full((8703,), -1)]))
+                assert torch.equal(
+                    captured_common_attn_metadata.slot_mapping,
+                    torch.cat([torch.tensor([142]), torch.full((8703,), -1)]),
+                )
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([15]))
-                assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([14, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-13), dtype=torch.int64))
+                assert torch.equal(
+                    captured_common_attn_metadata.positions,
+                    torch.tensor([14, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0] * (8704 - 13), dtype=torch.int64),
+                )
                 assert captured_common_attn_metadata.num_input_tokens == 13
 
         if self.is_decode(flag_prefill_decode):
@@ -828,43 +1101,140 @@ class TestEagleProposerPropose():
             assert captured_common_attn_metadata.num_actual_tokens == 3
             assert captured_common_attn_metadata.max_query_len == 1
             assert captured_common_attn_metadata.max_seq_len == 0
-            assert torch.equal(captured_common_attn_metadata.block_table_tensor, torch.cat([torch.eye(256, device="cpu", dtype=torch.int32)[0].unsqueeze(0)*i for i in [1,2,3]], dim=0))
-            assert captured_common_attn_metadata._seq_lens_cpu == None
-            if model_type == 'qwen_dense':
+            assert torch.equal(
+                captured_common_attn_metadata.block_table_tensor,
+                torch.cat(
+                    [torch.eye(256, device="cpu", dtype=torch.int32)[0].unsqueeze(0) * i for i in [1, 2, 3]], dim=0
+                ),
+            )
+            assert captured_common_attn_metadata._seq_lens_cpu is None
+            if model_type == "qwen_dense":
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([23, 19, 19]))
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([148, 274, 402]), torch.full((8701,), -1)]))
+                assert torch.equal(
+                    captured_common_attn_metadata.slot_mapping,
+                    torch.cat([torch.tensor([148, 274, 402]), torch.full((8701,), -1)]),
+                )
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([23, 19, 19]))
                 assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([19, 15, 15]))
-                assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([20, 18, 18, 20, 13, 14, 15, 16, 13, 14, 15, 16, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-30), dtype=torch.int64))
-            if model_type == 'qwen_moe':
+                assert torch.equal(
+                    captured_common_attn_metadata.positions,
+                    torch.tensor(
+                        [
+                            20,
+                            18,
+                            18,
+                            20,
+                            13,
+                            14,
+                            15,
+                            16,
+                            13,
+                            14,
+                            15,
+                            16,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                        ]
+                        + [0] * (8704 - 30),
+                        dtype=torch.int64,
+                    ),
+                )
+            if model_type == "qwen_moe":
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([21, 19, 19]))
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([145, 272, 400]), torch.full((8701,), -1)]))
+                assert torch.equal(
+                    captured_common_attn_metadata.slot_mapping,
+                    torch.cat([torch.tensor([145, 272, 400]), torch.full((8701,), -1)]),
+                )
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([21, 19, 19]))
                 assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([17, 15, 15]))
-                assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([17, 16, 16, 18, 13, 14, 15, 16, 13, 14, 15, 16, 8, 9, 10, 11, 12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-30), dtype=torch.int64))
-            if model_type == 'deepseek':
+                assert torch.equal(
+                    captured_common_attn_metadata.positions,
+                    torch.tensor(
+                        [
+                            17,
+                            16,
+                            16,
+                            18,
+                            13,
+                            14,
+                            15,
+                            16,
+                            13,
+                            14,
+                            15,
+                            16,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                        ]
+                        + [0] * (8704 - 30),
+                        dtype=torch.int64,
+                    ),
+                )
+            if model_type == "deepseek":
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([16, 15, 16]))
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([142, 268, 396]), torch.full((8701,), -1)]))
+                assert torch.equal(
+                    captured_common_attn_metadata.slot_mapping,
+                    torch.cat([torch.tensor([142, 268, 396]), torch.full((8701,), -1)]),
+                )
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([16, 15, 16]))
                 assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([12, 11, 12]))
-                assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([14, 12, 12, 13, 9, 10, 11, 12, 10, 11, 12, 13, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9] + [0]*(8704-23), dtype=torch.int64))
-        assert captured_common_attn_metadata.causal == True
-        assert captured_common_attn_metadata.logits_indices_padded == None
-        assert captured_common_attn_metadata.num_logits_indices == None
-        assert captured_common_attn_metadata.encoder_seq_lens == None
-        assert captured_common_attn_metadata.encoder_seq_lens_cpu == None
-        assert captured_common_attn_metadata.dcp_local_seq_lens == None
-        assert captured_common_attn_metadata.dcp_local_seq_lens_cpu == None
-        assert captured_common_attn_metadata._num_computed_tokens_cpu == None
-        assert captured_common_attn_metadata._num_computed_tokens_cache == None
+                assert torch.equal(
+                    captured_common_attn_metadata.positions,
+                    torch.tensor(
+                        [14, 12, 12, 13, 9, 10, 11, 12, 10, 11, 12, 13, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+                        + [0] * (8704 - 23),
+                        dtype=torch.int64,
+                    ),
+                )
+        assert captured_common_attn_metadata.causal
+        assert captured_common_attn_metadata.logits_indices_padded is None
+        assert captured_common_attn_metadata.num_logits_indices is None
+        assert captured_common_attn_metadata.encoder_seq_lens is None
+        assert captured_common_attn_metadata.encoder_seq_lens_cpu is None
+        assert captured_common_attn_metadata.dcp_local_seq_lens is None
+        assert captured_common_attn_metadata.dcp_local_seq_lens_cpu is None
+        assert captured_common_attn_metadata._num_computed_tokens_cpu is None
+        assert captured_common_attn_metadata._num_computed_tokens_cache is None
         assert captured_common_attn_metadata.decode_token_per_req == 1
         assert captured_common_attn_metadata.actual_seq_lengths_q == []
-        if model_type == 'deepseek':
+        if model_type == "deepseek":
             assert captured_common_attn_metadata.attn_state == AscendAttentionState.SpecDecoding
         else:
             assert captured_common_attn_metadata.attn_state == AscendAttentionState.ChunkedPrefill
         assert captured_common_attn_metadata.graph_pad_size == -1
-        assert captured_common_attn_metadata.prefill_context_parallel_metadata == None
+        assert captured_common_attn_metadata.prefill_context_parallel_metadata is None
 
     # prefill or decode
     def is_decode(self, flag_prefill_decode):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -80,14 +80,10 @@ class TestAscendConfig(TestBase):
     def test_init_ascend_config_enable_npugraph_ex(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
-            "ascend_compilation_config": {
-                "enable_npugraph_ex": True,
-                "enable_static_kernel": True
-            },
-            "refresh": True
+            "ascend_compilation_config": {"enable_npugraph_ex": True, "enable_static_kernel": True},
+            "refresh": True,
         }
-        ascend_compilation_config = init_ascend_config(
-            test_vllm_config).ascend_compilation_config
+        ascend_compilation_config = init_ascend_config(test_vllm_config).ascend_compilation_config
         self.assertTrue(ascend_compilation_config.enable_npugraph_ex)
         self.assertTrue(ascend_compilation_config.enable_static_kernel)
 

--- a/tests/ut/test_envs.py
+++ b/tests/ut/test_envs.py
@@ -20,7 +20,6 @@ from tests.ut.base import TestBase
 
 
 class TestEnvVariables(TestBase):
-
     def setUp(self):
         self.env_vars = list(envs_ascend.env_variables.keys())
 
@@ -33,21 +32,19 @@ class TestEnvVariables(TestBase):
                 try:
                     if var_name in os.environ:
                         del os.environ[var_name]
-                    self.assertEqual(getattr(envs_ascend, var_name),
-                                     var_handler())
+                    self.assertEqual(getattr(envs_ascend, var_name), var_handler())
 
                     handler_source = inspect.getsource(var_handler)
-                    if 'int(' in handler_source:
+                    if "int(" in handler_source:
                         test_vals = ["123", "456"]
-                    elif 'bool(int(' in handler_source:
+                    elif "bool(int(" in handler_source:
                         test_vals = ["0", "1"]
                     else:
                         test_vals = [f"test_{var_name}", f"custom_{var_name}"]
 
                     for test_val in test_vals:
                         os.environ[var_name] = test_val
-                        self.assertEqual(getattr(envs_ascend, var_name),
-                                         var_handler())
+                        self.assertEqual(getattr(envs_ascend, var_name), var_handler())
 
                 finally:
                     if original_val is None:

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -65,8 +65,7 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.quantization.modelslim_config.AscendModelSlimConfig")
-    def test_pre_register_and_update_with_parser(self, mock_quant_config,
-                                                 mock_adapt_patch):
+    def test_pre_register_and_update_with_parser(self, mock_quant_config, mock_adapt_patch):
         mock_parser = MagicMock()
         mock_action = MagicMock()
         mock_action.choices = ["awq", "gptq"]
@@ -81,16 +80,14 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.quantization.modelslim_config.AscendModelSlimConfig")
-    def test_pre_register_and_update_without_parser(self, mock_quant_config,
-                                                    mock_adapt_patch):
+    def test_pre_register_and_update_without_parser(self, mock_quant_config, mock_adapt_patch):
         self.platform.pre_register_and_update(None)
 
         mock_adapt_patch.assert_called_once_with(is_global_patch=True)
 
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.quantization.modelslim_config.AscendModelSlimConfig")
-    def test_pre_register_and_update_with_parser_no_quant_action(
-            self, mock_quant_config, mock_adapt_patch):
+    def test_pre_register_and_update_with_parser_no_quant_action(self, mock_quant_config, mock_adapt_patch):
         mock_parser = MagicMock()
         mock_parser._option_string_actions = {}
 
@@ -100,8 +97,7 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.quantization.modelslim_config.AscendModelSlimConfig")
-    def test_pre_register_and_update_with_existing_ascend_quant(
-            self, mock_quant_config, mock_adapt_patch):
+    def test_pre_register_and_update_with_existing_ascend_quant(self, mock_quant_config, mock_adapt_patch):
         mock_parser = MagicMock()
         mock_action = MagicMock()
         mock_action.choices = ["awq", ASCEND_QUANTIZATION_METHOD]
@@ -126,9 +122,7 @@ class TestNPUPlatform(TestBase):
             ):
                 vllm_config = TestNPUPlatform.mock_vllm_config()
                 vllm_config.scheduler_config.max_num_seqs = max_num_seqs
-                vllm_config.speculative_config = MagicMock(
-                    num_speculative_tokens=num_speculative_tokens
-                )
+                vllm_config.speculative_config = MagicMock(num_speculative_tokens=num_speculative_tokens)
                 vllm_config.compilation_config.max_cudagraph_capture_size = None
                 vllm_config.compilation_config.cudagraph_capture_sizes = None
 
@@ -202,9 +196,7 @@ class TestNPUPlatform(TestBase):
 
         observed_inputs: list[int | None] = []
         vllm_config._set_cudagraph_sizes = MagicMock(
-            side_effect=lambda: observed_inputs.append(
-                vllm_config.compilation_config.max_cudagraph_capture_size
-            )
+            side_effect=lambda: observed_inputs.append(vllm_config.compilation_config.max_cudagraph_capture_size)
         )
 
         self.platform.check_and_update_config(vllm_config)
@@ -229,7 +221,7 @@ class TestNPUPlatform(TestBase):
         device_properties.uuid = "01020304-0000-0000-0000-01020304"
         mock_get_device_properties.return_value = device_properties
         self.assertEqual(self.platform.get_device_uuid(device_id), device_properties.uuid)
-        mock_get_device_properties.assert_called_once_with(0)        
+        mock_get_device_properties.assert_called_once_with(0)
 
     @patch("torch.inference_mode")
     def test_inference_mode(self, mock_inference_mode):
@@ -349,7 +341,9 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
-    def test_check_and_update_config_enforce_eager_mode(self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect):
+    def test_check_and_update_config_enforce_eager_mode(
+        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+    ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.model_config.enforce_eager = True
@@ -422,7 +416,9 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    def test_check_and_update_config_unsupported_cudagraph_mode(self, mock_init_ascend, mock_soc_version, mock_auto_detect):
+    def test_check_and_update_config_unsupported_cudagraph_mode(
+        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+    ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.model_config.enforce_eager = False
@@ -493,9 +489,11 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with pytest.raises(ValueError, match=r"recompute_scheduler_enable.*PD-disaggregated.*PD-mixed"):
-            with patch.object(platform.NPUPlatform, "_fix_incompatible_config"):
-                self.platform.check_and_update_config(vllm_config)
+        with (
+            pytest.raises(ValueError, match=r"recompute_scheduler_enable.*PD-disaggregated.*PD-mixed"),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -521,12 +519,12 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with pytest.raises(ValueError, match=r"recompute_scheduler_enable.*PD-disaggregated.*PD-mixed"):
-            with (
-                patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
-                patch.object(platform, "check_kv_extra_config"),
-            ):
-                self.platform.check_and_update_config(vllm_config)
+        with (
+            pytest.raises(ValueError, match=r"recompute_scheduler_enable.*PD-disaggregated.*PD-mixed"),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -552,13 +550,13 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True):
-            with pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"):
-                with (
-                    patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
-                    patch.object(platform, "check_kv_extra_config"),
-                ):
-                    self.platform.check_and_update_config(vllm_config)
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
+            pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -584,13 +582,13 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True):
-            with pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"):
-                with (
-                    patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
-                    patch.object(platform, "check_kv_extra_config"),
-                ):
-                    self.platform.check_and_update_config(vllm_config)
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
+            pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -617,10 +615,12 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True):
-            with pytest.raises(ValueError, match=r"VLLM_ASCEND_ENABLE_FUSED_MC2.*kv_role='kv_consumer'.*PD-mixed"):
-                with patch.object(platform.NPUPlatform, "_fix_incompatible_config"):
-                    self.platform.check_and_update_config(vllm_config)
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True),
+            pytest.raises(ValueError, match=r"VLLM_ASCEND_ENABLE_FUSED_MC2.*kv_role='kv_consumer'.*PD-mixed"),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -647,13 +647,13 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True):
-            with pytest.raises(ValueError, match=r"VLLM_ASCEND_ENABLE_FUSED_MC2.*kv_role='kv_consumer'.*kv_role='kv_both'"):
-                with (
-                    patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
-                    patch.object(platform, "check_kv_extra_config"),
-                ):
-                    self.platform.check_and_update_config(vllm_config)
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True),
+            pytest.raises(ValueError, match=r"VLLM_ASCEND_ENABLE_FUSED_MC2.*kv_role='kv_consumer'.*kv_role='kv_both'"),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -680,13 +680,15 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True):
-            with pytest.raises(ValueError, match=r"VLLM_ASCEND_ENABLE_FUSED_MC2.*kv_role='kv_consumer'.*kv_role='kv_producer'"):
-                with (
-                    patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
-                    patch.object(platform, "check_kv_extra_config"),
-                ):
-                    self.platform.check_and_update_config(vllm_config)
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True),
+            pytest.raises(
+                ValueError, match=r"VLLM_ASCEND_ENABLE_FUSED_MC2.*kv_role='kv_consumer'.*kv_role='kv_producer'"
+            ),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -713,12 +715,12 @@ class TestNPUPlatform(TestBase):
         importlib.reload(platform)
         self.platform = platform.NPUPlatform()
 
-        with patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True):
-            with (
-                patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
-                patch.object(platform, "check_kv_extra_config"),
-            ):
-                self.platform.check_and_update_config(vllm_config)
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2", 1, create=True),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     def test_update_block_size_for_backend_preserves_hybrid_block_size(self):
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -810,7 +812,9 @@ class TestNPUPlatform(TestBase):
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType._310P)
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
-    def test_check_and_update_config_310p_no_custom_ops(self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect):
+    def test_check_and_update_config_310p_no_custom_ops(
+        self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect
+    ):
         mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.compilation_config.custom_ops = []

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -15,13 +15,11 @@
 
 import math
 import os
-from threading import Lock
 from unittest import mock
 
 import pytest
 import torch
-from vllm.config import (CompilationConfig, ModelConfig, ParallelConfig,
-                         VllmConfig)
+from vllm.config import CompilationConfig, ModelConfig, ParallelConfig, VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
@@ -29,11 +27,11 @@ from vllm_ascend.utils import REGISTERED_ASCEND_OPS
 
 
 class TestUtils(TestBase):
-
     def setUp(self):
         import importlib
 
         from vllm_ascend import platform
+
         importlib.reload(platform)
         utils.enable_dsa_cp_with_layer_shard.cache_clear()
         utils.enable_dsa_cp_with_o_proj_tp.cache_clear()
@@ -72,22 +70,29 @@ class TestUtils(TestBase):
         input_tensor = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
         output = utils.nd_to_nz_2d(input_tensor)
         expected = torch.tensor(
-            [[[[1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]]])
+            [
+                [
+                    [
+                        [1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    ]
+                ]
+            ]
+        )
         self.assertTrue(torch.allclose(output, expected))
 
     def test_aligned_16(self):
@@ -107,23 +112,20 @@ class TestUtils(TestBase):
         output_tensor = utils.aligned_16(input_tensor)
         self.assertEqual(output_tensor.shape[0], 32)
 
-    @pytest.mark.skip(
-        "Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
+    @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_enable_custom_op(self):
         result = utils.enable_custom_op()
         self.assertTrue(result)
 
         utils._CUSTOM_OP_ENABLED = None
 
-        with mock.patch('builtins.__import__') as mock_import_module:
+        with mock.patch("builtins.__import__") as mock_import_module:
             mock_import_module.side_effect = ImportError("import error")
             self.assertFalse(utils.enable_custom_op())
 
     def test_find_hccl_library(self):
-        with mock.patch.dict(os.environ,
-                             {"HCCL_SO_PATH": "/path/to/hccl/libhccl.so"}):
-            self.assertEqual(utils.find_hccl_library(),
-                             "/path/to/hccl/libhccl.so")
+        with mock.patch.dict(os.environ, {"HCCL_SO_PATH": "/path/to/hccl/libhccl.so"}):
+            self.assertEqual(utils.find_hccl_library(), "/path/to/hccl/libhccl.so")
         with mock.patch("torch.version.cann", None):
             self.assertRaises(ValueError, utils.find_hccl_library)
         with mock.patch("torch.version.cann", "Ascend910"):
@@ -139,8 +141,10 @@ class TestUtils(TestBase):
             kv_role="kv_producer", is_kv_producer=True, is_kv_consumer=False
         )
 
-        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
-             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
             self.assertTrue(utils.enable_dsa_cp_with_layer_shard())
 
     def test_enable_dsa_cp_with_layer_shard_rejects_kv_both(self):
@@ -149,16 +153,20 @@ class TestUtils(TestBase):
             kv_role="kv_both", is_kv_producer=True, is_kv_consumer=True
         )
 
-        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
-             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
             self.assertFalse(utils.enable_dsa_cp_with_layer_shard())
 
     def test_enable_dsa_cp_with_layer_shard_rejects_missing_kv_transfer(self):
         mock_vllm_config = mock.MagicMock()
         mock_vllm_config.kv_transfer_config = None
 
-        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
-             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
             self.assertFalse(utils.enable_dsa_cp_with_layer_shard())
 
     def test_enable_dsa_cp_with_layer_shard_rejects_when_dsa_cp_disabled(self):
@@ -169,8 +177,10 @@ class TestUtils(TestBase):
         mock_vllm_config = mock.MagicMock()
         mock_vllm_config.kv_transfer_config = None
 
-        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
-             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
             self.assertTrue(utils.enable_dsa_cp_with_o_proj_tp())
 
     def test_enable_dsa_cp_with_o_proj_tp_accepts_kv_both(self):
@@ -179,8 +189,10 @@ class TestUtils(TestBase):
             kv_role="kv_both", is_kv_producer=True, is_kv_consumer=True
         )
 
-        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
-             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
             self.assertTrue(utils.enable_dsa_cp_with_o_proj_tp())
 
     def test_enable_dsa_cp_with_o_proj_tp_rejects_single_role_pd(self):
@@ -189,8 +201,10 @@ class TestUtils(TestBase):
             kv_role="kv_producer", is_kv_producer=True, is_kv_consumer=False
         )
 
-        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
-             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
             self.assertFalse(utils.enable_dsa_cp_with_o_proj_tp())
 
     def test_enable_dsa_cp_with_o_proj_tp_rejects_when_dsa_cp_disabled(self):
@@ -226,7 +240,6 @@ class TestUtils(TestBase):
         from transformers import PretrainedConfig
 
         class SimpleConfig(PretrainedConfig):
-
             def __init__(self, num_hidden_layers=12):
                 self.num_hidden_layers = num_hidden_layers
 
@@ -237,39 +250,24 @@ class TestUtils(TestBase):
         self.assertEqual(utils.get_max_hidden_layers(SimpleConfig(24)), 24)
 
         class NestedConfig(PretrainedConfig):
-
             def to_dict(self):
                 return {
-                    "model": {
-                        "encoder": {
-                            "num_hidden_layers": 8
-                        },
-                        "decoder": {
-                            "num_hidden_layers": 12
-                        }
-                    },
-                    "other_setting": True
+                    "model": {"encoder": {"num_hidden_layers": 8}, "decoder": {"num_hidden_layers": 12}},
+                    "other_setting": True,
                 }
 
         self.assertEqual(utils.get_max_hidden_layers(NestedConfig()), 12)
 
         class MultiValueConfig(PretrainedConfig):
-
             def to_dict(self):
                 return {
                     "num_hidden_layers": 6,
-                    "submodule": {
-                        "num_hidden_layers": 18,
-                        "subsub": {
-                            "num_hidden_layers": 9
-                        }
-                    }
+                    "submodule": {"num_hidden_layers": 18, "subsub": {"num_hidden_layers": 9}},
                 }
 
         self.assertEqual(utils.get_max_hidden_layers(MultiValueConfig()), 18)
 
         class NoLayerConfig(PretrainedConfig):
-
             def to_dict(self):
                 return {"attention_heads": 8}
 
@@ -278,47 +276,44 @@ class TestUtils(TestBase):
         self.assertIn("num_hidden_layers", str(context.exception))
 
     def test_update_aclgraph_sizes(self):
-        test_compilation_config = CompilationConfig(
-            cudagraph_capture_sizes=[i for i in range(150)])
+        test_compilation_config = CompilationConfig(cudagraph_capture_sizes=[i for i in range(150)])
         model_path = os.path.join(os.path.dirname(__file__), "fake_weight")
         test_model_config = ModelConfig(model=model_path, enforce_eager=True)
         test_parallel_config = ParallelConfig()
         test_vllm_config = VllmConfig(
             model_config=test_model_config,
             compilation_config=test_compilation_config,
-            parallel_config=test_parallel_config)
+            parallel_config=test_parallel_config,
+        )
         utils.update_aclgraph_sizes(test_vllm_config)
-        os.environ['HCCL_OP_EXPANSION_MODE'] = 'AIV'
+        os.environ["HCCL_OP_EXPANSION_MODE"] = "AIV"
         utils.update_aclgraph_sizes(test_vllm_config)
-        del os.environ['HCCL_OP_EXPANSION_MODE']
+        del os.environ["HCCL_OP_EXPANSION_MODE"]
 
-        self.assertEqual(
-            0,
-            len(test_vllm_config.compilation_config.cudagraph_capture_sizes))
+        self.assertEqual(0, len(test_vllm_config.compilation_config.cudagraph_capture_sizes))
 
     @mock.patch("vllm.model_executor.custom_op.CustomOp")
     @mock.patch("vllm_ascend.ops.activation.AscendQuickGELU")
     @mock.patch("vllm_ascend.ops.activation.AscendSiluAndMul")
     @mock.patch("vllm_ascend.ops.layernorm.AscendRMSNorm")
-    def test_register_ascend_customop(self, mock_ascend_rmsnorm,
-                                      mock_ascend_silu_and_mul,
-                                      mock_ascend_quick_gelu, mock_customop):
+    def test_register_ascend_customop(
+        self, mock_ascend_rmsnorm, mock_ascend_silu_and_mul, mock_ascend_quick_gelu, mock_customop
+    ):
         utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
 
         # ascend custom op is not registered
         utils.register_ascend_customop()
-        self.assertEqual(mock_customop.register_oot.call_count,
-                         len(REGISTERED_ASCEND_OPS))
+        self.assertEqual(mock_customop.register_oot.call_count, len(REGISTERED_ASCEND_OPS))
         self.assertTrue(utils._ASCEND_CUSTOMOP_IS_REIGISTERED)
 
         # ascend custom op is already registered
         utils.register_ascend_customop()
-        self.assertEqual(mock_customop.register_oot.call_count,
-                         len(REGISTERED_ASCEND_OPS))
-    
+        self.assertEqual(mock_customop.register_oot.call_count, len(REGISTERED_ASCEND_OPS))
+
     @mock.patch("torch_npu.npu_format_cast")
     def test_maybe_trans_nz(self, mock_npu_format_cast):
         from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+
         mock_npu_format_cast.side_effect = lambda weight, fmt: weight
 
         def assert_nz_cast(weight):

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -9,7 +9,6 @@ from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):
-
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.device = torch.device("cpu")
@@ -84,8 +83,8 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
 
-class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
 
+class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.device = torch.device("cpu")
@@ -93,7 +92,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         runner.model_config = MagicMock()
         return runner
 
-    @patch('vllm_ascend.worker.model_runner_v1.lmhead_tp_enable')
+    @patch("vllm_ascend.worker.model_runner_v1.lmhead_tp_enable")
     def test_sample_updates_output_token_ids_before_sampler(self, mock_lmhead_tp_enable):
         """Verify output_token_ids are updated before sampler is called"""
         mock_lmhead_tp_enable.return_value = False
@@ -123,6 +122,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
                 req_output = output_token_ids[index]
                 if req_output and req_output[-1] == -1:
                     req_output[-1] = sampled_ids[prev_index]
+
         input_batch.update_async_output_token_ids.side_effect = mock_update_output_token_ids
 
         # Build runner and inject dependencies
@@ -144,6 +144,7 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         actual_output_token_ids = actual_sampling_metadata.output_token_ids
         self.assertEqual(actual_output_token_ids[0], [1, 2, 3, 6])
         self.assertEqual(actual_output_token_ids[1], [4, 5, 7])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -29,26 +29,29 @@ from vllm_ascend.worker.pcp_utils import PCPManager
         (2, 1, 4, [5, 10, 40, 60], 2, True, 100, True),
         (2, 1, 3, [5, 10, 15], 3, False, 50, True),
         (2, 1, 3, [40, 50, 60], 0, False, 150, True),
-    ])
-def test_generate_pcp_metadata_basic(pcp_size, dcp_size, num_reqs, query_lens,
-                                     num_decodes, use_mla, total_tokens,
-                                     expect_not_none):
+    ],
+)
+def test_generate_pcp_metadata_basic(
+    pcp_size, dcp_size, num_reqs, query_lens, num_decodes, use_mla, total_tokens, expect_not_none
+):
     vllm_config = MagicMock()
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.use_mla = use_mla
     vllm_config.parallel_config.cp_kv_cache_interleave_size = 64
     vllm_config.speculative_config.num_speculative_tokens = 0
 
-    pcp_manager = PCPManager(pcp_world_size=pcp_size,
-                             pcp_rank=0,
-                             dcp_world_size=dcp_size,
-                             dcp_rank=0,
-                             max_buffer_num_tokens=10000,
-                             max_num_reqs=1000,
-                             device="cpu",
-                             vllm_config=vllm_config,
-                             use_async_scheduling=False,
-                             pin_memory=False)
+    pcp_manager = PCPManager(
+        pcp_world_size=pcp_size,
+        pcp_rank=0,
+        dcp_world_size=dcp_size,
+        dcp_rank=0,
+        max_buffer_num_tokens=10000,
+        max_num_reqs=1000,
+        device="cpu",
+        vllm_config=vllm_config,
+        use_async_scheduling=False,
+        pin_memory=False,
+    )
     input_batch = MagicMock()
     input_batch.num_reqs = num_reqs
 
@@ -69,40 +72,42 @@ def test_generate_pcp_metadata_basic(pcp_size, dcp_size, num_reqs, query_lens,
     input_batch.num_computed_tokens_cpu = np.array(num_computed_tokens)
     input_batch.num_prompt_tokens = torch.tensor(num_prompt_tokens)
     input_batch.num_tokens = torch.tensor(num_tokens)
-    num_scheduled_tokens = np.array(
-        query_lens) - input_batch.num_computed_tokens_cpu
+    num_scheduled_tokens = np.array(query_lens) - input_batch.num_computed_tokens_cpu
 
     query_lens = torch.tensor(query_lens)
-    result, _ = pcp_manager.generate_pcp_metadata(total_tokens, query_lens,
-                                               input_batch,
-                                               num_scheduled_tokens,
-                                               torch.tensor([]),
-                                               num_reqs_padded=num_reqs,
-                                               num_reqs=num_reqs)
+    result, _ = pcp_manager.generate_pcp_metadata(
+        total_tokens,
+        query_lens,
+        input_batch,
+        num_scheduled_tokens,
+        torch.tensor([]),
+        num_reqs_padded=num_reqs,
+        num_reqs=num_reqs,
+    )
 
     if not expect_not_none:
         assert result is None, f"Expected to return None, but got {type(result)}"
     else:
         assert result is not None, "Expected to return a metadata object, but got None."
 
-        assert hasattr(result, 'num_actual_tokens_pcp_padded')
-        assert hasattr(result, 'num_computed_tokens_of_pcp_dcp')
+        assert hasattr(result, "num_actual_tokens_pcp_padded")
+        assert hasattr(result, "num_computed_tokens_of_pcp_dcp")
 
         if pcp_size > 1:
-            assert hasattr(result, 'pcp_allgather_restore_idx')
+            assert hasattr(result, "pcp_allgather_restore_idx")
 
             has_prefill_requests = (num_reqs - num_decodes) > 0
             if has_prefill_requests:
-                assert hasattr(result, 'q_head_idx_tensor')
-                assert hasattr(result, 'q_tail_idx_tensor')
-                assert hasattr(result, 'q_full_idx')
-                assert hasattr(result, 'kv_with_q_head_nomask_idx_tensor')
-                assert hasattr(result, 'kv_with_q_head_mask_idx_tensor')
-                assert hasattr(result, 'kv_with_q_tail_nomask_idx_tensor')
-                assert hasattr(result, 'kv_with_q_tail_mask_idx_tensor')
-                assert hasattr(result, 'attn_mask_seqlens')
-                assert hasattr(result, 'head_attn_nomask_seqlens')
-                assert hasattr(result, 'tail_attn_nomask_seqlens')
+                assert hasattr(result, "q_head_idx_tensor")
+                assert hasattr(result, "q_tail_idx_tensor")
+                assert hasattr(result, "q_full_idx")
+                assert hasattr(result, "kv_with_q_head_nomask_idx_tensor")
+                assert hasattr(result, "kv_with_q_head_mask_idx_tensor")
+                assert hasattr(result, "kv_with_q_tail_nomask_idx_tensor")
+                assert hasattr(result, "kv_with_q_tail_mask_idx_tensor")
+                assert hasattr(result, "attn_mask_seqlens")
+                assert hasattr(result, "head_attn_nomask_seqlens")
+                assert hasattr(result, "tail_attn_nomask_seqlens")
 
 
 @pytest.mark.parametrize(
@@ -110,51 +115,51 @@ def test_generate_pcp_metadata_basic(pcp_size, dcp_size, num_reqs, query_lens,
     [
         # Case 1: prefill only
         ([8, 12, 16], 3, [0, 0, 0], [8, 12, 16], 4, 0, [2, 4, 4]),
-
         # # Case 2: mix prefill and decode
         ([8, 4, 12], 3, [8, 4, 0], [8, 0, 12], 4, 0, [2, 2, 4]),
-
         # # Case 3: request which need to be padded
         ([3, 7, 9], 3, [0, 0, 0], [3, 7, 9], 4, 0, [2, 2, 4]),
-
         # Case 4: single request
         ([10], 1, [0], [10], 4, 0, [4]),
-    ])
-def test_update_tokens_for_pcp_basic(tokens, num_reqs, num_computed_tokens,
-                                     num_prompt_tokens, pcp_size, pcp_rank,
-                                     expected_pcp_tokens):
+    ],
+)
+def test_update_tokens_for_pcp_basic(
+    tokens, num_reqs, num_computed_tokens, num_prompt_tokens, pcp_size, pcp_rank, expected_pcp_tokens
+):
     vllm_config = MagicMock()
     vllm_config.model_config = MagicMock()
     vllm_config.speculative_config.num_speculative_tokens = 0
     vllm_config.scheduler_config.max_num_seqs = 1000
 
-    pcp_manager = PCPManager(pcp_world_size=pcp_size,
-                             pcp_rank=0,
-                             dcp_world_size=1,
-                             dcp_rank=0,
-                             max_buffer_num_tokens=10000,
-                             max_num_reqs=1000,
-                             device="cpu",
-                             vllm_config=vllm_config,
-                             use_async_scheduling=False,
-                             pin_memory=False)
+    pcp_manager = PCPManager(
+        pcp_world_size=pcp_size,
+        pcp_rank=0,
+        dcp_world_size=1,
+        dcp_rank=0,
+        max_buffer_num_tokens=10000,
+        max_num_reqs=1000,
+        device="cpu",
+        vllm_config=vllm_config,
+        use_async_scheduling=False,
+        pin_memory=False,
+    )
     input_batch = MagicMock()
     input_batch.num_reqs = num_reqs
-    input_batch.num_computed_tokens_cpu = np.array(num_computed_tokens,
-                                                   dtype=np.int32)
+    input_batch.num_computed_tokens_cpu = np.array(num_computed_tokens, dtype=np.int32)
     input_batch.num_prompt_tokens = np.array(num_prompt_tokens, dtype=np.int32)
     arange_np = np.arange(10000)
     num_scheduled_tokens = np.array(tokens)
     pcp_manager.init_batch_info(num_scheduled_tokens, num_reqs)
-    pcp_tokens_result, positions_result = pcp_manager.update_tokens_for_pcp(
-        num_scheduled_tokens, arange_np)
+    pcp_tokens_result, positions_result = pcp_manager.update_tokens_for_pcp(num_scheduled_tokens, arange_np)
 
-    assert np.array_equal(pcp_tokens_result, expected_pcp_tokens), \
+    assert np.array_equal(pcp_tokens_result, expected_pcp_tokens), (
         f"Expected pcp_tokens: {expected_pcp_tokens}, got: {pcp_tokens_result}"
+    )
 
     total_pcp_tokens: int = np.sum(pcp_tokens_result)
-    assert positions_result.shape == (total_pcp_tokens,), \
+    assert positions_result.shape == (total_pcp_tokens,), (
         f"Positions shape mismatch. Expected length {total_pcp_tokens}, got {positions_result.shape}"
+    )
 
 
 # yapf: disable
@@ -318,4 +323,3 @@ def test_generate_pcp_mtp_input(
         target_input_ids_pcp_full)
     assert torch.equal(pcp_manager.query_start_loc_pcp_full.cpu[:num_reqs + 1],
                        target_query_start_loc_pcp_full)
-

--- a/tests/ut/worker/test_worker_multi_instance.py
+++ b/tests/ut/worker/test_worker_multi_instance.py
@@ -83,9 +83,9 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         """Baseline: single instance on an empty card yields positive KV cache."""
         total = int(64 * GiB_bytes)
         gpu_util = 0.9
-        requested_memory = int(total * gpu_util)   # 57.6 GiB
-        init_free = int(62 * GiB_bytes)            # almost all free
-        non_kv_cache = int(0.5 * GiB_bytes)        # Qwen3-0.6B weights
+        requested_memory = int(total * gpu_util)  # 57.6 GiB
+        init_free = int(62 * GiB_bytes)  # almost all free
+        non_kv_cache = int(0.5 * GiB_bytes)  # Qwen3-0.6B weights
 
         worker = self._make_worker(requested_memory, init_free, total)
         profile_result = self._make_profile_result(
@@ -122,15 +122,15 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         """
         total = int(64 * GiB_bytes)
         gpu_util = 0.4
-        requested_memory = int(total * gpu_util)          # 25.6 GiB
+        requested_memory = int(total * gpu_util)  # 25.6 GiB
 
         # First instance already occupies its full requested_memory slice
-        first_instance_used = requested_memory            # 25.6 GiB
-        init_free = total - first_instance_used           # ~38.4 GiB
+        first_instance_used = requested_memory  # 25.6 GiB
+        init_free = total - first_instance_used  # ~38.4 GiB
 
         # After the fix: profiling correctly reports only the second
         # instance's own model weights, not the first instance's memory.
-        non_kv_cache = int(0.5 * GiB_bytes)              # Qwen3-0.6B weights
+        non_kv_cache = int(0.5 * GiB_bytes)  # Qwen3-0.6B weights
 
         worker = self._make_worker(requested_memory, init_free, total)
         profile_result = self._make_profile_result(
@@ -142,7 +142,8 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
             result = worker.determine_available_memory()
 
         self.assertGreater(
-            result, 0,
+            result,
+            0,
             "Second instance must have positive KV cache memory. "
             "A non-positive value means the multi-instance OOM bug "
             "(PR #7427) has regressed.",
@@ -167,10 +168,10 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         """
         total = int(64 * GiB_bytes)
         gpu_util = 0.4
-        requested_memory = int(total * gpu_util)   # 25.6 GiB
+        requested_memory = int(total * gpu_util)  # 25.6 GiB
 
-        first_instance_used = requested_memory     # 25.6 GiB
-        init_free = total - first_instance_used    # ~38.4 GiB
+        first_instance_used = requested_memory  # 25.6 GiB
+        init_free = total - first_instance_used  # ~38.4 GiB
 
         # Buggy: non_kv_cache_memory = first-instance memory + second-instance weights
         buggy_non_kv_cache = int((25.6 + 0.5) * GiB_bytes)  # ~26.1 GiB
@@ -187,7 +188,8 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
 
         # Pre-fix: 25.6 GiB - 26.1 GiB = -0.5 GiB  (negative → OOM)
         self.assertLess(
-            result, 0,
+            result,
+            0,
             "With the pre-fix (buggy) non_kv_cache_memory the result must be "
             "negative; this documents the OOM regression that PR #7427 fixed.",
         )
@@ -210,9 +212,8 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
             non_kv_cache_memory=int(0.5 * GiB_bytes),
         )
 
-        with self._patch_memory_profiling(profile_result):
-            with self.assertRaises(AssertionError) as ctx:
-                worker.determine_available_memory()
+        with self._patch_memory_profiling(profile_result), self.assertRaises(AssertionError) as ctx:
+            worker.determine_available_memory()
 
         self.assertIn("Error in memory profiling", str(ctx.exception))
 
@@ -225,13 +226,13 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         non_kv_cache_memory (i.e. there is room for at least some KV blocks),
         the result must be positive.
         """
-        total = int(32 * GiB_bytes)       # smaller card (e.g. 910B1)
+        total = int(32 * GiB_bytes)  # smaller card (e.g. 910B1)
         gpu_util = 0.3
-        requested_memory = int(total * gpu_util)   # 9.6 GiB
+        requested_memory = int(total * gpu_util)  # 9.6 GiB
 
         # First instance has consumed most of its requested slice
-        first_instance_used = requested_memory     # 9.6 GiB
-        init_free = total - first_instance_used    # 22.4 GiB
+        first_instance_used = requested_memory  # 9.6 GiB
+        init_free = total - first_instance_used  # 22.4 GiB
 
         non_kv_cache = int(0.5 * GiB_bytes)  # Qwen3-0.6B
 

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -10,7 +10,6 @@ init_cached_hf_modules_path = "vllm.utils.import_utils.init_cached_hf_modules"
 
 
 class TestNPUWorker(TestBase):
-
     def setUp(self):
         """Setup test environment"""
         # Create configuration mocks
@@ -23,8 +22,8 @@ class TestNPUWorker(TestBase):
 
         self.hf_config_mock = MagicMock()
         self.hf_config_mock.model_type = "test_model"
-        if hasattr(self.hf_config_mock, 'index_topk'):
-            delattr(self.hf_config_mock, 'index_topk')
+        if hasattr(self.hf_config_mock, "index_topk"):
+            delattr(self.hf_config_mock, "index_topk")
 
         self.model_config_mock.hf_config = self.hf_config_mock
 
@@ -175,8 +174,7 @@ class TestNPUWorker(TestBase):
         # Create NPUWorker instance
         from vllm_ascend.worker.worker import NPUWorker
 
-        with patch("vllm.utils.torch_utils.STR_DTYPE_TO_TORCH_DTYPE",
-                   {"float32": torch.float32}):
+        with patch("vllm.utils.torch_utils.STR_DTYPE_TO_TORCH_DTYPE", {"float32": torch.float32}):
             worker = NPUWorker(
                 vllm_config=self.vllm_config_mock,
                 local_rank=self.local_rank,
@@ -236,16 +234,14 @@ class TestNPUWorker(TestBase):
 
             mock_allocator.wake_up.assert_called_once_with(tags=["test_tag"])
 
-    @patch(
-        "vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment"
-    )
+    @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
     @patch("vllm_ascend.worker.worker.init_device_properties_triton")
     @patch("torch.npu.set_device")
     @patch("torch.npu.empty_cache")
     @patch("torch.npu.mem_get_info")
-    def test_init_device(self, mock_mem_get_info, mock_set_device,
-                         mock_empty_cache, mock_init_triton,
-                         mock_init_dist_env):
+    def test_init_device(
+        self, mock_mem_get_info, mock_set_device, mock_empty_cache, mock_init_triton, mock_init_dist_env
+    ):
         """Test _init_device method"""
         from vllm_ascend.worker.worker import NPUWorker
 
@@ -266,10 +262,8 @@ class TestNPUWorker(TestBase):
             result = worker._init_device()
 
             # Verify the parameter passed to set_device is a torch.device object
-            mock_mem_get_info.assert_called_once(
-            )  # Called once in _init_device method
-            mock_init_dist_env.assert_called_once(
-            )  # Verify distributed initialization is called
+            mock_mem_get_info.assert_called_once()  # Called once in _init_device method
+            mock_init_dist_env.assert_called_once()  # Verify distributed initialization is called
 
             # Verify return value is a torch.device object
             self.assertEqual(str(result), "npu:1")
@@ -329,11 +323,13 @@ class TestNPUWorker(TestBase):
             worker.profiler = None
             worker.rank = 0
 
-        with patch("vllm.distributed.utils.get_worker_rank_suffix", return_value="dp0_pp0_tp0_dcp0_ep0_rank0"):
-            with patch.object(NPUWorker, "_create_profiler", return_value=MagicMock()) as mock_create:
-                worker.profile(is_start=True, profile_prefix="warmup")
+        with (
+            patch("vllm.distributed.utils.get_worker_rank_suffix", return_value="dp0_pp0_tp0_dcp0_ep0_rank0"),
+            patch.object(NPUWorker, "_create_profiler", return_value=MagicMock()) as mock_create,
+        ):
+            worker.profile(is_start=True, profile_prefix="warmup")
 
-                mock_create.assert_called_once_with("warmup_dp0_pp0_tp0_dcp0_ep0_rank0")
+            mock_create.assert_called_once_with("warmup_dp0_pp0_tp0_dcp0_ep0_rank0")
 
     def test_profile_lazy_init(self):
         """[RFC #6954] Profiler is lazily created on first profile(is_start=True) call"""
@@ -363,7 +359,7 @@ class TestNPUWorker(TestBase):
             self.assertIsNotNone(worker.profiler)
 
     def test_profile_restart_reuses_existing_profiler(self):
-        """[RFC #6954] Restarting profile (stop then start) reuses existing profiler, does not call _create_profiler again"""
+        """[RFC #6954] Restarting profile reuses existing profiler."""
         from vllm_ascend.worker.worker import NPUWorker
 
         profiler_config = ProfilerConfig(
@@ -378,15 +374,17 @@ class TestNPUWorker(TestBase):
             worker.profiler = None
             worker.rank = 0
 
-        with patch("vllm.distributed.utils.get_worker_rank_suffix", return_value="dp0_pp0_tp0_dcp0_ep0_rank0"):
-            with patch.object(NPUWorker, "_create_profiler", return_value=mock_profiler) as mock_create:
-                worker.profile(is_start=True, profile_prefix="session1")
-                mock_create.assert_called_once_with("session1_dp0_pp0_tp0_dcp0_ep0_rank0")
+        with (
+            patch("vllm.distributed.utils.get_worker_rank_suffix", return_value="dp0_pp0_tp0_dcp0_ep0_rank0"),
+            patch.object(NPUWorker, "_create_profiler", return_value=mock_profiler) as mock_create,
+        ):
+            worker.profile(is_start=True, profile_prefix="session1")
+            mock_create.assert_called_once_with("session1_dp0_pp0_tp0_dcp0_ep0_rank0")
 
-                worker.profile(is_start=False)
-                worker.profile(is_start=True)  # Restart without new prefix
-                # Should NOT create new profiler, just restart existing
-                mock_create.assert_called_once()
+            worker.profile(is_start=False)
+            worker.profile(is_start=True)  # Restart without new prefix
+            # Should NOT create new profiler, just restart existing
+            mock_create.assert_called_once()
 
     def test_trace_handler_uses_worker_name(self):
         """[RFC #6954] _create_profiler passes worker_name to tensorboard_trace_handler"""
@@ -414,17 +412,13 @@ class TestNPUWorker(TestBase):
                 self.assertEqual(call_kwargs.get("worker_name"), "warmup_dp0_pp0_tp0_dcp0_ep0_rank0")
 
     @patch("vllm_ascend.worker.worker.envs_ascend")
-    def test_profile_and_msmonitor_both_enabled_raises_error(
-            self, mock_envs_ascend):
+    def test_profile_and_msmonitor_both_enabled_raises_error(self, mock_envs_ascend):
         """Test _create_profiler raises when both profiler and msmonitor are enabled"""
         from vllm_ascend.worker.worker import NPUWorker
 
         mock_envs_ascend.MSMONITOR_USE_DAEMON = 1
 
-        profiler_config = ProfilerConfig(
-            profiler="torch",
-            torch_profiler_dir="/path/to/traces"
-        )
+        profiler_config = ProfilerConfig(profiler="torch", torch_profiler_dir="/path/to/traces")
         vllm_config_mock = MagicMock()
         vllm_config_mock.profiler_config = profiler_config
 
@@ -437,8 +431,8 @@ class TestNPUWorker(TestBase):
                 _ = worker._create_profiler("test_trace")
 
             self.assertIn(
-                "MSMONITOR_USE_DAEMON and torch profiler cannot be both enabled at the same time.",
-                str(cm.exception))
+                "MSMONITOR_USE_DAEMON and torch profiler cannot be both enabled at the same time.", str(cm.exception)
+            )
 
     def test_lora_methods(self):
         """Test LoRA related methods"""
@@ -488,17 +482,14 @@ class TestNPUWorker(TestBase):
 
             mock_model_runner.get_model.return_value = mock_model
             mock_model_runner.get_kv_cache_spec.return_value = mock_kv_cache_spec
-            mock_model_runner.get_supported_pooling_tasks.return_value = (
-                mock_pooling_tasks)
+            mock_model_runner.get_supported_pooling_tasks.return_value = mock_pooling_tasks
             mock_model_runner.get_supported_tasks.return_value = mock_supported_tasks
 
             # Test each get method
             self.assertEqual(worker.get_model(), mock_model)
             self.assertEqual(worker.get_kv_cache_spec(), mock_kv_cache_spec)
-            self.assertEqual(worker.get_supported_pooling_tasks(),
-                             mock_pooling_tasks)
-            self.assertEqual(worker.get_supported_tasks(),
-                             mock_supported_tasks)
+            self.assertEqual(worker.get_supported_pooling_tasks(), mock_pooling_tasks)
+            self.assertEqual(worker.get_supported_tasks(), mock_supported_tasks)
 
     def test_execute_dummy_batch(self):
         """Test execute_dummy_batch method"""
@@ -518,7 +509,8 @@ class TestNPUWorker(TestBase):
 
             # Verify call
             mock_model_runner._dummy_run.assert_called_once_with(
-                num_tokens=mock_decode_token_per_req, uniform_decode=True)
+                num_tokens=mock_decode_token_per_req, uniform_decode=True
+            )
 
     @patch("vllm_ascend.worker.worker.envs_ascend")
     @patch("torch_npu.profiler._ExperimentalConfig")
@@ -548,7 +540,7 @@ class TestNPUWorker(TestBase):
             profiler="torch",
             torch_profiler_dir="/path/to/traces",
             torch_profiler_with_stack=True,
-            torch_profiler_with_memory=True
+            torch_profiler_with_memory=True,
         )
         vllm_config_mock = MagicMock()
         vllm_config_mock.profiler_config = profiler_config
@@ -608,10 +600,7 @@ class TestNPUWorker(TestBase):
         """Test _create_profiler raises when profiler disabled"""
         from vllm_ascend.worker.worker import NPUWorker
 
-        profiler_config = ProfilerConfig(
-            profiler=None,
-            torch_profiler_dir=""
-        )
+        profiler_config = ProfilerConfig(profiler=None, torch_profiler_dir="")
 
         with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
             worker = NPUWorker()
@@ -660,12 +649,8 @@ class TestNPUWorker(TestBase):
             (7000, 10000),  # 2nd call: after profile execution
         ]
         mock_torch_memory_stats.side_effect = [
-            {
-                "allocated_bytes.all.peak": 2000
-            },  # peak memory
-            {
-                "allocated_bytes.all.current": 3000
-            },  # current allocated = total_allocated_bytes
+            {"allocated_bytes.all.peak": 2000},  # peak memory
+            {"allocated_bytes.all.current": 3000},  # current allocated = total_allocated_bytes
         ]
         # Mock setup to simulate memory change between calls, exposing potential race condition
         # The implementation calls torch_npu.npu.mem_get_info() twice in total_allocated_bytes calculation
@@ -683,9 +668,7 @@ class TestNPUWorker(TestBase):
         # Create worker mock
         with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
             worker = NPUWorker()
-            worker.init_npu_memory = (
-                8500  # Initial memory greater than current free memory
-            )
+            worker.init_npu_memory = 8500  # Initial memory greater than current free memory
             worker.model_runner = MagicMock()
             worker.cache_config = MagicMock()
             worker.cache_config.gpu_memory_utilization = 0.8
@@ -735,12 +718,8 @@ class TestNPUWorker(TestBase):
             (7000, 10000),  # 2nd call
         ]
         mock_torch_memory_stats.side_effect = [
-            {
-                "allocated_bytes.all.peak": 1500
-            },  # peak memory
-            {
-                "allocated_bytes.all.current": 1000
-            },  # current allocated
+            {"allocated_bytes.all.peak": 1500},  # peak memory
+            {"allocated_bytes.all.current": 1000},  # current allocated
         ]
         # Mock setup to expose race condition in total_allocated_bytes calculation
         # Setup non-torch allocations > 0 case with memory change simulation
@@ -783,8 +762,8 @@ class TestNPUWorker(TestBase):
     @patch("torch.npu.reset_peak_memory_stats")
     @patch("torch.npu.empty_cache")
     def test_determine_available_memory_memory_profiling_error(
-            self, mock_torch_empty_cache, mock_torch_reset_peak_memory_stats,
-            mock_torch_mem_get_info):
+        self, mock_torch_empty_cache, mock_torch_reset_peak_memory_stats, mock_torch_mem_get_info
+    ):
         """Test determine_available_memory throws exception on memory profiling error"""
         from vllm_ascend.worker.worker import NPUWorker
 
@@ -828,12 +807,8 @@ class TestNPUWorker(TestBase):
             (3000, 10000),  # 2nd call
         ]
         mock_torch_memory_stats.side_effect = [
-            {
-                "allocated_bytes.all.peak": 9000
-            },  # High peak memory
-            {
-                "allocated_bytes.all.current": 7000
-            },
+            {"allocated_bytes.all.peak": 9000},  # High peak memory
+            {"allocated_bytes.all.current": 7000},
         ]
         # Mock setup to expose race condition even in negative result scenarios
         mock_torch_mem_get_info.side_effect = [
@@ -877,9 +852,8 @@ class TestNPUWorker(TestBase):
 
         # Create worker mock
         with (
-                patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
-                patch("vllm_ascend.worker.worker.get_pp_group") as
-                mock_get_pp_group,
+            patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
+            patch("vllm_ascend.worker.worker.get_pp_group") as mock_get_pp_group,
         ):
             worker = NPUWorker()
             worker.model_runner = MagicMock()
@@ -904,15 +878,13 @@ class TestNPUWorker(TestBase):
             result = worker.execute_model(mock_scheduler_output)
 
             # Verify call
-            worker.model_runner.execute_model.assert_called_once_with(
-                mock_scheduler_output, None)
+            worker.model_runner.execute_model.assert_called_once_with(mock_scheduler_output, None)
             self.assertEqual(result, mock_model_output)
 
     @patch("vllm_ascend.worker.worker.enable_sp", return_value=False)
     @patch("vllm_ascend.worker.worker.get_pp_group")
     @patch("vllm_ascend.worker.worker.get_tp_group")
-    def test_execute_model_middle_rank(self, mock_get_tp_group,
-                                       mock_get_pp_group, mock_enable_sp):
+    def test_execute_model_middle_rank(self, mock_get_tp_group, mock_get_pp_group, mock_enable_sp):
         """Test execute_model method - middle rank case"""
         from vllm.sequence import IntermediateTensors
 
@@ -938,9 +910,7 @@ class TestNPUWorker(TestBase):
             # Mock return IntermediateTensors - use real type
             mock_intermediate_output = MagicMock(spec=IntermediateTensors)
             mock_intermediate_output.tensors = {"output_tensor": "data"}
-            mock_intermediate_output.kv_connector_output = (
-                None  # Set to None to trigger return None
-            )
+            mock_intermediate_output.kv_connector_output = None  # Set to None to trigger return None
             worker.model_runner.execute_model.return_value = mock_intermediate_output
 
             mock_scheduler_output = MagicMock()
@@ -973,16 +943,14 @@ class TestNPUWorker(TestBase):
 
         # Create worker mock
         with (
-                patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
-                patch("vllm_ascend.worker.worker.get_pp_group") as
-                mock_get_pp_group,
+            patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
+            patch("vllm_ascend.worker.worker.get_pp_group") as mock_get_pp_group,
         ):
             worker = NPUWorker()
             worker.model_runner = MagicMock()
             worker.vllm_config = MagicMock()
             worker.vllm_config.parallel_config = MagicMock()
-            worker.vllm_config.parallel_config.distributed_executor_backend = (
-                "external_launcher")
+            worker.vllm_config.parallel_config.distributed_executor_backend = "external_launcher"
 
             # Set as non-last rank
             mock_pp_group = MagicMock()
@@ -1028,8 +996,7 @@ class TestNPUWorker(TestBase):
             # Verify calls
             mock_allocator_class.get_instance.assert_called_once()
             mock_allocator.get_current_usage.assert_called_once()
-            mock_allocator.use_memory_pool.assert_called_once_with(
-                tag="weights")
+            mock_allocator.use_memory_pool.assert_called_once_with(tag="weights")
             worker.model_runner.load_model.assert_called_once()
 
     def test_load_model_without_sleep_mode(self):
@@ -1076,8 +1043,7 @@ class TestNPUWorker(TestBase):
 
     @patch("vllm_ascend.worker.worker.logger")
     @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
-    def test_compile_or_warm_up_model_with_eager_mode(self, mock_warm_up_atb,
-                                                      mock_logger):
+    def test_compile_or_warm_up_model_with_eager_mode(self, mock_warm_up_atb, mock_logger):
         """Test compile_or_warm_up_model method - eager mode"""
         from vllm_ascend.worker.worker import NPUWorker
 
@@ -1093,9 +1059,7 @@ class TestNPUWorker(TestBase):
             # Setup compilation config
             worker.vllm_config.compilation_config = MagicMock()
             worker.vllm_config.compilation_config.compile_sizes = [1, 4, 8, 16]
-            worker.vllm_config.compilation_config.cudagraph_capture_sizes = [
-                4, 8
-            ]
+            worker.vllm_config.compilation_config.cudagraph_capture_sizes = [4, 8]
 
             # Test compile_or_warm_up_model
             worker.compile_or_warm_up_model()
@@ -1120,8 +1084,7 @@ class TestNPUWorker(TestBase):
 
     @patch("vllm_ascend.worker.worker.logger")
     @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
-    def test_compile_or_warm_up_model_with_graph_capture(
-            self, mock_warm_up_atb, mock_logger):
+    def test_compile_or_warm_up_model_with_graph_capture(self, mock_warm_up_atb, mock_logger):
         """Test compile_or_warm_up_model method - with graph capture enabled"""
         from vllm_ascend.worker.worker import NPUWorker
 
@@ -1137,9 +1100,7 @@ class TestNPUWorker(TestBase):
             # Setup compilation config
             worker.vllm_config.compilation_config = MagicMock()
             worker.vllm_config.compilation_config.compile_sizes = [1, 4, 8, 16]
-            worker.vllm_config.compilation_config.cudagraph_capture_sizes = [
-                4, 8
-            ]
+            worker.vllm_config.compilation_config.cudagraph_capture_sizes = [4, 8]
 
             # Test compile_or_warm_up_model
             worker.compile_or_warm_up_model()
@@ -1155,8 +1116,7 @@ class TestNPUWorker(TestBase):
             mock_warm_up_atb.assert_called_once()
 
     @patch("vllm_ascend.worker.worker.CaMemAllocator")
-    def test_initialize_from_config_with_sleep_mode(self,
-                                                    mock_allocator_class):
+    def test_initialize_from_config_with_sleep_mode(self, mock_allocator_class):
         """Test initialize_from_config method - with sleep mode enabled"""
         from vllm_ascend.worker.worker import NPUWorker
 
@@ -1182,10 +1142,8 @@ class TestNPUWorker(TestBase):
 
             # Verify calls
             mock_allocator_class.get_instance.assert_called_once()
-            mock_allocator.use_memory_pool.assert_called_once_with(
-                tag="kv_cache")
-            worker.model_runner.initialize_kv_cache.assert_called_once_with(
-                mock_kv_cache_config)
+            mock_allocator.use_memory_pool.assert_called_once_with(tag="kv_cache")
+            worker.model_runner.initialize_kv_cache.assert_called_once_with(mock_kv_cache_config)
 
     def test_initialize_from_config_without_sleep_mode(self):
         """Test initialize_from_config method - without sleep mode enabled"""
@@ -1206,17 +1164,15 @@ class TestNPUWorker(TestBase):
             worker.initialize_from_config(mock_kv_cache_config)
 
             # Verify calls
-            worker.model_runner.initialize_kv_cache.assert_called_once_with(
-                mock_kv_cache_config)
+            worker.model_runner.initialize_kv_cache.assert_called_once_with(mock_kv_cache_config)
 
     @patch("vllm_ascend.worker.worker.enable_sp", return_value=False)
     @patch("vllm_ascend.worker.worker.get_pp_group")
     @patch("vllm_ascend.worker.worker.get_tp_group")
     @patch("vllm_ascend.worker.worker.EMPTY_MODEL_RUNNER_OUTPUT")
-    def test_execute_model_kv_connector_not_finished(self, mock_empty_output,
-                                                     mock_get_tp_group,
-                                                     mock_get_pp_group,
-                                                     mock_enable_sp):
+    def test_execute_model_kv_connector_not_finished(
+        self, mock_empty_output, mock_get_tp_group, mock_get_pp_group, mock_enable_sp
+    ):
         """Test execute_model method - kv_connector_output not finished sending/recving case"""
         from vllm.sequence import IntermediateTensors
 
@@ -1260,5 +1216,5 @@ class TestNPUWorker(TestBase):
             mock_pp_group.recv_tensor_dict.assert_called_once()
             mock_pp_group.send_tensor_dict.assert_called_once()
 
-            # When both finished_sending and finished_recving are False, should return EMPTY_MODEL_RUNNER_OUTPUT directly
+            # When both flags are False, return EMPTY_MODEL_RUNNER_OUTPUT directly.
             self.assertEqual(result, mock_empty_output)


### PR DESCRIPTION
### What this PR does / why we need it?
| File Path |
| :--- |
| `tests/ut/ops/test_activation.py` |
| `tests/ut/ops/test_comm_utils.py` |
| `tests/ut/ops/test_fused_moe.py` |
| `tests/ut/ops/test_linear.py` |
| `tests/ut/ops/test_mla.py` |
| `tests/ut/ops/test_moe_comm_method.py` |
| `tests/ut/ops/test_moe_mlp.py` |
| `tests/ut/ops/test_prepare_finalize.py` |
| `tests/ut/ops/test_token_dispatcher.py` |
| `tests/ut/ops/test_vocab_parallel_embedding.py` |
| `tests/ut/patch/worker/patch_common/test_patch_distributed.py` |
| `tests/ut/patch/worker/patch_common/test_patch_routed_experts_capturer.py` |
| `tests/ut/quantization/test_kv_c8.py` |
| `tests/ut/quantization/test_modelslim_config.py` |
| `tests/ut/quantization/test_quant_utils.py` |
| `tests/ut/quantization/test_w4a16.py` |
| `tests/ut/quantization/test_w4a4_flatquant_dynamic.py` |
| `tests/ut/quantization/test_w4a8_dynamic.py` |
| `tests/ut/quantization/test_w8a16.py` |
| `tests/ut/quantization/test_w8a8.py` |
| `tests/ut/quantization/test_w8a8_dynamic.py` |
| `tests/ut/sample/test_rejection_sampler.py` |
| `tests/ut/sample/test_sampler.py` |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4497431df654e46fb1fb5e64bf8611e762ae5d87
