### PR TITLE
[model_runner_v2] optimize the performance of _min_p_kernel and _rank…

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_topk_logprobs.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_topk_logprobs.py
@@ -1,0 +1,58 @@
+import torch
+import pytest
+# 请根据实际路径修改导入
+from vllm_ascend.worker.v2.sample.logprob import compute_topk_logprobs
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+@pytest.mark.parametrize("batch_size,vocab_size,num_logprobs", [
+    (48, 102400, 5),   # 常规情况
+    (96, 102400, 0),   # 边缘测试：只计算 sampled_token，不计算 topK
+    (24, 151936, 1),   # 边缘测试：top-1
+    (1, 32000, 10),    # 边缘测试：batch_size = 1
+])
+def test_compute_topk_logprobs(batch_size, vocab_size, num_logprobs):
+    """Test compute_topk_logprobs for correctness of IDs, logprobs, and ranks.
+    Args:
+        batch_size: Number of sequences in the batch
+        vocab_size: Size of the vocabulary
+        num_logprobs: Number of top-k logprobs to return (excluding the sampled token)
+    """
+    init_device_properties_triton()
+    # ========== 1. Setup test data ==========
+    torch.manual_seed(42)
+    device = 'npu'
+
+    logits = torch.randn(batch_size, vocab_size, device=device, dtype=torch.float32)
+    
+    sampled_token_ids = torch.randint(0, vocab_size, (batch_size,), device=device, dtype=torch.int64)
+
+    # ========== 2. Execute Triton implementation ==========
+    triton_output = compute_topk_logprobs(logits, num_logprobs, sampled_token_ids)
+    torch.npu.synchronize()
+
+    # ========== 3. Compute reference values using PyTorch ==========
+    
+    if num_logprobs == 0:
+        ref_token_ids = sampled_token_ids.unsqueeze(-1)
+    else:
+        topk_indices = torch.topk(logits, num_logprobs, dim=-1).indices
+        ref_token_ids = torch.cat((sampled_token_ids.unsqueeze(-1), topk_indices), dim=1)
+
+    ref_all_logprobs = torch.log_softmax(logits, dim=-1)
+    ref_logprobs = torch.gather(ref_all_logprobs, dim=1, index=ref_token_ids)
+
+    sampled_logits = torch.gather(logits, 1, sampled_token_ids.unsqueeze(-1))
+    ref_ranks = (logits > sampled_logits).sum(dim=1).to(torch.int64)
+
+    # ========== 4. Verify results ==========
+    
+    assert torch.equal(triton_output.logprob_token_ids, ref_token_ids), \
+        "Token IDs (Sampled + TopK) do not match between Triton and PyTorch."
+
+    assert torch.equal(triton_output.selected_token_ranks, ref_ranks), \
+        f"Token Ranks do not match.\n" \
+        f"Triton: {triton_output.selected_token_ranks}\n" \
+        f"PyTorch: {ref_ranks}"
+
+    assert torch.allclose(triton_output.logprobs, ref_logprobs, rtol=1e-3, atol=1e-4), \
+        f"Logprobs values differ between Triton and PyTorch.\n" \
+        f"Max diff: {torch.max(torch.abs(triton_output.logprobs - ref_logprobs))}"

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_min_p.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_min_p.py
@@ -1,0 +1,57 @@
+import torch
+import pytest
+from vllm_ascend.worker.v2.sample.min_p import apply_min_p
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+@pytest.mark.parametrize("num_reqs,vocab_size", [
+    (48, 102400),
+    (96, 102400),
+    (24, 151936),
+    (1, 32000),
+])
+def test_apply_min_p_kernel(num_reqs, vocab_size):
+    """Test apply_min_p for computing Min-P sampling mask
+    Args:
+        num_reqs: Number of sequences in the batch
+        vocab_size: Size of the vocabulary
+    """
+    init_device_properties_triton()
+    # ========== Setup test data ==========
+    torch.manual_seed(42)
+
+    # Generate random logits (using float32 as specified in your kernel)
+    device = 'npu'
+    
+    original_logits = torch.randn(num_reqs, vocab_size, device=device, dtype=torch.float32)
+    
+    triton_logits = original_logits.clone()
+    ref_logits = original_logits.clone()
+
+    # Generate random min_p values (valid range is typically (0, 1.0])
+    min_p = torch.empty(num_reqs, device=device, dtype=torch.float32).uniform_(0.01, 0.5)
+
+    # ========== Execute test ==========
+    # 1. Invoke your Triton kernel wrapper
+    apply_min_p(triton_logits, min_p)
+    torch.npu.synchronize()
+
+    # 2. Compute reference values using PyTorch
+    max_vals = ref_logits.max(dim=-1, keepdim=True).values
+    
+    thresholds = max_vals + torch.log(min_p.unsqueeze(1))
+    
+    ref_logits[ref_logits < thresholds] = float("-inf")
+
+    # ========== Verify results ==========
+    
+    triton_inf_mask = torch.isinf(triton_logits)
+    ref_inf_mask = torch.isinf(ref_logits)
+    
+    assert torch.equal(triton_inf_mask, ref_inf_mask), \
+        "Masked positions (where logits == -inf) do not match between Triton and PyTorch."
+
+    valid_triton_logits = triton_logits[~triton_inf_mask]
+    valid_ref_logits = ref_logits[~ref_inf_mask]
+    
+    assert torch.allclose(valid_triton_logits, valid_ref_logits, rtol=1e-5, atol=1e-5), \
+        f"Logits values differ between Triton and PyTorch reference.\n" \
+        f"Max diff: {torch.max(torch.abs(valid_triton_logits - valid_ref_logits))}"

