### PR TITLE
[0.18.0][profiler] profile AICore and MTE time with torch profiler

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -602,7 +602,7 @@ class NPUWorker(WorkerBase):
             export_type=torch_npu.profiler.ExportType.Text,
             profiler_level=torch_npu.profiler.ProfilerLevel.Level1,
             msprof_tx=False,
-            aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+            aic_metrics=torch_npu.profiler.AiCMetrics.PipeUtilization,
             l2_cache=False,
             op_attr=False,
             data_simplification=True,


### PR DESCRIPTION

### What this PR does / why we need it?
This pull request updates the NPU profiler configuration in the Ascend worker by changing the `aic_metrics` parameter from `AiCoreNone` to `PipeUtilization`. This change enables the collection of pipe utilization metrics during profiling sessions.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
CI passed.