### PR TITLE
[bugfix] Fix crash when enabling FC2 and multi-step speculative decoding

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -47,6 +47,7 @@ from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+import vllm_ascend.envs as envs_ascend
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -883,6 +884,11 @@ class SpecDecodeBaseProposer(EagleProposer):
             }
             if self.pass_hidden_states_to_model:
                 model_kwargs["hidden_states"] = model_hidden_states
+
+            if envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE > 0:
+                tp_size = get_tp_group().world_size
+                get_forward_context().pad_size = (tp_size -
+                            (model_hidden_states.shape[0] % tp_size)) % tp_size
 
             ret_hidden_states = self.model(**model_kwargs)
             if not self.model_returns_tuple():


### PR DESCRIPTION
### What this PR does / why we need it?
Fix  P node crash with FlashComm2 and Eagle multi-step speculation enabled.
Fixes #7809 

### Does this PR introduce _any_ user-facing change?
No user-facing changes
### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
