### PR TITLE
[main][bugfix] Solved the problem of the d node getting stuck in the pd-separation scenario

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -442,7 +442,6 @@ class SpecDecodeBaseProposer(EagleProposer):
                 target_positions=model_positions,
                 inputs_embeds=None,
                 multi_steps_attn_metadata=multi_steps_attn_metadata,
-                is_dummy=True,
                 num_tokens=num_tokens,
             )
             forward_context = get_forward_context()
@@ -708,7 +707,6 @@ class SpecDecodeBaseProposer(EagleProposer):
         inputs_embeds,
         multi_steps_attn_metadata,
         num_tokens,
-        is_dummy=False,
         is_prefill=None,
     ) -> torch.Tensor:
         # The lifecycle of `input_ids`, `positions`, `hidden_states` runs through all
@@ -761,7 +759,7 @@ class SpecDecodeBaseProposer(EagleProposer):
                     self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: last_hidden_states.shape[0]],
                 )
 
-        if lmhead_tp_enable() and not is_dummy:
+        if lmhead_tp_enable():
             max_num_reqs_across_dp = (
                 self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
             )
@@ -772,7 +770,7 @@ class SpecDecodeBaseProposer(EagleProposer):
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
         logits = self.model.compute_logits(sample_hidden_states)
 
-        if lmhead_tp_enable() and num_indices < logits.shape[0] and not is_dummy:
+        if lmhead_tp_enable() and num_indices < logits.shape[0]:
             logits = logits[:num_indices]
             token_indices_to_sample = token_indices_to_sample[:num_indices]
 
@@ -885,7 +883,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             )
 
             num_indices = token_indices_to_sample.shape[0]
-            if lmhead_tp_enable() and not is_dummy:
+            if lmhead_tp_enable():
                 max_num_reqs_across_dp = (
                     self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
                 )
@@ -897,7 +895,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             sample_hidden_states = last_hidden_states[token_indices_to_sample]
             logits = self.model.compute_logits(sample_hidden_states)
 
-            if lmhead_tp_enable() and num_indices < logits.shape[0] and not is_dummy:
+            if lmhead_tp_enable() and num_indices < logits.shape[0]:
                 logits = logits[:num_indices]
                 token_indices_to_sample = token_indices_to_sample[:num_indices]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

A problem of the d node getting stuck in the pd-separation scenario is solved.

The error message was:

```text
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880] Traceback (most recent call last):
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm/vllm/v1/executor/multiproc_executor.py", line 875, in worker_busy_loop
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     output = func(*args, **kwargs)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]              ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/worker/worker.py", line 584, in execute_dummy_batch
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     self.model_runner._dummy_run(num_tokens=self.model_runner.decode_token_per_req, uniform_decode=True)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return func(*args, **kwargs)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2483, in _dummy_run
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     self.drafter.dummy_run(
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return func(*args, **kwargs)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/spec_decode/eagle_proposer.py", line 431, in dummy_run
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     self._runnable(
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/spec_decode/eagle_proposer.py", line 775, in _run_merged_draft
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     logits = self.model.compute_logits(sample_hidden_states)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm/vllm/model_executor/models/deepseek_mtp.py", line 233, in compute_logits
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return self.model.compute_logits(hidden_states, spec_step_idx)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm/vllm/model_executor/models/deepseek_mtp.py", line 176, in compute_logits
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     logits = self.logits_processor(
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]              ^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return self._call_impl(*args, **kwargs)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return forward_call(*args, **kwargs)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm/vllm/model_executor/layers/logits_processor.py", line 64, in forward
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     logits = self._get_logits(hidden_states, lm_head, embedding_bias)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/ops/vocab_parallel_embedding.py", line 254, in _get_logits
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return self._get_logits_lmheadtp(hidden_states, lm_head, embedding_bias)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/ops/vocab_parallel_embedding.py", line 270, in _get_logits_lmheadtp
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     local_logits = lm_head.quant_method.apply(lm_head, gathered_hidden_states, bias=embedding_bias)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm/vllm/model_executor/layers/vocab_parallel_embedding.py", line 69, in apply
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/patch/worker/patch_unquantized_gemm.py", line 55, in default_unquantized_gemm
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return torch.ops.vllm.unquantized_gemm(x, weight, bias)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/usr/local/python3.11.10/lib/python3.11/site-packages/torch/_ops.py", line 1255, in __call__
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return self._op(*args, **kwargs)
(Worker pid=611608) (Worker_DP4_EP4 pid=611608) (Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880]   File "/llsm/vllm-ascend/vllm_ascend/patch/worker/patch_unquantized_gemm.py", line 27, in unquantized_gemm
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880]     return torch.nn.functional.linear(x, weight, bias)
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880] RuntimeError: RunOpApiV2:build/CMakeFiles/torch_npu.dir/compiler_depend.ts:256 NPU function error: c10_npu::acl::AclrtSynchronizeStreamWithTimeout(stream), error code is 507034
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880] [ERROR] 2026-03-21-17:14:47 (PID:611609, Device:0, RankID:-1) ERR00100 PTA call acl api failed
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880] [Error]: Vector core execution timed out. 
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880]         Rectify the fault based on the error information in the ascend log.
(Worker pid=611609) (Worker_DP3_EP3 pid=611609) ERROR 03-21 17:14:47 [multiproc_executor.py:880] [PID: 611609] 2026-03-21-17:14:47.426.192 Communication_Error_Timeout(EI0002): The wait execution of the Notify register times out. Reason: The Notify register has not received the Notify record from remote rank: [0]. base information: [streamID:[38], taskID[264], taskType[Task AIV], tag[AllGather_group_name_265], AlgType(level 0-1-2):[ring-ring-ring].]. task information: [cmdType:[6], tag:[26], size:[14336], blockDim:[8], rankSize:[8], aivRdmaStep:[-1], flagMem:[0x12c0e0a00000], isOpbase:[1]
```

