### PR TITLE
[CPU Binding][Performance] Defer CPU binding until worker warmup completes

### DIFF
--- a/docs/source/developer_guide/feature_guide/cpu_binding.md
+++ b/docs/source/developer_guide/feature_guide/cpu_binding.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CPU binding pins vLLM Ascend worker processes and key threads to specific CPU cores to reduce CPU–NPU cross‑NUMA traffic and stabilize latency under multi‑process workloads. It is designed for ARM servers running Ascend NPUs and is automatically executed during worker initialization when enabled.
+CPU binding pins vLLM Ascend worker processes and key threads to specific CPU cores to reduce CPU–NPU cross‑NUMA traffic and stabilize latency under multi‑process workloads. It is designed for ARM servers running Ascend NPUs and is executed after worker warmup completes when enabled.
 
 ## Background
 
@@ -28,7 +28,7 @@ On multi‑socket ARM systems, the OS scheduler may place vLLM threads on CPUs f
 
 ### Execution flow (simplified)
 
-1. **Feature entry**: worker initialization calls `bind_cpus(local_rank)` when `enable_cpu_binding` is true.
+1. **Feature entry**: `compile_or_warm_up_model()` calls `bind_cpus(local_rank)` after warmup, graph capture, and ATB warmup when `enable_cpu_binding` is true.
 2. **CPU architecture gate**: If the CPU is not ARM, binding is skipped with a log.
 3. **Collect device info**:
    - Map logical NPU IDs from `npu‑smi info -m`.
@@ -223,6 +223,6 @@ Use the standard vLLM logging configuration to enable debug logs. The binding pr
 ## References
 
 - CPU binding implementation: vllm_ascend/cpu_binding.py (`DeviceInfo`, `CpuAlloc`, `bind_cpus`)
-- Worker integration: vllm_ascend/worker/worker.py (`NPUWorker._init_device`)
+- Worker integration: vllm_ascend/worker/worker.py (`NPUWorker.compile_or_warm_up_model`)
 - Additional config option: docs/source/user_guide/configuration/additional_config.md (`enable_cpu_binding`)
 - Tests: tests/ut/device_allocator/test_cpu_binding.py

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -298,12 +298,6 @@ class NPUWorker(WorkerBase):
         # Initialize device properties used by triton kernels.
         init_device_properties_triton()
 
-        # binding cpu
-        if get_ascend_config().enable_cpu_binding:
-            try:
-                bind_cpus(self.local_rank)
-            except Exception as e:
-                logger.warning(f"Bind cpus failed in rank{self.local_rank}: {e} Skip binding cpu.")
         return device
 
     def init_device(self):
@@ -468,6 +462,13 @@ class NPUWorker(WorkerBase):
         # may cause performance degradation at runtime.
         if get_ascend_device_type() != AscendDeviceType.A5:
             self._warm_up_atb()
+        # Bind after warmup so hot allocations are already materialized on the
+        # worker process before migratepages/taskset run.
+        if get_ascend_config().enable_cpu_binding:
+            try:
+                bind_cpus(self.local_rank)
+            except Exception as e:
+                logger.warning(f"Bind cpus failed in rank{self.local_rank}: {e} Skip binding cpu.")
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)


### PR DESCRIPTION
### What this PR does / why we need it?
- defer CPU binding from `_init_device()` to the end of `compile_or_warm_up_model()` so binding happens after warmup, graph capture, and ATB warmup have materialized the worker's hot pages
- improve NUMA locality for the pages that matter in steady state instead of migrating only early cold allocations, which helps CPU binding work with the actual runtime memory footprint
- improve performance in Graph mode(ACLGraph) when enabling CPU binding feature
- keep CPU binding best-effort by preserving the existing warning-and-skip behavior if binding fails after warmup
- update the CPU binding developer guide to document the new execution point and the motivation behind it

Related RFC:
#6966 

### Does this PR introduce _any_ user-facing change?
No.

## Testing
Case ： 
N：128
Max Concurrency：1
Prompt：64
Output：128
Repeat：5
CLI args: 
--served-model-name qwen \
--model /home/chenchuwei/Qwen3-8B \
--trust-remote-code \
--data-parallel-size 1 \
--tensor-parallel-size 8 \
--max-model-len 32768 \
--port 20002 \
--gpu_memory_utilization 0.8 \
--no_enable_prefix_caching \
--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
--additional-config '{"enable_cpu_binding": true}'

Before fix, take 5th repeat result:
Avg TTFT: 72.73ms
Avg TPOT: 10.27ms
Avg OutputTokenThroughput: 93.07token/s

After fix, take 5th repeat result:
Avg TTFT: 71.74ms
Avg TPOT: 9.90ms
Avg OutputTokenThroughput: 96.31token/s


- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
