### PR TITLE
[main][BugFix][KV Pool] preserve drafted connector output 

### DIFF
--- a/tests/ut/distributed/mooncake/test_ascend_store_connector.py
+++ b/tests/ut/distributed/mooncake/test_ascend_store_connector.py
@@ -1,0 +1,84 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+if not hasattr(torch, "npu"):
+    torch.npu = SimpleNamespace(Event=object)  # type: ignore[attr-defined]
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector import (  # noqa: E402
+    AscendStoreConnector,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (  # noqa: E402
+    KVPoolWorker,
+)
+
+
+class TestAscendStoreConnectorDeferredFinalize(unittest.TestCase):
+
+    def test_wait_for_save_replays_finished_requests(self):
+        connector = AscendStoreConnector.__new__(AscendStoreConnector)
+        connector.kv_role = "kv_producer"
+        connector.consumer_is_to_put = False
+        connector.use_layerwise = False
+        connector.connector_worker = MagicMock()
+        connector._finished_req_ids_waiting_for_save = {"req-1"}
+        connector._late_finished_sending = set()
+
+        metadata = SimpleNamespace()
+        connector._get_connector_metadata = MagicMock(return_value=metadata)
+        connector.connector_worker.register_finished_requests.return_value = {"req-1"}
+
+        AscendStoreConnector.wait_for_save(connector)
+
+        connector.connector_worker.wait_for_save.assert_called_once_with(metadata)
+        connector.connector_worker.register_finished_requests.assert_called_once_with({"req-1"})
+        self.assertEqual(connector._late_finished_sending, {"req-1"})
+        self.assertEqual(connector._finished_req_ids_waiting_for_save, set())
+
+    def test_get_finished_drains_late_finished_sending(self):
+        connector = AscendStoreConnector.__new__(AscendStoreConnector)
+        connector.connector_worker = MagicMock()
+        connector._finished_req_ids_waiting_for_save = set()
+        connector._late_finished_sending = {"req-late"}
+        connector._get_connector_metadata = MagicMock(return_value=SimpleNamespace())
+        connector.connector_worker.get_finished.return_value = ({"req-now"}, {"req-recv"})
+
+        done_sending, done_recving = AscendStoreConnector.get_finished(connector, {"req-finished"})
+
+        self.assertEqual(done_sending, {"req-late", "req-now"})
+        self.assertEqual(done_recving, {"req-recv"})
+        self.assertEqual(connector._finished_req_ids_waiting_for_save, {"req-finished"})
+        self.assertEqual(connector._late_finished_sending, set())
+
+
+class TestKVPoolWorkerFinishedReplay(unittest.TestCase):
+
+    def test_register_finished_requests_tracks_deferred_sends(self):
+        worker = KVPoolWorker.__new__(KVPoolWorker)
+        worker.kv_send_thread = SimpleNamespace(
+            stored_requests={"req-pending": 1, "req-ready": 0},
+            delete_finished_stored_request=MagicMock(),
+        )
+        worker.finished_store_req = set()
+
+        finished_now = KVPoolWorker.register_finished_requests(
+            worker, {"req-pending", "req-ready", "req-missing"}
+        )
+
+        self.assertEqual(finished_now, {"req-ready"})
+        self.assertEqual(worker.finished_store_req, {"req-pending"})
+        worker.kv_send_thread.delete_finished_stored_request.assert_called_once_with("req-ready")
+
+        worker.kv_send_thread.stored_requests["req-pending"] = 0
+        finished_later = KVPoolWorker.get_and_clear_finished_requests(
+            worker, set(), SimpleNamespace(preempted_req_ids=set())
+        )
+
+        self.assertEqual(finished_later, {"req-pending"})
+        worker.kv_send_thread.delete_finished_stored_request.assert_called_with("req-pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -84,6 +84,8 @@ class AscendStoreConnector(KVConnectorBase_V1):
         self._kv_cache_events: AscendStoreKVEvents | None = None
 
         self.sended_but_unfinished_reqs: set[str] = set()
+        self._finished_req_ids_waiting_for_save: set[str] = set()
+        self._late_finished_sending: set[str] = set()
 
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler = KVPoolScheduler(vllm_config, self.use_layerwise)
@@ -192,14 +194,24 @@ class AscendStoreConnector(KVConnectorBase_V1):
         if self.use_layerwise:
             return
 
-        self.connector_worker.wait_for_save(self._get_connector_metadata())
+        connector_metadata = self._get_connector_metadata()
+        self.connector_worker.wait_for_save(connector_metadata)
+        if self._finished_req_ids_waiting_for_save:
+            self._late_finished_sending |= self.connector_worker.register_finished_requests(
+                self._finished_req_ids_waiting_for_save
+            )
+            self._finished_req_ids_waiting_for_save = set()
 
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
         """Get the finished recving and sending requests."""
         assert self.connector_worker is not None
+        self._finished_req_ids_waiting_for_save = set(finished_req_ids)
         done_sending, done_recving = self.connector_worker.get_finished(
             finished_req_ids, self._get_connector_metadata()
         )
+        if self._late_finished_sending:
+            done_sending |= self._late_finished_sending
+            self._late_finished_sending = set()
         return done_sending, done_recving
 
     def get_kv_connector_kv_cache_events(self) -> AscendStoreKVEvents | None:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -523,6 +523,18 @@ class KVPoolWorker:
                     req_id
                 )
 
+        finished_sending |= self.register_finished_requests(finished_req_ids)
+        return finished_sending
+
+    def register_finished_requests(self, finished_req_ids: set[str]) -> set[str]:
+        """Replay finished request IDs after wait_for_save publishes store jobs.
+
+        When deferred KV connector finalization is enabled, get_finished() runs
+        before wait_for_save(). At that point the just-finished requests are not
+        yet present in stored_requests, so they would never enter
+        finished_store_req and their delay-free blocks would never be released.
+        """
+        finished_sending = set()
         for req_id in finished_req_ids:
             req_remain_jobs = self.kv_send_thread.stored_requests.get(  # type: ignore[union-attr]
                 req_id

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1516,10 +1516,9 @@ class NPUModelRunner(GPUModelRunner):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
-        kv_connector_output = self.kv_connector_output
-        self.kv_connector_output = None
-
         if self.execute_model_state is None:
+            kv_connector_output = self.kv_connector_output
+            self.kv_connector_output = None
             # Nothing to do (PP non-final rank case), output isn't used.
             # receive sampled token ids from the last PP rank when using
             # async scheduling + pipeline parallelism so downstream code
@@ -1628,6 +1627,10 @@ class NPUModelRunner(GPUModelRunner):
             # draft model runs so KV pool save/put can complete.
             if self.speculative_config is not None:
                 self.finalize_kv_connector()
+
+        # self.kv_connector_output may be modified during drafting.
+        kv_connector_output = self.kv_connector_output
+        self.kv_connector_output = None
 
         if self.model_config.enable_return_routed_experts:
             capturer = RoutedExpertsCapturer.get_instance()


### PR DESCRIPTION
### What this PR does / why we need it?

This fixes a KV Pool regression in PD + speculative decoding on `main`.

When speculative decoding is enabled, vLLM defers KV connector finalization
during target-model forward, and finalizes it after draft model execution.
`vllm-ascend` already calls `finalize_kv_connector()` in this path, but
`sample_tokens()` still returned the stale `kv_connector_output` captured at
the beginning of the function.

As a result, worker-side connector state updated during drafting/finalization
could be dropped before being sent back to the scheduler. For KV Pool, this
can prevent the scheduler from observing finished send events, so request
blocks remain in delay-free state and KV cache usage keeps increasing until
new waiting requests can no longer enter running.

This PR aligns `vllm-ascend` with upstream behavior:
- keep the PP non-final-rank passthrough path unchanged
- after speculative drafting and deferred connector finalization, re-read
  `self.kv_connector_output`
- return the post-drafting connector output instead of the stale pre-drafting
  snapshot

### Root cause

`sample_tokens()` did this too early:

- read `kv_connector_output = self.kv_connector_output`
- clear `self.kv_connector_output`

But in speculative decoding, connector output may be updated during:
- draft token generation
- deferred `finalize_kv_connector()`

So the returned connector output could miss the finished sending state needed
by the scheduler to free delayed KV blocks.

### Does this PR introduce any user-facing change?

Yes.

It fixes a runtime regression where KV Pool blocks may not be released
correctly in PD + speculative decoding scenarios, causing KV cache usage to
grow continuously and eventually preventing waiting requests from being
scheduled.

### How was this patch tested?
pending
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/29e48707e8144b78dd5d756f793c26a405043f3d
