### PR TITLE
[Doc] Fix wrong version map

### DIFF
--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -60,7 +60,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | vLLM Ascend | vLLM         | Python           | Stable CANN | PyTorch/torch_npu  | Triton Ascend |
 |-------------|--------------|------------------|-------------|--------------------|---------------|
-|     main    | {{main_vllm_commit}} | {{main_python_version}}   | {{main_cann_version}} | {{main_pytorch_torch_npu_version}} | {{main_triton_ascend_version}} |
+|     main    | {{main_vllm_commit}}, {{main_vllm_tag}} | {{main_python_version}}   | {{main_cann_version}} | {{main_pytorch_torch_npu_version}} | {{main_triton_ascend_version}} |
 
 ## Release cadence
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,9 +83,9 @@ myst_substitutions = {
     "ci_vllm_version": "v0.18.0",
     # main branch compatibility matrix - updated dynamically
     # vLLM commit hash for main branch
-    "main_vllm_commit": "v0.19.0",
+    "main_vllm_commit": "",
     # vLLM tag for main branch
-    "main_vllm_tag": "",
+    "main_vllm_tag": "v0.19.0",
     # Python version for main branch
     "main_python_version": ">= 3.10, < 3.12",
     # CANN version for main branch


### PR DESCRIPTION
Fix wrong version map in version policy doc

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