We find it will crash at `torch.nn.functional.linear(x, weight, bias)` after being stuck for a long time.

But why would matrix multiplication get stuck? That's impossible.

After a long period of debugging, we found that the shapes of each dp node were not aligned. this is the root cause.

```text
(Worker pid=611606) (Worker_DP10_EP10 pid=611606) last_hidden_states.shape=torch.Size([2, 7168]) + token_indices_to_sample.shape=torch.Size([1])
(Worker pid=611606) (Worker_DP10_EP10 pid=611606) torch.distributed.get_rank()=10 get_lmhead_tp_group()=<vllm_ascend.patch.worker.patch_distributed.GroupCoordinatorPatch object at 0xfffe5d2c6e50> hidden_states.shape=torch.Size([1, 7168]) hidden_states.dtype=torch.bfloat16
(Worker pid=611607) (Worker_DP11_EP11 pid=611607) last_hidden_states.shape=torch.Size([2, 7168]) + token_indices_to_sample.shape=torch.Size([1])
(Worker pid=611607) (Worker_DP11_EP11 pid=611607) torch.distributed.get_rank()=11 get_lmhead_tp_group()=<vllm_ascend.patch.worker.patch_distributed.GroupCoordinatorPatch object at 0xfffe60570990> hidden_states.shape=torch.Size([1, 7168]) hidden_states.dtype=torch.bfloat16
(Worker pid=611605) (Worker_DP8_EP8 pid=611605) torch.distributed.get_rank()=8 all_gather end
(Worker pid=611606) (Worker_DP10_EP10 pid=611606) torch.distributed.get_rank()=10 all_gather end
(Worker pid=611607) (Worker_DP11_EP11 pid=611607) torch.distributed.get_rank()=11 all_gather end
(Worker pid=611601) (Worker_DP0_EP0 pid=611601) token_indices_to_sample: %s tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
(Worker pid=611601) (Worker_DP0_EP0 pid=611601)         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
(Worker pid=611601) (Worker_DP0_EP0 pid=611601)         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
(Worker pid=611601) (Worker_DP0_EP0 pid=611601)        device='npu:0', dtype=torch.int32)
(Worker pid=611601) (Worker_DP0_EP0 pid=611601) num_indices: %s 1
(Worker pid=611601) (Worker_DP0_EP0 pid=611601) torch.distributed.get_rank()=0 ends
(Worker pid=611601) (Worker_DP0_EP0 pid=611601) last_hidden_states.shape=torch.Size([2, 7168]) + token_indices_to_sample.shape=torch.Size([72])
(Worker pid=611601) (Worker_DP0_EP0 pid=611601) torch.distributed.get_rank()=0 get_lmhead_tp_group()=<vllm_ascend.patch.worker.patch_distributed.GroupCoordinatorPatch object at 0xfffe5add7d90> hidden_states.shape=torch.Size([72, 7168]) hidden_states.dtype=torch.bfloat16
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

N/A

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

After applying the changes in this PR, the result is okay.

```text
curl http://90.90.97.15:1999/v1/completions     -H "Content-Type: application/json"     -d '{
        "model": "ds_r1",
        "prompt": "San Francisco is a",
        "max_tokens": 10,
        "temperature": 0
    }'
{"id":"cmpl-38ee1574-04e4-4e02-a3d9-73584b6db9b2","object":"text_completion","created":1774162887,"model":"ds_r1","choices":[{"index":0,"text":" city that is known for its vibrant culture, stunning","logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":5,"total_tokens":15,"completion_tokens":10,"prompt_tokens_details":null},"kv_transfer_params":null}
```

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/4034c3d32e30d01639459edd3ab486f56993876d
