### PR TITLE
[v0.18.0][P/D][Feature]Layerwise connector supports Mamba prefill prefix caching

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -227,7 +227,11 @@ class KVCacheSendingLayerThread(threading.Thread):
         self.kv_cache_specs = kv_cache_specs
         self.attn_resharding_group_idx = attn_resharding_group_idx
         self.mamba_cache_mode = self.vllm_config.cache_config.mamba_cache_mode
-        self.num_speculative_tokens = self.vllm_config.speculative_config.num_speculative_tokens if self.vllm_config.speculative_config is not None else 0
+        self.num_speculative_tokens = (
+            self.vllm_config.speculative_config.num_speculative_tokens
+            if self.vllm_config.speculative_config is not None
+            else 0
+        )
         self.tp_size = tp_size
         self.tp_rank = tp_rank
         self.pd_head_ratio = pd_head_ratio
@@ -277,10 +281,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         if isinstance(layer_kv_cache_spec, MambaSpec):
             # only support one block transfer for mamba
             if self.mamba_cache_mode == "align":
-                if self.num_speculative_tokens == 0:
-                    transfer_block_idx = len(local_block_ids) - 1
-                else:
-                    transfer_block_idx = len(local_block_ids) - self.num_speculative_tokens - 1
+                transfer_block_idx = len(local_block_ids) - self.num_speculative_tokens - 1
             else:
                 transfer_block_idx = 0
             local_conv_addr, local_ssm_addr = local_layer_metadata.kv_caches_base_addr
@@ -329,7 +330,9 @@ class KVCacheSendingLayerThread(threading.Thread):
                             (i * conv_shape[1] + local_conv_offset) * tp_ratio
                             + (self.tp_rank % tp_ratio) * local_conv_size
                         ) * get_dtype_size(conv_dtype)
-                        src_list.append(local_conv_addr + local_block_ids[transfer_block_idx] * local_conv_len + local_addr_offset)
+                        src_list.append(
+                            local_conv_addr + local_block_ids[transfer_block_idx] * local_conv_len + local_addr_offset
+                        )
                         dst_list.append(remote_conv_addr + remote_block_ids[0] * remote_conv_len + remote_addr_offset)
                         length_list.append(local_conv_size * get_dtype_size(conv_dtype))
                 # ssm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
Mooncake layerwise connector supports Mamba prefix caching on prefiller nodes.

### Does this PR introduce _any_ user-facing change?
Yes. Use `--enable-prefix-caching` and `--mamba-cache-mode align` to enable mamba align mode prefix caching on P/D prefill nodes. This function does not supports on decode nodes now.

### How was this patch tested?
By P/D E2E test.
