### PR TITLE
[Misc] Remove useless Conv2d CustomOp

### DIFF
--- a/vllm_ascend/ops/conv.py
+++ b/vllm_ascend/ops/conv.py
@@ -17,13 +17,7 @@
 
 
 import torch
-from vllm.model_executor.layers.conv import Conv2dLayer, Conv3dLayer
-
-
-class AscendConv2dLayer(Conv2dLayer):
-    def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
-        # Use aclnn BatchMatMulV2 for better performance on Ascend NPU.
-        return self._forward_conv(x)
+from vllm.model_executor.layers.conv import Conv3dLayer
 
 
 class AscendConv3dLayer(Conv3dLayer):


### PR DESCRIPTION
### What this PR does / why we need it?
Remove useless `AscendConv2dLayer` CustomOp.

Enforcing `Conv2dLayer` to use linear matmul hurts performance, since it only benefits performance for `Conv3dLayer`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No.

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/14acf429ac08b6d538ca6feb3e06b6d13895804d
