### PR TITLE
[Bugfix] Fix hidden_states shape mismatch in AscendDraftModelProposer

### DIFF
--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -534,3 +534,61 @@ def test_parallel_drafting_acceptance(
         print(f"golden: {golden}")
 
     assert match
+
+
+def test_draft_model_no_parallel():
+    """
+    Test the corner case that draft model's hidden_size diff from target model and do not use parallel drafting.
+    """
+    main_model_name = "Qwen/Qwen3-8B"
+    spec_model_name = "Qwen/Qwen3-0.6B"
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        main_model_name,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    prompts = [
+        {
+            "role": "user",
+            "content": "Hello, your name is",
+        },
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [prompt],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for prompt in prompts
+    ]
+
+    speculative_config = {
+        "method": "draft_model",
+        "model": spec_model_name,
+        "num_speculative_tokens": 5,
+    }
+
+    compilation_config = CompilationConfig(cudagraph_capture_sizes=[12])
+
+    with VllmRunner(
+        main_model_name,
+        max_model_len=4096,
+        disable_log_stats=False,
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        enable_prefix_caching=False,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"Output tokens: {output_tokens}")

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -105,7 +105,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             self._raise_if_mrope()
         # If needs_extra_input_slots is now True but was False during super().__init__,
         # the dependent buffers were never allocated — create them now.
-        if self.needs_extra_input_slots and self.is_rejected_token_mask is None:
+        if self.needs_extra_input_slots:
             self.is_rejected_token_mask = torch.zeros((self.max_num_tokens,), dtype=torch.bool, device=device)
             self.is_masked_token_mask = torch.zeros((self.max_num_tokens,), dtype=torch.bool, device=device)
         self.decode_threshold = 1 + self.num_speculative_tokens

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -89,10 +89,27 @@ class SpecDecodeBaseProposer(EagleProposer):
     _runnable: ACLGraphWrapper | Callable
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device, pass_hidden_states_to_model: bool, runner=None):
+        # vllm.EagleProposer.__init__ hardcodes pass_hidden_states_to_model=True
+        # when calling vllm.SpecDecodeBaseProposer.__init__, so the derived
+        # attributes (net_num_new_slots_per_request, needs_extra_input_slots) and
+        # the dependent buffers (is_rejected_token_mask, is_masked_token_mask) may
+        # be computed/initialized incorrectly when pass_hidden_states_to_model=False.
+        # We fix this up after super().__init__ completes.
         super().__init__(vllm_config, device, runner)
 
         self.use_async_scheduling = self.vllm_config.scheduler_config.async_scheduling
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
+        # Recompute the two attributes that vllm.SpecDecodeBaseProposer derived
+        # from the hardcoded True value so they reflect the actual argument.
+        self.net_num_new_slots_per_request = self.extra_slots_per_request - (
+            1 if self.pass_hidden_states_to_model else 0
+        )
+        self.needs_extra_input_slots = self.net_num_new_slots_per_request > 0
+        # If needs_extra_input_slots is now True but was False during super().__init__,
+        # the dependent buffers were never allocated — create them now.
+        if self.needs_extra_input_slots and self.is_rejected_token_mask is None:
+            self.is_rejected_token_mask = torch.zeros((self.max_num_tokens,), dtype=torch.bool, device=device)
+            self.is_masked_token_mask = torch.zeros((self.max_num_tokens,), dtype=torch.bool, device=device)
         self.decode_threshold = 1 + self.num_speculative_tokens
         self.query_start_loc = self.runner._make_buffer(self.runner.max_num_reqs + 2, dtype=torch.int32)
         self.arange_cpu = torch.arange(self.arange.shape[0], device="cpu", dtype=torch.int32)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -89,12 +89,6 @@ class SpecDecodeBaseProposer(EagleProposer):
     _runnable: ACLGraphWrapper | Callable
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device, pass_hidden_states_to_model: bool, runner=None):
-        # vllm.EagleProposer.__init__ hardcodes pass_hidden_states_to_model=True
-        # when calling vllm.SpecDecodeBaseProposer.__init__, so the derived
-        # attributes (net_num_new_slots_per_request, needs_extra_input_slots) and
-        # the dependent buffers (is_rejected_token_mask, is_masked_token_mask) may
-        # be computed/initialized incorrectly when pass_hidden_states_to_model=False.
-        # We fix this up after super().__init__ completes.
         super().__init__(vllm_config, device, runner)
 
         self.use_async_scheduling = self.vllm_config.scheduler_config.async_scheduling

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -31,6 +31,7 @@ from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.eagle import SpecDecodeBaseProposer as VllmSpecDecodeBaseProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.utils import (
     PADDING_SLOT_ID,
@@ -89,25 +90,18 @@ class SpecDecodeBaseProposer(EagleProposer):
     _runnable: ACLGraphWrapper | Callable
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device, pass_hidden_states_to_model: bool, runner=None):
-        super().__init__(vllm_config, device, runner)
+        # Bypass EagleProposer.__init__ which hardcodes pass_hidden_states_to_model=True.
+        # Call vllm.SpecDecodeBaseProposer.__init__ directly so the parameter is set
+        # correctly from the start, avoiding downstream recompute hacks.
+        VllmSpecDecodeBaseProposer.__init__(
+            self,
+            vllm_config,
+            device,
+            pass_hidden_states_to_model=pass_hidden_states_to_model,
+            runner=runner,
+        )
 
         self.use_async_scheduling = self.vllm_config.scheduler_config.async_scheduling
