### PR TITLE
[CI][Lint] Restrict python-init check to tracked package directories

### DIFF
--- a/tools/check_python_src_init.py
+++ b/tools/check_python_src_init.py
@@ -60,7 +60,7 @@ def find_missing_init_dirs(src_dir):
             capture_output=True,
             text=True,
         )
-        tracked_files = {f for f in result.stdout.split('\0') if f}
+        tracked_files = {f for f in result.stdout.split("\0") if f}
     except (subprocess.CalledProcessError, FileNotFoundError):
         tracked_files = None
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a false positive in the python-init pre-commit hook by changing it to validate only Git-tracked Python package directories.

Previously, `tools/check_python_src_init.py` walked all directories under the source tree. That included ignored or generated vendor paths, which could trigger failures for directories that are not part of the tracked source.

For example, after running `pip install -e .`, some scripts are added under `vllm_ascend/_cann_ops_custom`, which causes `pre-commit run --all-files` to throw:

```bash
Enforce __init__.py in Python packages....................................Failed
- hook id: python-init
- exit code: 1

❌ Missing '__init__.py' files in the following Python package directories:
 - vllm_ascend/_cann_ops_custom/vendors/vllm-ascend/op_impl/ai_core/tbe/vllm-ascend_impl/dynamic

```

The hook now:

- Collects tracked files using `git ls-files` for the target source directory.
- Derives candidate package directories from tracked .py files.
- Checks only those directories for missing init.py.
- Keeps the previous `os.walk` fallback when git metadata is unavailable.

This makes the hook consistent with repository tracking rules and avoids blocking commits on ignored/generated content.

### Does this PR introduce _any_ user-facing change?

No.
This is a CI/lint behavior fix for contributor workflow only.

### How was this patch tested?

1. Ran the checker directly:
 `python tools/check_python_src_init.py`
2. Verified it no longer reports ignored/generated vendor directories as missing `__init__.py`.
3. Confirmed the change is isolated to `check_python_src_init.py`.
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
