### PR TITLE
[Feature] Initialize VLLM metrics in EPLB worker

### DIFF
--- a/vllm_ascend/eplb/core/eplb_worker.py
+++ b/vllm_ascend/eplb/core/eplb_worker.py
@@ -320,7 +320,7 @@ class EplbProcess:
         call do_update, then notify main process update is complete.
         """
         try:
-            from ms_service_metric.adapters.vllm.adapter import get_vllm_adapter, initialize_vllm_metric
+            from ms_service_metric.adapters.vllm.adapter import get_vllm_adapter, initialize_vllm_metric  # type: ignore
 
             initialize_vllm_metric()
             adapter = get_vllm_adapter()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the initialization of VLLM metrics within the EPLB worker subprocess. This is necessary to enable metric collection and monitoring for the load balancing logic that runs in this background process, ensuring visibility into its performance and state.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/14acf429ac08b6d538ca6feb3e06b6d13895804d

<img width="490" height="156" alt="93C66C8F-C669-449D-EF34-01FD32DCAFD4" src="https://github.com/user-attachments/assets/49053e4c-fc91-4b49-b151-dd2a62c21bc4" />

Now, mindstudio can catch the metrics of eplb.