### PR TITLE
[Feature] Add EARS entropy-adaptive rejection sampling for speculative decoding

### DIFF
--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+import os
 from unittest.mock import patch
 
 import torch
@@ -248,3 +249,52 @@ class TestAscendRejectionSampler(TestBase):
         )
         assert output_token_ids[0].item() == 0
         assert output_token_ids[1].item() == 0
+
+    def test_ears_uniform_probs_adjustment(self):
+        """Test that EARS shifts uniform_probs down by tolerance * uncertainty
+        and clamps to dtype epsilon when VLLM_EARS_TOLERANCE > 0."""
+        import vllm_ascend.envs as envs_ascend
+        from vllm_ascend.sample.rejection_sampler import generate_uniform_probs
+
+        # target_probs: high uncertainty token (max=0.2) and low uncertainty token (max=0.9)
+        target_probs = torch.tensor([[0.1, 0.2, 0.3, 0.4],   # max=0.4, uncertainty=0.6
+                                     [0.9, 0.05, 0.03, 0.02]])  # max=0.9, uncertainty=0.1
+        # Use fixed uniform_probs to make the test deterministic
+        uniform_probs = torch.tensor([0.5, 0.5])
+
+        ears_tolerance = 0.5
+        expected_uncertainties = 1.0 - target_probs.max(dim=-1).values
+        expected_tolerance = ears_tolerance * expected_uncertainties
+        eps = torch.finfo(uniform_probs.dtype).eps
+        expected = (uniform_probs - expected_tolerance).clamp_min(eps)
+
+        with patch.dict(os.environ, {"VLLM_EARS_TOLERANCE": str(ears_tolerance)}):
+            # Reload env var
+            adjusted = uniform_probs.clone()
+            _ears_tolerance = envs_ascend.VLLM_EARS_TOLERANCE
+            max_target_probs = target_probs.max(dim=-1).values
+            uncertainties = 1.0 - max_target_probs
+            tolerance = _ears_tolerance * uncertainties
+            adjusted = (adjusted - tolerance).clamp_min(eps)
+
+        assert torch.allclose(adjusted, expected), (
+            f"EARS adjustment mismatch: got {adjusted}, expected {expected}")
+        # High-uncertainty token should be shifted more than low-uncertainty token
+        assert adjusted[0] < uniform_probs[0]
+        assert adjusted[1] > adjusted[0]
+
+    def test_ears_disabled_when_tolerance_zero(self):
+        """Test that EARS does not modify uniform_probs when tolerance=0 (default)."""
+        import vllm_ascend.envs as envs_ascend
+
+        uniform_probs = torch.tensor([0.3, 0.7, 0.5])
+
+        with patch.dict(os.environ, {"VLLM_EARS_TOLERANCE": "0.0"}):
+            ears_tolerance = envs_ascend.VLLM_EARS_TOLERANCE
+            assert ears_tolerance == 0.0
+            # The if-guard in rejection_sample ensures no modification
+            if ears_tolerance > 0:
+                raise AssertionError("EARS should be disabled when tolerance=0")
+
+        assert torch.equal(uniform_probs,
+                           torch.tensor([0.3, 0.7, 0.5])), "uniform_probs should be unchanged"

--- a/tests/ut/test_envs.py
+++ b/tests/ut/test_envs.py
@@ -37,10 +37,13 @@ class TestEnvVariables(TestBase):
                                      var_handler())
 
                     handler_source = inspect.getsource(var_handler)
-                    if 'int(' in handler_source:
-                        test_vals = ["123", "456"]
-                    elif 'bool(int(' in handler_source:
+                    if 'bool(int(' in handler_source:
                         test_vals = ["0", "1"]
+                    elif 'int(' in handler_source:
+                        test_vals = ["123", "456"]
+                    elif ('float(' in handler_source
+                          or '_parse_ears_tolerance' in handler_source):
+                        test_vals = ["0.3", "0.7"]
                     else:
                         test_vals = [f"test_{var_name}", f"custom_{var_name}"]
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -22,6 +22,14 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+
+def _parse_ears_tolerance(value: str) -> float:
+    v = float(value)
+    if not (0.0 <= v <= 1.0):
+        raise ValueError(f"VLLM_EARS_TOLERANCE must be in [0.0, 1.0], got {v}")
+    return v
+
+
 # The begin-* and end* here are used by the documentation generator
 # to extract the used env vars.
 
@@ -111,7 +119,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # When > 0, dynamically relaxes rejection threshold based on target model uncertainty.
     # Higher values accept more draft tokens but may reduce quality.
     # Only effective for random sampling (not greedy). Range: [0.0, 1.0]. Default: 0.0 (disabled).
