### PR TITLE
[Bugfix]Reinstall triton-ascend after vllm-ascend install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,14 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
 
 # Install vllm-ascend
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-# vllm-ascend on x86 may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton triton-ascend && python3 -m pip install -v triton-ascend==3.2.0; fi && \
+    python3 -m pip uninstall -y triton triton-ascend && \
+    python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
 # Install clang-15 (for triton-ascend)

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -49,13 +49,14 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
 
 # Install vllm-ascend
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-# vllm-ascend on x86 may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton triton-ascend && python3 -m pip install -v triton-ascend==3.2.0; fi && \
+    python3 -m pip uninstall -y triton triton-ascend && \
+    python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
 # Install modelscope (for fast download) and ray (for multinode)

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -44,14 +44,15 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# vllm-ascend on x86 may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton triton-ascend && python3 -m pip install -v triton-ascend==3.2.0; fi && \
+    python3 -m pip uninstall -y triton triton-ascend && \
+    python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
 # Install modelscope (for fast download) and ray (for multinode)

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -58,13 +58,14 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
 
 # Install vllm-ascend
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-# vllm-ascend on x86 may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton triton-ascend && python3 -m pip install -v triton-ascend==3.2.0; fi && \
+    python3 -m pip uninstall -y triton triton-ascend && \
+    python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
 # Install clang-15 (for triton-ascend)

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -58,14 +58,15 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# vllm-ascend on x86 may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton triton-ascend && python3 -m pip install -v triton-ascend==3.2.0; fi && \
+    python3 -m pip uninstall -y triton triton-ascend && \
+    python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
 # Install clang (for triton-ascend)

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -58,14 +58,15 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
     python3 -m pip cache purge
 
 # Install vllm-ascend
-# vllm-ascend on x86 may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
+# vllm-ascend may pull upstream triton; uninstall triton & triton-ascend, then reinstall triton-ascend.
 RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux && \
     python3 -m pip install -v -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    if [ "$(uname -i)" = "x86_64" ]; then python3 -m pip uninstall -y triton triton-ascend && python3 -m pip install -v triton-ascend==3.2.0; fi && \
+    python3 -m pip uninstall -y triton triton-ascend && \
+    python3 -m pip install -v triton-ascend==3.2.0 && \
     python3 -m pip cache purge
 
 # Install clang (for triton-ascend)


### PR DESCRIPTION
### What this PR does / why we need it?
Triton and triton-ascend share the same directory. Uninstalling triton alone will corrupt the triton-ascend directory. Therefore, both triton and triton-ascend need to be uninstalled and then triton-ascend reinstalled.

Link：
- https://github.com/vllm-project/vllm-ascend/pull/7497
- https://github.com/vllm-project/vllm-ascend/issues/7359

``` bash
Successfully uninstalled triton-3.6.0
root@e1b97234c7be:/vllm-workspace/vllm-ascend# python3 -c "import torch"

Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/__init__.py", line 2833, in _import_device_backends
    entrypoint = backend_extension.load()
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/__init__.py", line 41, in <module>
    import torch_npu.npu
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/npu/__init__.py", line 140, in <module>
    from torch_npu.utils import _should_print_warning
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/utils/__init__.py", line 14, in <module>
    from ._dynamo import add_dynamo_methods
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/utils/_dynamo.py", line 6, in <module>
    from torch._dynamo.utils import tensortype_to_dtype
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_dynamo/__init__.py", line 13, in <module>
    from . import (
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_dynamo/aot_compile.py", line 15, in <module>
    from . import convert_frame
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 57, in <module>
    from torch._dynamo.symbolic_convert import TensorifyState
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 53, in <module>
    from torch._dynamo.exc import ObservedException, TensorifyScalarRestartAnalysis
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_dynamo/exc.py", line 45, in <module>
    from .utils import counters
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_dynamo/utils.py", line 2417, in <module>
    common_constant_types.add(triton.language.dtype)
                              ^^^^^^^^^^^^^^^
AttributeError: module 'triton' has no attribute 'language'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/__init__.py", line 2878, in <module>
    _import_device_backends()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/__init__.py", line 2837, in _import_device_backends
    raise RuntimeError(
RuntimeError: Failed to load the backend extension: torch_npu. You can disable extension auto-loading with TORCH_DEVICE_BACKEND_AUTOLOAD=0.
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
