### PR TITLE
[Doc][KV Pool]Revision KV Pool User Guide [2/2]

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -470,6 +470,7 @@ ock.mmc.config_store.tls.decrypter.path =
 ```
 
 **Key Focuses：**
+
 | Parameter | Description |
 | :--- | :--- |
 | `ock.mmc.meta_service_url` | Configure the IP address and port number of the master node. The IP address and port number of the P node and D node can be the same. |
@@ -543,6 +544,7 @@ ock.mmc.client.write_thread_pool.size = 2
 ```
 
 **Key Focuses：**
+
 | Parameter | Description |
 | :--- | :--- |
 | `ock.mmc.meta_service_url` | Configure the IP address and port number of the master node. The IP address and port number of the P node and D node can be the same. |


### PR DESCRIPTION
### What this PR does / why we need it?
Revise the KV Pool user guide:
4. Revise parameters for Memcache for better clarity, at notification that currently heterogeneous protocol setting is not supported (e.g. enable `device_rdma` and `device_sdma` at the same time, a example scenario would be data transfer by memcache across different super pods)
5. Modify the condition for Mooncakestore warmup, warmup is now needed only when `ASCEND_BUFFER_POOL` is enabled.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8a680463fab3bc9e6760417cd5c0a6aa58283065
