### PR TITLE
[BugFix]unpad block table when enable_sp and eagle3 in eager mode

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -567,7 +567,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             num_reqs_padded = common_attn_metadata.num_reqs
             # In the below scenario, padding has been applied by _pad_query_start_loc_for_fia in the model runner.
             # We need to unpad here for eager mode to maintain compatibility.
-            if enable_sp() and not self.use_mla and self.pcp_size * self.dcp_size == 1:
+            if (enable_sp() and not self.vllm_config.model_config.use_mla) and self.pcp_size * self.dcp_size == 1:
                 common_attn_metadata.block_table_tensor = self._adjust_tensor(
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )


### PR DESCRIPTION
### What this PR does / why we need it?
In the `enable_sp` scenario, the `_pad_query_start_loc_for_fia` method in `model_runner_v1` performs padding on the `num_tokens` of the request. Therefore, in some scenarios, the number of padded requests `(num_reqs_padded)` is one more than the original number of requests.
Currently, the unpad method in `vllm_ascend/attention/utils` does not support unpadding of `block_table.` Therefore, when eagle is enabled, the number of requests and the first dimension of `block_table` do not match during attention calculation of the drafter model. 
The FIA operator verification of Ascend A5 is stricter, requiring that the number of requests must be the same as the first dimension of `block_table`. Therefore, in the scenario where the padding operation is introduced, this PR adds the unpad operation on `block_table` to the drafter.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/35141a7eeda941a60ad5a4956670c60fd5a77029
