### PR TITLE
[Bugfix][CI] Fix aisbench installation to avoid Gitee authentication

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -88,6 +88,7 @@ jobs:
         if: ${{ inputs.is_pr_test }}
         run: |
           pip uninstall -y vllm vllm-ascend || true
+          cp -r /vllm-workspace/vllm-ascend/benchmark /tmp/aisbench-backup || true
           rm -rf /vllm-workspace/vllm /vllm-workspace/vllm-ascend
 
       - name: Checkout vllm-project/vllm repo
@@ -132,9 +133,9 @@ jobs:
 
       - name: Install aisbench
         if: ${{ inputs.is_pr_test }}
-        shell: bash -l {0} 
+        shell: bash -l {0}
         run: |
-          git clone -b v3.0-20250930-master --depth 1 https://gitee.com/aisbench/benchmark.git /vllm-workspace/vllm-ascend/benchmark
+          cp -r /tmp/aisbench-backup /vllm-workspace/vllm-ascend/benchmark
           cd /vllm-workspace/vllm-ascend/benchmark
           pip install pytest asyncio pytest-asyncio
           pip install -e . -r requirements/api.txt -r requirements/extra.txt

--- a/.github/workflows/dockerfiles/Dockerfile.nightly.a2
+++ b/.github/workflows/dockerfiles/Dockerfile.nightly.a2
@@ -20,6 +20,8 @@ FROM quay.io/ascend/vllm-ascend:main
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"
 ARG AIS_BENCH_URL="https://gitee.com/aisbench/benchmark.git"
+ARG GITEE_USERNAME=""
+ARG GITEE_TOKEN=""
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
@@ -35,7 +37,8 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip cache purge
 
 # Install benchmark tools
-RUN git clone -b ${AIS_BENCH_TAG} --depth 1 ${AIS_BENCH_URL} /vllm-workspace/vllm-ascend/benchmark && \
+RUN CLONE_URL=$(echo "${AIS_BENCH_URL}" | sed "s|https://|https://${GITEE_USERNAME}:${GITEE_TOKEN}@|") && \
+    git clone -b ${AIS_BENCH_TAG} --depth 1 "${CLONE_URL}" /vllm-workspace/vllm-ascend/benchmark && \
     cd /vllm-workspace/vllm-ascend/benchmark && \
     pip install -e . -r requirements/api.txt -r requirements/extra.txt && \
     python3 -m pip cache purge

--- a/.github/workflows/dockerfiles/Dockerfile.nightly.a3
+++ b/.github/workflows/dockerfiles/Dockerfile.nightly.a3
@@ -20,6 +20,8 @@ FROM quay.io/ascend/vllm-ascend:main-a3
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"
 ARG AIS_BENCH_URL="https://gitee.com/aisbench/benchmark.git"
+ARG GITEE_USERNAME=""
+ARG GITEE_TOKEN=""
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive
@@ -35,7 +37,8 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     python3 -m pip cache purge
 
 # Install benchmark tools
-RUN git clone -b ${AIS_BENCH_TAG} --depth 1 ${AIS_BENCH_URL} /vllm-workspace/vllm-ascend/benchmark && \
+RUN CLONE_URL=$(echo "${AIS_BENCH_URL}" | sed "s|https://|https://${GITEE_USERNAME}:${GITEE_TOKEN}@|") && \
+    git clone -b ${AIS_BENCH_TAG} --depth 1 "${CLONE_URL}" /vllm-workspace/vllm-ascend/benchmark && \
     cd /vllm-workspace/vllm-ascend/benchmark && \
     pip install -e . -r requirements/api.txt -r requirements/extra.txt && \
     python3 -m pip cache purge

--- a/.github/workflows/schedule_nightly_image_build.yaml
+++ b/.github/workflows/schedule_nightly_image_build.yaml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Build image
         id: build-image
+        env:
+          GITEE_USERNAME: ${{ vars.GITEE_USERNAME }}
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
         run: |
           TARGET="${{ matrix.target }}"
           IMAGE_TAG="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${TARGET}"
@@ -50,6 +53,8 @@ jobs:
             --build-arg CANN_VERSION="8.5.1" \
             --build-arg UBUNTU_VERSION="22.04" \
             --build-arg PYTHON_VERSION="3.11" \
+            --build-arg GITEE_USERNAME="${GITEE_USERNAME}" \
+            --build-arg GITEE_TOKEN="${GITEE_TOKEN}" \
             -t "$IMAGE_TAG" .
 
           echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -139,6 +139,7 @@ checkout_src() {
     mkdir -p "$WORKSPACE"
     cd "$WORKSPACE"
     pip uninstall -y vllm vllm-ascend || true
+    cp -r "$WORKSPACE/vllm-ascend/benchmark" /tmp/aisbench-backup || true
     rm -rf "$WORKSPACE/vllm" "$WORKSPACE/vllm-ascend"
 
     if [ ! -d "$WORKSPACE/vllm-ascend" ]; then
@@ -170,19 +171,10 @@ install_vllm() {
 
 install_aisbench() {
     echo "====> Install AISBench benchmark"
-    
-    export AIS_BENCH_URL="https://gitee.com/aisbench/benchmark.git"
-    : "${AIS_BENCH_TAG:=v3.0-20250930-master}"  
 
     BENCH_DIR="$WORKSPACE/vllm-ascend/benchmark"
 
-    if [ -d "$BENCH_DIR" ]; then
-        echo "Removing existing benchmark directory..."
-        rm -rf "$BENCH_DIR"
-    fi
-
-    git clone -b "${AIS_BENCH_TAG}" --depth 1 \
-        "${AIS_BENCH_URL}" "${BENCH_DIR}"
+    cp -r /tmp/aisbench-backup "$BENCH_DIR"
 
     cd "$BENCH_DIR"
     pip install -e . \


### PR DESCRIPTION
### What this PR does / why we need it?
- Pass GITEE_USERNAME (var) and GITEE_TOKEN (secret) as Docker build
  args in nightly image build so Dockerfile can authenticate to Gitee
- In Dockerfile.nightly.a2/a3, embed credentials into clone URL to
  avoid auth failure during `git clone`
- In single-node and multi-node PR test workflows, backup the
  pre-installed benchmark from the nightly image before wiping
  vllm-ascend, then restore it instead of re-cloning from Gitee,
  which is inaccessible from fork PR contexts

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8b6325758cce5f9c36d38f2462edbd368b97a07c
