### PR TITLE
[Doc] Update supported vLLM for main

### DIFF
--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -60,7 +60,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  | Triton Ascend |
 |-------------|--------------|------------------|-------------|--------------------|---------------|
-|     main    | {{main_vllm_commit}}, {{main_vllm_tag}} tag | {{main_python_version}}   | {{main_cann_version}} | {{main_pytorch_torch_npu_version}} | {{main_triton_ascend_version}} |
+|     main    | {{main_vllm_commit}} | {{main_python_version}}   | {{main_cann_version}} | {{main_pytorch_torch_npu_version}} | {{main_triton_ascend_version}} |
 
 ## Release cadence
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ myst_substitutions = {
     # vLLM commit hash for main branch
     "main_vllm_commit": "35141a7eeda941a60ad5a4956670c60fd5a77029",
     # vLLM tag for main branch
-    "main_vllm_tag": "v0.18.0",
+    "main_vllm_tag": "",
     # Python version for main branch
     "main_python_version": ">= 3.10, < 3.12",
     # CANN version for main branch


### PR DESCRIPTION
We have dropped 0.18.0 support for main already. Let's update the doc as well

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
