### PR TITLE
[Triton] Fix triton-ascend version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton; fi && \
+    pip install triton-ascend==3.2.0.dev20260322 -i -i https://test.pypi.org/simple/ && \
     python3 -m pip cache purge
 
 # Install clang-15 (for triton-ascend)

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -65,6 +65,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton; fi && \
+    pip install triton-ascend==3.2.0.dev20260322 -i -i https://test.pypi.org/simple/ && \
     python3 -m pip cache purge
 
 # Install clang-15 (for triton-ascend)

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -66,6 +66,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton; fi && \
+    pip install triton-ascend==3.2.0.dev20260322 -i -i https://test.pypi.org/simple/ && \
     python3 -m pip cache purge
 
 # Install clang (for triton-ascend)

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -66,6 +66,7 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton; fi && \
+    pip install triton-ascend==3.2.0.dev20260322 -i -i https://test.pypi.org/simple/ && \
     python3 -m pip cache purge
 
 # Install clang (for triton-ascend)


### PR DESCRIPTION
### What this PR does / why we need it?
Triton-ascend occasionally encounters compilation errors, which is a known issue in triton-ascend 3.2.0. However, we want to use the official version rather than the development version, so we only changed the triton-ascend version in the Dockerfile and added a FAQ to explain this issue.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
