### PR TITLE
Release v0.17.1rc1

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -30,6 +30,7 @@ on:
         type: choice
         options:
           - main
+          - v0.17.1rc1
           - v0.17.0rc1
           - v0.16.0rc1
           - v0.15.0rc1

--- a/.github/workflows/schedule_update_estimated_time.yaml
+++ b/.github/workflows/schedule_update_estimated_time.yaml
@@ -23,7 +23,7 @@ jobs:
     name: e2e-test
     strategy:
       matrix:
-        vllm_version: [v0.17.0]
+        vllm_version: [v0.17.1]
         type: [full, light]
     uses: ./.github/workflows/_e2e_test.yaml
     with:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please use the following recommended versions to get started quickly:
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-| v0.17.0rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) for more details |
+| v0.17.1rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) for more details |
 | v0.13.0 | Latest stable version | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.13.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.13.0/installation.html) for more details |
 
 ## Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,7 +57,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-|v0.17.0rc1| 最新RC版本 |请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)了解更多|
+|v0.17.1rc1| 最新RC版本 |请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)了解更多|
 |v0.13.0| 最新正式/稳定版本 |[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.13.0/quick_start.html) and [安装指南](https://docs.vllm.ai/projects/ascend/en/v0.13.0/installation.html)了解更多|
 
 ## 贡献

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -23,6 +23,7 @@ The table below is the release compatibility matrix for vLLM Ascend release.
 
 | vLLM Ascend | vLLM              | Python          | Stable CANN |        PyTorch/torch_npu        | Triton Ascend |
 |-------------|-------------------|-----------------|-------------|---------------------------------|---------------|
+| v0.17.1rc1  | v0.17.1           | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
 | v0.17.0rc1  | v0.17.0           | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
 | v0.16.0rc1  | v0.16.0           | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
 | v0.15.0rc1  | v0.15.0           | >= 3.10, < 3.12 | 8.5.0       | 2.9.0  / 2.9.0                  | 3.2.0         |
@@ -67,6 +68,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | Date       | Event                                     |
 |------------|-------------------------------------------|
+| 2026.03.20 | Release candidates, v0.17.1rc1            |
 | 2026.03.15 | Release candidates, v0.17.0rc1            |
 | 2026.03.10 | Release candidates, v0.16.0rc1            |
 | 2026.02.27 | Release candidates, v0.15.0rc1            |

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ copyright = "2025, vllm-ascend team"
 author = "the vllm-ascend team"
 
 # The full version, including alpha/beta/rc tags
-release = ""
+release = "0.17.1rc1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,6 +2,7 @@
 
 ## Version Specific FAQs
 
+- [[v0.17.1rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/7466)
 - [[v0.17.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/7173)
 - [[v0.13.0] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/6583)
 

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,5 +1,63 @@
 # Release Notes
 
+## v0.17.1rc1 - 2026.03.20
+
+This is the rc1 release candidate of v0.17.1 for vLLM Ascend. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.
+
+### Highlights
+
+* Upgraded upstream vLLM main branch to 0317 afternoon version (#7409, #7213).
+* Supported DeepSeek-V3.1 Prefill-Decode (PD) Separation and C8 Quantization (#7222).
+* Introduced virtual push functionality on node D for LayerwiseConnector in P/D Separation (#7361).
+* Expanded hardware support on Ascend 310P for Mamba Cache and attention head size larger than 128 (#7372).
+* Replaced `npu_ring_mla` with FIA in MLA prefill for improved performance (#5704).
+
+### Features
+
+* Supported DeepSeek-V3.1 PD separation and C8 quantization (#7222).
+* Supported virtual push functionality on node D for LayerwiseConnector in P/D Separation (#7361).
+* Fixed model type bug for `qwen3_vl_8b_instruct_w8a8` (#7383).
+* Fixed DeepSeek indexer accuracy problem caused by k rope (#7341).
+* Fixed assertion error when decode prefix cache fully hits (#7236).
+* Fixed bugs related to A2 MOE method, layerwise MTP, and Mamba `gdn_metadata` (#7364).
+* Fixed bug for Eagle3 and cp enable (#7309).
+* Fixed `TransposeKvCacheByBlock` op error report in plog (#7235).
+* Fixed the problem that Eagle3 crashes in `FULL_DECODE_ONLY` mode (#7290).
+
+### Hardware and Operator Support
+
+* Supported Mamba Cache and `attn_head_size` larger than 128 on Ascend 310P (#7372).
+* Supported `mrope` and `deepstack` features in xlite backend (#7295).
+
+### Performance
+
+* Replaced `npu_ring_mla` with FIA in MLA prefill for better performance (#5704).
+* Enabled `dispatch_ffn_combine` feature for Qwen 3.5 (#7066).
+* Optimized bias handling in `AscendRMSNorm` (#7226).
+* Optimized the performance of the `_topk_log_softmax_kernel` (#7221).
+
+### Dependencies
+
+* Upgraded upstream vLLM main branch to 0317 afternoon version (#7409).
+* Upgraded upstream vLLM main branch to 0308 version (#7213).
+
+### Documentation
+
+* Added Prefill-Decode Disaggregation documentation for GLM-5 (#7300), and a known issue for GLM-5 2-node PD mixed deployment (#7436).
+* Added documentation for Kimi-K2.5 (#7371).
+* Added MiniMax-M2.5 model introduction (#7296).
+* Revised KV Pool User Guide (#7434).
+* Refreshed the documentation for DeepSeek-V3.2 (#7403) and GLM-4.7 (#7292).
+* Uploaded documentation for `qwen3.5-27B` and `qwen3.5-397B-A17B` on Ascend (#7313).
+
+### Others
+
+* Dropped the Prefetch MLP environment variable (#7357).
+* Fixed logger which does not take effect in patches (#7402).
+* Fixed unzip file path for fia operator (#7367).
+* Restored pr-7029 and fixed patch error (#7294).
+
+
 ## v0.17.0rc1 - 2026.03.15
 
 This is the first release candidate of v0.17.0 for vLLM Ascend. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.


### PR DESCRIPTION
Release notes and version updates for v0.17.1rc1
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8a680463fab3bc9e6760417cd5c0a6aa58283065
