### PR TITLE
[Feature] Heterogeneous-vocab (TLI) support for draft_model spec decode

### DIFF
--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
 from vllm.config import CUDAGraphMode
+from vllm.v1.spec_decode.vocab_mapping import VocabMapping
 
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
@@ -110,3 +112,106 @@ class TestDisablePaddedDrafterBatchWithFullGraph:
         )
 
         proposer._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer for building a real ``VocabMapping`` in tests.
+
+    ``encode`` returns ``[]`` so ``VocabMapping`` falls back to its default
+    space-prefix set; the toy tokens carry no prefix, so normalization is the
+    identity and ``get_vocab`` defines the intersection directly.
+    """
+
+    def __init__(self, vocab: dict[str, int], unk_token_id: int):
+        self._vocab = vocab
+        self._id_to_token = {i: t for t, i in vocab.items()}
+        self.unk_token_id = unk_token_id
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(self._vocab)
+
+    def encode(self, text, add_special_tokens=False):  # noqa: ARG002
+        return []
+
+    def convert_ids_to_tokens(self, idx):
+        return self._id_to_token.get(idx, "")
+
+
+class TestHeterogeneousVocabTLI:
+    """TLI (vllm#38174) helpers on ``AscendSpecDecodeBaseProposer``.
+
+    Target vocab ``{a, b, c, x, <unk_t>}`` and draft vocab
+    ``{a, b, c, y, <unk_d>}`` share the intersection ``{a, b, c}`` (ids 0, 1, 2
+    in both). Draft id 3 (``y``) and target id 3 (``x``) sit outside it.
+    """
+
+    @staticmethod
+    def _make_vocab_mapping() -> VocabMapping:
+        target = _FakeTokenizer({"a": 0, "b": 1, "c": 2, "x": 3, "<unk_t>": 4}, unk_token_id=4)
+        draft = _FakeTokenizer({"a": 0, "b": 1, "c": 2, "y": 3, "<unk_d>": 4}, unk_token_id=4)
+        return VocabMapping(
+            target_tokenizer=target,
+            draft_tokenizer=draft,
+            target_vocab_size=5,
+            draft_vocab_size=5,
+            device="cpu",
+        )
+
+    @staticmethod
+    def _make_proposer(*, use_heterogeneous_vocab, vocab_mapping) -> AscendSpecDecodeBaseProposer:
+        """Bypass ``__init__`` and set only the attrs the helpers read.
+
+        ``use_heterogeneous_vocab=None`` leaves the attribute unset, exercising
+        the ``getattr(self, "use_heterogeneous_vocab", False)`` guard.
+        """
+        proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+        if use_heterogeneous_vocab is not None:
+            proposer.use_heterogeneous_vocab = use_heterogeneous_vocab
+        proposer.vocab_mapping = vocab_mapping
+        return proposer
+
+    def test_vocab_mapping_intersection(self):
+        vm = self._make_vocab_mapping()
+        assert vm.intersection_size == 3
+        assert vm.intersection_mask_draft.tolist() == [True, True, True, False, False]
+
+    def test_sample_constrains_to_intersection_and_maps_to_target(self):
+        """Raw argmax lands on a non-intersection id (3); after constraining, the
+        helper must pick the best *intersection* id and return it in target space."""
+        proposer = self._make_proposer(
+            use_heterogeneous_vocab=True,
+            vocab_mapping=self._make_vocab_mapping(),
+        )
+        # Draft id 3 ("y", outside the intersection) has the highest logit.
+        logits = torch.tensor([[0.1, 0.2, 0.3, 9.0, 8.0]])
+        out = proposer._sample_draft_token_ids(logits)
+        # id 3 is masked to -inf -> best intersection id is 2 ("c") -> target id 2.
+        assert out.tolist() == [2]
+
+    def test_to_draft_vocab_maps_and_falls_back_to_unk(self):
+        proposer = self._make_proposer(
+            use_heterogeneous_vocab=True,
+            vocab_mapping=self._make_vocab_mapping(),
+        )
+        # target ids 0, 1 are shared; 3 ("x") is out of intersection -> draft unk (4).
+        out = proposer._to_draft_vocab(torch.tensor([0, 1, 3]))
+        assert out.tolist() == [0, 1, 4]
+
+    def test_helpers_are_noop_when_flag_disabled(self):
+        proposer = self._make_proposer(
+            use_heterogeneous_vocab=False,
+            vocab_mapping=self._make_vocab_mapping(),
+        )
+        logits = torch.tensor([[0.1, 0.2, 0.3, 9.0, 8.0]])
+        # Plain argmax, no constraint -> id 3.
+        assert proposer._sample_draft_token_ids(logits).tolist() == [3]
+        # Passthrough.
+        assert proposer._to_draft_vocab(torch.tensor([0, 1, 3])).tolist() == [0, 1, 3]
+
+    def test_helpers_are_noop_when_flag_attr_missing(self):
+        """Non-draft_model proposers never set ``use_heterogeneous_vocab``; the
+        ``getattr(..., False)`` guard must keep them on the plain path."""
+        proposer = self._make_proposer(use_heterogeneous_vocab=None, vocab_mapping=None)
+        logits = torch.tensor([[0.1, 0.2, 0.3, 9.0, 8.0]])
+        assert proposer._sample_draft_token_ids(logits).tolist() == [3]
+        assert proposer._to_draft_vocab(torch.tensor([0, 1, 3])).tolist() == [0, 1, 3]

--- a/vllm_ascend/spec_decode/draft_proposer.py
+++ b/vllm_ascend/spec_decode/draft_proposer.py
@@ -1,6 +1,8 @@
 import torch
 from vllm.config import VllmConfig
+from vllm.tokenizers.registry import get_tokenizer
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
+from vllm.v1.spec_decode.vocab_mapping import VocabMapping
 
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
@@ -13,5 +15,31 @@ class AscendDraftModelProposer(DraftModelProposer, AscendSpecDecodeBaseProposer)
         runner=None,
     ):
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, False, runner=runner)
-        self._raise_if_vocab_size_mismatch()
         self._raise_if_draft_tp_mismatch()
+
+        # TLI (vllm#38174): when target and draft use different tokenizers,
+        # build a VocabMapping to translate token IDs between the two vocabs
+        # and constrain draft logits to the intersection. NOTE: the ascend
+        # base __init__ above does NOT run core DraftModelProposer.__init__,
+        # so we must build vocab_mapping here (mirror of draft_model.py).
+        self.use_heterogeneous_vocab = self.speculative_config.use_heterogeneous_vocab
+        spec = self.speculative_config
+        if self.use_heterogeneous_vocab:
+            target_tokenizer = get_tokenizer(
+                spec.target_model_config.tokenizer,
+                trust_remote_code=spec.target_model_config.trust_remote_code,
+            )
+            draft_tokenizer = get_tokenizer(
+                spec.draft_model_config.model,
+                trust_remote_code=spec.draft_model_config.trust_remote_code,
+            )
+            self.vocab_mapping: VocabMapping | None = VocabMapping(
+                target_tokenizer=target_tokenizer,
+                draft_tokenizer=draft_tokenizer,
+                target_vocab_size=spec.target_model_config.get_vocab_size(),
+                draft_vocab_size=spec.draft_model_config.get_vocab_size(),
+                device=device,
+            )
+        else:
+            self._raise_if_vocab_size_mismatch()
+            self.vocab_mapping = None

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1329,9 +1329,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # cast to int32 is crucial when eagle model is compiled.
             # tensor.argmax() returns int64 by default.
             input_ids = draft_token_ids_tensor[draft_index]
-            # TLI: draft_token_ids_tensor holds target-vocab ids (mapped in
-            # _sample_draft_token_ids); map back to draft-vocab space before re-feeding
-            # the draft model.
+            # if use_heterogeneous_vocab is True, use TLI: draft_token_ids_tensor holds
+            # target-vocab ids (mapped in _sample_draft_token_ids);
+            # map back to draft-vocab space before re-feeding the draft model.
+            # otherwise, no changes of input_ids.
             input_ids = self._to_draft_vocab(input_ids)
             positions += 1
 
@@ -1465,6 +1466,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_tokens = target_token_ids.shape[0]
             # TLI: the draft model consumes ids in draft-vocab space; map the
             # target-vocab context/next tokens before filling the input buffer.
+            # No-op when heterogeneous vocab is disabled
             shifted_ids = self._to_draft_vocab(target_token_ids[1:])
             mapped_next_token_ids = self._to_draft_vocab(next_token_ids)
             # Shift the input ids by one token.

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1100,7 +1100,30 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             return next_token + bias
         else:
             logits = self.model.compute_logits(hidden_states)
+            if getattr(self, "use_heterogeneous_vocab", False):
+                return self._sample_draft_token_ids(logits)
             return greedy_sample(logits)
+
+    def _sample_draft_token_ids(self, logits: torch.Tensor) -> torch.Tensor:
+        """TLI (vllm#38174) draft sampling for heterogeneous vocabularies.
+
+        Constrain draft logits to the target/draft vocab intersection, greedy
+        sample, then map the chosen draft-vocab id to its target-vocab id so
+        the verifier / rejection sampler sees target-space ids. Falls back to
+        plain argmax when heterogeneous vocab is disabled.
+        """
+        if getattr(self, "use_heterogeneous_vocab", False):
+            logits = self.vocab_mapping.constrain_draft_logits(logits)
+            draft_token_ids = logits.argmax(dim=-1)
+            return self.vocab_mapping.map_draft_to_target_ids(draft_token_ids)
+        return logits.argmax(dim=-1)
+
+    def _to_draft_vocab(self, ids: torch.Tensor) -> torch.Tensor:
+        """TLI: map target-vocab ids to draft-vocab space before feeding the
+        draft model. No-op when heterogeneous vocab is disabled."""
+        if getattr(self, "use_heterogeneous_vocab", False):
+            return self.vocab_mapping.map_target_to_draft_ids(ids)
+        return ids
 
     def _run_merged_draft(
         self,
@@ -1228,7 +1251,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         ori_token_indices_to_sample,
                         is_logits=True,
                     )
-                draft_token_ids = logits.argmax(dim=-1)
+                draft_token_ids = self._sample_draft_token_ids(logits)
         else:
             if self.method == "dspark":
                 # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
@@ -1254,7 +1277,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         ori_token_indices_to_sample,
                         is_logits=True,
                     )
-                draft_token_ids = logits.argmax(dim=-1)
+                draft_token_ids = self._sample_draft_token_ids(logits)
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
@@ -1306,6 +1329,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # cast to int32 is crucial when eagle model is compiled.
             # tensor.argmax() returns int64 by default.
             input_ids = draft_token_ids_tensor[draft_index]
+            # TLI: draft_token_ids_tensor holds target-vocab ids (mapped in
+            # _sample_draft_token_ids); map back to draft-vocab space before re-feeding
+            # the draft model.
+            input_ids = self._to_draft_vocab(input_ids)
             positions += 1
 
             # NOTE(woosuk): We should handle the case where the draft model
@@ -1398,13 +1425,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     if lmhead_tp_enable() and num_indices < logits.shape[0]:
                         logits = logits[:num_indices]
                         token_indices_to_sample = token_indices_to_sample[:num_indices]
-                    draft_token_ids = logits.argmax(dim=-1)
+                    draft_token_ids = self._sample_draft_token_ids(logits)
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable() and num_indices < logits.shape[0]:
                     logits = logits[:num_indices]
                     token_indices_to_sample = token_indices_to_sample[:num_indices]
-                draft_token_ids = logits.argmax(dim=-1)
+                draft_token_ids = self._sample_draft_token_ids(logits)
 
             # TODO(wenlong): get more than one token for tree attention
             hidden_states = hidden_states[:batch_size]
@@ -1436,12 +1463,16 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 token_indices_to_sample = cad.query_start_loc[1:] - 1
 
             num_tokens = target_token_ids.shape[0]
+            # TLI: the draft model consumes ids in draft-vocab space; map the
+            # target-vocab context/next tokens before filling the input buffer.
+            shifted_ids = self._to_draft_vocab(target_token_ids[1:])
+            mapped_next_token_ids = self._to_draft_vocab(next_token_ids)
             # Shift the input ids by one token.
             # E.g., [a1, b1, b2, c1, c2, c3] -> [b1, b2, c1, c2, c3, c3]
-            self.input_ids[: num_tokens - 1] = target_token_ids[1:]
+            self.input_ids[: num_tokens - 1] = shifted_ids
             # Replace the last token with the next token.
             # E.g., [b1, b2, c1, c2, c3, c3] -> [a2, b2, b3, c2, c3, c4]
-            self.input_ids[token_indices_to_sample] = next_token_ids
+            self.input_ids[token_indices_to_sample] = mapped_next_token_ids
 
             assert self.runner is not None
             # update pcp related params


### PR DESCRIPTION
## What this PR does / why we need it?

This PR adds Ascend NPU support for the **universal speculative decoding** method introduced in upstream [vllm-project/vllm#38174](https://github.com/vllm-project/vllm/pull/38174). It enables speculative decoding with **heterogeneous vocabularies** — the draft and target models can use different tokenizers (e.g., Llama-8B target + Qwen-0.5B draft).

The core algorithm uses **Token-Level Intersection (TLI)**: the draft model generates tokens constrained to the vocabulary intersection, and a `VocabMapping` layer translates token IDs between the two vocabularies. Rejection sampling runs unchanged, preserving the target model's output distribution (provably lossless).

Currently, `AscendDraftModelProposer` enforces `verify_equal_vocab_size_if_draft_model()`, blocking heterogeneous model pairs. This PR adds a new `AscendUniversalDraftProposer` that lifts this restriction.

Closes #7663

## Changes
  
  Adapt the Token-Level Intersection (TLI) algorithm from [vllm#38174](https://github.com/vllm-project/vllm/pull/38174) to vllm-ascend's  `draft_model` speculative decoding path. Enabled by the upstream
  `use_heterogeneous_vocab` flag — **no new config or spec-decode method on the ascend side**; it extends the existing `draft_model` proposer instead of adding a standalone one.

  | File | Change |
  |------|--------|
  | `vllm_ascend/spec_decode/draft_proposer.py` | Build a `VocabMapping` in `AscendDraftModelProposer.__init__` when `use_heterogeneous_vocab` is set, and skip the equal-vocab-size check in that case |
  | `vllm_ascend/spec_decode/llm_base_proposer.py` | Add two flag-gated helpers and wire them into the existing draft sampling / input path |

  **Key implementation details:**

  - **Why the init change:** `AscendDraftModelProposer.__init__` calls `AscendSpecDecodeBaseProposer.__init__` directly (not `super()`), so core `DraftModelProposer.__init__` never runs and `vocab_mapping` is not built. It is therefore constructed here, mirroring upstream `draft_model.py`. Reuses upstream `VocabMapping` from `vllm.v1.spec_decode.vocab_mapping` (device-agnostic).
  - **`_sample_draft_token_ids(logits)`:** constrain draft logits to the
  target/draft vocab intersection → greedy `argmax` → map the draft-vocab id to
  its target-vocab id. Falls back to plain `argmax` when heterogeneous vocab is
  disabled. Mirrors upstream's centralized `_greedy_sample`.
  - **`_to_draft_vocab(ids)`:** map target-vocab ids to draft-vocab space before feeding the draft model; no-op when disabled.
  - **Wiring:** the draft model runs entirely in draft-vocab space while the verifier / rejection sampler sees target-vocab ids — `_sample_draft_token_ids` replaces the draft `argmax` sites (step-0 and the multi-step loop), and 
  `_to_draft_vocab` is applied at the input-buffer fill (`set_inputs_first_pass`) and the per-step feedback.
  - **Zero impact when disabled:** every change is gated on `use_heterogeneous_vocab`; the existing multi-step drafting loop and homogeneous-vocab behavior are unchanged. Small footprint (+66/−7 across 2 files), no code duplication.

## Dependencies

- **Upstream vLLM PR**: [vllm-project/vllm#38174](https://github.com/vllm-project/vllm/pull/38174) 

## Usage

```bash
python -m vllm.entrypoints.openai.api_server \
    --model Qwen2.5-7B-Instruct \
    --speculative-config '{"model": "Qwen2.5-0.5B-Instruct", "num_speculative_tokens": 5, "use_heterogeneous_vocab": True,}'
```

## Testing
 **Verified on Atlas 800T A2 (910B3):** Qwen2.5-1.5B (target) + Qwen2.5-0.5B (draft), `num_speculative_tokens=3`, greedy — vocab intersection 151665/151936= **99.8%**, draft acceptance **170/264 = 64.4%**, coherent/correct outputs.

## Related

- Upstream: [vllm-project/vllm#38174](https://github.com/vllm-project/vllm/pull/38174)
- Issue: #7663
- Algorithm: Timor et al., "Speculative Decoding with Heterogeneous Vocabularies", ICML 2025

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
