### PR TITLE
[CI] Add OBS-based artifact upload alongside official actions in nightly workflows

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -61,6 +61,10 @@ on:
     secrets:
       KUBECONFIG_B64:
         required: true
+      OBS_ACCESS_KEY:
+        required: true
+      OBS_SECRET_KEY:
+        required: true
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -377,7 +381,19 @@ jobs:
 
       - name: Upload Ascend logs
         if: always()
-        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          name: ${{ inputs.config_file_path }}-ascend-logs
+          path: /tmp/ascend-logs.tar.gz
+          retention-days: 7
+
+      - name: Upload Ascend logs (GitHub Artifacts)
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.vars.outputs.artifact_name }}
           path: /tmp/ascend-logs.tar.gz
@@ -390,6 +406,19 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          name: nightly-test-benchmark-results-${{ inputs.name || inputs.config_file_path }}-${{ steps.bench_ts.outputs.artifact_ts }}
+          path: /tmp/benchmark_results/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload benchmark results (GitHub Artifacts)
+        if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: nightly-test-benchmark-results-${{ steps.vars.outputs.benchmark_job_name }}-${{ steps.bench_ts.outputs.artifact_ts }}

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -62,9 +62,9 @@ on:
       KUBECONFIG_B64:
         required: true
       OBS_ACCESS_KEY:
-        required: true
+        required: false
       OBS_SECRET_KEY:
-        required: true
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -393,7 +393,7 @@ jobs:
       - name: Upload Ascend logs (GitHub Artifacts)
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.vars.outputs.artifact_name }}
           path: /tmp/ascend-logs.tar.gz

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -46,9 +46,9 @@ on:
         description: branch name used as prefix in artifact/benchmark names to distinguish dual-branch test runs
     secrets:
       OBS_ACCESS_KEY:
-        required: true
+        required: false
       OBS_SECRET_KEY:
-        required: true
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -44,6 +44,11 @@ on:
         type: string
         default: ''
         description: branch name used as prefix in artifact/benchmark names to distinguish dual-branch test runs
+    secrets:
+      OBS_ACCESS_KEY:
+        required: true
+      OBS_SECRET_KEY:
+        required: true
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -224,6 +229,19 @@ jobs:
 
       - name: Upload benchmark results
         if: ${{ always() && inputs.config_file_path != '' }}
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          name: nightly-test-benchmark-results-${{ inputs.name }}-${{ steps.bench_ts.outputs.artifact_ts }}
+          path: /vllm-workspace/vllm-ascend/benchmark_results/${{ inputs.name }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload benchmark results (GitHub Artifacts)
+        if: ${{ always() && inputs.config_file_path != '' }}
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: nightly-test-benchmark-results-${{ steps.bench_ts.outputs.effective_name }}-${{ steps.bench_ts.outputs.artifact_ts }}

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -42,9 +42,9 @@ on:
         type: boolean
     secrets:
       OBS_ACCESS_KEY:
-        required: true
+        required: false
       OBS_SECRET_KEY:
-        required: true
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -255,7 +255,7 @@ jobs:
       - name: Upload Report (GitHub Artifacts)
         if: ${{ inputs.upload == true }}
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: report-${{ env.GHA_VLLM_ASCEND_VERSION }}-${{ steps.ts.outputs.artifact_ts }}
           path: /vllm-workspace/vllm-ascend/benchmarks/accuracy/

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -40,6 +40,11 @@ on:
       is_run:
         required: true
         type: boolean
+    secrets:
+      OBS_ACCESS_KEY:
+        required: true
+      OBS_SECRET_KEY:
+        required: true
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -237,7 +242,20 @@ jobs:
 
       - name: Upload Report
         if: ${{ inputs.upload == true }}
-        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY }}
+          secret_key: ${{ secrets.OBS_SECRET_KEY }}
+          name: report-${{ env.GHA_VLLM_ASCEND_VERSION }}-${{ steps.ts.outputs.artifact_ts }}
+          path: ./benchmarks/accuracy/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload Report (GitHub Artifacts)
+        if: ${{ inputs.upload == true }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
         with:
           name: report-${{ env.GHA_VLLM_ASCEND_VERSION }}-${{ steps.ts.outputs.artifact_ts }}
           path: /vllm-workspace/vllm-ascend/benchmarks/accuracy/

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -177,6 +177,9 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
+    secrets:
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   multi-node-tests:
     name: multi-node
@@ -218,6 +221,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_HK_001_INTERNAL_B64 }}
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   generate-accuracy-matrix:
     name: Generate accuracy test matrix
