### PR TITLE
[CI][v0.18.0] Build nightly image for releases/v0.18.0 per pr

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -47,6 +47,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+        ref: ${{ github.ref }}
 
     - uses: actions/checkout@v6
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -113,6 +114,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
 
       - name: Download arm64 digests
         uses: actions/download-artifact@v8
@@ -154,9 +157,9 @@ jobs:
           #      which follow the rule from vLLM with prefix v
           # TODO(yikun): the post release might be considered as latest release
           tags: |
+            type=ref,event=branch,suffix=${{ env.SUFFIX }}
+            type=ref,event=pr,suffix=${{ env.SUFFIX }}
             type=pep440,pattern={{raw}},suffix=${{ env.SUFFIX }}
-            type=schedule,pattern=main,suffix=${{ env.SUFFIX }}
-            type=raw,value=${{ inputs.workflow_dispatch_tag }},enable=${{ github.event_name == 'workflow_dispatch' }},suffix=${{ env.SUFFIX }}
           flavor:
             latest=false
 

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -11,15 +11,35 @@
 #   - Publish when tag with v* (pep440 version)  ===>  vllm-ascend:v1.2.3 / vllm-ascend:v1.2.3rc1
 name: Image Build and Push
 on:
-  schedule:
-    # UTC+8: 8am, 12pm, 16pm, 21pm
-    - cron: '0 0,4,8,13 * * *'
   push:
+    # Publish image when tagging, the Dockerfile in tag will be build as tag image
+    branches:
+      - 'releases/*'
     tags:
       - 'v*'
-  pull_request: 
+    paths:
+      - '.github/workflows/schedule_image_build_and_push.yaml'
+      - 'Dockerfile*'
+      - 'vllm_ascend/**'
+      - 'setup.py'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'csrc/**'
+  pull_request:
     branches:
-      - 'main'
+      - 'releases/*'
+    paths:
+      - '.github/workflows/schedule_image_build_and_push.yaml'
+      - 'Dockerfile*'
+      - 'vllm_ascend/**'
+      - 'setup.py'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'csrc/**'
     types: [ labeled, synchronize ]
   workflow_dispatch:
     inputs:
@@ -36,10 +56,14 @@ on:
           - v0.14.0rc1
           - v0.13.0rc3
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   image_build:
     name: Image Build and Push
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'image-build')  }}
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'image-build') }}
     strategy:
       matrix:
         build_meta:
@@ -66,7 +90,7 @@ jobs:
       dockerfile: ${{ matrix.build_meta.dockerfile }}
       suffix: ${{ matrix.build_meta.suffix }}
       quay_username: ${{ vars.QUAY_USERNAME }}
-      should_push: ${{ github.repository_owner == 'vllm-project' && (github.event_name != 'pull_request') }}
+      should_push: ${{ github.repository_owner == 'vllm-project' && github.event_name == 'push'}}
       workflow_dispatch_tag: ${{ inputs.tag }}
     secrets:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

This patch add per pr image build for branch `releases/v0.18.0`, Due to the limitations of the quay naming convention, we should not name the image tag the same as branch name, we name the image tag`releases-v0.18.0` for daily build.


<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
