### PR TITLE
[Feat] Support MXFP8 rollout for veRL on Ascend 950

### DIFF
--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -89,10 +89,80 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         return output
 
     def process_weights_after_loading(self, layer):
+        """Process weights after loading for MXFP8 inference.
+
+        This method transforms weights for NPU MXFP8 computation:
+        - weight: (output_size, input_size) -> (input_size, output_size)
+        - weight_scale: (n_dim, k_dim) -> (k_dim//2, n_dim, 2)
+
+        For RL training scenarios where weights need to be reloaded multiple times,
+        this method stores original shapes and can be called multiple times safely.
+        Use restore_weights_for_rl_loading() before weight reload, then call this
+        method again after loading.
+        """
+
+        # Check if already transformed to avoid double transformation
+        if getattr(layer, "_mxfp8_transformed", False):
+            return
+
+        # Store original shapes for RL weight reloading
+        # Only store on first call (when shapes are in original format)
+        if not hasattr(layer, "_mxfp8_original_shapes"):
+            layer._mxfp8_original_shapes = {
+                "weight": tuple(layer.weight.data.shape),
+                "weight_scale": tuple(layer.weight_scale.data.shape),
+            }
+
         n_dim, k_dim = layer.weight_scale.data.shape
         layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
         layer.weight.data = layer.weight.data.transpose(0, 1)
         layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+
+        # Mark as transformed
+        layer._mxfp8_transformed = True
+
+    def restore_weights_for_rl_loading(self, layer):
+        """Restore weights to original shapes for RL weight reloading.
+
+        This method must be called BEFORE model.load_weights() in RL training
+        loops to restore the tensors to their original shapes that the weight
+        loader expects.
+
+        After weight loading, call process_weights_after_loading() again to
+        re-apply the MXFP8 transformations.
+
+        Shape transformations reversed:
+        - weight: (input_size, output_size) -> (output_size, input_size)
+        - weight_scale: (k_dim//2, n_dim, 2) -> (n_dim, k_dim)
+        """
+
+        if not getattr(layer, "_mxfp8_transformed", False):
+            # Not transformed, nothing to restore
+            return
+
+        if not hasattr(layer, "_mxfp8_original_shapes"):
+            raise RuntimeError(
+                "Cannot restore weights: original shapes not recorded. "
+                "This should not happen if process_weights_after_loading was called first."
+            )
+
+        orig_shapes = layer._mxfp8_original_shapes
+        orig_scale_shape = orig_shapes["weight_scale"]
+
+        # Restore weight: (input_size, output_size) -> (output_size, input_size)
+        target_weight = layer.weight.data.transpose(0, 1).contiguous()
+        layer.weight.data = layer.weight.data.transpose(0, 1)
+        layer.weight.data.copy_(target_weight)
+
+        # Restore weight_scale: (k_dim//2, n_dim, 2) -> (n_dim, k_dim)
+        # Current shape: (k_dim//2, n_dim, 2)
+        # Target shape: (n_dim, k_dim)
+        target_scale = layer.weight_scale.data.transpose(0, 1).reshape(orig_scale_shape).contiguous()
+        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).view(orig_scale_shape)
+        layer.weight_scale.data.copy_(target_scale)
+
+        # Mark as not transformed (ready for weight loading)
+        layer._mxfp8_transformed = False
 
 
 @register_scheme("W8A8_MXFP8", "moe")
@@ -209,6 +279,34 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         )
 
     def process_weights_after_loading(self, layer):
+        """Process weights after loading for MXFP8 inference.
+
+        This method transforms weights for NPU MXFP8 computation:
+        - w13_weight: (g_num, n_size, k_size) -> (g_num, k_size, n_size)
+        - w2_weight: (g_num, n_size, k_size) -> (g_num, k_size, n_size)
+        - w13_weight_scale: (g_num, n_size, k_size) -> (g_num, k_size//2, n_size, 2)
+        - w2_weight_scale: (g_num, n_size, k_size) -> (g_num, k_size//2, n_size, 2)
+
+        For RL training scenarios where weights need to be reloaded multiple times,
+        this method stores original shapes and can be called multiple times safely.
+        Use restore_weights_for_rl_loading() before weight reload, then call this
+        method again after loading.
+        """
+
+        # Check if already transformed to avoid double transformation
+        if getattr(layer, "_mxfp8_transformed", False):
+            return
+
+        # Store original shapes for RL weight reloading
+        # Only store on first call (when shapes are in original format)
+        if not hasattr(layer, "_mxfp8_original_shapes"):
+            layer._mxfp8_original_shapes = {
+                "w13_weight": tuple(layer.w13_weight.data.shape),
+                "w13_weight_scale": tuple(layer.w13_weight_scale.data.shape),
+                "w2_weight": tuple(layer.w2_weight.data.shape),
+                "w2_weight_scale": tuple(layer.w2_weight_scale.data.shape),
+            }
+
         g_num, n_size, k_size = layer.w13_weight_scale.shape
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g_num, n_size, k_size // 2, 2)
         g_num, n_size, k_size = layer.w2_weight_scale.shape
