### PR TITLE
[Doc][0.18.0][KV Pool]add mooncake rdma timeout

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -125,7 +125,6 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
 **device_name**: ""
 **master_server_address**: Configured with the IP and port of the master service.  
 **global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.**
-**default_kv_lease_ttl** Default lease TTL for KV objects. The default unit is milliseconds. Set this via `--default_kv_lease_ttl` when starting `mooncake_master`, and keep it larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
 
 #### 2.Start mooncake_master
 
@@ -136,6 +135,7 @@ mooncake_master --port 50088 --eviction_high_watermark_ratio 0.9 --eviction_rati
 ```
 
 `eviction_high_watermark_ratio` determines the watermark where Mooncake Store will perform eviction，and `eviction_ratio` determines the portion of stored objects that would be evicted.
+`default_kv_lease_ttl` controls the default lease TTL for KV objects (milliseconds); configure it via `--default_kv_lease_ttl` and keep it larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
 
 ### PD Disaggregation Scenario
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -160,8 +160,9 @@ export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #export HCCL_INTRA_ROCE_ENABLE=1
 
 #Minimum retransmission timeout of the RDMA，equals 4.096 μs * 2 ^ timeout.
-#Needs to satisfy the equation: transfer time > RDMA_TIMEOUT * 7, where 7 is the default number of retry for RDMA transfer.
-export HCCL_RDMA_TIMEOUT=16
+#Needs to satisfy the equation: ASCEND_TRANSFER_TIMEOUT > RDMA_TIMEOUT * 7, where 7 is the default number of retry for RDMA transfer.
+#HCCL_RDMA_TIMEOUT also affects collective communication behavior and should be configured carefully.
+export HCCL_RDMA_TIMEOUT=17
 
 # Unit: ms. The timeout for one-sided communication connection establishment is set to 10 seconds by default (see PR: https://github.com/kvcache-ai/Mooncake/pull/1039). Users can adjust this value based on their specific setup.
 # The recommended formula is: ASCEND_CONNECT_TIMEOUT = connection_time_per_card (typically within 500ms) × total_number_of_Decode_cards.
@@ -235,7 +236,7 @@ export ACL_OP_INIT_MODE=1
 export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #A2
 #export HCCL_INTRA_ROCE_ENABLE=1
-export HCCL_RDMA_TIMEOUT=16
+export HCCL_RDMA_TIMEOUT=17
 export ASCEND_CONNECT_TIMEOUT=10000
 export ASCEND_TRANSFER_TIMEOUT=10000
 
@@ -350,7 +351,7 @@ export ACL_OP_INIT_MODE=1
 export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #A2
 #export HCCL_INTRA_ROCE_ENABLE=1
-export HCCL_RDMA_TIMEOUT=16
+export HCCL_RDMA_TIMEOUT=17
 export ASCEND_CONNECT_TIMEOUT=10000
 export ASCEND_TRANSFER_TIMEOUT=10000
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -117,7 +117,6 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
     "device_name": "",
     "master_server_address": "xx.xx.xx.xx:50088",
     "global_segment_size": "1GB" (1024MB/1048576KB/1073741824B/1073741824)
-    "default_kv_lease_ttl": 11000,
 }
 ```
 
@@ -126,14 +125,14 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
 **device_name**: ""
 **master_server_address**: Configured with the IP and port of the master service.  
 **global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.**
-**default_kv_lease_ttl** Default lease TTL for KV objects. The default unit is milliseconds. Needs to be larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
+**default_kv_lease_ttl** Default lease TTL for KV objects. The default unit is milliseconds. Set this via `--default_kv_lease_ttl` when starting `mooncake_master`, and keep it larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
 
 #### 2.Start mooncake_master
 
 Under the mooncake folder:
 
 ```shell
-mooncake_master --port 50088 --eviction_high_watermark_ratio 0.9 --eviction_ratio 0.1
+mooncake_master --port 50088 --eviction_high_watermark_ratio 0.9 --eviction_ratio 0.1 --default_kv_lease_ttl 11000
 ```
 
 `eviction_high_watermark_ratio` determines the watermark where Mooncake Store will perform eviction，and `eviction_ratio` determines the portion of stored objects that would be evicted.

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -112,7 +112,7 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
     "device_name": "",
     "master_server_address": "xx.xx.xx.xx:50088",
     "global_segment_size": "1GB" (1024MB/1048576KB/1073741824B/1073741824)
