### PR TITLE
[Releases/v0.18.0][CI] Updated the parameters for the single-node test to fix the OOM issue for DeepSeek-V3.2

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
@@ -74,5 +74,5 @@ test_cases:
         max_out_len: 1500
         batch_size: 32
         request_rate: 11.2
-        baseline: 220
+        baseline: 210
         threshold: 0.97


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the OOM (Out-of-Memory) error in the single-node-deepseek-v3-2-w8a8 nightly test of vllm-ascend:

- Reduced the value of HCCL_BUFFSIZE

- Lowered the gpu-memory-utilization

Optimize service-side performance:
Updated service-oriented configuration parameters (e.g., max-num-seqs, cudagraph_capture_sizes, batch_size) to improve the inference performance,so that the performance is closer to the optimal performance of the current mainline.
Align performance baseline with main branch:
Updated the performance baseline according to the latest performance data

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The test has passed.
https://github.com/vllm-project/vllm-ascend/actions/runs/23734079080/job/69134387320?pr=7793
