### PR TITLE
[CI] Qwen3-Next-80B-A3B-Instruct-W8A8 weights re-download

### DIFF
--- a/.github/workflows/misc/model_list.json
+++ b/.github/workflows/misc/model_list.json
@@ -221,7 +221,6 @@
       "vllm-ascend/Qwen3-8B",
       "vllm-ascend/Qwen3-8B-W4A8",
       "vllm-ascend/Qwen3-8B-W8A8",
-      "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8",
       "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8-Pruning",
       "vllm-ascend/Qwen3-Omni-30B-A3B-Thinking",
       "vllm-ascend/Qwen3-VL-8B-Instruct",
@@ -249,6 +248,7 @@
       "MiniMax/MiniMax-M2.5",
       "Eco-Tech/Qwen3.5-27B-w8a8-mtp",
       "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot",
-      "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+      "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp",
+      "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8"
     ]
   }


### PR DESCRIPTION
### What this PR does / why we need it?
We have modified the `Qwen3-Next-80B-A3B-Instruct-W8A8` weights on `modelscope` and need to have the CI machines re-download the new weights.
### Does this PR introduce _any_ user-facing change?
N/A
### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/14acf429ac08b6d538ca6feb3e06b6d13895804d
