### PR TITLE
[Misc] Add manual_seed_all interface

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -866,3 +866,7 @@ class NPUPlatform(Platform):
     @classmethod
     def use_custom_op_collectives(cls) -> bool:
         return True
+
+    @classmethod
+    def manual_seed_all(cls, seed: int) -> None:
+        pass


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds the `manual_seed_all` interface to the `NPUPlatform` class. This is necessary to allow setting the random seed across all NPU devices, ensuring reproducibility in NPU-based workloads.

### Does this PR introduce _any_ user-facing change?
Yes, it adds a new method to the platform interface that can be used to set seeds.

### How was this patch tested?
CI passed.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
