### PR TITLE
[Feature][PCP][MM] Support multimodel reasoning when prefill context parallel feature is on

### DIFF
--- a/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
@@ -17,7 +17,11 @@
 # Adapted from vllm/tests/basic_correctness/test_basic_correctness.py
 #
 import os
+from unittest.mock import patch
 
+import pytest
+import torch
+from PIL import Image
 from vllm import SamplingParams
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
@@ -282,3 +286,64 @@ def test_dcp_piece_wise():
                     enable_expert_parallel=True,
                     block_size=128) as runner:
         runner.model.generate(prompts, sampling_params)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "OMP_NUM_THREADS": "1",
+        "OMP_PROC_BIND": "false",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free()
+@pytest.mark.skipif(
+    torch.npu.device_count() < 4,
+    reason="Kimi-K2.5-W4A8 multimodal test requires at least 4 NPUs.",
+)
+def test_kimi_k25_multimodal_basic():
+    image_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../310p/data/qwen.png"))
+    image = Image.open(image_path).convert("RGB")
+    prompts = [
+        (
+            "<|im_user|>user<|media_begin|>image<|media_content|><|media_pad|>"
+            "<|media_end|>What is the content of this image?<|im_end|>"
+            "<|im_assistant|>assistant<|im_middle|>"
+        ),
+        (
+            "<|im_user|>user<|media_begin|>image<|media_content|><|media_pad|>"
+            "<|media_end|>Describe the content of this image in detail.<|im_end|>"
+            "<|im_assistant|>assistant<|im_middle|>"
+        ),
+    ]
+
+    inputs = [
+        {
+            "prompt": prompt,
+            "multi_modal_data": {"vision_chunk": {"type": "image", "image": image}},
+            "multi_modal_uuids": {"vision_chunk": f"kimi_k25_image_{i}"},
+        }
+        for i, prompt in enumerate(prompts)
+    ]
+
+    sampling_params = SamplingParams(max_tokens=32, temperature=0.0)
+    model = "Eco-Tech/Kimi-K2.5-w4a8"
+    with VllmRunner(
+        model,
+        enforce_eager=True,
+        max_model_len=1024,
+        tensor_parallel_size=4,
+        prefill_context_parallel_size=4,
+        decode_context_parallel_size=1,
+        max_num_batched_tokens=1024,
+        gpu_memory_utilization=0.8,
+        enable_expert_parallel=True,
+        limit_mm_per_prompt={"vision_chunk": 1},
+        block_size=128,
+        quantization="ascend",
+    ) as runner:
+        outputs = runner.model.generate(inputs, sampling_params=sampling_params)
+        assert len(outputs) == len(prompts)
+        for output in outputs:
+            assert output.outputs and output.outputs[0].text.strip()

--- a/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
@@ -300,50 +300,130 @@ def test_dcp_piece_wise():
 @wait_until_npu_memory_free()
 @pytest.mark.skipif(
     torch.npu.device_count() < 4,
-    reason="Kimi-K2.5-W4A8 multimodal test requires at least 4 NPUs.",
+    reason="Qwen3-VL-8B-Instruct multimodal test requires at least 4 NPUs.",
 )
-def test_kimi_k25_multimodal_basic():
+def test_qwen3_vl_8b_multimodal_single_and_multi_image():
     image_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../310p/data/qwen.png"))
     image = Image.open(image_path).convert("RGB")
-    prompts = [
-        (
-            "<|im_user|>user<|media_begin|>image<|media_content|><|media_pad|>"
-            "<|media_end|>What is the content of this image?<|im_end|>"
-            "<|im_assistant|>assistant<|im_middle|>"
-        ),
-        (
-            "<|im_user|>user<|media_begin|>image<|media_content|><|media_pad|>"
-            "<|media_end|>Describe the content of this image in detail.<|im_end|>"
-            "<|im_assistant|>assistant<|im_middle|>"
-        ),
-    ]
+
+    single_image_prompt = (
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>"
+        "Describe this image in detail.<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    multi_image_prompt = (
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>"
+        "<|vision_start|><|image_pad|><|vision_end|>"
+        "Compare these two images and describe similarities.<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
 
     inputs = [
         {
-            "prompt": prompt,
-            "multi_modal_data": {"vision_chunk": {"type": "image", "image": image}},
-            "multi_modal_uuids": {"vision_chunk": f"kimi_k25_image_{i}"},
-        }
-        for i, prompt in enumerate(prompts)
+            "prompt": single_image_prompt,
+            "multi_modal_data": {"image": image},
+        },
+        {
+            "prompt": multi_image_prompt,
+            "multi_modal_data": {"image": [image, image.copy()]},
+        },
     ]
 
     sampling_params = SamplingParams(max_tokens=32, temperature=0.0)
