### PR TITLE
[bugfix] adapt to main2main for model runnerv2 and add gc in sleep mode

### DIFF
--- a/.github/workflows/scripts/config.yaml
+++ b/.github/workflows/scripts/config.yaml
@@ -61,7 +61,6 @@ e2e-singlecard:
   estimated_time: 600
 - name: tests/e2e/singlecard/model_runner_v2/test_basic.py
   estimated_time: 80
-  is_skipped: true
 e2e-singlecard-light:
 - name: tests/e2e/singlecard/test_aclgraph_accuracy.py::test_piecewise_res_consistency
   estimated_time: 229

--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -54,60 +54,60 @@ def test_qwen3_dense_eager_mode(
         runner.model.generate(prompts, sampling_params)
 
 
-@pytest.mark.parametrize("model", MAIN_MODELS)
-@pytest.mark.parametrize("eagle_model", EGALE_MODELS)
-@pytest.mark.parametrize("max_tokens", [32])
-@pytest.mark.parametrize("enforce_eager", [True])
-@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
-def test_egale_spec_decoding(
-    model: str,
-    eagle_model: str,
-    max_tokens: int,
-    enforce_eager: bool,
-) -> None:
-    prompts = [
-        "Hello, my name is",
-        "The president of the United States is",
-        "The capital of France is",
-        "The future of AI is",
-    ]
+# @pytest.mark.parametrize("model", MAIN_MODELS)
+# @pytest.mark.parametrize("eagle_model", EGALE_MODELS)
+# @pytest.mark.parametrize("max_tokens", [32])
+# @pytest.mark.parametrize("enforce_eager", [True])
+# @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+# def test_egale_spec_decoding(
+#     model: str,
+#     eagle_model: str,
+#     max_tokens: int,
+#     enforce_eager: bool,
+# ) -> None:
+#     prompts = [
+#         "Hello, my name is",
+#         "The president of the United States is",
+#         "The capital of France is",
+#         "The future of AI is",
+#     ]
 
-    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
-    with VllmRunner(
-        model,
-        max_model_len=1024,
-        enforce_eager=enforce_eager,
-        async_scheduling=True,
-        speculative_config={
-            "model": eagle_model,
-            "method": "eagle",
-            "num_speculative_tokens": 3,
-        },
-    ) as runner:
-        runner.model.generate(prompts, sampling_params)
+#     sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+#     with VllmRunner(
+#         model,
+#         max_model_len=1024,
+#         enforce_eager=enforce_eager,
+#         async_scheduling=True,
+#         speculative_config={
+#             "model": eagle_model,
+#             "method": "eagle",
+#             "num_speculative_tokens": 3,
+#         },
+#     ) as runner:
+#         runner.model.generate(prompts, sampling_params)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("max_tokens", [32])
-@pytest.mark.parametrize("enforce_eager", [False])
-@pytest.mark.parametrize("compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY"}, {}])
-@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
-def test_qwen3_dense_graph_mode(
-    model: str,
-    max_tokens: int,
-    enforce_eager: bool,
-) -> None:
-    prompts = [
-        "Hello, my name is",
-        "The president of the United States is",
-        "The capital of France is",
-        "The future of AI is",
-    ]
+# @pytest.mark.parametrize("model", MODELS)
+# @pytest.mark.parametrize("max_tokens", [32])
+# @pytest.mark.parametrize("enforce_eager", [False])
+# @pytest.mark.parametrize("compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY"}, {}])
+# @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+# def test_qwen3_dense_graph_mode(
+#     model: str,
+#     max_tokens: int,
+#     enforce_eager: bool,
+# ) -> None:
+#     prompts = [
+#         "Hello, my name is",
+#         "The president of the United States is",
+#         "The capital of France is",
+#         "The future of AI is",
+#     ]
 
-    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
-    with VllmRunner(
-        model,
-        max_model_len=1024,
-        enforce_eager=enforce_eager,
-    ) as runner:
-        runner.model.generate(prompts, sampling_params)
+#     sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+#     with VllmRunner(
+#         model,
+#         max_model_len=1024,
+#         enforce_eager=enforce_eager,
+#     ) as runner:
+#         runner.model.generate(prompts, sampling_params)

