### PR TITLE
[BugFix] Fix some errors for running the model_runner_v2 in full graph mode

### DIFF
--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -87,11 +87,12 @@ def test_egale_spec_decoding(
         runner.model.generate(prompts, sampling_params)
 
 
-@pytest.mark.skip(reason="graph function isn't adapted to the newest main commit.")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [False])
-@pytest.mark.parametrize("compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY"}, {}])
+@pytest.mark.parametrize(
+    "compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 2, 4, 8]}, {}]
+)
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 def test_qwen3_dense_graph_mode(
     model: str,

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -33,6 +33,10 @@ class NPUCommunicator(DeviceCommunicatorBase):
         # init device according to rank
         self.device = torch.npu.current_device()
 
+        # For compatibility (mainly for reusing graph capturing code in vllm),
+        # init custom all-reduce implementation interface as in CUDACommunicator.
+        self.ca_comm = None
+
     def all_to_all(
         self,
         input_: torch.Tensor,

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -24,6 +24,7 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import logger
+from vllm.sequence import IntermediateTensors
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor, ModelCudaGraphManager
@@ -33,6 +34,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.worker.v2.utils import communicator_switch
 
 
 class ModelAclGraphManager(ModelCudaGraphManager):
@@ -74,13 +76,13 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # calculate num_tokens_across_dp.
         num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens, device=self.device)
         with set_forward_context(
-            self.model_runner.input_batch.attn_metadata,
+            self.model_runner.model_state.attn_metadata,
             self.vllm_config,
             num_tokens=num_tokens,
             cudagraph_runtime_mode=desc.cg_mode,
             num_tokens_across_dp=num_tokens_across_dp,
             batch_descriptor=None,  # Full graph model don't need batch_descriptor
-            slot_mapping=self.model_runner.input_batch.slot_mappings,
+            slot_mapping=None,
         ):
             forward_context = get_forward_context()
             update_full_graph_params(
@@ -100,6 +102,7 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         model: nn.Module,
         model_state: ModelState,
         input_buffers: InputBuffers,
+        intermediate_tensors: IntermediateTensors | None,
         block_tables: BlockTables,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
@@ -109,17 +112,19 @@ class ModelAclGraphManager(ModelCudaGraphManager):
     ) -> None:
         """Capture CUDA graphs for model forward pass."""
         model = ModelWithContext(model)
-        return super().capture(
-            model,
-            model_state,
-            input_buffers,
-            block_tables,
-            attn_groups,
-            kv_cache_config,
-            has_lora,
-            use_aux_hidden_state_outputs,
-            progress_bar_desc,
-        )
+        with communicator_switch():
+            super().capture(
+                model,
+                model_state,
+                input_buffers,
+                intermediate_tensors,
+                block_tables,
+                attn_groups,
+                kv_cache_config,
+                has_lora,
+                use_aux_hidden_state_outputs,
+                progress_bar_desc,
+            )
 
 
 class ModelWithContext(nn.Module):

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -53,7 +53,9 @@ class AscendModelState(DefaultModelState):
             num_tokens = input_batch.num_tokens
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()
-        attn_metadata = build_attn_metadata(
+        # attn_metadata is needed when update_full_graph_params, but no way can get it now.
+        # Temporarily store it in model_state.
+        self.attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
             num_tokens=num_tokens,
@@ -70,4 +72,4 @@ class AscendModelState(DefaultModelState):
             seq_lens_np=input_batch.seq_lens_np,
             attn_state=input_batch.attn_state,
         )
-        return attn_metadata
+        return self.attn_metadata

--- a/vllm_ascend/worker/v2/utils.py
+++ b/vllm_ascend/worker/v2/utils.py
@@ -23,3 +23,18 @@ def torch_cuda_wrapper():
         yield
     finally:
         pass
+
+
+@contextmanager
+def communicator_switch():
+    import vllm.distributed.device_communicators.cuda_communicator
+
+    from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
+
+    CudaCommunicator = vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator
+    vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator = NPUCommunicator
+
+    try:
+        yield
+    finally:
+        vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator = CudaCommunicator


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to fix errors for running model_runner_v2 in full graph.

Main changes involve:
1. add input parameter to match vllm commit
2. switch communicator when capturing for avoiding assertion error
3. set `self.attn_metadata` in `AscendModelState` so that `update_full_graph_params` can get `attn_metadata` (to be considered)
4. enable the skipped e2e test case

Some problems left:
1. Using default `cudagraph_capture_sizes` leads to OOM when capturing (to be solved)

RFC: #5208

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