-    "default_kv_lease_ttl": 11000
+    "default_kv_lease_ttl": 11000,
 }
 ```
 
@@ -160,7 +160,7 @@ export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #export HCCL_INTRA_ROCE_ENABLE=1
 
 #Minimum retransmission timeout of the RDMA，equals 4.096 μs * 2 ^ timeout.
-#Needs to satisfy the equation: transfer time > RMDA_TIMEOUT * 7, where 7 is the default number of retry for RDMA transfer.
+#Needs to satisfy the equation: transfer time > RDMA_TIMEOUT * 7, where 7 is the default number of retry for RDMA transfer.
 export HCCL_RDMA_TIMEOUT=16
 
 # Unit: ms. The timeout for one-sided communication connection establishment is set to 10 seconds by default (see PR: https://github.com/kvcache-ai/Mooncake/pull/1039). Users can adjust this value based on their specific setup.

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -112,6 +112,7 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
     "device_name": "",
     "master_server_address": "xx.xx.xx.xx:50088",
     "global_segment_size": "1GB" (1024MB/1048576KB/1073741824B/1073741824)
+    "default_kv_lease_ttl": 11000
 }
 ```
 
@@ -120,6 +121,7 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
 **device_name**: ""
 **master_server_address**: Configured with the IP and port of the master service.  
 **global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.**
+**default_kv_lease_ttl** Default lease TTL for KV objects. The default unit is milliseconds. Needs to be larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
 
 #### 2.Start mooncake_master
 
@@ -156,6 +158,10 @@ export ACL_OP_INIT_MODE=1
 export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #A2
 #export HCCL_INTRA_ROCE_ENABLE=1
+
+#Minimum retransmission timeout of the RDMA，equals 4.096 μs * 2 ^ timeout.
+#Needs to satisfy the equation: transfer time > RMDA_TIMEOUT * 7, where 7 is the default number of retry for RDMA transfer.
+export HCCL_RDMA_TIMEOUT=16
 
 # Unit: ms. The timeout for one-sided communication connection establishment is set to 10 seconds by default (see PR: https://github.com/kvcache-ai/Mooncake/pull/1039). Users can adjust this value based on their specific setup.
 # The recommended formula is: ASCEND_CONNECT_TIMEOUT = connection_time_per_card (typically within 500ms) × total_number_of_Decode_cards.
@@ -229,6 +235,7 @@ export ACL_OP_INIT_MODE=1
 export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #A2
 #export HCCL_INTRA_ROCE_ENABLE=1
+export HCCL_RDMA_TIMEOUT=16
 export ASCEND_CONNECT_TIMEOUT=10000
 export ASCEND_TRANSFER_TIMEOUT=10000
 
@@ -343,6 +350,7 @@ export ACL_OP_INIT_MODE=1
 export ASCEND_ENABLE_USE_FABRIC_MEM=1
 #A2
 #export HCCL_INTRA_ROCE_ENABLE=1
+export HCCL_RDMA_TIMEOUT=16
 export ASCEND_CONNECT_TIMEOUT=10000
 export ASCEND_TRANSFER_TIMEOUT=10000
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -99,6 +99,11 @@ export PYTHONHASHSEED=0
 | 800 I/T A3 series | 25.5.0<=HDK<26.0.0 | `export ASCEND_BUFFER_POOL=4:8` | Configures the number and size of buffers on the NPU Device for aggregation and KV transfer (e.g., `4:8` means 4 buffers of 8MB). |
 | 800 I/T A2 series | N/A | `export HCCL_INTRA_ROCE_ENABLE=1` | Required by direct transmission cheme on 800 I/T A2 series|
 
+### FAQ for HIXL (ascend_direct) backend
+
+For common troubleshooting and issue localization guidance for HIXL (ascend_direct), see:
+<https://gitcode.com/cann/hixl/wiki/HIXL%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E5%AE%9A%E4%BD%8D%E6%89%8B%E5%86%8C.md>
+
 ### Run Mooncake Master
 
 #### 1.Configure mooncake.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
- Add `default_kv_lease_ttl` to the `mooncake.json` example in the KV Pool guide.
- Document `default_kv_lease_ttl` semantics and clarify that it should be larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
- Add `HCCL_RDMA_TIMEOUT` explanation for Mooncake RDMA retransmission timeout, including the recommended constraint note.
- Add `HCCL_RDMA_TIMEOUT=16` to relevant KV Pool environment setup examples for consistency.

<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
