### PR TITLE
[bugfix]fixes #7598

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -324,19 +324,25 @@ class NPUPlatform(Platform):
             if decode_query_len > 1:
                 max_size = compilation_config.max_cudagraph_capture_size
                 aligned_sizes = list(range(decode_query_len, max_size + 1, decode_query_len))
-             if aligned_sizes:
+            if aligned_sizes:
                 compilation_config.cudagraph_capture_sizes = aligned_sizes
                 compilation_config.max_cudagraph_capture_size = aligned_sizes[-1]
                 compilation_config.post_init_cudagraph_sizes()
                 logger.info(
                     "Adjusted cudagraph_capture_sizes for speculative decoding "
-                    "(decode_query_len=%d): %d sizes from %d to %d",
+                    "(decode_query_len=%d): from %d to %d",
                     decode_query_len,
                     len(aligned_sizes),
                     aligned_sizes[0],
                     aligned_sizes[-1],
                 )
-                    )
+            else:
+                logger.warning(
+                    "Skip adjusting cudagraph_capture_sizes: max_cudagraph_capture_size (%d) "
+                    "is smaller than decode_query_len (%d).",
+                    max_size,
+                    decode_query_len,
+                )
         # TODO delete graph size update here when compilation_config.pass_config.enable_sp
         # is supported by vllm-ascend.
         if (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -318,15 +318,12 @@ class NPUPlatform(Platform):
             speculative_config
             and speculative_config.num_speculative_tokens
             and compilation_config.cudagraph_capture_sizes
-            and compilation_config.cudagraph_mode
-            in (CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.FULL)
+            and compilation_config.cudagraph_mode in (CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.FULL)
         ):
             decode_query_len = 1 + speculative_config.num_speculative_tokens
             if decode_query_len > 1:
                 max_size = compilation_config.max_cudagraph_capture_size
