### PR TITLE
[CI] Support branch-based nightly testing with dynamic vLLM version

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: "v0.18.0"
+      vllm_ascend_ref:
+        required: false
+        type: string
+        default: ""
+        description: "vllm-ascend branch/tag/sha to checkout on dispatch (updates code in the image)"
       should_run:
         required: true
         type: boolean
@@ -81,57 +86,69 @@ jobs:
           cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
           pip install uv
       
-      - name: uninstall vlm vllm-ascend and remove code (if pr test)
+      - name: Checkout vllm-ascend from branch (if dispatch with ref)
+        if: ${{ github.event_name != 'pull_request' && inputs.vllm_ascend_ref != '' }}
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          ref: ${{ inputs.vllm_ascend_ref }}
+          path: ./temp-vllm-ascend
+          fetch-depth: 1
+
+      - name: Update vllm-ascend in workspace and reinstall (if dispatch with ref)
+        if: ${{ github.event_name != 'pull_request' && inputs.vllm_ascend_ref != '' }}
+        env:
+          PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
+        run: |
+          pip uninstall -y vllm-ascend || true
+          cp -r /vllm-workspace/vllm-ascend/benchmark /tmp/aisbench-backup || true
+          rm -rf /vllm-workspace/vllm-ascend
+          mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
+          cp -r /tmp/aisbench-backup /vllm-workspace/vllm-ascend/benchmark || true
+          git config --global --add safe.directory /vllm-workspace/vllm-ascend
+          pip install uc-manager
+          uv pip install -r /vllm-workspace/vllm-ascend/requirements-dev.txt
+          uv pip install -v -e /vllm-workspace/vllm-ascend
+
+      - name: Uninstall vllm/vllm-ascend and remove code (if PR)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           pip uninstall -y vllm vllm-ascend || true
           cp -r /vllm-workspace/vllm-ascend/benchmark /tmp/aisbench-backup || true
           rm -rf /vllm-workspace/vllm /vllm-workspace/vllm-ascend
 
-      - name: Checkout vllm-project/vllm repo
+      - name: Checkout vllm-project/vllm repo (if PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v6
         with:
           repository: vllm-project/vllm
           ref: ${{ inputs.vllm_version }}
-          path: ./temp-vllm 
+          path: ./temp-vllm
           fetch-depth: 1
 
-      - name: Checkout vllm-project/vllm-ascend repo
+      - name: Checkout vllm-project/vllm-ascend repo (if PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v6
         with:
           path: ./temp-vllm-ascend
           fetch-depth: 1
 
-      - name: Move code to /vllm-workspace
+      - name: Setup environment from source (if PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          mv ./temp-vllm /vllm-workspace/vllm
-          mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
-          ls -R /vllm-workspace
-
-      - name: Install vllm-project/vllm from source
-        if: ${{ github.event_name == 'pull_request' }}
-        working-directory: /vllm-workspace/vllm
-        run: |
-          VLLM_TARGET_DEVICE=empty uv pip install -e .
-      
-      - name: Install vllm-project/vllm-ascend
-        if: ${{ github.event_name == 'pull_request' }}
-        working-directory: /vllm-workspace/vllm-ascend
+        shell: bash -l {0}
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
+          mv ./temp-vllm /vllm-workspace/vllm
+          mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
+
+          VLLM_TARGET_DEVICE=empty uv pip install -e /vllm-workspace/vllm
+
           git config --global --add safe.directory /vllm-workspace/vllm-ascend
           pip install uc-manager
-          uv pip install -r requirements-dev.txt
-          uv pip install -v -e .
+          uv pip install -r /vllm-workspace/vllm-ascend/requirements-dev.txt
+          uv pip install -v -e /vllm-workspace/vllm-ascend
 
-      - name: Install aisbench
-        if: ${{ github.event_name == 'pull_request' }}
-        shell: bash -l {0}
-        run: |
           cp -r /tmp/aisbench-backup /vllm-workspace/vllm-ascend/benchmark
           cd /vllm-workspace/vllm-ascend/benchmark
           pip install pytest asyncio pytest-asyncio

--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -24,6 +24,10 @@ on:
         required: true
         type: string
         description: "Build target: 'a2' or 'a3'"
+      vllm_version:
+        required: true
+        type: string
+        description: "The vLLM version to build the image"
     secrets:
       HW_USERNAME:
         required: false
@@ -53,7 +57,7 @@ jobs:
           GITEE_USERNAME: ${{ vars.GITEE_USERNAME }}
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
         run: |
-          IMAGE="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ inputs.target }}"
+          IMAGE="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ inputs.vllm_version }}-${{ inputs.target }}"
           docker build \
             --network host \
             --platform linux/arm64 \
@@ -68,4 +72,4 @@ jobs:
       - name: Push image to SWR
         if: ${{ github.repository_owner == 'vllm-project' && steps.login-swr.conclusion == 'success' }}
         run: |
-          docker push swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ inputs.target }}
+          docker push swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ inputs.vllm_version }}-${{ inputs.target }}