-    model = "Eco-Tech/Kimi-K2.5-w4a8"
+    model = "Qwen/Qwen3-VL-8B-Instruct"
+    with VllmRunner(
+        model,
+        enforce_eager=False,
+        max_model_len=4096,
+        tensor_parallel_size=2,
+        prefill_context_parallel_size=2,
+        decode_context_parallel_size=1,
+        max_num_batched_tokens=1024,
+        block_size=128,
+        limit_mm_per_prompt={"image": 2},
+        mm_processor_kwargs={
+            "min_pixels": 28 * 28,
+            "max_pixels": 1280 * 28 * 28,
+            "fps": 1,
+        },
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [4, 8, 24, 48, 60],
+        },
+    ) as runner:
+        outputs = runner.model.generate(inputs, sampling_params=sampling_params)
+        assert len(outputs) == len(inputs)
+        for output in outputs:
+            assert output.outputs and output.outputs[0].text.strip()
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "OMP_NUM_THREADS": "1",
+        "OMP_PROC_BIND": "false",
+        "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    },
+)
+@wait_until_npu_memory_free()
+@pytest.mark.skipif(
+    torch.npu.device_count() < 4,
+    reason="Qwen3.5-4B multimodal test requires at least 4 NPUs.",
+)
+def test_qwen3_5_4b_multimodal_single_and_multi_image():
+    image_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../310p/data/qwen.png"))
+    image_1 = Image.open(image_path).convert("RGB")
+    image_2 = Image.open(image_path).convert("RGB")
+
+    single_image_prompt = (
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\n"
+        "<|vision_start|><|image_pad|><|vision_end|>"
+        "Describe this image in detail.<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    multi_image_prompt = (
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\n"
+        "Image 1: <|vision_start|><|image_pad|><|vision_end|>\n"
+        "Image 2: <|vision_start|><|image_pad|><|vision_end|>\n"
+        "Compare these two images and describe one similarity.<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+
+    inputs = [
+        {
+            "prompt": single_image_prompt,
+            "multi_modal_data": {"image": image_1},
+        },
+        {
+            "prompt": multi_image_prompt,
+            "multi_modal_data": {"image": [image_1, image_2]},
+        },
+    ]
+
+    sampling_params = SamplingParams(max_tokens=32, temperature=0.0)
+    model = "Qwen/Qwen3.5-4B"
     with VllmRunner(
         model,
         enforce_eager=True,
-        max_model_len=1024,
-        tensor_parallel_size=4,
+        dtype="float16",
+        max_model_len=4096,
+        tensor_parallel_size=1,
         prefill_context_parallel_size=4,
         decode_context_parallel_size=1,
         max_num_batched_tokens=1024,
         gpu_memory_utilization=0.8,
-        enable_expert_parallel=True,
-        limit_mm_per_prompt={"vision_chunk": 1},
+        limit_mm_per_prompt={"image": 2},
         block_size=128,
-        quantization="ascend",
     ) as runner:
         outputs = runner.model.generate(inputs, sampling_params=sampling_params)
-        assert len(outputs) == len(prompts)
+        assert len(outputs) == len(inputs)
         for output in outputs:
             assert output.outputs and output.outputs[0].text.strip()
+

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1065,13 +1065,10 @@ class NPUModelRunner(GPUModelRunner):
 
         total_num_scheduled_tokens = int(np.sum(local_num_scheduled_tokens))
         positions_np = self.positions.np if hasattr(self.positions, "np") else self._positions_np_buf
-
-        # Swap to the other buffer to avoid race condition with previous
-        # iteration's async copy that may still be reading from CPU.
-        self.is_mm_embed_idx = 1 - self.is_mm_embed_idx  # type: ignore
-        is_mm_embed_buf = self.is_mm_embed_buffers[self.is_mm_embed_idx]
-        is_mm_embed = is_mm_embed_buf.cpu
-        is_mm_embed[:total_num_scheduled_tokens] = False
+        mm_embeds = list[torch.Tensor]()
+        is_mm_embed = torch.zeros(
+            total_num_scheduled_tokens, dtype=torch.bool, device="cpu"
+        )
 
         (
             mm_embeds,
@@ -1091,7 +1088,6 @@ class NPUModelRunner(GPUModelRunner):
             warning_once=logger.warning_once,
         )
 
-        is_mm_embed_gpu = is_mm_embed_buf.copy_to_gpu(total_num_scheduled_tokens)
         if should_sync_mrope_positions:
             self._calc_mrope_positions(scheduler_output)
             self.mrope_positions.copy_to_gpu(total_num_scheduled_tokens)
@@ -1100,7 +1096,7 @@ class NPUModelRunner(GPUModelRunner):
             self._calc_xdrope_positions(scheduler_output)
             self.xdrope_positions.copy_to_gpu(total_num_scheduled_tokens)
 
-        return mm_embeds, is_mm_embed_gpu
+        return mm_embeds, is_mm_embed
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
         if np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1068,7 +1068,7 @@ class NPUModelRunner(GPUModelRunner):
 
         # Swap to the other buffer to avoid race condition with previous
         # iteration's async copy that may still be reading from CPU.
-        self.is_mm_embed_idx = 1 - self.is_mm_embed_idx
+        self.is_mm_embed_idx = 1 - self.is_mm_embed_idx  # type: ignore
         is_mm_embed_buf = self.is_mm_embed_buffers[self.is_mm_embed_idx]
         is_mm_embed = is_mm_embed_buf.cpu
         is_mm_embed[:total_num_scheduled_tokens] = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -726,21 +726,12 @@ class NPUModelRunner(GPUModelRunner):
                     # PCP can split one request into non-contiguous token positions.
                     # We must gather prompt embeds by actual scheduled positions.
                     req_positions_np = positions_np[output_idx : output_idx + num_sched]
-                    valid_mask_np = req_positions_np < req_embeds.shape[0]
-
-                    if valid_mask_np.any():
-                        dst_slice = self.inputs_embeds.cpu[output_idx : output_idx + num_sched]
-                        if valid_mask_np.all():
-                            torch.index_select(
-                                req_embeds,
-                                0,
-                                torch.from_numpy(req_positions_np.astype(np.int64)),
-                                out=dst_slice,
-                            )
-                        else:
-                            src_positions = torch.from_numpy(req_positions_np[valid_mask_np].astype(np.int64))
-                            dst_positions = torch.from_numpy(np.nonzero(valid_mask_np)[0].astype(np.int64))
-                            dst_slice.index_copy_(0, dst_positions, req_embeds.index_select(0, src_positions))
+                    dst_slice = self.inputs_embeds.cpu[output_idx : output_idx + num_sched]
+                    self.pcp_manager.fill_prompt_embeds_for_pcp(
+                        req_embeds=req_embeds,
+                        req_positions_np=req_positions_np,
+                        dst_slice=dst_slice,
+                    )
                 else:
                     start_pos = self.input_batch.num_computed_tokens_cpu[req_idx]
 
@@ -988,8 +979,17 @@ class NPUModelRunner(GPUModelRunner):
             logits_indices = nn.functional.pad(logits_indices, (0, max_num_reqs_across_dp - logits_indices.shape[0]))
 
         # Cache local scheduled token layout for PCP-aware multimodal preprocess.
-        self._local_num_scheduled_tokens = num_scheduled_tokens[:base_num_reqs].copy()
-        self._local_total_num_scheduled_tokens = int(total_num_scheduled_tokens)
+        if (
+            self.pcp_size > 1
+            and self.supports_mm_inputs
+            and get_pp_group().is_first_rank
+            and not self.model_config.is_encoder_decoder
+        ):
+            self.pcp_manager.cache_local_schedule_layout(
+                num_scheduled_tokens=num_scheduled_tokens,
+                num_reqs=base_num_reqs,
+                total_num_scheduled_tokens=total_num_scheduled_tokens,
+            )
 
         return (
             logits_indices,
@@ -1010,54 +1010,7 @@ class NPUModelRunner(GPUModelRunner):
         dict[str, Any],
         ECConnectorOutput | None,
     ]:
-        def build_local_mm_schedule(
-            local_num_scheduled_tokens: np.ndarray,
-        ) -> tuple[dict[str, list[int]], set[str]]:
-            scheduled_encoder_inputs: dict[str, list[int]] = {}
-            needed_mm_hashes: set[str] = set()
-
-            req_start_idx = 0
-            for req_idx, req_id in enumerate(self.input_batch.req_ids):
-                if req_idx >= local_num_scheduled_tokens.shape[0]:
-                    break
-
-                num_sched = int(local_num_scheduled_tokens[req_idx])
-                if num_sched <= 0:
-                    req_start_idx += num_sched
-                    continue
-
-                req_positions = self.positions.np[req_start_idx : req_start_idx + num_sched]
-                req_state = self.requests[req_id]
-                mm_input_ids = list[int]()
-
-                for mm_input_id, mm_feature in enumerate(req_state.mm_features):
-                    pos_info = mm_feature.mm_position
-                    start_pos = pos_info.offset
-                    end_pos = start_pos + pos_info.length
-                    mm_hash = mm_feature.identifier
-
-                    local_mask = (req_positions >= start_pos) & (req_positions < end_pos)
-                    if not local_mask.any():
-                        continue
-
-                    local_indices = np.nonzero(local_mask)[0]
-                    rel_positions = req_positions[local_indices] - start_pos
-                    is_embed = pos_info.is_embed
-                    if is_embed is not None:
-                        is_embed_np = is_embed.cpu().numpy()
-                        if not is_embed_np[rel_positions].any():
-                            continue
-
-                    needed_mm_hashes.add(mm_hash)
-                    if mm_hash not in self.encoder_cache:
-                        mm_input_ids.append(mm_input_id)
-
-                if mm_input_ids:
-                    scheduled_encoder_inputs[req_id] = mm_input_ids
-
-                req_start_idx += num_sched
-
-            return scheduled_encoder_inputs, needed_mm_hashes
+        restore_state = None
 
         # For PCP, local worker token count can differ from scheduler global count.
         # Multimodal preprocessing must use local scheduled token count.
@@ -1067,52 +1020,36 @@ class NPUModelRunner(GPUModelRunner):
             and get_pp_group().is_first_rank
             and not self.model_config.is_encoder_decoder
         ):