-    "VLLM_EARS_TOLERANCE": lambda: float(os.getenv("VLLM_EARS_TOLERANCE", "0.0")),
+    "VLLM_EARS_TOLERANCE": lambda: _parse_ears_tolerance(os.getenv("VLLM_EARS_TOLERANCE", "0.0")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -189,7 +189,8 @@ def rejection_sample(
         max_target_probs = target_probs.max(dim=-1).values  # [num_tokens]
         uncertainties = 1.0 - max_target_probs
         tolerance = ears_tolerance * uncertainties
-        uniform_probs = (uniform_probs - tolerance).clamp(min=0.01)
+        eps = torch.finfo(uniform_probs.dtype).eps
+        uniform_probs = (uniform_probs - tolerance).clamp_min(eps)
 
     # Sample recovered tokens for each position.
     # [num_tokens]


### PR DESCRIPTION
Closes #5471

### What this PR does / why we need it?

This PR implements **EARS (Entropy-Adaptive Rejection Sampling)**, proposed in #5471, as a lightweight optimization for speculative decoding. The current rejection sampling uses a fixed random threshold, which causes plausible draft tokens to be unnecessarily rejected when the target model is uncertain. EARS dynamically relaxes the rejection threshold based on target model confidence, improving acceptance rate and throughput with no accuracy regression.

Key changes:
- Added `VLLM_EARS_TOLERANCE` environment variable (float, range `[0.0, 1.0]`, default `0.0` = disabled) to control the adaptive threshold.
- Modified `rejection_sample()` to adjust `uniform_probs` based on target model uncertainty (`1.0 - max(target_probs)`) before dispatching to sequential/block-verify kernels.
- Added input validation for `VLLM_EARS_TOLERANCE` with a clear error message for out-of-range values.
- Used `torch.finfo(dtype).eps` as the lower clamp bound to avoid distorting block-verify cumprod statistics.

### Does this PR introduce _any_ user-facing change?

Yes. A new environment variable `VLLM_EARS_TOLERANCE` (default `0.0`) is introduced. No behavior change when unset or set to `0.0`.

### How was this patch tested?

Tested on **8× Ascend 910B4-1 (64 GB HBM each)**, model: **GLM-4.7 W8A8-mtp**, tp=8.

---

#### 1. Startup Scripts

**Baseline (MTP only):**
```bash
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

vllm serve /data/weight/GLM_4.7_W8A8-mtp \
    --tensor-parallel-size 8 \
    --port 9000 \
    --served-model-name GLM-4.7 \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}' \
    --trust-remote-code
```

**With EARS:**
```bash
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_EARS_TOLERANCE=0.3   # or 0.5 for higher throughput

vllm serve /data/weight/GLM_4.7_W8A8-mtp \
    --tensor-parallel-size 8 \
    --port 9000 \
    --served-model-name GLM-4.7 \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}' \
    --trust-remote-code
```

---

#### 2. Benchmark Scripts

**Throughput benchmark** (evalscope perf, openqa dataset, parallel=1, n=20, temperature=0.9, max_tokens=2048):
```bash
evalscope perf \
    --url "http://localhost:9000/v1/chat/completions" \
    --parallel 1 \
    --model GLM-4.7 \
    --number 20 \
    --api openai \
    --dataset openqa \
    --temperature 0.9 \
    --stream
```

**Accuracy evaluation** (evalscope eval, GSM8K, 4-shot CoT, 1319 samples):
```bash
evalscope eval \
    --model GLM-4.7 \
    --api-url http://localhost:9000/v1 \
    --api-key EMPTY \
    --eval-type openai_api \
    --datasets gsm8k \
    --generation-config '{"temperature": 0.9}' \
    --eval-batch-size 50
```

---

#### 3. Performance Results

**num_speculative_tokens=3 (block-verify path):**

| Config | Throughput (tok/s) | Improvement | Avg Latency (s) | TPOT (s) |
|--------|--------------------|-------------|-----------------|----------|
| MTP baseline | 21.69 | — | 93.31 | 0.046 |
| MTP + EARS 0.3 | 23.69 | **+9.2%** | 83.26 | 0.042 |
| MTP + EARS 0.5 | 24.85 | **+14.6%** | 79.43 | 0.040 |

**num_speculative_tokens=1 (sequential path):**

| Config | Throughput (tok/s) | Improvement | Avg Latency (s) | TPOT (s) |
|--------|--------------------|-------------|-----------------|----------|
| MTP baseline | 19.26 | — | 100.88 | 0.052 |
| MTP + EARS 0.3 | 20.02 | **+3.9%** | 100.52 | 0.050 |

**Accuracy (GSM8K, 4-shot CoT, 1319 samples):**

| Config | Accuracy | Delta |
|--------|----------|-------|
| MTP baseline | 97.12% | — |
| MTP + EARS 0.3 | 97.42% | +0.30% |
| MTP + EARS 0.5 | 97.04% | -0.08% |

All accuracy differences are within statistical noise (binomial 95% CI ≈ ±0.9%). EARS has no meaningful impact on output quality.

> **Note:** The block-verify path (spec_tokens≥3) benefits more from EARS due to the cumprod cascade effect — tolerance adjustments at each position are multiplicatively amplified, resulting in larger acceptance rate improvements.