### PR TITLE
[v0.18.0][bugfix][eplb] remove unnecessary weight_scale wrap behavior

### DIFF
--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -267,8 +267,8 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 log2phy=log2phy,
                 pertoken_scale=pertoken_scale,
                 activation=activation,
-                w1_scale=[layer.fused_w1_scale] if fused_scale_flag else w1_scale,
-                w2_scale=[layer.fused_w2_scale] if fused_scale_flag else w2_scale,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR simplifies the apply method in w8a8_dynamic.py by removing the conditional logic that used fused_w1_scale and fused_w2_scale based on the fused_scale_flag. This redundant wrap behavior leads to EPLB break in int8 quantization scenarios.

Cherrypick from PR to main branch #7732 which was finally merged in #7188.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with existing tests.
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
