### PR TITLE
[draft] split flashcomm1 & dsa-cp

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -171,6 +171,10 @@ class AscendConfig:
         self.mix_placement = additional_config.get("mix_placement", False)
         self._check_mix_placement()
 
+        # Improves dsv3.2/glm5 accuracy after enabling dsa-cp in scenarios with strict accuracy requirements,
+        # especially for customized cases, at the cost of performance degradation due to extra communication.
+        self.enable_dsa_cp_strict_accuracy = additional_config.get("enable_dsa_cp_strict_accuracy", False)
+
     def _check_mix_placement(self):
         if self.mix_placement:
             if self.enable_shared_expert_dp or self.multistream_overlap_shared_expert:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -450,6 +450,13 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # Enable layer sharding via DSA-CP on the P node in the PD-disaggregated setup.
         self.enable_dsa_cp_with_layer_shard = enable_dsa_cp_with_layer_shard()
+        
+        # Improves dsv3.2/glm5 accuracy after enabling dsa-cp in scenarios with strict accuracy requirements,
+        # especially for customized cases, at the cost of performance degradation due to extra communication.
+        self.enable_dsa_cp_strict_accuracy = (
+            self.enable_dsa_cp_with_layer_shard
+            and ascend_config.enable_dsa_cp_strict_accuracy
+        )
 
         # use original TP o_proj weight in PD mix stage, and full gather
         # for o_proj weight for prefill stage.
@@ -1250,7 +1257,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 return result
             attn_output = result
 
-        if self.enable_dsa_cp_with_layer_shard:
+        if self.enable_dsa_cp_strict_accuracy:
             send = (
                 attn_output.view(-1, self.tp_size, self.num_heads * self.v_head_dim)
                 .permute(1, 0, 2)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1250,6 +1250,16 @@ class AscendSFAImpl(MLAAttentionImpl):
                 return result
             attn_output = result
 
+        if self.enable_dsa_cp_with_layer_shard:
+            send = (
+                attn_output.view(-1, self.tp_size, self.num_heads * self.v_head_dim)
+                .permute(1, 0, 2)
+                .reshape(-1, self.num_heads * self.v_head_dim)
+            )
+
+            attn_output = torch.empty_like(send)
+            torch.distributed.all_to_all_single(attn_output, send, group=get_tp_group().device_group)
+
         output[...] = self.o_proj(attn_output)[0]
 
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1040,6 +1040,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
+
         if attn_metadata is None:
             # Profiling run.
             if self.enable_dsa_cp_with_layer_shard and not _EXTRA_CTX.in_profile_run:
@@ -1047,6 +1048,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                     if is_hidden_layer(layer):
                         reach_layer_for_shard_weight_series(layer)
             return output.fill_(0)
+
+        if self.enable_dsa_cp:
+            need_gather_q_kv = False
+        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states.contiguous(), need_gather_q_kv)
 
         cos = attn_metadata.cos
         sin = attn_metadata.sin

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -72,6 +72,8 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Whether to enable FlashComm optimization when tensor parallel is enabled.
     # This feature will get better performance when concurrency is large.
     "VLLM_ASCEND_ENABLE_FLASHCOMM1": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0"))),
+    # DSA-CP
+    "VLLM_ASCEND_ENABLE_DSA_CP": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_DSA_CP", "0"))),
     # Whether to enable FLASHCOMM2. Setting it to 0 disables the feature, while setting it to 1 or above enables it.
     # The specific value set will be used as the O-matrix TP group size for flashcomm2.
     # For a detailed introduction to the parameters and the differences and applicable scenarios

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -662,8 +662,10 @@ def _get_row_parallel_op(
     | ShardedCPRowParallelOp
     | None
 ):
-    # if enable_dsa_cp_with_layer_shard() and "o_proj" in prefix:
-    #     return ShardedCPRowParallelOp(layer)
+    if enable_dsa_cp_with_layer_shard() and \
+        "o_proj" in prefix and \
+        not get_ascend_config().enable_dsa_cp_strict_accuracy:
+        return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPRowParallelOp(layer)
     if "o_proj" in prefix and oproj_tp_enable():

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -662,8 +662,8 @@ def _get_row_parallel_op(
     | ShardedCPRowParallelOp
     | None
 ):
-    if enable_dsa_cp_with_layer_shard() and "o_proj" in prefix:
-        return ShardedCPRowParallelOp(layer)
+    # if enable_dsa_cp_with_layer_shard() and "o_proj" in prefix:
+    #     return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPRowParallelOp(layer)
     if "o_proj" in prefix and oproj_tp_enable():

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1172,7 +1172,7 @@ def enable_dsa_cp() -> bool:
     is_ds_v32 = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
         vllm_config.model_config.hf_text_config, "index_topk"
     )
-    return bool(is_ds_v32 and enable_sp())
+    return bool(is_ds_v32 and envs_ascend.VLLM_ASCEND_ENABLE_DSA_CP)
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR splits flashcomm1 & dsa-cp with different envs and fixs accuracy bug in some cases with additional commu methods.

### Does this PR introduce _any_ user-facing change?
**If you want to enable dsa-cp:**
   export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
   export VLLM_ASCEND_ENABLE_DSA_CP=1

**if you want to better accuracy in some case:**
   --additional-config '{"enable_dsa_cp_strict_accuracy": true}'

### How was this patch tested?
CI passed with new added/existing test.
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
