### PR TITLE
[v0.13.0][bugfix][accuracy] Fix ds indexer accuracy problem caused by k rope

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -953,7 +953,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             sin = sin.view(-1, 1, 1, self.qk_rope_head_dim)
 
             k_pe = k_pe.unsqueeze(2)
-            k_pe = torch_npu.npu_interleave_rope(k_pe, cos, sin)
+            k_pe = torch_npu.npu_rotary_mul(k_pe, cos, sin)
             k_pe = k_pe.squeeze(2)
 
             k = torch.cat([k_pe, k_nope], dim=-1)  # [b*s,128]


### PR DESCRIPTION
### What this PR does / why we need it?
The rotary algorithm in deepseek indexer should be neox-style instead of gptj style. PR https://github.com/vllm-project/vllm-ascend/pull/4641 fix this accuracy bug in original pytorch version. But PR https://github.com/vllm-project/vllm-ascend/pull/5701 accidentally removed the fixed code line and reverted the implementation back to the problematic version. This PR fixes it.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with new added/existing test.