--- a/.github/workflows/_parse_trigger.yaml
+++ b/.github/workflows/_parse_trigger.yaml
@@ -24,6 +24,16 @@ on:
         required: false
         type: string
         default: linux-aarch64-a2b3-0
+      branch:
+        required: false
+        type: string
+        default: ''
+        description: "Branch to test; 'releases-v0.13.0' → vllm_version='v0.13.0'"
+      vllm_version:
+        required: false
+        type: string
+        default: 'v0.18.0'
+        description: "Fallback vLLM version when branch carries no version info"
     outputs:
       run:
         description: "Whether nightly tests should run"
@@ -34,6 +44,9 @@ on:
       ref:
         description: "The vllm-ascend ref (commit SHA for PRs, branch/tag name otherwise)"
         value: ${{ jobs.parse.outputs.ref }}
+      vllm_version:
+        description: "The vLLM version used for nightly image tag"
+        value: ${{ jobs.parse.outputs.vllm_version }}
 
 jobs:
   parse:
@@ -43,6 +56,7 @@ jobs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
       ref: ${{ steps.parse.outputs.ref }}
+      vllm_version: ${{ steps.parse.outputs.vllm_version }}
     steps:
       - name: Parse trigger
         id: parse
@@ -50,6 +64,16 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
+
+            // Derive vllm_version from:
+            //   - dispatch: inputs.branch (e.g. 'releases-v0.13.0' → 'v0.13.0')
+            //   - pull_request: PR target branch (so a PR into releases-v0.13.0 uses nightly-v0.13.0 image)
+            //   - fallback: inputs.vllm_version default
+            const versionBranch = eventName === 'pull_request'
+              ? context.payload.pull_request.base.ref
+              : '${{ inputs.branch }}';
+            const verMatch = versionBranch.match(/releases-(v\d+\.\d+\.\d+)/);
+            core.setOutput('vllm_version', verMatch ? verMatch[1] : '${{ inputs.vllm_version }}');
 
             function parseNightlyComment(body) {
               if (!body) return null;
@@ -65,6 +89,9 @@ jobs:
               if (eventName === 'pull_request') {
                 return context.payload.pull_request.head.sha;
               }
+              // For dispatch: prefer explicit branch input over the running workflow ref
+              const branchInput = '${{ inputs.branch }}';
+              if (branchInput) return branchInput;
               return (context.ref || '').replace(/^refs\/(heads|tags)\//, '') || 'main';
             }
 

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -22,13 +22,19 @@ name: Nightly Image Build Schedule
 
 on:
   workflow_dispatch:
-    # Next step: Add more inputs here if needed, e.g. vllm version, vllm-ascend version, image tag, etc.
+    inputs:
+      vllm_version:
+        description: "vLLM version to build the image"
+        required: false
+        default: 'v0.18.0'
+        type: string
 
 jobs:
   build-a2:
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
+      vllm_version: ${{ inputs.vllm_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -38,6 +44,7 @@ jobs:
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3
+      vllm_version: ${{ inputs.vllm_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -24,6 +24,17 @@ on:
       # Run test at 23:45 Beijing time (UTC+8)
       - cron: "45 15 * * *"
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch or tag to test (defaults to the branch selected above)'
+        required: false
+        default: ''
+        type: string
+      test_filter:
+        description: 'Tests to run — space-separated names or "all". E.g.: test_custom_op qwen3-32b multi-node-deepseek-dp'
+        required: false
+        default: 'all'
+        type: string
   pull_request:
     branches:
       - 'main'
@@ -54,13 +65,18 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'nightly-test')
     uses: ./.github/workflows/_parse_trigger.yaml
+    with:
+      runner: linux-aarch64-a2b3-0
+      branch: ${{ inputs.branch || '' }}
 
   build-image:
     name: Build nightly-a2 image
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: [parse-trigger]
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
+      vllm_version: ${{ needs.parse-trigger.outputs.vllm_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -97,10 +113,11 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a2'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ needs.parse-trigger.outputs.vllm_version }}-a2'
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -131,7 +148,7 @@ jobs:
     with:
       soc_version: a2
       runner: linux-amd64-cpu-8-hk
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a2'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ needs.parse-trigger.outputs.vllm_version }}-a2'
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -25,6 +25,17 @@ on:
       # Run test at 23:45 Beijing time (UTC+8)
       - cron: "45 15 * * *"
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch or tag to test (defaults to the branch selected above)'
+        required: false
+        default: ''
+        type: string
+      test_filter:
+        description: 'Tests to run — space-separated names or "all". E.g.: multi-node-deepseek-pd'
+        required: false
+        default: 'all'
+        type: string
   pull_request:
     branches:
       - 'main'
@@ -54,13 +65,18 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'nightly-test')
     uses: ./.github/workflows/_parse_trigger.yaml
+    with:
+      runner: linux-aarch64-a2b3-0
+      branch: ${{ inputs.branch || '' }}
 
   build-image:
     name: Build nightly-a3 image
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: [parse-trigger]
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3
+      vllm_version: ${{ needs.parse-trigger.outputs.vllm_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -124,7 +140,7 @@ jobs:
     with:
       soc_version: a3
       runner: linux-aarch64-a3-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ needs.parse-trigger.outputs.vllm_version }}-a3'
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
@@ -224,10 +240,11 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-${{ needs.parse-trigger.outputs.vllm_version }}-a3'
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (

--- a/docs/source/developer_guide/contribution/multi_node_test.md
+++ b/docs/source/developer_guide/contribution/multi_node_test.md
@@ -99,7 +99,7 @@ Currently, the multi-node test workflow is defined in the [nightly_test_a3.yaml]
         with:
         soc_version: a3
         runner: linux-aarch64-a3-0
-        image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3'
+        image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-|ci_vllm_version|-a3'
         replicas: 1
         size: ${{ matrix.test_config.size }}
         config_file_path: ${{ matrix.test_config.config_file_path }}
@@ -140,7 +140,7 @@ This section assumes that you already have a [Kubernetes](https://kubernetes.io/
             containers:
             - name: vllm-leader
                 imagePullPolicy: Always
-                image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3
+                image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-|ci_vllm_version|-a3
                 env:
                 - name: CONFIG_YAML_PATH
                     value: DeepSeek-V3.yaml
@@ -193,7 +193,7 @@ This section assumes that you already have a [Kubernetes](https://kubernetes.io/
             containers:
             - name: vllm-worker
                 imagePullPolicy: Always
-                image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3
+                image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-|ci_vllm_version|-a3
                 env:
                 - name: CONFIG_YAML_PATH
                     value: DeepSeek-V3.yaml

--- a/tests/e2e/nightly/multi_node/scripts/lws-a2.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws-a2.yaml.jinja2
@@ -16,7 +16,7 @@ spec:
         containers:
           - name: vllm-leader
             imagePullPolicy: Always
-            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a2") }}
+            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-" + vllm_version + "-a2") }}
             env:
               - name: CONFIG_YAML_PATH
                 value: {{ config_file_path | default("DeepSeek-V3.yaml") }}
@@ -76,7 +76,7 @@ spec:
         containers:
           - name: vllm-worker
             imagePullPolicy: Always
-            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a2") }}
+            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-" + vllm_version + "-a2") }}
             env:
               - name: CONFIG_YAML_PATH
                 value: {{ config_file_path | default("DeepSeek-V3.yaml") }}

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -16,7 +16,7 @@ spec:
         containers:
           - name: vllm-leader
             imagePullPolicy: Always
-            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3") }}
+            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-" + vllm_version + "-a3") }}
             env:
               - name: CONFIG_YAML_PATH
                 value: {{ config_file_path | default("DeepSeek-V3.yaml") }}
@@ -76,7 +76,7 @@ spec:
         containers:
           - name: vllm-worker
             imagePullPolicy: Always
-            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3") }}
+            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-" + vllm_version + "-a3") }}
             env:
               - name: CONFIG_YAML_PATH
                 value: {{ config_file_path | default("DeepSeek-V3.yaml") }}


### PR DESCRIPTION
### What this PR does / why we need it?

Nightly CI workflows previously hardcoded the vLLM version (`v0.18.0`) and image tag (`nightly-a2`/`nightly-a3`) in multiple places. This PR introduces a unified mechanism to derive the version from the branch name, enabling proper multi-branch nightly testing.
Key changes:
* `_parse_trigger.yaml`: Add `branch` input; auto-derive `vllm_version` from branch name (`releases-v0.13.0` → `v0.13.0`); detect PR target branch to select the matching nightly image; `getRef()` prefers `inputs.branch` for dispatch triggers
* `_nightly_image_build.yaml`: Image tag now includes version (e.g., `nightly-v0.18.0-a2`)
* `_e2e_nightly_single_node.yaml`: Add `vllm_ascend_ref` input; on dispatch with a ref, checkout and reinstall vllm-ascend from the branch; consolidate PR setup steps (7 → 4 steps); rename `is_run` → `should_run`
* `schedule_nightly_test_a2.yaml` / `schedule_nightly_test_a3.yaml`: Pass `branch` input; derive `vllm_version` dynamically via `parse-trigger`; propagate `vllm_ascend_ref` to single-node tests
* `nightly_image_build.yaml`: Add `vllm_version` input to fix missing required parameter
* `lws*.yaml.jinja2`: Image default constructed from `vllm_version` variable
* `multi_node_test.md`: Use `|ci_vllm_version|` substitution instead of hardcoded version


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ed359c497a728f08b5b41456c07a688ccd510fbc
