### PR TITLE
[Feature] Adapted eagle for model_runner_v2

### DIFF
--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -54,7 +54,6 @@ def test_qwen3_dense_eager_mode(
         runner.model.generate(prompts, sampling_params)
 
 
-@pytest.mark.skip(reason="eagle function isn't adapted to the newest main commit.")
 @pytest.mark.parametrize("model", MAIN_MODELS)
 @pytest.mark.parametrize("eagle_model", EGALE_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])

--- a/vllm_ascend/patch/worker/patch_v2/patch_eagle.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_eagle.py
@@ -16,9 +16,13 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+from typing import Any
+
 import torch
 import vllm
+from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
+from vllm.v1.worker.gpu.dp_utils import sync_cudagraph_and_dp_padding
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import prepare_eagle_decode, prepare_eagle_inputs
@@ -30,6 +34,8 @@ from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
 def propose(
     self,
     input_batch: InputBatch,
+    attn_metadata: dict[str, Any],
+    slot_mappings: dict[str, torch.Tensor],
     # [num_tokens, hidden_size]
     last_hidden_states: torch.Tensor,
     # num_layers x [num_tokens, hidden_size]
@@ -46,6 +52,10 @@ def propose(
     temperature: torch.Tensor,
     # [max_num_reqs]
     seeds: torch.Tensor,
+    num_tokens_across_dp: torch.Tensor | None = None,
+    dummy_run: bool = False,
+    skip_attn_for_dummy_run: bool = False,
+    mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
 ) -> torch.Tensor:
     # NOTE(woosuk): To avoid CPU-GPU synchronization without CPU knowing the
     # number of rejected tokens, we maintain the size of eagle's input_ids and
@@ -75,28 +85,32 @@ def propose(
     # TODO(woosuk): Support CUDA graph for prefill.
     last_hidden_states, hidden_states = self.run_model(
         num_tokens,
-        input_batch.attn_metadata,
-        input_batch.slot_mappings,
-        num_tokens_across_dp=None,  # FIXME
+        attn_metadata,
+        slot_mappings,
+        num_tokens_across_dp=num_tokens_across_dp,
+        mm_inputs=mm_inputs,
     )
     sample_hidden_states = last_hidden_states[last_token_indices]
     logits = self.model.compute_logits(sample_hidden_states)
 
     num_reqs = input_batch.num_reqs
+    num_reqs_padded = input_batch.num_reqs_after_padding
     # NOTE(woosuk): For draft sampling, we only consider the temperature
     # and ignore the other sampling parameters such as top_k and top_p,
     # for simplicity and performance.
     # While this may slightly degrade the acceptance rate, it does not
     # affect the output distribution after rejection sampling.
-    # NOTE(Ronald1995): torch.gather will pollute the cache such as self.input_buffers.positions
-    # the bug is reported to huawei CANN team, but not fixed yet.
-    # So we clone the tensors before calling torch.gather to avoid the issue.
     idx_mapping = self.idx_mapping[:num_reqs]
     idx_mapping.copy_(input_batch.idx_mapping)
     self.temperature.copy_(temperature)
     self.seeds.copy_(seeds)
-    pos = self.input_buffers.positions[:num_reqs].clone()
+
+    # NOTE(Ronald1995): torch.gather will pollute the cache such as self.input_buffers.positions
+    # the bug is reported to huawei CANN team, but not fixed yet.
+    # So we clone the tensors before calling torch.gather to avoid the issue.
+
     # Gather the values and copy them to the pre-allocated buffers.
+    pos = self.input_buffers.positions[:num_reqs].clone()
     torch.gather(input_batch.positions, 0, last_token_indices, out=pos)
     # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
     # used for draft and target sampling.
@@ -107,7 +121,9 @@ def propose(
         self.seeds,
         pos + 1,
         apply_temperature=True,
+        processed_logits_out=self.draft_logits[:, 0] if self.draft_logits is not None else None,
     )
+
     if self.num_speculative_steps == 1:
         # Early exit.
         return draft_tokens.view(-1, 1)
@@ -126,45 +142,64 @@ def propose(
         self.max_model_len,
         self.max_num_reqs,
     )
-    query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
-    slot_mappings = self.block_tables.compute_slot_mappings(
-        idx_mapping,
-        query_start_loc,
-        pos,
-    )
 
-    cudagraph_size = self.cudagraph_manager.get_cudagraph_size(num_reqs)
-    if cudagraph_size is not None:
-        # Run CUDA graph.
-        self.cudagraph_manager.run(cudagraph_size)
-        return self.draft_tokens[:num_reqs]
+    # Get batch descriptor and sync across DP ranks.
+    # Eagle uses FULL-only mode, dispatch with uniform_token_count=1 for decode
 
-    # Run eager mode.
-    query_start_loc_cpu = torch.arange(num_reqs + 1, dtype=torch.int32, device="cpu")
-    # HACK(woosuk)
-    block_tables = [x[:num_reqs] for x in self.block_tables.input_block_tables]
+    batch_desc = self.cudagraph_manager.dispatch(num_reqs, num_reqs, 1)
+    num_tokens_across_dp = None
 
-    # FIXME(woosuk): This is UNSAFE!!
-    attn_metadata = build_attn_metadata(
-        attn_groups=self.attn_groups,
-        num_reqs=num_reqs,
-        num_tokens=num_reqs,
-        query_start_loc_gpu=query_start_loc,
-        query_start_loc_cpu=query_start_loc_cpu,
-        max_query_len=1,
-        seq_lens=self.input_buffers.seq_lens[:num_reqs],
-        max_seq_len=self.max_model_len,
-        block_tables=block_tables,
-        slot_mappings=slot_mappings,
-        kv_cache_config=self.kv_cache_config,
-    )
-    slot_mappings_by_layer = build_slot_mappings_by_layer(slot_mappings, self.kv_cache_config)
+    if self.dp_size > 1:
+        batch_desc, num_tokens_across_dp = sync_cudagraph_and_dp_padding(
+            self.cudagraph_manager,
+            batch_desc,
+            num_reqs,
+            num_reqs,
+            1,  # uniform_token_count
+            self.dp_size,
+            self.dp_rank,
+        )
+
+    if not (dummy_run and skip_attn_for_dummy_run):
+        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
+        slot_mappings = self.block_tables.compute_slot_mappings(
+            idx_mapping, query_start_loc, pos, batch_desc.num_tokens
+        )
+
+    if batch_desc.cg_mode == CUDAGraphMode.FULL:
+        return self.cudagraph_manager.run_fullgraph(batch_desc)[:num_reqs]
+
+    # Run eager or piecewise CUDA graph.
+    attn_metadata_updated = None
+    slot_mappings_updated = None
+    if not (dummy_run and skip_attn_for_dummy_run):
+        query_start_loc_cpu = torch.arange(num_reqs_padded + 1, dtype=torch.int32, device="cpu")
+        block_tables = [x[:num_reqs_padded] for x in self.block_tables.input_block_tables]
+
+        # FIXME(woosuk): This is UNSAFE!!
+        attn_metadata_updated = build_attn_metadata(
+            attn_groups=self.attn_groups,
+            num_reqs=num_reqs_padded,
+            num_tokens=num_reqs_padded,
+            query_start_loc_gpu=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            max_query_len=1,
+            seq_lens=self.input_buffers.seq_lens[:num_reqs_padded],
+            max_seq_len=self.max_model_len,
+            block_tables=block_tables,
+            slot_mappings=slot_mappings,
+            kv_cache_config=self.kv_cache_config,
+        )
+        slot_mappings_updated = build_slot_mappings_by_layer(slot_mappings, self.kv_cache_config)
+
     self.generate_draft(
         num_reqs,
-        attn_metadata,
-        slot_mappings_by_layer,
-        num_tokens_across_dp=None,
-    )  # FIXME
+        batch_desc.num_tokens,
+        attn_metadata_updated,
+        slot_mappings_updated,
+        num_tokens_across_dp=num_tokens_across_dp,
+        cudagraph_runtime_mode=batch_desc.cg_mode,
+    )
     return self.draft_tokens[:num_reqs]
 
 

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -1,5 +1,5 @@
 from vllm.v1.worker.gpu import input_batch
-from vllm.v1.worker.gpu.sample import gumbel, logprob, penalties
+from vllm.v1.worker.gpu.sample import gumbel, logprob, penalties, sampler
 
 from vllm_ascend.worker.v2.input_batch import post_update
 from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
@@ -9,4 +9,6 @@ from vllm_ascend.worker.v2.sample.penalties import apply_penalties
 logprob.compute_token_logprobs = compute_token_logprobs
 penalties.apply_penalties = apply_penalties
 gumbel.gumbel_sample = gumbel_sample
+# because sampler.py is imported before this patch, it must be overridden
+sampler.gumbel_sample = gumbel_sample
 input_batch.post_update = post_update

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -38,8 +38,8 @@ from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.sample.sampler import AscendSampler
-from vllm_ascend.worker.v2.spec_decode import init_speculator
-from vllm_ascend.worker.v2.spec_decode.eagle import AscendEagleSpeculator
+from vllm_ascend.worker.v2.spec_decode.eagle import init_speculator
+from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
 from vllm_ascend.worker.v2.states import AscendRequestState
 from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
 
@@ -68,7 +68,7 @@ class NPUModelRunner(GPUModelRunner):
             model_runner=self,
         )
 
