### PR TITLE
Only specify issue auto-add label

### DIFF
--- a/.github/workflows/bot_issue_manage.yaml
+++ b/.github/workflows/bot_issue_manage.yaml
@@ -10,8 +10,13 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.issue.labels.*.name, 'document') ||
+      contains(github.event.issue.labels.*.name, 'installation') ||
+      contains(github.event.issue.labels.*.name, 'usage') ||
+      contains(github.event.issue.labels.*.name, 'bug')
     steps:
-    - uses: github/issue-labeler@v3.4 
+    - uses: github/issue-labeler@v3.4
       with:
         configuration-path: .github/issue-labeler.yml
         enable-versioned-regex: 0


### PR DESCRIPTION
### What this PR does / why we need it?
Optimize the current automatic issue tagging mechanism so that only issues with specific labels(document, installation, usage, bug) are automatically tagged.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA
- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8b6325758cce5f9c36d38f2462edbd368b97a07c
