### PR TITLE
[Bailing2.5] Enable Ring/Ling 2.5 model on Ascend NPU

### DIFF
--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -111,7 +111,7 @@ class AscendGemmaRMSNorm(GemmaRMSNorm):
 
 class LayerNormFn(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, weight, bias, z=None, eps=1e-6, group_size=None, norm_before_gate=True, is_rms_norm=False):
+    def forward(ctx, x, weight, bias, z=None, eps=1e-6, group_size=None, norm_before_gate=True, is_rms_norm=False, activation: str = "swish"):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
 
         x_shape_og = x.shape

--- a/vllm_ascend/ops/triton/fla/layernorm_guard.py
+++ b/vllm_ascend/ops/triton/fla/layernorm_guard.py
@@ -168,6 +168,7 @@ class LayerNormFn(torch.autograd.Function):
         group_size=None,
         norm_before_gate=True,
         is_rms_norm=False,
+        activation: str = "swish",
     ):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
 

--- a/vllm_ascend/ops/triton/linearnorm/lightning_attention_ops.py
+++ b/vllm_ascend/ops/triton/linearnorm/lightning_attention_ops.py
@@ -1,0 +1,632 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""NPU-compatible linear attention operators for BailingMoE.
+
+This module provides NPU-compatible replacements for GPU-only Triton kernels
+used in BailingMoELinearAttention:
+  - ``linear_decode_forward_npu``: replaces ``linear_decode_forward_triton``
+  - ``LightningAttentionKernelNPU``: replaces ``MiniMaxText01LinearKernel``
+"""
+
+import torch
+
+from einops import rearrange
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _fwd_diag_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    S,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n: tl.constexpr,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    CBLOCK: tl.constexpr,
+    NUM_BLOCK: tl.constexpr,
+):
+    # This kernel computes the diagonal blocks of the attention matrix
+    # Each diagonal block represents attention
+    # where queries attend to keys in the same block
+    off = tl.program_id(0)
+    off_bh = off // NUM_BLOCK  # batch-head index
+    off_block = off % NUM_BLOCK  # block index within the sequence
+    off_cblock = tl.program_id(1)  # sub-block index within a block
+
+    off_h = off_bh % h  # head index
+
+    # Calculate base offsets for the current batch and head
+    qk_offset = off_bh * n * d
+    v_offset = off_bh * n * e
+    o_offset = off_bh * n * e
+
+    # Calculate offsets for the current block
+    block_offset = off_block * BLOCK
+    qk_block_offset = block_offset * d
+    v_block_offset = block_offset * e
+    o_block_offset = block_offset * e
+
+    # Calculate offsets for the current sub-block
+    cblock_offset = off_cblock * CBLOCK
+    q_cblock_offset = cblock_offset * d
+    o_cblock_offset = cblock_offset * e
+
+    # Calculate pointers to the query, key, value, and output tensors
+    Q_block_ptr = (
+        Q
+        + qk_offset
+        + qk_block_offset
+        + q_cblock_offset
+        + tl.arange(0, CBLOCK)[:, None] * d
+        + tl.arange(0, d)[None, :]
+    )
+    K_block_ptr = (
+        K
+        + qk_offset
+        + qk_block_offset
+        + tl.arange(0, CBLOCK)[:, None] * d
+        + tl.arange(0, d)[None, :]
+    )
+    V_block_ptr = (
+        V
+        + v_offset
+        + v_block_offset
+        + tl.arange(0, CBLOCK)[:, None] * e
+        + tl.arange(0, e)[None, :]
+    )
+    O_block_ptr = (
+        Out
+        + o_offset
+        + o_block_offset
+        + o_cblock_offset
+        + tl.arange(0, CBLOCK)[:, None] * e
+        + tl.arange(0, e)[None, :]
+    )
+
+    # Load the decay rate for the current head
+    S_block_ptr = S + off_h
+    s = tl.load(S_block_ptr)
+
+    i = off_cblock
+    q_index = tl.arange(0, CBLOCK) + i * CBLOCK
+
+    # Load query values
+    q = tl.load(Q_block_ptr, mask=block_offset + q_index[:, None] < n, other=0.0).to(
+        tl.float32
+    )
+    # Initialize output accumulator
+    qkv = tl.zeros([CBLOCK, e], dtype=tl.float32)
+
+    # Process all sub-blocks up to and
+    # including the current one (causal attention)
+    for j in range(i + 1):
+        kv_index = tl.arange(0, CBLOCK) + j * CBLOCK
+        diff = q_index[:, None] - kv_index[None, :]
+        s_index = s * diff
+        # Apply causal mask: only attend to positions before the current one
+        s_index = tl.where(diff >= 0, -s_index, float("-inf"))
+        decay = tl.exp(s_index)
+        decay = tl.clamp(decay, -1e6, 1e6)
+
+        # Load key and value
+        k = tl.load(
+            K_block_ptr,
+            mask=block_offset + kv_index[:, None] < n,
+            other=0.0,
+        ).to(tl.float32)
+
+        v = tl.load(
+            V_block_ptr,
+            mask=block_offset + kv_index[:, None] < n,
+            other=0.0,
+        ).to(tl.float32)
+
+        # Compute attention scores and apply decay
+        qk = tl.dot(q, k.trans()) * decay
+
+        # Compute weighted values and accumulate
+        qkv += tl.dot(qk, v)
+
+        # Move to the next sub-block
+        K_block_ptr += CBLOCK * d
+        V_block_ptr += CBLOCK * e
+
+    # Store the result
+    tl.store(
+        O_block_ptr,
+        qkv.to(O_block_ptr.dtype.element_ty),
+        mask=block_offset + q_index[:, None] < n,
+    )
+
+
+@triton.jit
+def _fwd_kv_parallel(
+    K,
+    V,
+    K_decay,
+    KV,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_BLOCK,
+    D_FBLOCK: tl.constexpr,
+    E_FBLOCK: tl.constexpr,
+    NUM_FBLOCK: tl.constexpr,
+    CBLOCK: tl.constexpr,
+    NUM_CBLOCK: tl.constexpr,
+):
+    # This kernel computes the key-value outer
+    # products for each block in parallel
+    off_bh = tl.program_id(0)  # batch-head index
+    off_block = tl.program_id(1)  # block index
+
+    off_h = off_bh % h  # head index
+
+    block_offset = off_block * BLOCK
+
+    # Calculate offsets for the current block
+    k_block_offset = block_offset * d
+    v_block_offset = block_offset * e
+    kv_block_offset = off_block * d * e
+
+    # Calculate base offsets for the current batch and head
+    k_offset = off_bh * n * d
+    v_offset = off_bh * n * e
+    kv_offset = off_bh * NUM_BLOCK * d * e
+
+    # Calculate pointers to the key, value, and key-value tensors
+    K_trans_block_ptr = (
+        K
+        + k_offset
+        + k_block_offset
+        + tl.arange(0, CBLOCK)[None, :] * d
+        + tl.arange(0, D_FBLOCK)[:, None]
+    )
+    V_block_ptr = (
+        V
+        + v_offset
+        + v_block_offset
+        + tl.arange(0, CBLOCK)[:, None] * e
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+    KV_block_ptr = (
+        KV
+        + kv_offset
+        + kv_block_offset
+        + tl.arange(0, D_FBLOCK)[:, None] * e
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+
+    # Load the decay factors for the current head and block
+    k_decay_ptr = K_decay + off_h * BLOCK + tl.arange(0, CBLOCK)
+
+    kv_index = tl.arange(0, CBLOCK)
+
+    # Initialize the key-value outer product accumulator
+    kv = tl.zeros([D_FBLOCK, E_FBLOCK], dtype=tl.float32)
+
+    # Handle the last block which might be smaller than BLOCK
+    split_n = n - (NUM_BLOCK - 1) * BLOCK if off_block == NUM_BLOCK - 1 else BLOCK
+    left_shift = tl.cdiv(split_n, CBLOCK) * CBLOCK - split_n
+    num_blocks = min(tl.cdiv(split_n, CBLOCK), NUM_CBLOCK)
+    k_decay_ptr += (NUM_CBLOCK - num_blocks) * CBLOCK
+
+    # Process all sub-blocks in the current block
+    for j in range(num_blocks):
+        left_bound = (1 - j) * left_shift
+        # Load key and value, handling boundary conditions
+        k_trans = tl.load(
+            K_trans_block_ptr - left_shift * d,
+            mask=kv_index[None, :] >= left_bound,
+            other=0.0,
+        )
+        v = tl.load(
+            V_block_ptr - left_shift * e,
+            mask=kv_index[:, None] >= left_bound,
+            other=0.0,
+        )
+
+        # Load decay factor and compute weighted key-value outer product
+        k_decay = tl.load(k_decay_ptr)
+
+        # NOTE: Need to add the extra dim here due to AMD MLIR lowering error.
+        # Please don't move it back until issue is resolved.
+        # Issue: https://github.com/ROCm/triton/issues/907
+        k_decay = k_decay[None, :]
+
+        kv += tl.dot(k_trans * k_decay, v)
+
+        # Move to the next sub-block
+        K_trans_block_ptr += CBLOCK * d
+        V_block_ptr += CBLOCK * e
+        k_decay_ptr += CBLOCK
+
+    # Store the result
+    tl.store(KV_block_ptr, kv.to(KV_block_ptr.dtype.element_ty))
+
+
+@triton.jit
+def _fwd_kv_reduce(
+    S,
+    KV,
+    KV_HISTORY,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_BLOCK,
+    D_FBLOCK: tl.constexpr,
+    E_FBLOCK: tl.constexpr,
+):
+    # This kernel reduces the key-value outer products
+    # across blocks and updates the KV history
+    off_bh = tl.program_id(0)  # batch-head index
+    off_h = off_bh % h  # head index
+
+    kv_offset = off_bh * NUM_BLOCK * d * e
+
+    # Calculate pointer to the key-value tensor
+    KV_block_ptr = (
+        KV
+        + kv_offset
+        + tl.arange(0, D_FBLOCK)[:, None] * e
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+
+    # Load the decay rate for the current head
+    s_ptrs = S + off_h
+    s = tl.load(s_ptrs)
+
+    # Calculate pointer to the key-value history tensor
+    kv_history_offset = off_bh * d * e
+    KV_HISTORY_block_ptr = (
+        KV_HISTORY
+        + kv_history_offset
+        + tl.arange(0, D_FBLOCK)[:, None] * e
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+
+    # Load the previous key-value history
+    kv_pre = tl.load(KV_HISTORY_block_ptr).to(tl.float32)
+
+    # Process all blocks in reverse order to compute the prefix sum
+    for i in range(NUM_BLOCK):
+        block_size = min(n - i * BLOCK, BLOCK)
+        # Compute decay factor for the current block
+        block_decay = tl.exp(-s.to(tl.float32) * block_size)
+
+        # Load the current key-value outer product
+        kv_cur = tl.load(KV_block_ptr).to(tl.float32)
+        # Store the previous key-value history to the current block
+        tl.store(KV_block_ptr, kv_pre.to(KV_block_ptr.dtype.element_ty))
+
+        # Update the key-value history with the current block
+        kv_pre = block_decay * kv_pre + kv_cur
+        KV_block_ptr += d * e
+
+    # Store the updated key-value history
+    tl.store(KV_HISTORY_block_ptr, kv_pre)
+
+
+@triton.jit
+def _fwd_none_diag_kernel(
+    Q,
+    Out,
+    S,
+    KV,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_BLOCK,
+    E_FBLOCK: tl.constexpr,
+    CBLOCK: tl.constexpr,
+    NUM_CBLOCK: tl.constexpr,
+):
+    # This kernel computes the non-diagonal blocks of the attention matrix
+    # Each non-diagonal block represents attention
+    # where queries attend to keys in different blocks
+    off_bh = tl.program_id(0)  # batch-head index
+    off_h = off_bh % h  # head index
+
+    off_nc = tl.program_id(1)
+    off_n = off_nc // NUM_CBLOCK  # block index
+    off_c = off_nc % NUM_CBLOCK  # sub-block index
+    off_e = tl.program_id(2)  # output feature block index
+
+    n_offset = off_n * BLOCK
+    c_offset = off_c * CBLOCK
+    e_offset = off_e * E_FBLOCK
+    block_offset = n_offset + c_offset
+
+    # Calculate offsets for the current batch, head, and block
+    q_offset = off_bh * n * d + (n_offset + c_offset) * d
+    o_offset = off_bh * n * e + (n_offset + c_offset) * e + e_offset
+    kv_offset = off_bh * NUM_BLOCK * d * e + off_n * d * e + e_offset
+
+    # Calculate pointers to the query, output, and key-value tensors
+    Q_block_ptr = (
+        Q + q_offset + tl.arange(0, CBLOCK)[:, None] * d + tl.arange(0, d)[None, :]
+    )
+    O_block_ptr = (
+        Out
+        + o_offset
+        + tl.arange(0, CBLOCK)[:, None] * e
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+    KV_block_ptr = (
+        KV + kv_offset + tl.arange(0, d)[:, None] * e + tl.arange(0, E_FBLOCK)[None, :]
+    )
+
+    # Load the decay rate for the current head
+    S_block_ptr = S + off_h
+    s = tl.load(S_block_ptr)
+
+    c_array = tl.arange(0, CBLOCK)
+
+    # Load the key-value outer product for the current block
+    kv = tl.load(KV_block_ptr).to(tl.float32)
+    q_index = block_offset + tl.arange(0, CBLOCK)
+
+    # Load query values
+    q = tl.load(Q_block_ptr, mask=q_index[:, None] < n, other=0.0).to(tl.float32)
+
+    # Compute decay factors for the current sub-block
+    q_decay = tl.exp(-s.to(tl.float32) * (off_c * CBLOCK + c_array[:, None]))
+
+    # Compute non-diagonal attention output
+    qkv_none_diag = tl.dot(q, kv) * q_decay
+
+    # Load diagonal attention output (computed by _fwd_diag_kernel)
+    qkv_diag = tl.load(O_block_ptr, mask=q_index[:, None] < n, other=0.0).to(tl.float32)
+
+    # Combine diagonal and non-diagonal attention outputs
+    qkv = qkv_diag + qkv_none_diag
+
+    # Store the result
+    tl.store(
+        O_block_ptr, qkv.to(O_block_ptr.dtype.element_ty), mask=q_index[:, None] < n
+    )
+
+
+class _attention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, s, kv_history):
+        # Forward pass of the lightning attention algorithm
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        s = s.contiguous()
+
+        # Get input dimensions
+        b, h, n, d = q.shape
+        e = v.shape[-1]
+
+        # Initialize output tensor
+        o = torch.empty((b, h, n, e), dtype=q.dtype, device=q.device)
+
+        # Set block sizes
+        BLOCK = 64
+        NUM_BLOCK = triton.cdiv(n, BLOCK)
+
+        CBLOCK = 32
+        NUM_CBLOCK = BLOCK // CBLOCK
+        assert BLOCK % CBLOCK == 0, "BLOCK must be a multiple of CBLOCK"
+
+        # Step 1: Compute diagonal blocks of attention
+        grid = (b * h * NUM_BLOCK, NUM_CBLOCK)
+        _fwd_diag_kernel[grid](
+            q,
+            k,
+            v,
+            o,
+            s,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            CBLOCK=CBLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            multibuffer=True,
+            limit_auto_multi_buffer_only_for_local_buffer=False,
+            set_workspace_multibuffer=4,
+            tile_mix_vector_loop=2,
+            tile_mix_cube_loop=2,
+        )
+
+
+        BLOCK = 256
+        NUM_BLOCK = triton.cdiv(n, BLOCK)
+        # Compute decay factors for keys
+        array = torch.arange(0, BLOCK, device=q.device) + 1
+        k_decay = torch.exp(-s * (BLOCK - array.reshape(1, -1)))
+        # Set feature block sizes
+        NUM_FBLOCK = 1
+        D_FBLOCK = d // NUM_FBLOCK
+        assert d % NUM_FBLOCK == 0
+        E_FBLOCK = e // NUM_FBLOCK
+        assert e % NUM_FBLOCK == 0
+
+        CBLOCK = 64
+        NUM_CBLOCK = BLOCK // CBLOCK
+        assert BLOCK % CBLOCK == 0, "BLOCK must be a multiple of CBLOCK"
+
+        # Step 2: Compute key-value outer products for each block in parallel
+        kv = torch.empty((b, h, NUM_BLOCK, d, e), dtype=torch.float32, device=q.device)
+        grid = (b * h, NUM_BLOCK)
+        _fwd_kv_parallel[grid](
+            k,
+            v,
+            k_decay,
+            kv,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            D_FBLOCK=D_FBLOCK,
+            E_FBLOCK=E_FBLOCK,
+            NUM_FBLOCK=NUM_FBLOCK,
+            CBLOCK=CBLOCK,
+            NUM_CBLOCK=NUM_CBLOCK,
+        )
+
+        # Step 3: Reduce key-value outer products
+        # across blocks and update KV history
+        grid = (b * h, NUM_FBLOCK)
+        E_FBLOCK = E_FBLOCK // 2
+        _fwd_kv_reduce[grid](
+            s,
+            kv,
+            kv_history,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            D_FBLOCK=D_FBLOCK,
+            E_FBLOCK=E_FBLOCK,
+        )
+
+        # Step 4: Compute non-diagonal blocks of attention
+        grid = (b * h, NUM_BLOCK * NUM_CBLOCK)
+        _fwd_none_diag_kernel[grid](
+            q,
+            o,
+            s,
+            kv,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            E_FBLOCK=E_FBLOCK,
+            CBLOCK=CBLOCK,
+            NUM_CBLOCK=NUM_CBLOCK,
+        )
+        
+        # Save tensors for backward pass
+        ctx.save_for_backward(q, k, v, s, kv)
+        ctx.BLOCK = BLOCK
+
+        return o, torch.cat([kv, kv_history.unsqueeze(2)], dim=2)
+
+
+lightning_attention_npu_ = _attention.apply
+
+
+def lightning_attention_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    ed: torch.Tensor,
+    block_size: int,
+    kv_history: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """lightning attention forward pass (NPU-friendly).
+    """
+    d = q.shape[-1]
+    e = v.shape[-1]
+
+    if ed.dim() == 1:
+        ed = ed.view(1, -1, 1, 1)
+
+    # Split the computation into chunks for better parallelism
+    m = 128 if d >= 128 else 64
+    arr = [m * i for i in range(d // m + 1)]
+    if arr[-1] != d:
+        arr.append(d)
+    n = len(arr)
+    output = 0
+
+    # Initialize or clone key-value history
+    if kv_history is None:
+        kv_history = torch.zeros(
+            (q.shape[0], q.shape[1], d, e), dtype=torch.float32, device=q.device
+        )
+    else:
+        kv_history = kv_history.clone().contiguous()
+
+    # Process each chunk and accumulate results
+    for i in range(n - 1):
+        s = arr[i]
+        e = arr[i + 1]
+        q1 = q[..., s:e]
+        k1 = k[..., s:e]
+        o, kv = lightning_attention_npu_(q1, k1, v, ed, kv_history)
+        output = output + o
+    return output, kv
+
+class LightningAttentionKernelNPU:
+    """NPU-friendly lightning attention kernel for BailingMoE prefill.
+
+    Replaces ``MiniMaxText01LinearKernel`` by providing an NPU-friendly
+    implementation of the prefill forward pass
+    """
+
+    @staticmethod
+    def jit_linear_forward_prefix_npu(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        kv_caches: torch.Tensor,
+        slope_rate: torch.Tensor,
+        block_size: int,
+        layer_idx: int | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        slope_rate = slope_rate.to(torch.float32)
+        should_squeeze = q.dim() == 3
+        if should_squeeze:
+            q = q.unsqueeze(0)
+            k = k.unsqueeze(0)
+            v = v.unsqueeze(0)
+        b, h, n, d = q.shape
+        e = v.shape[-1]
+        kv_history = kv_caches.reshape(1, h, d, e).contiguous()
+        output, kv_history = lightning_attention_npu(
+            q,
+            k,
+            v,
+            slope_rate,
+            block_size=block_size,
+            kv_history=kv_history,
+        )
+        kv_caches.copy_(kv_history[:, :, -1, :, :].reshape(h, d, e))
+        assert output.shape[0] == 1, "batch size must be 1"
+        return rearrange(output.squeeze(0), "h n d -> n (h d)")

--- a/vllm_ascend/ops/triton/linearnorm/linear_attention_npu.py
+++ b/vllm_ascend/ops/triton/linearnorm/linear_attention_npu.py
@@ -1,0 +1,185 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""NPU-friendly method replacements for BailingMoELinearAttention.
+
+This module provides NPU-friendly drop-in replacements for the following
+methods of ``BailingMoELinearAttention``:
+
+- ``_prefill_and_mix_infer``: replaces the GPU Triton-based prefill path.
+- ``_decode_infer``: replaces the GPU Triton-based decode path.
+- ``_forward``: replaces the full forward pass to fix the group-norm branch.
+
+These functions are designed to be monkey-patched onto the class via
+``vllm_ascend/patch/worker/patch_bailing_linear_attn.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn.functional as F
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.fla.ops.layernorm_guard import layernorm_fn
+from vllm.model_executor.layers.mamba.linear_attn import (
+    clear_linear_attention_cache_for_new_sequences,
+    linear_attention_prefill_and_mix,
+)
+from vllm.platforms import current_platform
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.attention.backends.linear_attn import LinearAttentionMetadata
+
+from vllm_ascend.ops.triton.linearnorm.lightning_attention_ops import (
+    LightningAttentionKernelNPU,
+)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.models.bailing_moe_linear import BailingMoELinearAttention
+
+
+def _prefill_and_mix_infer_npu(
+    self: "BailingMoELinearAttention",
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kv_cache: torch.Tensor,
+    state_indices_tensor: torch.Tensor,
+    attn_metadata: LinearAttentionMetadata,
+) -> torch.Tensor:
+ 
+    return linear_attention_prefill_and_mix(
+        q=q,
+        k=k,
+        v=v,
+        kv_cache=kv_cache,
+        state_indices_tensor=state_indices_tensor,
+        attn_metadata=attn_metadata,
+        slope_rate=self.tp_slope,
+        block_size=self.BLOCK,
+        decode_fn=self._decode_infer,
+        prefix_fn=LightningAttentionKernelNPU.jit_linear_forward_prefix_npu,
+        layer_idx=self.layer_id,
+    )
+
+
+def _forward_npu(
+    self: "BailingMoELinearAttention",
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    positions: torch.Tensor,
+) -> None:
+
+    forward_context = get_forward_context()
+    attn_metadata: AttentionMetadata = forward_context.attn_metadata
+    if attn_metadata is not None:
+        assert isinstance(attn_metadata, dict)
+        attn_metadata = attn_metadata[self.prefix]
+        assert isinstance(attn_metadata, LinearAttentionMetadata)
+        num_actual_tokens = (
+            attn_metadata.num_prefill_tokens + attn_metadata.num_decode_tokens
+        )
+    else:
+        num_actual_tokens = hidden_states.shape[0]
+
+    # QKV projection
+    qkv, _ = self.query_key_value(hidden_states[:num_actual_tokens])
+
+    if self.linear_silu:
+        qkv = F.silu(qkv)
+
+    # Split q, k, v
+    q, k, v = torch.split(
+        qkv,
+        [self.q_size_per_rank, self.kv_size_per_rank, self.kv_size_per_rank],
+        dim=-1,
+    )
+
+    # Apply QK norm if needed
+    if self.use_qk_norm:
+        q = q.reshape(-1, self.tp_heads, self.head_dim)
+        k = k.reshape(-1, self.tp_kv_heads, self.head_dim)
+        q = layernorm_fn(
+            q,
+            self.query_layernorm.weight.data,
+            bias=None,
+            eps=self.rms_norm_eps,
+            is_rms_norm=True,
+        )
+        k = layernorm_fn(
+            k,
+            self.key_layernorm.weight.data,
+            bias=None,
+            eps=self.rms_norm_eps,
+            is_rms_norm=True,
+        )
+        q = q.reshape(-1, self.q_size_per_rank)
+        k = k.reshape(-1, self.kv_size_per_rank)
+
+    # Apply rotary embeddings
+    if self.linear_rope:
+        q, k = self.rotary_emb(positions[:num_actual_tokens], q, k)
+
+    # Reshape to [batch, heads, head_dim]
+    q = q.view((qkv.shape[0], self.tp_heads, self.head_dim))
+    k = k.view((qkv.shape[0], self.tp_kv_heads, self.head_dim))
+    v = v.view((qkv.shape[0], self.tp_kv_heads, self.head_dim))
+
+    # Apply scaling if using minimax backend
+    if self.linear_scale:
+        q = q * self.scaling
+
+    # Get KV cache and state indices
+    if attn_metadata is not None:
+        kv_cache = self.kv_cache[forward_context.virtual_engine][0]
+        state_indices_tensor = attn_metadata.state_indices_tensor
+        clear_linear_attention_cache_for_new_sequences(
+            kv_cache, state_indices_tensor, attn_metadata
+        )
+
+    # Compute attention
+    decode_only = getattr(attn_metadata, "num_prefills", 0) == 0
+    if attn_metadata is None:
+        hidden = torch.empty(
+            (q.shape[0], q.shape[1] * q.shape[2]), device=q.device, dtype=q.dtype
+        )
+    else:
+        if not decode_only:
+            hidden = self._prefill_and_mix_infer(
+                q, k, v, kv_cache, state_indices_tensor, attn_metadata
+            )
+        else:
+            hidden = self._decode_infer(
+                q, k, v, kv_cache, state_indices_tensor, attn_metadata
+            )
+
+    # Apply group norm and gate (matching SGLang behavior).
+    gate, _ = self.g_proj(hidden_states[:num_actual_tokens])
+
+    # if self.group_norm_size > 1 and not current_platform.is_cpu():
+    #     hidden = self.g_norm(hidden, gate)
+    # else:
+    #     hidden = self.g_norm(hidden)
+    #     hidden = F.sigmoid(gate) * hidden
+    hidden = self.g_norm(hidden)
+    hidden = F.sigmoid(gate) * hidden
+
+    hidden = hidden.to(hidden_states.dtype)
+
+    # Output projection
+    dense_out, _ = self.dense(hidden)
+    output[:num_actual_tokens] = dense_out

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -45,3 +45,4 @@ import vllm_ascend.patch.worker.patch_kimi_k25  # noqa
 import vllm_ascend.patch.worker.patch_draft_quarot  # noqa
 import vllm_ascend.patch.worker.patch_cudagraph  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
+import vllm_ascend.patch.worker.patch_bailing_moe_linear_attn  # noqa

--- a/vllm_ascend/patch/worker/patch_bailing_moe_linear_attn.py
+++ b/vllm_ascend/patch/worker/patch_bailing_moe_linear_attn.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Patch for BailingMoELinear models to support Ascend NPU.
+
+This module provides NPU-fridendly patches for the following classes:
+- ``BailingMoeLinearMLA``
+- ``BailingMoELinearAttention``
+
+Patches include:
+
+1. **BF16 Rotary Embedding**: Forces BF16 dtype for rotary embedding cache
+   because NPU operators ``npu_interleave_rope`` and ``npu_kv_rmsnorm_rope_cache``
+   do not support FP32 input dtype.
+
+2. **NPU-fridendly Linear Attention Methods**: Replaces GPU-fridendly Triton kernel
+   calls with NPU-fridendly implementations:
+
+   - ``_prefill_and_mix_infer``: uses ``BailingLinearKernelNPU`` instead of
+     ``MiniMaxText01LinearKernel`` 
+   - ``_decode_infer``: uses ``linear_decode_forward_npu`` instead of
+     ``linear_decode_forward_triton``
+   - ``_forward``: fixes the group-norm branch, replacing it with
+     ``current_platform``-based dispatch.
+"""
+
+import torch
+
+# isort: off
+import vllm.model_executor.models.bailing_moe_linear as bailing_moe_linear
+from vllm_ascend.ops.triton.linearnorm.linear_attention_npu import (
+    _forward_npu,
+    _prefill_and_mix_infer_npu,
+)
+
+BailingMoELinearAttention = bailing_moe_linear.BailingMoELinearAttention
+BailingMoeMLAAttention = bailing_moe_linear.BailingMoeV25MLAAttention
+
+# =============================================================================
+# Patch 1: NPU-friendly Linear Attention Methods
+# =============================================================================
+BailingMoELinearAttention._prefill_and_mix_infer = _prefill_and_mix_infer_npu
+BailingMoELinearAttention._forward = _forward_npu
+
+# =============================================================================
+# Patch 2: BF16 Rotary Embedding
+# =============================================================================
+
+
+def _patch_init_to_use_bf16_rope(cls):
+    """Patch a class's __init__ to force BF16 dtype for rotary embedding.
+
+    The NPU operators ``npu_interleave_rope`` and ``npu_kv_rmsnorm_rope_cache``
+    used by MLA/SFA attention backends do not support FP32 input dtype.
+    This patch ensures the rotary embedding cache is created with BF16 dtype.
+
+    The module-level ``get_rope`` is temporarily replaced during ``__init__``
+    and restored afterwards via ``try/finally``, so the patch is contained and
+    does not permanently mutate global state.
+    """
+    original_init = cls.__init__
+    original_get_rope = bailing_moe_linear.get_rope
+
+    def bf16_get_rope(*args, **kwargs):
+        kwargs['dtype'] = torch.bfloat16
+        return original_get_rope(*args, **kwargs)
+
+    def patched_init(self, *args, **kwargs):
+        bailing_moe_linear.get_rope = bf16_get_rope
+        try:
+            original_init(self, *args, **kwargs)
+        finally:
+            bailing_moe_linear.get_rope = original_get_rope
+
+    cls.__init__ = patched_init
+
+
+# Apply BF16 rotary embedding patch to both classes
+_patch_init_to_use_bf16_rope(BailingMoeMLAAttention)
+_patch_init_to_use_bf16_rope(BailingMoELinearAttention)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enables BailingMoELinear model to run on Ascend NPU by addressing
two compatibility issues:

1. **NPU-friendly Linear Attention Methods**: Replaces GPU-friendly Triton kernel
   calls with NPU-friendly implementations:
   - `_prefill_and_mix_infer`: uses `BailingLinearKernelNPU` instead of
     `MiniMaxText01LinearKernel` (CUDA-friendly )
   - `_forward`: fixes g_norm branch

2. **BF16 Rotary Embedding**: bailing_moe_linear.py in vLLM creates rotary embedding cache with
   FP32 dtype, but NPU operators `npu_interleave_rope` and
   `npu_kv_rmsnorm_rope_cache` do not support FP32 input dtype. This patch
   forces BF16 dtype for rotary embedding cache to ensure compatibility.
-->

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
vllm-ascend: main
vllm: v0.17.0

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6a9cceb219fcbd6b1eb540ddfdc77ec160f0e209