-        # we define AscendEagleSpeculator in vllm_ascend.worker.v2.spec_decode.eagle
+        # we define AscendEagleSpeculator in vllm_ascend.worker.v2.spec_decode.eagle.speculator
         # init_speculator will return AscendEagleSpeculator when eagle is used.
         # so here we just call init_speculator to reinitialize speculator.
         self.speculator: AscendEagleSpeculator | None = None
@@ -219,15 +219,17 @@ class NPUModelRunner(GPUModelRunner):
         # Some attention backends like FA3 require query_start_loc to be non-decreasing.
         query_start_loc_np[num_reqs + 1 :] = num_tokens
 
-        # This is only required for vllm-ascend.
-        query_start_loc_np, num_reqs_padded = self._pad_query_start_loc_for_fia(
-            num_tokens_after_padding,
-            num_reqs_padded,
-            num_reqs,
-            query_start_loc_np,
-            batch_desc.cg_mode,
-            batch_desc.num_reqs,
-        )
+        if batch_desc.cg_mode == CUDAGraphMode.FULL:
+            # This is only required for vllm-ascend.
+            query_start_loc_np, num_reqs_padded = self._pad_query_start_loc_for_fia(
+                num_tokens_after_padding,
+                num_reqs_padded,
+                num_reqs,
+                query_start_loc_np,
+                batch_desc.cg_mode,
+                batch_desc.num_reqs,
+            )
+
         async_copy_to_gpu(query_start_loc_np, out=self.input_buffers.query_start_loc)
 
         query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -90,6 +90,7 @@ def gumbel_sample(
     seed: torch.Tensor,  # [num_reqs]
     pos: torch.Tensor,  # [num_reqs]
     apply_temperature: bool,
+    processed_logits_out: torch.Tensor | None = None,  # [num_reqs, vocab_size]
 ) -> torch.Tensor:
     num_reqs, vocab_size = logits.shape
     BLOCK_SIZE = 1024

