### PR TITLE
verify and support Kimi-K2.5 model

### DIFF
--- a/tests/e2e/models/configs/Kimi-K2.5-W4A8.yaml
+++ b/tests/e2e/models/configs/Kimi-K2.5-W4A8.yaml
@@ -1,0 +1,12 @@
+model_name: "Eco-Tech/Kimi-K2.5-W4A8"
+hardware: "Atlas A3 Series"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "accuracy"
+    value: 0.9462
+- name: "textvqa"
+  metrics:
+  - name: "accuracy"
+    value: 0.8029
+trust_remote_code: True


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces the official E2E verification test configuration for the `moonshotai/Kimi-K2.5` model (W4A8 quantized version) on the vLLM Ascend backend. 
﻿
**Changes proposed:**
- **Test Cases**: Added `tests/e2e/models/configs/Kimi-K2.5-W4A8.yaml` to automate the verification pipeline based on the existing deployment tutorial.
﻿
This is needed to ensure continuous integration (CI) and automated verification for the newly supported Kimi-K2.5 model on Ascend NPU environments (Atlas 800 A2/A3).
﻿
Fixes #6683
﻿
### Does this PR introduce _any_ user-facing change?
No user-facing APIs or existing documentation were modified. This PR solely adds internal E2E testing configurations for CI validation.
﻿
### How was this patch tested?
- **Automated Testing**: CI validation via the newly added E2E test configuration `Kimi-K2.5-W4A8.yaml`. The test parameters were strictly aligned with the existing `Kimi-K2.5.md` documentation.
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ed359c497a728f08b5b41456c07a688ccd510fbc