-                aligned_sizes = list(range(
-                    decode_query_len, max_size + 1, decode_query_len
-                ))
+                aligned_sizes = list(range(decode_query_len, max_size + 1, decode_query_len))
                 update_cudagraph_capture_sizes(vllm_config, aligned_sizes)
                 logger.info(
                     "Adjusted cudagraph_capture_sizes for speculative decoding "

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -331,7 +331,6 @@ class NPUPlatform(Platform):
                 logger.info(
                     "Adjusted cudagraph_capture_sizes for speculative decoding, (decode_query_len=%d): from %d to %d",
                     decode_query_len,
-                    len(aligned_sizes),
                     aligned_sizes[0],
                     aligned_sizes[-1],
                 )

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -324,23 +324,16 @@ class NPUPlatform(Platform):
             if decode_query_len > 1:
                 max_size = compilation_config.max_cudagraph_capture_size
                 aligned_sizes = list(range(decode_query_len, max_size + 1, decode_query_len))
-            if aligned_sizes:
                 compilation_config.cudagraph_capture_sizes = aligned_sizes
                 compilation_config.max_cudagraph_capture_size = aligned_sizes[-1]
                 compilation_config.post_init_cudagraph_sizes()
-                logger.info(
-                    "Adjusted cudagraph_capture_sizes for speculative decoding, (decode_query_len=%d): from %d to %d",
-                    decode_query_len,
-                    aligned_sizes[0],
-                    aligned_sizes[-1],
-                )
-            else:
-                logger.warning(
-                    "Skip adjusting cudagraph_capture_sizes: max_cudagraph_capture_size (%d) "
-                    "is smaller than decode_query_len (%d).",
-                    max_size,
-                    decode_query_len,
-                )
+                if aligned_sizes:
+                    logger.info(
+                        "Adjusted cudagraph_capture_sizes for speculative decoding, (decode_query_len=%d): from %d to %d",
+                        decode_query_len,
+                        aligned_sizes[0],
+                        aligned_sizes[-1],
+                    )
         # TODO delete graph size update here when compilation_config.pass_config.enable_sp
         # is supported by vllm-ascend.
         if (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -329,8 +329,7 @@ class NPUPlatform(Platform):
                 compilation_config.max_cudagraph_capture_size = aligned_sizes[-1]
                 compilation_config.post_init_cudagraph_sizes()
                 logger.info(
-                    "Adjusted cudagraph_capture_sizes for speculative decoding "
-                    "(decode_query_len=%d): from %d to %d",
+                    "Adjusted cudagraph_capture_sizes for speculative decoding, (decode_query_len=%d): from %d to %d",
                     decode_query_len,
                     len(aligned_sizes),
                     aligned_sizes[0],

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -325,14 +325,15 @@ class NPUPlatform(Platform):
                 max_size = compilation_config.max_cudagraph_capture_size
                 aligned_sizes = list(range(decode_query_len, max_size + 1, decode_query_len))
                 update_cudagraph_capture_sizes(vllm_config, aligned_sizes)
-                logger.info(
-                    "Adjusted cudagraph_capture_sizes for speculative decoding "
-                    "(decode_query_len=%d): %d sizes from %d to %d",
-                    decode_query_len,
-                    len(aligned_sizes),
-                    aligned_sizes[0],
-                    aligned_sizes[-1],
-                )
+                if aligned_sizes:
+                    logger.info(
+                        "Adjusted cudagraph_capture_sizes for speculative decoding "
+                        "(decode_query_len=%d): %d sizes from %d to %d",
+                        decode_query_len,
+                        len(aligned_sizes),
+                        aligned_sizes[0],
+                        aligned_sizes[-1],
+                    )
         # TODO delete graph size update here when compilation_config.pass_config.enable_sp
         # is supported by vllm-ascend.
         if (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -312,6 +312,30 @@ class NPUPlatform(Platform):
         # `apply_config_platform_defaults`, so this late pass should only honor
         # the current max / size inputs after the mode adjustments above.
         vllm_config._set_cudagraph_sizes()
+        # 新增：投机推理场景下，强制 capture sizes 为 decode_query_len 的倍数
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        if (
+            speculative_config
+            and speculative_config.num_speculative_tokens
+            and compilation_config.cudagraph_capture_sizes
+            and compilation_config.cudagraph_mode
+            in (CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.FULL)
+        ):
+            decode_query_len = 1 + speculative_config.num_speculative_tokens
+            if decode_query_len > 1:
+                max_size = compilation_config.max_cudagraph_capture_size
+                aligned_sizes = list(range(
+                    decode_query_len, max_size + 1, decode_query_len
+                ))
+                update_cudagraph_capture_sizes(vllm_config, aligned_sizes)
+                logger.info(
+                    "Adjusted cudagraph_capture_sizes for speculative decoding "
+                    "(decode_query_len=%d): %d sizes from %d to %d",
+                    decode_query_len,
+                    len(aligned_sizes),
+                    aligned_sizes[0],
+                    aligned_sizes[-1],
+                )
         # TODO delete graph size update here when compilation_config.pass_config.enable_sp
         # is supported by vllm-ascend.
         if (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -324,15 +324,18 @@ class NPUPlatform(Platform):
             if decode_query_len > 1:
                 max_size = compilation_config.max_cudagraph_capture_size
                 aligned_sizes = list(range(decode_query_len, max_size + 1, decode_query_len))
-                update_cudagraph_capture_sizes(vllm_config, aligned_sizes)
-                if aligned_sizes:
-                    logger.info(
-                        "Adjusted cudagraph_capture_sizes for speculative decoding "
-                        "(decode_query_len=%d): %d sizes from %d to %d",
-                        decode_query_len,
-                        len(aligned_sizes),
-                        aligned_sizes[0],
-                        aligned_sizes[-1],
+             if aligned_sizes:
+                compilation_config.cudagraph_capture_sizes = aligned_sizes
+                compilation_config.max_cudagraph_capture_size = aligned_sizes[-1]
+                compilation_config.post_init_cudagraph_sizes()
+                logger.info(
+                    "Adjusted cudagraph_capture_sizes for speculative decoding "
+                    "(decode_query_len=%d): %d sizes from %d to %d",
+                    decode_query_len,
+                    len(aligned_sizes),
+                    aligned_sizes[0],
+                    aligned_sizes[-1],
+                )
                     )
         # TODO delete graph size update here when compilation_config.pass_config.enable_sp
         # is supported by vllm-ascend.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes https://github.com/vllm-project/vllm-ascend/issues/7598.

When `full_decode_only` is enabled, all speculative decoding methods are affected by this issue. This patch fixes that behavior.
- vLLM version: v0.18.0
- vLLM version: main

Subsequent speculative decoding will automatically align based on your set **"num_speculative_tokens"**, without needing to explicitly set **"cudagraph_capture_sizes"**.