--- a/vllm_ascend/worker/v2/spec_decode/eagle/__init__.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/__init__.py
@@ -30,7 +30,7 @@ def init_speculator(
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
     if speculative_config.use_eagle():
-        from vllm_ascend.worker.v2.spec_decode.eagle import AscendEagleSpeculator
+        from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
 
         return AscendEagleSpeculator(vllm_config, device)
     raise NotImplementedError(f"{speculative_config.method} is not supported yet.")

--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -22,6 +22,7 @@ from typing import Any
 import torch
 import vllm
 from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
 
@@ -43,6 +44,8 @@ class AscendEagleSpeculator(EagleSpeculator):
     def propose(
         self,
         input_batch: InputBatch,
+        attn_metadata: dict[str, Any],
+        slot_mappings: dict[str, torch.Tensor],
         # [num_tokens, hidden_size]
         last_hidden_states: torch.Tensor,
         # num_layers x [num_tokens, hidden_size]
@@ -59,6 +62,10 @@ class AscendEagleSpeculator(EagleSpeculator):
         temperature: torch.Tensor,
         # [max_num_reqs]
         seeds: torch.Tensor,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
     ):
         """Override GPU EagleSpeculator.propose for Ascend NPUs,
         because npu attention metadata needs more information,
@@ -71,6 +78,8 @@ class AscendEagleSpeculator(EagleSpeculator):
         with build_attn_metadata_wrapper():
             return super().propose(
                 input_batch,
+                attn_metadata,
+                slot_mappings,
                 last_hidden_states,
                 aux_hidden_states,
                 num_sampled,
@@ -79,14 +88,20 @@ class AscendEagleSpeculator(EagleSpeculator):
                 next_prefill_tokens,
                 temperature,
                 seeds,
+                num_tokens_across_dp,
+                dummy_run,
+                skip_attn_for_dummy_run,
+                mm_inputs,
             )
 
     def generate_draft(
         self,
         num_reqs: int,
+        num_tokens_padded: int,
         attn_metadata: dict[str, Any],
         slot_mappings: dict[str, torch.Tensor],
-        num_tokens_across_dp,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     ):
         """Override GPU EagleSpeculator.generate_draft for Ascend NPUs, because
         attn_metadata is created in super propose method, it does not have some
@@ -96,9 +111,11 @@ class AscendEagleSpeculator(EagleSpeculator):
 
         return super().generate_draft(
             num_reqs,
+            num_tokens_padded,
             attn_metadata,
             slot_mappings,
             num_tokens_across_dp,
+            cudagraph_runtime_mode,
         )
 
     @torch.inference_mode()
@@ -108,6 +125,8 @@ class AscendEagleSpeculator(EagleSpeculator):
         attn_metadata: dict[str, Any],
         slot_mappings: dict[str, torch.Tensor] | None,
         num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Override GPU EagleSpeculator.run_model for Ascend NPUs, because
         in decode phase, we need to update seq_lens_cpu in attn_metadata after
@@ -118,6 +137,8 @@ class AscendEagleSpeculator(EagleSpeculator):
             attn_metadata,
             slot_mappings,
             num_tokens_across_dp,
+            cudagraph_runtime_mode,
+            mm_inputs,
         )
 
         # attn_metadata is None in profile_run and dummy_run.
