### PR TITLE
[UT] Optimize prefix caching validation: focus on prefill TTFT gains under full concurrency

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
@@ -42,7 +42,7 @@ test_cases:
       - metric: "TTFT"
         baseline: "prefix0"
         target: "prefix75"
-        ratio: 0.6
+        ratio: 0.4
         operator: "<"
     benchmarks:
       warm_up:

--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-Qwen3-32B-Int8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-Qwen3-32B-Int8.yaml
@@ -35,7 +35,7 @@ test_cases:
       - metric: "TTFT"
         baseline: "prefix0"
         target: "prefix75"
-        ratio: 0.6
+        ratio: 0.4
         operator: "<"
     benchmarks:
       warm_up:


### PR DESCRIPTION

## What this PR does / why we need it?

Current test cases mix prefill and decode phases, obscuring the true performance benefits of prefix caching. This PR refocuses validation on the core optimization target: **prefill TTFT reduction under full concurrent load with high cache hit ratios**.

## Theoretical Analysis

In continuous batch scheduling, `n` requests are scheduled `k` times, with `m` requests per batch. Assuming each batch has consistent total input length and first batch TTFT is `T`:

- Batch 1: TTFT = T

- Batch 2: TTFT = 2T (waiting for Batch 1)

- Batch k: TTFT = kT

**Average TTFT (without cache)**:

$$\text{TTFT}_{\text{ave}} = \frac{T + 2T + \dots + kT}{k} = \frac{(k + 1)T}{2}$$

When `r` ratio of tokens hit cache, computation per request becomes `(1-r)`. Batch capacity increases from `m` to `m/(1-r)`:

$$k' = k \cdot (1 - r)$$

**Performance Gain Definition** (reduction in average TTFT):

$$\text{Gain} = 1 - \frac{\text{TTFT}_{\text{ave, cached}}}{\text{TTFT}_{\text{ave, random}}} = 1 - \frac{k' + 1}{k + 1}$$

Substituting $k' = k(1-r)$:

$$\boxed{\text{Gain} = \frac{k \cdot r}{k + 1}}$$

**Key Insight**: When scheduling rounds increase (k → ∞), gain asymptotically approaches cache hit ratio r:

$$\lim_{k \to \infty} \text{Gain} = r$$

## Practical Validation: UT Analysis

### Case Parameters

- Total requests: **210**

- Max concurrent: **18**

- Input length: **1024 tokens**

- Max batched tokens: **4096**

- Output length: **1 tokens**

- Cache hit ratio: **75%**

### Calculation

#### Step 1: Baseline Batch Capacity (without cache)

Limited by max-num-batched-tokens:

$$m = \min(18, \lfloor 4096 / 1024 \rfloor) = \min(18, 4) = 4 \text{ requests/batch}$$

Initial scheduling rounds:

$$k = \lceil 210 / 4 \rceil = 53 \text{ rounds}$$

#### Step 2: With 75% Cache Hit

Effective computation per request:

$$\text{Tokens per request} = 1024 \times (1 - 0.75) = 256 \text{ tokens}$$

New batch capacity:

$$m' = \min(18, \lfloor 4096 / 256 \rfloor) = \min(18, 16) = 16 \text{ requests/batch}$$

Scheduling rounds with cache:

$$k' = \lceil 210 / 16 \rceil = 14 \text{ rounds}$$

#### Step 3: TTFT Performance Gain

$$\text{Gain} = 1 - \frac{k' + 1}{k + 1} = 1 - \frac{14 + 1}{53 + 1} = 1 - \frac{15}{54} = 1 - 0.278 = \text{72.22\%}$$

**Result**: ~72% TTFT improvement, approaching the 75% cache hit ratio as predicted by theory.

---

## Test Case Updates

### 1. Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml

- Model: DeepSeek-R1-0528-W8A8 (MoE + speculative decoding)

- Updated dataset: `prefix75-in3500-bs210` (75% cache hit validation)

- TTFT gain target: 60% (conservative, real-world 72% achievable)

- Tensor parallel: 8, Data parallel: 2

### 2. Prefix-Cache-Qwen3-32B-Int8.yaml

- Model: Qwen3-32B (dense model)

- Updated dataset: `prefix75-in3500-bs210` (75% cache hit validation)

- TTFT gain target: 60% (conservative)

- Tensor parallel: 4

## Key Design Decisions

Prefill-Only Focus: Unlike the decode phase, which is bound by sequential dependencies, the prefill phase scales with compute availability. Caching allows for 4x-16x batch scaling, making it the primary optimization lever.

Conservative Target (60%): While theory predicts ~72%, the 60% threshold accounts for real-world production overheads (Kernel launch latency, Cache management, etc.) while ensuring CI stability.

## Summary of Modified Files

Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml

Prefix-Cache-Qwen3-32B-Int8.yaml


- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8a680463fab3bc9e6760417cd5c0a6aa58283065
