### PR TITLE
[CI] upgrade main2main to vllm v0.19.0

### DIFF
--- a/.github/workflows/bot_pr_create.yaml
+++ b/.github/workflows/bot_pr_create.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get vLLM version
         run: |
-          VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+          VLLM_COMMIT=v0.19.0
           echo "VLLM_COMMIT=https://github.com/vllm-project/vllm/commit/$VLLM_COMMIT" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -80,7 +80,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [29e48707e8144b78dd5d756f793c26a405043f3d]
+        vllm_version: [v0.19.0]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vllm_version: [14acf429ac08b6d538ca6feb3e06b6d13895804d]
+        vllm_version: [v0.19.0]
     needs: [parse-trigger]
     if: ${{ needs.parse-trigger.outputs.allowed == 'true' }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 29e48707e8144b78dd5d756f793c26a405043f3d
+      vllm: v0.19.0
   changes:
     runs-on: linux-aarch64-a2b3-0
     outputs:
@@ -91,7 +91,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && (needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.ut_tracker == 'true') }}
     strategy:
       matrix:
-        vllm_version: [29e48707e8144b78dd5d756f793c26a405043f3d]
+        vllm_version: [v0.19.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -103,7 +103,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [29e48707e8144b78dd5d756f793c26a405043f3d]
+        vllm_version: [v0.19.0]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/schedule_codecov_refresh.yaml
+++ b/.github/workflows/schedule_codecov_refresh.yaml
@@ -33,7 +33,7 @@ jobs:
     name: refresh codecov
     strategy:
       matrix:
-        vllm_version: [29e48707e8144b78dd5d756f793c26a405043f3d]
+        vllm_version: [v0.19.0]
     uses: ./.github/workflows/_unit_test.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_test_benchmarks.yaml
+++ b/.github/workflows/schedule_test_benchmarks.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - vllm_branch: 14acf429ac08b6d538ca6feb3e06b6d13895804d
+          - vllm_branch: v0.19.0
             vllm_ascend_branch: main
       max-parallel: 1
     container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -33,7 +33,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -32,7 +32,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -50,7 +50,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -49,7 +49,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -49,7 +49,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_COMMIT=29e48707e8144b78dd5d756f793c26a405043f3d
+ARG VLLM_COMMIT=v0.19.0
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ myst_substitutions = {
     "ci_vllm_version": "v0.18.0",
     # main branch compatibility matrix - updated dynamically
     # vLLM commit hash for main branch
-    "main_vllm_commit": "14acf429ac08b6d538ca6feb3e06b6d13895804d",
+    "main_vllm_commit": "v0.19.0",
     # vLLM tag for main branch
     "main_vllm_tag": "",
     # Python version for main branch

--- a/vllm_ascend/worker/v2/README.md
+++ b/vllm_ascend/worker/v2/README.md
@@ -5,5 +5,5 @@ This directory contains the new model runner which is under active development.
 please see [Model Runner V2](https://github.com/vllm-project/vllm-ascend/issues/5208)
 to get specific plans.
 
-supported vllm version: main@14acf429ac08b6d538ca6feb3e06b6d13895804d
+supported vllm version: main@v0.19.0
 related PR: <https://github.com/vllm-project/vllm-ascend/pull/7709>


### PR DESCRIPTION
### What this PR does / why we need it?
upgrade main2main to vllm releases/v0.19.0

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
