### PR TITLE
[BugFix] Fix swap_blocks wrong device and missing task_done in KV transfer

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -121,7 +121,7 @@ class AscendAttentionBackend(AttentionBackend):
         dst_indices = src_to_dst[:, 1]
 
         dst_key_cache[dst_indices] = src_key_cache[src_indices].to(dst_key_cache.device)
-        dst_value_cache[dst_indices] = src_value_cache[src_indices].to(dst_key_cache.device)
+        dst_value_cache[dst_indices] = src_value_cache[src_indices].to(dst_value_cache.device)
 
     @staticmethod
     def copy_blocks(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -471,6 +471,7 @@ class KVTransferThread(threading.Thread):
                     type(e).__name__,
                     e,
                 )
+                self.request_queue.task_done()
 
     def _handle_request(self, req_meta: Any):
         pass


### PR DESCRIPTION
## Purpose

Fix two functional bugs: a wrong-device copy in `swap_blocks` and a missing `task_done()` call in the KV transfer error path that can cause queue deadlocks.

## Modifications

### Bug 1: `swap_blocks` copies value cache to wrong device

**File:** `vllm_ascend/attention/attention_v1.py`, line 114

```python
# Before (copies value cache to KEY cache's device)
dst_value_cache[dst_indices] = src_value_cache[src_indices].to(dst_key_cache.device)

# After (copies value cache to VALUE cache's device)
dst_value_cache[dst_indices] = src_value_cache[src_indices].to(dst_value_cache.device)
```

This is a copy-paste error from line 113 (the key cache line). While key and value caches typically share a device today, this would silently corrupt data in heterogeneous memory setups where they reside on different devices.

### Bug 2: Missing `task_done()` on exception in `KVTransferThread.run()`

**File:** `vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py`, line 82-83

When `_handle_request()` raises an exception, the `except` block logs the error but never calls `self.request_queue.task_done()`. This means any code that calls `queue.join()` will deadlock permanently, as the task counter is never decremented for failed requests.

## Test

- `ruff check` passes on both modified files.
- Both fixes are single-line corrections to existing logic.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