--- a/vllm_ascend/worker/v2/sample/logprob.py
+++ b/vllm_ascend/worker/v2/sample/logprob.py
@@ -19,6 +19,9 @@
 
 import torch
 from vllm.triton_utils import tl, triton
+from vllm.v1.outputs import LogprobsTensors
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
 @triton.jit
@@ -83,3 +86,83 @@ def compute_token_logprobs(logits: torch.Tensor, token_ids: torch.Tensor) -> tor
         PADDED_TOPK=max(triton.next_power_of_2(num_logprobs), 2),
     )
     return logprobs
+
+
+@triton.jit
+def _ranks_kernel(
+    output_ptr,
+    logits_ptr,
+    logits_stride,
+    token_ids_ptr,
+    vocab_size,
+    batch_size,
+    rows_per_core,
+    BLOCK_SIZE: tl.constexpr,
+):
+    core_id = tl.program_id(0)
+
+    start_row = core_id * rows_per_core
+    end_row = start_row + rows_per_core
+
+    for req_idx in range(start_row, end_row):
+        if req_idx < batch_size:
+            row_ptr = logits_ptr + req_idx * logits_stride
+
+            token_id = tl.load(token_ids_ptr + req_idx)
+            x = tl.load(row_ptr + token_id)
+
+            n_vec = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+            for i in range(0, vocab_size, BLOCK_SIZE):
+                block = i + tl.arange(0, BLOCK_SIZE)
+                logits = tl.load(row_ptr + block, mask=block < vocab_size, other=float("-inf"))
+                n_vec += (logits > x).to(tl.int32)
+            n = tl.sum(n_vec)
+            tl.store(output_ptr + req_idx, n)
+
+
+def compute_topk_logprobs(
+    logits: torch.Tensor,
+    num_logprobs: int,
+    sampled_token_ids: torch.Tensor,
+) -> LogprobsTensors:
+    assert num_logprobs >= 0
+    batch_size, vocab_size = logits.shape
+    if num_logprobs == 0:
+        logprob_token_ids = sampled_token_ids.unsqueeze(-1)
+    else:
+        topk_indices = torch.topk(logits, num_logprobs, dim=-1).indices
+        logprob_token_ids = torch.cat((sampled_token_ids.unsqueeze(-1), topk_indices), dim=1)
+
+    # NOTE(woosuk): Here, to save GPU memory, we do not materialize the full
+    # logprobs tensor. Instead, we only compute and return the logprobs of
+    # the topk + 1 tokens.
+    logprobs = compute_token_logprobs(logits, logprob_token_ids)
+    token_ranks = torch.empty(
+        batch_size,
+        dtype=torch.int64,
+        device=logits.device,
+    )
+
+    vec_core = get_vectorcore_num()
+    NUM_CORES = min(batch_size, vec_core)
+
+    rows_per_core = triton.cdiv(batch_size, NUM_CORES)
+
+    grid = (NUM_CORES,)
+    _ranks_kernel[grid](
+        token_ranks,
+        logits,
+        logits.stride(0),
+        sampled_token_ids,
+        vocab_size,
+        batch_size,
+        rows_per_core,
+        BLOCK_SIZE=8 * 1024,
+        multibuffer=False,
+    )
+
+    return LogprobsTensors(
+        logprob_token_ids=logprob_token_ids,
+        logprobs=logprobs,
+        selected_token_ranks=token_ranks,
+    )

