### PR TITLE
[CI][310p] add qwen3.5-4B model weight for edge-device 310p

### DIFF
--- a/.github/workflows/misc/model_list.json
+++ b/.github/workflows/misc/model_list.json
@@ -104,6 +104,7 @@
       "Qwen/Qwen3-VL-30B-A3B-Instruct",
       "Qwen/Qwen3-VL-32B-Instruct",
       "Qwen/Qwen3-VL-8B-Instruct",
+      "Qwen/Qwen3.5-4B",
       "Qwen/Qwen3.5-27B",
       "Qwen/Qwen3.5-35B-A3B",
       "RedHatAI/Qwen3-32B-speculator.eagle3",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

The 310P edge device needs to run Qwen3.5-4B with **TP=1**, so we need to request that this option be added to the model list.

### Does this PR introduce _any_ user-facing change?

NA

### How was this patch tested?

NA
