### PR TITLE
[Feature] Xlite GLM-4.7 Support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,5 +20,5 @@ soundfile
 pytest_mock
 mindstudio-probe>=8.3.0
 arctic-inference==0.1.1
-xlite==0.1.0rc3
+xlite==0.1.0rc4
 uc-manager

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -30,6 +30,7 @@ from xlite._C import (  # type: ignore[attr-defined]
     Model,
     ModelConfig,
     Runtime,
+    ScoringFuncSigmoid,
     ScoringFuncSoftmax,
 )
 
@@ -207,6 +208,85 @@ class QwenMoeXliteModel(LlamaXliteModel):
         return xlite_model
 
 
+class Glm4MoeXliteModel(LlamaXliteModel):
+    def initialize(self, runnable: nn.Module, vllm_config: VllmConfig) -> tuple[Model, int, int, torch.dtype]:
+        dtype = vllm_config.model_config.dtype
+        config = self._build_model_config(vllm_config)
+        xlite_model = self._build_model(runnable, vllm_config, config)
+        rank = torch.distributed.get_rank()
+        xlite_model.init(config, rank)
+
+        freq_cis = super()._precompute_freqs_cis(config.rope_head_dim, config.max_seq_len, dtype, config.rope_theta)
+
+        return (xlite_model, freq_cis, config.hidden_size, dtype)
+
+    def _build_model_config(self, vllm_config: VllmConfig) -> ModelConfig:
+        config = super()._build_model_config(vllm_config)
+        hf_config = vllm_config.model_config.hf_text_config
+        ep_group = get_ep_group()
+        config.rope_head_dim = int(hf_config.head_dim * hf_config.partial_rotary_factor)
+        config.n_dense_layers = hf_config.first_k_dense_replace
+        config.n_routed_experts = hf_config.n_routed_experts
+        config.n_shared_experts = hf_config.n_shared_experts
+        config.n_act_experts = hf_config.num_experts_per_tok
+        config.def_dp_size = vllm_config.parallel_config.data_parallel_size
+        config.moe_ep_size = ep_group.world_size if vllm_config.parallel_config.enable_expert_parallel else 1
+        config.moe_tp_size = 1 if vllm_config.parallel_config.enable_expert_parallel else ep_group.world_size
+        config.experts_weight_transpose = True  # type: ignore
+        config.moe_intermediate_size = hf_config.moe_intermediate_size
+        config.norm_topk_prob = hf_config.norm_topk_prob  # type: ignore
+        config.scoring_func = ScoringFuncSigmoid  # type: ignore
+        config.route_scale = hf_config.routed_scaling_factor
+        return config
+
+    def _build_model(self, runnable: nn.Module, vllm_config: VllmConfig, config: ModelConfig) -> Model:
+        xlite_model = super()._build_model(runnable, vllm_config, config)
+        layers = runnable.model.layers
+        xlite_model.gate = [
+            layer.mlp.gate.weight
+            for layer in layers
+            if hasattr(layer.mlp, "gate") and layer.mlp.gate.weight is not None
+        ]
+        xlite_model.gate_bias = [
+            layer.mlp.gate.e_score_correction_bias.to(torch.float32)
+            for layer in layers
+            if hasattr(layer.mlp, "gate")
+            and hasattr(layer.mlp.gate, "e_score_correction_bias")
+            and layer.mlp.gate.e_score_correction_bias is not None
+        ]
+        xlite_model.re_up_gate = [
+            layer.mlp.experts.w13_weight[i]
+            for layer in layers
+            if hasattr(layer.mlp, "experts")
+            and hasattr(layer.mlp.experts, "w13_weight")
+            and layer.mlp.experts.w13_weight is not None
+            for i in range(layer.mlp.experts.local_num_experts)
+        ]
+        xlite_model.re_down = [
+            layer.mlp.experts.w2_weight[i]
+            for layer in layers
+            if hasattr(layer.mlp, "experts")
+            and hasattr(layer.mlp.experts, "w2_weight")
+            and layer.mlp.experts.w2_weight is not None
+            for i in range(layer.mlp.experts.local_num_experts)
+        ]
+        xlite_model.se_up_gate = [
+            layer.mlp.shared_experts.gate_up_proj.weight
+            for layer in layers
+            if hasattr(layer.mlp, "shared_experts")
+            and hasattr(layer.mlp.shared_experts, "gate_up_proj")
+            and layer.mlp.shared_experts.gate_up_proj.weight is not None
+        ]
+        xlite_model.se_down = [
+            layer.mlp.shared_experts.down_proj.weight
+            for layer in layers
+            if hasattr(layer.mlp, "shared_experts")
+            and hasattr(layer.mlp.shared_experts, "down_proj")
+            and layer.mlp.shared_experts.down_proj.weight is not None
+        ]
+        return xlite_model
+
+
 def xlite_model_init(runnable: nn.Module, vllm_config: VllmConfig) -> tuple[Model, int, int, torch.dtype]:
     strategy_map = {
         "LlamaForCausalLM": LlamaXliteModel,
@@ -214,6 +294,7 @@ def xlite_model_init(runnable: nn.Module, vllm_config: VllmConfig) -> tuple[Mode
         "Qwen3ForCausalLM": LlamaXliteModel,
         "Qwen3VLForConditionalGeneration": LlamaXliteModel,
         "Qwen3MoeForCausalLM": QwenMoeXliteModel,
+        "Glm4MoeForCausalLM": Glm4MoeXliteModel,
     }
 
     architecture = vllm_config.model_config.architectures[0]


### PR DESCRIPTION
### What this PR does / why we need it?
Xlite GLM-4.7 Support

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
node0:
```
#!/bin/bash
# this obtained through ifconfig
# nic_name is the network interface name corresponding to local_ip of the current node
nic_name="*"
local_ip="*"

# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
node0_ip="*"

export HCCL_OP_EXPANSION_MODE="AIV"

export HCCL_IF_IP=$local_ip
export GLOO_SOCKET_IFNAME=$nic_name
export TP_SOCKET_IFNAME=$nic_name
export HCCL_SOCKET_IFNAME=$nic_name
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=1
export VLLM_USE_V1=1
export HCCL_BUFFSIZE=200
export VLLM_ASCEND_ENABLE_MLAPO=1
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
#export HCCL_CONNECT_TIMEOUT=360
export TASK_QUEUE_ENABLE=1
export VLLM_ASCEND_ENABLE_FUSED_MC2=1
export VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE=1
export VLLM_ASCEND_BALANCE_SCHEDULING=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1

export VLLM_ASCEND_ENABLE_DENSE_OPTIMIZE=1
# export VLLM_ASCEND_ENABLE_FLASHCOMM3=1
export VLLM_TORCH_PROFILER_DIR=./vllm_profile
# export VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=1

export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
export PYTHONHASHSEED=0
export PYTHONPATH=$PYTHONPATH:/vllm-workspace/vllm
export MOONCAKE_CONFIG_PATH="/data/mooncake.json"
export ACL_OP_INIT_MODE=1
export ASCEND_BUFFER_POOL=4:8
#export ASCEND_CONNECT_TIMEOUT=10000
#export ASCEND_TRANSFER_TIMEOUT=10000

export XLITE_NODE_IPS="*,*"
export XLITE_FLASH_ATTENTION_ENABLE=True
export HCCL_CONNECT_TIMEOUT=3600
export HCCL_EXEC_TIMEOUT=3600
export ASCEND_CONNECT_TIMEOUT=100000
export ASCEND_TRANSFER_TIMEOUT=100000

sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0

vllm serve /data/models/GLM-4.7 \
--host 0.0.0.0 \
--port 8078 \
--data-parallel-size 2 \
--data-parallel-size-local 1 \
--data-parallel-address $node0_ip \
--data-parallel-rpc-port 8888 \
--tensor-parallel-size 8 \
--seed 1024 \
--served-model-name glm4.7 \
--enable-expert-parallel \
--max-num-seqs 32 \
--max-model-len 202752 \
--max-num-batched-tokens 8192 \
--gpu-memory-utilization 0.85 \
--tool-call-parser glm47 \
--reasoning-parser glm45 \
--async-scheduling \
--block-size 128 \
--additional-config='{"xlite_graph_config": {"enabled": true}}' \
--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,4,8,12,16,24,32]}' \
--enable-auto-tool-choice \
--profiler-config \
            '{"profiler": "torch",
            "torch_profiler_dir": "./vllm_profile",
            "torch_profiler_with_stack": false}' \
--kv-transfer-config \
    '{
    "kv_connector": "AscendStoreConnector",
    "kv_role": "kv_both",
    "kv_connector_extra_config": {
        "lookup_rpc_port":"1",
        "backend": "mooncake"
    }
}' \
2>&1 | split -b 5M -d -a 5 - /data/logs/vllm_log_ &

```

node1：

```
#!/bin/bash
# this obtained through ifconfig
# nic_name is the network interface name corresponding to local_ip of the current node
nic_name="*"
local_ip="*"

# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
node0_ip="*"

export HCCL_OP_EXPANSION_MODE="AIV"

export HCCL_IF_IP=$local_ip
export GLOO_SOCKET_IFNAME=$nic_name
export TP_SOCKET_IFNAME=$nic_name
export HCCL_SOCKET_IFNAME=$nic_name
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=1
export VLLM_USE_V1=1
export HCCL_BUFFSIZE=200
export VLLM_ASCEND_ENABLE_MLAPO=1
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
#export HCCL_CONNECT_TIMEOUT=360
export TASK_QUEUE_ENABLE=1
export VLLM_ASCEND_ENABLE_FUSED_MC2=1
export VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE=1
export VLLM_ASCEND_BALANCE_SCHEDULING=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1

export VLLM_ASCEND_ENABLE_DENSE_OPTIMIZE=1
# export VLLM_ASCEND_ENABLE_FLASHCOMM3=1
export VLLM_TORCH_PROFILER_DIR=./vllm_profile
# export VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE=1

export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
export PYTHONHASHSEED=0
export PYTHONPATH=$PYTHONPATH:/vllm-workspace/vllm
export MOONCAKE_CONFIG_PATH="/data/mooncake.json"
export ACL_OP_INIT_MODE=1
export ASCEND_BUFFER_POOL=4:8
#export ASCEND_CONNECT_TIMEOUT=10000
#export ASCEND_TRANSFER_TIMEOUT=10000

export XLITE_NODE_IPS="*,*"
export XLITE_FLASH_ATTENTION_ENABLE=True
export HCCL_CONNECT_TIMEOUT=3600
export HCCL_EXEC_TIMEOUT=3600
export ASCEND_CONNECT_TIMEOUT=100000
export ASCEND_TRANSFER_TIMEOUT=100000

sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0

vllm serve /data/models/GLM-4.7 \
--host 0.0.0.0 \
--port 8078 \
--headless \
--data-parallel-size 2 \
--data-parallel-size-local 1 \
--data-parallel-start-rank 1 \
--data-parallel-address $node0_ip \
--data-parallel-rpc-port 8888 \
--tensor-parallel-size 8 \
--seed 1024 \
--served-model-name glm4.7 \
--enable-expert-parallel \
--max-num-seqs 32 \
--max-model-len 202752 \
--max-num-batched-tokens 8192 \
--gpu-memory-utilization 0.85 \
--tool-call-parser glm47 \
--reasoning-parser glm45 \
--async-scheduling \
--block-size 128 \
--additional-config='{"xlite_graph_config": {"enabled": true}}' \
--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,4,8,12,16,24,32]}' \
--enable-auto-tool-choice \
--profiler-config \
            '{"profiler": "torch",
            "torch_profiler_dir": "./vllm_profile",
            "torch_profiler_with_stack": false}' \
--kv-transfer-config \
    '{
    "kv_connector": "AscendStoreConnector",
    "kv_role": "kv_both",
    "kv_connector_extra_config": {
        "lookup_rpc_port":"1",
        "backend": "mooncake"
    }
}' \
2>&1 | split -b 5M -d -a 5 - /data/logs/vllm_log_ &
```

test：
```
vllm bench serve --backend vllm --base-url http://127.0.0.1:8077 --tokenizer /mnt/nvme0n1/models/GLM-4.7/ --served-model-name glm4.7 --num-prompts 48 --request-rate 16 --dataset-name prefix_repetition --prefix-repetition-prefix-len 36864--prefix-repetition-suffix-len 4096 --prefix-repetition-output-len 1024 --prefix-repetition-num-prefixes 1
```

### Dual-Machine Inference Performance (40K Input, 1K Output)
With a 40K input length and a shared prefix configured to 36K, a scenario with a prefix caching hit rate approaching 90% can be constructed.

- vllm-ascend: main + aclgraph
- xlite: main + xlite
- diff: xlite vs aclgraph percentage difference

| num-prompts | item | TTFT Avg(ms) | TTFT P99(ms) | TPOT Avg(ms) | TPOT P99(ms) | QPS(req/s) | OutputSpeed(tok/s) |
|-------------|------|--------------|--------------|--------------|--------------|------------|--------------------|
| 32 | aclgraph | 28937.08 | 113146.86 | 111.03 | 303.49 | 0.16 | 129.91 |
| 32 | xlite | 39500.53 | 97991.48 | 91.56 | 276.42 | 0.19 | 147.11 |
| 32 | diff | 36.50% | -13.39% | -17.54% | -8.92% | 18.75% | 13.24% |
| 64 | aclgraph | 76156.11 | 285095.46 | 113.01 | 206.74 | 0.17 | 117.81 |
| 64 | xlite | 96731.87 | 233979.47 | 90.02 | 110.29 | 0.21 | 147.93 |
| 64 | diff | 27.02% | -17.93% | -20.34% | -46.65% | 23.53% | 25.57% |
| 128 | aclgraph | 263705.54 | 722577.33 | 123.7 | 186.74 | 0.15 | 126.23 |
| 128 | xlite | 260493.42 | 562466.22 | 88.42 | 109.74 | 0.2 | 164.51 |
| 128 | diff | -1.22% | -22.16% | -28.52% | -41.23% | 33.33% | 30.33% |
| 192 | aclgraph | 436687.05 | 1129361.49 | 126.64 | 183.74 | 0.15 | 122.06 |
| 192 | xlite | 365679.76 | 775411.86 | 89.14 | 169.08 | 0.22 | 171.64 |
| 192 | diff | -16.26% | -31.34% | -29.61% | -7.98% | 46.67% | 40.62% |


- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
