### PR TITLE
[Feature][xlite] Support `Qwen3VLMoeForConditionalGeneration` architecture in xlite backend

### DIFF
--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -173,6 +173,8 @@ class QwenMoeXliteModel(LlamaXliteModel):
     def _build_model_config(self, vllm_config: VllmConfig) -> ModelConfig:
         config = super()._build_model_config(vllm_config)
         hf_config = vllm_config.model_config.hf_text_config
+        if hasattr(hf_config, "text_config"):
+            hf_config = hf_config.text_config
         ep_group = get_ep_group()
         config.n_dense_layers = 0
         config.n_routed_experts = hf_config.num_experts
@@ -189,7 +191,10 @@ class QwenMoeXliteModel(LlamaXliteModel):
 
     def _build_model(self, runnable: nn.Module, vllm_config: VllmConfig, config: ModelConfig) -> Model:
         xlite_model = super()._build_model(runnable, vllm_config, config)
-        layers = runnable.model.layers
+        if hasattr(runnable, "language_model"):
+            layers = runnable.language_model.model.layers
+        else:
+            layers = runnable.model.layers
         xlite_model.gate = [layer.mlp.gate.weight for layer in layers]
         xlite_model.re_up_gate = [
             layer.mlp.experts.w13_weight[i] for layer in layers for i in range(layer.mlp.experts.local_num_experts)
@@ -276,6 +281,7 @@ def xlite_model_init(runnable: nn.Module, vllm_config: VllmConfig) -> tuple[Mode
         "Qwen3ForCausalLM": LlamaXliteModel,
         "Qwen3VLForConditionalGeneration": LlamaXliteModel,
         "Qwen3MoeForCausalLM": QwenMoeXliteModel,
+        "Qwen3VLMoeForConditionalGeneration": QwenMoeXliteModel,
         "Glm4MoeForCausalLM": Glm4MoeXliteModel,
     }
 


### PR DESCRIPTION
This PR is the result of the last two commits on `feat/xlite-qwen3-vl-moe`:

1. Refactor `LlamaXliteModel` so the shared `initialize` path uses `config.rope_head_dim` instead of duplicating subclass-specific setup.
2. Add `Qwen3VLMoeForConditionalGeneration` to the xlite strategy map and route it through `QwenMoeXliteModel`.

The net effect is that Qwen3-VL MoE models can reuse the existing xlite initialization flow while still applying the MoE-specific config and weight wiring in the subclass.

### What this PR does / why we need it?

This PR extends xlite backend coverage to the `Qwen3VLMoeForConditionalGeneration` architecture. The previous implementation only handled `Qwen3MoeForCausalLM` and related (non-)MoE variants, so Qwen3-VL MoE models were not routed into the xlite path.

At the same time, the shared rotary embedding precomputation was normalized to use `config.rope_head_dim`, which keeps the base `initialize` implementation generic and avoids duplicated subclass-specific logic.

### Does this PR introduce _any_ user-facing change?

Yes. Users running models with the `Qwen3VLMoeForConditionalGeneration` architecture can now use the xlite backend.

### How was this patch tested?

First, `Qwen3-VL-235B-A22B-Instruct`->`QwenMoeXliteModel` was tested and the vLLM server started successfully with the xlite backend, including launching the worker process and processing requests without crashing (see the script below). Previous models (`Qwen3-32B`->`LlamaXliteModel`, `Qwen3-235B-A22B`->`QwenMoeXliteModel`, `GLM-4.7`->`Glm4MoeXliteModel`) were also re-tested to confirm no regressions.

```bash
# Script to start the server and test a single request

# using Docker image for Ascend A3

export VLLM_USE_MODELSCOPE=true
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True

# server launch command (with xlite enabled)
vllm serve /path/to/model \
--host 0.0.0.0 \
--port 8000 \
--api-server-count 1 \
--data-parallel-size 1 \
--data-parallel-size-local 1 \
--tensor-parallel-size 16 \
--served-model-name mymodel \
--max-num-seqs 16 \
--max-model-len 40960 \
--max-num-batched-tokens 4096 \
--enable-expert-parallel \
--trust-remote-code \
--async-scheduling \
--gpu-memory-utilization 0.9 \
--block-size 128 \
--allowed-local-media-path /path/to/media \
--additional-config='{"xlite_graph_config": {"enabled": true, "full_mode": true}}' \

# single request example
curl http://localhost:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
        "model": "mymodel",
        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": "Tell me how to sleep well at night."}
        ],
        "max_tokens": 128,
        "temperature": "0.0"
}'
```

Further tests were performed to confirm the accuracy of the outputs using `ais_benchmark==3.1.0`. For `Qwen3-VL-235B-A22B-Instruct`, multiple datasets were evaluated, including a multimodal dataset `mmmu`. The results are summarized in the table below.

```bash
# command to run the evaluation for `Qwen3-VL-235B-A22B-Instruct` with xlite enabled
ais_bench --models vllm_api_general_chat --datasets \
aime2024_gen_0_shot_chat_prompt \
ceval_gen_0_shot_cot_chat_prompt \
gpqa_gen_0_shot_cot_chat_prompt \
gsm8k_gen_0_shot_cot_chat_prompt \
math_prm800k_500_0shot_cot_gen \
mmlu_gen_0_shot_cot_chat_prompt \
mmmu_gen_cot \
--work-dir "outputs/Qwen3-VL-235B-A22B-Instruct-xlite" \
--mode all \
--dump-eval-details --merge-ds \
--max-num-workers 128
```

For the `vllm_api_general_chat` task type, the corresponding `ais_bench/benchmark/configs/models/vllm_api/vllm_api_general_chat.py` was modified as:

```python
# ais_bench/benchmark/configs/models/vllm_api/vllm_api_general_chat.py
models = [
    dict(
        attr="service",
        type=VLLMCustomAPIChat,
        abbr="vllm-api-general-chat",
        path="",
        model="mymodel",
        stream=False,
        request_rate=0,
        use_timestamp=False,
        retry=2,
        api_key="",
        host_ip="localhost",
        host_port=8000,
        url="",
        max_out_len=32768,
        batch_size=512,
        trust_remote_code=False,
        generation_kwargs=dict(
            temperature=0.01,
            top_k=10,
            top_p=0.95,
            seed=None,
            repetition_penalty=1.03,
            ignore_eos=False,
        ),
        pred_postprocessor=dict(type=extract_non_reasoning_content),
    )
]
```

| dataset | version | metric | mode | w/ xlite | w/o xlite | Qwen official |
| ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| aime2024 | 544e9a | accuracy | gen | 83.33 | _N.A._ | _74.7 (aime2025)_ |
| ceval | - | accuracy-weighted | gen | 90.42 | 90.19 | _N.A._ |
| gpqa | 5d9994 | accuracy | gen | 70.20 | _N.A._ | _N.A._ |
| gsm8k | 271d0b | accuracy | gen | 96.51 | _N.A._ | _N.A._ |
| livecodebench | 270e7b | pass@1 | gen | 52.61 | _N.A._ | _54.3 (LCBV6)_ |
| math | 9eff90 | accuracy | gen | 94.40 | _N.A._ | _N.A._ |
| mmlu | - | accuracy-weighted | gen | 89.94 | _N.A._ | 88.8 |
| mmmu* | 14da4b | [validation]: Overall | gen | 71.11 | _N.A._ | 78.7 |
| mmmu* | 14da4b | [dev]: Overall | gen | 69.33 | _N.A._ | _N.A._ |

> *Multimodal datasets that include image inputs.\
> Qwen official: <https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct>\
> Bug fix from <https://github.com/AISBench/benchmark/pull/238> were also merged to ensure the evaluation correctness for the `mmmu` dataset.


For other previously supported models, their accuracies were also validated on the `ceval` dataset, with the results below:

| model | dataset | version | metric | mode | w/ xlite | w/o xlite |
| ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Qwen3-32B | ceval | - | accuracy-weighted | gen | 88.26 | 88.48 |
| Qwen3-235B-A22B | ceval | - | accuracy-weighted | gen | 91.01 | _N.A._ |
| GLM-4.7 | ceval | - | accuracy-weighted | gen | 90.79 | _N.A._ |

These results confirm that the xlite backend is functioning correctly for the `Qwen3VLMoeForConditionalGeneration` architecture, with no observed alterations to previous models.

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/29e48707e8144b78dd5d756f793c26a405043f3d
