### PR TITLE
[Feature] Optimize host-device sync problem in prefill phase for Qwen3Next/Qwen3.5

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_clear_ssm_states.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_clear_ssm_states.py
@@ -1,0 +1,37 @@
+import gc
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize(
+    "state_shape",
+    [
+        (6, 3, 5, 7),
+        (4, 5, 25, 41),
+    ],
+)
+def test_clear_ssm_states_ref_parity(state_shape, dtype):
+    torch.manual_seed(0)
+    device = "npu"
+
+    ssm_states = torch.randn(*state_shape, device=device, dtype=dtype)
+    has_initial_state = torch.tensor(
+        [True, False, True, False, False, True][: state_shape[0]],
+        device=device,
+        dtype=torch.bool,
+    )
+
+    ssm_states_ref = ssm_states.clone()
+    ssm_states_ref[~has_initial_state, ...] = 0
+
+    clear_ssm_states(ssm_states, has_initial_state)
+
+    torch.testing.assert_close(ssm_states, ssm_states_ref)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/ops/triton/fla/utils.py
+++ b/vllm_ascend/ops/triton/fla/utils.py
@@ -72,3 +72,61 @@ def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
 @triton.jit
 def safe_exp(x):
     return tl.exp(tl.where(x <= 0, x, float("-inf")))
+
+
+@triton.jit(do_not_specialize=["inner_size", "row_stride"])
+def _clear_ssm_states_kernel(
+    states_ptr,
+    has_initial_state_ptr,
+    inner_size,
+    row_stride,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(axis=0)
+    col_block_idx = tl.program_id(axis=1)
+
+    has_state = tl.load(has_initial_state_ptr + row_idx).to(tl.int1)
+    if has_state:
+        return
+
+    cols = col_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = cols < inner_size
+    row_ptr = states_ptr + row_idx * row_stride + cols
+    tl.store(row_ptr, tl.zeros((BLOCK_SIZE,), dtype=states_ptr.dtype.element_ty), mask=mask)
+
+
+def clear_ssm_states(ssm_states: torch.Tensor, has_initial_state: torch.Tensor) -> None:
+    """Zero out specific rows for the SSM states
+
+    Args:
+        ssm_states (torch.Tensor): input SSM states
+        has_initial_state (torch.Tensor): indicates whether the row has initial states already
+    """
+    if ssm_states.numel() == 0:
+        return
+
+    if has_initial_state.device != ssm_states.device:
+        has_initial_state = has_initial_state.to(ssm_states.device, non_blocking=True)
+    if has_initial_state.dtype != torch.bool:
+        has_initial_state = has_initial_state.to(torch.bool)
+
+    has_initial_state = has_initial_state.reshape(-1).contiguous()
+    num_rows = ssm_states.shape[0]
+    if num_rows == 0:
+        return
+    if has_initial_state.numel() != num_rows:
+        raise ValueError(f"has_initial_state size mismatch: expected {num_rows}, got {has_initial_state.numel()}")
+
+    inner_size = ssm_states.numel() // num_rows
+    if inner_size == 0:
+        return
+
+    block_size = 4096
+    grid = (num_rows, triton.cdiv(inner_size, block_size))
+    _clear_ssm_states_kernel[grid](
+        ssm_states,
+        has_initial_state,
+        inner_size,
+        ssm_states.stride(0),
+        BLOCK_SIZE=block_size,
+    )

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.ops.triton.fla.sigmoid_gating import fused_sigmoid_gating_delta_rule_update
+from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.utils import enable_sp
 
@@ -249,7 +250,7 @@ class AscendQwen3_5GatedDeltaNet(Qwen3_5GatedDeltaNet):
             # 2.2: Process the remaining part
             if attn_metadata.num_prefills > 0:
                 initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
-                initial_state[~has_initial_state, ...] = 0
+                clear_ssm_states(initial_state, has_initial_state)
                 non_spec_chunked_prefill_meta = getattr(
                     attn_metadata,
                     "non_spec_chunked_prefill_meta",

--- a/vllm_ascend/patch/worker/patch_qwen3_next.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_next.py
@@ -31,6 +31,7 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
+from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.patch.worker.patch_qwen3_5 import to_int64_tuple
 from vllm_ascend.utils import enable_sp
@@ -240,7 +241,7 @@ class AscendQwen3Next_GatedDeltaNet(Qwen3NextGatedDeltaNet):
         if attn_metadata.num_prefills > 0:
             initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
 
-            initial_state[~has_initial_state, ...] = 0
+            clear_ssm_states(initial_state, has_initial_state)
             non_spec_chunked_prefill_meta = getattr(
                 attn_metadata,
                 "non_spec_chunked_prefill_meta",


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the host-device sync problem in prefill phase for Qwen3Next/Qwen3.5 on Ascend.

Backgound:
- The original implementation clears the SSM state in non-spec prefill with an inefficient `aten::index_put_` operation, causing severe host-bound problem.
- Logically, this is an `index_fill_` operation, but it is not yet natively supported by Ascend.

Changes in this PR:
- Introduce a simple Triton-implemented kernel `clear_ssm_states` to tackle the problem.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Unit / correctness coverage:
- tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_clear_ssm_states.py

### Performance validation:

- Baseline: vLLM version=v0.18.0.rc1
- Model: Qwen3-Next-80B-A3B-Instruct, TP4 on 910B1
- Workload: context length=1024, max concurrency=16
- Result: Mean TTFT: Baseline 1385 ms, Current 1313 ms

------
- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
