### PR TITLE
[Refactor] Remove redundant conditional in broadcast method

### DIFF
--- a/vllm_ascend/distributed/device_communicators/pyhccl.py
+++ b/vllm_ascend/distributed/device_communicators/pyhccl.py
@@ -160,10 +160,7 @@ class PyHcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
-        if src == self.rank:
-            buffer = buffer_type(tensor.data_ptr())
-        else:
-            buffer = buffer_type(tensor.data_ptr())
+        buffer = buffer_type(tensor.data_ptr())
         self.hccl.hcclBroadcast(
             buffer,
             tensor.numel(),


### PR DESCRIPTION
### What this PR does / why we need it?

This PR simplifies the `broadcast` method in `vllm_ascend/distributed/device_communicators/pyhccl.py` by removing a redundant `if-else` statement. Both branches of the conditional were identical, performing the same buffer assignment, so they have been replaced with a single direct assignment.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a logic simplification that does not change the functional behavior of the code.
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
