### PR TITLE
[bugfix]fix extra npu context in device 0

### DIFF
--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_fusion_matcher_compat_ops  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa

--- a/vllm_ascend/patch/platform/patch_multiproc_executor.py
+++ b/vllm_ascend/patch/platform/patch_multiproc_executor.py
@@ -27,6 +27,7 @@ from vllm.v1.executor.multiproc_executor import (
 )
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
+
 class AscendMultiprocExecutor(MultiprocExecutor):
     def _init_executor(self) -> None:
         # Call self.shutdown at exit to clean up
@@ -165,7 +166,6 @@ class AscendMultiprocExecutor(MultiprocExecutor):
 
 
 class AscendWorkerProc(WorkerProc):
-
     @instrument(span_name="Worker init")
     def __init__(
         self,
@@ -180,9 +180,7 @@ class AscendWorkerProc(WorkerProc):
         self.rank = rank
         wrapper = WorkerWrapperBase(rpc_rank=local_rank, global_rank=rank)
         # TODO: move `init_worker` to executor level as a collective rpc call
-        all_kwargs: list[dict] = [
-            {} for _ in range(vllm_config.parallel_config.world_size)
-        ]
+        all_kwargs: list[dict] = [{} for _ in range(vllm_config.parallel_config.world_size)]
         all_kwargs[local_rank] = {
             "vllm_config": vllm_config,
             "local_rank": local_rank,
@@ -194,18 +192,14 @@ class AscendWorkerProc(WorkerProc):
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
 
-        self.setup_proc_title_and_log_prefix(
-            enable_ep=vllm_config.parallel_config.enable_expert_parallel
-        )
+        self.setup_proc_title_and_log_prefix(enable_ep=vllm_config.parallel_config.enable_expert_parallel)
 
         # Load model
         is_eep_new_worker = envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH
         if not is_eep_new_worker:
             self.worker.init_device()
             # Update process title now that parallel groups are initialized
-            self.setup_proc_title_and_log_prefix(
-                enable_ep=vllm_config.parallel_config.enable_expert_parallel
-            )
+            self.setup_proc_title_and_log_prefix(enable_ep=vllm_config.parallel_config.enable_expert_parallel)
             self.worker.load_model()
 
         scheduler_config = vllm_config.scheduler_config
@@ -233,6 +227,7 @@ class AscendWorkerProc(WorkerProc):
     @staticmethod
     def worker_main(*args, **kwargs):
         from vllm_ascend.utils import adapt_patch
+
         adapt_patch(is_global_patch=True)
         WorkerProc.worker_main(*args, **kwargs)
 
@@ -277,20 +272,16 @@ class AscendWorkerProc(WorkerProc):
             "inherited_fds": inherited_fds if inherited_fds is not None else [],
         }
         # Run EngineCore busy loop in background process.
-        if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
-            proc = context.Process(
-                target=WorkerProc.worker_main,
-                kwargs=process_kwargs,
-                name=f"VllmWorker-{rank}",
-                daemon=False,
-            )
-        else:
-            proc = context.Process(
-                target=AscendWorkerProc.worker_main,
-                kwargs=process_kwargs,
-                name=f"VllmWorker-{rank}",
-                daemon=True,
-            )
+        daemon_mode = not (
+            os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
+            or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
+        )
+        proc = context.Process(
+            target=AscendWorkerProc.worker_main,
+            kwargs=process_kwargs,
+            name=f"VllmWorker-{rank}",
+            daemon=daemon_mode,
+        )
 
         proc.start()
         # Close child ends of pipes here in the parent


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
When we launch a PD-disaggregated process and send requests, an additional processes appear on NPU 0, becasue when a thread has a primary npu context, the child thread it creates automatically doesn't inherit the npu context. See https://forums.developer.nvidia.com/t/when-a-thread-has-a-primary-cuda-context-does-the-child-thread-it-creates-automatically-inherit-the-cuda-context/362810. vLLM has fixed this issue in [pr-37449 ](https://github.com/vllm-project/vllm/pull/37449), but version 0.18.0 does not include the fix. Therefore, we need to patch it.
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
