### PR TITLE
[P/D] [Bugfix] fix mooncake layerconnector dead when update_decoder_info fail

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -1628,7 +1628,7 @@ class MooncakeLayerwiseConnectorWorker:
                 try:
                     req_meta_update = self.update_decoder_info(req_id, req_meta)
                 except Exception as e:
-                    logger.error(
+                    logger.warning(
                         f"MooncakeLayerwiseConnector transfer fail for req_id {req_id} in layer_idx "
                         f"{self.current_layer}, update_decoder_info with error: {e}"
                     )


### PR DESCRIPTION

### What this PR does / why we need it?
Fix mooncake layerconnector dead when update_decoder_info fail. For the scenario where node D is dead, node P failing to update_decoder_info should not cause node P to become dead.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
by CI

- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8b6325758cce5f9c36d38f2462edbd368b97a07c
