### PR TITLE
[BugFix][Config] resolve PD KV head count via ModelConfig.get_total_num_kv_heads()

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -100,7 +100,7 @@ class AscendConfig:
             if self.pd_tp_ratio > 1:
                 # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
                 num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
-                if num_kv_head < 1:
+                if not num_kv_head or num_kv_head < 1:
                     raise ValueError(
                         "Could not determine a positive total KV head count for PD "
                         "disaggregation (pd_tp_ratio > 1). Check that the model config "

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -98,21 +98,18 @@ class AscendConfig:
             assert prefill_tp_size % decode_tp_size == 0, "Prefill TP size must be divisible by Decode TP size."
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
-                try:
-                    # only support Qwen model now
-                    # TODO: use a more robust method to get kv_head_num
-                    num_kv_head = vllm_config.model_config.hf_text_config.num_key_value_heads
-                    self.num_head_replica = prefill_tp_size // num_kv_head if prefill_tp_size >= num_kv_head else 1
-                    prefill_tp_size = min(prefill_tp_size, num_kv_head)
-                    decode_tp_size = min(decode_tp_size, num_kv_head)
-                    self.pd_head_ratio = prefill_tp_size // decode_tp_size
-                except Exception:
+                # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
+                num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
+                if num_kv_head < 1:
                     raise ValueError(
-                        "The text_config extracted from the model config does not have "
-                        "`num_key_value_heads` attribute. This indicates a mismatch "
-                        "between the model config and vLLM's expectations. Please "
-                        "ensure that the model config is compatible with vLLM."
+                        "Could not determine a positive total KV head count for PD "
+                        "disaggregation (pd_tp_ratio > 1). Check that the model config "
+                        "is compatible with vLLM."
                     )
+                self.num_head_replica = prefill_tp_size // num_kv_head if prefill_tp_size >= num_kv_head else 1
+                prefill_tp_size = min(prefill_tp_size, num_kv_head)
+                decode_tp_size = min(decode_tp_size, num_kv_head)
+                self.pd_head_ratio = prefill_tp_size // decode_tp_size
 
             if self.pd_tp_ratio == 0:
                 raise AssertionError("Only support P node tp size lagger then D node tp size")


### PR DESCRIPTION
### What this PR does / why we need it?

resolve PD KV head count via `ModelConfig.get_total_num_kv_heads()` rather than hard coded `num_key_value_heads`.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

run step3.5 with PD deployment，rely on https://github.com/vllm-project/vllm/pull/39796 and https://github.com/vllm-project/vllm-ascend/pull/8210

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/14acf429ac08b6d538ca6feb3e06b6d13895804d