--- a/vllm_ascend/worker/v2/sample/min_p.py
+++ b/vllm_ascend/worker/v2/sample/min_p.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit
+def _min_p_kernel(
+    logits_ptr,
+    logits_out_ptr,
+    logits_stride,
+    min_p_ptr,
+    num_reqs,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    SUB_BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    start_req = pid * SUB_BLOCK_SIZE
+    end_req = tl.minimum(start_req + SUB_BLOCK_SIZE, num_reqs)
+
+    for req_idx in range(start_req, end_req):
+        min_p = tl.load(min_p_ptr + req_idx).to(tl.float32)
+
+        if min_p > 0.0:
+            max_val_vec = tl.full([BLOCK_SIZE], float("-inf"), dtype=tl.float32)
+            for i in range(0, vocab_size, BLOCK_SIZE):
+                offsets = i + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < vocab_size
+
+                logits = tl.load(logits_ptr + req_idx * logits_stride + offsets, mask=mask, other=float("-inf"))
+
+                max_val_vec = tl.maximum(logits, max_val_vec)
+            max_val = tl.max(max_val_vec).to(tl.float32)
+
+            threshold = max_val + tl.log(min_p)
+            for i in range(0, vocab_size, BLOCK_SIZE):
+                offsets = i + tl.arange(0, BLOCK_SIZE)
+                mask = offsets < vocab_size
+
+                logits = tl.load(logits_ptr + req_idx * logits_stride + offsets, mask=mask, other=float("-inf"))
+
+                logits = tl.where(logits < threshold, float("-inf"), logits)
+                tl.store(logits_out_ptr + req_idx * logits_stride + offsets, logits, mask=mask)
+
+
+def apply_min_p(logits: torch.Tensor, min_p: torch.Tensor) -> None:
+    if logits.numel() == 0:
+        return
+
+    num_reqs, vocab_size = logits.shape
+
+    assert logits.stride(-1) == 1, "The last dimension of logits (vocab_size) must be contiguous in memory."
+    assert min_p.is_contiguous(), "The min_p tensor must be contiguous."
+    assert min_p.dim() == 1 and min_p.size(0) == num_reqs, "The shape of min_p must be (num_reqs,)."
+
+    vec_core = get_vectorcore_num()
+    core_nums = min(num_reqs, vec_core)
+
+    BLOCK_SIZE = 8 * 1024
+
+    BLOCK_SIZE = min(triton.next_power_of_2(vocab_size), BLOCK_SIZE)
+
+    _min_p_kernel[(core_nums,)](
+        logits,
+        logits,
+        logits.stride(0),
+        min_p,
+        num_reqs,
+        vocab_size,
+        BLOCK_SIZE,
+        SUB_BLOCK_SIZE=triton.cdiv(num_reqs, core_nums),
+        multibuffer=False,
+    )


### PR DESCRIPTION
### What this PR does / why we need it?
This PR significantly improves the execution efficiency of sampling operations in `model_runner_v2` for Ascend NPU. Specifically, it optimizes the performance of the following Triton operators:
* `_min_p_kernel`: Optimized the memory access and threshold calculation logic for Min-P sampling.
* `_ranks_kernel`: Accelerated the token rank calculation during the top-k logprobs extraction process.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
`pytest tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_min_p.py`
`pytest tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_topk_logprobs.py`

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