-        self.pass_hidden_states_to_model = pass_hidden_states_to_model
-        # Recompute the two attributes that vllm.SpecDecodeBaseProposer derived
-        # from the hardcoded True value so they reflect the actual argument.
-        self.net_num_new_slots_per_request = self.extra_slots_per_request - (
-            1 if self.pass_hidden_states_to_model else 0
-        )
-        self.needs_extra_input_slots = self.net_num_new_slots_per_request > 0
-        if self.needs_extra_input_slots:
-            self._raise_if_padded_drafter_batch_disabled()
-            self._raise_if_multimodal()
-            self._raise_if_mrope()
-        # If needs_extra_input_slots is now True but was False during super().__init__,
-        # the dependent buffers were never allocated — create them now.
-        if self.needs_extra_input_slots:
-            self.is_rejected_token_mask = torch.zeros((self.max_num_tokens,), dtype=torch.bool, device=device)
-            self.is_masked_token_mask = torch.zeros((self.max_num_tokens,), dtype=torch.bool, device=device)
         self.decode_threshold = 1 + self.num_speculative_tokens
         self.query_start_loc = self.runner._make_buffer(self.runner.max_num_reqs + 2, dtype=torch.int32)
         self.arange_cpu = torch.arange(self.arange.shape[0], device="cpu", dtype=torch.int32)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -99,6 +99,10 @@ class SpecDecodeBaseProposer(EagleProposer):
             1 if self.pass_hidden_states_to_model else 0
         )
         self.needs_extra_input_slots = self.net_num_new_slots_per_request > 0
+        if self.needs_extra_input_slots:
+            self._raise_if_padded_drafter_batch_disabled()
+            self._raise_if_multimodal()
+            self._raise_if_mrope()
         # If needs_extra_input_slots is now True but was False during super().__init__,
         # the dependent buffers were never allocated — create them now.
         if self.needs_extra_input_slots and self.is_rejected_token_mask is None:


### PR DESCRIPTION
### What this PR does / why we need it?
Running the following script:
```python
from vllm import LLM, SamplingParams

prompts = ["The future of AI is"]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

llm = LLM(
    model="Qwen/Qwen3-8B",
    tensor_parallel_size=1,
    speculative_config={
        "model": "Qwen/Qwen3-0.6B",
        "num_speculative_tokens": 5,
        "method": "draft_model",
    },
)
outputs = llm.generate(prompts, sampling_params)

for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```
There exists a bug:
AscendDraftModelProposer crashed with a shape mismatch error when assigning target hidden states to the draft model's hidden_states buffer:
```shell
 RuntimeError: The expanded size of the tensor (1024) must match the existing
 size (4096) at non-singleton dimension 1.
```

Root cause:
ascend's SpecDecodeBaseProposer incorrectly inherited from vllm.EagleProposer instead of vllm.SpecDecodeBaseProposer. vllm.EagleProposer.__init__ hardcodes pass_hidden_states_to_model=True when calling super().__init__, which caused needs_extra_input_slots to be computed as False for all subclasses regardless
of the actual value passed. As a result, AscendDraftModelProposer (which passes pass_hidden_states_to_model=False) was forced into the EAGLE code path in set_inputs_first_pass, where it attempted to copy target hidden states (hidden_size=4096) into a buffer allocated for the draft model (hidden_size=1024).

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ed359c497a728f08b5b41456c07a688ccd510fbc
