### PR TITLE
[BugFix] Fix server init error when set max_num_seqs not a multiple of tp while FLASHCOMM is on

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -326,7 +326,6 @@ class NPUPlatform(Platform):
                 f"values that are multiples of tp_size "
                 f"{vllm_config.parallel_config.tensor_parallel_size}"
             )
-            
             if len(sp_aclgraph_sizes) != len(original_sizes):
                 # If user set the max_num_seqs miss fit the multiple of tp_size,
                 # we need to match the max_cudagraph_capture_size with the valid max size,


### PR DESCRIPTION
### What this PR does / why we need it?
Current version will run into init error when user set max_num_seqs to number not a multiple of tp size. The reason is that we will first find out the valid size of sequence parallelism, and then remove numbers that are not the multiple of tp size. This may cause an error when we set a max_num_seqs above a multiple of 8 before a multiple of tp size, say when the tp size is 16 and the max_num_seqs is 90. The system will just drop the calculated max graph capture size 88 from the valid size list but not reset the max_cudagraph_capture_size to the next valid number. Thus, we will need to add the line to match them up.

### Does this PR introduce _any_ user-facing change?
Any version of vllm-ascend, after commit: 05a561129e9b0ceda47093e3bd507f1f44179e86, will run into a init error when set a max_num_seqs above a multiple of 8 before a multiple of tp size. Now they can run successfully.
This will help to remain consistency for users use the same startup command before commit: 05a561129e9b0ceda47093e3bd507f1f44179e86. 

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