--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -100,6 +100,7 @@ def test_qwen3_dense_graph_mode(
     model: str,
     max_tokens: int,
     enforce_eager: bool,
+    compilation_config: dict,
 ) -> None:
     prompts = [
         "Hello, my name is",
@@ -113,5 +114,6 @@ def test_qwen3_dense_graph_mode(
         model,
         max_model_len=1024,
         enforce_eager=enforce_eager,
+        compilation_config=compilation_config,
     ) as runner:
         runner.model.generate(prompts, sampling_params)

--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -30,7 +30,7 @@ MAIN_MODELS = ["LLM-Research/Meta-Llama-3.1-8B-Instruct"]
 EGALE_MODELS = ["vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B"]
 
 
-@pytest.skipif(vllm_version_is("0.18.0"), reason="model runner v2 don't support vllm 0.18.0")
+@pytest.mark.skipif(vllm_version_is("0.18.0"), reason="model runner v2 don't support vllm 0.18.0")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [True])
@@ -56,7 +56,7 @@ def test_qwen3_dense_eager_mode(
         runner.model.generate(prompts, sampling_params)
 
 
-@pytest.skip(reason="eagle function isn't adapted to the newest main commit.")
+@pytest.mark.skip(reason="eagle function isn't adapted to the newest main commit.")
 @pytest.mark.parametrize("model", MAIN_MODELS)
 @pytest.mark.parametrize("eagle_model", EGALE_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
@@ -90,7 +90,7 @@ def test_egale_spec_decoding(
         runner.model.generate(prompts, sampling_params)
 
 
-@pytest.skip(reason="graph function isn't adapted to the newest main commit.")
+@pytest.mark.skip(reason="graph function isn't adapted to the newest main commit.")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [False])

--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -22,6 +22,7 @@ import pytest
 from vllm import SamplingParams
 
 from tests.e2e.conftest import VllmRunner
+from vllm_ascend.utils import vllm_version_is
 
 MODELS = ["Qwen/Qwen3-0.6B"]
 
@@ -29,6 +30,7 @@ MAIN_MODELS = ["LLM-Research/Meta-Llama-3.1-8B-Instruct"]
 EGALE_MODELS = ["vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B"]
 
 
+@pytest.skipif(vllm_version_is("0.18.0"), reason="model runner v2 don't support vllm 0.18.0")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [True])
@@ -54,60 +56,62 @@ def test_qwen3_dense_eager_mode(
         runner.model.generate(prompts, sampling_params)
 
 
-# @pytest.mark.parametrize("model", MAIN_MODELS)
-# @pytest.mark.parametrize("eagle_model", EGALE_MODELS)
-# @pytest.mark.parametrize("max_tokens", [32])
-# @pytest.mark.parametrize("enforce_eager", [True])
-# @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
-# def test_egale_spec_decoding(
-#     model: str,
-#     eagle_model: str,
-#     max_tokens: int,
-#     enforce_eager: bool,
-# ) -> None:
-#     prompts = [
-#         "Hello, my name is",
-#         "The president of the United States is",
-#         "The capital of France is",
-#         "The future of AI is",
-#     ]
+@pytest.skip(reason="eagle function isn't adapted to the newest main commit.")
+@pytest.mark.parametrize("model", MAIN_MODELS)
+@pytest.mark.parametrize("eagle_model", EGALE_MODELS)
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [True])
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+def test_egale_spec_decoding(
+    model: str,
+    eagle_model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+) -> None:
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
 
-#     sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
-#     with VllmRunner(
-#         model,
-#         max_model_len=1024,
-#         enforce_eager=enforce_eager,
-#         async_scheduling=True,
-#         speculative_config={
-#             "model": eagle_model,
-#             "method": "eagle",
-#             "num_speculative_tokens": 3,
-#         },
-#     ) as runner:
-#         runner.model.generate(prompts, sampling_params)
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    with VllmRunner(
+        model,
+        max_model_len=1024,
+        enforce_eager=enforce_eager,
+        async_scheduling=True,
+        speculative_config={
+            "model": eagle_model,
+            "method": "eagle",
+            "num_speculative_tokens": 3,
+        },
+    ) as runner:
+        runner.model.generate(prompts, sampling_params)
 
 
-# @pytest.mark.parametrize("model", MODELS)
-# @pytest.mark.parametrize("max_tokens", [32])
-# @pytest.mark.parametrize("enforce_eager", [False])
-# @pytest.mark.parametrize("compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY"}, {}])
-# @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
-# def test_qwen3_dense_graph_mode(
-#     model: str,
-#     max_tokens: int,
-#     enforce_eager: bool,
-# ) -> None:
-#     prompts = [
-#         "Hello, my name is",
-#         "The president of the United States is",
-#         "The capital of France is",
-#         "The future of AI is",
-#     ]
+@pytest.skip(reason="graph function isn't adapted to the newest main commit.")
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize("compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY"}, {}])
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+def test_qwen3_dense_graph_mode(
+    model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+) -> None:
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
 
