### PR TITLE
[UT][v0.18.0] Fix APC nightly UT and TTFT ratio (cherry-pick #7468)

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
@@ -42,7 +42,7 @@ test_cases:
       - metric: "TTFT"
         baseline: "prefix0"
         target: "prefix75"
-        ratio: 0.8
+        ratio: 0.4
         operator: "<"
     benchmarks:
       warm_up:
@@ -51,7 +51,7 @@ test_cases:
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 210
-        max_out_len: 2
+        max_out_len: 1
         batch_size: 1000
         baseline: 0
         threshold: 0.97
@@ -61,7 +61,7 @@ test_cases:
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 210
-        max_out_len: 1500
+        max_out_len: 1
         batch_size: 18
         baseline: 1
         threshold: 0.97
@@ -71,7 +71,7 @@ test_cases:
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 210
-        max_out_len: 1500
+        max_out_len: 1
         batch_size: 18
         baseline: 1
         threshold: 0.97

--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-Qwen3-32B-Int8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-Qwen3-32B-Int8.yaml
@@ -35,7 +35,7 @@ test_cases:
       - metric: "TTFT"
         baseline: "prefix0"
         target: "prefix75"
-        ratio: 0.8
+        ratio: 0.4
         operator: "<"
     benchmarks:
       warm_up:
@@ -44,7 +44,7 @@ test_cases:
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 210
-        max_out_len: 2
+        max_out_len: 1
         batch_size: 1000
         baseline: 0
         threshold: 0.97
@@ -54,7 +54,7 @@ test_cases:
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 210
-        max_out_len: 1500
+        max_out_len: 1
         batch_size: 48
         baseline: 1
         threshold: 0.97
@@ -64,7 +64,7 @@ test_cases:
         request_conf: vllm_api_stream_chat
         dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
         num_prompts: 210
-        max_out_len: 1500
+        max_out_len: 1
         batch_size: 48
         baseline: 1
         threshold: 0.97


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Cherry-pick from https://github.com/vllm-project/vllm-ascend/pull/7468

- Fix TTFT ratio threshold from 0.8 to 0.4 for prefix cache benchmarks
- Fix max_out_len values for warm_up and benchmark configs
- Applied to both DeepSeek-R1-0528-W8A8 and Qwen3-32B-Int8 configs

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
