### PR TITLE
[Bugfix] Fix the bug of MTP1 crashing in multiple concurrent scenarios.

### DIFF
--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -56,7 +56,6 @@ def rejection_greedy_sample_spec_len_1_triton(
 
     draft_token_id = tl.load(draft_token_ids_ptr + offset, mask)
     target_argmax_id = tl.load(target_argmax_ptr + offset, mask)
-    # Use batch_mask when writing to output_token_ids to avoid out-of-bounds errors
     tl.store(output_token_ids_ptr + offset * 2, target_argmax_id, mask)
 
     # Add validity check for pos within the loop


### PR DESCRIPTION
### What this PR does / why we need it?
The triton operator does not perform boundary checks on the global position within the loop, leading to the memory overflow in scenarios with multiple concurrency + 1-step  MTP launch.

Solution: Add a check that global_pos < vec_len, and strictly limit the boundaries of all memory accesses to avoid out-of-bounds writes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d

Signed-off-by: chenyue1122 <oyoy7102@163.com>

