### PR TITLE
[CI] fix acc baseline of qwen3vl 235b

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
@@ -47,7 +47,7 @@ _benchmarks: &benchmarks
     dataset_conf: textvqa/textvqa_gen_base64
     max_out_len: 2048
     batch_size: 128
-    baseline: 85
+    baseline: 83
     temperature: 0
     top_k: -1
     top_p: 1


### PR DESCRIPTION
### What this PR does / why we need it?
fix acc baseline of qwen3vl 235b

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
