### PR TITLE
[main][BugFix][KV Pool]pcp and dcp bugfix

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -30,9 +30,6 @@ class MemcacheBackend(Backend):
         try:
             soc_version = get_ascend_device_type()
             if soc_version in {AscendDeviceType.A2}:
-                import torch
-                from vllm.distributed import get_world_group
-
                 tmp_tensor = torch.zeros(1, device="npu")
                 output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
                 torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 import torch
 from vllm.config import ParallelConfig
+from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
@@ -35,15 +36,10 @@ class MemcacheBackend(Backend):
                 tmp_tensor = torch.zeros(1, device="npu")
                 output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
                 torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)
-                self.rank = parallel_config.rank
-                self.store = DistributedObjectStore()
-                res = self.store.init(self.rank)
-                assert res == 0
-            else:
-                self.rank = parallel_config.rank
-                self.store = DistributedObjectStore()
-                res = self.store.init(self.rank)
-                assert res == 0
+            self.local_rank = get_world_group().local_rank
+            self.store = DistributedObjectStore()
+            res = self.store.init(self.local_rank)
+            assert res == 0
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
             raise
@@ -52,7 +48,7 @@ class MemcacheBackend(Backend):
             raise
 
     def set_device(self):
-        device = torch.device(f"npu:{self.rank}")
+        device = torch.device(f"npu:{self.local_rank}")
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -8,6 +8,7 @@ import torch
 
 # Third Party
 from vllm.config import ParallelConfig
+from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 
@@ -30,7 +31,6 @@ class MooncakeBackend(Backend):
             ) from e
         self.config = MooncakeStoreConfig.load_from_env()
         self.store = MooncakeDistributedStore()
-        self.rank = parallel_config.rank
         if self.config.protocol == "ascend":
             local_hostname = get_ip()
             # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
@@ -67,7 +67,8 @@ class MooncakeBackend(Backend):
             raise RuntimeError(msg)
 
     def set_device(self):
-        device = torch.device(f"npu:{self.rank}")
+        local_rank = get_world_group().local_rank
+        device = torch.device(f"npu:{local_rank}")
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):


### PR DESCRIPTION
## What this PR does / why we need it?
This pull request refactors the AscendStore backends, specifically memcache_backend.py and mooncake_backend.py. It updates the initialization of the distributed object store and the NPU device setting to consistently use local_rank obtained from vllm.distributed.parallel_state.get_world_group().local_rank instead of parallel_config.rank. This change ensures correct rank handling within the distributed environment for Ascend NPUs.

## Does this PR introduce any user-facing change?
No, this is an internal refactoring to ensure correct distributed rank handling.

## How was this patch tested?
No specific testing information was provided in the pull request description.