### PR TITLE
[CI] Optimize nightly test scheduling strategy

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -78,6 +78,7 @@ concurrency:
 jobs:
   e2e:
     name: ${{ inputs.config_file_path }}
+    timeout-minutes: 120
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -62,7 +62,7 @@ jobs:
     name: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}
-    timeout-minutes: 600
+    timeout-minutes: 120
     container:
       image: ${{ inputs.image }}
     env:

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -22,7 +22,15 @@ name: Nightly Image Build Schedule
 
 on:
   workflow_dispatch:
-    # Next step: Add more inputs here if needed, e.g. vllm version, vllm-ascend version, image tag, etc.
+    inputs:
+      vllm_ascend_branch:
+        description: 'Branch to nightly test'
+        required: true
+        default: 'main'
+        type: choice
+        options:
+          - main
+          - releases/v0.18.0
 
 jobs:
   build-a2:

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -172,7 +172,7 @@ jobs:
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 5
       matrix:
         vllm_ascend_branch: [releases-v0.18.0]
         test_config:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -123,42 +123,6 @@ jobs:
       matrix:
         vllm_ascend_branch: [releases-v0.18.0]
         test_config:
-          - name: multi-node-deepseek-pd
-            config_file_path: DeepSeek-V3.yaml
-            size: 2
-          - name: multi-node-qwen3-dp
-            config_file_path: Qwen3-235B-A22B.yaml
-            size: 2
-          - name: multi-node-qwenw8a8-2node
-            config_file_path: Qwen3-235B-W8A8.yaml
-            size: 2
-          - name: multi-node-qwenw8a8-2node-eplb
-            config_file_path: Qwen3-235B-W8A8-EPLB.yaml
-            size: 2
-          - name: multi-node-dpsk3.2-2node
-            config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
-            size: 2
-          - name: multi-node-qwen3-dp-mooncake-layerwise
-            config_file_path: Qwen3-235B-A22B-Mooncake-Layerwise.yaml
-            size: 2
-          - name: multi-node-deepseek-r1-w8a8-longseq
-            config_file_path: DeepSeek-R1-W8A8-longseq.yaml
-            size: 2
-          - name: multi-node-qwenw8a8-2node-longseq
-            config_file_path: Qwen3-235B-W8A8-longseq.yaml
-            size: 2
-          - name: multi-node-qwen-disagg-pd
-            config_file_path: Qwen3-235B-disagg-pd.yaml
-            size: 2
-          - name: multi-node-qwen-vl-disagg-pd
-            config_file_path: Qwen3-VL-235B-disagg-pd.yaml
-            size: 2
-          - name: multi-node-kimi-k2-instruct-w8a8
-            config_file_path: Kimi-K2-Instruct-W8A8.yaml
-            size: 2
-          - name: multi-node-deepseek-v3.1
-            config_file_path: DeepSeek-V3.1-BF16.yaml
-            size: 2
           - name: multi-node-deepseek-v3.2-W8A8-EP
             config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
             size: 4
@@ -183,9 +147,79 @@ jobs:
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
 
+  double-node-tests:
+    name: multi-node
+    needs: [setup-vars, parse-trigger, build-image, multi-node-tests]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        vllm_ascend_branch: [releases-v0.18.0]
+        test_config:
+          - name: multi-node-deepseek-r1-w8a8-longseq
+            config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+            size: 2
+          - name: multi-node-deepseek-pd
+            config_file_path: DeepSeek-V3.yaml
+            size: 2
+          - name: multi-node-qwen3-dp
+            config_file_path: Qwen3-235B-A22B.yaml
+            size: 2
+          - name: multi-node-qwenw8a8-2node
+            config_file_path: Qwen3-235B-W8A8.yaml
+            size: 2
+          - name: multi-node-qwenw8a8-2node-eplb
+            config_file_path: Qwen3-235B-W8A8-EPLB.yaml
+            size: 2
+          - name: multi-node-dpsk3.2-2node
+            config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+            size: 2
+          - name: multi-node-qwen3-dp-mooncake-layerwise
+            config_file_path: Qwen3-235B-A22B-Mooncake-Layerwise.yaml
+            size: 2
+          - name: multi-node-qwenw8a8-2node-longseq
+            config_file_path: Qwen3-235B-W8A8-longseq.yaml
+            size: 2
+          - name: multi-node-qwen-disagg-pd
+            config_file_path: Qwen3-235B-disagg-pd.yaml
+            size: 2
+          - name: multi-node-qwen-vl-disagg-pd
+            config_file_path: Qwen3-VL-235B-disagg-pd.yaml
+            size: 2
+          - name: multi-node-kimi-k2-instruct-w8a8
+            config_file_path: Kimi-K2-Instruct-W8A8.yaml
+            size: 2
+          - name: multi-node-deepseek-v3.1
+            config_file_path: DeepSeek-V3.1-BF16.yaml
+            size: 2
+    uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
+    with:
+      soc_version: a3
+      runner: linux-aarch64-a3-0
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}
+      replicas: 1
+      size: ${{ matrix.test_config.size }}
+      config_file_path: ${{ matrix.test_config.config_file_path }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_ref: ${{ needs.parse-trigger.outputs.ref }}
+      should_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' && (
+            needs.parse-trigger.outputs.filter == 'all' ||
+            contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+          )
+        }}
+    secrets:
+      KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+
   single-node-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image, multi-node-tests]
+    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -296,8 +330,8 @@ jobs:
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0
-    needs: [multi-node-tests]
-    if: github.event_name == 'schedule' && needs.multi-node-tests.result != 'skipped'
+    needs: [multi-node-tests, double-node-tests]
+    if: github.event_name == 'schedule' && (needs.multi-node-tests.result != 'skipped' || needs.double-node-tests.result != 'skipped')
     steps:
       - name: Clear pre-logs on pvc
         run: |


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves and reorganizes the nightly CI test workflows:

- **Split multi-node tests**: Extract the 4-node `DeepSeek-V3_2-W8A8-EP` test into a
  separate `multi-node-tests` job (requiring 4 nodes), and group remaining 2-node tests
  into a new `double-node-tests` job. This avoids resource contention and allows more
  efficient parallel scheduling.

- **Add job timeout**: Add `timeout-minutes: 120` to multi-node jobs; reduce single-node
  job timeout from 600 to 120 minutes to prevent runaway jobs.

- **Increase a2 parallelism**: Raise `max-parallel` from 2 to 5 for a2 single-node tests
  to speed up the nightly run.

- **Add branch selection for nightly image build**: Add a `vllm_ascend_branch` input
  (choices: `main`, `releases/v0.18.0`) to the `workflow_dispatch` trigger of
  `nightly_image_build.yaml`, enabling manual builds against specific branches.

- **Fix `clear-pre-logs` dependency**: Update the `clear-pre-logs` job to wait on both
  `multi-node-tests` and `double-node-tests`.

A3:
<img width="815" height="1426" alt="image" src="https://github.com/user-attachments/assets/c88c1141-18b2-439b-8306-6792c43db3e8" />

A2：
<img width="759" height="1291" alt="image" src="https://github.com/user-attachments/assets/c5d4dbef-f6b0-4216-a258-beffd0ee02de" />

After optimization:
A3:
<img width="749" height="1341" alt="image" src="https://github.com/user-attachments/assets/fd0243eb-2281-4f93-940a-0f1d61fedcae" />
A2:
<img width="774" height="1525" alt="image" src="https://github.com/user-attachments/assets/85cb24ac-c9fe-48fe-a258-04529fa61210" />


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/14acf429ac08b6d538ca6feb3e06b6d13895804d
