### PR TITLE
[BugFix] Disable block verify to avoid incorrect verification on NPU

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -111,7 +111,9 @@ def rejection_sample(
     assert target_logits.shape == (num_tokens, vocab_size)
 
     # When num_speculative_tokens>=3, using block verify.
-    using_block_verify = max_spec_len >= 3
+    # Skip block verify when draft_probs is None (suffix/ngram methods)
+    # to avoid incorrect verification results.
+    using_block_verify = max_spec_len >= 3 and draft_probs is not None
 
     # Create output buffer.
     output_token_ids = torch.empty(


### PR DESCRIPTION
### What this PR does / why we need it?
   Block verify uses cumprod(target_probs / draft_probs) for joint acceptance. Suffix/ngram methods have
   draft_probs=None, the fallback draft_token_probs=1.0 with cumprod is not equivalent to per-token    
  verification, causing incorrect accept/reject results.                                               
                                                                                                     
  Fix: using_block_verify = max_spec_len >= 3 and draft_probs is not None. MTP/Eagle3 unaffected.

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ed359c497a728f08b5b41456c07a688ccd510fbc
