### PR TITLE
[bugfix][CI]Skip e2e log summary when the log file is missing or empty

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -298,6 +298,7 @@ jobs:
           uv pip install -v -e .
           uv pip install git+https://github.com/modelscope/modelscope.git@dbbcbf631fe6d10cc6446df2ad2fef24039fe7fe
       - name: Run vllm-project/vllm-ascend test (light)
+        if: ${{ false }}
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         shell: bash

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -298,7 +298,6 @@ jobs:
           uv pip install -v -e .
           uv pip install git+https://github.com/modelscope/modelscope.git@dbbcbf631fe6d10cc6446df2ad2fef24039fe7fe
       - name: Run vllm-project/vllm-ascend test (light)
-        if: ${{ false }}
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
         shell: bash

--- a/.github/workflows/scripts/ci_log_summary.py
+++ b/.github/workflows/scripts/ci_log_summary.py
@@ -977,6 +977,8 @@ def main() -> None:
     if args.run_id is not None:
         result = process_run(args.run_id, repo=args.repo)
     else:
+        if not args.log_file.exists() or args.log_file.stat().st_size == 0:
+            return
         log_text = args.log_file.read_text(encoding="utf-8", errors="replace")
         result = process_local_log(log_text, job_name=args.step_name)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Avoid failing `ci_log_summary.py` when the e2e log file is missing or empty.

Test in CI :https://github.com/vllm-project/vllm-ascend/actions/runs/23428406256/job/68149271871
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/8b6325758cce5f9c36d38f2462edbd368b97a07c
