### PR TITLE
[bugfix][CI] fix '_OpNamespace' 'vllm' object has no attribute 'qkv_rmsnorm_rope'

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -79,6 +79,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:
@@ -185,6 +186,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:
@@ -288,6 +290,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:
@@ -391,6 +394,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:
@@ -513,6 +517,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:
@@ -609,6 +614,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:
@@ -684,6 +690,7 @@ jobs:
         working-directory: ./vllm-empty
         run: |
           VLLM_TARGET_DEVICE=empty uv pip install -e .
+          uv pip uninstall triton
 
       - name: Install vllm-project/vllm-ascend
         env:


### PR DESCRIPTION
### What this PR does / why we need it?
fix '_OpNamespace' 'vllm' object has no attribute 'qkv_rmsnorm_rope' by uinstall triton
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ed359c497a728f08b5b41456c07a688ccd510fbc
