### PR TITLE
[CI] Recover pd disaggregated encoder test case that been incorrectly skipped

### DIFF
--- a/tests/e2e/multicard/2-cards/test_disaggregated_encoder.py
+++ b/tests/e2e/multicard/2-cards/test_disaggregated_encoder.py
@@ -32,9 +32,6 @@ TENSOR_PARALLELS = [1]
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tp_size", TENSOR_PARALLELS)
 async def test_models(model: str, tp_size: int) -> None:
-    pytest.skip(
-        "EPLB output is different without EPLB, see issue: https://github.com/vllm-project/vllm-ascend/issues/7408",
-    )
     encode_port = get_open_port()
     pd_port = get_open_port()
     vllm_server_args = [


### PR DESCRIPTION
### What this PR does / why we need it?
[CI] Recover pd disaggregated encoder test case that been incorrectly skipped in PR: https://github.com/vllm-project/vllm-ascend/pull/7412

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8b6325758cce5f9c36d38f2462edbd368b97a07c
