### PR TITLE
add eagle3 patch for qwen3.5

### DIFF
--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -42,6 +42,7 @@ else:
     import vllm_ascend.patch.worker.patch_qwen3_next  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
+    import vllm_ascend.patch.worker.patch_qwen3_5_eagle3  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_eagle  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_uva  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_5_eagle3.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5_eagle3.py
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Monkeypatch Qwen3.5 conditional-generation classes for Eagle3 support."""
+
+from typing import TYPE_CHECKING
+
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+
+def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+    self.language_model.set_aux_hidden_state_layers(tuple(int(x) for x in layers))
+
+
+def _get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+    return self.language_model.get_eagle3_default_aux_hidden_state_layers()
+
+
+def _get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+    return _get_eagle3_default_aux_hidden_state_layers(self)
+
+
+for _cls in (Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration):
+    # SupportsEagleBase protocol attributes.
+    _cls.has_own_lm_head = False  # type: ignore[misc]
+    _cls.has_own_embed_tokens = False  # type: ignore[misc]
+    _cls.supports_eagle3 = True  # type: ignore[misc]
+
+    # SupportsEagle3 protocol methods.
+    _cls.set_aux_hidden_state_layers = _set_aux_hidden_state_layers  # type: ignore[attr-defined]
+    _cls.get_eagle3_default_aux_hidden_state_layers = (  # type: ignore[attr-defined]
+        _get_eagle3_default_aux_hidden_state_layers
+    )
+    _cls.get_eagle3_aux_hidden_state_layers = _get_eagle3_aux_hidden_state_layers  # type: ignore[attr-defined]
+


### PR DESCRIPTION
What this PR does / why we need it?
This PR fixes Eagle3 compatibility for Qwen3.5 conditional-generation models on vLLM-Ascend.
Background
When enabling Eagle3 in vLLM-Ascend, worker startup could fail with:
AssertionError: Model instance must inherit from EagleModelMixin to set auxiliary layers
The failure happened in model_runner_v1.py when calling
set_aux_hidden_state_layers(...) on Qwen3.5 conditional-generation classes that did not explicitly expose Eagle3 methods in the expected runtime path.
Changes
Added a new monkeypatch file:
vllm_ascend/patch/worker/patch_qwen3_5_eagel3.py
Injected Eagle3 protocol-compatible attributes/methods into:
Qwen3_5ForConditionalGeneration
Qwen3_5MoeForConditionalGeneration
Added idempotent patch guard (_vllm_ascend_qwen3_5_eagle3_patched) to avoid reapplying monkeypatch on repeated imports.
Registered the patch in:
vllm_ascend/patch/worker/__init__.py
This aligns Qwen3.5 conditional-generation runtime behavior with Eagle3 expectations in vLLM-Ascend, similar to existing model-specific Eagle3 patches (e.g. MiniMax-M2).
Does this PR introduce any user-facing change?
Yes.
User-facing behavior changes for Eagle3 + Qwen3.5 on vLLM-Ascend:
Previously, startup could fail with worker init assertion errors.
After this patch, Eagle3 can proceed with Qwen3.5 conditional-generation models through monkeypatched Eagle3 interface methods.
No API/CLI argument changes.
How was this patch tested?
Manual functional validation was performed:
Start vLLM-Ascend with Qwen3.5 + Eagle3 speculative config:
method: "eagle3"
valid draft model
Confirm worker initialization no longer fails at
set_aux_hidden_state_layers(...).
Verify patched classes are loaded and monkeypatch is applied once (idempotent guard).
Run generation sanity check to confirm service is alive and returns outputs.
No dedicated new unit test was added in this patch because this is a runtime monkeypatch integration fix tied to model loading path and distributed worker init flow. Existing CI/lint checks were used for static validation.
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
