### PR TITLE
[P/D][BugFix][Core]Replace decoder MTP padding token_id

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -42,7 +42,6 @@ from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutp
 from vllm.v1.metrics.perf import PerfStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
-from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
@@ -149,7 +148,10 @@ class RecomputeScheduler(Scheduler):
                 request._all_token_ids.pop()
                 request.num_prompt_tokens -= 1
             if self.is_mtp_kv_consumer:
-                request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
+                padding_token_id = (
+                    request.sampling_params.eos_token_id if request.sampling_params.eos_token_id is not None else 0
+                )
+                request.spec_token_ids = [padding_token_id] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.log_stats:


### PR DESCRIPTION
### What this PR does / why we need it?
Due to unknown reasons, padding -1 causes sampling operator error when using qwen3.5 with sampling parameters. This PR changes the padding token_id to the EOS token_id to avoid this problem.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By P/D with MTP test, use a curl with all sample parameters to check. For example:
```
curl http://141.61.81.164:8900/v1/chat/completions  -H "Accept: application/json"  -H "Content-type: application/json"  -X POST  -d  '{
        "model": "qwen", 
        "messages": [{"role": "user", "content": "哈基米是什么？"}], 
        "temperature": 0.7, 
        "top_p": 0.7, 
        "top_k": 4, 
        "max_tokens": 100, 
        "seed": null, 
        "stream": false, 
        "repetition_penalty": 1.0 , 
        "chat_template_kwargs": {"enable_thinking": false}
   }'
```

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