@@ -133,6 +154,9 @@ class AscendEagleSpeculator(EagleSpeculator):
         attn_metadata: dict[str, Any],
     ):
         """Update attention metadata for decode phase on Ascend NPUs."""
+        if attn_metadata is None:
+            return
+
         attn_state = AscendAttentionState.DecodeOnly
         seq_lens_cpu = self._get_seq_lens_cpu()
         # attn_metadata is build in vllm's super class.
@@ -151,9 +175,9 @@ class AscendEagleSpeculator(EagleSpeculator):
 @contextmanager
 def build_attn_metadata_wrapper():
     """Context manager to override attention metadata building for Ascend NPUs."""
-    original_func = vllm.v1.worker.gpu.spec_decode.eagle.build_attn_metadata
+    original_func = vllm.v1.worker.gpu.spec_decode.eagle.speculator.build_attn_metadata
     try:
-        vllm.v1.worker.gpu.spec_decode.eagle.build_attn_metadata = build_attn_metadata
+        vllm.v1.worker.gpu.spec_decode.eagle.speculator.build_attn_metadata = build_attn_metadata
         yield
     finally:
-        vllm.v1.worker.gpu.spec_decode.eagle.build_attn_metadata = original_func
+        vllm.v1.worker.gpu.spec_decode.eagle.speculator.build_attn_metadata = original_func


### PR DESCRIPTION
### What this PR does / why we need it?

We adapted eagle in eager mode for model_runner_v2, following https://github.com/vllm-project/vllm-ascend/pull/7709.

Please view model runner v2's plan https://github.com/vllm-project/vllm-ascend/issues/5208 for detail.

There are main changes:

- Updated some functions to match vllm's interface.
- Updated propose in `patch_eagle.py`.
- Added a more patch for `gumbel_sample` to `sampler`.
- Enabled an e2e for spec decoding.
- Changed v2's structure, following vllm.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

We test it with this script:

```python
os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"

if __name__ == '__main__':
    prompts = [
        "Who are you?",
    ]

    sampling_params = SamplingParams(temperature=0.0, top_p=0.95, top_k=40, max_tokens=5)
    llm = LLM(
        model="/home/model/Meta-Llama-3.1-8B-Instruct",
        tensor_parallel_size=1,
        enforce_eager=True,
        distributed_executor_backend="mp",
        gpu_memory_utilization=0.7,
        async_scheduling=True,

        speculative_config={
            "model": "/home/model/EAGLE3-LLaMA3.1-Instruct-8B",
            "disable_padded_drafter_batch": False,
            "method": "eagle3",
            "num_speculative_tokens": 3,
        },

        compilation_config={
            "cudagraph_mode": "FULL_DECODE_ONLY",
            "cudagraph_capture_sizes": [4],
        },

        max_model_len=4096, 
        enable_prefix_caching=False
    )

    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(output.outputs[0].token_ids)
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

It runs quite well:

```text
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  2.39it/s, est. speed input: 11.95 toks/s, output: 11.95 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  2.39it/s, est. speed input: 11.95 toks/s, output: 11.95 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:00<00:00,  2.39it/s, est. speed input: 11.95 toks/s, output: 11.95 toks/s]
(EngineCore pid=1515492) INFO 04-01 10:42:45 [core.py:1210] Shutdown initiated (timeout=0)
(EngineCore pid=1515492) INFO 04-01 10:42:45 [core.py:1233] Shutdown complete
(Worker pid=1515591) INFO 04-01 10:42:45 [multiproc_executor.py:764] Parent process exited, terminating worker queues
(Worker pid=1515591) INFO 04-01 10:42:45 [multiproc_executor.py:859] WorkerProc shutting down.
[3639, 656, 499, 656, 30]
Prompt: 'Who are you?', Generated text: ' What do you do?'
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029