### PR TITLE
[CI] Fix push event do not trigger image build error

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -66,6 +66,20 @@ jobs:
             tag: arm64
     steps:
 
+    - name: Validate inputs (workflow_dispatch only)
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        tag="${{ inputs.workflow_dispatch_tag }}"
+        branch="${{ inputs.branch_ref }}"
+        if [[ -n "$tag" && -n "$branch" ]]; then
+          echo "Error: 'tag' and 'branch' are mutually exclusive. Please specify only one."
+          exit 1
+        fi
+        if [[ -z "$tag" && -z "$branch" ]]; then
+          echo "Error: Either 'tag' or 'branch' must be specified."
+          exit 1
+        fi
+
     - uses: actions/checkout@v6
       if: ${{ github.event_name != 'workflow_dispatch' }}
       with:

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -55,33 +55,9 @@ permissions:
   contents: read
 
 jobs:
-  validate_inputs:
-    name: Validate Dispatch Inputs
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: linux-aarch64-a2b3-0
-    steps:
-      - name: Validate tag and branch are mutually exclusive
-        run: |
-          tag="${{ inputs.tag }}"
-          branch="${{ inputs.branch }}"
-          [[ "$tag" == "none" ]] && tag=""
-          [[ "$branch" == "none" ]] && branch=""
-          if [[ -n "$tag" && -n "$branch" ]]; then
-            echo "Error: 'tag' and 'branch' are mutually exclusive. Please specify only one."
-            exit 1
-          fi
-          if [[ -z "$tag" && -z "$branch" ]]; then
-            echo "Error: Either 'tag' or 'branch' must be specified."
-            exit 1
-          fi
-
   image_build:
     name: Image Build and Push
-    needs: [validate_inputs]
-    if: >-
-      ${{ (needs.validate_inputs.result == 'success' || needs.validate_inputs.result == 'skipped')
-          && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'image-build'))
-          && github.event_name != 'schedule' }}
+    if: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'image-build')) && github.event_name != 'schedule' }}
     strategy:
       matrix:
         build_meta:


### PR DESCRIPTION
### What this PR does / why we need it?
Fixed push event do not trigger image build error
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