-#     sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
-#     with VllmRunner(
-#         model,
-#         max_model_len=1024,
-#         enforce_eager=enforce_eager,
-#     ) as runner:
-#         runner.model.generate(prompts, sampling_params)
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    with VllmRunner(
+        model,
+        max_model_len=1024,
+        enforce_eager=enforce_eager,
+    ) as runner:
+        runner.model.generate(prompts, sampling_params)

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -43,7 +43,13 @@ class AscendAttentionBackend310(AscendAttentionBackend):
         super().__init__(*args, **kwargs)
 
     @staticmethod
-    def get_kv_cache_shape(num_blocks: int, block_size: int, num_kv_heads: int, head_size: int):
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ):
         """
         Determines the shape of the Key-Value (KV) cache tensor.
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -95,6 +95,7 @@ class AscendAttentionBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
+        cache_type: str = "",
     ) -> tuple[int, ...]:
         return (2, num_blocks, block_size, num_kv_heads, head_size)
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -82,7 +82,13 @@ class AscendMLABackend(AttentionBackend):
         return AscendMLAMetadataBuilder
 
     @staticmethod
-    def get_kv_cache_shape(num_blocks: int, block_size: int, num_kv_heads: int, head_size: int) -> tuple[int, ...]:
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
         return num_blocks, block_size, num_kv_heads, head_size
 
     @staticmethod

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -84,7 +84,13 @@ class AscendSFABackend(AttentionBackend):
         return AscendSFAMetadataBuilder
 
     @staticmethod
-    def get_kv_cache_shape(num_blocks: int, block_size: int, num_kv_heads: int, head_size: int) -> tuple[int, ...]:
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
         return (num_blocks, block_size, num_kv_heads, head_size)
 
     @staticmethod

--- a/vllm_ascend/device_allocator/camem.py
+++ b/vllm_ascend/device_allocator/camem.py
@@ -17,6 +17,7 @@
 # CANN-mem-based pytorch pluggable allocator to implement sleep mode.
 #
 import dataclasses
+import gc
 import os
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -202,6 +203,9 @@ class CaMemAllocator:
                 memcpy(cpu_ptr, dest_max, ptr, size_in_bytes, ACL_MEMCPY_DEVICE_TO_HOST)
                 data.cpu_backup_tensor = cpu_backup_tensor
             unmap_and_release(handle)
+
+        gc.collect()
+        torch.npu.empty_cache()
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         """

--- a/vllm_ascend/worker/v2/README.md
+++ b/vllm_ascend/worker/v2/README.md
@@ -5,5 +5,5 @@ This directory contains the new model runner which is under active development.
 please see [Model Runner V2](https://github.com/vllm-project/vllm-ascend/issues/5208)
 to get specific plans.
 
-supported vllm version: main@ed359c497a728f08b5b41456c07a688ccd510fbc
-related PR: <https://github.com/vllm-project/vllm-ascend/pull/7598>
+supported vllm version: main@35141a7eeda941a60ad5a4956670c60fd5a77029
+related PR: <https://github.com/vllm-project/vllm-ascend/pull/7709>


### PR DESCRIPTION
### What this PR does / why we need it?
This PR do two things:
- adapt to main2main for model runner v2.
- add gc.collect and torch.npu.empty_cache for sleep mode, which refers to https://github.com/vllm-project/vllm/pull/15248.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
