### PR TITLE
[BugFix]add error message: PCP/DCP does not support full graph mode

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -417,17 +417,16 @@ class NPUPlatform(Platform):
                 "needs to be equal if use pcp or dcp > 1 in P/D disaggregate and kv pool scenario."
             )
 
-        # pcp&dcp are not compatible with full graph
+        # pcp/dcp are not compatible with full graph
         if (
             compilation_config.cudagraph_mode == CUDAGraphMode.FULL
-            and parallel_config.decode_context_parallel_size > 1 
-            and parallel_config.prefill_context_parallel_size > 1
+            and parallel_config.decode_context_parallel_size * parallel_config.prefill_context_parallel_size > 1
         ):
             raise ValueError(
                 f"prefill_context_parallel_size({parallel_config.prefill_context_parallel_size}) "
                 f"decode_context_parallel_size({parallel_config.decode_context_parallel_size}) "
                 f"cudagraph_mode({compilation_config.cudagraph_mode}) "
-                "Long sequence with PCP&DCP does not support full graph mode. "
+                "PCP/DCP does not support full graph mode. "
             )
 
         use_sparse = (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -417,6 +417,19 @@ class NPUPlatform(Platform):
                 "needs to be equal if use pcp or dcp > 1 in P/D disaggregate and kv pool scenario."
             )
 
+        # pcp&dcp are not compatible with full graph
+        if (
+            compilation_config.cudagraph_mode == CUDAGraphMode.FULL
+            and parallel_config.decode_context_parallel_size > 1 
+            and parallel_config.prefill_context_parallel_size > 1
+        ):
+            raise ValueError(
+                f"prefill_context_parallel_size({parallel_config.prefill_context_parallel_size}) "
+                f"decode_context_parallel_size({parallel_config.decode_context_parallel_size}) "
+                f"cudagraph_mode({compilation_config.cudagraph_mode}) "
+                "Long sequence with PCP&DCP does not support full graph mode. "
+            )
+
         use_sparse = (
             model_config is not None
             and model_config.hf_text_config is not None


### PR DESCRIPTION
### What this PR does / why we need it?
When using DCP or PCP, full graph mode is not supported temporarily.
Add this error message to provide a clear warning to users.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