@@ -271,6 +276,9 @@ jobs:
           )
         }}
       upload: false
+    secrets:
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   single-node-accuracy-tests-pr-only:
     needs: [setup-vars, parse-trigger, build-image, generate-accuracy-matrix]
@@ -298,6 +306,9 @@ jobs:
           contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
         }}
       upload: false
+    secrets:
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   doc-test:
     name: doc-test
@@ -366,6 +377,7 @@ jobs:
     runs-on: linux-aarch64-a2b3-0
     steps:
       - name: Merge all benchmark result artifacts
+        continue-on-error: true
         uses: actions/upload-artifact/merge@v4
         continue-on-error: true
         with:

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -276,9 +276,6 @@ jobs:
           )
         }}
       upload: false
-    secrets:
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   single-node-accuracy-tests-pr-only:
     needs: [setup-vars, parse-trigger, build-image, generate-accuracy-matrix]
@@ -306,9 +303,6 @@ jobs:
           contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
         }}
       upload: false
-    secrets:
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   doc-test:
     name: doc-test

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -373,7 +373,6 @@ jobs:
       - name: Merge all benchmark result artifacts
         continue-on-error: true
         uses: actions/upload-artifact/merge@v4
-        continue-on-error: true
         with:
           name: nightly-a2
           pattern: nightly-test-benchmark-results-*

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -166,6 +166,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
 
   double-node-tests:
@@ -238,6 +240,8 @@ jobs:
         }}
     secrets:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
   single-node-tests:
     name: single-node
@@ -375,6 +379,9 @@ jobs:
             contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
           )
         }}
+    secrets:
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_KEY }}
 
 
   clear-pre-logs:
@@ -397,6 +404,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge all benchmark result artifacts
+        continue-on-error: true
         uses: actions/upload-artifact/merge@v4
         continue-on-error: true
         with:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -406,7 +406,6 @@ jobs:
       - name: Merge all benchmark result artifacts
         continue-on-error: true
         uses: actions/upload-artifact/merge@v4
-        continue-on-error: true
         with:
           name: nightly-a3
           pattern: nightly-test-benchmark-results-*


### PR DESCRIPTION
### What this PR does / why we need it?

Add OBS-based artifact upload (`ascend-gha-runners/artifact/upload@v0.3`) as an additional upload mechanism alongside the official `actions/upload-artifact` in all nightly test workflows running on self-hosted runners.

Self-hosted runners have limited connectivity to GitHub's artifact storage, causing frequent upload failures. Both upload paths are retained with `continue-on-error: true` so that a failure in either does not block the workflow.

**Changes:**
- Add `ascend-gha-runners/artifact/upload@v0.3` alongside `actions/upload-artifact@v4` in 3 reusable nightly workflows, both with `continue-on-error: true`
- Restore `actions/upload-artifact/merge@v4` with `continue-on-error: true` for merge steps
- Add `OBS_ACCESS_KEY` and `OBS_SECRET_KEY` secrets to reusable workflow definitions and pass them from schedule callers

**Files changed:**
- `_e2e_nightly_multi_node.yaml` — 2 upload steps duplicated (Ascend logs + benchmark results)
- `_e2e_nightly_single_node.yaml` — 1 upload step duplicated (benchmark results)
- `_e2e_nightly_single_node_models.yaml` — 1 upload step duplicated (accuracy report)
- `schedule_nightly_test_a2.yaml` — pass OBS secrets to 4 reusable workflows; merge step restored with `continue-on-error`
- `schedule_nightly_test_a3.yaml` — pass OBS secrets to 3 reusable workflows; merge step restored with `continue-on-error`

### Does this PR introduce _any_ user-facing change?

No. This only affects CI infrastructure — artifact uploads now go to both GitHub Actions artifacts and Huawei Cloud OBS. No API, interface, or behavior changes for end users.

### How was this patch tested?

- `OBS_ACCESS_KEY` and `OBS_SECRET_KEY` must be configured in the repository's GitHub Secrets before merging.
- Verified by triggering nightly workflow after secrets are configured.