### PR TITLE
main2main upgrade vLLM to 0320

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -166,7 +166,7 @@ class AscendConfig:
         if vllm_version_is("0.17.0"):
             return compilation_config.compile_ranges_split_points
         else:
-            return compilation_config.compile_ranges_endpoints
+            return compilation_config.compile_ranges_endpoints or []
 
     @staticmethod
     def _set_compile_ranges(compilation_config, value):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -251,6 +251,12 @@ class AscendMoERunner(DefaultMoERunner):
         else:
             self.moe_forward = torch.ops.vllm.moe_forward_shared
 
+    @property
+    def use_dp_chunking(self) -> bool:
+        """Ascend uses its own forward_impl path, not the FlashInfer Cutlass
+        chunked path. Always return False to stay on forward_impl."""
+        return False
+
     def forward_impl(
         self,
         layer: torch.nn.Module,


### PR DESCRIPTION
## Summary

Fixes CI failures in `schedule_test_vllm_main` caused by upstream vLLM changes in commit range `6a9cceb219..ed359c497`.

**Commit range:** `6a9cceb219fcbd6b1eb540ddfdc77ec160f0e209`..`ed359c497a728f08b5b41456c07a688ccd510fbc`

### Issues Fixed

- **Issue 1** (`test_qwen3_inference_dp2`): `AttributeError: '_moe_C' object has no attribute 'topk_softmax'`
  - Upstream commit `9279c59a0` ([MoE Refactor] DefaultMoERunner simplification) changed `_moe_forward` to call `forward_impl_chunked()` when `runner.use_dp_chunking` is True.
  - Ascend sets `all2all_backend = "flashinfer_all2allv"` in `platform.py`, which makes `FusedMoEParallelConfig.use_fi_nvl_two_sided_kernels` return True for DP runs, causing `DefaultMoERunner.use_dp_chunking` to return True.
  - `AscendMoERunner` only overrides `forward_impl`, not `forward_impl_chunked`. The base class path calls `torch.ops._moe_C.topk_softmax` which doesn't exist on Ascend.
  - **Fix:** Override `use_dp_chunking = False` in `AscendMoERunner` (same pattern as `SharedFusedMoERunner`).

- **Issue 2** (`test_qwen3_vl_sp_tp2`): `TypeError: object of type 'NoneType' has no len()`
  - Upstream commit `638a872d7` (fix(xpu): Re-compute compile ranges after platform-specific config updates) moved `self._set_compile_ranges()` in `VllmConfig.__post_init__` from before `check_and_update_config()` to after it.
  - Ascend's `update_compile_ranges_split_points()` (called inside `check_and_update_config`) now runs when `compile_ranges_endpoints` is still `None`.
  - **Fix:** `_get_compile_ranges()` returns `compile_ranges_endpoints or []` to handle the `None` case gracefully.

### Test Results

Both fixes reproduced and verified locally:
- `test_qwen3_inference_dp2[32-Qwen/Qwen3-30B-A3B]`: ✅ passes after fix
- `test_qwen3_vl_sp_tp2[Qwen/Qwen3-VL-2B-Instruct]`: ✅ passes after fix (`1 passed in 171.29s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6a9cceb219fcbd6b1eb540ddfdc77ec160f0e209