@@ -217,3 +315,57 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2)
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2)
+
+        # Mark as transformed
+        layer._mxfp8_transformed = True
+
+    def restore_weights_for_rl_loading(self, layer):
+        """Restore weights to original shapes for RL weight reloading.
+
+        This method must be called BEFORE model.load_weights() in RL training
+        loops to restore the tensors to their original shapes that the weight
+        loader expects.
+
+        After weight loading, call process_weights_after_loading() again to
+        re-apply the MXFP8 transformations.
+
+        Shape transformations reversed:
+        - w13_weight: (g_num, k_size, n_size) -> (g_num, n_size, k_size)
+        - w2_weight: (g_num, k_size, n_size) -> (g_num, n_size, k_size)
+        - w13_weight_scale: (g_num, k_size//2, n_size, 2) -> (g_num, n_size, k_size)
+        - w2_weight_scale: (g_num, k_size//2, n_size, 2) -> (g_num, n_size, k_size)
+        """
+
+        if not getattr(layer, "_mxfp8_transformed", False):
+            # Not transformed, nothing to restore
+            return
+
+        if not hasattr(layer, "_mxfp8_original_shapes"):
+            raise RuntimeError(
+                "Cannot restore weights: original shapes not recorded. "
+                "This should not happen if process_weights_after_loading was called first."
+            )
+
+        orig_shapes = layer._mxfp8_original_shapes
+
+        def _restore(weight_key: str, scale_key: str):
+            """Helper to restore a single MoE weight and its scale using safe memory copies."""
+            # --- 1. Restore Weight ---
+            weight_tensor = getattr(layer, weight_key)
+            target_weight = weight_tensor.data.transpose(1, 2).contiguous()
+            weight_tensor.data = weight_tensor.data.transpose(1, 2)
+            weight_tensor.data.copy_(target_weight)
+
+            # --- 2. Restore Weight Scale ---
+            scale_tensor = getattr(layer, scale_key)
+            orig_scale_shape = orig_shapes[scale_key]
+
+            target_scale = scale_tensor.data.transpose(1, 2).reshape(orig_scale_shape).contiguous()
+            scale_tensor.data = scale_tensor.data.transpose(1, 2).view(orig_scale_shape)
+            scale_tensor.data.copy_(target_scale)
+
+        _restore("w13_weight", "w13_weight_scale")
+        _restore("w2_weight", "w2_weight_scale")
+
+        # Mark as not transformed (ready for weight loading)
+        layer._mxfp8_transformed = False

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -216,7 +216,7 @@ class NPUWorker(WorkerBase):
 
         hidden_size = self.vllm_config.model_config.hf_text_config.hidden_size
         model = self.model_runner.model
-        if tags is None or "weights" in tags:
+        if self.vllm_config.quant_config is None and (tags is None or "weights" in tags):
             for name, param in model.named_parameters():
                 if "w2_weight" in name and param.shape[2] == hidden_size:
                     parts = name.split(".")


### PR DESCRIPTION
### What this PR does / why we need it?

Enables MXFP8 rollout in veRL v0.8.0 when using Ascend 950 devices (DV100 and DV120).

**Key Changes:**

1. verl Integration: Implements the `restore_weights_for_rl_loading` method (required by veRL but previously missing in the Ascend backend).  Additional `_mxfp8_transformed` flag is attached, allowing for the correct sequential execution of `process_weights_after_loading` under the W8A8 MXFP8 config.
2. Attribute Protection: Adds quantization configuration checks to prevent resetting attributes of `w13` and `w2` weights when quantization is enabled.

### Does this PR introduce _any_ user-facing change?

No additional user-facing change

### How was this patch tested?
Tested by running Qwen3 Dense and MoE models on DV120.

Dense: Qwen3-06B, Qwen3-32B

MoE: Qwen3-30B-A3B

`export PYTORCH_NPU_ALLOC_CONF="expandable_segments:False` because expandable_segments are not supported in memory pool when invoking vllm using verl.


- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8a680463fab3bc9e6760417cd5c0a6aa58283065
