### PR TITLE
[Doc] Parameterize versioning policy compatibility matrix

### DIFF
--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -57,9 +57,9 @@ If you're using v0.7.3, don't forget to install [mindie-turbo](https://pypi.org/
 
 For main branch of vLLM Ascend, we usually make it compatible with the latest vLLM release and a newer commit hash of vLLM. Please note that this table is usually updated. Please check it regularly.
 
-| vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  |
-|-------------|--------------|------------------|-------------|--------------------|
-|     main    | 35141a7eeda941a60ad5a4956670c60fd5a77029, v0.18.0 tag | >= 3.10, < 3.12   | 8.5.0 | 2.9.0 / 2.9.0 |
+| vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  | Triton Ascend |
+|-------------|--------------|------------------|-------------|--------------------|---------------|
+|     main    | {{main_vllm_commit}}, {{main_vllm_tag}} tag | {{main_python_version}}   | {{main_cann_version}} | {{main_pytorch_torch_npu_version}} | {{main_triton_ascend_version}} |
 
 ## Release cadence
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,6 +78,19 @@ myst_substitutions = {
     "cann_image_tag": "8.5.1-910b-ubuntu22.04-py3.11",
     # vllm version in ci
     "ci_vllm_version": "v0.18.0",
+    # main branch compatibility matrix - updated dynamically
+    # vLLM commit hash for main branch
+    "main_vllm_commit": "35141a7eeda941a60ad5a4956670c60fd5a77029",
+    # vLLM tag for main branch
+    "main_vllm_tag": "v0.18.0",
+    # Python version for main branch
+    "main_python_version": ">= 3.10, < 3.12",
+    # CANN version for main branch
+    "main_cann_version": "8.5.0",
+    # PyTorch/torch_npu version for main branch
+    "main_pytorch_torch_npu_version": "2.9.0 / 2.9.0",
+    # Triton Ascend version for main branch
+    "main_triton_ascend_version": "3.2.0",
 }
 
 # For cross-file header anchors


### PR DESCRIPTION
### What this PR does / why we need it?
This PR refactors the versioning policy documentation to use substitution variables for the compatibility matrix, allowing for centralized version management in `conf.py`. It also adds a "Triton Ascend" column to the matrix. A review comment was made to clarify that while the documentation is generated dynamically, the source values in `conf.py` still require manual updates.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Documentation build verification.

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
