### PR TITLE
[CI] Nightly test for releases/v0.18.0

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -38,6 +38,9 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: releases/v0.18.0
 
       - name: Login to Huawei Cloud SWR
         id: login-swr

--- a/.github/workflows/dockerfiles/Dockerfile.nightly.a2
+++ b/.github/workflows/dockerfiles/Dockerfile.nightly.a2
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:main
+FROM quay.io/ascend/vllm-ascend:releases-v0.18.0
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"

--- a/.github/workflows/dockerfiles/Dockerfile.nightly.a3
+++ b/.github/workflows/dockerfiles/Dockerfile.nightly.a3
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/vllm-ascend:main-a3
+FROM quay.io/ascend/vllm-ascend:releases-v0.18.0-a3
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG AIS_BENCH_TAG="v3.0-20250930-master"


### PR DESCRIPTION
### What this PR does / why we need it?
This patch add per pr image build for branch releases/v0.18.0, Due to the limitations of the quay naming convention, we should not name the image tag the same as branch name, we name the image tag v0.18.0-dev for daily build.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
