### PR TITLE
[BugFix] inductor_fix

### DIFF
--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -257,7 +257,8 @@ class NPUWorker(WorkerBase):
         from vllm.triton_utils import HAS_TRITON
 
         if HAS_TRITON:
-            import torch_npu._inductor  # noqa: F401
+            with torch.inference_mode():
+                import torch_npu._inductor  # noqa: F401
 
         gc.collect()
         torch.npu.empty_cache()


### PR DESCRIPTION
### What this PR does / why we need it?
See issue for details: https://github.com/vllm-project/vllm-ascend/issues/7721
Currently, calling `worker.NPUWorker_init_device()` imports `torch_npu._inductor`, which via `register_fa_pass()` initializes patching functions for both _training_ and _inference_. Our use case only requires **inference mode**.

torch_npu/_inductor/npu_fusion_attention_graph.py:
torch/_inductor/pattern_matcher.py:
```python
    if trace_fn is joint_fwd_bwd:
        # If inference mode is enabled during compilation, assume that we don't
        # want to match on any training graph patterns
        if torch.is_inference_mode_enabled():
            return False
```
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
