### PR TITLE
[Feature] Add recurrent ascendc ops

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -23,7 +23,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     export CPATH=${ABSOLUTE_CATLASS_PATH}:${CPATH}
 
 
-    CUSTOM_OPS="moe_grouped_matmul;grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;copy_and_expand_eagle_inputs;causal_conv1d;lightning_indexer_quant;hamming_dist_top_k;reshape_and_cache_bnsd;"
+    CUSTOM_OPS="moe_grouped_matmul;grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;copy_and_expand_eagle_inputs;causal_conv1d;lightning_indexer_quant;hamming_dist_top_k;reshape_and_cache_bnsd;recurrent_gated_delta_rule;"
     SOC_ARG="ascend910b"
 elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
@@ -63,6 +63,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "lightning_indexer_quant"
         "hamming_dist_top_k"
         "reshape_and_cache_bnsd"
+        "recurrent_gated_delta_rule"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/recurrent_gated_delta_rule/op_host/CMakeLists.txt
+++ b/csrc/recurrent_gated_delta_rule/op_host/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+
+add_ops_compile_options(
+        OP_NAME RecurrentGatedDeltaRule
+        OPTIONS --cce-auto-sync=on
+                -Wno-deprecated-declarations
+                -Werror
+)
+
+target_sources(op_host_aclnnExc PRIVATE
+    recurrent_gated_delta_rule_def.cpp
+)
+
+target_sources(opapi PRIVATE
+    aclnn_recurrent_gated_delta_rule.cpp
+    recurrent_gated_delta_rule.cpp
+)
+
+if (NOT BUILD_OPEN_PROJECT)
+    target_sources(aclnn_ops_train PRIVATE
+        recurrent_gated_delta_rule.cpp
+        aclnn_recurrent_gated_delta_rule.cpp
+    )
+
+    target_sources(aclnn_ops_infer PRIVATE
+        recurrent_gated_delta_rule.cpp
+        aclnn_recurrent_gated_delta_rule.cpp
+    )
+endif ()
+
+target_sources(optiling PRIVATE
+    recurrent_gated_delta_rule_tiling.cpp
+)
+
+target_include_directories(optiling PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_sources(opsproto PRIVATE)
+
+file(GLOB _RGDR_Aclnn_header "${CMAKE_CURRENT_SOURCE_DIR}/aclnn_recurrent_gated_delta_rule.h")
+
+install(FILES ${_RGDR_Aclnn_header}
+        DESTINATION ${ACLNN_INC_INSTALL_DIR} OPTIONAL
+)

--- a/csrc/recurrent_gated_delta_rule/op_host/aclnn_recurrent_gated_delta_rule.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_host/aclnn_recurrent_gated_delta_rule.cpp
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file aclnn_recurrent_gated_delta_rule.cpp
+ * \brief
+ */
+#include <dlfcn.h>
+#include "aclnn_recurrent_gated_delta_rule.h"
+#include "recurrent_gated_delta_rule.h"
+
+#include "securec.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/platform.h"
+
+#include "aclnn_kernels/transdata.h"
+#include "aclnn_kernels/transpose.h"
+#include "aclnn_kernels/contiguous.h"
+#include "aclnn_kernels/reshape.h"
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace {
+constexpr size_t QUERY_DIM_NUM = 3;
+constexpr size_t KEY_DIM_NUM = 3;
+constexpr size_t VALUE_DIM_NUM = 3;
+constexpr size_t BETA_DIM_NUM = 2;
+constexpr size_t STATE_DIM_NUM = 4;
+
+struct RecurrentGatedDeltaRuleParams {
+    // mandatory
+    const aclTensor *query {nullptr};
+    const aclTensor *key {nullptr};
+    const aclTensor *value {nullptr};
+    const aclTensor *beta {nullptr};
+    const aclTensor *state {nullptr};
+    const aclTensor *actual_seq_lengths {nullptr};
+    const aclTensor *ssm_state_indices {nullptr};
+    // optional
+    const aclTensor *g {nullptr};
+    const aclTensor *gk {nullptr};
+    const aclTensor *num_accepted_tokens {nullptr};
+    // attrs
+    float scale {1.0f};
+    //output
+    const aclTensor *out {nullptr};
+};
+
+// support dtype
+static const std::initializer_list<op::DataType> QKV_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
+static const std::initializer_list<op::DataType> STATE_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16,op::DataType::DT_FLOAT};
+static const std::initializer_list<op::DataType> BETA_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
+static const std::initializer_list<op::DataType> SEQ_LENS_TYPE_SUPPORT_LIST = {op::DataType::DT_INT32};
+static const std::initializer_list<op::DataType> SSM_TYPE_SUPPORT_LIST = {op::DataType::DT_INT32};
+static const std::initializer_list<op::DataType> G_TYPE_SUPPORT_LIST = {op::DataType::DT_FLOAT};
+static const std::initializer_list<op::DataType> ACC_TO_TYPE_SUPPORT_LIST = {op::DataType::DT_INT32};
+static const std::initializer_list<op::DataType> OUT_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
+
+static inline bool CheckNotNull(const RecurrentGatedDeltaRuleParams &params)
+{
+    // 必选参数
+    OP_CHECK_NULL(params.query, return false);
+    OP_CHECK_NULL(params.key, return false);
+    OP_CHECK_NULL(params.value, return false);
+    OP_CHECK_NULL(params.state, return false);
+    OP_CHECK_NULL(params.beta, return false);
+    OP_CHECK_NULL(params.actual_seq_lengths, return false);
+    OP_CHECK_NULL(params.ssm_state_indices, return false);
+    OP_CHECK_NULL(params.out, return false);
+
+    return true;
+}
+
+static inline bool CheckDtypeVaild(const RecurrentGatedDeltaRuleParams &params)
+{
+    // 检查必选参数数据类型
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.query, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.key, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.value, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.state, STATE_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.beta, BETA_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.actual_seq_lengths, SEQ_LENS_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.ssm_state_indices, SSM_TYPE_SUPPORT_LIST, return false);
+
+    // 检查可选参数数据类型
+    if (params.g != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(params.g, G_TYPE_SUPPORT_LIST, return false);
+    }
+    if (params.gk != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(params.gk, G_TYPE_SUPPORT_LIST, return false);
+    }
+    if (params.num_accepted_tokens != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(params.num_accepted_tokens, ACC_TO_TYPE_SUPPORT_LIST, return false);
+    }
+
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.out, OUT_TYPE_SUPPORT_LIST, return false);
+    return true;
+}
+
+static aclnnStatus CheckParams(RecurrentGatedDeltaRuleParams &params)
+{
+    // 检查输入参数是否在支持的数据类型范围内
+    CHECK_RET(CheckDtypeVaild(params), ACLNN_ERR_PARAM_INVALID);
+
+    OP_LOGD("RecurrentGatedDeltaRule check params success.");
+
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus PreProcess(RecurrentGatedDeltaRuleParams &params)
+{
+    params.query->SetOriginalShape(params.query->GetViewShape());
+    params.key->SetOriginalShape(params.key->GetViewShape());
+    params.value->SetOriginalShape(params.value->GetViewShape());
+    params.beta->SetOriginalShape(params.beta->GetViewShape());
+    params.state->SetOriginalShape(params.state->GetViewShape());
+    params.actual_seq_lengths->SetOriginalShape(params.actual_seq_lengths->GetViewShape());
+    params.ssm_state_indices->SetOriginalShape(params.ssm_state_indices->GetViewShape());
+
+    return ACLNN_SUCCESS;
+}
+} // namespace
+
+aclnnStatus aclnnRecurrentGatedDeltaRuleGetWorkspaceSize(const aclTensor *query, const aclTensor *key,
+                                                         const aclTensor *value, const aclTensor *beta,
+                                                         aclTensor *stateRef, const aclTensor *actualSeqLengths,
+                                                         const aclTensor *ssmStateIndices, const aclTensor *g,
+                                                         const aclTensor *gk, const aclTensor *numAcceptedTokens,
+                                                         float scaleValue, aclTensor *out, uint64_t *workspaceSize,
+                                                         aclOpExecutor **executor)
+{
+    L2_DFX_PHASE_1(aclnnRecurrentGatedDeltaRule,
+                   DFX_IN(query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk,
+                          numAcceptedTokens, scaleValue),
+                   DFX_OUT(out, stateRef));
+
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+
+    RecurrentGatedDeltaRuleParams params {query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk, numAcceptedTokens,scaleValue, out};
+
+    CHECK_RET(CheckNotNull(params), ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckParams(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    auto ret = PreProcess(params);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+
+    auto query_ = l0op::Contiguous(query, uniqueExecutor.get());
+    auto key_ = l0op::Contiguous(key, uniqueExecutor.get());
+    auto value_ = l0op::Contiguous(value, uniqueExecutor.get());
+    auto beta_ = l0op::Contiguous(beta, uniqueExecutor.get());
+    auto actualSeqLengths_ = l0op::Contiguous(actualSeqLengths, uniqueExecutor.get());
+    auto ssmStateIndices_ = l0op::Contiguous(ssmStateIndices, uniqueExecutor.get());
+    if (g != nullptr) {
+        g = l0op::Contiguous(g, uniqueExecutor.get());
+    }
+    if (gk != nullptr) {
+        gk = l0op::Contiguous(gk, uniqueExecutor.get());
+    }
+    if (numAcceptedTokens != nullptr) {
+        numAcceptedTokens = l0op::Contiguous(numAcceptedTokens, uniqueExecutor.get());
+    }
+
+    auto out_ = l0op::Contiguous(out, uniqueExecutor.get());
+
+    // 调用l0接口
+    auto outRet =
+        l0op::RecurrentGatedDeltaRule(query_, key_, value_, beta_, stateRef, actualSeqLengths_, ssmStateIndices_, g, gk,
+                                      numAcceptedTokens, scaleValue, uniqueExecutor.get());
+    if (outRet == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+
+    auto ViewCopyResult = l0op::ViewCopy(outRet, out_, uniqueExecutor.get());
+    if (ViewCopyResult == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+
+    // 获取计算过程中需要使用的workspace大小。
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnRecurrentGatedDeltaRule(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+                                         aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnRecurrentGatedDeltaRule);
+    return CommonOpExecutorRun(workspace, workspaceSize, executor, stream);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/recurrent_gated_delta_rule/op_host/aclnn_recurrent_gated_delta_rule.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/aclnn_recurrent_gated_delta_rule.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef OP_API_ACLNN_RECURRENT_GETED_DELTA_RULE_H
+#define OP_API_ACLNN_RECURRENT_GETED_DELTA_RULE_H
+
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief RecurrentGatedDeltaRule 的第一段接口，根据具体的计算流程，计算workspace大小。
+ * @param [in] query: 数据类型支持：bfloat16。
+ * @param [in] key: 数据类型支持：bfloat16。
+ * @param [in] value: 数据类型支持：bfloat16。
+ * @param [in] beta: 数据类型支持：bfloat16。
+ * @param [in] state: 数据类型支持：bfloat16。
+ * @param [in] actualSeqLengths: 数据类型支持：int32。
+ * @param [in] ssmStateIndices: 数据类型支持：int32。
+ * @param [in] g: 数据类型支持：float32。
+ * @param [in] gk: 数据类型支持：float32。
+ * @param [in] numAcceptedTokens: 数据类型支持：int32。
+ * @param [in] scaleValue: 数据类型支持：float32。
+ * @param [out] out: 数据类型支持：bfloat16。
+ * @param [out] 返回需要在npu device侧申请的workspace大小。
+ * @param [out] executor: 返回op执行器，包含了算子计算流程。
+ * @return aclnnStatus: 返回状态码
+ */
+__attribute__((visibility("default"))) aclnnStatus aclnnRecurrentGatedDeltaRuleGetWorkspaceSize(
+    const aclTensor *query, const aclTensor *key, const aclTensor *value, const aclTensor *beta, aclTensor *stateRef,
+    const aclTensor *actualSeqLengths, const aclTensor *ssmStateIndices, const aclTensor *g, const aclTensor *gk,
+    const aclTensor *numAcceptedTokens, float scaleValue, aclTensor *out, uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/**
+ * @brief 
+ * @param [in] workspace: 在npu device侧申请的workspace内存起址。
+ * @param [in] workspace_size: 在npu
+ * device侧申请的workspace大小，由第一段接口aclnnRecurrentGatedDeltaRuleGetWorkspaceSize获取。
+ * @param [in] executor: op执行器，包含了算子计算流程。
+ * @param [in] stream: acl stream流。
+ * @return aclnnStatus: 返回状态码
+ */
+__attribute__((visibility("default"))) aclnnStatus aclnnRecurrentGatedDeltaRule(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+                                                   aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OP_API_ACLNN_RECURRENT_GETED_DELTA_RULE_H

--- a/csrc/recurrent_gated_delta_rule/op_host/error_log.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/error_log.h
@@ -1,0 +1,71 @@
+#ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+#define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+
+#include <string>
+#include "toolchain/slog.h"
+
+#define OP_LOGI(opname, ...)
+#define OP_LOGW(opname, ...)             \
+    do {                                 \
+        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
+        printf("\n");                    \
+    } while (0)
+
+#define OP_LOGE_WITHOUT_REPORT(opname, ...) \
+    do {                                    \
+        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
+        printf("\n");                       \
+    } while (0)
+
+#define OP_LOGE(opname, ...)              \
+    do {                                  \
+        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
+        printf("\n");                     \
+    } while (0)
+
+#define OP_LOGD(opname, ...)
+
+namespace optiling {
+
+#define VECTOR_INNER_ERR_REPORT_TILIING(op_name, err_msg, ...)   \
+    do {                                                         \
+        OP_LOGE_WITHOUT_REPORT(op_name, err_msg, ##__VA_ARGS__); \
+    } while (0)
+
+
+#define OP_CHECK_IF(cond, log_func, expr) \
+    do {                                      \
+        if (cond) {                           \
+            log_func;                         \
+            expr;                             \
+        }                                     \
+    } while (0)
+
+
+
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                          \
+    do {                                                                  \
+        if ((ptr) == nullptr) {                                           \
+            OP_LOGE(context->GetNodeType(), "%s is null", #ptr);               \
+            return ge::GRAPH_FAILED;                                      \
+        }                                                                 \
+    } while (0)
+
+}  // namespace optiling
+
+template <typename T>
+T CeilAlign(T a, T b)
+{
+    return (a + b - 1) / b * b;
+}
+
+template <typename T>
+T CeilDiv(T a, T b)
+{
+    if (b == 0) {
+        return a;
+    }
+    return (a + b - 1) / b;
+}
+
+#endif  // OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_

--- a/csrc/recurrent_gated_delta_rule/op_host/math_util.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/math_util.h
@@ -1,0 +1,61 @@
+/**
+* Copyright (c) 2025 Huawei Technologies Co., Ltd.
+* This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+* CANN Open Software License Agreement Version 2.0 (the "License").
+* Please refer to the License for details. You may not use this file except in compliance with the License.
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+* See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+/*!
+ * \file math_util.h
+ * \brief
+ */
+
+#ifndef TILING_MATMUL_MATH_UTIL_H
+#define TILING_MATMUL_MATH_UTIL_H
+
+#include <array>
+#include <cstdint>
+#include <vector>
+#include <utility>
+namespace matmul_tiling {
+class MathUtil {
+public:
+    static bool IsEqual(float leftValue, float rightValue);
+    template<typename T>
+    static auto CeilDivision(T num1, T num2) -> T
+    {
+        if (num2 == 0) {
+            return 0;
+        }
+        return static_cast<T>((static_cast<int64_t>(num1) + static_cast<int64_t>(num2) - 1) /
+            static_cast<int64_t>(num2));
+    }
+    template<typename T>
+    static auto Align(T num1, T num2) -> T
+    {
+        return CeilDivision(num1, num2) * num2;
+    }
+    static int32_t AlignDown(int32_t num1, int32_t num2);
+    static bool CheckMulOverflow(int32_t a, int32_t b, int32_t &c);
+    static int32_t MapShape(int32_t shape, bool roundUpFlag = true);
+    static void AddFactor(std::vector<int32_t> &dimsFactors, int32_t dim);
+    static void GetFactorCnt(const int32_t shape, int32_t &factorCnt, const int32_t factorStart,
+        const int32_t factorEnd);
+    static void GetFactorLayerCnt(const int32_t shape, int32_t &factorCnt, const int32_t factorStart,
+        const int32_t factorEnd);
+    static bool CheckFactorNumSatisfy(const int32_t dim);
+    static int32_t FindBestSingleCore(const int32_t oriShape, const int32_t mappedShape, const int32_t coreNum,
+        bool isKDim);
+    static void GetFactors(std::vector<int32_t> &factorList, int32_t srcNum, int32_t minFactor, int32_t maxFactor);
+    static void GetFactors(std::vector<int32_t> &factorList, int32_t srcNum, int32_t maxFactor);
+    static void GetBlockFactors(std::vector<int32_t> &factorList, const int32_t oriShape, const int32_t mpShape,
+        const int32_t coreNum, const int32_t maxNum);
+    static int32_t GetNonFactorMap(std::vector<int32_t> &factorList, int32_t srcNum, int32_t maxFactor);
+    static std::vector<std::pair<int, int>> GetFactorPairs(int32_t num);
+    static std::pair<int32_t, int32_t> DivideIntoMainAndTail(int32_t num, int32_t divisor);
+};
+} // namespace matmul_tiling
+#endif // _MATH_UTIL_H_

--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.cpp
+ * \brief
+ */
+#include "recurrent_gated_delta_rule.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_def.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/shape_utils.h"
+
+using namespace op;
+
+namespace l0op {
+
+OP_TYPE_REGISTER(RecurrentGatedDeltaRule);
+
+const aclTensor *RecurrentGatedDeltaRule(const aclTensor *query, const aclTensor *key, const aclTensor *value,
+                                         const aclTensor *beta, aclTensor *stateRef, const aclTensor *actualSeqLengths,
+                                         const aclTensor *ssmStateIndices, const aclTensor *g, const aclTensor *gk,
+                                         const aclTensor *numAcceptedTokens, float scaleValue, aclOpExecutor *executor)
+{
+    L0_DFX(RecurrentGatedDeltaRule, query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk,
+           numAcceptedTokens, scaleValue);
+
+    DataType outType = DataType::DT_BF16;
+    Format format = Format::FORMAT_ND;
+
+    auto out = executor->AllocTensor(outType, format, format);
+
+    OP_CHECK(out != nullptr, OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "out AllocTensor failed."),
+             return nullptr);
+
+    // infershape
+    auto ret = INFER_SHAPE(
+        RecurrentGatedDeltaRule,
+        OP_INPUT(query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk, numAcceptedTokens),
+        OP_OUTPUT(out, stateRef), OP_ATTR(scaleValue));
+    OP_CHECK_INFERSHAPE(ret != ACLNN_SUCCESS, return nullptr, "RecurrentGatedDeltaRule InferShape failed.");
+
+    ret = ADD_TO_LAUNCHER_LIST_AICORE(
+        RecurrentGatedDeltaRule,
+        OP_INPUT(query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk, numAcceptedTokens),
+        OP_OUTPUT(out, stateRef), OP_ATTR(scaleValue));
+    OP_CHECK_ADD_TO_LAUNCHER_LIST_AICORE(ret != ACLNN_SUCCESS, return nullptr,
+                                         "RecurrentGatedDeltaRule ADD_TO_LAUNCHER_LIST_AICORE failed.");
+
+    return out;
+}
+} // namespace l0op

--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_RECURRENT_GETED_DELTA_RULE
+#define PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_RECURRENT_GETED_DELTA_RULE
+
+#include "opdev/op_executor.h"
+#include "opdev/make_op_executor.h"
+
+namespace l0op {
+const aclTensor *RecurrentGatedDeltaRule(const aclTensor *query, const aclTensor *key, const aclTensor *value,
+                                         const aclTensor *beta, aclTensor *stateRef, const aclTensor *actualSeqLengths,
+                                         const aclTensor *ssmStateIndices, const aclTensor *g, const aclTensor *gk,
+                                         const aclTensor *numAcceptedTokens, float scaleValue, aclOpExecutor *executor);
+}
+
+#endif // PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_RECURRENT_GETED_DELTA_RULE

--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_def.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_def.cpp
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.h.cpp
+ * \brief
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class RecurrentGatedDeltaRule : public OpDef {
+public:
+    explicit RecurrentGatedDeltaRule(const char *name) : OpDef(name)
+    {
+        this->Input("query")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("key")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("value")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("beta")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("state")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("actual_seq_lengths")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("ssm_state_indices")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("g")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("gk")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("num_accepted_tokens")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("out")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("state")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Attr("scale_value").AttrType(OPTIONAL).Float(1.0);
+        
+        OpAICoreConfig aicConfig;
+        aicConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .ExtendCfgInfo("softsync.flag", "true");
+        this->AICore().AddConfig("ascend910b", aicConfig);
+        this->AICore().AddConfig("ascend910_93", aicConfig);
+    }
+};
+
+OP_ADD(RecurrentGatedDeltaRule);
+
+} // namespace ops

--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_infershape.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_infershape.cpp
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/* !
+ * \file recurrent_gated_delta_rule_infershape.cpp
+ * \brief
+ */
+#include <map>
+#include <string>
+#include <sstream>
+#include <initializer_list>
+
+#include "exe_graph/runtime/infer_shape_context.h"
+#include "exe_graph/runtime/shape.h"
+#include "exe_graph/runtime/storage_shape.h"
+#include "register/op_impl_registry.h"
+#include "error_log.h"
+
+using namespace gert;
+namespace ops {
+
+const size_t VALUE_INDEX = 2;
+const size_t STATE_INDEX = 4;
+const size_t VALUE_DIM = 3;
+const size_t STATE_DIM = 4;
+
+const size_t DIM_0 = 0;
+const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
+const size_t DIM_3 = 3;
+
+static ge::graphStatus InferShapeRecurrentGatedDeltaRule(InferShapeContext *context)
+{
+    if (context == nullptr) {
+        OP_LOGE("RecurrentGatedDeltaRule", "inference context is null");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto opName = context->GetNodeName();
+    auto shapeValue = context->GetInputShape(VALUE_INDEX);
+    auto shapeInitialState = context->GetInputShape(STATE_INDEX);
+    auto shapeOut = context->GetOutputShape(DIM_0);
+    auto shapeFinalState = context->GetOutputShape(DIM_1);
+    if (shapeValue == nullptr || shapeInitialState == nullptr || shapeOut == nullptr || shapeFinalState == nullptr) {
+        OP_LOGE(opName, "[InferShape] shape is null");
+        return ge::GRAPH_FAILED;
+    }
+
+    shapeOut->SetDimNum(VALUE_DIM);
+    int64_t outDim0 = shapeValue->GetDim(DIM_0);
+    int64_t outDim1 = shapeValue->GetDim(DIM_1);
+    int64_t outDim2 = shapeValue->GetDim(DIM_2);
+    shapeOut->SetDim(DIM_0, outDim0);
+    shapeOut->SetDim(DIM_1, outDim1);
+    shapeOut->SetDim(DIM_2, outDim2);
+
+    shapeFinalState->SetDimNum(STATE_DIM);
+    int64_t stateDim0 = shapeInitialState->GetDim(DIM_0);
+    int64_t stateDim1 = shapeInitialState->GetDim(DIM_1);
+    int64_t stateDim2 = shapeInitialState->GetDim(DIM_2);
+    int64_t stateDim3 = shapeInitialState->GetDim(DIM_3);
+    shapeFinalState->SetDim(DIM_0, stateDim0);
+    shapeFinalState->SetDim(DIM_1, stateDim1);
+    shapeFinalState->SetDim(DIM_2, stateDim2);
+    shapeFinalState->SetDim(DIM_3, stateDim3);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus InferDataTypeRecurrentGatedDeltaRule(gert::InferDataTypeContext *context)
+{
+    context->SetOutputDataType(0, ge::DT_BF16);
+    context->SetOutputDataType(1, ge::DT_BF16);
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(RecurrentGatedDeltaRule)
+    .InferShape(InferShapeRecurrentGatedDeltaRule)
+    .InferDataType(InferDataTypeRecurrentGatedDeltaRule);
+} // namespace ops

--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -1,0 +1,681 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_tiling.cpp
+ * \brief
+ */
+#include "recurrent_gated_delta_rule_tiling.h"
+
+#include "tiling_templates_registry.h"
+#include "register/op_def_registry.h"
+#include "platform/platform_infos_def.h"
+#include "error_log.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "math_util.h"
+#include "error/ops_error.h"
+#include <array>
+
+namespace optiling {
+
+REGISTER_OPS_TILING_TEMPLATE(RecurrentGatedDeltaRule, RecurrentGatedDeltaRuleTiling, 0);
+
+const size_t QUERY_INDEX = 0;
+const size_t KEY_INDEX = 1;
+const size_t VALUE_INDEX = 2;
+const size_t BETA_INDEX = 3;
+const size_t STATE_INDEX = 4;
+const size_t CUSEQLENS_INDEX = 5;
+const size_t SSM_STATE_INDICES_INDEX = 6;
+const size_t G_INDEX = 7;
+const size_t GK_INDEX = 8;
+const size_t ACC_TO_INDEX = 9;
+
+const size_t QKV_DIM_NUM = 3;
+const size_t BETA_DIM_NUM = 2;
+const size_t STATE_DIM_NUM = 4;
+const size_t CUSEQLENS_DIM_NUM = 1;
+const size_t SSM_STATE_INDICES_DIM_NUM = 1;
+const size_t G_DIM_NUM = 2;
+
+const size_t DIM_0 = 0;
+const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
+const size_t DIM_3 = 3;
+
+const size_t MAX_MTP = 8;
+
+template <typename T1, typename T2>
+static T1 CeilDiv(T1 a, T2 b)
+{
+    if (b == 0) {
+        return 0;
+    }
+    return (a + b - 1) / b;
+}
+
+template <typename T>
+typename std::enable_if <std::is_integral<T>::value, T>::type CeilAlign(T x, T align) {
+    return CeilDiv(x, align) * align;
+}
+
+void RecurrentGatedDeltaRuleTiling::InitCompileInfo()
+{
+    auto platformInfoPtr = context_->GetPlatformInfo();
+    if (platformInfoPtr == nullptr) {
+        OP_LOGE(context_->GetNodeName(), "platformInfoPtr is null");
+        return;
+    }
+    const auto &ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, compileInfo_.ubSize);
+    compileInfo_.aivNum = ascendcPlatform.GetCoreNumAiv();
+
+    if (compileInfo_.aivNum <= 0) {
+        OP_LOGE(context_->GetNodeName(), "aivNum <= 0");
+        return;
+    }
+    tilingData_.vectorCoreNum = compileInfo_.aivNum;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetPlatformInfo()
+{
+    return ge::GRAPH_SUCCESS;
+};
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetShapeAttrsInfo()
+{
+    OP_CHECK_IF(CheckContext() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid context."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeDtype() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid dtypes."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeShapes() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid shapes."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetScale() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetScale."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetOptionalInput() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetOptionalInput."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeFormat() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid Format."),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::DoOpTiling()
+{
+    OP_CHECK_IF(CalUbSize() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "CalUbSize failed."),
+                return ge::GRAPH_FAILED);
+
+    PrintTilingData();
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::DoLibApiTiling()
+{
+    tilingKey_ = 0;
+    return ge::GRAPH_SUCCESS;
+};
+
+uint64_t RecurrentGatedDeltaRuleTiling::GetTilingKey() const
+{
+    return tilingKey_;
+};
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetWorkspaceSize()
+{
+    // system workspace size is 16 * 1024 * 1024 = 16M;
+    constexpr int64_t sysWorkspaceSize = 16777216;
+    workspaceSize_ = sysWorkspaceSize;
+
+    return ge::GRAPH_SUCCESS;
+};
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::PostTiling()
+{
+    context_->SetBlockDim(tilingData_.vectorCoreNum);
+    auto tilingDataSize = sizeof(RecurrentGatedDeltaRuleTilingData);
+    errno_t ret = memcpy_s(context_->GetRawTilingData()->GetData(), context_->GetRawTilingData()->GetCapacity(),
+                           reinterpret_cast<void *>(&tilingData_), tilingDataSize);
+    if (ret != EOK) {
+        OP_LOGE(context_->GetNodeName(), "memcpy_s failed, ret=%d", ret);
+        return ge::GRAPH_FAILED;
+    }
+    context_->GetRawTilingData()->SetDataSize(tilingDataSize);
+
+    size_t *workspaces = context_->GetWorkspaceSizes(1); // set workspace
+    OP_CHECK_IF(workspaces == nullptr, OPS_REPORT_CUBE_INNER_ERR(context_->GetNodeName(), "workspaces is null"),
+                return ge::GRAPH_FAILED);
+    workspaces[0] = workspaceSize_;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckContext()
+{
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(QUERY_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(QUERY_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(KEY_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(KEY_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(VALUE_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(VALUE_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(BETA_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(BETA_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(STATE_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(STATE_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(CUSEQLENS_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(CUSEQLENS_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(SSM_STATE_INDICES_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(SSM_STATE_INDICES_INDEX));
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeDtype()
+{
+    auto queryDtype = context_->GetInputDesc(QUERY_INDEX)->GetDataType();
+    auto keyDtype = context_->GetInputDesc(KEY_INDEX)->GetDataType();
+    auto valueDtype = context_->GetInputDesc(VALUE_INDEX)->GetDataType();
+    OP_CHECK_IF(queryDtype != ge::DT_BF16 || keyDtype != ge::DT_BF16 || valueDtype != ge::DT_BF16,
+                OP_LOGE(context_->GetNodeName(), "query dtype, key dtype and value dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+
+    auto betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    OP_CHECK_IF(betaDtype != ge::DT_BF16 ,
+                OP_LOGE(context_->GetNodeName(), "beta dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(stateDtype != ge::DT_FLOAT && stateDtype != ge::DT_BF16,
+                OP_LOGE(context_->GetNodeName(), "state dtype should be bfloat16 or float32"),
+                return ge::GRAPH_FAILED);
+    auto cuSeqlensDtype = context_->GetInputDesc(CUSEQLENS_INDEX)->GetDataType();
+    auto ssmStateIndicesDtype = context_->GetInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType();
+    OP_CHECK_IF(cuSeqlensDtype != ge::DT_INT32 || ssmStateIndicesDtype != ge::DT_INT32,
+                OP_LOGE(context_->GetNodeName(), "cuSeqlens dtype and ssmStateIndices dtype should be int32"),
+                return ge::GRAPH_FAILED);
+
+    if (context_->GetOptionalInputDesc(G_INDEX) != nullptr) {
+        auto gamaDtype = context_->GetOptionalInputDesc(G_INDEX)->GetDataType();
+        OP_CHECK_IF(gamaDtype != ge::DT_FLOAT, OP_LOGE(context_->GetNodeName(), "gama dtype should be float32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    if (context_->GetOptionalInputDesc(GK_INDEX) != nullptr) {
+        auto gamaKDtype = context_->GetOptionalInputDesc(GK_INDEX)->GetDataType();
+        OP_CHECK_IF(gamaKDtype != ge::DT_FLOAT, OP_LOGE(context_->GetNodeName(), "gamaK dtype should be float32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    if (context_->GetOptionalInputDesc(ACC_TO_INDEX) != nullptr) {
+        auto numAcceptedTokensDtype = context_->GetOptionalInputDesc(ACC_TO_INDEX)->GetDataType();
+        OP_CHECK_IF(numAcceptedTokensDtype != ge::DT_INT32,
+                    OP_LOGE(context_->GetNodeName(), "numAcceptedTokens dtype should be int32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+
+bool RecurrentGatedDeltaRuleTiling::CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB,
+                                                  const std::string &nameA, const std::string &nameB,
+                                                  const std::string &dimDesc)
+{
+    if (a.GetDim(dimA) != b.GetDim(dimB)) {
+        OP_LOGE(context_->GetNodeName(), "The %s of %s and %s should be the same, but %s is %ld while %s is %ld",
+                dimDesc.c_str(), nameA.c_str(), nameB.c_str(), nameA.c_str(), a.GetDim(dimA), nameB.c_str(),
+                b.GetDim(dimB));
+        return false;
+    }
+    return true;
+}
+
+bool RecurrentGatedDeltaRuleTiling::CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc)
+{
+    if (shape.GetDimNum() != dim) {
+        OP_LOGE(context_->GetNodeName(), "The number of dimensions of %s should be %zu, but it is %zu",
+                dimDesc.c_str(), dim, shape.GetDimNum());
+        return false;
+    }
+    return true;
+}
+
+// Split shape checks/fill/scheduling decisions to improve readability and maintenance.
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckShapeDimAndRelation(const gert::Shape &queryShape,
+                                                                         const gert::Shape &keyShape,
+                                                                         const gert::Shape &valueShape,
+                                                                         const gert::Shape &betaShape,
+                                                                         const gert::Shape &stateShape,
+                                                                         const gert::Shape &cuSeqlensShape,
+                                                                         const gert::Shape &ssmStateShape)
+{
+    if (!CheckDim(queryShape, QKV_DIM_NUM, "query") || !CheckDim(keyShape, QKV_DIM_NUM, "key") ||
+        !CheckDim(valueShape, QKV_DIM_NUM, "value") || !CheckDim(betaShape, BETA_DIM_NUM, "beta") ||
+        !CheckDim(stateShape, STATE_DIM_NUM, "state") ||
+        !CheckDim(cuSeqlensShape, CUSEQLENS_DIM_NUM, "actual_seq_lengths") ||
+        !CheckDim(ssmStateShape, SSM_STATE_INDICES_DIM_NUM, "ssm_state_indices")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (!CheckDimEqual(queryShape, DIM_0, keyShape, DIM_0, "query", "key", "T dimension") ||
+        !CheckDimEqual(queryShape, DIM_1, keyShape, DIM_1, "query", "key", "Nk dimension") ||
+        !CheckDimEqual(queryShape, DIM_2, keyShape, DIM_2, "query", "key", "Dk dimension") ||
+        !CheckDimEqual(stateShape, DIM_1, valueShape, DIM_1, "state", "value", "Nv dimension") ||
+        !CheckDimEqual(stateShape, DIM_2, valueShape, DIM_2, "state", "value", "Dv dimension") ||
+        !CheckDimEqual(valueShape, DIM_0, queryShape, DIM_0, "value", "query", "T dimension") ||
+        !CheckDimEqual(betaShape, DIM_0, queryShape, DIM_0, "beta", "query", "T dimension") ||
+        !CheckDimEqual(betaShape, DIM_1, valueShape, DIM_1, "beta", "value", "Nv dimension") ||
+        !CheckDimEqual(stateShape, DIM_3, queryShape, DIM_2, "state", "query", "Dk dimension")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void RecurrentGatedDeltaRuleTiling::FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape,
+                                                         const gert::Shape &stateShape,
+                                                         const gert::Shape &cuSeqlensShape)
+{
+    tilingData_.t = queryShape.GetDim(DIM_0);
+    tilingData_.nk = queryShape.GetDim(DIM_1);
+    tilingData_.dk = queryShape.GetDim(DIM_2);
+    tilingData_.nv = valueShape.GetDim(DIM_1);
+    tilingData_.dv = valueShape.GetDim(DIM_2);
+    tilingData_.sBlockNum = stateShape.GetDim(DIM_0);
+    tilingData_.b = cuSeqlensShape.GetDim(DIM_0) - 1;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CheckShapeValueRangeAndRule()
+{
+    OP_CHECK_IF(tilingData_.nk > 256 || tilingData_.nv > 256 || tilingData_.dk > 512 || tilingData_.dv > 512,
+                OP_LOGE(inputParams_.opName,
+                        "nk and nv should no bigger than 256, dk and dv should no bigger than 512, but nk is %u, nv is "
+                        "%u, dk is %u, dv is %u",
+                        tilingData_.nk, tilingData_.nv, tilingData_.dk, tilingData_.dv),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(tilingData_.nv % tilingData_.nk != 0,
+                OP_LOGE(inputParams_.opName,
+                        "nv should be an integer multiple of nk, but nv is %u, nk is %u",
+                        tilingData_.nv, tilingData_.nk),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void RecurrentGatedDeltaRuleTiling::UpdateDynamicBlockDimByTaskUnits()
+{
+    // Dynamic blockDim: do not launch more cores than effective (batch, head) task units.
+    uint64_t taskUnits = static_cast<uint64_t>(tilingData_.b) * static_cast<uint64_t>(tilingData_.nv);
+    if (taskUnits == 0) {
+        taskUnits = 1;
+    }
+    uint64_t maxCoreNum = (compileInfo_.aivNum > 0) ? compileInfo_.aivNum : 1;
+    uint64_t selectedCoreNum = (taskUnits < maxCoreNum) ? taskUnits : maxCoreNum;
+    tilingData_.vectorCoreNum = static_cast<uint32_t>(selectedCoreNum);
+    OP_LOGD(context_->GetNodeName(), "taskUnits: [%llu], selected vectorCoreNum: [%u]",
+            static_cast<unsigned long long>(taskUnits), tilingData_.vectorCoreNum);
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCheckShapeDimAndRelation()
+{
+    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+    const auto &keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
+    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    const auto &betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
+    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+    const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
+    const auto &ssmStateShape = context_->GetInputShape(SSM_STATE_INDICES_INDEX)->GetOriginShape();
+    return CheckShapeDimAndRelation(queryShape, keyShape, valueShape, betaShape, stateShape, cuSeqlensShape, ssmStateShape);
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleFillTilingShapeData()
+{
+    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+    const auto &cuSeqlensShape = context_->GetInputShape(CUSEQLENS_INDEX)->GetOriginShape();
+    FillTilingShapeData(queryShape, valueShape, stateShape, cuSeqlensShape);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCheckShapeValueRangeAndRule()
+{
+    return CheckShapeValueRangeAndRule();
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleUpdateDynamicBlockDimByTaskUnits()
+{
+    UpdateDynamicBlockDimByTaskUnits();
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleInitUbCalcContext()
+{
+    ubCalcCtx_.ubSize = compileInfo_.ubSize;
+    ubCalcCtx_.aNv = CeilAlign(tilingData_.nv, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    ubCalcCtx_.aDv = CeilAlign(tilingData_.dv, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    ubCalcCtx_.aDk = CeilAlign(tilingData_.dk, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcFixedUbBytes()
+{
+    ubCalcCtx_.fixedUbBytes = CalcFixedUbBytes(ubCalcCtx_.aNv, ubCalcCtx_.aDv, ubCalcCtx_.aDk);
+    tilingData_.ubRestBytes = ubCalcCtx_.ubSize - ubCalcCtx_.fixedUbBytes;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcWorkingUbBytes()
+{
+    ubCalcCtx_.workingUbBytes = CalcWorkingUbBytes(ubCalcCtx_.aNv, ubCalcCtx_.aDv, ubCalcCtx_.aDk);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleCalcVStepCoeff()
+{
+    ubCalcCtx_.coeff = CalcVStepCoeff(ubCalcCtx_.aDk, 1, 1);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::RuleFinalizeVStepFromUb()
+{
+    return FinalizeVStepFromUb(ubCalcCtx_.ubSize, ubCalcCtx_.workingUbBytes, ubCalcCtx_.coeff);
+}
+
+// AnalyzeShapes now executes a deterministic rule-chain, easier to extend/maintain.
+ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeShapes()
+{
+    struct RuleItem {
+        const char *name;
+        HostRuleFn fn;
+    };
+    const std::array<RuleItem, 4> shapeRules = {{
+        {"RuleCheckShapeDimAndRelation", &RecurrentGatedDeltaRuleTiling::RuleCheckShapeDimAndRelation},
+        {"RuleFillTilingShapeData", &RecurrentGatedDeltaRuleTiling::RuleFillTilingShapeData},
+        {"RuleCheckShapeValueRangeAndRule", &RecurrentGatedDeltaRuleTiling::RuleCheckShapeValueRangeAndRule},
+        {"RuleUpdateDynamicBlockDimByTaskUnits", &RecurrentGatedDeltaRuleTiling::RuleUpdateDynamicBlockDimByTaskUnits},
+    }};
+    for (const auto &rule : shapeRules) {
+        OP_CHECK_IF((this->*(rule.fn))() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "AnalyzeShapes rule failed: %s", rule.name),
+                    return ge::GRAPH_FAILED);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+
+bool RecurrentGatedDeltaRuleTiling::CheckFormat(ge::Format format, const std::string &Desc)
+{
+    if (format == ge::FORMAT_FRACTAL_NZ) {
+        OP_LOGE(context_->GetNodeName(), "%s format not support NZ", Desc.c_str());
+        return false;
+    }
+    return true;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::AnalyzeFormat()
+{
+    if (!CheckFormat(context_->GetInputDesc(QUERY_INDEX)->GetStorageFormat(), "query") ||
+        !CheckFormat(context_->GetInputDesc(KEY_INDEX)->GetStorageFormat(), "key") ||
+        !CheckFormat(context_->GetInputDesc(VALUE_INDEX)->GetStorageFormat(), "value") ||
+        !CheckFormat(context_->GetInputDesc(STATE_INDEX)->GetStorageFormat(), "state") ||
+        !CheckFormat(context_->GetInputDesc(CUSEQLENS_INDEX)->GetStorageFormat(), "actual_seq_lengths") ||
+        !CheckFormat(context_->GetInputDesc(SSM_STATE_INDICES_INDEX)->GetStorageFormat(), "ssm_state_indices")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (context_->GetOptionalInputDesc(G_INDEX) != nullptr) {
+        auto gamaFormat = context_->GetOptionalInputDesc(G_INDEX)->GetStorageFormat();
+        OP_CHECK_IF(gamaFormat == ge::FORMAT_FRACTAL_NZ, OP_LOGE(context_->GetNodeName(), "gama format not support NZ"),
+                    return ge::GRAPH_FAILED);
+    }
+    if (context_->GetOptionalInputDesc(GK_INDEX) != nullptr) {
+        auto gamaKFormat = context_->GetOptionalInputDesc(GK_INDEX)->GetStorageFormat();
+        OP_CHECK_IF(gamaKFormat == ge::FORMAT_FRACTAL_NZ, OP_LOGE(context_->GetNodeName(), "gamaK format not support NZ"),
+                    return ge::GRAPH_FAILED);
+    }
+    if (context_->GetOptionalInputDesc(ACC_TO_INDEX) != nullptr) {
+        auto numAcceptedTokensFormat = context_->GetOptionalInputDesc(ACC_TO_INDEX)->GetStorageFormat();
+        OP_CHECK_IF(numAcceptedTokensFormat == ge::FORMAT_FRACTAL_NZ,
+                    OP_LOGE(context_->GetNodeName(), "numAcceptedTokens format not support NZ"), return ge::GRAPH_FAILED);
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetScale()
+{
+    auto attrs = context_->GetAttrs();
+    float scaleValue = *attrs->GetAttrPointer<float>(0);
+    tilingData_.scale = scaleValue;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetOptionalInput()
+{
+    if (context_->GetOptionalInputDesc(G_INDEX) == nullptr) {
+        tilingData_.hasGama = 0;
+    } else {
+        tilingData_.hasGama = 1;
+    }
+    if (context_->GetOptionalInputDesc(GK_INDEX) == nullptr) {
+        tilingData_.hasGamaK = 0;
+    } else {
+        tilingData_.hasGamaK = 1;
+    }
+    if (context_->GetOptionalInputDesc(ACC_TO_INDEX) == nullptr) {
+        tilingData_.hasAcceptedTokens = 0;
+    } else {
+        tilingData_.hasAcceptedTokens = 1;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void RecurrentGatedDeltaRuleTiling::PrintTilingData()
+{
+    OP_LOGD(context_->GetNodeName(), "vectorCoreNum: [%u]", tilingData_.vectorCoreNum);
+    OP_LOGD(context_->GetNodeName(), "ubCalSize: [%u]", tilingData_.ubCalSize);
+    OP_LOGD(context_->GetNodeName(), "ubRestBytes: [%u]", tilingData_.ubRestBytes);
+    OP_LOGD(context_->GetNodeName(), "t: [%u]", tilingData_.t);
+    OP_LOGD(context_->GetNodeName(), "nk: [%u]", tilingData_.nk);
+    OP_LOGD(context_->GetNodeName(), "dk: [%u]", tilingData_.dk);
+    OP_LOGD(context_->GetNodeName(), "nv: [%u]", tilingData_.nv);
+    OP_LOGD(context_->GetNodeName(), "dv: [%u]", tilingData_.dv);
+    OP_LOGD(context_->GetNodeName(), "sBlockNum: [%u]", tilingData_.sBlockNum);
+    OP_LOGD(context_->GetNodeName(), "b: [%u]", tilingData_.b);
+    OP_LOGD(context_->GetNodeName(), "vStep: [%u]", tilingData_.vStep);
+    OP_LOGD(context_->GetNodeName(), "stateOutBufferNum: [%u]", tilingData_.stateOutBufferNum);
+    OP_LOGD(context_->GetNodeName(), "attnOutBufferNum: [%u]", tilingData_.attnOutBufferNum);
+    OP_LOGD(context_->GetNodeName(), "scale: [%f]", tilingData_.scale);
+    OP_LOGD(context_->GetNodeName(), "hasGama: [%u]", tilingData_.hasGama);
+    OP_LOGD(context_->GetNodeName(), "hasGamaK: [%u]", tilingData_.hasGamaK);
+    OP_LOGD(context_->GetNodeName(), "hasAcceptedTokens: [%u]", tilingData_.hasAcceptedTokens);
+}
+
+int64_t RecurrentGatedDeltaRuleTiling::CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
+{
+    int64_t usedUbBytes = MAX_MTP * (4 * aDk + 2 * aDv); // 4 for qInQueue_ & kInQueue_, 2 for vInQueue_
+    usedUbBytes += 128;                                  // reserve 128 Bytes
+    if (tilingData_.hasGamaK) {
+        usedUbBytes += MAX_MTP * 4 * aDk; // 4 for gk gamaInQueue_
+    }
+    if (tilingData_.hasGama) {
+        usedUbBytes += MAX_MTP * 4 * aNv; // 4 for g gamaInQueue_
+    }
+    usedUbBytes += MAX_MTP * 2 * aNv; // 2 for betaInQueue_
+    return usedUbBytes;
+}
+
+int64_t RecurrentGatedDeltaRuleTiling::CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
+{
+    int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk);
+    usedUbBytes += MAX_MTP * (8 * aDk + 4 * aDv + 4 * aNv); // 8 for qk in ub, 4 for v in ub, 4 for beta in ub
+    return usedUbBytes;
+}
+
+int64_t RecurrentGatedDeltaRuleTiling::CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum,
+                                                       uint32_t attnOutBufferNum) const
+{
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
+    int64_t coeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * stateOutBufferNum)) * aDk +
+                    static_cast<int64_t>(4 * attnOutBufferNum); // stateIn/stateOut/attnOut queues
+    coeff += (4 + 4) * aDk + 4 + 4;                             // qInUb/kInUb/vInUb/deltaInUb/attnInUb
+    return coeff;
+}
+
+bool RecurrentGatedDeltaRuleTiling::EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk,
+                                                           uint32_t stateOutBufferNum, uint32_t attnOutBufferNum,
+                                                           BufferProfile &profile) const
+{
+    int64_t coeff = CalcVStepCoeff(aDk, stateOutBufferNum, attnOutBufferNum);
+    int64_t vStep = (ubSize - usedUbBytes) / coeff / 8 * 8; // 8 * sizeof(float) = 32
+    if (vStep < 8) {
+        return false;
+    }
+    int64_t repeatTime = CeilDiv(tilingData_.dv, static_cast<uint32_t>(vStep));
+    vStep = CeilAlign(CeilDiv(tilingData_.dv, static_cast<uint32_t>(repeatTime)),
+                                 static_cast<uint32_t>(8));
+    if (vStep < 8) {
+        return false;
+    }
+    profile.stateOutBufferNum = stateOutBufferNum;
+    profile.attnOutBufferNum = attnOutBufferNum;
+    profile.vStep = static_cast<uint32_t>(vStep);
+    profile.repeatTime = static_cast<uint32_t>(repeatTime);
+    profile.valid = true;
+    return true;
+}
+
+bool RecurrentGatedDeltaRuleTiling::IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const
+{
+    if (!current.valid) {
+        return true;
+    }
+    if (candidate.repeatTime != current.repeatTime) {
+        return candidate.repeatTime < current.repeatTime;
+    }
+    uint32_t candidateDepth = candidate.stateOutBufferNum + candidate.attnOutBufferNum;
+    uint32_t currentDepth = current.stateOutBufferNum + current.attnOutBufferNum;
+    if (candidateDepth != currentDepth) {
+        return candidateDepth > currentDepth;
+    }
+    return candidate.vStep > current.vStep;
+}
+
+ge::graphStatus RecurrentGatedDeltaRuleTiling::FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff)
+{
+    (void)coeff;
+    int64_t aDk = CeilAlign(tilingData_.dk, static_cast<uint32_t>(16)); // 16 * 2 = 32B
+    BufferProfile selected;
+    const std::array<BufferProfile, 4> candidates = {{
+        BufferProfile(1u, 1u, 0u, 0u, false),
+        BufferProfile(1u, 2u, 0u, 0u, false),
+        BufferProfile(2u, 2u, 0u, 0u, false),
+        BufferProfile(3u, 3u, 0u, 0u, false)
+    }};
+    for (const auto &candidate : candidates) {
+        BufferProfile profile;
+        if (!EvaluateBufferProfile(ubSize, usedUbBytes, aDk, candidate.stateOutBufferNum, candidate.attnOutBufferNum,
+                                   profile)) {
+            continue;
+        }
+        if (IsBetterProfile(profile, selected)) {
+            selected = profile;
+        }
+    }
+    
+    OP_LOGD(context_->GetNodeName(), "selected profile: stateOutBufferNum=[%u], attnOutBufferNum=[%u], vStep=[%u], repeatTime=[%u], valid=[%d]",
+            selected.stateOutBufferNum, selected.attnOutBufferNum, selected.vStep, selected.repeatTime, selected.valid);
+
+    if (!selected.valid) {
+        OP_LOGE(context_->GetNodeName(), "vStep should be bigger than 8, shape is too big");
+        return ge::GRAPH_FAILED;
+    }
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+
+    int64_t stateDtypeSize = (stateDtype == ge::DT_FLOAT) ? 4 : 2;
+
+    int64_t queueCoeff = (stateDtypeSize + static_cast<int64_t>(stateDtypeSize * selected.stateOutBufferNum)) * aDk +
+                         static_cast<int64_t>(4 * selected.attnOutBufferNum);
+    int64_t ubRestBytes = ubSize - ubCalcCtx_.fixedUbBytes - queueCoeff * static_cast<int64_t>(selected.vStep);
+    if (ubRestBytes < 0) {
+        OP_LOGE(context_->GetNodeName(), "ubRestBytes should be non-negative, but got %ld", ubRestBytes);
+        return ge::GRAPH_FAILED;
+    }
+    tilingData_.ubCalSize = compileInfo_.ubSize;
+    tilingData_.vStep = selected.vStep;
+    tilingData_.stateOutBufferNum = selected.stateOutBufferNum;
+    tilingData_.attnOutBufferNum = selected.attnOutBufferNum;
+    tilingData_.ubRestBytes = static_cast<uint32_t>(ubRestBytes);
+    return ge::GRAPH_SUCCESS;
+}
+
+// CalUbSize now runs an ordered UB rule-chain with explicit intermediate states.
+ge::graphStatus RecurrentGatedDeltaRuleTiling::CalUbSize()
+{
+    struct RuleItem {
+        const char *name;
+        HostRuleFn fn;
+    };
+    const std::array<RuleItem, 5> ubRules = {{
+        {"RuleInitUbCalcContext", &RecurrentGatedDeltaRuleTiling::RuleInitUbCalcContext},
+        {"RuleCalcFixedUbBytes", &RecurrentGatedDeltaRuleTiling::RuleCalcFixedUbBytes},
+        {"RuleCalcWorkingUbBytes", &RecurrentGatedDeltaRuleTiling::RuleCalcWorkingUbBytes},
+        {"RuleCalcVStepCoeff", &RecurrentGatedDeltaRuleTiling::RuleCalcVStepCoeff},
+        {"RuleFinalizeVStepFromUb", &RecurrentGatedDeltaRuleTiling::RuleFinalizeVStepFromUb},
+    }};
+    for (const auto &rule : ubRules) {
+        OP_CHECK_IF((this->*(rule.fn))() != ge::GRAPH_SUCCESS,
+                    OP_LOGE(inputParams_.opName, "CalUbSize rule failed: %s", rule.name),
+                    return ge::GRAPH_FAILED);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus RecurrentGatedDeltaRuleTilingFunc(gert::TilingContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_CUBE_INNER_ERR("RecurrentGatedDeltaRule", "context is null"),
+                return ge::GRAPH_FAILED);
+    return Ops::Transformer::OpTiling::TilingRegistry::GetInstance().DoTilingImpl(context);
+}
+
+static ge::graphStatus TilingPrepareForRecurrentGatedDeltaRule(gert::TilingParseContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_CUBE_INNER_ERR("RecurrentGatedDeltaRule", "context is null"),
+                return ge::GRAPH_FAILED);
+
+    fe::PlatFormInfos *platformInfo = context->GetPlatformInfo();
+    OP_CHECK_IF(platformInfo == nullptr, OPS_REPORT_CUBE_INNER_ERR(context->GetNodeName(), "platformInfoPtr is null"),
+                return ge::GRAPH_FAILED);
+
+    auto compileInfoPtr = context->GetCompiledInfo<RecurrentGatedDeltaRuleCompileInfo>();
+    OP_CHECK_IF(compileInfoPtr == nullptr, OPS_REPORT_CUBE_INNER_ERR(context->GetNodeName(), "compileInfoPtr is null"),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(RecurrentGatedDeltaRule)
+    .Tiling(RecurrentGatedDeltaRuleTilingFunc)
+    .TilingParse<RecurrentGatedDeltaRuleCompileInfo>(TilingPrepareForRecurrentGatedDeltaRule);
+} // namespace optiling
+

--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule_tiling.h
+ * \brief
+ */
+#ifndef __OP_HOST_RECURRENT_GETED_DELTA_RULE_TILING_H__
+#define __OP_HOST_RECURRENT_GETED_DELTA_RULE_TILING_H__
+#include <tiling/tiling_api.h>
+#include "register/tilingdata_base.h"
+#include "tiling_base.h"
+#include "error_log.h"
+#include "../op_kernel/recurrent_gated_delta_rule_tiling_data.h"
+
+namespace optiling {
+using namespace RecurrentGatedDeltaRule;
+
+struct RecurrentGatedDeltaRuleCompileInfo {
+    uint64_t aivNum{0UL};
+    uint64_t ubSize{0UL};
+};
+
+struct RecurrentGatedDeltaRuleInfo {
+public:
+    int64_t usedCoreNum = 0;
+    const char *opName = "RecurrentGatedDeltaRule";
+};
+
+class RecurrentGatedDeltaRuleTiling : public Ops::Transformer::OpTiling::TilingBaseClass {
+public:
+    explicit RecurrentGatedDeltaRuleTiling(gert::TilingContext *context) : Ops::Transformer::OpTiling::TilingBaseClass(context)
+    {
+        InitCompileInfo();
+    };
+    ~RecurrentGatedDeltaRuleTiling() override = default;
+
+protected:
+    bool IsCapable() override
+    {
+        return true;
+    }
+    // 1、获取平台信息比如CoreNum、UB/L1/L0C资源大小
+    ge::graphStatus GetPlatformInfo() override;
+    // 2、获取INPUT/OUTPUT/ATTR信息
+    ge::graphStatus GetShapeAttrsInfo() override;
+    // 3、计算数据切分TilingData
+    ge::graphStatus DoOpTiling() override;
+    // 4、计算高阶API的TilingData
+    ge::graphStatus DoLibApiTiling() override;
+    // 5、计算TilingKey
+    uint64_t GetTilingKey() const override;
+    // 6、计算Workspace 大小
+    ge::graphStatus GetWorkspaceSize() override;
+    // 7、保存Tiling数据
+    ge::graphStatus PostTiling() override;
+
+protected:
+    void InitCompileInfo();
+    void PrintTilingData();
+
+    //Host tiling rule-chain engine: compose shape/UB steps by ordered rules.
+    using HostRuleFn = ge::graphStatus (RecurrentGatedDeltaRuleTiling::*)();
+    struct UbCalcContext {
+        int64_t ubSize = 0;
+        int64_t aNv = 0;
+        int64_t aDv = 0;
+        int64_t aDk = 0;
+        int64_t fixedUbBytes = 0;
+        int64_t workingUbBytes = 0;
+        int64_t coeff = 0;
+    };
+
+    struct BufferProfile {
+        BufferProfile() = default;
+        BufferProfile(uint32_t s, uint32_t a, uint32_t v, uint32_t r, bool val)
+            : stateOutBufferNum(s), attnOutBufferNum(a), vStep(v), repeatTime(r), valid(val) {}
+
+        uint32_t stateOutBufferNum = 1;
+        uint32_t attnOutBufferNum = 1;
+        uint32_t vStep = 0;
+        uint32_t repeatTime = 0;
+        bool valid = false;
+    };
+
+    ge::graphStatus CheckContext();
+    ge::graphStatus AnalyzeDtype();
+    ge::graphStatus AnalyzeShapes();
+    ge::graphStatus CalUbSize();
+    ge::graphStatus GetScale();
+    ge::graphStatus GetOptionalInput();
+    ge::graphStatus AnalyzeFormat();
+    //Host tiling refactor helpers: split shape validation/fill and UB calculation.
+    ge::graphStatus CheckShapeDimAndRelation(const gert::Shape &queryShape, const gert::Shape &keyShape,
+                                             const gert::Shape &valueShape, const gert::Shape &betaShape,
+                                             const gert::Shape &stateShape, const gert::Shape &cuSeqlensShape,
+                                             const gert::Shape &ssmStateShape);
+    void FillTilingShapeData(const gert::Shape &queryShape, const gert::Shape &valueShape, const gert::Shape &stateShape,
+                             const gert::Shape &cuSeqlensShape);
+    ge::graphStatus CheckShapeValueRangeAndRule();
+    void UpdateDynamicBlockDimByTaskUnits();
+    int64_t CalcFixedUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const;
+    int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const;
+    int64_t CalcVStepCoeff(int64_t aDk, uint32_t stateOutBufferNum, uint32_t attnOutBufferNum) const;
+    bool EvaluateBufferProfile(int64_t ubSize, int64_t usedUbBytes, int64_t aDk, uint32_t stateOutBufferNum,
+                               uint32_t attnOutBufferNum, BufferProfile &profile) const;
+    bool IsBetterProfile(const BufferProfile &candidate, const BufferProfile &current) const;
+    ge::graphStatus FinalizeVStepFromUb(int64_t ubSize, int64_t usedUbBytes, int64_t coeff);
+    ge::graphStatus RuleCheckShapeDimAndRelation();
+    ge::graphStatus RuleFillTilingShapeData();
+    ge::graphStatus RuleCheckShapeValueRangeAndRule();
+    ge::graphStatus RuleUpdateDynamicBlockDimByTaskUnits();
+    ge::graphStatus RuleInitUbCalcContext();
+    ge::graphStatus RuleCalcFixedUbBytes();
+    ge::graphStatus RuleCalcWorkingUbBytes();
+    ge::graphStatus RuleCalcVStepCoeff();
+    ge::graphStatus RuleFinalizeVStepFromUb();
+
+    bool CheckDimEqual(const gert::Shape a, const int64_t dimA, gert::Shape b, const int64_t dimB, const std::string &nameA,
+                       const std::string &nameB, const std::string &dimDesc);
+    bool CheckDim(const gert::Shape shape, const size_t dim, const std::string &dimDesc);
+    bool CheckFormat(ge::Format format, const std::string &Desc);
+
+    RecurrentGatedDeltaRuleCompileInfo compileInfo_;
+    RecurrentGatedDeltaRuleTilingData tilingData_;
+    RecurrentGatedDeltaRuleInfo inputParams_;
+    UbCalcContext ubCalcCtx_;
+};
+
+} // namespace optiling
+#endif // __OP_HOST_RECURRENT_GETED_DELTA_RULE_TILING_H__

--- a/csrc/recurrent_gated_delta_rule/op_host/tiling_base.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/tiling_base.h
@@ -1,0 +1,256 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_base.h
+ * \brief
+ */
+
+#pragma once
+
+#include <sstream>
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
+#include "tiling/platform/platform_ascendc.h"
+#include "error_log.h"
+
+#ifdef ASCENDC_OP_TEST
+#define ASCENDC_EXTERN_C extern "C"
+#else
+#define ASCENDC_EXTERN_C
+#endif
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+struct AiCoreParams {
+    uint64_t ubSize = 0;
+    uint64_t blockDim = 0;
+    uint64_t aicNum = 0;
+    uint64_t l1Size = 0;
+    uint64_t l0aSize = 0;
+    uint64_t l0bSize = 0;
+    uint64_t l0cSize = 0;
+};
+
+struct CompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+struct FlashAttentionScoreGradCompileInfo {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    platform_ascendc::SocVersion socVersion;
+};
+
+struct FACompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+class TilingBaseClass {
+public:
+    explicit TilingBaseClass(gert::TilingContext* context) : context_(context)
+    {}
+
+    virtual ~TilingBaseClass() = default;
+
+    // Tiling execution framework
+    //     1. GRAPH_SUCCESS: Success, and no need to continue executing subsequent Tiling class implementations
+    //     2. GRAPH_FAILED: Failure, abort the entire Tiling process
+    //     3. GRAPH_PARAM_INVALID: This class does not support, need to continue executing other Tiling class implementations
+    ge::graphStatus DoTiling()
+    {
+        auto ret = GetShapeAttrsInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetPlatformInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        if (!IsCapable()) {
+            return ge::GRAPH_PARAM_INVALID;
+        }
+        ret = DoOpTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = DoLibApiTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetWorkspaceSize();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = PostTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        context_->SetTilingKey(GetTilingKey());
+        DumpTilingInfo();
+        return ge::GRAPH_SUCCESS;
+    }
+
+    // Update context
+    virtual void Reset(gert::TilingContext* context)
+    {
+        context_ = context;
+    }
+
+protected:
+    virtual bool IsCapable() = 0;
+    // 1. Get platform information such as CoreNum, UB/L1/L0C resource sizes
+    virtual ge::graphStatus GetPlatformInfo() = 0;
+    // 2. Get INPUT/OUTPUT/ATTR information
+    virtual ge::graphStatus GetShapeAttrsInfo() = 0;
+    // 3. Calculate data splitting TilingData
+    virtual ge::graphStatus DoOpTiling() = 0;
+    // 4. Calculate high-level API TilingData
+    virtual ge::graphStatus DoLibApiTiling() = 0;
+    // 5. Calculate TilingKey
+    [[nodiscard]] virtual uint64_t GetTilingKey() const = 0;
+    // 6. Calculate Workspace size
+    virtual ge::graphStatus GetWorkspaceSize() = 0;
+    // 7. Save Tiling data
+    virtual ge::graphStatus PostTiling() = 0;
+    // 8. Dump Tiling data
+    virtual void DumpTilingInfo()
+    {
+        int32_t enable = CheckLogLevel(static_cast<int32_t>(OP), DLOG_DEBUG);
+        if (enable != 1) {
+            return;
+        }
+        auto buf = (uint32_t*)context_->GetRawTilingData()->GetData();
+        auto bufLen = context_->GetRawTilingData()->GetDataSize();
+        std::ostringstream oss;
+        oss << "Start to dump tiling info. tilingkey:" << context_->GetTilingKey() << ", tiling data size:" << bufLen
+            << ", content:";
+        for (size_t i = 0; i < bufLen / sizeof(uint32_t); i++) {
+            oss << *(buf + i) << ",";
+            if (oss.str().length() > 640) { // Split according to 640 to avoid truncation
+                OP_LOGD(context_, "%s", oss.str().c_str());
+                oss.str("");
+            }
+        }
+        OP_LOGD(context_, "%s", oss.str().c_str());
+    }
+
+    static uint32_t CalcTschBlockDim(uint32_t sliceNum, uint32_t aicCoreNum, uint32_t aivCoreNum)
+    {
+        uint32_t ration;
+        if (aicCoreNum == 0 || aivCoreNum == 0 || aicCoreNum > aivCoreNum) {
+            return sliceNum;
+        }
+        ration = aivCoreNum / aicCoreNum;
+        return (sliceNum + (ration - 1)) / ration;
+    }
+
+    template <typename T>
+    [[nodiscard]] std::string GetShapeDebugStr(const T& shape) const
+    {
+        std::ostringstream oss;
+        oss << "[";
+        if (shape.GetDimNum() > 0) {
+            for (size_t i = 0; i < shape.GetDimNum() - 1; ++i) {
+                oss << shape.GetDim(i) << ", ";
+            }
+            oss << shape.GetDim(shape.GetDimNum() - 1);
+        }
+        oss << "]";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTensorDebugStr(
+        const gert::StorageShape* shape, const gert::CompileTimeTensorDesc* tensor)
+    {
+        if (shape == nullptr || tensor == nullptr) {
+            return "nil ";
+        }
+        std::ostringstream oss;
+        oss << "(dtype: " << ge::TypeUtils::DataTypeToSerialString(tensor->GetDataType()) << "),";
+        oss << "(shape:" << GetShapeDebugStr(shape->GetStorageShape()) << "),";
+        oss << "(ori_shape:" << GetShapeDebugStr(shape->GetOriginShape()) << "),";
+        oss << "(format: "
+            << ge::TypeUtils::FormatToSerialString(
+                   static_cast<ge::Format>(ge::GetPrimaryFormat(tensor->GetStorageFormat())))
+            << "),";
+        oss << "(ori_format: " << ge::TypeUtils::FormatToSerialString(tensor->GetOriginFormat()) << ") ";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingContextDebugStr()
+    {
+        std::ostringstream oss;
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetInputsNum(); ++i) {
+            oss << "input" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetInputShape(i), context_->GetInputDesc(i));
+        }
+
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetOutputsNum(); ++i) {
+            oss << "output" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetOutputShape(i), context_->GetOutputDesc(i));
+        }
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingDataDebugStr() const
+    {
+        auto rawTilingData = context_->GetRawTilingData();
+        auto rawTilingDataSize = rawTilingData->GetDataSize();
+        auto data = reinterpret_cast<const int32_t*>(rawTilingData->GetData());
+        size_t len = rawTilingDataSize / sizeof(int32_t);
+        std::ostringstream oss;
+        for (size_t i = 0; i < len; i++) {
+            oss << data[i] << ", ";
+        }
+        return oss.str();
+    }
+
+protected:
+    gert::TilingContext* context_ = nullptr;
+    std::unique_ptr<platform_ascendc::PlatformAscendC> ascendcPlatform_{nullptr};
+    uint32_t blockDim_{0};
+    uint64_t workspaceSize_{0};
+    uint64_t tilingKey_{0};
+    AiCoreParams aicoreParams_;
+};
+
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/recurrent_gated_delta_rule/op_host/tiling_templates_registry.h
+++ b/csrc/recurrent_gated_delta_rule/op_host/tiling_templates_registry.h
@@ -1,0 +1,351 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_templates_registry.h
+ * \brief
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+#include "exe_graph/runtime/tiling_context.h"
+#include "tiling_base.h"
+#include "error_log.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+template <typename T>
+std::unique_ptr<TilingBaseClass> TILING_CLASS(gert::TilingContext* context)
+{
+    return std::unique_ptr<T>(new (std::nothrow) T(context));
+}
+
+using TilingClassCase = std::unique_ptr<TilingBaseClass> (*)(gert::TilingContext*);
+
+class TilingCases {
+public:
+    explicit TilingCases(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    void AddTiling(int32_t priority)
+    {
+        OP_CHECK_IF(
+            cases_.find(priority) != cases_.end(), OP_LOGE(op_type_, "There are duplicate registrations."), return);
+        cases_[priority] = TILING_CLASS<T>;
+        OP_CHECK_IF(
+            cases_[priority] == nullptr,
+            OP_LOGE(op_type_, "Register op tiling func failed, please check the class name."), return);
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingCases()
+    {
+        return cases_;
+    }
+
+private:
+    std::map<int32_t, TilingClassCase> cases_;
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce with soc version --------------------------------
+class TilingRegistryNew {
+public:
+    TilingRegistryNew() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistryNew& GetInstance();
+#else
+    static TilingRegistryNew& GetInstance()
+    {
+        static TilingRegistryNew registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        if (soc_iter == registry_map_.end()) {
+            std::map<std::string, std::shared_ptr<TilingCases>> op_type_map;
+            op_type_map[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            registry_map_[soc_version] = op_type_map;
+        } else {
+            if (soc_iter->second.find(op_type) == soc_iter->second.end()) {
+                soc_iter->second[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            }
+        }
+
+        OP_CHECK_IF(
+            registry_map_[soc_version][op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[soc_version][op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        int32_t soc_version = (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION;
+        const char* op_type = context->GetNodeType();
+        fe::PlatFormInfos* platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = static_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+            if (soc_version == (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION) {
+                OP_LOGE(op_type, "Do op tiling failed, cannot find soc version.");
+                return ge::GRAPH_FAILED;
+            }
+        }
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        int32_t soc_version;
+        const char* op_type = context->GetNodeType();
+        auto platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = reinterpret_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+        }
+
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto priority_id : priorities) {
+            auto tilingCaseIter = tilingTemplateRegistryMap.find(priority_id);
+            if (tilingCaseIter != tilingTemplateRegistryMap.end()) {
+                auto templateFunc = tilingCaseIter->second(context);
+                if (templateFunc != nullptr) {
+                    ge::graphStatus status = templateFunc->DoTiling();
+                    if (status == ge::GRAPH_SUCCESS) {
+                        OP_LOGD(context, "Do general op tiling success priority=%d", priority_id);
+                        return status;
+                    }
+                    OP_LOGD(context, "Ignore general op tiling priority=%d", priority_id);
+                }
+            }
+        }
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        OP_CHECK_IF(
+            soc_iter == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the soc version %d", soc_version),
+            return empty_tiling_case_);
+        auto op_iter = soc_iter->second.find(op_type);
+        OP_CHECK_IF(
+            op_iter == soc_iter->second.end(), OP_LOGE(op_type, "Get op tiling func failed, please check the op name."),
+            return empty_tiling_case_);
+        return op_iter->second->GetTilingCases();
+    }
+
+private:
+    std::map<int32_t, std::map<std::string, std::shared_ptr<TilingCases>>> registry_map_; // key is socversion
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_{};
+};
+
+class RegisterNew {
+public:
+    explicit RegisterNew(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, int32_t soc_version)
+    {
+        auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, const std::vector<int32_t>& soc_versions)
+    {
+        for (int32_t soc_version : soc_versions) {
+            auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+            OP_CHECK_IF(
+                tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."),
+                return *this);
+            tilingCases->AddTiling<T>(priority);
+        }
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce without soc version --------------------------------
+class TilingRegistry {
+public:
+    TilingRegistry() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistry& GetInstance();
+#else
+    static TilingRegistry& GetInstance()
+    {
+        static TilingRegistry registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type)
+    {
+        if (registry_map_.find(op_type) == registry_map_.end()) {
+            registry_map_[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+        }
+        OP_CHECK_IF(
+            registry_map_[op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto priorityId : priorities) {
+            auto templateFunc = tilingTemplateRegistryMap[priorityId](context);
+            if (templateFunc != nullptr) {
+                ge::graphStatus status = templateFunc->DoTiling();
+                if (status == ge::GRAPH_SUCCESS) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", priorityId);
+                    return status;
+                }
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do op tiling failed");
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", priorityId);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type)
+    {
+        OP_CHECK_IF(
+            registry_map_.find(op_type) == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the op name."), return empty_tiling_case_);
+        return registry_map_[op_type]->GetTilingCases();
+    }
+
+private:
+    std::map<std::string, std::shared_ptr<TilingCases>> registry_map_;
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_;
+};
+
+class Register {
+public:
+    explicit Register(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    Register& tiling(int32_t priority)
+    {
+        auto tilingCases = TilingRegistry::GetInstance().RegisterOp(op_type_);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops
+
+// op_type: operator name, class_name: registered tiling class, soc_version: chip version number
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_WITH_SOCVERSION(op_type, class_name, soc_versions, priority)    \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_versions)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+#define REGISTER_TILING_TEMPLATE(op_type, class_name, priority)                                \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register VAR_UNUSED##op_type_##class_name##priority_register = \
+        Ops::Transformer::OpTiling::Register(op_type).tiling<class_name>(priority)
+
+// op_type: operator name, class_name: registered tiling class
+// soc_version: SOC version, used to distinguish different SOCs
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_NEW(op_type, class_name, soc_version, priority)                 \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_version)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+// Replaces REGISTER_TILING_TEMPLATE, if op_type is a string constant, remove the quotes
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register                                                  \
+        __attribute__((unused)) tiling_##op_type##_##class_name##_##priority##_register = \
+            Ops::Transformer::OpTiling::Register(#op_type).tiling<class_name>(priority)

--- a/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.cpp
+ * \brief
+ */
+#include "recurrent_gated_delta_rule.h"
+#include "recurrent_gated_delta_rule_tiling_data.h"
+
+
+using namespace AscendC;
+using namespace matmul; 
+using namespace RecurrentGatedDeltaRule;
+
+
+extern "C" __global__ __aicore__ void
+recurrent_gated_delta_rule(GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR beta, GM_ADDR state, GM_ADDR cuSeqlens,
+                           GM_ADDR ssmStateIndices, GM_ADDR g, GM_ADDR gk, GM_ADDR numAcceptedTokens, GM_ADDR out,
+                           GM_ADDR stateOut, GM_ADDR workspaceGM, GM_ADDR tilingGM)
+{
+    REGISTER_TILING_DEFAULT(RecurrentGatedDeltaRuleTilingData);
+    GET_TILING_DATA(tilingData, tilingGM);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
+    TPipe pipe;
+    RGDR<bfloat16_t, bfloat16_t, DTYPE_STATE> op(&tilingData);
+    RGDRInitParams initParams{query, key, value, g, gk, beta, state, cuSeqlens,
+                              ssmStateIndices, numAcceptedTokens, out, stateOut};
+    op.Init(initParams, &pipe);
+    op.Process();
+}

--- a/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
+++ b/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
@@ -1,0 +1,581 @@
+/**
+?* Copyright (c) 2025 Huawei Technologies Co., Ltd.
+?* This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+?* Please refer to the License for details. You may not use this file except in compliance with the License.
+?* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+?* INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+?* See LICENSE in the root of the software repository for the full text of the License.
+?*/
+
+/*!
+ * \file grouped_matmul_finalize_routing.h
+ * \brief
+ */
+
+#ifndef __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
+#define __RECURRENT_GATED_DELTA_RULE_KERNEL_H_
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+#include "recurrent_gated_delta_rule_tiling_data.h"
+
+namespace RecurrentGatedDeltaRule {
+
+using namespace matmul;
+using namespace AscendC;
+constexpr uint64_t BUFFER_NUM = 1;
+constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
+constexpr uint64_t MAX_MTP = 8;
+constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
+constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
+constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float
+constexpr uint32_t MAX_REPEAT_TIME = 255;
+constexpr uint32_t ADD_FOLD_REDUCE_MIN_K = 128;
+
+#ifndef RGDR_ENABLE_ADD_FOLD_REDUCE
+#define RGDR_ENABLE_ADD_FOLD_REDUCE  1
+#endif
+struct RGDRInitParams {
+    GM_ADDR query;
+    GM_ADDR key;
+    GM_ADDR value;
+    GM_ADDR gama;
+    GM_ADDR gamaK;
+    GM_ADDR beta;
+    GM_ADDR initState;
+    GM_ADDR cuSeqlens;
+    GM_ADDR ssmStateIndices;
+    GM_ADDR numAcceptedTokens;
+    GM_ADDR attnOut;
+    GM_ADDR finalState;
+};
+
+template <typename inType, typename outType, typename stateType>
+class RGDR {
+public:
+    __aicore__ inline RGDR(const RecurrentGatedDeltaRuleTilingData *tilingData)
+    {
+        B_ = tilingData->b;
+        T_ = tilingData->t;
+        NK_ = tilingData->nk;
+        realK_ = tilingData->dk;
+        NV_ = tilingData->nv;
+        realV_ = tilingData->dv;
+        scale_ = tilingData->scale;
+        hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
+        hasGama_ = (tilingData->hasGama == 1);
+        hasGamaK_ = (tilingData->hasGamaK == 1);
+        useAddFoldReduce_ = (RGDR_ENABLE_ADD_FOLD_REDUCE != 0);
+        vStep_ = tilingData->vStep;
+        stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        attnOutBufferNum_ = (tilingData->attnOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
+        restUbSize_ = tilingData->ubRestBytes;
+        alignK_ = Ceil(tilingData->dk, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        alignV_ = Ceil(tilingData->dv, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        load = 0;
+        usedblk = 0;
+    }
+
+    __aicore__ inline void Init(const RGDRInitParams &initParams, TPipe *pipe)
+    {
+        uint64_t blockDim = GetBlockNum();
+        blockIdx = GetBlockIdx();
+        if (blockIdx >= blockDim) {
+            return;
+        }
+        pipe_ = pipe;
+        SetGlobalTensors(initParams);
+        InitLocalBuffers();
+    }
+
+    __aicore__ inline void SetGlobalTensors(const RGDRInitParams &initParams)
+    {
+        queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
+        keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
+        valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
+        gamaGm_.SetGlobalBuffer((__gm__ float *)initParams.gama);
+        gamaKGm_.SetGlobalBuffer((__gm__ float *)initParams.gamaK);
+        betaGm_.SetGlobalBuffer((__gm__ inType *)initParams.beta);
+        initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
+        cuSeqlensGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
+        attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        uint32_t cubeSize = alignK_ * vStep_ * sizeof(float);
+        uint32_t singleVSize = vStep_ * sizeof(float);
+        uint32_t vSize = MAX_MTP * alignV_ * sizeof(float);
+        uint32_t kSize = MAX_MTP * alignK_ * sizeof(float);
+        uint32_t betaUbSize =
+            Ceil(MAX_MTP * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK * sizeof(float); //  8: 8 * 4 = 32B;
+        pipe_->InitBuffer(qInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
+        pipe_->InitBuffer(kInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(inType));
+        pipe_->InitBuffer(vInQueue_, BUFFER_NUM, MAX_MTP * alignV_ * sizeof(inType));
+        pipe_->InitBuffer(stateInQueue_, BUFFER_NUM, alignK_ * vStep_ * sizeof(stateType));
+        if (hasGama_) {
+            pipe_->InitBuffer(gamaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(float));
+        }
+        if (hasGamaK_) {
+            pipe_->InitBuffer(gamaKInQueue_, BUFFER_NUM, MAX_MTP * alignK_ * sizeof(float));
+        }
+        pipe_->InitBuffer(betaInQueue_, BUFFER_NUM, MAX_MTP * NV_ * sizeof(inType));
+        pipe_->InitBuffer(stateOutQueue_, stateOutBufferNum_, alignK_ * vStep_ * sizeof(stateType));
+        pipe_->InitBuffer(attnOutQueue_, attnOutBufferNum_, vStep_ * sizeof(outType));
+        pipe_->InitBuffer(tmpBuff, restUbSize_);
+        uint32_t buffOffset = 0;
+        deltaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
+        buffOffset += singleVSize;
+        attnInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(vStep_), buffOffset);
+        buffOffset += singleVSize;
+        vInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignV_), buffOffset);
+        buffOffset += vSize;
+        qInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
+        buffOffset += kSize;
+        kInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
+        buffOffset += kSize;
+        stateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+        buffOffset += cubeSize;
+        broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
+        buffOffset += cubeSize;
+        betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize), buffOffset);
+    }
+
+    __aicore__ inline void ComputeAvgload()
+    {
+        uint64_t realT = 0;
+        for (uint64_t batch_i = 1; batch_i < B_ + 1; batch_i++) {
+            realT += cuSeqlensGm_.GetValue(batch_i);
+        }
+        avgload = Ceil(realT * NV_, GetBlockNum());
+    }
+
+    __aicore__ inline void Process()
+    {
+        ComputeAvgload();
+        int32_t seq1 = cuSeqlensGm_.GetValue(0);
+        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
+            int32_t seqLen = cuSeqlensGm_.GetValue(batch_i+1);
+            if (seqLen <= 0) {
+                continue;
+            }
+            if (seqLen > static_cast<int32_t>(MAX_MTP)) {
+                return;
+            }
+            if (seq1 < 0 || seq1 > static_cast<int32_t>(T_) || (seq1 + seqLen) > static_cast<int32_t>(T_)) {
+                return;
+            }
+            int32_t seq0 = seq1;
+            seq1 += seqLen;
+            uint32_t copyFlag = 0;
+            uint64_t stateOffset;
+            for (uint64_t head_i = 0; head_i < NV_; head_i++) {
+                if (!IsCurrentBlock(seq1 - seq0)) {
+                    continue;
+                }
+                copyFlag++;
+                if (copyFlag == 1) {
+                    int32_t stateTokenIdx = seq0;
+                    if (hasAcceptedTokens_) {
+                        int32_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batch_i);
+                        if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
+                            return;
+                        }
+                        stateTokenIdx = seq0 + acceptedTokenNum - 1;
+                    }
+                    stateOffset = ssmStateIndicesGm_.GetValue(stateTokenIdx);
+                    CopyInGamaBeta(seq0, seq1);
+                }
+                ProcessHead(seq0, seq1, head_i, stateOffset);
+            }
+            if (hasGama_ && copyFlag != 0) {
+                gamaInQueue_.FreeTensor(gamaInUb);
+            }
+        }
+    }
+
+private:
+    __aicore__ inline void CopyInQKV(uint64_t vOffset, uint64_t qkOffset, int32_t seqLen)
+    {
+        LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
+        LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
+        LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
+        DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
+                                     static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
+        DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
+                                    static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
+        DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
+        if (hasGamaK_) {
+            uint32_t alignKGamma = Ceil(realK_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+            uint32_t stride = alignKGamma < alignK_ ? 1 : 0;
+            DataCopyExtParams gkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
+                                     static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), stride, 0};
+            DataCopyPadExtParams<float> gkPadParams{true, 0, static_cast<uint8_t>(alignKGamma - realK_), 0};
+            LocalTensor<float> gamaKLocal = gamaKInQueue_.AllocTensor<float>();
+            Duplicate<float>(gamaKLocal, 0, alignK_ * seqLen);
+            TEventID evevtIdVtoMte2 = GetTPipePtr()->FetchEventID(HardEvent::V_MTE2);
+            SetFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
+            WaitFlag<HardEvent::V_MTE2>(evevtIdVtoMte2);
+            DataCopyPad(gamaKLocal, gamaKGm_[vOffset / realV_ * realK_], gkInParams, gkPadParams);
+            gamaKInQueue_.EnQue<float>(gamaKLocal);
+            gamaKInUb = gamaKInQueue_.DeQue<float>();
+            Exp(gamaKInUb, gamaKInUb, alignK_ * seqLen);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
+        DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
+        qInQueue_.EnQue<inType>(qLocal);
+        kInQueue_.EnQue<inType>(kLocal);
+        vInQueue_.EnQue<inType>(vLocal);
+        qLocal = qInQueue_.DeQue<inType>();
+        kLocal = kInQueue_.DeQue<inType>();
+        vLocal = vInQueue_.DeQue<inType>();
+        Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
+        Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
+        Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
+        AscendC::PipeBarrier<PIPE_V>();
+        Muls(qInUb, qInUb, scale_, seqLen * alignK_);
+        qInQueue_.FreeTensor(qLocal);
+        kInQueue_.FreeTensor(kLocal);
+        vInQueue_.FreeTensor(vLocal);
+    }
+
+    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
+        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        stateInQueue_.EnQue<stateType>(stateLocal);
+    }
+
+    __aicore__ inline void LoadPrefetchedState(uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateLocal = stateInQueue_.DeQue<stateType>();
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateInUb, stateLocal, alignK_ * curSingleV);
+        } else {
+            Cast(stateInUb, stateLocal, AscendC::RoundMode::CAST_NONE, alignK_ * curSingleV);
+        }
+        stateInQueue_.FreeTensor(stateLocal);
+    }
+
+    __aicore__ inline void MatVecMul(const LocalTensor<float> &cubeTensor, const LocalTensor<float> &vecTensor,
+                                          LocalTensor<float> &dstTensor, uint32_t cols, bool isAdd)
+    {
+        uint8_t repeatStride = alignK_ / FP32_NUM_PER_BLOCK;
+        for (uint32_t i = 0; i < alignK_; i += REPEAT_LENTH) {
+            uint64_t mask = Std::min(REPEAT_LENTH, alignK_ - i);
+            for (uint32_t j = 0; j < cols; j += MAX_REPEAT_TIME) {
+                uint64_t repeatTime = Std::min(MAX_REPEAT_TIME, cols - j);
+                if (isAdd) {
+                    MulAddDst(dstTensor[j * alignK_ + i], cubeTensor[j * alignK_ + i], vecTensor[i], mask, repeatTime,
+                              {1, 1, 1, repeatStride, repeatStride, 0});
+                } else {
+                    Mul(dstTensor[j * alignK_ + i], cubeTensor[j * alignK_ + i], vecTensor[i], mask, repeatTime,
+                        {1, 1, 1, repeatStride, repeatStride, 0});
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void ReduceSumBaseline(LocalTensor<float> &dstTensor, const LocalTensor<float> &srcTensor,
+                                             uint32_t rows)
+    {
+        uint32_t stateShape[2] = {rows, alignK_};
+        ReduceSum<float, Pattern::Reduce::AR, true>(dstTensor, srcTensor, stateShape, true);
+    }
+
+    __aicore__ inline bool CanUseK128AddFoldFastPath(uint32_t rows) const
+    {
+        if (alignK_ != ADD_FOLD_REDUCE_MIN_K) {
+            return false;
+        }
+        if (rows == 0 || rows > MAX_REPEAT_TIME) {
+            return false;
+        }
+        return true;
+    }
+
+    __aicore__ inline void ReduceSumAddFoldK128(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                                uint32_t rows)
+    {
+        const uint8_t repeatTime = static_cast<uint8_t>(rows);
+        const uint8_t rowRepStride = static_cast<uint8_t>(alignK_ / FP32_NUM_PER_BLOCK);
+
+        // Write the folded result to the upper half to avoid the multi-repeat src0/dst overlap case.
+        Add(srcTensor[REPEAT_LENTH], srcTensor, srcTensor[REPEAT_LENTH], REPEAT_LENTH, repeatTime,
+            {1, 1, 1, rowRepStride, rowRepStride, rowRepStride});
+        AscendC::PipeBarrier<PIPE_V>();
+        WholeReduceSum(dstTensor, srcTensor[REPEAT_LENTH], REPEAT_LENTH, repeatTime, 1, 1, rowRepStride);
+    }
+
+    __aicore__ inline void ReduceSumAddFold(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                            uint32_t rows)
+    {
+        if (alignK_ < REPEAT_LENTH) {
+            ReduceSumBaseline(dstTensor, srcTensor, rows);
+            return;
+        }
+        
+        if ((alignK_ & (alignK_ - 1)) != 0) {
+            ReduceSumBaseline(dstTensor, srcTensor, rows);
+            return;
+        }
+
+        if (CanUseK128AddFoldFastPath(rows)) {
+            ReduceSumAddFoldK128(dstTensor, srcTensor, rows);
+            return;
+        }
+
+        for (uint32_t row = 0; row < rows; ++row) {
+            uint32_t rowOffset = row * alignK_;
+            uint32_t activeLen = alignK_;
+            while (activeLen > REPEAT_LENTH) {
+                uint32_t half = activeLen >> 1;
+                Add(srcTensor[rowOffset], srcTensor[rowOffset], srcTensor[rowOffset + half], half);
+                AscendC::PipeBarrier<PIPE_V>();
+                activeLen = half;
+            }
+
+            WholeReduceSum(dstTensor[row], srcTensor[rowOffset], REPEAT_LENTH, 1, 1, 1, FP32_NUM_PER_BLOCK);
+        }
+    }
+
+    __aicore__ inline void ReduceSumDispatch(LocalTensor<float> &dstTensor, LocalTensor<float> &srcTensor,
+                                             uint32_t rows)
+    {
+        if (useAddFoldReduce_ && alignK_ >= ADD_FOLD_REDUCE_MIN_K) {
+            ReduceSumAddFold(dstTensor, srcTensor, rows);
+            return;
+        }
+        ReduceSumBaseline(dstTensor, srcTensor, rows);
+    }
+
+    __aicore__ inline void Compute(uint32_t curSingleV, uint64_t curQKOffset, uint64_t curVOffset)
+    {
+        uint32_t stateShape[2] = {curSingleV, alignK_};
+        uint32_t ktShape[2] = {1, alignK_};
+        uint32_t deltaShape[2] = {curSingleV, 1};
+        if (hasGama_) {
+            Muls(stateInUb, stateInUb, gama_, alignK_ * curSingleV);
+        }
+        if (hasGamaK_) {
+            MatVecMul(stateInUb, gamaKInUb[curQKOffset], stateInUb, curSingleV, false);
+        }
+        if (hasGama_ || hasGamaK_) {
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        MatVecMul(stateInUb, kInUb[curQKOffset], broadTmpInUb, curSingleV, false);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSumDispatch(deltaInUb, broadTmpInUb, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        deltaInUb = vInUb[curVOffset] - deltaInUb;
+        AscendC::PipeBarrier<PIPE_V>();
+        Muls(deltaInUb, deltaInUb, beta_, curSingleV);
+        AscendC::PipeBarrier<PIPE_V>();
+        Broadcast<float, 2, 1>(broadTmpInUb, deltaInUb, stateShape, deltaShape); //  2: Dim Number 1: Second Dim
+        AscendC::PipeBarrier<PIPE_V>();
+        MatVecMul(broadTmpInUb, kInUb[curQKOffset], stateInUb, curSingleV, true);
+        AscendC::PipeBarrier<PIPE_V>();
+        MatVecMul(stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV, false);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
+        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+        LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
+        if constexpr (std::is_same<stateType, float32_t>()) {
+            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+        } else {
+            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        }
+        stateOutQueue_.EnQue<stateType>(stateOutLocal);
+        Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
+        attnOutQueue_.EnQue<outType>(attnOutLocal);
+    }
+
+    __aicore__ inline void CopyOutAttn(uint64_t attnOffset, uint32_t curSingleV)
+    {
+        LocalTensor<outType> attnLocal = attnOutQueue_.DeQue<outType>();
+        DataCopyParams attnOutParams{1, static_cast<uint16_t>(curSingleV * sizeof(outType)), 0, 0};
+        DataCopyPad(attnOutGm_[attnOffset], attnLocal, attnOutParams);
+        attnOutQueue_.FreeTensor(attnLocal);
+    }
+
+    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    {
+        LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
+        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    __aicore__ inline void CopyInGamaBeta(int32_t seq0, int32_t seq1)
+    {
+        int32_t seqLen = seq1 - seq0;
+        uint64_t bBatchSize = Ceil(seqLen * NV_, BF16_NUM_PER_BLOCK) * BF16_NUM_PER_BLOCK;
+        LocalTensor<inType> betaLocal = betaInQueue_.AllocTensor<inType>();
+        DataCopyParams betaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(inType)), 0, 0};
+        DataCopyPadParams padParams;
+        DataCopyPad(betaLocal, betaGm_[seq0 * NV_], betaInParams, padParams);
+        betaInQueue_.EnQue<inType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<inType>();
+        Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, bBatchSize);
+        betaInQueue_.FreeTensor(betaLocal);
+        if (hasGama_) {
+            LocalTensor<float> gamaLocal = gamaInQueue_.AllocTensor<float>();
+            DataCopyParams gamaInParams{1, static_cast<uint16_t>(seqLen * NV_ * sizeof(float)), 0, 0};
+            DataCopyPad(gamaLocal, gamaGm_[seq0 * NV_], gamaInParams, padParams);
+            gamaInQueue_.EnQue<float>(gamaLocal);
+            gamaInUb = gamaInQueue_.DeQue<float>();
+            Exp(gamaInUb, gamaInUb, seqLen * NV_);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+    }
+
+    __aicore__ inline void ProcessHead(int32_t seq0, int32_t seq1, uint64_t head_i, uint64_t stateOffset)
+    {
+        uint64_t vOffset = (seq0 * NV_ + head_i) * realV_;
+        uint64_t qkOffset = (seq0 * NK_ + head_i / (NV_ / NK_)) * realK_;
+        CopyInQKV(vOffset, qkOffset, seq1 - seq0);
+        if (realV_ == 0) {
+            if (hasGamaK_) {
+                gamaKInQueue_.FreeTensor(gamaKInUb);
+            }
+            return;
+        }
+        uint64_t nextVOffset = 0;
+        uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
+        uint64_t nextStateOffset = ((stateOffset * NV_ + head_i) * realV_) * realK_;
+        PrefetchState(nextStateOffset, nextSingleV);
+        for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
+            uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
+            LoadPrefetchedState(curSingleV);
+            nextVOffset = v_i + vStep_;
+            if (nextVOffset < realV_) {
+                nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
+                nextStateOffset = ((stateOffset * NV_ + head_i) * realV_ + nextVOffset) * realK_;
+                PrefetchState(nextStateOffset, nextSingleV);
+            }
+            uint64_t pendingAttnOffset = 0;
+            uint64_t pendingStateOffset = 0;
+            bool hasPendingAttn = false;
+            bool hasPendingState = false;
+            for (uint64_t seq_i = seq0; seq_i < seq1; seq_i++) {
+                uint64_t gbOffset = head_i + (seq_i - seq0) * NV_;
+                uint64_t curQKOffset = (seq_i - seq0) * alignK_;
+                uint64_t curVOffset = (seq_i - seq0) * alignV_ + v_i;
+                uint64_t attnOffset = (seq_i * NV_ + head_i) * realV_ + v_i;
+                uint64_t curStateOutOffset =
+                    ((ssmStateIndicesGm_.GetValue(seq_i) * NV_ + head_i) * realV_ + v_i) * realK_;
+                gama_ = hasGama_ ? gamaInUb.GetValue(gbOffset) : 1;
+                beta_ = betaInUb.GetValue(gbOffset);
+                Compute(curSingleV, curQKOffset, curVOffset);
+                if (attnOutBufferNum_ == BUFFER_NUM) {
+                    CopyOutAttn(attnOffset, curSingleV);
+                } else {
+                    if (hasPendingAttn) {
+                        CopyOutAttn(pendingAttnOffset, curSingleV);
+                    }
+                    pendingAttnOffset = attnOffset;
+                    hasPendingAttn = true;
+                }
+                if (stateOutBufferNum_ == BUFFER_NUM) {
+                    CopyOutState(curStateOutOffset, curSingleV);
+                } else {
+                    if (hasPendingState) {
+                        CopyOutState(pendingStateOffset, curSingleV);
+                    }
+                    pendingStateOffset = curStateOutOffset;
+                    hasPendingState = true;
+                }
+            }
+            if (hasPendingAttn) {
+                CopyOutAttn(pendingAttnOffset, curSingleV);
+            }
+            if (hasPendingState) {
+                CopyOutState(pendingStateOffset, curSingleV);
+            }
+        }
+        if (hasGamaK_) {
+            gamaKInQueue_.FreeTensor(gamaKInUb);
+        }
+    }
+
+    __aicore__ inline bool IsCurrentBlock(int32_t seqlen)
+    {
+        load += seqlen;
+        bool ret = (blockIdx == usedblk && seqlen > 0);
+        if (load >= avgload) {
+            load = 0;
+            usedblk++;
+        }
+        return ret;
+    }
+
+private:
+    GlobalTensor<inType> queryGm_;
+    GlobalTensor<inType> keyGm_;
+    GlobalTensor<inType> valueGm_;
+    GlobalTensor<inType> betaGm_;
+    GlobalTensor<float> gamaGm_;
+    GlobalTensor<float> gamaKGm_;
+    GlobalTensor<stateType> initStateGm_;
+    GlobalTensor<int32_t> cuSeqlensGm_;
+    GlobalTensor<int32_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> numAcceptedTokensGm_;
+    GlobalTensor<stateType> finalStateGm_;
+    GlobalTensor<outType> attnOutGm_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, 1> qInQueue_;
+    TQue<QuePosition::VECIN, 1> kInQueue_;
+    TQue<QuePosition::VECIN, 1> vInQueue_;
+    TQue<QuePosition::VECIN, 1> gamaInQueue_;
+    TQue<QuePosition::VECIN, 1> gamaKInQueue_;
+    TQue<QuePosition::VECIN, 1> betaInQueue_;
+    TQue<QuePosition::VECIN, 1> stateInQueue_;
+    TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> attnOutQueue_;
+    TQue<QuePosition::VECOUT, MAX_OUT_BUFFER_NUM> stateOutQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff;
+    LocalTensor<float> qInUb;
+    LocalTensor<float> kInUb;
+    LocalTensor<float> vInUb;
+    LocalTensor<float> gamaInUb;
+    LocalTensor<float> gamaKInUb;
+    LocalTensor<float> betaInUb;
+    LocalTensor<float> deltaInUb;
+    LocalTensor<float> broadTmpInUb;
+    LocalTensor<float> attnInUb;
+    LocalTensor<float> stateInUb;
+    uint32_t B_;
+    uint32_t T_;
+    uint32_t NK_;
+    uint32_t alignK_;
+    uint32_t realK_;
+    uint32_t NV_;
+    uint32_t alignV_;
+    uint32_t realV_;
+    uint32_t vStep_;
+    uint32_t stateOutBufferNum_;
+    uint32_t attnOutBufferNum_;
+    uint32_t restUbSize_;
+    uint32_t load;
+    uint32_t usedblk;
+    uint32_t avgload;
+    bool hasAcceptedTokens_;
+    bool hasGama_;
+    bool hasGamaK_;
+    bool useAddFoldReduce_;
+    float gama_;
+    float beta_;
+    float scale_;
+    uint64_t blockIdx;
+};
+} // namespace RecurrentGatedDeltaRule
+#endif

--- a/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h
+++ b/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file recurrent_gated_delta_rule.cpp
+ * \brief
+ */
+#ifndef RECURRENT_GATED_DELTA_RULE_TILING_DATA_H
+#define RECURRENT_GATED_DELTA_RULE_TILING_DATA_H
+
+#include "kernel_tiling/kernel_tiling.h"
+
+namespace RecurrentGatedDeltaRule {
+#pragma pack(push, 8)
+struct alignas(8) RecurrentGatedDeltaRuleTilingData { // alignas(8)确保8字节对齐
+    uint32_t vectorCoreNum;
+    uint32_t ubCalSize;
+    uint32_t ubRestBytes;
+    uint32_t t;
+    uint32_t nk;
+    uint32_t dk;
+    uint32_t nv;
+    uint32_t dv;
+    uint32_t sBlockNum;
+    uint32_t b;
+    uint32_t vStep;
+    uint32_t stateOutBufferNum;
+    uint32_t attnOutBufferNum;
+    float scale;
+    uint32_t hasGama;
+    uint32_t hasGamaK;
+    uint32_t hasAcceptedTokens;
+};
+#pragma pack(pop)
+} // RecurrentGatedDeltaRule
+
+#endif // RECURRENT_GATED_DELTA_RULE_TILING_DATA_H

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_recurrent_gated_delta_rule.py
@@ -1,0 +1,232 @@
+import gc
+import os
+import random
+
+import numpy as np
+import pytest
+import torch
+import torch_npu
+
+torch_npu.npu.set_compile_mode(jit_compile=False)
+
+seed = 42
+random.seed(seed)
+np.random.seed(seed)
+torch.manual_seed(seed)
+
+
+def golden_recurrent_gated_delta_rule(
+    query, key, value, state, beta, scale, actual_seq_lengths,
+    ssm_state_indices, g, num_accepted_tokens,
+):
+    """Pure torch/CPU golden implementation of recurrent gated delta rule.
+
+    Args:
+        query: [T, nk, dk]
+        key: [T, nk, dk]
+        value: [T, nv, dv]
+        state: [S, nv, dv, dk]
+        beta: [T, nv]
+        scale: float
+        actual_seq_lengths: [batch_size] per-sequence lengths
+        ssm_state_indices: [T] per-token state block index
+        g: [T, nv] or None
+        num_accepted_tokens: [batch_size] or None
+
+    Returns:
+        (output [T, nv, dv], updated_state [S, nv, dv, dk])
+    """
+    q = query.to(torch.float32)
+    k = key.to(torch.float32)
+    v = value.to(torch.float32)
+    initial_state = state.clone().to(torch.float32)
+    T, n_heads_v, Dv = v.shape
+    n_heads_k = q.shape[-2]
+    g = (
+        torch.ones(T, n_heads_v).to(torch.float32)
+        if g is None
+        else g.to(torch.float32).exp()
+    )
+    beta = (
+        torch.ones(T, n_heads_v).to(torch.float32)
+        if beta is None
+        else beta.to(torch.float32)
+    )
+    o = torch.empty_like(v).to(torch.float32)
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    q = q * scale
+
+    seq_start = 0
+    for i in range(len(actual_seq_lengths)):
+        if num_accepted_tokens is None:
+            init_state = initial_state[ssm_state_indices[seq_start]]
+        else:
+            init_state = initial_state[
+                ssm_state_indices[seq_start + num_accepted_tokens[i] - 1]
+            ]
+        for head_id in range(n_heads_v):
+            S = init_state[head_id]
+            for slot_id in range(seq_start, seq_start + actual_seq_lengths[i]):
+                q_i = q[slot_id][head_id // (n_heads_v // n_heads_k)]
+                k_i = k[slot_id][head_id // (n_heads_v // n_heads_k)]
+                v_i = v[slot_id][head_id]
+                alpha_i = g[slot_id][head_id]
+                beta_i = beta[slot_id][head_id]
+                S = S * alpha_i
+                x = (S * k_i.unsqueeze(-2)).sum(dim=-1)
+                y = (v_i - x) * beta_i
+                S_ = y[:, None] * k_i[None, :]
+                S = S + S_
+                initial_state[ssm_state_indices[slot_id]][head_id] = S
+                o[slot_id][head_id] = (S * q_i.unsqueeze(-2)).sum(dim=-1)
+        seq_start += actual_seq_lengths[i]
+
+    return o.to(query.dtype), initial_state.to(query.dtype)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 8])
+@pytest.mark.parametrize("mtp", [1, 2])
+@pytest.mark.parametrize("headnum", [(4, 8), (8, 16), (16, 32)])
+@pytest.mark.parametrize("headdim_k", [128])
+@pytest.mark.parametrize("headdim_v", [128])
+@pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
+def test_recurrent_gated_delta_rule(
+    batch_size, mtp, headnum, headdim_k, headdim_v, state_dtype,
+):
+    torch.manual_seed(seed)
+    dtype = torch.bfloat16
+    headnum_k, headnum_v = headnum
+    seq_lengths = torch.ones(batch_size, dtype=torch.int32) * mtp
+    T = int(torch.sum(seq_lengths))
+
+    state = torch.rand((T, headnum_v, headdim_v, headdim_k)).to(state_dtype)
+    query = torch.nn.functional.normalize(
+        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+    ).to(dtype)
+    key = torch.nn.functional.normalize(
+        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+    ).to(dtype)
+    value = torch.rand((T, headnum_v, headdim_v)).to(dtype)
+    g = torch.rand((T, headnum_v), dtype=torch.float32)
+    beta = torch.rand((T, headnum_v)).to(dtype)
+    ssm_state_indices = torch.arange(T, dtype=torch.int32)
+    num_accepted_tokens = torch.randint(1, mtp + 1, (batch_size,), dtype=torch.int32)
+    scale = headdim_k**-0.5
+
+    out_golden, state_golden = golden_recurrent_gated_delta_rule(
+        query, key, value, state, beta, scale,
+        seq_lengths, ssm_state_indices, g, num_accepted_tokens,
+    )
+    out_golden = out_golden.to(torch.float32)
+    state_golden = state_golden.to(torch.float32)
+
+    # torch_npu op expects actual_seq_lengths = [start_pos, len1, len2, ..., lenB]
+    actual_seq_lengths_npu = torch.cat([
+        torch.zeros(1, dtype=torch.int32), seq_lengths,
+    ])
+
+    state_npu = state.npu()
+    npu_out = torch_npu.npu_recurrent_gated_delta_rule(
+        query=query.npu(),
+        key=key.npu(),
+        value=value.npu(),
+        g=g.npu(),
+        beta=beta.npu(),
+        state=state_npu,
+        scale=scale,
+        actual_seq_lengths=actual_seq_lengths_npu.npu(),
+        ssm_state_indices=ssm_state_indices.npu(),
+        num_accepted_tokens=num_accepted_tokens.npu(),
+    )
+
+    torch.testing.assert_close(
+        npu_out.to(torch.float32).cpu(),
+        out_golden,
+        rtol=3e-3,
+        atol=1e-2,
+        equal_nan=True,
+    )
+    torch.testing.assert_close(
+        state_npu.to(torch.float32).cpu(),
+        state_golden,
+        rtol=3e-3,
+        atol=1e-2,
+        equal_nan=True,
+    )
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 8])
+@pytest.mark.parametrize("mtp", [1, 2])
+@pytest.mark.parametrize("headnum", [(4, 8), (8, 16)])
+@pytest.mark.parametrize("headdim_k", [128])
+@pytest.mark.parametrize("headdim_v", [128])
+@pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
+def test_recurrent_gated_delta_rule_no_accepted(
+    batch_size, mtp, headnum, headdim_k, headdim_v, state_dtype,
+):
+    torch.manual_seed(seed)
+    dtype = torch.bfloat16
+    headnum_k, headnum_v = headnum
+    seq_lengths = torch.ones(batch_size, dtype=torch.int32) * mtp
+    T = int(torch.sum(seq_lengths))
+
+    state = torch.rand((T, headnum_v, headdim_v, headdim_k)).to(state_dtype)
+    query = torch.nn.functional.normalize(
+        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+    ).to(dtype)
+    key = torch.nn.functional.normalize(
+        torch.rand((T, headnum_k, headdim_k)), p=2, dim=-1,
+    ).to(dtype)
+    value = torch.rand((T, headnum_v, headdim_v)).to(dtype)
+    g = torch.rand((T, headnum_v), dtype=torch.float32)
+    beta = torch.rand((T, headnum_v)).to(dtype)
+    ssm_state_indices = torch.arange(T, dtype=torch.int32)
+    scale = headdim_k**-0.5
+
+    out_golden, state_golden = golden_recurrent_gated_delta_rule(
+        query, key, value, state, beta, scale,
+        seq_lengths, ssm_state_indices, g, None,
+    )
+    out_golden = out_golden.to(torch.float32)
+    state_golden = state_golden.to(torch.float32)
+
+    actual_seq_lengths_npu = torch.cat([
+        torch.zeros(1, dtype=torch.int32), seq_lengths,
+    ])
+
+    state_npu = state.npu()
+    npu_out = torch_npu.npu_recurrent_gated_delta_rule(
+        query=query.npu(),
+        key=key.npu(),
+        value=value.npu(),
+        g=g.npu(),
+        beta=beta.npu(),
+        state=state_npu,
+        scale=scale,
+        actual_seq_lengths=actual_seq_lengths_npu.npu(),
+        ssm_state_indices=ssm_state_indices.npu(),
+    )
+
+    torch.testing.assert_close(
+        npu_out.to(torch.float32).cpu(),
+        out_golden,
+        rtol=3e-3,
+        atol=1e-2,
+        equal_nan=True,
+    )
+    torch.testing.assert_close(
+        state_npu.to(torch.float32).cpu(),
+        state_golden,
+        rtol=3e-3,
+        atol=1e-2,
+        equal_nan=True,
+    )
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -19,9 +19,6 @@ import torch
 import torch_npu
 from einops import rearrange
 from vllm.forward_context import get_forward_context
-from vllm.model_executor.layers.fla.ops import (
-    fused_recurrent_gated_delta_rule,
-)
 from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
 from vllm.model_executor.layers.mamba.gdn_linear_attn import GatedDeltaNetAttention
 from vllm.triton_utils import triton
@@ -271,9 +268,13 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             # 2.1: Process the multi-query part
             if spec_sequence_masks is not None:
                 cu_seqlens = spec_query_start_loc[: attn_metadata.num_spec_decodes + 1]
-                actual_seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
                 query_spec = l2norm_fwd(query_spec)
                 key_spec = l2norm_fwd(key_spec)
+                # Dispatches to the vllm-ascend AscendC custom operator
+                # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
+                # The custom op extends dtype support (e.g. float32 state) and is
+                # loaded at runtime via ASCEND_CUSTOM_OPP_PATH.
                 core_attn_out_spec = torch_npu.npu_recurrent_gated_delta_rule(
                     query=query_spec.squeeze(0),
                     key=key_spec.squeeze(0),
@@ -311,9 +312,11 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 )
             elif attn_metadata.num_decodes > 0:
                 cu_seqlens = non_spec_query_start_loc[: attn_metadata.num_decodes + 1]
-                actual_seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
                 query_non_spec = l2norm_fwd(query_non_spec)
                 key_non_spec = l2norm_fwd(key_non_spec)
+                # Dispatches to the vllm-ascend AscendC custom operator
+                # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
                 core_attn_out_non_spec = torch_npu.npu_recurrent_gated_delta_rule(
                     query=query_non_spec.squeeze(0),
                     key=key_non_spec.squeeze(0),
@@ -351,25 +354,30 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
                 # 2.1: Process the multi-query part
                 if spec_sequence_masks is not None:
-                    core_attn_out_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
-                        q=query_spec,
-                        k=key_spec,
-                        v=value_spec,
-                        g=g_spec,
-                        beta=beta_spec,
-                        initial_state=ssm_state,
-                        inplace_final_state=True,
-                        cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
-                        ssm_state_indices=spec_state_indices_tensor,
-                        num_accepted_tokens=num_accepted_tokens,
-                        use_qk_l2norm_in_kernel=True,
-                    )
+                    cu_seqlens = spec_query_start_loc[: attn_metadata.num_spec_decodes + 1]
+                    actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
+                    query_spec = l2norm_fwd(query_spec)
+                    key_spec = l2norm_fwd(key_spec)
+                    # Dispatches to the vllm-ascend AscendC custom operator
+                    # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
+                    core_attn_out_spec = torch_npu.npu_recurrent_gated_delta_rule(
+                        query=query_spec.squeeze(0),
+                        key=key_spec.squeeze(0),
+                        value=value_spec.squeeze(0),
+                        g=g_spec.squeeze(0),
+                        beta=beta_spec.squeeze(0),
+                        state=ssm_state,
+                        scale=key_spec.shape[-1] ** -0.5,
+                        actual_seq_lengths=actual_seq_lengths,
+                        ssm_state_indices=spec_state_indices_tensor.flatten(),
+                        num_accepted_tokens=num_accepted_tokens.to(torch.int32),
+                    ).unsqueeze(0)
                 else:
                     core_attn_out_spec, last_recurrent_state = None, None
 
                 # 2.2: Process the remaining part
                 if attn_metadata.num_prefills > 0:
-                    initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
+                    initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
                     clear_ssm_states(initial_state, has_initial_state)
                     (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
                         q=query_non_spec,
@@ -384,20 +392,27 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                         head_first=False,
                         use_qk_l2norm_in_kernel=True,
                     )
-                    ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(ssm_state.dtype)
-                elif attn_metadata.num_decodes > 0:
-                    core_attn_out_non_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
-                        q=query_non_spec,
-                        k=key_non_spec,
-                        v=value_non_spec,
-                        g=g_non_spec,
-                        beta=beta_non_spec,
-                        initial_state=ssm_state,
-                        inplace_final_state=True,
-                        cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
-                        ssm_state_indices=non_spec_state_indices_tensor,
-                        use_qk_l2norm_in_kernel=True,
+                    ssm_state[non_spec_state_indices_tensor] = (
+                        last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
                     )
+                elif attn_metadata.num_decodes > 0:
+                    cu_seqlens = non_spec_query_start_loc[: attn_metadata.num_decodes + 1]
+                    actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
+                    query_non_spec = l2norm_fwd(query_non_spec)
+                    key_non_spec = l2norm_fwd(key_non_spec)
+                    # Dispatches to the vllm-ascend AscendC custom operator
+                    # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
+                    core_attn_out_non_spec = torch_npu.npu_recurrent_gated_delta_rule(
+                        query=query_non_spec.squeeze(0),
+                        key=key_non_spec.squeeze(0),
+                        value=value_non_spec.squeeze(0),
+                        g=g_non_spec.squeeze(0) if g_non_spec is not None else g_non_spec,
+                        beta=beta_non_spec.squeeze(0) if beta_non_spec is not None else beta_non_spec,
+                        state=ssm_state,
+                        scale=key_non_spec.shape[-1] ** -0.5,
+                        actual_seq_lengths=actual_seq_lengths,
+                        ssm_state_indices=non_spec_state_indices_tensor,
+                    ).unsqueeze(0)
                 else:
                     core_attn_out_non_spec, last_recurrent_state = None, None
             elif attn_metadata.num_decodes > 0:


### PR DESCRIPTION
### What this PR does / why we need it?
1. New AscendC custom operator RecurrentGatedDeltaRule (csrc/recurrent_gated_delta_rule/)
2.  Updated GDN attention core computation paths (vllm_ascend/ops/gdn.py)
3. Updated build script (csrc/build_aclnn.sh)

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.18.0
- vLLM main: https://github.com/vllm-project/vllm/commit/29e48707e8144b78dd5d756f793c26a405043f3d

nightly case：
<img width="845" height="39" alt="image" src="https://github.com/user-attachments/assets/da0e7bbf-9dbb-48e4-b246-13031a18fca5" />
single ops performance：
<img width="685" height="24" alt="image" src="https://github.com/user-attachments/assets/4d6948ff-407c-4650-a670-11745f766cce" />
<img width="595" height="26" alt="image" src="https://github.com/user-attachments/assets/0c74931b-d696-479f-8456-57517bfc16f5" />
精度：
GPQA：85.01
gsm8k:
<img width="444" height="43" alt="image" src="https://github.com/user-attachments/assets/a97317bc-d3c2-4cb8-98e7-97f8560777d9" />