-            local_total = getattr(self, "_local_total_num_scheduled_tokens", None)
-            local_num_sched = getattr(self, "_local_num_scheduled_tokens", None)
-            need_localize = (
-                local_total is not None
-                and local_total != scheduler_output.total_num_scheduled_tokens
+            positions_np = (
+                self.positions.np
+                if hasattr(self.positions, "np")
+                else self._positions_np_buf
             )
-            if not need_localize and local_num_sched is not None:
-                for req_idx, req_id in enumerate(self.input_batch.req_ids):
-                    if req_idx >= local_num_sched.shape[0]:
-                        break
-                    global_sched = scheduler_output.num_scheduled_tokens.get(req_id)
-                    if global_sched is None or int(global_sched) != int(local_num_sched[req_idx]):
-                        need_localize = True
-                        break
+            local_num_sched, local_total = self.pcp_manager.get_local_schedule_layout()
+            restore_state = self.pcp_manager.maybe_localize_scheduler_output_for_mm_preprocess(
+                scheduler_output=scheduler_output,
+                req_ids=self.input_batch.req_ids,
+                requests=self.requests,
+                positions_np=positions_np,
+                local_num_scheduled_tokens=local_num_sched,
+                local_total_num_scheduled_tokens=local_total,
+                encoder_cache=self.encoder_cache,
+            )
 
-            if need_localize:
-                scheduler_output = copy(scheduler_output)
-                if local_total is not None:
-                    scheduler_output.total_num_scheduled_tokens = local_total
-                if local_num_sched is not None:
-                    num_sched_by_req = dict(scheduler_output.num_scheduled_tokens)
-                    for req_idx, req_id in enumerate(self.input_batch.req_ids):
-                        if req_idx >= local_num_sched.shape[0]:
-                            break
-                        num_sched_by_req[req_id] = int(local_num_sched[req_idx])
-                    scheduler_output.num_scheduled_tokens = num_sched_by_req
-                    (
-                        scheduler_output.scheduled_encoder_inputs,
-                        local_needed_mm_hashes,
-                    ) = build_local_mm_schedule(local_num_sched)
-
-                    # Under PCP, global free list can be earlier than local
-                    # consumption. Keep MM hashes for all active requests.
-                    active_mm_hashes = {
-                        mm_feature.identifier
-                        for req_state in self.requests.values()
-                        for mm_feature in req_state.mm_features
-                    }
-                    keep_hashes = active_mm_hashes | local_needed_mm_hashes
-                    scheduler_output.free_encoder_mm_hashes = [
-                        mm_hash
-                        for mm_hash in scheduler_output.free_encoder_mm_hashes
-                        if mm_hash not in keep_hashes
-                    ]
-
-        return super()._preprocess(scheduler_output, num_input_tokens, intermediate_tensors)
+        try:
+            return super()._preprocess(
+                scheduler_output, num_input_tokens, intermediate_tensors
+            )
+        finally:
+            if (
+                self.pcp_size > 1
+                and self.supports_mm_inputs
+                and get_pp_group().is_first_rank
+                and not self.model_config.is_encoder_decoder
+            ):
+                self.pcp_manager.restore_scheduler_output_after_mm_preprocess(
+                    scheduler_output, restore_state
+                )
 
     def _gather_mm_embeddings(
         self,
@@ -1122,11 +1059,12 @@ class NPUModelRunner(GPUModelRunner):
         if self.pcp_size <= 1:
             return super()._gather_mm_embeddings(scheduler_output, shift_computed_tokens)
 
-        local_num_scheduled_tokens = getattr(self, "_local_num_scheduled_tokens", None)
+        local_num_scheduled_tokens, _ = self.pcp_manager.get_local_schedule_layout()
         if local_num_scheduled_tokens is None:
             return super()._gather_mm_embeddings(scheduler_output, shift_computed_tokens)
 
         total_num_scheduled_tokens = int(np.sum(local_num_scheduled_tokens))
+        positions_np = self.positions.np if hasattr(self.positions, "np") else self._positions_np_buf
 
         # Swap to the other buffer to avoid race condition with previous
         # iteration's async copy that may still be reading from CPU.
@@ -1135,104 +1073,23 @@ class NPUModelRunner(GPUModelRunner):
         is_mm_embed = is_mm_embed_buf.cpu
         is_mm_embed[:total_num_scheduled_tokens] = False
 
-        mm_embeds = list[torch.Tensor]()
-        req_start_idx = 0
-        should_sync_mrope_positions = False
-        should_sync_xdrope_positions = False
-
-        for req_idx, req_id in enumerate(self.input_batch.req_ids):
-            num_sched = int(local_num_scheduled_tokens[req_idx])
-            req_positions = self.positions.np[req_start_idx : req_start_idx + num_sched]
-            if shift_computed_tokens:
-                req_positions = req_positions + shift_computed_tokens
-            req_state = self.requests[req_id]
-            req_taken_mask = np.zeros(num_sched, dtype=np.bool_)
-            mm_embeds_req: list[torch.Tensor] = []
-            req_mm_local_indices: list[np.ndarray] = []
-
-            for mm_feature in req_state.mm_features:
-                pos_info = mm_feature.mm_position
-                start_pos = pos_info.offset
-                end_pos = start_pos + pos_info.length
-                mm_hash = mm_feature.identifier
-
-                local_mask = (req_positions >= start_pos) & (req_positions < end_pos)
-                if not local_mask.any():
-                    continue
-
-                local_indices = np.nonzero(local_mask)[0]
-                rel_positions = req_positions[local_indices] - start_pos
-
-                is_embed = pos_info.is_embed
-                if is_embed is not None:
-                    is_embed_np = is_embed.cpu().numpy()
-                    keep_mask = is_embed_np[rel_positions]
-                    if not keep_mask.any():
-                        continue
-                    local_indices = local_indices[keep_mask]
-                    rel_positions = rel_positions[keep_mask]
-                    embed_index_map = np.cumsum(is_embed_np.astype(np.int64)) - 1
-                    embed_indices = embed_index_map[rel_positions]
-                else:
-                    embed_indices = rel_positions
-
-                # OR semantics for overlapping mm features: keep first writer.
-                keep_new = ~req_taken_mask[local_indices]
-                if not keep_new.any():
-                    continue
-                local_indices = local_indices[keep_new]
-                embed_indices = embed_indices[keep_new]
-                req_taken_mask[local_indices] = True
-
-                encoder_output = self.encoder_cache.get(mm_hash, None)
-                assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
-                embed_index_tensor = torch.from_numpy(embed_indices.astype(np.int64)).to(
-                    device=encoder_output.device,
-                    non_blocking=True,
-                )
-                mm_embeds_item = torch.index_select(encoder_output, 0, embed_index_tensor)
-                mm_embeds_req.append(mm_embeds_item)
-                req_mm_local_indices.append(local_indices.astype(np.int64, copy=False))
-                is_mm_embed[req_start_idx + local_indices] = True
-
-            if self.is_multimodal_pruning_enabled and self.uses_mrope:
-                assert req_state.mrope_positions is not None
-                should_sync_mrope_positions = True
-                mm_embeds_req, new_mrope_positions, new_delta = (
-                    self.model.recompute_mrope_positions(
-                        input_ids=req_state.prompt_token_ids,
-                        multimodal_embeddings=mm_embeds_req,
-                        mrope_positions=req_state.mrope_positions,
-                        num_computed_tokens=req_state.num_computed_tokens,
-                    )
-                )
-                req_state.mrope_positions.copy_(new_mrope_positions)
-                req_state.mrope_position_delta = new_delta
-
-            # Keep multimodal embedding order aligned with is_mm_embed scanning order.
-            # Under PCP, request positions may be non-monotonic; concatenating by
-            # feature order can misalign embeddings with boolean mask traversal.
-            if len(mm_embeds_req) > 1:
-                total_local_idx = sum(x.size for x in req_mm_local_indices)
-                total_embed_rows = sum(x.shape[0] for x in mm_embeds_req)
-                if total_local_idx == total_embed_rows and total_local_idx > 0:
-                    local_idx_cat = np.concatenate(req_mm_local_indices, axis=0)
-                    embed_cat = torch.cat(mm_embeds_req, dim=0)
-                    order = np.argsort(local_idx_cat, kind="stable")
-                    order_t = torch.from_numpy(order.astype(np.int64)).to(
-                        device=embed_cat.device,
-                        non_blocking=True,
-                    )
-                    mm_embeds_req = [embed_cat.index_select(0, order_t)]
-                else:
-                    logger.warning_once(
-                        "PCP MM reorder skipped due to size mismatch: local_idx=%d, embed_rows=%d",
-                        total_local_idx,
-                        total_embed_rows,
-                    )
-
-            mm_embeds.extend(mm_embeds_req)
-            req_start_idx += num_sched
+        (
+            mm_embeds,
+            should_sync_mrope_positions,
+            should_sync_xdrope_positions,
+        ) = self.pcp_manager.gather_mm_embeddings_for_pcp(
+            req_ids=self.input_batch.req_ids,
+            requests=self.requests,
+            positions_np=positions_np,
+            local_num_scheduled_tokens=local_num_scheduled_tokens,
+            shift_computed_tokens=shift_computed_tokens,
+            encoder_cache=self.encoder_cache,
+            is_mm_embed=is_mm_embed,
+            model=self.model,
+            is_multimodal_pruning_enabled=self.is_multimodal_pruning_enabled,
+            uses_mrope=self.uses_mrope,
+            warning_once=logger.warning_once,
+        )
 
         is_mm_embed_gpu = is_mm_embed_buf.copy_to_gpu(total_num_scheduled_tokens)
         if should_sync_mrope_positions:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1384,9 +1384,16 @@ class NPUModelRunner(GPUModelRunner):
         # scheduler_output in engine core process.
         # TODO(Ronald1995): deepcopy is expensive when there is a large
         # number of requests, optimize it later.
-        if (
+        if ((
             self.use_async_scheduling and self.num_spec_tokens and self._draft_token_ids is None  # type: ignore[has-type]
-        ):
+        ) or (
+            # NOTE: This branch specifically triggers a deepcopy during the prefill phase 
+            # only for PCP (Parallel Context Processing) + Multi-Modal (MM) scenarios. 
+            # It does not affect other use cases. This is a temporary workaround and 
+            # will be removed once upstream vLLM provides native support for PCP + MM.
+            self.pcp_size > 1 and self.supports_mm_inputs and get_pp_group().is_first_rank
+            and not self.model_config.is_encoder_decoder
+        )):
             scheduler_output = deepcopy(scheduler_output)
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("prepare input"):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -722,22 +722,42 @@ class NPUModelRunner(GPUModelRunner):
                     continue
 
                 req_embeds = self.input_batch.req_prompt_embeds[req_idx]
-                start_pos = self.input_batch.num_computed_tokens_cpu[req_idx]
+                if self.pcp_size > 1:
+                    # PCP can split one request into non-contiguous token positions.
+                    # We must gather prompt embeds by actual scheduled positions.
+                    req_positions_np = positions_np[output_idx : output_idx + num_sched]
+                    valid_mask_np = req_positions_np < req_embeds.shape[0]
 
-                # Skip if trying to read beyond available embeddings
-                if start_pos >= req_embeds.shape[0]:
-                    output_idx += num_sched
-                    continue
+                    if valid_mask_np.any():
+                        dst_slice = self.inputs_embeds.cpu[output_idx : output_idx + num_sched]
+                        if valid_mask_np.all():
+                            torch.index_select(
+                                req_embeds,
+                                0,
+                                torch.from_numpy(req_positions_np.astype(np.int64)),
+                                out=dst_slice,
+                            )
+                        else:
+                            src_positions = torch.from_numpy(req_positions_np[valid_mask_np].astype(np.int64))
+                            dst_positions = torch.from_numpy(np.nonzero(valid_mask_np)[0].astype(np.int64))
+                            dst_slice.index_copy_(0, dst_positions, req_embeds.index_select(0, src_positions))
+                else:
+                    start_pos = self.input_batch.num_computed_tokens_cpu[req_idx]
 
-                # Copy available embeddings
-                end_pos = start_pos + num_sched
-                actual_end = min(end_pos, req_embeds.shape[0])
-                actual_num_sched = actual_end - start_pos
+                    # Skip if trying to read beyond available embeddings
+                    if start_pos >= req_embeds.shape[0]:
+                        output_idx += num_sched
+                        continue
 
-                if actual_num_sched > 0:
-                    self.inputs_embeds.cpu[output_idx : output_idx + actual_num_sched].copy_(
-                        req_embeds[start_pos:actual_end]
-                    )
+                    # Copy available embeddings
+                    end_pos = start_pos + num_sched
+                    actual_end = min(end_pos, req_embeds.shape[0])
+                    actual_num_sched = actual_end - start_pos
+
+                    if actual_num_sched > 0:
+                        self.inputs_embeds.cpu[output_idx : output_idx + actual_num_sched].copy_(
+                            req_embeds[start_pos:actual_end]
+                        )
 
                 output_idx += num_sched
 
@@ -967,11 +987,263 @@ class NPUModelRunner(GPUModelRunner):
             max_num_reqs_across_dp = self.max_num_reqs * self.uniform_decode_query_len
             logits_indices = nn.functional.pad(logits_indices, (0, max_num_reqs_across_dp - logits_indices.shape[0]))
 
+        # Cache local scheduled token layout for PCP-aware multimodal preprocess.
+        self._local_num_scheduled_tokens = num_scheduled_tokens[:base_num_reqs].copy()
+        self._local_total_num_scheduled_tokens = int(total_num_scheduled_tokens)
+
         return (
             logits_indices,
             spec_decode_metadata,
             total_num_scheduled_tokens,
         )
+
+    def _preprocess(
+        self,
+        scheduler_output: "SchedulerOutput",
+        num_input_tokens: int,
+        intermediate_tensors: IntermediateTensors | None = None,
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor,
+        IntermediateTensors | None,
+        dict[str, Any],
+        ECConnectorOutput | None,
+    ]:
+        def build_local_mm_schedule(
+            local_num_scheduled_tokens: np.ndarray,
+        ) -> tuple[dict[str, list[int]], set[str]]:
+            scheduled_encoder_inputs: dict[str, list[int]] = {}
+            needed_mm_hashes: set[str] = set()
+
+            req_start_idx = 0
+            for req_idx, req_id in enumerate(self.input_batch.req_ids):
+                if req_idx >= local_num_scheduled_tokens.shape[0]:
+                    break
+
+                num_sched = int(local_num_scheduled_tokens[req_idx])
+                if num_sched <= 0:
+                    req_start_idx += num_sched
+                    continue
+
+                req_positions = self.positions.np[req_start_idx : req_start_idx + num_sched]
+                req_state = self.requests[req_id]
+                mm_input_ids = list[int]()
+
+                for mm_input_id, mm_feature in enumerate(req_state.mm_features):
+                    pos_info = mm_feature.mm_position
+                    start_pos = pos_info.offset
+                    end_pos = start_pos + pos_info.length
+                    mm_hash = mm_feature.identifier
+
+                    local_mask = (req_positions >= start_pos) & (req_positions < end_pos)
+                    if not local_mask.any():
+                        continue
+
+                    local_indices = np.nonzero(local_mask)[0]
+                    rel_positions = req_positions[local_indices] - start_pos
+                    is_embed = pos_info.is_embed
+                    if is_embed is not None:
+                        is_embed_np = is_embed.cpu().numpy()
+                        if not is_embed_np[rel_positions].any():
+                            continue
+
+                    needed_mm_hashes.add(mm_hash)
+                    if mm_hash not in self.encoder_cache:
+                        mm_input_ids.append(mm_input_id)
+
+                if mm_input_ids:
+                    scheduled_encoder_inputs[req_id] = mm_input_ids
+
+                req_start_idx += num_sched
+
+            return scheduled_encoder_inputs, needed_mm_hashes
+
+        # For PCP, local worker token count can differ from scheduler global count.
+        # Multimodal preprocessing must use local scheduled token count.
+        if (
+            self.pcp_size > 1
+            and self.supports_mm_inputs
+            and get_pp_group().is_first_rank
+            and not self.model_config.is_encoder_decoder
+        ):
+            local_total = getattr(self, "_local_total_num_scheduled_tokens", None)
+            local_num_sched = getattr(self, "_local_num_scheduled_tokens", None)
+            need_localize = (
+                local_total is not None
+                and local_total != scheduler_output.total_num_scheduled_tokens
+            )
+            if not need_localize and local_num_sched is not None:
+                for req_idx, req_id in enumerate(self.input_batch.req_ids):
+                    if req_idx >= local_num_sched.shape[0]:
+                        break
+                    global_sched = scheduler_output.num_scheduled_tokens.get(req_id)
+                    if global_sched is None or int(global_sched) != int(local_num_sched[req_idx]):
+                        need_localize = True
+                        break
+
+            if need_localize:
+                scheduler_output = copy(scheduler_output)
+                if local_total is not None:
+                    scheduler_output.total_num_scheduled_tokens = local_total
+                if local_num_sched is not None:
+                    num_sched_by_req = dict(scheduler_output.num_scheduled_tokens)
+                    for req_idx, req_id in enumerate(self.input_batch.req_ids):
+                        if req_idx >= local_num_sched.shape[0]:
+                            break
+                        num_sched_by_req[req_id] = int(local_num_sched[req_idx])
+                    scheduler_output.num_scheduled_tokens = num_sched_by_req
+                    (
+                        scheduler_output.scheduled_encoder_inputs,
+                        local_needed_mm_hashes,
+                    ) = build_local_mm_schedule(local_num_sched)
+
+                    # Under PCP, global free list can be earlier than local
+                    # consumption. Keep MM hashes for all active requests.
+                    active_mm_hashes = {
+                        mm_feature.identifier
+                        for req_state in self.requests.values()
+                        for mm_feature in req_state.mm_features
+                    }
+                    keep_hashes = active_mm_hashes | local_needed_mm_hashes
+                    scheduler_output.free_encoder_mm_hashes = [
+                        mm_hash
+                        for mm_hash in scheduler_output.free_encoder_mm_hashes
+                        if mm_hash not in keep_hashes
+                    ]
+
+        return super()._preprocess(scheduler_output, num_input_tokens, intermediate_tensors)
+
+    def _gather_mm_embeddings(
+        self,
+        scheduler_output: "SchedulerOutput",
+        shift_computed_tokens: int = 0,
+    ) -> tuple[list[torch.Tensor], torch.Tensor]:
+        if self.pcp_size <= 1:
+            return super()._gather_mm_embeddings(scheduler_output, shift_computed_tokens)
+
+        local_num_scheduled_tokens = getattr(self, "_local_num_scheduled_tokens", None)
+        if local_num_scheduled_tokens is None:
+            return super()._gather_mm_embeddings(scheduler_output, shift_computed_tokens)
+
+        total_num_scheduled_tokens = int(np.sum(local_num_scheduled_tokens))
+
+        # Swap to the other buffer to avoid race condition with previous
+        # iteration's async copy that may still be reading from CPU.
+        self.is_mm_embed_idx = 1 - self.is_mm_embed_idx
+        is_mm_embed_buf = self.is_mm_embed_buffers[self.is_mm_embed_idx]
+        is_mm_embed = is_mm_embed_buf.cpu
+        is_mm_embed[:total_num_scheduled_tokens] = False
+
+        mm_embeds = list[torch.Tensor]()
+        req_start_idx = 0
+        should_sync_mrope_positions = False
+        should_sync_xdrope_positions = False
+
+        for req_idx, req_id in enumerate(self.input_batch.req_ids):
+            num_sched = int(local_num_scheduled_tokens[req_idx])
+            req_positions = self.positions.np[req_start_idx : req_start_idx + num_sched]
+            if shift_computed_tokens:
+                req_positions = req_positions + shift_computed_tokens
+            req_state = self.requests[req_id]
+            req_taken_mask = np.zeros(num_sched, dtype=np.bool_)
+            mm_embeds_req: list[torch.Tensor] = []
+            req_mm_local_indices: list[np.ndarray] = []
+
+            for mm_feature in req_state.mm_features:
+                pos_info = mm_feature.mm_position
+                start_pos = pos_info.offset
+                end_pos = start_pos + pos_info.length
+                mm_hash = mm_feature.identifier
+
+                local_mask = (req_positions >= start_pos) & (req_positions < end_pos)
+                if not local_mask.any():
+                    continue
+
+                local_indices = np.nonzero(local_mask)[0]
+                rel_positions = req_positions[local_indices] - start_pos
+
+                is_embed = pos_info.is_embed
+                if is_embed is not None:
+                    is_embed_np = is_embed.cpu().numpy()
+                    keep_mask = is_embed_np[rel_positions]
+                    if not keep_mask.any():
+                        continue
+                    local_indices = local_indices[keep_mask]
+                    rel_positions = rel_positions[keep_mask]
+                    embed_index_map = np.cumsum(is_embed_np.astype(np.int64)) - 1
+                    embed_indices = embed_index_map[rel_positions]
+                else:
+                    embed_indices = rel_positions
+
+                # OR semantics for overlapping mm features: keep first writer.
+                keep_new = ~req_taken_mask[local_indices]
+                if not keep_new.any():
+                    continue
+                local_indices = local_indices[keep_new]
+                embed_indices = embed_indices[keep_new]
+                req_taken_mask[local_indices] = True
+
+                encoder_output = self.encoder_cache.get(mm_hash, None)
+                assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
+                embed_index_tensor = torch.from_numpy(embed_indices.astype(np.int64)).to(
+                    device=encoder_output.device,
+                    non_blocking=True,
+                )
+                mm_embeds_item = torch.index_select(encoder_output, 0, embed_index_tensor)
+                mm_embeds_req.append(mm_embeds_item)
+                req_mm_local_indices.append(local_indices.astype(np.int64, copy=False))
+                is_mm_embed[req_start_idx + local_indices] = True
+
+            if self.is_multimodal_pruning_enabled and self.uses_mrope:
+                assert req_state.mrope_positions is not None
+                should_sync_mrope_positions = True
+                mm_embeds_req, new_mrope_positions, new_delta = (
+                    self.model.recompute_mrope_positions(
+                        input_ids=req_state.prompt_token_ids,
+                        multimodal_embeddings=mm_embeds_req,
+                        mrope_positions=req_state.mrope_positions,
+                        num_computed_tokens=req_state.num_computed_tokens,
+                    )
+                )
+                req_state.mrope_positions.copy_(new_mrope_positions)
+                req_state.mrope_position_delta = new_delta
+
+            # Keep multimodal embedding order aligned with is_mm_embed scanning order.
+            # Under PCP, request positions may be non-monotonic; concatenating by
+            # feature order can misalign embeddings with boolean mask traversal.
+            if len(mm_embeds_req) > 1:
+                total_local_idx = sum(x.size for x in req_mm_local_indices)
+                total_embed_rows = sum(x.shape[0] for x in mm_embeds_req)
+                if total_local_idx == total_embed_rows and total_local_idx > 0:
+                    local_idx_cat = np.concatenate(req_mm_local_indices, axis=0)
+                    embed_cat = torch.cat(mm_embeds_req, dim=0)
+                    order = np.argsort(local_idx_cat, kind="stable")
+                    order_t = torch.from_numpy(order.astype(np.int64)).to(
+                        device=embed_cat.device,
+                        non_blocking=True,
+                    )
+                    mm_embeds_req = [embed_cat.index_select(0, order_t)]
+                else:
+                    logger.warning_once(
+                        "PCP MM reorder skipped due to size mismatch: local_idx=%d, embed_rows=%d",
+                        total_local_idx,
+                        total_embed_rows,
+                    )
+
+            mm_embeds.extend(mm_embeds_req)
+            req_start_idx += num_sched
+
+        is_mm_embed_gpu = is_mm_embed_buf.copy_to_gpu(total_num_scheduled_tokens)
+        if should_sync_mrope_positions:
+            self._calc_mrope_positions(scheduler_output)
+            self.mrope_positions.copy_to_gpu(total_num_scheduled_tokens)
+
+        if should_sync_xdrope_positions:
+            self._calc_xdrope_positions(scheduler_output)
+            self.xdrope_positions.copy_to_gpu(total_num_scheduled_tokens)
+
+        return mm_embeds, is_mm_embed_gpu
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
         if np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0):

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -17,7 +17,8 @@
 # Adapted from vllm-project/vllm/vllm/worker/worker.py
 #
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -334,7 +335,7 @@ class PCPManager:
                 embed_indices = embed_indices[keep_new]
                 req_taken_mask[local_indices] = True
 
-                encoder_output = encoder_cache.get(mm_hash, None)
+                encoder_output = encoder_cache.get(mm_hash)
                 assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
                 embed_index_tensor = torch.from_numpy(embed_indices.astype(np.int64)).to(
                     device=encoder_output.device,
@@ -348,13 +349,11 @@ class PCPManager:
             if is_multimodal_pruning_enabled and uses_mrope:
                 assert req_state.mrope_positions is not None
                 should_sync_mrope_positions = True
-                mm_embeds_req, new_mrope_positions, new_delta = (
-                    model.recompute_mrope_positions(
-                        input_ids=req_state.prompt_token_ids,
-                        multimodal_embeddings=mm_embeds_req,
-                        mrope_positions=req_state.mrope_positions,
-                        num_computed_tokens=req_state.num_computed_tokens,
-                    )
+                mm_embeds_req, new_mrope_positions, new_delta = model.recompute_mrope_positions(
+                    input_ids=req_state.prompt_token_ids,
+                    multimodal_embeddings=mm_embeds_req,
+                    mrope_positions=req_state.mrope_positions,
+                    num_computed_tokens=req_state.num_computed_tokens,
                 )
                 req_state.mrope_positions.copy_(new_mrope_positions)
                 req_state.mrope_position_delta = new_delta
@@ -398,18 +397,14 @@ class PCPManager:
     ) -> dict[str, Any] | None:
         need_localize = (
             local_total_num_scheduled_tokens is not None
-            and local_total_num_scheduled_tokens
-            != scheduler_output.total_num_scheduled_tokens
+            and local_total_num_scheduled_tokens != scheduler_output.total_num_scheduled_tokens
         )
         if not need_localize and local_num_scheduled_tokens is not None:
             for req_idx, req_id in enumerate(req_ids):
                 if req_idx >= local_num_scheduled_tokens.shape[0]:
                     break
                 global_sched = scheduler_output.num_scheduled_tokens.get(req_id)
-                if (
-                    global_sched is None
-                    or int(global_sched) != int(local_num_scheduled_tokens[req_idx])
-                ):
+                if global_sched is None or int(global_sched) != int(local_num_scheduled_tokens[req_idx]):
                     need_localize = True
                     break
 
@@ -424,9 +419,7 @@ class PCPManager:
         }
 
         if local_total_num_scheduled_tokens is not None:
-            scheduler_output.total_num_scheduled_tokens = (
-                local_total_num_scheduled_tokens
-            )
+            scheduler_output.total_num_scheduled_tokens = local_total_num_scheduled_tokens
 
         if local_num_scheduled_tokens is None:
             return restore_state
@@ -452,15 +445,11 @@ class PCPManager:
         # Under PCP, global free list can be earlier than local consumption.
         # Keep MM hashes for all active requests.
         active_mm_hashes = {
-            mm_feature.identifier
-            for req_state in requests.values()
-            for mm_feature in req_state.mm_features
+            mm_feature.identifier for req_state in requests.values() for mm_feature in req_state.mm_features
         }
         keep_hashes = active_mm_hashes | local_needed_mm_hashes
         scheduler_output.free_encoder_mm_hashes = [
-            mm_hash
-            for mm_hash in scheduler_output.free_encoder_mm_hashes
-            if mm_hash not in keep_hashes
+            mm_hash for mm_hash in scheduler_output.free_encoder_mm_hashes if mm_hash not in keep_hashes
         ]
 
         return restore_state
@@ -473,18 +462,10 @@ class PCPManager:
         if restore_state is None:
             return
 
-        scheduler_output.total_num_scheduled_tokens = restore_state[
-            "total_num_scheduled_tokens"
-        ]
-        scheduler_output.num_scheduled_tokens = restore_state[
-            "num_scheduled_tokens"
-        ]
-        scheduler_output.scheduled_encoder_inputs = restore_state[
-            "scheduled_encoder_inputs"
-        ]
-        scheduler_output.free_encoder_mm_hashes = restore_state[
-            "free_encoder_mm_hashes"
-        ]
+        scheduler_output.total_num_scheduled_tokens = restore_state["total_num_scheduled_tokens"]
+        scheduler_output.num_scheduled_tokens = restore_state["num_scheduled_tokens"]
+        scheduler_output.scheduled_encoder_inputs = restore_state["scheduled_encoder_inputs"]
+        scheduler_output.free_encoder_mm_hashes = restore_state["free_encoder_mm_hashes"]
 
     def initialize_slot_mapping(self) -> None:
         """

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -17,7 +17,7 @@
 # Adapted from vllm-project/vllm/vllm/worker/worker.py
 #
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 import torch
@@ -135,6 +135,8 @@ class PCPManager:
         self.max_num_tokens_across_pcp = 0
         self.pcp_tokens_padded = None
         self.total_num_scheduled_tokens = 0
+        self._local_num_scheduled_tokens: np.ndarray | None = None
+        self._local_total_num_scheduled_tokens: int | None = None
 
     def _get_cumsum_and_arange(
         self,
@@ -176,6 +178,313 @@ class PCPManager:
         self.query_lens_pcp_full.cpu[: self.num_reqs] = torch.from_numpy(num_scheduled_tokens)
         self.query_lens_pcp_full.cpu[self.num_reqs :].fill_(0)
         self.query_lens_pcp_full.copy_to_gpu()
+
+    def cache_local_schedule_layout(
+        self,
+        num_scheduled_tokens: np.ndarray,
+        num_reqs: int,
+        total_num_scheduled_tokens: int,
+    ) -> None:
+        # Copy to decouple from mutable batch arrays.
+        self._local_num_scheduled_tokens = num_scheduled_tokens[:num_reqs].copy()
+        self._local_total_num_scheduled_tokens = int(total_num_scheduled_tokens)
+
+    def get_local_schedule_layout(
+        self,
+    ) -> tuple[np.ndarray | None, int | None]:
+        return self._local_num_scheduled_tokens, self._local_total_num_scheduled_tokens
+
+    def fill_prompt_embeds_for_pcp(
+        self,
+        req_embeds: torch.Tensor,
+        req_positions_np: np.ndarray,
+        dst_slice: torch.Tensor,
+    ) -> None:
+        valid_mask_np = req_positions_np < req_embeds.shape[0]
+        if not valid_mask_np.any():
+            return
+
+        if valid_mask_np.all():
+            torch.index_select(
+                req_embeds,
+                0,
+                torch.from_numpy(req_positions_np.astype(np.int64)),
+                out=dst_slice,
+            )
+            return
+
+        src_positions = torch.from_numpy(req_positions_np[valid_mask_np].astype(np.int64))
+        dst_positions = torch.from_numpy(np.nonzero(valid_mask_np)[0].astype(np.int64))
+        dst_slice.index_copy_(0, dst_positions, req_embeds.index_select(0, src_positions))
+
+    def build_local_mm_schedule(
+        self,
+        req_ids: list[str],
+        requests: dict[str, Any],
+        positions_np: np.ndarray,
+        local_num_scheduled_tokens: np.ndarray,
+        encoder_cache: dict[str, torch.Tensor],
+    ) -> tuple[dict[str, list[int]], set[str]]:
+        scheduled_encoder_inputs: dict[str, list[int]] = {}
+        needed_mm_hashes: set[str] = set()
+
+        req_start_idx = 0
+        for req_idx, req_id in enumerate(req_ids):
+            if req_idx >= local_num_scheduled_tokens.shape[0]:
+                break
+
+            num_sched = int(local_num_scheduled_tokens[req_idx])
+            if num_sched <= 0:
+                req_start_idx += num_sched
+                continue
+
+            req_positions = positions_np[req_start_idx : req_start_idx + num_sched]
+            req_state = requests[req_id]
+            mm_input_ids = list[int]()
+
+            for mm_input_id, mm_feature in enumerate(req_state.mm_features):
+                pos_info = mm_feature.mm_position
+                start_pos = pos_info.offset
+                end_pos = start_pos + pos_info.length
+                mm_hash = mm_feature.identifier
+
+                local_mask = (req_positions >= start_pos) & (req_positions < end_pos)
+                if not local_mask.any():
+                    continue
+
+                local_indices = np.nonzero(local_mask)[0]
+                rel_positions = req_positions[local_indices] - start_pos
+                is_embed = pos_info.is_embed
+                if is_embed is not None:
+                    is_embed_np = is_embed.cpu().numpy()
+                    if not is_embed_np[rel_positions].any():
+                        continue
+
+                needed_mm_hashes.add(mm_hash)
+                if mm_hash not in encoder_cache:
+                    mm_input_ids.append(mm_input_id)
+
+            if mm_input_ids:
+                scheduled_encoder_inputs[req_id] = mm_input_ids
+
+            req_start_idx += num_sched
+
+        return scheduled_encoder_inputs, needed_mm_hashes
+
+    def gather_mm_embeddings_for_pcp(
+        self,
+        req_ids: list[str],
+        requests: dict[str, Any],
+        positions_np: np.ndarray,
+        local_num_scheduled_tokens: np.ndarray,
+        shift_computed_tokens: int,
+        encoder_cache: dict[str, torch.Tensor],
+        is_mm_embed: torch.Tensor,
+        model: Any,
+        is_multimodal_pruning_enabled: bool,
+        uses_mrope: bool,
+        warning_once: Callable[..., Any] | None = None,
+    ) -> tuple[list[torch.Tensor], bool, bool]:
+        mm_embeds = list[torch.Tensor]()
+        req_start_idx = 0
+        should_sync_mrope_positions = False
+        should_sync_xdrope_positions = False
+
+        for req_idx, req_id in enumerate(req_ids):
+            num_sched = int(local_num_scheduled_tokens[req_idx])
+            req_positions = positions_np[req_start_idx : req_start_idx + num_sched]
+            if shift_computed_tokens:
+                req_positions = req_positions + shift_computed_tokens
+            req_state = requests[req_id]
+            req_taken_mask = np.zeros(num_sched, dtype=np.bool_)
+            mm_embeds_req: list[torch.Tensor] = []
+            req_mm_local_indices: list[np.ndarray] = []
+
+            for mm_feature in req_state.mm_features:
+                pos_info = mm_feature.mm_position
+                start_pos = pos_info.offset
+                end_pos = start_pos + pos_info.length
+                mm_hash = mm_feature.identifier
+
+                local_mask = (req_positions >= start_pos) & (req_positions < end_pos)
+                if not local_mask.any():
+                    continue
+
+                local_indices = np.nonzero(local_mask)[0]
+                rel_positions = req_positions[local_indices] - start_pos
+
+                is_embed = pos_info.is_embed
+                if is_embed is not None:
+                    is_embed_np = is_embed.cpu().numpy()
+                    keep_mask = is_embed_np[rel_positions]
+                    if not keep_mask.any():
+                        continue
+                    local_indices = local_indices[keep_mask]
+                    rel_positions = rel_positions[keep_mask]
+                    embed_index_map = np.cumsum(is_embed_np.astype(np.int64)) - 1
+                    embed_indices = embed_index_map[rel_positions]
+                else:
+                    embed_indices = rel_positions
+
+                # OR semantics for overlapping mm features: keep first writer.
+                keep_new = ~req_taken_mask[local_indices]
+                if not keep_new.any():
+                    continue
+                local_indices = local_indices[keep_new]
+                embed_indices = embed_indices[keep_new]
+                req_taken_mask[local_indices] = True
+
+                encoder_output = encoder_cache.get(mm_hash, None)
+                assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
+                embed_index_tensor = torch.from_numpy(embed_indices.astype(np.int64)).to(
+                    device=encoder_output.device,
+                    non_blocking=True,
+                )
+                mm_embeds_item = torch.index_select(encoder_output, 0, embed_index_tensor)
+                mm_embeds_req.append(mm_embeds_item)
+                req_mm_local_indices.append(local_indices.astype(np.int64, copy=False))
+                is_mm_embed[req_start_idx + local_indices] = True
+
+            if is_multimodal_pruning_enabled and uses_mrope:
+                assert req_state.mrope_positions is not None
+                should_sync_mrope_positions = True
+                mm_embeds_req, new_mrope_positions, new_delta = (
+                    model.recompute_mrope_positions(
+                        input_ids=req_state.prompt_token_ids,
+                        multimodal_embeddings=mm_embeds_req,
+                        mrope_positions=req_state.mrope_positions,
+                        num_computed_tokens=req_state.num_computed_tokens,
+                    )
+                )
+                req_state.mrope_positions.copy_(new_mrope_positions)
+                req_state.mrope_position_delta = new_delta
+
+            # Keep multimodal embedding order aligned with is_mm_embed scanning order.
+            # Under PCP, request positions may be non-monotonic; concatenating by
+            # feature order can misalign embeddings with boolean mask traversal.
+            if len(mm_embeds_req) > 1:
+                total_local_idx = sum(x.size for x in req_mm_local_indices)
+                total_embed_rows = sum(x.shape[0] for x in mm_embeds_req)
+                if total_local_idx == total_embed_rows and total_local_idx > 0:
+                    local_idx_cat = np.concatenate(req_mm_local_indices, axis=0)
+                    embed_cat = torch.cat(mm_embeds_req, dim=0)
+                    order = np.argsort(local_idx_cat, kind="stable")
+                    order_t = torch.from_numpy(order.astype(np.int64)).to(
+                        device=embed_cat.device,
+                        non_blocking=True,
+                    )
+                    mm_embeds_req = [embed_cat.index_select(0, order_t)]
+                elif warning_once is not None:
+                    warning_once(
+                        "PCP MM reorder skipped due to size mismatch: local_idx=%d, embed_rows=%d",
+                        total_local_idx,
+                        total_embed_rows,
+                    )
+
+            mm_embeds.extend(mm_embeds_req)
+            req_start_idx += num_sched
+
+        return mm_embeds, should_sync_mrope_positions, should_sync_xdrope_positions
+
+    def maybe_localize_scheduler_output_for_mm_preprocess(
+        self,
+        scheduler_output: "SchedulerOutput",
+        req_ids: list[str],
+        requests: dict[str, Any],
+        positions_np: np.ndarray,
+        local_num_scheduled_tokens: np.ndarray | None,
+        local_total_num_scheduled_tokens: int | None,
+        encoder_cache: dict[str, torch.Tensor],
+    ) -> dict[str, Any] | None:
+        need_localize = (
+            local_total_num_scheduled_tokens is not None
+            and local_total_num_scheduled_tokens
+            != scheduler_output.total_num_scheduled_tokens
+        )
+        if not need_localize and local_num_scheduled_tokens is not None:
+            for req_idx, req_id in enumerate(req_ids):
+                if req_idx >= local_num_scheduled_tokens.shape[0]:
+                    break
+                global_sched = scheduler_output.num_scheduled_tokens.get(req_id)
+                if (
+                    global_sched is None
+                    or int(global_sched) != int(local_num_scheduled_tokens[req_idx])
+                ):
+                    need_localize = True
+                    break
+
+        if not need_localize:
+            return None
+
+        restore_state: dict[str, Any] = {
+            "total_num_scheduled_tokens": scheduler_output.total_num_scheduled_tokens,
+            "num_scheduled_tokens": scheduler_output.num_scheduled_tokens,
+            "scheduled_encoder_inputs": scheduler_output.scheduled_encoder_inputs,
+            "free_encoder_mm_hashes": scheduler_output.free_encoder_mm_hashes,
+        }
+
+        if local_total_num_scheduled_tokens is not None:
+            scheduler_output.total_num_scheduled_tokens = (
+                local_total_num_scheduled_tokens
+            )
+
+        if local_num_scheduled_tokens is None:
+            return restore_state
+
+        num_sched_by_req = dict(scheduler_output.num_scheduled_tokens)
+        for req_idx, req_id in enumerate(req_ids):
+            if req_idx >= local_num_scheduled_tokens.shape[0]:
+                break
+            num_sched_by_req[req_id] = int(local_num_scheduled_tokens[req_idx])
+        scheduler_output.num_scheduled_tokens = num_sched_by_req
+
+        (
+            scheduler_output.scheduled_encoder_inputs,
+            local_needed_mm_hashes,
+        ) = self.build_local_mm_schedule(
+            req_ids=req_ids,
+            requests=requests,
+            positions_np=positions_np,
+            local_num_scheduled_tokens=local_num_scheduled_tokens,
+            encoder_cache=encoder_cache,
+        )
+
+        # Under PCP, global free list can be earlier than local consumption.
+        # Keep MM hashes for all active requests.
+        active_mm_hashes = {
+            mm_feature.identifier
+            for req_state in requests.values()
+            for mm_feature in req_state.mm_features
+        }
+        keep_hashes = active_mm_hashes | local_needed_mm_hashes
+        scheduler_output.free_encoder_mm_hashes = [
+            mm_hash
+            for mm_hash in scheduler_output.free_encoder_mm_hashes
+            if mm_hash not in keep_hashes
+        ]
+
+        return restore_state
+
+    def restore_scheduler_output_after_mm_preprocess(
+        self,
+        scheduler_output: "SchedulerOutput",
+        restore_state: dict[str, Any] | None,
+    ) -> None:
+        if restore_state is None:
+            return
+
+        scheduler_output.total_num_scheduled_tokens = restore_state[
+            "total_num_scheduled_tokens"
+        ]
+        scheduler_output.num_scheduled_tokens = restore_state[
+            "num_scheduled_tokens"
+        ]
+        scheduler_output.scheduled_encoder_inputs = restore_state[
+            "scheduled_encoder_inputs"
+        ]
+        scheduler_output.free_encoder_mm_hashes = restore_state[
+            "free_encoder_mm_hashes"
+        ]
 
     def initialize_slot_mapping(self) -> None:
         """


### PR DESCRIPTION
### What this PR does / why we need it?

Fix multimodel reasoning precision issue when active prefill context parallel function on NPU

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Verified both text and multimodel reasoning case when PCP is on.

- Text case: 
``` bash
curl http://localhost:8008/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "kimi",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "The capital of France is"
          }
        ]
      }
    ],
    "max_tokens": 256
  }'
```

- Multimodel case:
``` python
import json
import base64
import os
import requests
img_path = r"/home/aaa/datasets/flower.jpg"
base64_str = base64.b64encode(open(img_path, 'rb').read()).decode()
url = "http://141.61.39.185:8008/v1/chat/completions"
payload = json.dumps(
    {
        "model": "kimi",
        "messages": [
            {
                "role": "user",
                "content": [
                    {
                        "type": "text",
                        "text": "describe the picture"
                    },
                    {
                        "type": "image_url",
                        "image_url": {
                            "url": f"data:image/jpg;base64,{base64_str}",
                            "detail": "high"
                        }
                    },
                ]
            }
        ],
        "max_tokens": 1024,
        "temperature": 0
    }
)

headers = {
    'Content-Type': 'application/json'
}
response = requests.request("POST", url, headers=headers, data=payload)
print(response)
```


- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/14acf429ac08b6d538ca6feb3e06b6d13895804d
