### PR TITLE
[Feature] Optimize GDN non-spec prefill fallback metadata

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_gdn_chunk_meta.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_gdn_chunk_meta.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.gdn_chunk_meta import build_chunk_meta_device
+from vllm_ascend.ops.triton.fla.utils import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+    prepare_final_chunk_indices,
+    prepare_update_chunk_offsets,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+
+@pytest.mark.parametrize(
+    ("cu_seqlens_data", "chunk_size", "input_dtype", "output_dtype"),
+    [
+        ([0, 4, 7], 4, torch.int32, torch.int32),
+        ([0, 4, 4, 12], 4, torch.int32, torch.int32),
+        ([0, 128, 1024, 1024, 4096], 64, torch.int64, torch.int32),
+    ],
+)
+@torch.inference_mode()
+def test_build_chunk_meta_device_correctness(
+    cu_seqlens_data: list[int],
+    chunk_size: int,
+    input_dtype: torch.dtype,
+    output_dtype: torch.dtype,
+):
+    init_device_properties_triton()
+    device = "npu"
+
+    cu_seqlens_cpu = torch.tensor(cu_seqlens_data, dtype=input_dtype)
+    cu_seqlens = cu_seqlens_cpu.to(device)
+
+    expected_chunk_indices = prepare_chunk_indices(cu_seqlens_cpu, chunk_size).to(output_dtype)
+    expected_chunk_offsets = prepare_chunk_offsets(cu_seqlens_cpu, chunk_size).to(output_dtype)
+    expected_update_chunk_offsets = prepare_update_chunk_offsets(cu_seqlens_cpu, chunk_size).to(output_dtype)
+    expected_final_chunk_indices = prepare_final_chunk_indices(cu_seqlens_cpu, chunk_size).to(output_dtype)
+
+    out_chunk_indices = torch.empty(
+        tuple(expected_chunk_indices.shape),
+        dtype=output_dtype,
+        device=device,
+    )
+    out_chunk_offsets = torch.empty(
+        tuple(expected_chunk_offsets.shape),
+        dtype=output_dtype,
+        device=device,
+    )
+    out_update_chunk_offsets = torch.empty(
+        tuple(expected_update_chunk_offsets.shape),
+        dtype=output_dtype,
+        device=device,
+    )
+    out_final_chunk_indices = torch.empty(
+        tuple(expected_final_chunk_indices.shape),
+        dtype=output_dtype,
+        device=device,
+    )
+
+    build_chunk_meta_device(
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        out_chunk_indices=out_chunk_indices,
+        out_chunk_offsets=out_chunk_offsets,
+        out_update_chunk_offsets=out_update_chunk_offsets,
+        out_final_chunk_indices=out_final_chunk_indices,
+    )
+
+    torch.testing.assert_close(out_chunk_indices.cpu(), expected_chunk_indices)
+    torch.testing.assert_close(out_chunk_offsets.cpu(), expected_chunk_offsets)
+    torch.testing.assert_close(out_update_chunk_offsets.cpu(), expected_update_chunk_offsets)
+    torch.testing.assert_close(out_final_chunk_indices.cpu(), expected_final_chunk_indices)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton import gdn_chunk_meta
+from vllm_ascend.ops.triton.fla import chunk, chunk_o, chunk_o_update
+from vllm_ascend.ops.triton.gdn_chunk_meta import build_chunk_meta_device
+
+
+class _FakeKernel:
+    def __init__(self):
+        self.grid = None
+        self.grid_result = None
+        self.launch_kwargs: dict[str, object] | None = None
+
+    def __getitem__(self, grid):
+        self.grid = grid
+        self.grid_result = grid({"BV": 128})
+
+        def launch(**kwargs):
+            self.launch_kwargs = kwargs
+
+        return launch
+
+
+class _DummyTensor:
+    def __init__(self, name: str):
+        self.name = name
+        self.shape = (1,)
+        self.dtype = torch.float32
+
+    def unsqueeze(self, dim: int):
+        return self
+
+    def new_empty(self, *shape):
+        return _DummyTensor(f"{self.name}.new_empty")
+
+    def __getitem__(self, item):
+        return self
+
+    def __setitem__(self, item, value):
+        return None
+
+    def __add__(self, other):
+        return self
+
+    def transpose(self, dim0, dim1):
+        return self
+
+    def contiguous(self):
+        return self
+
+
+class _GatherResult:
+    def __init__(self, items):
+        self.items = items
+
+    def __getitem__(self, item):
+        if isinstance(item, tuple):
+            item = item[0]
+        return self.items[item]
+
+
+def _next_power_of_2(value: int) -> int:
+    if value <= 1:
+        return 1
+    return 1 << (value - 1).bit_length()
+
+
+def _patch_missing_cdiv(monkeypatch: pytest.MonkeyPatch, module) -> None:
+    if hasattr(module.triton, "cdiv"):
+        return
+    monkeypatch.setattr(
+        module.triton,
+        "cdiv",
+        lambda x, y: (x + y - 1) // y,
+        raising=False,
+    )
+
+
+@pytest.mark.parametrize("target", ["chunk_o", "chunk_o_update"])
+def test_chunk_leaf_wrappers_use_prebuilt_chunk_offsets(
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+):
+    fake_kernel = _FakeKernel()
+    sentinel = torch.tensor([0, 2, 5], dtype=torch.int32)
+    cu_seqlens = torch.tensor([0, 4, 7], dtype=torch.int32)
+
+    if target == "chunk_o":
+        _patch_missing_cdiv(monkeypatch, chunk_o)
+        monkeypatch.setattr(chunk_o, "chunk_fwd_kernel_o", fake_kernel)
+        monkeypatch.setattr(
+            chunk_o,
+            "prepare_chunk_offsets",
+            lambda *args, **kwargs: pytest.fail("prepare_chunk_offsets should not be called"),
+        )
+        chunk_o.chunk_fwd_o(
+            q=torch.zeros((2, 4, 1, 8), dtype=torch.float32),
+            k=torch.zeros((2, 4, 1, 8), dtype=torch.float32),
+            v=torch.zeros((2, 4, 1, 16), dtype=torch.float32),
+            h=torch.zeros((4, 1, 8, 16), dtype=torch.float32),
+            g=torch.zeros((2, 4, 1), dtype=torch.float32),
+            cu_seqlens=cu_seqlens,
+            chunk_offsets=sentinel,
+        )
+    else:
+        _patch_missing_cdiv(monkeypatch, chunk_o_update)
+        monkeypatch.setattr(chunk_o_update, "chunk_fwd_kernel_o_update", fake_kernel)
+        monkeypatch.setattr(
+            chunk_o_update,
+            "prepare_chunk_offsets",
+            lambda *args, **kwargs: pytest.fail("prepare_chunk_offsets should not be called"),
+        )
+        chunk_o_update.chunk_fwd_o_update(
+            q=torch.zeros((2, 4, 1, 8), dtype=torch.float32),
+            v=torch.zeros((2, 4, 1, 16), dtype=torch.float32),
+            h=torch.zeros((4, 1, 8, 16), dtype=torch.float32),
+            h_update=torch.zeros((5, 1, 8, 8), dtype=torch.float32),
+            updated_h_state=torch.zeros((1, 8, 16), dtype=torch.float32),
+            cu_seqlens=cu_seqlens,
+            chunk_offsets=sentinel,
+        )
+
+    assert fake_kernel.launch_kwargs is not None
+    assert fake_kernel.launch_kwargs["chunk_offsets"] is sentinel
+
+
+def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    chunk_offsets = torch.tensor([0, 2, 5], dtype=torch.int32)
+    update_chunk_offsets = torch.tensor([0, 3, 7], dtype=torch.int32)
+    final_chunk_indices = torch.tensor([1, 3], dtype=torch.int32)
+    prebuilt_meta = type(
+        "PrebuiltMeta",
+        (),
+        {
+            "block_indices_cumsum": None,
+            "chunk_indices_chunk64": None,
+            "chunk_offsets_chunk64": chunk_offsets,
+            "update_chunk_offsets_chunk64": update_chunk_offsets,
+            "final_chunk_indices_chunk64": final_chunk_indices,
+            "chunk_indices_large_block": None,
+        },
+    )()
+
+    q = _DummyTensor("q")
+    k = _DummyTensor("k")
+    v = _DummyTensor("v")
+    g = _DummyTensor("g")
+    beta = _DummyTensor("beta")
+    initial_state = _DummyTensor("initial_state")
+
+    non_pcp_calls: list[tuple[str, object]] = []
+    pcp_calls: list[tuple[str, object]] = []
+
+    def run_case(world_size: int, calls: list[tuple[str, object]]):
+        group = type(
+            "Group",
+            (),
+            {
+                "world_size": world_size,
+                "rank_in_group": 0,
+                "all_gather": lambda self, value, dim: _GatherResult(
+                    [_DummyTensor("g0"), _DummyTensor("g1")]
+                ),
+            },
+        )()
+
+        monkeypatch.setattr(chunk, "get_forward_context", lambda: type("Ctx", (), {"attn_metadata": None})())
+        monkeypatch.setattr(chunk, "get_pcp_group", lambda: group)
+        monkeypatch.setattr(chunk, "chunk_local_cumsum", lambda *args, **kwargs: _DummyTensor("g_cumsum"))
+        monkeypatch.setattr(chunk, "chunk_scaled_dot_kkt_fwd", lambda *args, **kwargs: _DummyTensor("A"))
+        monkeypatch.setattr(chunk, "solve_tril", lambda *args, **kwargs: _DummyTensor("A_solved"))
+        monkeypatch.setattr(chunk, "recompute_w_u_fwd", lambda *args, **kwargs: (_DummyTensor("w"), _DummyTensor("u")))
+        monkeypatch.setattr(
+            chunk,
+            "chunk_gated_delta_rule_fwd_h",
+            lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
+        )
+        monkeypatch.setattr(
+            chunk,
+            "chunk_gated_delta_rule_fwd_hupdate",
+            lambda *args, **kwargs: _DummyTensor("h_update"),
+        )
+        monkeypatch.setattr(
+            chunk.torch,
+            "matmul",
+            lambda *args, **kwargs: _DummyTensor("matmul"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            chunk.torch,
+            "zeros_like",
+            lambda *args, **kwargs: _DummyTensor("zeros_like"),
+            raising=False,
+        )
+
+        def fake_chunk_fwd_o(*args, **kwargs):
+            calls.append(("o", kwargs["chunk_offsets"]))
+            return _DummyTensor("o")
+
+        def fake_chunk_fwd_o_update(*args, **kwargs):
+            calls.append(("o_update", kwargs["chunk_offsets"]))
+            return _DummyTensor("h_updated")
+
+        monkeypatch.setattr(chunk, "chunk_fwd_o", fake_chunk_fwd_o)
+        monkeypatch.setattr(chunk, "chunk_fwd_o_update", fake_chunk_fwd_o_update)
+
+        chunk.chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=1.0,
+            initial_state=initial_state,
+            output_final_state=False,
+            cu_seqlens=torch.tensor([0, 4, 7], dtype=torch.int32),
+            prebuilt_meta=prebuilt_meta,
+        )
+
+    run_case(1, non_pcp_calls)
+    assert non_pcp_calls == [("o", chunk_offsets)]
+
+    run_case(2, pcp_calls)
+    assert pcp_calls == [("o_update", chunk_offsets), ("o", chunk_offsets)]
+
+
+def test_build_chunk_meta_device_rejects_non_npu_input():
+    cu_seqlens = torch.tensor([0, 4, 4, 12], dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="must be on NPU"):
+        build_chunk_meta_device(
+            cu_seqlens=cu_seqlens,
+            chunk_size=64,
+            out_chunk_indices=torch.empty((2, 2), dtype=torch.int32),
+        )
+
+
+def test_build_chunk_offsets_falls_back_without_triton_kernel(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(gdn_chunk_meta, "_build_chunk_offsets_kernel", object())
+
+    chunk_counts = torch.tensor([2, 0, 3], dtype=torch.int32)
+    chunk_offsets = torch.empty(4, dtype=torch.int32)
+    update_chunk_offsets = torch.empty(4, dtype=torch.int32)
+
+    gdn_chunk_meta._build_chunk_offsets(chunk_counts, chunk_offsets, add_one=0)
+    gdn_chunk_meta._build_chunk_offsets(chunk_counts, update_chunk_offsets, add_one=1)
+
+    assert torch.equal(chunk_offsets, torch.tensor([0, 2, 2, 5], dtype=torch.int32))
+    assert torch.equal(update_chunk_offsets, torch.tensor([0, 3, 4, 8], dtype=torch.int32))
+
+
+def test_build_chunk_offsets_does_not_launch_triton_prefix_sum_kernel(monkeypatch: pytest.MonkeyPatch):
+    class _RaisingKernel:
+        def __getitem__(self, grid):
+            raise AssertionError("_build_chunk_offsets should use torch.cumsum instead of the Triton prefix-sum kernel")
+
+    monkeypatch.setattr(gdn_chunk_meta, "_build_chunk_offsets_kernel", _RaisingKernel())
+
+    chunk_counts = torch.tensor([2, 0, 3], dtype=torch.int32)
+    chunk_offsets = torch.empty(4, dtype=torch.int32)
+    update_chunk_offsets = torch.empty(4, dtype=torch.int32)
+
+    gdn_chunk_meta._build_chunk_offsets(chunk_counts, chunk_offsets, add_one=0)
+    gdn_chunk_meta._build_chunk_offsets(chunk_counts, update_chunk_offsets, add_one=1)
+
+    assert torch.equal(chunk_offsets, torch.tensor([0, 2, 2, 5], dtype=torch.int32))
+    assert torch.equal(update_chunk_offsets, torch.tensor([0, 3, 4, 8], dtype=torch.int32))
+
+
+def test_build_final_chunk_indices_falls_back_without_triton_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(gdn_chunk_meta, "_build_final_chunk_indices_kernel", object())
+
+    chunk_counts = torch.tensor([2, 0, 3], dtype=torch.int32)
+    update_chunk_offsets = torch.tensor([0, 3, 4, 8], dtype=torch.int32)
+    out_final_chunk_indices = torch.empty(3, dtype=torch.int32)
+
+    gdn_chunk_meta._build_final_chunk_indices(
+        chunk_counts,
+        update_chunk_offsets,
+        out_final_chunk_indices,
+    )
+
+    assert torch.equal(out_final_chunk_indices, torch.tensor([2, 3, 7], dtype=torch.int32))

--- a/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 import torch
@@ -11,6 +12,18 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import MambaSpec
+from vllm_ascend.ops.gdn import (
+    get_non_spec_causal_conv1d_host_args,
+    get_non_spec_chunked_prefill_meta,
+    to_int64_tuple,
+)
+from vllm_ascend.ops.triton.fla import utils as fla_utils
+from vllm_ascend.ops.triton.fla.utils import (
+    prepare_chunk_indices as runtime_prepare_chunk_indices,
+    prepare_chunk_offsets as runtime_prepare_chunk_offsets,
+    prepare_final_chunk_indices as runtime_prepare_final_chunk_indices,
+    prepare_update_chunk_offsets as runtime_prepare_update_chunk_offsets,
+)
 
 
 @dataclass
@@ -20,7 +33,7 @@ class BatchSpec:
     name: str = "unnamed"
 
     @property
-    def batch_size(self):
+    def batch_size(self) -> int:
         return len(self.seq_lens)
 
 
@@ -125,71 +138,96 @@ def _make_builder(*, device: torch.device, num_heads: int, num_speculative_token
     return GDNAttentionMetadataBuilder(spec, ["layer0"], vllm_config, device)
 
 
-def _next_power_of_2(value: int) -> int:
-    if value <= 1:
-        return 1
-    return 1 << (value - 1).bit_length()
-
-
-def _prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
-    lens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
-    pairs: list[list[int]] = []
-    for seq_idx, seq_len in enumerate(lens):
-        num_chunks = (seq_len + chunk_size - 1) // chunk_size
-        for chunk_idx in range(num_chunks):
-            pairs.append([seq_idx, chunk_idx])
-    if not pairs:
-        return torch.empty((0, 2), dtype=cu_seqlens.dtype, device=cu_seqlens.device)
-    return torch.tensor(pairs, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
-
-
-def _prepare_chunk_offsets(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
-    lens = cu_seqlens[1:] - cu_seqlens[:-1]
-    num_chunks = torch.div(
-        lens + chunk_size - 1,
-        chunk_size,
-        rounding_mode="floor",
+def _build_attn_metadata(
+    batch_spec: BatchSpec,
+    *,
+    num_speculative_tokens: int,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+):
+    device = torch.device("cpu")
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=batch_spec,
+        block_size=16,
+        device=device,
     )
-    offsets = torch.zeros(len(num_chunks) + 1, dtype=cu_seqlens.dtype)
-    torch.cumsum(num_chunks, dim=0, out=offsets[1:])
-    return offsets.to(cu_seqlens.device)
+    builder = _make_builder(
+        device=device,
+        num_heads=32,
+        num_speculative_tokens=num_speculative_tokens,
+    )
+    num_accepted_tokens = None
+    if num_decode_draft_tokens_cpu is not None:
+        num_accepted_tokens = torch.ones(
+            batch_spec.batch_size,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_accepted_tokens=num_accepted_tokens,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+    )
+    return builder, common_attn_metadata, attn_metadata
 
 
-def _prepare_update_chunk_offsets(
-    cu_seqlens: torch.Tensor, chunk_size: int
-) -> torch.Tensor:
-    lens = cu_seqlens[1:] - cu_seqlens[:-1]
-    num_chunks = torch.div(
-        lens + chunk_size - 1,
-        chunk_size,
-        rounding_mode="floor",
-    ) + 1
-    offsets = torch.zeros(len(num_chunks) + 1, dtype=cu_seqlens.dtype)
-    torch.cumsum(num_chunks, dim=0, out=offsets[1:])
-    return offsets.to(cu_seqlens.device)
+def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Tensor) -> None:
+    assert torch.equal(
+        chunk_meta.chunk_indices_chunk64,
+        runtime_prepare_chunk_indices(cu_seqlens, patch_gdn_attn._GDN_CHUNK_SIZE),
+    )
+    assert torch.equal(
+        chunk_meta.chunk_offsets_chunk64,
+        runtime_prepare_chunk_offsets(cu_seqlens, patch_gdn_attn._GDN_CHUNK_SIZE),
+    )
+    assert torch.equal(
+        chunk_meta.update_chunk_offsets_chunk64,
+        runtime_prepare_update_chunk_offsets(
+            cu_seqlens,
+            patch_gdn_attn._GDN_CHUNK_SIZE,
+        ),
+    )
+    assert torch.equal(
+        chunk_meta.final_chunk_indices_chunk64,
+        runtime_prepare_final_chunk_indices(
+            cu_seqlens,
+            patch_gdn_attn._GDN_CHUNK_SIZE,
+        ),
+    )
+    assert torch.equal(
+        chunk_meta.chunk_indices_large_block,
+        runtime_prepare_chunk_indices(
+            cu_seqlens,
+            patch_gdn_attn._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE,
+        ),
+    )
+    assert torch.equal(
+        chunk_meta.block_indices_cumsum,
+        runtime_prepare_chunk_indices(
+            cu_seqlens,
+            builder._ascend_gdn_cumsum_block_size,
+        ),
+    )
 
 
-def _prepare_final_chunk_indices(
-    cu_seqlens: torch.Tensor, chunk_size: int
-) -> torch.Tensor:
-    lens = cu_seqlens[1:] - cu_seqlens[:-1]
-    num_chunks = torch.div(
-        lens + chunk_size - 1,
-        chunk_size,
-        rounding_mode="floor",
-    ) + 1
-    return (torch.cumsum(num_chunks, dim=0) - 1).to(cu_seqlens.device)
+def _patch_missing_runtime_cdiv(monkeypatch: pytest.MonkeyPatch) -> None:
+    if hasattr(fla_utils.triton, "cdiv"):
+        return
+    monkeypatch.setattr(
+        fla_utils.triton,
+        "cdiv",
+        lambda x, y: (x + y - 1) // y,
+        raising=False,
+    )
 
 
-def _build_non_spec_query_start_loc_cpu(
-    batch_spec: BatchSpec, spec_mask_cpu: torch.Tensor | None
-) -> torch.Tensor:
-    query_lens = torch.tensor(batch_spec.query_lens, dtype=torch.int32)
-    if spec_mask_cpu is not None:
-        query_lens = query_lens[~spec_mask_cpu]
-    query_start_loc = torch.zeros(query_lens.numel() + 1, dtype=torch.int32)
-    torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
-    return query_start_loc
+def _expected_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    return (
+        to_int64_tuple(attn_metadata.non_spec_query_start_loc),
+        to_int64_tuple(attn_metadata.non_spec_state_indices_tensor),
+        to_int64_tuple(attn_metadata.has_initial_state),
+    )
 
 
 @pytest.mark.parametrize(
@@ -225,128 +263,192 @@ def _build_non_spec_query_start_loc_cpu(
     ],
     ids=lambda case: case.name if isinstance(case, BatchSpec) else None,
 )
-def test_builder_prebuilds_non_spec_chunk_metadata_exactly(
+def test_non_spec_prefill_fallback_meta_matches_original_inputs_and_runtime_helpers(
     batch_spec: BatchSpec,
     num_speculative_tokens: int,
     num_decode_draft_tokens_cpu: torch.Tensor | None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
-    device = torch.device("cpu")
-    num_heads = 32
-    common_attn_metadata = create_common_attn_metadata(
-        batch_spec=batch_spec,
-        block_size=16,
-        device=device,
-    )
-    builder = _make_builder(
-        device=device,
-        num_heads=num_heads,
+    _patch_missing_runtime_cdiv(monkeypatch)
+    builder, _, attn_metadata = _build_attn_metadata(
+        batch_spec,
         num_speculative_tokens=num_speculative_tokens,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
     )
 
-    num_accepted_tokens = None
-    spec_mask_cpu = None
-    if num_decode_draft_tokens_cpu is not None:
-        num_accepted_tokens = torch.ones(
-            batch_spec.batch_size, dtype=torch.int32, device=device
+    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
+    assert fallback_meta is not None
+    assert fallback_meta.causal_conv1d is not None
+    assert fallback_meta.chunk is not None
+
+    assert get_non_spec_causal_conv1d_host_args(attn_metadata) == _expected_conv1d_host_args(attn_metadata)
+
+    _assert_chunk_meta_matches_runtime(
+        builder,
+        fallback_meta.chunk,
+        attn_metadata.non_spec_query_start_loc,
+    )
+
+def test_build_non_spec_causal_conv1d_host_meta_avoids_seq_lens_cpu_fallback():
+    class GuardSeqLens:
+        def to(self, *args, **kwargs):
+            raise AssertionError("seq_lens.to('cpu') should not be reached")
+
+    builder = SimpleNamespace(use_spec_decode=False)
+    attn_metadata = SimpleNamespace(
+        num_prefills=2,
+        non_spec_state_indices_tensor=torch.tensor([3, 9], dtype=torch.int32),
+        has_initial_state=torch.tensor([True, False]),
+    )
+
+    host_meta = patch_gdn_attn._build_non_spec_causal_conv1d_host_meta(
+        builder,
+        attn_metadata,
+        non_spec_query_start_loc_cpu=torch.tensor([0, 4, 12], dtype=torch.int32),
+    )
+
+    assert host_meta is not None
+    assert torch.equal(
+        host_meta.has_initial_state_cpu,
+        torch.tensor([True, False]),
+    )
+
+
+def test_build_non_spec_causal_conv1d_host_meta_requires_has_initial_state():
+    builder = SimpleNamespace(use_spec_decode=False)
+    attn_metadata = SimpleNamespace(
+        num_prefills=2,
+        non_spec_state_indices_tensor=torch.tensor([3, 9], dtype=torch.int32),
+        has_initial_state=None,
+    )
+    with pytest.raises(RuntimeError, match="has_initial_state"):
+        patch_gdn_attn._build_non_spec_causal_conv1d_host_meta(
+            builder,
+            attn_metadata,
+            non_spec_query_start_loc_cpu=torch.tensor([0, 4, 12], dtype=torch.int32),
         )
-        spec_mask_cpu = num_decode_draft_tokens_cpu >= 0
+
+
+def test_get_non_spec_causal_conv1d_host_args_requires_prefill_fallback_meta():
+    attn_metadata = SimpleNamespace(
+        non_spec_prefill_fallback_meta=None,
+        non_spec_causal_conv1d_meta=SimpleNamespace(
+            query_start_loc_opt=(0, 4, 12),
+            cache_indices_opt=(3, 9),
+            initial_state_mode_opt=(1, 0),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="non_spec_prefill_fallback_meta\\.causal_conv1d"):
+        get_non_spec_causal_conv1d_host_args(
+            attn_metadata,
+        )
+
+
+def test_get_non_spec_chunked_prefill_meta_requires_prefill_fallback_meta():
+    attn_metadata = SimpleNamespace(
+        non_spec_prefill_fallback_meta=None,
+        non_spec_chunked_prefill_meta=SimpleNamespace(chunk_offsets_chunk64=torch.tensor([0, 1])),
+    )
+
+    with pytest.raises(RuntimeError, match="non_spec_prefill_fallback_meta\\.chunk"):
+        get_non_spec_chunked_prefill_meta(attn_metadata)
+
+
+def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeypatch):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    batch_spec = BatchSpec(
+        seq_lens=[8, 4, 0, 12],
+        query_lens=[4, 4, 0, 8],
+        name="mixed_spec_non_spec_with_padding",
+    )
+    builder, common_attn_metadata, _ = _build_attn_metadata(
+        batch_spec,
+        num_speculative_tokens=3,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1, -1], dtype=torch.int32),
+    )
+
+    builder._ascend_gdn_chunk_meta_initialized = True
+    builder._ascend_gdn_chunk_meta_device = SimpleNamespace(type="npu")
+    builder._ascend_gdn_chunk_size = patch_gdn_attn._GDN_CHUNK_SIZE
+    builder._ascend_gdn_large_block_size = patch_gdn_attn._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE
+    builder._ascend_gdn_cumsum_block_size = 256
+    builder._ascend_gdn_chunked_prefill_pool_idx = -1
+    builder._ascend_gdn_chunked_prefill_pool = [
+        SimpleNamespace(
+            chunk_indices_chunk64=torch.zeros((8, 2), dtype=torch.int32),
+            chunk_offsets_chunk64=torch.zeros((8,), dtype=torch.int32),
+            update_chunk_offsets_chunk64=torch.zeros((8,), dtype=torch.int32),
+            final_chunk_indices_chunk64=torch.zeros((8,), dtype=torch.int32),
+            chunk_indices_large_block=torch.zeros((8, 2), dtype=torch.int32),
+            block_indices_cumsum=torch.zeros((8, 2), dtype=torch.int32),
+        )
+    ]
+    builder._ascend_gdn_causal_conv1d_host_meta_initialized = True
+    builder._ascend_gdn_causal_conv1d_host_pool = []
+    builder._ascend_gdn_causal_conv1d_host_pool_idx = -1
+
+    helper_calls: dict[int, dict[str, object]] = {}
+
+    def fake_build_chunk_meta_device(**kwargs):
+        helper_calls[kwargs["chunk_size"]] = kwargs
+
+    monkeypatch.setattr(
+        patch_gdn_attn,
+        "build_chunk_meta_device",
+        fake_build_chunk_meta_device,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        patch_gdn_attn,
+        "_prepare_chunk_counts_cpu",
+        lambda *args, **kwargs: pytest.fail("_prepare_chunk_counts_cpu should not be used on the device path"),
+    )
 
     attn_metadata = builder.build(
         0,
         common_attn_metadata,
-        num_accepted_tokens=num_accepted_tokens,
-        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        num_accepted_tokens=torch.ones(batch_spec.batch_size, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1, -1], dtype=torch.int32),
     )
 
-    non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
-        batch_spec,
-        spec_mask_cpu,
+    expected_chunk_indices = runtime_prepare_chunk_indices(
+        attn_metadata.non_spec_query_start_loc,
+        patch_gdn_attn._GDN_CHUNK_SIZE,
     )
-    legacy_chunk_indices_64 = _prepare_chunk_indices(non_spec_query_start_loc_cpu, 64)
-    legacy_chunk_offsets_64 = _prepare_chunk_offsets(non_spec_query_start_loc_cpu, 64)
-    legacy_update_chunk_offsets_64 = _prepare_update_chunk_offsets(
-        non_spec_query_start_loc_cpu,
-        64,
+    expected_chunk_offsets = runtime_prepare_chunk_offsets(
+        attn_metadata.non_spec_query_start_loc,
+        patch_gdn_attn._GDN_CHUNK_SIZE,
     )
-    legacy_final_chunk_indices_64 = _prepare_final_chunk_indices(
-        non_spec_query_start_loc_cpu,
-        64,
+    expected_update_chunk_offsets = runtime_prepare_update_chunk_offsets(
+        attn_metadata.non_spec_query_start_loc,
+        patch_gdn_attn._GDN_CHUNK_SIZE,
     )
-    legacy_chunk_indices_large_block = _prepare_chunk_indices(
-        non_spec_query_start_loc_cpu,
-        patch_gdn_attn._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE,
-    )
-    optim_block_size = _next_power_of_2(
-        patch_gdn_attn._GDN_CUMSUM_WORKING_SET
-        // (num_heads * patch_gdn_attn._GDN_CHUNK_SIZE)
-    )
-    legacy_block_indices_cumsum = _prepare_chunk_indices(
-        non_spec_query_start_loc_cpu,
-        optim_block_size,
+    expected_final_chunk_indices = runtime_prepare_final_chunk_indices(
+        attn_metadata.non_spec_query_start_loc,
+        patch_gdn_attn._GDN_CHUNK_SIZE,
     )
 
-    prebuilt_meta = getattr(attn_metadata, "non_spec_chunked_prefill_meta", None)
-    assert prebuilt_meta is not None
-    assert torch.equal(prebuilt_meta.chunk_indices_chunk64, legacy_chunk_indices_64)
-    assert torch.equal(prebuilt_meta.chunk_offsets_chunk64, legacy_chunk_offsets_64)
-    assert torch.equal(
-        prebuilt_meta.update_chunk_offsets_chunk64, legacy_update_chunk_offsets_64
+    chunk64_call = helper_calls[patch_gdn_attn._GDN_CHUNK_SIZE]
+    out_chunk_indices = cast(torch.Tensor, chunk64_call["out_chunk_indices"])
+    out_chunk_offsets = cast(torch.Tensor, chunk64_call["out_chunk_offsets"])
+    out_update_chunk_offsets = cast(
+        torch.Tensor,
+        chunk64_call["out_update_chunk_offsets"],
     )
-    assert torch.equal(
-        prebuilt_meta.final_chunk_indices_chunk64, legacy_final_chunk_indices_64
+    out_final_chunk_indices = cast(
+        torch.Tensor,
+        chunk64_call["out_final_chunk_indices"],
     )
-    assert torch.equal(
-        prebuilt_meta.chunk_indices_large_block,
-        legacy_chunk_indices_large_block,
-    )
-    assert torch.equal(
-        prebuilt_meta.block_indices_cumsum,
-        legacy_block_indices_cumsum,
-    )
-
-
-def test_allocate_chunked_prefill_slot_uses_cpugpubuffer(monkeypatch):
-    class DummyCpuGpuBuffer:
-        def __init__(
-            self,
-            *size,
-            dtype: torch.dtype,
-            device: torch.device,
-            pin_memory: bool,
-            with_numpy: bool = True,
-        ) -> None:
-            self.cpu = torch.zeros(*size, dtype=dtype, device="cpu")
-            self.gpu = torch.zeros_like(self.cpu, device=device)
-            self.dtype = dtype
-            self.device = device
-            self.pin_memory = pin_memory
-            self.with_numpy = with_numpy
-
-    device = torch.device("cpu")
-    builder = _make_builder(
-        device=device,
-        num_heads=32,
-        num_speculative_tokens=0,
-    )
-    monkeypatch.setattr(patch_gdn_attn, "CpuGpuBuffer", DummyCpuGpuBuffer)
-
-    slot = patch_gdn_attn._allocate_chunked_prefill_slot(builder, device)
-
-    assert isinstance(slot.chunk_indices_chunk64, DummyCpuGpuBuffer)
-    assert isinstance(slot.chunk_offsets_chunk64, DummyCpuGpuBuffer)
-    assert isinstance(slot.update_chunk_offsets_chunk64, DummyCpuGpuBuffer)
-    assert isinstance(slot.final_chunk_indices_chunk64, DummyCpuGpuBuffer)
-    assert slot.chunk_indices_chunk64.pin_memory is True
-    assert slot.chunk_indices_chunk64.with_numpy is False
-    assert slot.chunk_indices_chunk64.device == device
-    assert slot.chunk_indices_chunk64.cpu.shape == (
-        builder.vllm_config.scheduler_config.max_num_batched_tokens,
-        2,
-    )
-    assert slot.chunk_indices_chunk64.gpu.shape == (
-        builder.vllm_config.scheduler_config.max_num_batched_tokens,
-        2,
-    )
+    assert chunk64_call["cu_seqlens"] is attn_metadata.non_spec_query_start_loc
+    assert out_chunk_indices.shape == expected_chunk_indices.shape
+    assert out_chunk_indices.dtype == expected_chunk_indices.dtype
+    assert out_chunk_offsets.shape == expected_chunk_offsets.shape
+    assert out_chunk_offsets.dtype == torch.int32
+    assert out_update_chunk_offsets.shape == expected_update_chunk_offsets.shape
+    assert out_update_chunk_offsets.dtype == torch.int32
+    assert out_final_chunk_indices.shape == expected_final_chunk_indices.shape
+    assert out_final_chunk_indices.dtype == torch.int32
 
 
 @pytest.mark.parametrize(
@@ -357,26 +459,29 @@ def test_allocate_chunked_prefill_slot_uses_cpugpubuffer(monkeypatch):
     ],
 )
 def test_builder_skips_prebuilt_meta_without_non_spec_prefill(batch_spec: BatchSpec):
-    device = torch.device("cpu")
     builder = _make_builder(
-        device=device,
+        device=torch.device("cpu"),
         num_heads=32,
         num_speculative_tokens=3 if batch_spec.name == "spec_only" else 0,
     )
     common_attn_metadata = create_common_attn_metadata(
         batch_spec=batch_spec,
         block_size=16,
-        device=device,
+        device=torch.device("cpu"),
     )
 
     num_accepted_tokens = None
     num_decode_draft_tokens_cpu = None
     if batch_spec.name == "spec_only":
         num_accepted_tokens = torch.ones(
-            batch_spec.batch_size, dtype=torch.int32, device=device
+            batch_spec.batch_size,
+            dtype=torch.int32,
+            device="cpu",
         )
         num_decode_draft_tokens_cpu = torch.full(
-            (batch_spec.batch_size,), 3, dtype=torch.int32
+            (batch_spec.batch_size,),
+            3,
+            dtype=torch.int32,
         )
 
     attn_metadata = builder.build(
@@ -386,4 +491,4 @@ def test_builder_skips_prebuilt_meta_without_non_spec_prefill(batch_spec: BatchS
         num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
     )
 
-    assert getattr(attn_metadata, "non_spec_chunked_prefill_meta", None) is None
+    assert getattr(attn_metadata, "non_spec_prefill_fallback_meta", None) is None

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -33,13 +33,41 @@ from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.sigmoid_gating import fused_sigmoid_gating_delta_rule_update
+from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_update_npu
 from vllm_ascend.utils import enable_sp
 
 
-def to_int64_tuple(tensor: torch.Tensor) -> tuple:
-    return tuple(tensor.to(torch.int64).tolist())
+def to_int64_tuple(tensor: torch.Tensor) -> tuple[int, ...]:
+    tensor = tensor.to(torch.int64)
+    if tensor.dim() == 0:
+        return (tensor.item(),)
+    return tuple(tensor.tolist())
+
+
+def _require_non_spec_prefill_fallback_meta(attn_metadata, field_name: str):
+    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
+    if fallback_meta is None:
+        raise RuntimeError(
+            f"Expected attn_metadata.non_spec_prefill_fallback_meta.{field_name} for patched GDN non-spec prefill path."
+        )
+    return fallback_meta
+
+
+def get_non_spec_causal_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    fallback_meta = _require_non_spec_prefill_fallback_meta(attn_metadata, "causal_conv1d")
+    causal_conv1d_meta = fallback_meta.causal_conv1d
+    return (
+        to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu),
+        to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
+        to_int64_tuple(causal_conv1d_meta.has_initial_state_cpu),
+    )
+
+
+def get_non_spec_chunked_prefill_meta(attn_metadata):
+    fallback_meta = _require_non_spec_prefill_fallback_meta(attn_metadata, "chunk")
+    return fallback_meta.chunk
 
 
 class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
@@ -184,14 +212,19 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             if mixed_qkv_non_spec is not None:
                 conv_weights_T = conv_weights.transpose(0, 1)
                 activation_num = 1 if self.activation else 0
+                (
+                    query_start_loc_opt,
+                    cache_indices_opt,
+                    initial_state_mode_opt,
+                ) = get_non_spec_causal_conv1d_host_args(attn_metadata)
                 mixed_qkv_non_spec = torch.ops._C_ascend.npu_causal_conv1d_custom(
                     mixed_qkv_non_spec,
                     conv_weights_T,
                     conv_state=self_kv_cache[0],
                     bias_opt=self.conv1d.bias,
-                    query_start_loc_opt=to_int64_tuple(non_spec_query_start_loc),
-                    cache_indices_opt=to_int64_tuple(non_spec_state_indices_tensor),
-                    initial_state_mode_opt=to_int64_tuple(has_initial_state),
+                    query_start_loc_opt=query_start_loc_opt,
+                    cache_indices_opt=cache_indices_opt,
+                    initial_state_mode_opt=initial_state_mode_opt,
                     num_accepted_tokens_opt=[],
                     activation_mode=activation_num,
                     pad_slot_id=PAD_SLOT_ID,
@@ -259,8 +292,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             # 2.2: Process the remaining part
             if attn_metadata.num_prefills > 0:
                 initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
-                initial_state[~has_initial_state, ...] = 0
-                non_spec_chunked_prefill_meta = getattr(attn_metadata, "non_spec_chunked_prefill_meta", None)
+                clear_ssm_states(initial_state, has_initial_state)
                 (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
                     q=query_non_spec,
                     k=key_non_spec,
@@ -270,7 +302,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     initial_state=initial_state,
                     output_final_state=True,
                     cu_seqlens=non_spec_query_start_loc,
-                    prebuilt_meta=non_spec_chunked_prefill_meta,
+                    prebuilt_meta=get_non_spec_chunked_prefill_meta(attn_metadata),
                     head_first=False,
                     use_qk_l2norm_in_kernel=True,
                 )
@@ -338,8 +370,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 # 2.2: Process the remaining part
                 if attn_metadata.num_prefills > 0:
                     initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
-                    initial_state[~has_initial_state, ...] = 0
-                    non_spec_chunked_prefill_meta = getattr(attn_metadata, "non_spec_chunked_prefill_meta", None)
+                    clear_ssm_states(initial_state, has_initial_state)
                     (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
                         q=query_non_spec,
                         k=key_non_spec,
@@ -349,7 +380,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                         initial_state=initial_state,
                         output_final_state=True,
                         cu_seqlens=non_spec_query_start_loc,
-                        prebuilt_meta=non_spec_chunked_prefill_meta,
+                        prebuilt_meta=get_non_spec_chunked_prefill_meta(attn_metadata),
                         head_first=False,
                         use_qk_l2norm_in_kernel=True,
                     )

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -138,6 +138,7 @@ def chunk_gated_delta_rule_fwd(
             h_update=h_update,
             updated_h_state=updated_h_state,
             cu_seqlens=cu_seqlens,
+            chunk_offsets=chunk_offsets_chunk64,
         )
 
     o = chunk_fwd_o(
@@ -148,6 +149,7 @@ def chunk_gated_delta_rule_fwd(
         g=g,
         scale=scale,
         cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets_chunk64,
     )
 
     if SUPPRESS_LEVEL < 3:

--- a/vllm_ascend/ops/triton/fla/chunk_o.py
+++ b/vllm_ascend/ops/triton/fla/chunk_o.py
@@ -118,6 +118,7 @@ def chunk_fwd_o(
     scale: float | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
+    chunk_offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     B, T, Hg, K, V = *q.shape, v.shape[-1]
     H = v.shape[-2]
@@ -130,10 +131,9 @@ def chunk_fwd_o(
     if cu_seqlens is None:
         N, chunk_offsets = B, None
     else:
-        N, chunk_offsets = (
-            len(cu_seqlens) - 1,
-            prepare_chunk_offsets(cu_seqlens, BT),
-        )
+        N = len(cu_seqlens) - 1
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)

--- a/vllm_ascend/ops/triton/fla/chunk_o_update.py
+++ b/vllm_ascend/ops/triton/fla/chunk_o_update.py
@@ -85,6 +85,7 @@ def chunk_fwd_o_update(
     updated_h_state: torch.Tensor,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
+    chunk_offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     B, T, Hg, K, V = *q.shape, v.shape[-1]
     H = v.shape[-2]
@@ -93,10 +94,9 @@ def chunk_fwd_o_update(
     if cu_seqlens is None:
         N, chunk_offsets = B, None
     else:
-        N, chunk_offsets = (
-            len(cu_seqlens) - 1,
-            prepare_chunk_offsets(cu_seqlens, BT),
-        )
+        N = len(cu_seqlens) - 1
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)

--- a/vllm_ascend/ops/triton/gdn_chunk_meta.py
+++ b/vllm_ascend/ops/triton/gdn_chunk_meta.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from vllm.triton_utils import tl, triton
+
+
+def _cdiv(x: int, y: int) -> int:
+    triton_cdiv = getattr(triton, "cdiv", None)
+    if triton_cdiv is not None:
+        return triton_cdiv(x, y)
+    return (x + y - 1) // y
+
+
+@triton.jit
+def _build_chunk_counts_kernel(
+    cu_seqlens_ptr,
+    chunk_counts_ptr,
+    num_seqs,
+    chunk_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_seqs
+
+    bos = tl.load(cu_seqlens_ptr + offsets, mask=mask, other=0).to(tl.int32)
+    eos = tl.load(cu_seqlens_ptr + offsets + 1, mask=mask, other=0).to(tl.int32)
+    seq_lens = eos - bos
+    chunk_counts = (seq_lens + chunk_size - 1) // chunk_size
+
+    tl.store(chunk_counts_ptr + offsets, chunk_counts, mask=mask)
+
+
+@triton.jit
+def _build_chunk_offsets_kernel(
+    chunk_counts_ptr,
+    out_offsets_ptr,
+    num_seqs,
+    ADD_ONE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets <= num_seqs
+    prefix = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+
+    for seq_idx in range(0, num_seqs):
+        chunk_count = tl.load(chunk_counts_ptr + seq_idx, mask=seq_idx < num_seqs, other=0).to(tl.int32)
+        prefix += tl.where(mask & (offsets > seq_idx), chunk_count + ADD_ONE, 0)
+
+    tl.store(out_offsets_ptr + offsets, prefix.to(out_offsets_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _build_final_chunk_indices_kernel(
+    update_chunk_offsets_ptr,
+    out_final_chunk_indices_ptr,
+    num_seqs,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_seqs
+    final_indices = tl.load(update_chunk_offsets_ptr + offsets + 1, mask=mask, other=0).to(tl.int32) - 1
+    tl.store(
+        out_final_chunk_indices_ptr + offsets,
+        final_indices.to(out_final_chunk_indices_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+def _validate_optional_output(
+    name: str,
+    tensor: torch.Tensor | None,
+    *,
+    expected_shape: tuple[int, ...] | None,
+    expected_device: torch.device,
+) -> None:
+    if tensor is None:
+        return
+    if tensor.device != expected_device:
+        raise ValueError(f"{name} must be on device {expected_device}, got {tensor.device}")
+    if tensor.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"{name} must have int32 or int64 dtype, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    if expected_shape is not None and tuple(tensor.shape) != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}, got {tuple(tensor.shape)}")
+
+
+def _validate_cu_seqlens(cu_seqlens: torch.Tensor, chunk_size: int) -> None:
+    if not isinstance(cu_seqlens, torch.Tensor):
+        raise TypeError("cu_seqlens must be a torch.Tensor")
+    if cu_seqlens.device.type != "npu":
+        raise ValueError(f"cu_seqlens must be on NPU, got {cu_seqlens.device}")
+    if cu_seqlens.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"cu_seqlens must have int32 or int64 dtype, got {cu_seqlens.dtype}")
+    if cu_seqlens.ndim != 1:
+        raise ValueError(f"cu_seqlens must be 1D, got shape {tuple(cu_seqlens.shape)}")
+    if cu_seqlens.shape[0] < 1:
+        raise ValueError("cu_seqlens must contain at least one element")
+    if not cu_seqlens.is_contiguous():
+        raise ValueError("cu_seqlens must be contiguous")
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+
+
+def _build_seq_lens(cu_seqlens: torch.Tensor) -> torch.Tensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def _build_chunk_counts(seq_lens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    chunk_counts = torch.empty(
+        seq_lens.shape[0],
+        dtype=seq_lens.dtype,
+        device=seq_lens.device,
+    )
+    if seq_lens.numel() == 0:
+        return chunk_counts
+    torch.div(
+        seq_lens + chunk_size - 1,
+        chunk_size,
+        rounding_mode="floor",
+        out=chunk_counts,
+    )
+    return chunk_counts
+
+
+def _build_chunk_offsets(
+    chunk_counts: torch.Tensor,
+    out_offsets: torch.Tensor,
+    *,
+    add_one: int,
+) -> None:
+    out_offsets[0] = 0
+    if chunk_counts.numel() > 0:
+        torch.cumsum(chunk_counts + add_one, dim=0, out=out_offsets[1:])
+
+
+def _build_final_chunk_indices(
+    chunk_counts: torch.Tensor,
+    update_chunk_offsets: torch.Tensor,
+    out_final_chunk_indices: torch.Tensor,
+) -> None:
+    num_seqs = chunk_counts.shape[0]
+    if hasattr(_build_final_chunk_indices_kernel, "__getitem__"):
+        block_size = 256
+        grid = (_cdiv(num_seqs, block_size),)
+        _build_final_chunk_indices_kernel[grid](
+            update_chunk_offsets_ptr=update_chunk_offsets,
+            out_final_chunk_indices_ptr=out_final_chunk_indices,
+            num_seqs=num_seqs,
+            BLOCK_SIZE=block_size,
+        )
+        return
+
+    if num_seqs > 0:
+        torch.cumsum(chunk_counts + 1, dim=0, out=out_final_chunk_indices)
+        out_final_chunk_indices.sub_(1)
+
+
+def _build_chunk_meta_device_from_seq_lens(
+    seq_lens: torch.Tensor,
+    chunk_size: int,
+    out_chunk_indices: torch.Tensor | None = None,
+    out_chunk_offsets: torch.Tensor | None = None,
+    out_update_chunk_offsets: torch.Tensor | None = None,
+    out_final_chunk_indices: torch.Tensor | None = None,
+) -> None:
+    if (
+        out_chunk_indices is None
+        and out_chunk_offsets is None
+        and out_update_chunk_offsets is None
+        and out_final_chunk_indices is None
+    ):
+        return
+
+    num_seqs = seq_lens.shape[0]
+    expected_prefix_shape = (num_seqs + 1,)
+    expected_final_shape = (num_seqs,)
+
+    _validate_optional_output(
+        "out_chunk_indices",
+        out_chunk_indices,
+        expected_shape=None,
+        expected_device=seq_lens.device,
+    )
+    if out_chunk_indices is not None and (out_chunk_indices.ndim != 2 or out_chunk_indices.shape[1] != 2):
+        raise ValueError(f"out_chunk_indices must have shape [num_chunks, 2], got {tuple(out_chunk_indices.shape)}")
+    _validate_optional_output(
+        "out_chunk_offsets",
+        out_chunk_offsets,
+        expected_shape=expected_prefix_shape,
+        expected_device=seq_lens.device,
+    )
+    _validate_optional_output(
+        "out_update_chunk_offsets",
+        out_update_chunk_offsets,
+        expected_shape=expected_prefix_shape,
+        expected_device=seq_lens.device,
+    )
+    _validate_optional_output(
+        "out_final_chunk_indices",
+        out_final_chunk_indices,
+        expected_shape=expected_final_shape,
+        expected_device=seq_lens.device,
+    )
+
+    if num_seqs == 0:
+        if out_chunk_offsets is not None:
+            out_chunk_offsets.zero_()
+        if out_update_chunk_offsets is not None:
+            out_update_chunk_offsets.zero_()
+        if out_final_chunk_indices is not None:
+            out_final_chunk_indices.zero_()
+        return
+
+    chunk_counts = _build_chunk_counts(seq_lens, chunk_size)
+
+    chunk_offsets = out_chunk_offsets
+    if chunk_offsets is None and out_chunk_indices is not None:
+        chunk_offsets = torch.empty(
+            expected_prefix_shape,
+            dtype=seq_lens.dtype,
+            device=seq_lens.device,
+        )
+    update_chunk_offsets = out_update_chunk_offsets
+    if update_chunk_offsets is None and out_final_chunk_indices is not None:
+        update_chunk_offsets = torch.empty(
+            expected_prefix_shape,
+            dtype=seq_lens.dtype,
+            device=seq_lens.device,
+        )
+
+    if chunk_offsets is not None:
+        _build_chunk_offsets(chunk_counts, chunk_offsets, add_one=0)
+
+    if update_chunk_offsets is not None:
+        _build_chunk_offsets(chunk_counts, update_chunk_offsets, add_one=1)
+
+    if out_final_chunk_indices is not None:
+        _build_final_chunk_indices(
+            chunk_counts,
+            update_chunk_offsets,
+            out_final_chunk_indices,
+        )
+
+    if out_chunk_indices is not None:
+        total_chunks = out_chunk_indices.shape[0]
+        if total_chunks == 0:
+            return
+        rows = torch.arange(total_chunks, device=seq_lens.device, dtype=chunk_offsets.dtype)
+        compact_chunk_offsets = torch.unique_consecutive(chunk_offsets)
+        seq_indices = torch.bucketize(rows, compact_chunk_offsets[1:], right=True)
+        chunk_starts = compact_chunk_offsets.index_select(0, seq_indices)
+        out_chunk_indices[:, 0].copy_(seq_indices.to(dtype=out_chunk_indices.dtype))
+        out_chunk_indices[:, 1].copy_((rows - chunk_starts).to(dtype=out_chunk_indices.dtype))
+
+
+def build_chunk_meta_device(
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+    out_chunk_indices: torch.Tensor | None = None,
+    out_chunk_offsets: torch.Tensor | None = None,
+    out_update_chunk_offsets: torch.Tensor | None = None,
+    out_final_chunk_indices: torch.Tensor | None = None,
+    *,
+    seq_lens: torch.Tensor | None = None,
+    validate_inputs: bool = True,
+) -> None:
+    if validate_inputs:
+        _validate_cu_seqlens(cu_seqlens, chunk_size)
+    elif chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+    _build_chunk_meta_device_from_seq_lens(
+        _build_seq_lens(cu_seqlens) if seq_lens is None else seq_lens,
+        chunk_size,
+        out_chunk_indices=out_chunk_indices,
+        out_chunk_offsets=out_chunk_offsets,
+        out_update_chunk_offsets=out_update_chunk_offsets,
+        out_final_chunk_indices=out_final_chunk_indices,
+    )

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -17,7 +17,12 @@ from dataclasses import dataclass
 
 import torch
 import vllm.v1.attention.backends.gdn_attn as gdn_attn
-from vllm.v1.utils import CpuGpuBuffer
+
+from vllm_ascend.ops.triton.gdn_chunk_meta import (
+    _build_seq_lens,
+    _validate_cu_seqlens,
+    build_chunk_meta_device,
+)
 
 _GDN_CHUNK_SIZE = 64
 # Keep this aligned with solve_tril.LARGE_BLOCK_T in ops/triton/fla/solve_tril.py.
@@ -40,13 +45,48 @@ class GDNChunkedPrefillMetadata:
 
 
 @dataclass
+class GDNCausalConv1dHostMetadata:
+    query_start_loc_cpu: torch.Tensor
+    cache_indices_cpu: torch.Tensor
+    has_initial_state_cpu: torch.Tensor
+    _buffer_slot: object | None = None
+
+
+@dataclass
+class GDNPrefillFallbackMeta:
+    causal_conv1d: GDNCausalConv1dHostMetadata
+    chunk: GDNChunkedPrefillMetadata
+
+
+@dataclass
 class _GDNChunkedPrefillBufferSlot:
-    chunk_indices_chunk64: CpuGpuBuffer
-    chunk_offsets_chunk64: CpuGpuBuffer
-    update_chunk_offsets_chunk64: CpuGpuBuffer
-    final_chunk_indices_chunk64: CpuGpuBuffer
-    chunk_indices_large_block: CpuGpuBuffer
-    block_indices_cumsum: CpuGpuBuffer
+    chunk_indices_chunk64: torch.Tensor
+    chunk_offsets_chunk64: torch.Tensor
+    update_chunk_offsets_chunk64: torch.Tensor
+    final_chunk_indices_chunk64: torch.Tensor
+    chunk_indices_large_block: torch.Tensor
+    block_indices_cumsum: torch.Tensor
+
+
+@dataclass
+class _GDNCausalConv1dHostBufferSlot:
+    cache_indices_cpu: torch.Tensor
+    has_initial_state_cpu: torch.Tensor
+
+
+@dataclass
+class _GDNChunkMetaSizeInfo:
+    num_seqs: int
+    num_chunk_indices_chunk64: int
+    num_chunk_indices_large_block: int
+    num_block_indices_cumsum: int
+
+
+@dataclass
+class _GDNChunkMetaShapeInfo(_GDNChunkMetaSizeInfo):
+    chunk_counts_chunk64: torch.Tensor
+    chunk_counts_large_block: torch.Tensor
+    chunk_counts_cumsum: torch.Tensor
 
 
 def _next_power_of_2(value: int) -> int:
@@ -62,15 +102,19 @@ def _prepare_chunk_counts_cpu(cu_seqlens_cpu: torch.Tensor, chunk_size: int) -> 
 
 def _fill_chunk_indices_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> int:
     cursor = 0
-    for seq_idx, num_chunks in enumerate(chunk_counts.tolist()):
+    compact_seq_idx = 0
+    for num_chunks in chunk_counts.tolist():
         if num_chunks <= 0:
             continue
-        out[cursor : cursor + num_chunks, 0].fill_(seq_idx)
+        # `prepare_chunk_indices` compacts away zero-length sequences, so the
+        # sequence index here must follow the same compact numbering.
+        out[cursor : cursor + num_chunks, 0].fill_(compact_seq_idx)
         out[cursor : cursor + num_chunks, 1] = torch.arange(
             num_chunks,
             dtype=out.dtype,
         )
         cursor += num_chunks
+        compact_seq_idx += 1
     return cursor
 
 
@@ -99,6 +143,190 @@ def _fill_final_chunk_indices_cpu(out: torch.Tensor, chunk_counts: torch.Tensor)
     return chunk_counts.numel()
 
 
+def _build_chunk_meta_shape_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNChunkMetaShapeInfo:
+    chunk_counts_chunk64 = _prepare_chunk_counts_cpu(
+        cu_seqlens_cpu,
+        builder._ascend_gdn_chunk_size,
+    )
+    chunk_counts_large_block = _prepare_chunk_counts_cpu(
+        cu_seqlens_cpu,
+        builder._ascend_gdn_large_block_size,
+    )
+    chunk_counts_cumsum = _prepare_chunk_counts_cpu(
+        cu_seqlens_cpu,
+        builder._ascend_gdn_cumsum_block_size,
+    )
+    return _GDNChunkMetaShapeInfo(
+        num_seqs=chunk_counts_chunk64.numel(),
+        num_chunk_indices_chunk64=int(chunk_counts_chunk64.sum().item()),
+        num_chunk_indices_large_block=int(chunk_counts_large_block.sum().item()),
+        num_block_indices_cumsum=int(chunk_counts_cumsum.sum().item()),
+        chunk_counts_chunk64=chunk_counts_chunk64,
+        chunk_counts_large_block=chunk_counts_large_block,
+        chunk_counts_cumsum=chunk_counts_cumsum,
+    )
+
+
+def _count_chunk_indices_cpu(seq_lens_cpu: torch.Tensor, chunk_size: int) -> int:
+    return int(
+        torch.div(
+            seq_lens_cpu + chunk_size - 1,
+            chunk_size,
+            rounding_mode="floor",
+        )
+        .sum()
+        .item()
+    )
+
+
+def _build_chunk_meta_size_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNChunkMetaSizeInfo:
+    seq_lens_cpu = cu_seqlens_cpu[1:] - cu_seqlens_cpu[:-1]
+    return _GDNChunkMetaSizeInfo(
+        num_seqs=seq_lens_cpu.numel(),
+        num_chunk_indices_chunk64=_count_chunk_indices_cpu(
+            seq_lens_cpu,
+            builder._ascend_gdn_chunk_size,
+        ),
+        num_chunk_indices_large_block=_count_chunk_indices_cpu(
+            seq_lens_cpu,
+            builder._ascend_gdn_large_block_size,
+        ),
+        num_block_indices_cumsum=_count_chunk_indices_cpu(
+            seq_lens_cpu,
+            builder._ascend_gdn_cumsum_block_size,
+        ),
+    )
+
+
+def _allocate_chunk_meta_cpu_tensors(shape_info: _GDNChunkMetaSizeInfo) -> dict[str, torch.Tensor]:
+    return {
+        "chunk_indices_chunk64": torch.empty(
+            (shape_info.num_chunk_indices_chunk64, 2),
+            dtype=torch.int32,
+        ),
+        "chunk_offsets_chunk64": torch.empty(
+            (shape_info.num_seqs + 1,),
+            dtype=torch.int32,
+        ),
+        "update_chunk_offsets_chunk64": torch.empty(
+            (shape_info.num_seqs + 1,),
+            dtype=torch.int32,
+        ),
+        "final_chunk_indices_chunk64": torch.empty(
+            (shape_info.num_seqs,),
+            dtype=torch.int32,
+        ),
+        "chunk_indices_large_block": torch.empty(
+            (shape_info.num_chunk_indices_large_block, 2),
+            dtype=torch.int32,
+        ),
+        "block_indices_cumsum": torch.empty(
+            (shape_info.num_block_indices_cumsum, 2),
+            dtype=torch.int32,
+        ),
+    }
+
+
+def _slice_chunk_meta_slot_tensors(
+    slot: _GDNChunkedPrefillBufferSlot,
+    shape_info: _GDNChunkMetaSizeInfo,
+) -> dict[str, torch.Tensor]:
+    return {
+        "chunk_indices_chunk64": slot.chunk_indices_chunk64[: shape_info.num_chunk_indices_chunk64],
+        "chunk_offsets_chunk64": slot.chunk_offsets_chunk64[: shape_info.num_seqs + 1],
+        "update_chunk_offsets_chunk64": slot.update_chunk_offsets_chunk64[: shape_info.num_seqs + 1],
+        "final_chunk_indices_chunk64": slot.final_chunk_indices_chunk64[: shape_info.num_seqs],
+        "chunk_indices_large_block": slot.chunk_indices_large_block[: shape_info.num_chunk_indices_large_block],
+        "block_indices_cumsum": slot.block_indices_cumsum[: shape_info.num_block_indices_cumsum],
+    }
+
+
+def _fill_chunk_meta_cpu_tensors(
+    tensors: dict[str, torch.Tensor],
+    shape_info: _GDNChunkMetaShapeInfo,
+) -> None:
+    _fill_chunk_indices_cpu(
+        tensors["chunk_indices_chunk64"],
+        shape_info.chunk_counts_chunk64,
+    )
+    _fill_chunk_offsets_cpu(
+        tensors["chunk_offsets_chunk64"],
+        shape_info.chunk_counts_chunk64,
+    )
+    _fill_update_chunk_offsets_cpu(
+        tensors["update_chunk_offsets_chunk64"],
+        shape_info.chunk_counts_chunk64,
+    )
+    _fill_final_chunk_indices_cpu(
+        tensors["final_chunk_indices_chunk64"],
+        shape_info.chunk_counts_chunk64,
+    )
+    _fill_chunk_indices_cpu(
+        tensors["chunk_indices_large_block"],
+        shape_info.chunk_counts_large_block,
+    )
+    _fill_chunk_indices_cpu(
+        tensors["block_indices_cumsum"],
+        shape_info.chunk_counts_cumsum,
+    )
+
+
+def _fill_chunk_meta_device_tensors(
+    builder,
+    cu_seqlens: torch.Tensor,
+    tensors: dict[str, torch.Tensor],
+) -> None:
+    seq_lens = None
+    validate_inputs = True
+    if cu_seqlens.device.type == "npu":
+        _validate_cu_seqlens(cu_seqlens, builder._ascend_gdn_chunk_size)
+        assert builder._ascend_gdn_large_block_size > 0
+        assert builder._ascend_gdn_cumsum_block_size > 0
+        seq_lens = _build_seq_lens(cu_seqlens)
+        validate_inputs = False
+    build_chunk_meta_device(
+        cu_seqlens=cu_seqlens,
+        chunk_size=builder._ascend_gdn_chunk_size,
+        out_chunk_indices=tensors["chunk_indices_chunk64"],
+        out_chunk_offsets=tensors["chunk_offsets_chunk64"],
+        out_update_chunk_offsets=tensors["update_chunk_offsets_chunk64"],
+        out_final_chunk_indices=tensors["final_chunk_indices_chunk64"],
+        seq_lens=seq_lens,
+        validate_inputs=validate_inputs,
+    )
+    build_chunk_meta_device(
+        cu_seqlens=cu_seqlens,
+        chunk_size=builder._ascend_gdn_large_block_size,
+        out_chunk_indices=tensors["chunk_indices_large_block"],
+        seq_lens=seq_lens,
+        validate_inputs=validate_inputs,
+    )
+    build_chunk_meta_device(
+        cu_seqlens=cu_seqlens,
+        chunk_size=builder._ascend_gdn_cumsum_block_size,
+        out_chunk_indices=tensors["block_indices_cumsum"],
+        seq_lens=seq_lens,
+        validate_inputs=validate_inputs,
+    )
+
+
+def _build_chunked_prefill_metadata(
+    builder,
+    tensors: dict[str, torch.Tensor],
+    *,
+    slot: _GDNChunkedPrefillBufferSlot | None = None,
+) -> GDNChunkedPrefillMetadata:
+    return GDNChunkedPrefillMetadata(
+        chunk_indices_chunk64=tensors["chunk_indices_chunk64"],
+        chunk_offsets_chunk64=tensors["chunk_offsets_chunk64"],
+        update_chunk_offsets_chunk64=tensors["update_chunk_offsets_chunk64"],
+        final_chunk_indices_chunk64=tensors["final_chunk_indices_chunk64"],
+        chunk_indices_large_block=tensors["chunk_indices_large_block"],
+        block_indices_cumsum=tensors["block_indices_cumsum"],
+        _buffer_slot=slot,
+    )
+
+
 def _get_gdn_num_heads(builder) -> int:
     hf_text_config = getattr(builder.vllm_config.model_config, "hf_text_config", None)
     if hf_text_config is not None and hasattr(hf_text_config, "linear_num_value_heads"):
@@ -110,50 +338,35 @@ def _allocate_chunked_prefill_slot(builder, device: torch.device):
     max_num_batched_tokens = builder.vllm_config.scheduler_config.max_num_batched_tokens
     max_num_seqs = builder.vllm_config.scheduler_config.max_num_seqs
     return _GDNChunkedPrefillBufferSlot(
-        chunk_indices_chunk64=CpuGpuBuffer(
-            max_num_batched_tokens,
-            2,
+        chunk_indices_chunk64=torch.empty(
+            (max_num_batched_tokens, 2),
             dtype=torch.int32,
             device=device,
-            pin_memory=True,
-            with_numpy=False,
         ),
-        chunk_offsets_chunk64=CpuGpuBuffer(
-            max_num_seqs + 1,
+        chunk_offsets_chunk64=torch.empty(
+            (max_num_seqs + 1,),
             dtype=torch.int32,
             device=device,
-            pin_memory=True,
-            with_numpy=False,
         ),
-        update_chunk_offsets_chunk64=CpuGpuBuffer(
-            max_num_seqs + 1,
+        update_chunk_offsets_chunk64=torch.empty(
+            (max_num_seqs + 1,),
             dtype=torch.int32,
             device=device,
-            pin_memory=True,
-            with_numpy=False,
         ),
-        final_chunk_indices_chunk64=CpuGpuBuffer(
-            max_num_seqs,
+        final_chunk_indices_chunk64=torch.empty(
+            (max_num_seqs,),
             dtype=torch.int32,
             device=device,
-            pin_memory=True,
-            with_numpy=False,
         ),
-        chunk_indices_large_block=CpuGpuBuffer(
-            max_num_batched_tokens,
-            2,
+        chunk_indices_large_block=torch.empty(
+            (max_num_batched_tokens, 2),
             dtype=torch.int32,
             device=device,
-            pin_memory=True,
-            with_numpy=False,
         ),
-        block_indices_cumsum=CpuGpuBuffer(
-            max_num_batched_tokens,
-            2,
+        block_indices_cumsum=torch.empty(
+            (max_num_batched_tokens, 2),
             dtype=torch.int32,
             device=device,
-            pin_memory=True,
-            with_numpy=False,
         ),
     )
 
@@ -177,6 +390,16 @@ def _ensure_chunk_meta_state(builder, device: torch.device) -> None:
         ]
 
 
+def _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu: torch.Tensor | None) -> torch.Tensor | None:
+    if (
+        not getattr(builder, "use_spec_decode", False)
+        or num_decode_draft_tokens_cpu is None
+        or num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0].sum().item() == 0
+    ):
+        return None
+    return num_decode_draft_tokens_cpu >= 0
+
+
 def _build_non_spec_query_start_loc_cpu(
     builder,
     attn_metadata,
@@ -187,15 +410,8 @@ def _build_non_spec_query_start_loc_cpu(
         return None
 
     query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
-    if (
-        not getattr(builder, "use_spec_decode", False)
-        or num_decode_draft_tokens_cpu is None
-        or num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0].sum().item() == 0
-    ):
-        return query_start_loc_cpu
-
-    spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
-    if spec_sequence_masks_cpu.sum().item() == 0:
+    spec_sequence_masks_cpu = _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu)
+    if spec_sequence_masks_cpu is None:
         return query_start_loc_cpu
 
     query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
@@ -212,73 +428,123 @@ def _build_non_spec_query_start_loc_cpu(
     return non_spec_query_start_loc_cpu
 
 
-def _build_non_spec_chunked_prefill_meta_cpu(builder, cu_seqlens_cpu: torch.Tensor) -> GDNChunkedPrefillMetadata:
-    chunk_counts_chunk64 = _prepare_chunk_counts_cpu(cu_seqlens_cpu, builder._ascend_gdn_chunk_size)
-    chunk_counts_large = _prepare_chunk_counts_cpu(cu_seqlens_cpu, builder._ascend_gdn_large_block_size)
-    chunk_counts_cumsum = _prepare_chunk_counts_cpu(cu_seqlens_cpu, builder._ascend_gdn_cumsum_block_size)
-    num_seqs = chunk_counts_chunk64.numel()
-    chunk_indices_chunk64 = torch.empty((int(chunk_counts_chunk64.sum().item()), 2), dtype=torch.int32)
-    chunk_offsets_chunk64 = torch.empty((num_seqs + 1,), dtype=torch.int32)
-    update_chunk_offsets_chunk64 = torch.empty((num_seqs + 1,), dtype=torch.int32)
-    final_chunk_indices_chunk64 = torch.empty((num_seqs,), dtype=torch.int32)
-    chunk_indices_large_block = torch.empty((int(chunk_counts_large.sum().item()), 2), dtype=torch.int32)
-    block_indices_cumsum = torch.empty((int(chunk_counts_cumsum.sum().item()), 2), dtype=torch.int32)
-
-    _fill_chunk_indices_cpu(chunk_indices_chunk64, chunk_counts_chunk64)
-    _fill_chunk_offsets_cpu(chunk_offsets_chunk64, chunk_counts_chunk64)
-    _fill_update_chunk_offsets_cpu(update_chunk_offsets_chunk64, chunk_counts_chunk64)
-    _fill_final_chunk_indices_cpu(final_chunk_indices_chunk64, chunk_counts_chunk64)
-    _fill_chunk_indices_cpu(chunk_indices_large_block, chunk_counts_large)
-    _fill_chunk_indices_cpu(block_indices_cumsum, chunk_counts_cumsum)
-
-    return GDNChunkedPrefillMetadata(
-        chunk_indices_chunk64=chunk_indices_chunk64.to(builder._ascend_gdn_chunk_meta_device),
-        chunk_offsets_chunk64=chunk_offsets_chunk64.to(builder._ascend_gdn_chunk_meta_device),
-        update_chunk_offsets_chunk64=update_chunk_offsets_chunk64.to(builder._ascend_gdn_chunk_meta_device),
-        final_chunk_indices_chunk64=final_chunk_indices_chunk64.to(builder._ascend_gdn_chunk_meta_device),
-        chunk_indices_large_block=chunk_indices_large_block.to(builder._ascend_gdn_chunk_meta_device),
-        block_indices_cumsum=block_indices_cumsum.to(builder._ascend_gdn_chunk_meta_device),
+def _allocate_causal_conv1d_host_slot(
+    builder,
+    device: torch.device,
+) -> _GDNCausalConv1dHostBufferSlot:
+    max_num_seqs = builder.vllm_config.scheduler_config.max_num_seqs
+    return _GDNCausalConv1dHostBufferSlot(
+        cache_indices_cpu=torch.empty(
+            max_num_seqs,
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=device.type != "cpu",
+        ),
+        has_initial_state_cpu=torch.empty(
+            max_num_seqs,
+            dtype=torch.bool,
+            device="cpu",
+            pin_memory=device.type != "cpu",
+        ),
     )
 
 
-def _build_non_spec_chunked_prefill_meta(builder, cu_seqlens_cpu: torch.Tensor) -> GDNChunkedPrefillMetadata:
+def _ensure_causal_conv1d_host_meta_state(builder, device: torch.device) -> None:
+    if getattr(builder, "_ascend_gdn_causal_conv1d_host_meta_initialized", False):
+        return
+    builder._ascend_gdn_causal_conv1d_host_meta_initialized = True
+    builder._ascend_gdn_causal_conv1d_host_pool_idx = -1
+    builder._ascend_gdn_causal_conv1d_host_pool = []
+    if device.type != "cpu":
+        builder._ascend_gdn_causal_conv1d_host_pool = [
+            _allocate_causal_conv1d_host_slot(builder, device),
+            _allocate_causal_conv1d_host_slot(builder, device),
+        ]
+
+
+def _acquire_causal_conv1d_host_slot(builder) -> _GDNCausalConv1dHostBufferSlot:
+    pool = builder._ascend_gdn_causal_conv1d_host_pool
+    builder._ascend_gdn_causal_conv1d_host_pool_idx = (builder._ascend_gdn_causal_conv1d_host_pool_idx + 1) % len(pool)
+    return pool[builder._ascend_gdn_causal_conv1d_host_pool_idx]
+
+
+def _copy_to_pinned_cpu(
+    tensor: torch.Tensor,
+    pinned_buffer: torch.Tensor | None,
+) -> torch.Tensor:
+    if tensor.device.type == "cpu":
+        return tensor
+
+    assert pinned_buffer is not None
+    cpu_tensor = pinned_buffer[: tensor.numel()]
+    cpu_tensor.copy_(
+        tensor.reshape(-1),
+        non_blocking=True,
+    )
+    return cpu_tensor
+
+
+def _build_non_spec_causal_conv1d_host_meta(
+    builder,
+    attn_metadata,
+    non_spec_query_start_loc_cpu: torch.Tensor,
+) -> GDNCausalConv1dHostMetadata:
+    assert attn_metadata.num_prefills > 0
+    if attn_metadata.non_spec_state_indices_tensor is None:
+        raise RuntimeError(
+            "Expected attn_metadata.non_spec_state_indices_tensor for patched GDN non-spec prefill path."
+        )
+    if attn_metadata.has_initial_state is None:
+        raise RuntimeError("Expected attn_metadata.has_initial_state for patched GDN non-spec prefill path.")
+
+    slot = None
+    if (
+        attn_metadata.non_spec_state_indices_tensor.device.type != "cpu"
+        or attn_metadata.has_initial_state.device.type != "cpu"
+    ):
+        slot = _acquire_causal_conv1d_host_slot(builder)
+
+    cache_indices_cpu = _copy_to_pinned_cpu(
+        attn_metadata.non_spec_state_indices_tensor,
+        None if slot is None else slot.cache_indices_cpu,
+    )
+    has_initial_state_cpu = _copy_to_pinned_cpu(
+        attn_metadata.has_initial_state,
+        None if slot is None else slot.has_initial_state_cpu,
+    )
+
+    return GDNCausalConv1dHostMetadata(
+        query_start_loc_cpu=non_spec_query_start_loc_cpu,
+        cache_indices_cpu=cache_indices_cpu,
+        has_initial_state_cpu=has_initial_state_cpu,
+        _buffer_slot=slot,
+    )
+
+
+def _build_non_spec_chunked_prefill_meta_cpu(builder, cu_seqlens_cpu: torch.Tensor) -> GDNChunkedPrefillMetadata:
+    shape_info = _build_chunk_meta_shape_info(builder, cu_seqlens_cpu)
+    tensors = _allocate_chunk_meta_cpu_tensors(shape_info)
+    _fill_chunk_meta_cpu_tensors(tensors, shape_info)
+    return _build_chunked_prefill_metadata(builder, tensors)
+
+
+def _build_non_spec_chunked_prefill_meta(
+    builder,
+    cu_seqlens_cpu: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> GDNChunkedPrefillMetadata:
     device = builder._ascend_gdn_chunk_meta_device
     if device.type == "cpu":
         return _build_non_spec_chunked_prefill_meta_cpu(builder, cu_seqlens_cpu)
 
+    shape_info = _build_chunk_meta_size_info(builder, cu_seqlens_cpu)
     builder._ascend_gdn_chunked_prefill_pool_idx = (builder._ascend_gdn_chunked_prefill_pool_idx + 1) % len(
         builder._ascend_gdn_chunked_prefill_pool
     )
     slot = builder._ascend_gdn_chunked_prefill_pool[builder._ascend_gdn_chunked_prefill_pool_idx]
-    chunk_counts_chunk64 = _prepare_chunk_counts_cpu(cu_seqlens_cpu, builder._ascend_gdn_chunk_size)
-    chunk_counts_large = _prepare_chunk_counts_cpu(cu_seqlens_cpu, builder._ascend_gdn_large_block_size)
-    chunk_counts_cumsum = _prepare_chunk_counts_cpu(cu_seqlens_cpu, builder._ascend_gdn_cumsum_block_size)
-    num_chunk_indices_chunk64 = _fill_chunk_indices_cpu(slot.chunk_indices_chunk64.cpu, chunk_counts_chunk64)
-    num_chunk_offsets_chunk64 = _fill_chunk_offsets_cpu(slot.chunk_offsets_chunk64.cpu, chunk_counts_chunk64)
-    num_update_chunk_offsets_chunk64 = _fill_update_chunk_offsets_cpu(
-        slot.update_chunk_offsets_chunk64.cpu, chunk_counts_chunk64
-    )
-    num_final_chunk_indices_chunk64 = _fill_final_chunk_indices_cpu(
-        slot.final_chunk_indices_chunk64.cpu, chunk_counts_chunk64
-    )
-    num_chunk_indices_large = _fill_chunk_indices_cpu(slot.chunk_indices_large_block.cpu, chunk_counts_large)
-    num_block_indices_cumsum = _fill_chunk_indices_cpu(slot.block_indices_cumsum.cpu, chunk_counts_cumsum)
-
-    chunk_indices_chunk64 = slot.chunk_indices_chunk64.copy_to_gpu(num_chunk_indices_chunk64)
-    chunk_offsets_chunk64 = slot.chunk_offsets_chunk64.copy_to_gpu(num_chunk_offsets_chunk64)
-    update_chunk_offsets_chunk64 = slot.update_chunk_offsets_chunk64.copy_to_gpu(num_update_chunk_offsets_chunk64)
-    final_chunk_indices_chunk64 = slot.final_chunk_indices_chunk64.copy_to_gpu(num_final_chunk_indices_chunk64)
-    chunk_indices_large_block = slot.chunk_indices_large_block.copy_to_gpu(num_chunk_indices_large)
-    block_indices_cumsum = slot.block_indices_cumsum.copy_to_gpu(num_block_indices_cumsum)
-    return GDNChunkedPrefillMetadata(
-        chunk_indices_chunk64=chunk_indices_chunk64,
-        chunk_offsets_chunk64=chunk_offsets_chunk64,
-        update_chunk_offsets_chunk64=update_chunk_offsets_chunk64,
-        final_chunk_indices_chunk64=final_chunk_indices_chunk64,
-        chunk_indices_large_block=chunk_indices_large_block,
-        block_indices_cumsum=block_indices_cumsum,
-        _buffer_slot=slot,
-    )
+    tensors = _slice_chunk_meta_slot_tensors(slot, shape_info)
+    _fill_chunk_meta_device_tensors(builder, cu_seqlens, tensors)
+    return _build_chunked_prefill_metadata(builder, tensors, slot=slot)
 
 
 def _patched_build(
@@ -297,11 +563,15 @@ def _patched_build(
         num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
         fast_build=fast_build,
     )
-    attn_metadata.non_spec_chunked_prefill_meta = None
+    attn_metadata.non_spec_prefill_fallback_meta = None
     if attn_metadata.num_prefills <= 0:
         return attn_metadata
 
     _ensure_chunk_meta_state(self, common_attn_metadata.query_start_loc.device)
+    _ensure_causal_conv1d_host_meta_state(
+        self,
+        common_attn_metadata.query_start_loc.device,
+    )
     non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
         self,
         attn_metadata,
@@ -309,13 +579,26 @@ def _patched_build(
         num_decode_draft_tokens_cpu,
     )
     assert non_spec_query_start_loc_cpu is not None
-    attn_metadata.non_spec_chunked_prefill_meta = _build_non_spec_chunked_prefill_meta(
-        self, non_spec_query_start_loc_cpu
+    if attn_metadata.non_spec_query_start_loc is None:
+        raise RuntimeError("Expected attn_metadata.non_spec_query_start_loc for patched GDN non-spec prefill path.")
+    attn_metadata.non_spec_prefill_fallback_meta = GDNPrefillFallbackMeta(
+        causal_conv1d=_build_non_spec_causal_conv1d_host_meta(
+            self,
+            attn_metadata,
+            non_spec_query_start_loc_cpu,
+        ),
+        chunk=_build_non_spec_chunked_prefill_meta(
+            self,
+            non_spec_query_start_loc_cpu,
+            attn_metadata.non_spec_query_start_loc,
+        ),
     )
     return attn_metadata
 
 
 if not _IS_PATCHED:
     gdn_attn.GDNChunkedPrefillMetadata = GDNChunkedPrefillMetadata
+    gdn_attn.GDNCausalConv1dHostMetadata = GDNCausalConv1dHostMetadata
+    gdn_attn.GDNPrefillFallbackMeta = GDNPrefillFallbackMeta
     gdn_attn.GDNAttentionMetadataBuilder.build = _patched_build
     _IS_PATCHED = True


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the GDN non-spec prefill fallback path for the Ascend Qwen3.5 / Qwen3Next linear-attention backend.

Background:
- `causal_conv1d` in the current non-spec prefill path still needs host-side metadata, and the old path prepared that metadata lazily in forward.
- `chunk_gated_delta_rule` also relied on repeated hot-path `prepare_*` helpers (`prepare_chunk_indices`, `prepare_chunk_offsets`, etc.) instead of consuming a step-scoped prebuilt metadata bundle.
- The fallback contract was also too permissive: when required non-spec prefill metadata was missing, the code could silently fall back to legacy recomputation paths instead of failing explicitly.

Changes in this PR:
- Introduce a unified `non_spec_prefill_fallback_meta` for the GDN non-spec prefill path.
  - `causal_conv1d` host metadata is prepared during attention metadata build and consumed in forward.
  - `chunk_gated_delta_rule` prebuilt metadata is also prepared during metadata build and threaded through `gdn.py -> chunk.py`.
- Add `vllm_ascend/ops/triton/gdn_chunk_meta.py` to build:
  - `chunk_indices_chunk64`
  - `chunk_offsets_chunk64`
  - `update_chunk_offsets_chunk64`
  - `final_chunk_indices_chunk64`
  - `chunk_indices_large_block`
  - `block_indices_cumsum`
- The builder-side chunk-meta path now has two execution modes:
  - CPU path: generate metadata with the same semantics as the original runtime `prepare_*` helpers.
  - NPU path: write directly into pooled device tensors, reuse shared `seq_lens`, and avoid per-call helper fallback logic in the hot path.
- Thread prebuilt `chunk_offsets` through `chunk.py`, `chunk_o.py`, and `chunk_o_update.py` so wrapper code no longer re-prepares offsets when prebuilt metadata is available.
- Tighten the patched prefill contract:
  - remove legacy silent fallback branches that re-materialize metadata in unexpected paths
  - raise explicitly when required non-spec prefill fallback metadata is missing
- Keep metadata semantics aligned with the original runtime path for mixed spec/non-spec, padding, zero-length, and long-sequence cases.

Why this is needed:
- moves non-spec prefill fallback metadata generation to the metadata-builder stage instead of doing it lazily inside per-layer forward hot paths
- makes the fallback contract explicit and debuggable
- keeps `chunk_gated_delta_rule` operator inputs consistent with the original `prepare_*` path while reducing repeated hot-path preparation work
- preserves correctness for mixed/padded edge cases while improving TTFT / TPS on the target workload

### Does this PR introduce _any_ user-facing change?

There is no API or interface change.

User-visible impact is limited to backend behavior on Ascend:
- the GDN non-spec prefill path is stricter and will now fail loudly if the expected fallback metadata contract is violated
- performance for the targeted Qwen3.5 / Qwen3Next GDN prefill path is improved on the validated benchmark shape

### How was this patch tested?

Unit / correctness coverage:
- `tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py`
- `tests/ut/ops/test_gdn_chunk_meta.py`
- `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_gdn_chunk_meta.py`

The tests cover:
- `causal_conv1d` host args matching the original/runtime path
- chunk metadata parity with the original runtime `prepare_*` helpers
- CPU and NPU chunk-meta generation parity
- mixed spec/non-spec, padding, zero-length, and long-sequence edge cases
- strict failure when required non-spec prefill fallback metadata is missing
- prebuilt `chunk_offsets` wiring through the FLA wrappers

Additional validation:
- compared the current prebuilt `chunk_gated_delta_rule` metadata against the original non-prebuilt path on both CPU and NPU; for the tested long-sequence / mixed cases, the operator inputs were identical

Performance validation:
- methodology: for each code state, start the service once, run 5 benchmark rounds against the same warm service, and report the mean of the last 4 rounds
- model: `Qwen3.5-35B-A3B`
- target: `910B4 32G`
- benchmark config:
  - `tensor_parallel_size=4`
  - `--max-model-len 4096`
  - `--gpu-memory-utilization 0.9`
  - `--async-scheduling`
  - `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16]}'`
  - `--speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3}'`
  - `num_prompts=64`
  - `max_concurrency=16`
  - `output_len=1500`
- comparison states:
  - baseline: pre-PR state `dae3c99e`
  - original PR implementation: `cc3ca6f7`
  - current implementation in this PR: `8000a085`

Results (mean of last 4 rounds):

| State | TTFT | TPS |
| --- | ---: | ---: |
| baseline (`dae3c99e`) | `1048.64 ms` | `162.26` |
| original (`cc3ca6f7`) | `1008.81 ms` | `163.60` |
| current (`8000a085`) | `978.58 ms` | `164.67` |

Delta:
- current vs baseline:
  - TTFT: `-70.06 ms`
  - TPS: `+2.42`
- current vs original:
  - TTFT: `-30.22 ms`
  - TPS: `+1.07`

Summary:
- relative to the original PR implementation, the latest scheme keeps improving TTFT and TPS
