### PR TITLE
[CI] AI-Agent-Driven Main2Main Automation for vllm-ascend

### DIFF
--- a/.github/workflows/dispatch_main2main_bisect.yaml
+++ b/.github/workflows/dispatch_main2main_bisect.yaml
@@ -15,11 +15,25 @@
 #
 
 name: Bisect vLLM
-run-name: Bisect vLLM caller-${{ inputs.caller_run_id }}
+run-name: >-
+  ${{
+    inputs.caller_type == 'main2main' &&
+    format(
+      'Bisect vLLM caller-{0} pr-{1} token-{2}',
+      inputs.caller_run_id,
+      inputs.main2main_pr_number,
+      inputs.main2main_dispatch_token
+    ) ||
+    format('Bisect vLLM caller-{0}', inputs.caller_run_id)
+  }}
 
 on:
   workflow_dispatch:
     inputs:
+      caller_type:
+        description: 'Calling mode: standalone or main2main'
+        required: false
+        default: 'standalone'
       caller_run_id:
         description: 'Caller workflow run id for traceability'
         required: false
@@ -36,10 +50,22 @@ on:
         description: 'Failing pytest command(s), semicolon-separated for batch mode'
         required: true
         default: 'pytest -sv tests/e2e/multicard/4-cards/long_sequence/test_accuracy.py'
+      main2main_pr_number:
+        description: 'Main2Main PR number for callback-safe finalize dispatch'
+        required: false
+        default: ''
+      main2main_dispatch_token:
+        description: 'Current guarded dispatch token for main2main callback'
+        required: false
+        default: ''
 
 defaults:
   run:
     shell: bash -el {0}
+
+concurrency:
+  group: ${{ inputs.caller_type == 'main2main' && format('main2main-bisect-pr-{0}', inputs.main2main_pr_number) || format('bisect-vllm-{0}', github.run_id) }}
+  cancel-in-progress: false
 
 jobs:
   set-params:
@@ -48,7 +74,7 @@ jobs:
     outputs:
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
-      - name: Checkout vllm-benchmarks repo
+      - name: Checkout vllm-ascend repo
         uses: actions/checkout@v6
 
       - name: Install Python deps for bisect helper
@@ -57,7 +83,7 @@ jobs:
       - name: Resolve parameters and build matrix
         id: resolve
         run: |
-          python3 .github/workflows/scripts/bisect_helper.py batch-matrix \
+          python3 tools/bisect_helper.py batch-matrix \
             --test-cmds "${{ inputs.test_cmd }}" \
             --output-format github
 
@@ -87,7 +113,7 @@ jobs:
         UV_SYSTEM_PYTHON: ${{ matrix.cenv_UV_SYSTEM_PYTHON }}
         UV_PYTHON: ${{ matrix.cenv_UV_PYTHON }}
     steps:
-      - name: Checkout vllm-benchmarks repo
+      - name: Checkout vllm-ascend repo
         uses: actions/checkout@v6
         with:
           path: ./vllm-ascend
@@ -110,13 +136,13 @@ jobs:
           repository: vllm-project/vllm
           ref: ${{ inputs.bad_commit }}
           path: ./vllm-empty
-          fetch-depth: 500
+          fetch-depth: 0
 
       - name: Install vllm from source
         working-directory: ./vllm-empty
         run: ${{ matrix.vllm_install }}
 
-      - name: Install vllm-benchmarks
+      - name: Install vllm-ascend
         working-directory: ./vllm-ascend
         run: ${{ matrix.ascend_install }}
 
@@ -129,10 +155,10 @@ jobs:
             export "${key}=${val}"
           done
 
-          chmod +x .github/workflows/scripts/bisect_vllm.sh
+          chmod +x tools/bisect_vllm.sh
           echo "${{ matrix.test_cmds }}" > /tmp/bisect_cmds.txt
 
-          .github/workflows/scripts/bisect_vllm.sh \
+          tools/bisect_vllm.sh \
             --vllm-repo ../vllm-empty \
             --ascend-repo . \
             --test-cmds-file /tmp/bisect_cmds.txt \
@@ -164,7 +190,7 @@ jobs:
           path: /tmp/bisect_results
 
       - name: Combine summaries and emit bisect_result.json
-        run: |
+        run: |     
           : > /tmp/bisect_summary.md
           while IFS= read -r -d '' f; do
             cat "$f" >> /tmp/bisect_summary.md
@@ -173,11 +199,35 @@ jobs:
 
           cat /tmp/bisect_summary.md
 
+          python3 tools/bisect_helper.py result-json \
+            --caller-type "${{ inputs.caller_type }}" \
+            --caller-run-id "${{ inputs.caller_run_id }}" \
+            --bisect-run-id "${{ github.run_id }}" \
+            --good-commit "${{ inputs.good_commit }}" \
+            --bad-commit "${{ inputs.bad_commit }}" \
+            --test-cmd "${{ inputs.test_cmd }}" \
+            --results-dir /tmp/bisect_results \
+            --summary-file /tmp/bisect_summary.md \
+            --output /tmp/bisect_result.json
+
       - name: Upload combined summary and JSON result
         uses: actions/upload-artifact@v7
         with:
           name: bisect-summary
           path: |
             /tmp/bisect_summary.md
+            /tmp/bisect_result.json
           retention-days: 30
 
+  callback-main2main:
+    if: ${{ always() && inputs.caller_type == 'main2main' }}
+    needs: upload-all-results
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+    steps:
+      - name: Dispatch reconcile for main2main caller
+        run: |
+          gh workflow run schedule_main2main_reconcile.yaml \
+            --repo nv-action/vllm-benchmarks \
+            -f pr_number="${{ inputs.main2main_pr_number }}"

--- a/.github/workflows/dispatch_main2main_terminal.yaml
+++ b/.github/workflows/dispatch_main2main_terminal.yaml
@@ -54,7 +54,7 @@ concurrency:
 
 env:
   UPSTREAM_REPO: vllm-project/vllm-ascend
-  CONTROL_REPO_DIR: vllm-benchmarks
+  CONTROL_REPO_DIR: vllm-ascend
   MAIN2MAIN_MODEL: ${{ vars.MAIN2MAIN_MODEL || 'qwen3.6-plus' }}
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
     defaults:
       run:
-        working-directory: vllm-benchmarks
+        working-directory: vllm-ascend
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -133,14 +133,6 @@ jobs:
           print(state.get("e2e_run_id", ""))
           PY
           )
-          FIX_RUN_ID=$(python3 - <<'PY'
-          import json
-          from pathlib import Path
-          state = json.loads(Path("/tmp/main2main_state.json").read_text(encoding="utf-8"))
-          print(state.get("fix_run_id", ""))
-          PY
-          )
-
           if [ -n "${E2E_RUN_ID}" ]; then
             python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/ci_log_summary.py" \
               --repo "${{ env.UPSTREAM_REPO }}" \

--- a/.github/workflows/dispatch_main2main_terminal.yaml
+++ b/.github/workflows/dispatch_main2main_terminal.yaml
@@ -1,0 +1,276 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Main2Main Terminal
+run-name: >-
+  ${{
+    format(
+      'Main2Main Terminal action={0} pr={1} token={2}',
+      github.event.inputs.action,
+      github.event.inputs.pr_number,
+      github.event.inputs.dispatch_token
+    )
+  }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Terminal action: make_ready or manual_review'
+        required: true
+      pr_number:
+        description: 'PR number for the associated main2main run'
+        required: true
+      dispatch_token:
+        description: 'Current guarded token from main2main-state'
+        required: true
+      terminal_reason:
+        description: 'Terminal reason for manual_review'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: main2main-pr-${{ github.event.inputs.pr_number }}
+  cancel-in-progress: false
+
+env:
+  UPSTREAM_REPO: vllm-project/vllm-ascend
+  CONTROL_REPO_DIR: vllm-benchmarks
+  MAIN2MAIN_MODEL: ${{ vars.MAIN2MAIN_MODEL || 'qwen3.6-plus' }}
+
+jobs:
+  terminal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      API_TIMEOUT_MS: 3000000
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+    defaults:
+      run:
+        working-directory: vllm-benchmarks
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.CONTROL_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Validate GitHub token scopes
+        run: |
+          gh auth status
+          gh api graphql -f query='query { organization(login: "nv-action") { login } }' >/dev/null
+
+      - name: Load state comment
+        id: state
+        run: |
+          if ! python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" load-phase-context \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --pr-number "${{ github.event.inputs.pr_number }}" \
+            --dispatch-token "${{ github.event.inputs.dispatch_token }}" \
+            --state-json-out /tmp/main2main_state.json \
+            --registration-json-out /tmp/main2main_register.json \
+            --context-json-out /tmp/main2main_ctx.json >/tmp/main2main_guard.json 2>/tmp/main2main_guard.err; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$(cat /tmp/main2main_guard.err)"
+            exit 0
+          fi
+          echo "stale=false" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Claude settings
+        if: steps.state.outputs.stale != 'true' && github.event.inputs.action == 'manual_review'
+        run: |
+          rm -f .claude/settings.json .claude/settings.local.json
+          if [ -f "$HOME/.claude/settings.json" ]; then
+            python3 -m json.tool "$HOME/.claude/settings.json" >/dev/null || rm -f "$HOME/.claude/settings.json"
+          fi
+
+      - name: Validate Claude gateway configuration
+        if: steps.state.outputs.stale != 'true' && github.event.inputs.action == 'manual_review'
+        run: |
+          test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
+          test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
+
+      - name: Make PR ready
+        if: steps.state.outputs.stale != 'true' && github.event.inputs.action == 'make_ready'
+        run: |
+          gh pr ready "${{ github.event.inputs.pr_number }}" --repo "${{ env.UPSTREAM_REPO }}"
+
+      - name: Collect manual review context
+        if: steps.state.outputs.stale != 'true' && github.event.inputs.action == 'manual_review'
+        run: |
+          PR_JSON=$(gh pr view "${{ github.event.inputs.pr_number }}" \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --json number,headRefName,headRefOid,body,url)
+          echo "${PR_JSON}" > /tmp/manual_review_pr.json
+
+          E2E_RUN_ID=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          state = json.loads(Path("/tmp/main2main_state.json").read_text(encoding="utf-8"))
+          print(state.get("e2e_run_id", ""))
+          PY
+          )
+          FIX_RUN_ID=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          state = json.loads(Path("/tmp/main2main_state.json").read_text(encoding="utf-8"))
+          print(state.get("fix_run_id", ""))
+          PY
+          )
+
+          if [ -n "${E2E_RUN_ID}" ]; then
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/ci_log_summary.py" \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --run-id "${E2E_RUN_ID}" \
+              --format llm-json \
+              --output /tmp/manual_review_analysis.json
+          else
+            echo '{}' > /tmp/manual_review_analysis.json
+          fi
+
+          python3 <<'PY'
+          import json
+          from pathlib import Path
+
+          pr = json.loads(Path("/tmp/manual_review_pr.json").read_text(encoding="utf-8"))
+          analysis = json.loads(Path("/tmp/manual_review_analysis.json").read_text(encoding="utf-8"))
+          state = json.loads(Path("/tmp/main2main_state.json").read_text(encoding="utf-8"))
+          context = {
+              "pr_number": pr.get("number"),
+              "pr_url": pr.get("url"),
+              "branch": pr.get("headRefName"),
+              "head_sha": pr.get("headRefOid"),
+              "terminal_reason": "${{ github.event.inputs.terminal_reason }}",
+              "e2e_run_id": state.get("e2e_run_id", ""),
+              "fix_run_id": state.get("fix_run_id", ""),
+              "bisect_run_id": state.get("bisect_run_id", ""),
+              "dispatch_token": state.get("dispatch_token", ""),
+              "old_commit": state.get("old_commit", ""),
+              "new_commit": state.get("new_commit", ""),
+              "analysis": analysis,
+          }
+          Path("manual_review_context.json").write_text(json.dumps(context, ensure_ascii=False, indent=2), encoding="utf-8")
+          PY
+
+      - name: Generate manual review issue body with Claude
+        if: steps.state.outputs.stale != 'true' && github.event.inputs.action == 'manual_review'
+        uses: anthropics/claude-code-action/base-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            Write the final GitHub issue body for a terminal main2main failure.
+
+            Read `manual_review_context.json` from the working directory.
+            Produce a concise but actionable issue body in markdown.
+            Include:
+            - a short summary
+            - evidence
+            - likely root cause
+            - suggested next manual steps
+
+            Write the final body to `manual_review_issue.md`.
+            Do not create branches, commits, or pull requests.
+          claude_args: "--model ${{ env.MAIN2MAIN_MODEL }} --dangerously-skip-permissions --allowed-tools 'Bash(cat *),Bash(python3 *),Read,Write,Edit,Glob,Grep'"
+          show_full_output: true
+        env:
+          CLAUDE_WORKING_DIR: ${{ github.workspace }}/${{ env.CONTROL_REPO_DIR }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+
+      - name: Create manual review issue
+        if: steps.state.outputs.stale != 'true' && github.event.inputs.action == 'manual_review'
+        run: |
+          test -s manual_review_issue.md || { echo "::error::manual_review_issue.md was not created"; exit 1; }
+          gh issue create \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --title "main2main: manual review needed ($(date +%Y-%m-%d))" \
+            --label "main2main" \
+            --body-file manual_review_issue.md > /tmp/manual_review_issue_url.txt
+
+      - name: Update state comment
+        if: steps.state.outputs.stale != 'true'
+        run: |
+          python3 <<'PY'
+          import json
+          from pathlib import Path
+
+          state = json.loads(Path("/tmp/main2main_state.json").read_text(encoding="utf-8"))
+          if "${{ github.event.inputs.action }}" == "make_ready":
+              state["phase"] = "done"
+              state["status"] = "ready"
+              state["terminal_reason"] = ""
+              state["dispatch_token"] = ""
+              state["workflow_error_count"] = 0
+              state["last_transition"] = "terminal/make_ready"
+          else:
+              state["phase"] = "done"
+              state["status"] = "manual_review"
+              state["terminal_reason"] = "${{ github.event.inputs.terminal_reason }}"
+              state["dispatch_token"] = ""
+              state["workflow_error_count"] = 0
+              state["last_transition"] = "terminal/manual_review"
+          state["updated_by"] = "dispatch_main2main_terminal.yaml/${{ github.event.inputs.action }}"
+          Path("/tmp/main2main_state_next.json").write_text(json.dumps(state, ensure_ascii=True, indent=2), encoding="utf-8")
+          PY
+          python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" state-write \
+            --json-file /tmp/main2main_state_next.json > /tmp/main2main_state_next_comment.md
+
+          COMMENT_ID=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/${COMMENT_ID}" \
+            -f body="$(cat /tmp/main2main_state_next_comment.md)" >/dev/null
+
+      - name: Retry terminal workflow after transient failure
+        if: ${{ failure() && steps.state.outputs.stale != 'true' }}
+        run: |
+          if [ ! -f /tmp/main2main_state.json ] || [ ! -f /tmp/main2main_ctx.json ]; then
+            echo "::warning::Terminal workflow failed before state was fully loaded; retry manually from the latest state comment."
+            exit 0
+          fi
+          mapfile -t RECOVERY_FIELDS < <(
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-workflow-error-recovery \
+              --state-file /tmp/main2main_state.json \
+              --max-retries 1 \
+              --terminal-reason "${{ github.event.inputs.terminal_reason }}" \
+              --retry-transition "retry/dispatch_main2main_terminal.yaml/${{ github.event.inputs.action }}" \
+              --terminal-transition "error_exhausted/dispatch_main2main_terminal.yaml/${{ github.event.inputs.action }}" \
+              --updated-by "dispatch_main2main_terminal.yaml/${{ github.event.inputs.action }}_failure" \
+              --state-json-out /tmp/main2main_state_error.json \
+              --state-comment-out /tmp/main2main_state_error_comment.md \
+            | python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload["action"]); print(payload["dispatch_token"])'
+          )
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_error_comment.md)" >/dev/null
+          NEXT_ACTION="${RECOVERY_FIELDS[0]}"
+          NEXT_TOKEN="${RECOVERY_FIELDS[1]}"
+          if [ "${NEXT_ACTION}" = "retry" ]; then
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action="${{ github.event.inputs.action }}" \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}" \
+              -f terminal_reason="${{ github.event.inputs.terminal_reason }}"
+          else
+            echo "::warning::Terminal workflow retry budget exhausted; leaving state for manual recovery."
+          fi

--- a/.github/workflows/schedule_main2main_auto.yaml
+++ b/.github/workflows/schedule_main2main_auto.yaml
@@ -61,9 +61,9 @@ permissions:
 
 env:
   UPSTREAM_REPO: vllm-project/vllm-ascend
-  FORK_OWNER: Meihan-chen
-  CONTROL_REPO_DIR: vllm-benchmarks
-  WORK_REPO_DIR: vllm-benchmarks-work
+  FORK_OWNER: vllm-ascend-ci
+  CONTROL_REPO_DIR: vllm-ascend
+  WORK_REPO_DIR: vllm-ascend-work
   MAIN2MAIN_MODEL: ${{ vars.MAIN2MAIN_MODEL || 'qwen3.6-plus' }}
 
 jobs:
@@ -76,33 +76,27 @@ jobs:
       cancel-in-progress: false
     defaults:
       run:
-        working-directory: vllm-benchmarks-work
+        working-directory: vllm-ascend-work
     env:
       GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       API_TIMEOUT_MS: 3000000
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
     steps:
-      - name: Checkout vLLM-benchmarks repo
+      - name: Checkout vllm-ascend repo
         uses: actions/checkout@v6
         with:
           repository: vllm-project/vllm-ascend
-          token: ${{ secrets.PAT_TOKEN }}
           path: ${{ env.CONTROL_REPO_DIR }}
           fetch-depth: 0
 
-      - name: Checkout vLLM-benchmarks fork repo
+      - name: Checkout vllm-ascend fork repo
         uses: actions/checkout@v6
         with:
-          repository: Meihan-chen/vllm-benchmarks
+          repository: vllm-ascend-ci/vllm-ascend
           token: ${{ secrets.PAT_TOKEN }}
           path: ${{ env.WORK_REPO_DIR }}
           fetch-depth: 0
-
-      - name: Configure git identity
-        run: |
-          git config user.name "Meihan-chen"
-          git config user.email "jcccx.cmh@gmail.com"
 
       - name: Validate GitHub token scopes
         run: |
@@ -111,6 +105,8 @@ jobs:
 
       - name: Validate Claude gateway configuration
         run: |
+          git config user.name "vllm-ascend-ci"
+          git config user.email "vllm-ascend-ci@users.noreply.github.com"
           test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
           test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
 
@@ -190,7 +186,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           prompt: |
-            Use the main2main skill to adapt vllm-benchmarks to the latest vLLM main branch.
+            Use the main2main skill to adapt vllm-ascend to the latest vLLM main branch.
             The NEW_COMMIT environment variable is set to ${{ steps.detect.outputs.new_commit }}.
             The upstream vLLM source is checked out at ../vllm-upstream.
             Analyze the upstream diff, apply adaptation fixes, and update all commit references.
@@ -221,12 +217,14 @@ jobs:
 
           Automated adaptation to upstream vLLM main branch changes.
           BODY_EOF
-          echo "" >> /tmp/pr_body.md
-          echo "**Commit range:** \`${{ steps.detect.outputs.old_commit }}\`...\`${{ steps.detect.outputs.new_commit }}\`" >> /tmp/pr_body.md
-          echo "### Phase 1: detect-and-adapt" >> /tmp/pr_body.md
-          echo "**Pipeline:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/pr_body.md
-          echo "" >> /tmp/pr_body.md
-          git log -1 --pretty=%B >> /tmp/pr_body.md
+          {
+            echo ""
+            echo "**Commit range:** \`${{ steps.detect.outputs.old_commit }}\`...\`${{ steps.detect.outputs.new_commit }}\`"
+            echo "### Phase 1: detect-and-adapt"
+            echo "**Pipeline:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            git log -1 --pretty=%B
+          } >> /tmp/pr_body.md
 
           HEAD_REF="${{ env.FORK_OWNER }}:${{ steps.branch.outputs.name }}"
           PR_URL=$(gh pr create \
@@ -284,20 +282,19 @@ jobs:
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
     defaults:
       run:
-        working-directory: vllm-benchmarks-work
+        working-directory: vllm-ascend-work
     steps:
-      - name: Checkout vLLM-benchmarks repo
+      - name: Checkout vllm-ascend repo
         uses: actions/checkout@v6
         with:
           repository: vllm-project/vllm-ascend
-          token: ${{ secrets.PAT_TOKEN }}
           path: ${{ env.CONTROL_REPO_DIR }}
           fetch-depth: 0
 
       - name: Checkout working repository
         uses: actions/checkout@v6
         with:
-          repository: Meihan-chen/vllm-benchmarks
+          repository: vllm-ascend-ci/vllm-ascend
           token: ${{ secrets.PAT_TOKEN }}
           path: ${{ env.WORK_REPO_DIR }}
           fetch-depth: 0
@@ -338,8 +335,8 @@ jobs:
       - name: Configure git and validate Claude gateway
         if: steps.ctx.outputs.stale != 'true'
         run: |
-          git config user.name "main2main-bot"
-          git config user.email "main2main-bot@noreply.github.com"
+          git config user.name "vllm-ascend-ci"
+          git config user.email "vllm-ascend-ci@users.noreply.github.com"
           test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
           test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
           rm -f .claude/settings.json .claude/settings.local.json
@@ -488,13 +485,12 @@ jobs:
       API_TIMEOUT_MS: 3000000
     defaults:
       run:
-        working-directory: vllm-benchmarks
+        working-directory: vllm-ascend
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          repository: vllm-project/vllm-ascend
-          token: ${{ secrets.PAT_TOKEN }}
+          repository: vllm-project/vllm-ascend、
           path: ${{ env.CONTROL_REPO_DIR }}
           fetch-depth: 0
 
@@ -554,7 +550,7 @@ jobs:
             -f main2main_dispatch_token="${{ github.event.inputs.dispatch_token }}"
 
           BISECT_RUN_ID=""
-          for attempt in $(seq 1 20); do
+          for _ in $(seq 1 20); do
             gh run list \
               --repo "${{ env.UPSTREAM_REPO }}" \
               --workflow dispatch_main2main_bisect.yaml \
@@ -637,20 +633,19 @@ jobs:
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
     defaults:
       run:
-        working-directory: vllm-benchmarks-work
+        working-directory: vllm-ascend-work
     steps:
-      - name: Checkout vLLM-benchmarks repo
+      - name: Checkout vllm-ascend repo
         uses: actions/checkout@v6
         with:
           repository: vllm-project/vllm-ascend
-          token: ${{ secrets.PAT_TOKEN }}
           path: ${{ env.CONTROL_REPO_DIR }}
           fetch-depth: 0
 
       - name: Checkout working repository
         uses: actions/checkout@v6
         with:
-          repository: Meihan-chen/vllm-benchmarks
+          repository: vllm-ascend-ci/vllm-ascend
           token: ${{ secrets.PAT_TOKEN }}
           path: ${{ env.WORK_REPO_DIR }}
           fetch-depth: 0
@@ -720,8 +715,8 @@ jobs:
       - name: Configure git and validate Claude gateway
         if: steps.ctx.outputs.stale != 'true'
         run: |
-          git config user.name "main2main-bot"
-          git config user.email "main2main-bot@noreply.github.com"
+          git config user.name "vllm-ascend-ci"
+          git config user.email "vllm-ascend-ci@users.noreply.github.com"
           test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
           test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
           rm -f .claude/settings.json .claude/settings.local.json

--- a/.github/workflows/schedule_main2main_auto.yaml
+++ b/.github/workflows/schedule_main2main_auto.yaml
@@ -1,0 +1,881 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Main2Main Auto
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'Main2Main Auto mode={0} pr={1} token={2}',
+      github.event.inputs.mode,
+      github.event.inputs.pr_number,
+      github.event.inputs.dispatch_token
+    ) ||
+    'Main2Main Auto detect'
+  }}
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Execution mode: detect, fix_phase2, fix_phase3_prepare, or fix_phase3_finalize'
+        required: false
+        default: 'detect'
+      target_commit:
+        description: 'Target vLLM commit hash (default: latest vLLM main HEAD)'
+        required: false
+        default: ''
+      pr_number:
+        description: 'PR number for explicit phase runs'
+        required: false
+        default: ''
+      dispatch_token:
+        description: 'Current guarded token for explicit phase runs'
+        required: false
+        default: ''
+      bisect_run_id:
+        description: 'Bisect workflow run id for fix_phase3_finalize'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+
+env:
+  UPSTREAM_REPO: vllm-project/vllm-ascend
+  FORK_OWNER: Meihan-chen
+  CONTROL_REPO_DIR: vllm-benchmarks
+  WORK_REPO_DIR: vllm-benchmarks-work
+  MAIN2MAIN_MODEL: ${{ vars.MAIN2MAIN_MODEL || 'qwen3.6-plus' }}
+
+jobs:
+  detect-and-adapt:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.mode == '' || github.event.inputs.mode == 'detect'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: main2main-detect
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: vllm-benchmarks-work
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      API_TIMEOUT_MS: 3000000
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+    steps:
+      - name: Checkout vLLM-benchmarks repo
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.CONTROL_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Checkout vLLM-benchmarks fork repo
+        uses: actions/checkout@v6
+        with:
+          repository: Meihan-chen/vllm-benchmarks
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.WORK_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "Meihan-chen"
+          git config user.email "jcccx.cmh@gmail.com"
+
+      - name: Validate GitHub token scopes
+        run: |
+          gh auth status
+          gh api graphql -f query='query { organization(login: "nv-action") { login } }' >/dev/null
+
+      - name: Validate Claude gateway configuration
+        run: |
+          test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
+          test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
+
+      - name: Checkout upstream vLLM source
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm
+          ref: ${{ inputs.target_commit != '' && inputs.target_commit || 'main' }}
+          path: vllm-upstream
+          fetch-depth: 0
+
+      - name: Detect vLLM version change
+        id: detect
+        run: |
+          OLD_COMMIT=$(grep -oE '[0-9a-f]{40}' "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/docs/source/community/versioning_policy.md" | head -1)
+          if [ -z "$OLD_COMMIT" ]; then
+            echo "::error::Could not extract pinned vLLM commit from versioning_policy.md"
+            exit 1
+          fi
+          echo "old_commit=$OLD_COMMIT" >> "$GITHUB_OUTPUT"
+
+          TARGET="${{ inputs.target_commit }}"
+          if [ -n "$TARGET" ]; then
+            if ! echo "$TARGET" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "::error::Invalid target_commit format: '$TARGET' (expected 40-char SHA)"
+              exit 1
+            fi
+          else
+            TARGET=$(git -C "$GITHUB_WORKSPACE/vllm-upstream" rev-parse HEAD)
+          fi
+          echo "new_commit=$TARGET" >> "$GITHUB_OUTPUT"
+
+          if [ "$OLD_COMMIT" = "$TARGET" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing main2main PR
+        if: steps.detect.outputs.skip != 'true'
+        id: dedup
+        run: |
+          EXISTING=$(gh pr list \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --label main2main \
+            --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Active main2main PR #${EXISTING} already exists. Skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create working branch
+        if: steps.detect.outputs.skip != 'true' && steps.dedup.outputs.skip != 'true'
+        id: branch
+        run: |
+          BRANCH="main2main_auto_$(date +%Y-%m-%d_%H-%M)"
+          git remote add upstream "https://github.com/${{ env.UPSTREAM_REPO }}.git" || \
+            git remote set-url upstream "https://github.com/${{ env.UPSTREAM_REPO }}.git"
+          git fetch upstream main
+          git checkout -B "$BRANCH" upstream/main
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Claude settings
+        if: steps.branch.outputs.name
+        run: |
+          rm -f .claude/settings.json .claude/settings.local.json
+          if [ -f "$HOME/.claude/settings.json" ]; then
+            python3 -m json.tool "$HOME/.claude/settings.json" >/dev/null || rm -f "$HOME/.claude/settings.json"
+          fi
+
+      - name: Claude adapt to new vLLM
+        if: steps.branch.outputs.name
+        uses: anthropics/claude-code-action/base-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            Use the main2main skill to adapt vllm-benchmarks to the latest vLLM main branch.
+            The NEW_COMMIT environment variable is set to ${{ steps.detect.outputs.new_commit }}.
+            The upstream vLLM source is checked out at ../vllm-upstream.
+            Analyze the upstream diff, apply adaptation fixes, and update all commit references.
+            Commit your changes with '-s' but do NOT create a PR — the workflow handles that.
+          claude_args: "--model ${{ env.MAIN2MAIN_MODEL }} --dangerously-skip-permissions --allowed-tools 'Bash(git *),Bash(gh *),Bash(grep *),Bash(sed *),Bash(python3 *),Read,Write,Edit,Glob,Grep'"
+          show_full_output: true
+        env:
+          OLD_COMMIT: ${{ steps.detect.outputs.old_commit }}
+          NEW_COMMIT: ${{ steps.detect.outputs.new_commit }}
+          VLLM_UPSTREAM_DIR: ${{ github.workspace }}/vllm-upstream
+          CLAUDE_WORKING_DIR: ${{ github.workspace }}/${{ env.WORK_REPO_DIR }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+
+      - name: Finalize branch and create draft PR
+        if: steps.branch.outputs.name
+        id: pr
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -s -m "feat: adapt to vLLM main (${{ steps.detect.outputs.old_commit }}...${{ steps.detect.outputs.new_commit }})"
+          fi
+
+          git push --force-with-lease -u origin "${{ steps.branch.outputs.name }}"
+
+          PR_TITLE="feat: adapt to vLLM main ($(date +%Y-%m-%d))"
+          cat > /tmp/pr_body.md <<'BODY_EOF'
+          ## Summary
+
+          Automated adaptation to upstream vLLM main branch changes.
+          BODY_EOF
+          echo "" >> /tmp/pr_body.md
+          echo "**Commit range:** \`${{ steps.detect.outputs.old_commit }}\`...\`${{ steps.detect.outputs.new_commit }}\`" >> /tmp/pr_body.md
+          echo "### Phase 1: detect-and-adapt" >> /tmp/pr_body.md
+          echo "**Pipeline:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> /tmp/pr_body.md
+          echo "" >> /tmp/pr_body.md
+          git log -1 --pretty=%B >> /tmp/pr_body.md
+
+          HEAD_REF="${{ env.FORK_OWNER }}:${{ steps.branch.outputs.name }}"
+          PR_URL=$(gh pr create \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --head "$HEAD_REF" \
+            --base main \
+            --title "$PR_TITLE" \
+            --body-file /tmp/pr_body.md \
+            --draft)
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Add labels to trigger E2E-Full
+        if: steps.pr.outputs.number
+        run: |
+          gh pr edit "${{ steps.pr.outputs.number }}" \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --add-label "main2main,ready,ready-for-test"
+
+      - name: Publish registration and live state comments
+        if: steps.pr.outputs.number
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          TOKEN=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" mint-dispatch-token)
+          python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-detect-artifacts \
+            --pr-number "${{ steps.pr.outputs.number }}" \
+            --branch "${{ steps.branch.outputs.name }}" \
+            --head-sha "${HEAD_SHA}" \
+            --old-commit "${{ steps.detect.outputs.old_commit }}" \
+            --new-commit "${{ steps.detect.outputs.new_commit }}" \
+            --dispatch-token "${TOKEN}" \
+            --state-json-out /tmp/main2main_state.json \
+            --register-json-out /tmp/main2main_register.json \
+            --state-comment-out /tmp/main2main_state_comment.md \
+            --register-comment-out /tmp/main2main_register_comment.md
+
+          gh pr comment "${{ steps.pr.outputs.number }}" \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --body-file /tmp/main2main_register_comment.md
+          gh pr comment "${{ steps.pr.outputs.number }}" \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --body-file /tmp/main2main_state_comment.md
+
+  fix-phase2:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'fix_phase2'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: main2main-pr-${{ github.event.inputs.pr_number }}
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      API_TIMEOUT_MS: 3000000
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+    defaults:
+      run:
+        working-directory: vllm-benchmarks-work
+    steps:
+      - name: Checkout vLLM-benchmarks repo
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.CONTROL_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Checkout working repository
+        uses: actions/checkout@v6
+        with:
+          repository: Meihan-chen/vllm-benchmarks
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.WORK_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Validate GitHub token scopes
+        run: |
+          gh auth status
+          gh api graphql -f query='query { organization(login: "nv-action") { login } }' >/dev/null
+
+      - name: Load state and checkout branch
+        id: ctx
+        run: |
+          if ! python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" load-phase-context \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --pr-number "${{ github.event.inputs.pr_number }}" \
+            --expected-phase 2 \
+            --expected-status fixing \
+            --dispatch-token "${{ github.event.inputs.dispatch_token }}" \
+            --state-json-out /tmp/main2main_state.json \
+            --registration-json-out /tmp/main2main_register.json \
+            --context-json-out /tmp/main2main_ctx.json >/tmp/main2main_guard.json 2>/tmp/main2main_guard.err; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$(cat /tmp/main2main_guard.err)"
+            exit 0
+          fi
+          PR_BRANCH=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_ctx.json \
+            --field branch)
+          PR_HEAD_SHA=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_ctx.json \
+            --field head_sha)
+          BRANCH="${PR_BRANCH}"
+          git fetch origin "${BRANCH}:${BRANCH}"
+          git checkout "${BRANCH}"
+          test "$(git rev-parse HEAD)" = "${PR_HEAD_SHA}"
+          echo "stale=false" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git and validate Claude gateway
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          git config user.name "main2main-bot"
+          git config user.email "main2main-bot@noreply.github.com"
+          test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
+          test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
+          rm -f .claude/settings.json .claude/settings.local.json
+
+      - name: Export phase 2 Claude context
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          {
+            echo "MAIN2MAIN_E2E_RUN_ID=$(python3 \"$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py\" json-get --json-file /tmp/main2main_state.json --field e2e_run_id)"
+            echo "MAIN2MAIN_OLD_COMMIT=$(python3 \"$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py\" json-get --json-file /tmp/main2main_state.json --field old_commit)"
+            echo "MAIN2MAIN_NEW_COMMIT=$(python3 \"$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py\" json-get --json-file /tmp/main2main_state.json --field new_commit)"
+          } >> "$GITHUB_ENV"
+
+      - name: Claude fix phase 2 with error-analysis skill
+        if: steps.ctx.outputs.stale != 'true'
+        uses: anthropics/claude-code-action/base-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            Use the main2main skill to diagnose and fix CI failures.
+            The E2E-Full CI has failed. Details:
+            - Run ID: ${{ env.MAIN2MAIN_E2E_RUN_ID }}
+            - Good commit (pinned): ${{ env.MAIN2MAIN_OLD_COMMIT }}
+            - Bad commit (upstream): ${{ env.MAIN2MAIN_NEW_COMMIT }}
+
+            Commit all fixes with '-s' but do NOT create a PR or branch.
+          claude_args: "--model ${{ env.MAIN2MAIN_MODEL }} --dangerously-skip-permissions --allowed-tools 'Bash(git *),Bash(gh *),Bash(grep *),Bash(sed *),Bash(python3 *),Read,Write,Edit,Glob,Grep'"
+          show_full_output: true
+        env:
+          CLAUDE_WORKING_DIR: ${{ github.workspace }}/${{ env.WORK_REPO_DIR }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+
+      - name: Push fixes and update comments
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          test -n "${PR_NUMBER}" || { echo "::error::pr_number is required for fix_phase2"; exit 1; }
+          BRANCH=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_ctx.json \
+            --field branch)
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -s -m "fix: address E2E-Full CI failures (Phase 2)"
+          fi
+
+          if ! git diff --quiet "origin/${BRANCH}"..HEAD 2>/dev/null; then
+            git push --force-with-lease origin "HEAD:${BRANCH}"
+            RESULT="changes_pushed"
+            NEW_HEAD_SHA=$(git rev-parse HEAD)
+            gh pr view "${PR_NUMBER}" \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --json body \
+              --jq .body > /tmp/pr_body_current.md
+            {
+              echo "**Pipeline:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              echo "**Head commit:** \`${NEW_HEAD_SHA}\`"
+              echo ""
+              echo '```text'
+              git show -s --format=fuller HEAD
+              echo '```'
+            } > /tmp/pr_phase_section_content.md
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" upsert-pr-phase-section \
+              --body-file /tmp/pr_body_current.md \
+              --heading "Phase 2: address E2E-Full CI failures" \
+              --content-file /tmp/pr_phase_section_content.md \
+              --output-file /tmp/pr_body_updated.md
+            gh pr edit "${PR_NUMBER}" \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --body-file /tmp/pr_body_updated.md
+          else
+            RESULT="no_changes"
+            NEW_HEAD_SHA=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+              --json-file /tmp/main2main_state.json \
+              --field head_sha)
+          fi
+
+          python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-fix-transition \
+            --state-file /tmp/main2main_state.json \
+            --result "${RESULT}" \
+            --new-head-sha "${NEW_HEAD_SHA}" \
+            --fix-run-id "${{ github.run_id }}" \
+            --last-transition "fix_phase2->waiting_e2e" \
+            --updated-by "schedule_main2main_auto.yaml/fix_phase2" \
+            --clear-dispatch-token \
+            --state-json-out /tmp/main2main_state_next.json \
+            --register-json-out /tmp/main2main_register_next.json \
+            --state-comment-out /tmp/main2main_state_next_comment.md \
+            --register-comment-out /tmp/main2main_register_next_comment.md
+
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_next_comment.md)" >/dev/null
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field register_comment_id)" \
+            -f body="$(cat /tmp/main2main_register_next_comment.md)" >/dev/null
+
+      - name: Dispatch manual review on phase 2 workflow failure
+        if: ${{ failure() && steps.ctx.outputs.stale != 'true' }}
+        run: |
+          if [ ! -f /tmp/main2main_state.json ] || [ ! -f /tmp/main2main_ctx.json ]; then
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${{ github.event.inputs.dispatch_token }}" \
+              -f terminal_reason=workflow_error
+            exit 0
+          fi
+          mapfile -t RECOVERY_FIELDS < <(
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-workflow-error-recovery \
+              --state-file /tmp/main2main_state.json \
+              --max-retries 1 \
+              --retry-transition "retry/fix_phase2" \
+              --terminal-transition "error_exhausted/fix_phase2" \
+              --updated-by "schedule_main2main_auto.yaml/fix_phase2_failure" \
+              --state-json-out /tmp/main2main_state_error.json \
+              --state-comment-out /tmp/main2main_state_error_comment.md \
+            | python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload["action"]); print(payload["dispatch_token"])'
+          )
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_error_comment.md)" >/dev/null
+          NEXT_ACTION="${RECOVERY_FIELDS[0]}"
+          NEXT_TOKEN="${RECOVERY_FIELDS[1]}"
+          if [ "${NEXT_ACTION}" = "retry" ]; then
+            gh workflow run schedule_main2main_auto.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f mode=fix_phase2 \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}"
+          else
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}" \
+              -f terminal_reason=workflow_error
+          fi
+
+  fix-phase3-prepare:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'fix_phase3_prepare'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: main2main-pr-${{ github.event.inputs.pr_number }}
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      API_TIMEOUT_MS: 3000000
+    defaults:
+      run:
+        working-directory: vllm-benchmarks
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.CONTROL_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Validate GitHub token scopes
+        run: |
+          gh auth status
+          gh api graphql -f query='query { organization(login: "nv-action") { login } }' >/dev/null
+
+      - name: Load guarded phase 3 state
+        id: ctx
+        run: |
+          if ! python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" load-phase-context \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --pr-number "${{ github.event.inputs.pr_number }}" \
+            --expected-phase 3 \
+            --expected-status fixing \
+            --dispatch-token "${{ github.event.inputs.dispatch_token }}" \
+            --state-json-out /tmp/main2main_state.json \
+            --registration-json-out /tmp/main2main_register.json \
+            --context-json-out /tmp/main2main_ctx.json >/tmp/main2main_guard.json 2>/tmp/main2main_guard.err; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$(cat /tmp/main2main_guard.err)"
+            exit 0
+          fi
+          echo "stale=false" >> "$GITHUB_OUTPUT"
+
+      - name: Build bisect payload and dispatch bisect workflow
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          E2E_RUN_ID=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_state.json \
+            --field e2e_run_id)
+          python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/ci_log_summary.py" \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --run-id "${E2E_RUN_ID}" \
+            --format bisect-json \
+            --output /tmp/ci_analysis.json
+
+          mapfile -t BISECT_FIELDS < <(
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-bisect-payload \
+              --state-file /tmp/main2main_state.json \
+              --ci-analysis-file /tmp/ci_analysis.json \
+            | python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload["old_commit"]); print(payload["new_commit"]); print(payload["test_cmd"])'
+          )
+          OLD_COMMIT="${BISECT_FIELDS[0]}"
+          NEW_COMMIT="${BISECT_FIELDS[1]}"
+          TEST_CMDS="${BISECT_FIELDS[2]}"
+
+            gh workflow run dispatch_main2main_bisect.yaml \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            -f caller_type=main2main \
+            -f caller_run_id="${E2E_RUN_ID}" \
+            -f good_commit="${OLD_COMMIT}" \
+            -f bad_commit="${NEW_COMMIT}" \
+            -f test_cmd="${TEST_CMDS}" \
+            -f main2main_pr_number="${{ github.event.inputs.pr_number }}" \
+            -f main2main_dispatch_token="${{ github.event.inputs.dispatch_token }}"
+
+          BISECT_RUN_ID=""
+          for attempt in $(seq 1 20); do
+            gh run list \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --workflow dispatch_main2main_bisect.yaml \
+              -L 50 \
+              --json databaseId,displayTitle > /tmp/main2main_bisect_runs.json
+            BISECT_RUN_ID=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" select-bisect-run-id \
+              --runs-file /tmp/main2main_bisect_runs.json \
+              --caller-run-id "${E2E_RUN_ID}" \
+              --dispatch-token "${{ github.event.inputs.dispatch_token }}" || true)
+            if [ -n "${BISECT_RUN_ID}" ]; then
+              break
+            fi
+            sleep 15
+          done
+
+          python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-waiting-bisect \
+            --state-file /tmp/main2main_state.json \
+            --bisect-run-id "${BISECT_RUN_ID}" \
+            --fix-run-id "${{ github.run_id }}" \
+            --last-transition "fix_phase3_prepare->waiting_bisect" \
+            --updated-by "schedule_main2main_auto.yaml/fix_phase3_prepare" \
+            --state-json-out /tmp/main2main_state_next.json \
+            --state-comment-out /tmp/main2main_state_next_comment.md
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_next_comment.md)" >/dev/null
+
+      - name: Dispatch manual review on phase 3 prepare failure
+        if: ${{ failure() && steps.ctx.outputs.stale != 'true' }}
+        run: |
+          if [ ! -f /tmp/main2main_state.json ] || [ ! -f /tmp/main2main_ctx.json ]; then
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${{ github.event.inputs.dispatch_token }}" \
+              -f terminal_reason=workflow_error
+            exit 0
+          fi
+          mapfile -t RECOVERY_FIELDS < <(
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-workflow-error-recovery \
+              --state-file /tmp/main2main_state.json \
+              --max-retries 1 \
+              --retry-transition "retry/fix_phase3_prepare" \
+              --terminal-transition "error_exhausted/fix_phase3_prepare" \
+              --updated-by "schedule_main2main_auto.yaml/fix_phase3_prepare_failure" \
+              --state-json-out /tmp/main2main_state_error.json \
+              --state-comment-out /tmp/main2main_state_error_comment.md \
+            | python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload["action"]); print(payload["dispatch_token"])'
+          )
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_error_comment.md)" >/dev/null
+          NEXT_ACTION="${RECOVERY_FIELDS[0]}"
+          NEXT_TOKEN="${RECOVERY_FIELDS[1]}"
+          if [ "${NEXT_ACTION}" = "retry" ]; then
+            gh workflow run schedule_main2main_auto.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f mode=fix_phase3_prepare \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}"
+          else
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}" \
+              -f terminal_reason=workflow_error
+          fi
+
+  fix-phase3-finalize:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'fix_phase3_finalize'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    concurrency:
+      group: main2main-pr-${{ github.event.inputs.pr_number }}
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      API_TIMEOUT_MS: 3000000
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+    defaults:
+      run:
+        working-directory: vllm-benchmarks-work
+    steps:
+      - name: Checkout vLLM-benchmarks repo
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.CONTROL_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Checkout working repository
+        uses: actions/checkout@v6
+        with:
+          repository: Meihan-chen/vllm-benchmarks
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.WORK_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Validate GitHub token scopes
+        run: |
+          gh auth status
+          gh api graphql -f query='query { organization(login: "nv-action") { login } }' >/dev/null
+
+      - name: Load waiting_bisect state and checkout branch
+        id: ctx
+        run: |
+          if ! python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" load-phase-context \
+            --repo "${{ env.UPSTREAM_REPO }}" \
+            --pr-number "${{ github.event.inputs.pr_number }}" \
+            --expected-phase 3 \
+            --allowed-statuses fixing waiting_bisect \
+            --dispatch-token "${{ github.event.inputs.dispatch_token }}" \
+            --state-json-out /tmp/main2main_state.json \
+            --registration-json-out /tmp/main2main_register.json \
+            --context-json-out /tmp/main2main_ctx.json >/tmp/main2main_guard.json 2>/tmp/main2main_guard.err; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$(cat /tmp/main2main_guard.err)"
+            exit 0
+          fi
+          PR_BRANCH=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_ctx.json \
+            --field branch)
+          PR_HEAD_SHA=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_ctx.json \
+            --field head_sha)
+          BRANCH="${PR_BRANCH}"
+          git fetch origin "${BRANCH}:${BRANCH}"
+          git checkout "${BRANCH}"
+          test "$(git rev-parse HEAD)" = "${PR_HEAD_SHA}"
+          echo "stale=false" >> "$GITHUB_OUTPUT"
+
+      - name: Mark phase 3 finalize as in progress
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-fixing-state \
+            --state-file /tmp/main2main_state.json \
+            --fix-run-id "${{ github.run_id }}" \
+            --last-transition "fix_phase3_finalize->fixing" \
+            --updated-by "schedule_main2main_auto.yaml/fix_phase3_finalize" \
+            --state-json-out /tmp/main2main_state.json \
+            --state-comment-out /tmp/main2main_state_in_progress_comment.md
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_in_progress_comment.md)" >/dev/null
+
+      - name: Download bisect summary
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          BISECT_RUN_ID="${{ github.event.inputs.bisect_run_id }}"
+          if [ -z "${BISECT_RUN_ID}" ]; then
+            BISECT_RUN_ID=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+              --json-file /tmp/main2main_state.json \
+              --field bisect_run_id)
+          fi
+          if [ -n "${BISECT_RUN_ID}" ]; then
+            gh run download "${BISECT_RUN_ID}" \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --name bisect-summary \
+              --dir /tmp/bisect_output 2>/dev/null || true
+          fi
+
+      - name: Configure git and validate Claude gateway
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          git config user.name "main2main-bot"
+          git config user.email "main2main-bot@noreply.github.com"
+          test -n "$ANTHROPIC_BASE_URL" || { echo "::error::ANTHROPIC_BASE_URL is empty"; exit 1; }
+          test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "::error::ANTHROPIC_AUTH_TOKEN is empty"; exit 1; }
+          rm -f .claude/settings.json .claude/settings.local.json
+
+      - name: Export phase 3 Claude context
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          {
+            echo "MAIN2MAIN_E2E_RUN_ID=$(python3 \"$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py\" json-get --json-file /tmp/main2main_state.json --field e2e_run_id)"
+            echo "MAIN2MAIN_OLD_COMMIT=$(python3 \"$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py\" json-get --json-file /tmp/main2main_state.json --field old_commit)"
+            echo "MAIN2MAIN_NEW_COMMIT=$(python3 \"$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py\" json-get --json-file /tmp/main2main_state.json --field new_commit)"
+          } >> "$GITHUB_ENV"
+
+      - name: Claude bisect-guided phase 3 fix
+        if: steps.ctx.outputs.stale != 'true'
+        uses: anthropics/claude-code-action/base-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            Use the main2main-error-analysis skill to apply targeted fixes based on bisect results and CI failures.
+
+            The E2E-Full CI still failed after the previous main2main-error-analysis fix. 
+            We extracted and deduplicated CI failures from the run id.
+            For each failure class, we selected representative test files and ran bisect.
+            The bisect results are summarized in /tmp/bisect_output/bisect_result.json.
+            Use both the CI failure json by ci_log_summary.py and bisect_result.json to analyze root causes and fix the code.
+
+            Context:
+            - Run ID: ${{ env.MAIN2MAIN_E2E_RUN_ID }}
+            - Good commit (pinned): ${{ env.MAIN2MAIN_OLD_COMMIT }}
+            - Bad commit (upstream): ${{ env.MAIN2MAIN_NEW_COMMIT }}
+            - Bisect result: /tmp/bisect_output/bisect_result.json if present
+
+            Commit all fixes with '-s' but do NOT create a PR or branch.
+          claude_args: "--model ${{ env.MAIN2MAIN_MODEL }} --dangerously-skip-permissions --allowed-tools 'Bash(git *),Bash(gh *),Bash(grep *),Bash(sed *),Bash(python3 *),Read,Write,Edit,Glob,Grep'"
+          show_full_output: true
+        env:
+          CLAUDE_WORKING_DIR: ${{ github.workspace }}/${{ env.WORK_REPO_DIR }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+
+      - name: Push phase 3 fixes or go terminal
+        if: steps.ctx.outputs.stale != 'true'
+        run: |
+          PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          test -n "${PR_NUMBER}" || { echo "::error::pr_number is required for fix_phase3_finalize"; exit 1; }
+          BRANCH=$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get \
+            --json-file /tmp/main2main_ctx.json \
+            --field branch)
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -s -m "fix: bisect-guided adaptation fixes (Phase 3)"
+          fi
+
+          if ! git diff --quiet "origin/${BRANCH}"..HEAD 2>/dev/null; then
+            git push --force-with-lease origin "HEAD:${BRANCH}"
+            NEW_HEAD_SHA=$(git rev-parse HEAD)
+            gh pr view "${PR_NUMBER}" \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --json body \
+              --jq .body > /tmp/pr_body_current.md
+            {
+              echo "**Pipeline:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              echo "**Head commit:** \`${NEW_HEAD_SHA}\`"
+              echo ""
+              echo '```text'
+              git show -s --format=fuller HEAD
+              echo '```'
+            } > /tmp/pr_phase_section_content.md
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" upsert-pr-phase-section \
+              --body-file /tmp/pr_body_current.md \
+              --heading "Phase 3: bisect-guided adaptation" \
+              --content-file /tmp/pr_phase_section_content.md \
+              --output-file /tmp/pr_body_updated.md
+            gh pr edit "${PR_NUMBER}" \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --body-file /tmp/pr_body_updated.md
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-fix-transition \
+              --state-file /tmp/main2main_state.json \
+              --result changes_pushed \
+              --new-head-sha "${NEW_HEAD_SHA}" \
+              --fix-run-id "${{ github.run_id }}" \
+              --last-transition "fix_phase3_finalize->waiting_e2e" \
+              --updated-by "schedule_main2main_auto.yaml/fix_phase3_finalize" \
+              --clear-dispatch-token \
+              --state-json-out /tmp/main2main_state_next.json \
+              --register-json-out /tmp/main2main_register_next.json \
+              --state-comment-out /tmp/main2main_state_next_comment.md \
+              --register-comment-out /tmp/main2main_register_next_comment.md
+            gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+              -f body="$(cat /tmp/main2main_state_next_comment.md)" >/dev/null
+            gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field register_comment_id)" \
+              -f body="$(cat /tmp/main2main_register_next_comment.md)" >/dev/null
+          else
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-manual-review-pending \
+              --state-file /tmp/main2main_state.json \
+              --terminal-reason phase3_no_changes \
+              --fix-run-id "${{ github.run_id }}" \
+              --last-transition "fix_phase3_finalize->manual_review_pending" \
+              --updated-by "schedule_main2main_auto.yaml/fix_phase3_finalize" \
+              --state-json-out /tmp/main2main_state_next.json \
+              --register-json-out /tmp/main2main_register_next.json \
+              --state-comment-out /tmp/main2main_state_next_comment.md \
+              --register-comment-out /tmp/main2main_register_next_comment.md
+            gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+              -f body="$(cat /tmp/main2main_state_next_comment.md)" >/dev/null
+            gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field register_comment_id)" \
+              -f body="$(cat /tmp/main2main_register_next_comment.md)" >/dev/null
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${{ github.event.inputs.dispatch_token }}" \
+              -f terminal_reason=phase3_no_changes
+          fi
+
+      - name: Dispatch manual review on phase 3 finalize failure
+        if: ${{ failure() && steps.ctx.outputs.stale != 'true' }}
+        run: |
+          if [ ! -f /tmp/main2main_state.json ] || [ ! -f /tmp/main2main_ctx.json ]; then
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${{ github.event.inputs.dispatch_token }}" \
+              -f terminal_reason=workflow_error
+            exit 0
+          fi
+          mapfile -t RECOVERY_FIELDS < <(
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" prepare-workflow-error-recovery \
+              --state-file /tmp/main2main_state.json \
+              --max-retries 1 \
+              --retry-transition "retry/fix_phase3_finalize" \
+              --terminal-transition "error_exhausted/fix_phase3_finalize" \
+              --updated-by "schedule_main2main_auto.yaml/fix_phase3_finalize_failure" \
+              --state-json-out /tmp/main2main_state_error.json \
+              --state-comment-out /tmp/main2main_state_error_comment.md \
+            | python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload["action"]); print(payload["dispatch_token"])'
+          )
+          gh api --method PATCH "repos/${{ env.UPSTREAM_REPO }}/issues/comments/$(python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" json-get --json-file /tmp/main2main_ctx.json --field state_comment_id)" \
+            -f body="$(cat /tmp/main2main_state_error_comment.md)" >/dev/null
+          NEXT_ACTION="${RECOVERY_FIELDS[0]}"
+          NEXT_TOKEN="${RECOVERY_FIELDS[1]}"
+          if [ "${NEXT_ACTION}" = "retry" ]; then
+            gh workflow run schedule_main2main_auto.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f mode=fix_phase3_finalize \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}" \
+              -f bisect_run_id="${{ github.event.inputs.bisect_run_id }}"
+          else
+            gh workflow run dispatch_main2main_terminal.yaml \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              -f action=manual_review \
+              -f pr_number="${{ github.event.inputs.pr_number }}" \
+              -f dispatch_token="${NEXT_TOKEN}" \
+              -f terminal_reason=workflow_error
+          fi

--- a/.github/workflows/schedule_main2main_reconcile.yaml
+++ b/.github/workflows/schedule_main2main_reconcile.yaml
@@ -1,0 +1,102 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Main2Main Reconcile
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Optional PR number to reconcile explicitly'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+  actions: write
+
+concurrency:
+  group: main2main-reconcile
+  cancel-in-progress: false
+
+env:
+  UPSTREAM_REPO: vllm-project/vllm-ascend
+  CONTROL_REPO_DIR: vllm-benchmarks
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+    defaults:
+      run:
+        working-directory: vllm-benchmarks
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: vllm-project/vllm-ascend
+          token: ${{ secrets.PAT_TOKEN }}
+          path: ${{ env.CONTROL_REPO_DIR }}
+          fetch-depth: 0
+
+      - name: Validate GitHub token scopes
+        run: |
+          gh auth status
+          gh api graphql -f query='query { organization(login: "nv-action") { login } }' >/dev/null
+
+      - name: Resolve target PRs
+        id: prs
+        run: |
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            PR_NUMBERS="${{ github.event.inputs.pr_number }}"
+          else
+            PR_NUMBERS="$(gh pr list \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --label main2main \
+              --state open \
+              --json number \
+              --jq '.[].number')"
+          fi
+          {
+            echo 'pr_numbers<<EOF'
+            printf '%s\n' "${PR_NUMBERS}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile waiting_e2e and waiting_bisect states
+        run: |
+          set -euo pipefail
+          PR_NUMBERS='${{ steps.prs.outputs.pr_numbers }}'
+          if [ -z "${PR_NUMBERS//$'\n'/}" ]; then
+            echo "::notice::No target main2main PRs to reconcile"
+            exit 0
+          fi
+
+          while IFS= read -r PR_NUMBER; do
+            [ -n "${PR_NUMBER}" ] || continue
+            echo "::group::Reconcile PR ${PR_NUMBER}"
+            python3 "$GITHUB_WORKSPACE/${{ env.CONTROL_REPO_DIR }}/.github/workflows/scripts/main2main_ci.py" reconcile-pr \
+              --repo "${{ env.UPSTREAM_REPO }}" \
+              --pr-number "${PR_NUMBER}"
+
+            echo "::endgroup::"
+          done <<< "${PR_NUMBERS}"

--- a/.github/workflows/schedule_main2main_reconcile.yaml
+++ b/.github/workflows/schedule_main2main_reconcile.yaml
@@ -38,7 +38,7 @@ concurrency:
 
 env:
   UPSTREAM_REPO: vllm-project/vllm-ascend
-  CONTROL_REPO_DIR: vllm-benchmarks
+  CONTROL_REPO_DIR: vllm-ascend
 
 jobs:
   reconcile:
@@ -48,7 +48,7 @@ jobs:
       GH_TOKEN: ${{ secrets.PAT_TOKEN }}
     defaults:
       run:
-        working-directory: vllm-benchmarks
+        working-directory: vllm-ascend
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/scripts/main2main_ci.py
+++ b/.github/workflows/scripts/main2main_ci.py
@@ -1,0 +1,1467 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import uuid
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+STATE_MARKER = "main2main-state:v1"
+REGISTER_MARKER = "main2main-register"
+
+_COMMIT_RANGE_RE = re.compile(
+    r"^\*\*Commit range:\*\* `([0-9a-f]{40})`\.\.\.`([0-9a-f]{40})`$",
+    re.MULTILINE,
+)
+_REGISTRATION_COMMENT_RE = re.compile(
+    r"<!-- main2main-register\s*"
+    r"pr_number=(\d+)\s*"
+    r"branch=([^\n]+)\s*"
+    r"head_sha=([0-9a-f]{40})\s*"
+    r"old_commit=([0-9a-f]{40})\s*"
+    r"new_commit=([0-9a-f]{40})\s*"
+    r"phase=(2|3|done)\s*"
+    r"-->",
+    re.MULTILINE,
+)
+_STATE_COMMENT_RE = re.compile(r"<!-- main2main-state:v1\s*(\{.*?\})\s*-->", re.DOTALL)
+_RUN_ID_FROM_DETAILS_URL_RE = re.compile(r"/actions/runs/(\d+)(?:/job/\d+)?")
+_PHASE_SECTION_RE_TEMPLATE = r"(?:\n)?### {heading}\n(?:.*?)(?=\n### |\Z)"
+DEFAULT_BISECT_TEST_CMD = (
+    "pytest -sv tests/e2e/singlecard/test_aclgraph_accuracy.py; "
+    "pytest -sv tests/e2e/multicard/4-cards/long_sequence/test_accuracy.py"
+)
+
+_FAILURE_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "stale",
+    "startup_failure",
+    "timed_out",
+}
+_CONFLICT_MERGEABLES = {"CONFLICTING"}
+_CONFLICT_MERGE_STATE_STATUSES = {"DIRTY", "CONFLICTING"}
+
+
+@dataclass(frozen=True)
+class PrMetadata:
+    old_commit: str
+    new_commit: str
+
+
+@dataclass(frozen=True)
+class RegistrationMetadata:
+    pr_number: int
+    branch: str
+    head_sha: str
+    old_commit: str
+    new_commit: str
+    phase: str
+
+
+@dataclass(frozen=True)
+class Main2MainState:
+    pr_number: int
+    branch: str
+    head_sha: str
+    old_commit: str
+    new_commit: str
+    phase: str
+    status: str
+    dispatch_token: str = ""
+    e2e_run_id: str = ""
+    fix_run_id: str = ""
+    bisect_run_id: str = ""
+    terminal_reason: str = ""
+    workflow_error_count: int = 0
+    last_transition: str = ""
+    updated_at: str = ""
+    updated_by: str = ""
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    ok: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ReconcileDecision:
+    action: str
+    reason: str = ""
+    terminal_reason: str = ""
+    run_id: str = ""
+
+
+@dataclass(frozen=True)
+class FixupOutcome:
+    result: str
+    phase: str
+
+
+@dataclass(frozen=True)
+class MarkerComment:
+    id: int
+    body: str
+
+
+@dataclass(frozen=True)
+class PhaseContext:
+    pr: dict[str, Any]
+    state: Main2MainState
+    registration: RegistrationMetadata
+    state_comment_id: int
+    register_comment_id: int
+    branch: str
+    head_sha: str
+
+
+def parse_pr_metadata(body: str) -> PrMetadata:
+    commit_match = _COMMIT_RANGE_RE.search(body)
+    if commit_match is None:
+        raise ValueError("PR body is missing main2main metadata")
+    return PrMetadata(
+        old_commit=commit_match.group(1),
+        new_commit=commit_match.group(2),
+    )
+
+
+def parse_registration_comment(body: str) -> RegistrationMetadata:
+    match = _REGISTRATION_COMMENT_RE.search(body)
+    if match is None:
+        raise ValueError("registration comment is missing main2main metadata")
+    return RegistrationMetadata(
+        pr_number=int(match.group(1)),
+        branch=match.group(2),
+        head_sha=match.group(3),
+        old_commit=match.group(4),
+        new_commit=match.group(5),
+        phase=match.group(6),
+    )
+
+
+def render_registration_comment(metadata: RegistrationMetadata) -> str:
+    return (
+        "<!-- main2main-register\n"
+        f"pr_number={metadata.pr_number}\n"
+        f"branch={metadata.branch}\n"
+        f"head_sha={metadata.head_sha}\n"
+        f"old_commit={metadata.old_commit}\n"
+        f"new_commit={metadata.new_commit}\n"
+        f"phase={metadata.phase}\n"
+        "-->"
+    )
+
+
+def _normalize_state_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = {
+        "pr_number": int(payload["pr_number"]),
+        "branch": payload["branch"],
+        "head_sha": payload["head_sha"],
+        "old_commit": payload["old_commit"],
+        "new_commit": payload["new_commit"],
+        "phase": payload["phase"],
+        "status": payload["status"],
+        "dispatch_token": str(payload.get("dispatch_token", "")),
+        "e2e_run_id": str(payload.get("e2e_run_id", "")),
+        "fix_run_id": str(payload.get("fix_run_id", "")),
+        "bisect_run_id": str(payload.get("bisect_run_id", "")),
+        "terminal_reason": str(payload.get("terminal_reason", "")),
+        "workflow_error_count": int(payload.get("workflow_error_count", 0)),
+        "last_transition": str(payload.get("last_transition", "")),
+        "updated_at": str(payload.get("updated_at", "")),
+        "updated_by": str(payload.get("updated_by", "")),
+    }
+    return normalized
+
+
+def parse_state_comment(body: str) -> Main2MainState:
+    match = _STATE_COMMENT_RE.search(body)
+    if match is None:
+        raise ValueError("state comment is missing main2main metadata")
+    payload = json.loads(match.group(1))
+    return Main2MainState(**_normalize_state_payload(payload))
+
+
+def render_state_comment(state: Main2MainState) -> str:
+    payload = json.dumps(asdict(state), ensure_ascii=True, indent=2, sort_keys=True)
+    return f"<!-- {STATE_MARKER}\n{payload}\n-->"
+
+
+def init_state_from_registration(
+    metadata: RegistrationMetadata,
+    *,
+    dispatch_token: str,
+    updated_at: str = "",
+    updated_by: str = "",
+) -> Main2MainState:
+    return Main2MainState(
+        pr_number=metadata.pr_number,
+        branch=metadata.branch,
+        head_sha=metadata.head_sha,
+        old_commit=metadata.old_commit,
+        new_commit=metadata.new_commit,
+        phase=metadata.phase,
+        status="waiting_e2e",
+        dispatch_token=dispatch_token,
+        last_transition="register->waiting_e2e",
+        updated_at=updated_at,
+        updated_by=updated_by,
+    )
+
+
+def mint_dispatch_token() -> str:
+    return uuid.uuid4().hex
+
+
+def upsert_pr_phase_section(body: str, *, heading: str, content_lines: list[str]) -> str:
+    section = "\n".join([f"### {heading}", *content_lines]).rstrip()
+    pattern = re.compile(_PHASE_SECTION_RE_TEMPLATE.format(heading=re.escape(heading)), re.DOTALL)
+    existing_body = body.rstrip()
+    if pattern.search(existing_body):
+        updated = pattern.sub("\n" + section, existing_body, count=1)
+        return updated.strip() + "\n"
+    joiner = "\n\n" if existing_body else ""
+    return f"{existing_body}{joiner}{section}\n"
+
+
+def check_state_guard(
+    state: Main2MainState,
+    *,
+    expected_phase: str | None = None,
+    expected_status: str | None = None,
+    dispatch_token: str | None = None,
+) -> GuardResult:
+    if expected_phase and state.phase != expected_phase:
+        return GuardResult(False, f"phase mismatch: expected {expected_phase}, got {state.phase}")
+    if expected_status and state.status != expected_status:
+        return GuardResult(False, f"status mismatch: expected {expected_status}, got {state.status}")
+    if dispatch_token is not None and state.dispatch_token != dispatch_token:
+        return GuardResult(False, "dispatch token mismatch")
+    return GuardResult(True)
+
+
+def check_pr_consistency(
+    state: Main2MainState,
+    *,
+    branch: str,
+    head_sha: str,
+) -> GuardResult:
+    if state.branch != branch:
+        return GuardResult(False, f"branch mismatch: expected {state.branch}, got {branch}")
+    if state.head_sha != head_sha:
+        return GuardResult(False, f"head_sha mismatch: expected {state.head_sha}, got {head_sha}")
+    return GuardResult(True)
+
+
+def check_registration_consistency(
+    state: Main2MainState,
+    registration: RegistrationMetadata,
+) -> GuardResult:
+    if state.branch != registration.branch:
+        return GuardResult(False, f"registration branch mismatch: expected {state.branch}, got {registration.branch}")
+    if state.head_sha != registration.head_sha:
+        return GuardResult(False, f"registration head_sha mismatch: expected {state.head_sha}, got {registration.head_sha}")
+    if state.old_commit != registration.old_commit or state.new_commit != registration.new_commit:
+        return GuardResult(False, "registration commit range mismatch")
+    if state.phase != registration.phase:
+        return GuardResult(False, f"registration phase mismatch: expected {state.phase}, got {registration.phase}")
+    return GuardResult(True)
+
+
+def _sort_run_key(run: dict[str, Any]) -> tuple[str, int]:
+    return (str(run.get("createdAt") or run.get("updatedAt") or ""), int(run.get("databaseId") or 0))
+
+
+def select_matching_e2e_run(runs: list[dict[str, Any]], *, head_sha: str) -> dict[str, Any] | None:
+    matching = [run for run in runs if run.get("headSha") == head_sha]
+    if not matching:
+        return None
+    return max(matching, key=_sort_run_key)
+
+
+def extract_run_id_from_details_url(url: str) -> str:
+    match = _RUN_ID_FROM_DETAILS_URL_RE.search(url or "")
+    if match is None:
+        return ""
+    return match.group(1)
+
+
+def resolve_e2e_run_id_from_status_checks(status_checks: list[dict[str, Any]]) -> str:
+    run_ids = [
+        extract_run_id_from_details_url(str(check.get("detailsUrl") or ""))
+        for check in status_checks
+        if check.get("workflowName") == "E2E-Full"
+    ]
+    run_ids = [run_id for run_id in run_ids if run_id]
+    if not run_ids:
+        return ""
+    return max(run_ids, key=int)
+
+
+def select_latest_marker_comment(comments: list[dict[str, Any]], marker: str) -> MarkerComment | None:
+    matches = [item for item in comments if marker in str(item.get("body") or "")]
+    if not matches:
+        return None
+    latest = max(matches, key=lambda item: int(item.get("id") or 0))
+    return MarkerComment(id=int(latest["id"]), body=str(latest.get("body") or ""))
+
+
+def select_bisect_run_id(runs: list[dict[str, Any]], *, caller_run_id: str, dispatch_token: str) -> str:
+    caller = f"caller-{caller_run_id}"
+    token = f"token-{dispatch_token}"
+    for item in sorted(runs, key=_sort_run_key, reverse=True):
+        display_title = str(item.get("displayTitle") or "")
+        if caller in display_title and token in display_title:
+            run_id = item.get("databaseId")
+            return str(run_id or "")
+    return ""
+
+
+def load_phase_context(
+    pr: dict[str, Any],
+    comments: list[dict[str, Any]],
+    *,
+    expected_phase: str | None = None,
+    expected_status: str | None = None,
+    allowed_statuses: list[str] | None = None,
+    dispatch_token: str | None = None,
+) -> PhaseContext:
+    state_comment = select_latest_marker_comment(comments, STATE_MARKER)
+    if state_comment is None:
+        raise ValueError("missing main2main-state comment")
+    register_comment = select_latest_marker_comment(comments, REGISTER_MARKER)
+    if register_comment is None:
+        raise ValueError("missing main2main-register comment")
+
+    state = parse_state_comment(state_comment.body)
+    registration = parse_registration_comment(register_comment.body)
+    branch = str(pr["headRefName"])
+    head_sha = str(pr["headRefOid"])
+
+    guard = check_state_guard(
+        state,
+        expected_phase=expected_phase,
+        expected_status=expected_status,
+        dispatch_token=dispatch_token,
+    )
+    if not guard.ok:
+        raise ValueError(guard.reason)
+
+    if allowed_statuses and state.status not in allowed_statuses:
+        raise ValueError(f"unexpected status: {state.status}")
+
+    consistency = check_pr_consistency(state, branch=branch, head_sha=head_sha)
+    if not consistency.ok:
+        raise ValueError(consistency.reason)
+
+    registration_consistency = check_registration_consistency(state, registration)
+    if not registration_consistency.ok:
+        raise ValueError(registration_consistency.reason)
+
+    return PhaseContext(
+        pr=pr,
+        state=state,
+        registration=registration,
+        state_comment_id=state_comment.id,
+        register_comment_id=register_comment.id,
+        branch=branch,
+        head_sha=head_sha,
+    )
+
+
+def normalize_conclusion(conclusion: str) -> str:
+    if conclusion == "success":
+        return "success"
+    if conclusion in _FAILURE_CONCLUSIONS:
+        return "failure"
+    return "skip"
+
+
+def is_merge_conflict(*, merge_state_status: str | None = None, mergeable: str | None = None) -> bool:
+    if mergeable and mergeable.upper() in _CONFLICT_MERGEABLES:
+        return True
+    if merge_state_status and merge_state_status.upper() in _CONFLICT_MERGE_STATE_STATUSES:
+        return True
+    return False
+
+
+def decide_reconcile_action(
+    state: Main2MainState,
+    *,
+    e2e_run: dict[str, Any] | None = None,
+    merge_state_status: str | None = None,
+    mergeable: str | None = None,
+    bisect_finished: bool = False,
+    finalize_missing: bool = False,
+) -> ReconcileDecision:
+    if is_merge_conflict(merge_state_status=merge_state_status, mergeable=mergeable):
+        return ReconcileDecision(
+            action="dispatch_manual_review",
+            terminal_reason="merge_conflict",
+            reason="merge conflict blocks further automation",
+        )
+
+    if state.status == "waiting_bisect":
+        if bisect_finished and finalize_missing:
+            return ReconcileDecision(
+                action="dispatch_fix_phase3_finalize",
+                reason="bisect finished and finalize callback needs recovery",
+                run_id=state.bisect_run_id,
+            )
+        return ReconcileDecision(action="wait", reason="bisect still in progress or finalize already handled")
+
+    if state.status != "waiting_e2e":
+        return ReconcileDecision(action="ignore", reason=f"state {state.status} is not handled by reconcile")
+
+    if e2e_run is None:
+        return ReconcileDecision(action="wait", reason="matching E2E run not found yet")
+
+    if e2e_run.get("headSha") != state.head_sha:
+        return ReconcileDecision(action="wait", reason="stale E2E run does not match current head_sha")
+
+    if e2e_run.get("status") != "completed":
+        return ReconcileDecision(action="wait", reason="matching E2E run is still in progress")
+
+    run_id = str(e2e_run.get("databaseId") or "")
+    normalized = normalize_conclusion(str(e2e_run.get("conclusion") or ""))
+    if normalized == "success":
+        return ReconcileDecision(
+            action="dispatch_make_ready",
+            reason="latest matching E2E run succeeded",
+            run_id=run_id,
+        )
+    if normalized == "failure":
+        if state.phase == "2":
+            return ReconcileDecision(
+                action="dispatch_fix_phase2",
+                reason="phase 2 requires another automated fix attempt",
+                run_id=run_id,
+            )
+        if state.phase == "3":
+            return ReconcileDecision(
+                action="dispatch_fix_phase3_prepare",
+                reason="phase 3 requires bisect-guided automated repair",
+                run_id=run_id,
+            )
+        if state.phase == "done":
+            return ReconcileDecision(
+                action="dispatch_manual_review",
+                terminal_reason="done_failure",
+                reason="all automated phases are exhausted",
+                run_id=run_id,
+            )
+    return ReconcileDecision(action="ignore", reason=f"unsupported conclusion: {e2e_run.get('conclusion')}")
+
+
+def apply_fixup_result(state: Main2MainState, *, new_head_sha: str) -> Main2MainState:
+    next_phase = "3" if state.phase == "2" else "done"
+    return replace(state, head_sha=new_head_sha, phase=next_phase, status="waiting_e2e", e2e_run_id="")
+
+
+def apply_no_change_fixup_result(state: Main2MainState) -> Main2MainState:
+    if state.phase == "2":
+        return replace(state, phase="3", status="waiting_e2e")
+    return replace(state, phase="done", status="manual_review_pending")
+
+
+def prepare_bisect_payload(
+    state: Main2MainState,
+    *,
+    ci_analysis: dict[str, Any] | None = None,
+    fallback_test_cmd: str = DEFAULT_BISECT_TEST_CMD,
+) -> dict[str, str]:
+    analysis = ci_analysis or {}
+    test_cmd = str(analysis.get("test_cmd") or "").strip() or fallback_test_cmd
+    return {
+        "e2e_run_id": state.e2e_run_id,
+        "old_commit": state.old_commit,
+        "new_commit": state.new_commit,
+        "test_cmd": test_cmd,
+    }
+
+
+def prepare_fixing_state(
+    state: Main2MainState,
+    *,
+    fix_run_id: str,
+    last_transition: str,
+    updated_by: str,
+) -> Main2MainState:
+    return replace(
+        state,
+        status="fixing",
+        fix_run_id=fix_run_id,
+        last_transition=last_transition,
+        updated_by=updated_by,
+    )
+
+
+def parse_fixup_job_output(output: str, *, phase: str) -> FixupOutcome:
+    if "No changes after phase" in output:
+        return FixupOutcome(result="no_changes", phase=phase)
+    if "fixes pushed" in output:
+        return FixupOutcome(result="changes_pushed", phase=phase)
+    raise ValueError("unable to determine fixup outcome from job output")
+
+
+def _write_json(data: Any) -> None:
+    json.dump(data, sys.stdout, ensure_ascii=True, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def _load_json(path: str) -> Any:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _load_text(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _write_text(path: str, content: str) -> None:
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def _write_json_file(path: str, payload: Any) -> None:
+    _write_text(path, json.dumps(payload, ensure_ascii=True, indent=2))
+
+
+def _registration_payload_from_state(state: Main2MainState) -> dict[str, Any]:
+    return {
+        "pr_number": state.pr_number,
+        "branch": state.branch,
+        "head_sha": state.head_sha,
+        "old_commit": state.old_commit,
+        "new_commit": state.new_commit,
+        "phase": state.phase,
+    }
+
+
+def _run_command(args: list[str], *, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        args,
+        check=False,
+        capture_output=True,
+        text=True,
+        input=input_text,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"command failed: {' '.join(args)}")
+    return result.stdout
+
+
+def _gh(args: list[str], *, input_text: str | None = None) -> str:
+    return _run_command(["gh", *args], input_text=input_text)
+
+
+def _gh_json(args: list[str]) -> Any:
+    output = _gh(args)
+    if not output.strip():
+        return None
+    return json.loads(output)
+
+
+def _gh_api_json(endpoint: str, *, method: str = "GET", payload: dict[str, Any] | None = None) -> Any:
+    args = ["api", endpoint]
+    if method != "GET":
+        args.extend(["--method", method])
+    input_text = None
+    if payload is not None:
+        args.extend(["--input", "-"])
+        input_text = json.dumps(payload)
+    output = _gh(args, input_text=input_text)
+    if not output.strip():
+        return None
+    return json.loads(output)
+
+
+def _patch_state_comment(repo: str, comment_id: int, state: Main2MainState) -> None:
+    _gh_api_json(
+        f"repos/{repo}/issues/comments/{comment_id}",
+        method="PATCH",
+        payload={"body": render_state_comment(state)},
+    )
+
+
+def _command_mint_dispatch_token(_args: argparse.Namespace) -> int:
+    sys.stdout.write(f"{mint_dispatch_token()}\n")
+    return 0
+
+
+def _command_state_read(args: argparse.Namespace) -> int:
+    state = parse_state_comment(_load_text(args.comment_file))
+    _write_json(asdict(state))
+    return 0
+
+
+def _command_state_write(args: argparse.Namespace) -> int:
+    payload = _load_json(args.json_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    sys.stdout.write(render_state_comment(state))
+    sys.stdout.write("\n")
+    return 0
+
+
+def _command_registration_read(args: argparse.Namespace) -> int:
+    metadata = parse_registration_comment(_load_text(args.comment_file))
+    _write_json(asdict(metadata))
+    return 0
+
+
+def _command_registration_write(args: argparse.Namespace) -> int:
+    payload = _load_json(args.json_file)
+    metadata = RegistrationMetadata(**payload)
+    sys.stdout.write(render_registration_comment(metadata))
+    sys.stdout.write("\n")
+    return 0
+
+
+def _command_state_init_from_register(args: argparse.Namespace) -> int:
+    metadata = parse_registration_comment(_load_text(args.comment_file))
+    state = init_state_from_registration(
+        metadata,
+        dispatch_token=args.dispatch_token,
+        updated_at=args.updated_at,
+        updated_by=args.updated_by,
+    )
+    _write_json(asdict(state))
+    return 0
+
+
+def _command_guard_check(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    result = check_state_guard(
+        state,
+        expected_phase=args.expected_phase,
+        expected_status=args.expected_status,
+        dispatch_token=args.dispatch_token,
+    )
+    _write_json(asdict(result))
+    return 0 if result.ok else 1
+
+
+def _command_pr_consistency_check(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    result = check_pr_consistency(
+        state,
+        branch=args.branch,
+        head_sha=args.head_sha,
+    )
+    _write_json(asdict(result))
+    return 0 if result.ok else 1
+
+
+def _command_registration_consistency_check(args: argparse.Namespace) -> int:
+    state_payload = _load_json(args.state_file)
+    registration_payload = _load_json(args.registration_file)
+    state = Main2MainState(**_normalize_state_payload(state_payload))
+    registration = RegistrationMetadata(**registration_payload)
+    result = check_registration_consistency(state, registration)
+    _write_json(asdict(result))
+    return 0 if result.ok else 1
+
+
+def _command_reconcile_decision(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    e2e_run = None
+    if args.e2e_run_file:
+        e2e_run = _load_json(args.e2e_run_file)
+    decision = decide_reconcile_action(
+        state,
+        e2e_run=e2e_run,
+        merge_state_status=args.merge_state_status,
+        mergeable=args.mergeable,
+        bisect_finished=args.bisect_finished,
+        finalize_missing=args.finalize_missing,
+    )
+    _write_json(asdict(decision))
+    return 0
+
+
+def _command_select_e2e_run(args: argparse.Namespace) -> int:
+    runs = _load_json(args.runs_file)
+    run = select_matching_e2e_run(runs, head_sha=args.head_sha)
+    if run is None:
+        return 1
+    _write_json(run)
+    return 0
+
+
+def _command_apply_fix_result(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    if args.result == "changes_pushed":
+        if not args.new_head_sha:
+            raise SystemExit("--new-head-sha is required for changes_pushed")
+        updated = apply_fixup_result(state, new_head_sha=args.new_head_sha)
+    else:
+        updated = apply_no_change_fixup_result(state)
+    _write_json(asdict(updated))
+    return 0
+
+
+def _command_json_get(args: argparse.Namespace) -> int:
+    payload = _load_json(args.json_file)
+    value: Any = payload
+    for part in args.field.split("."):
+        if not isinstance(value, dict) or part not in value:
+            raise SystemExit(f"missing field: {args.field}")
+        value = value[part]
+    sys.stdout.write(str(value))
+    sys.stdout.write("\n")
+    return 0
+
+
+def _command_upsert_pr_phase_section(args: argparse.Namespace) -> int:
+    body = _load_text(args.body_file)
+    content_lines = _load_text(args.content_file).splitlines()
+    updated = upsert_pr_phase_section(body, heading=args.heading, content_lines=content_lines)
+    _write_text(args.output_file, updated)
+    return 0
+
+
+def _command_prepare_detect_artifacts(args: argparse.Namespace) -> int:
+    register_payload = {
+        "pr_number": int(args.pr_number),
+        "branch": args.branch,
+        "head_sha": args.head_sha,
+        "old_commit": args.old_commit,
+        "new_commit": args.new_commit,
+        "phase": "2",
+    }
+    state = Main2MainState(
+        pr_number=int(args.pr_number),
+        branch=args.branch,
+        head_sha=args.head_sha,
+        old_commit=args.old_commit,
+        new_commit=args.new_commit,
+        phase="2",
+        status="waiting_e2e",
+        dispatch_token=args.dispatch_token,
+        last_transition="detect->waiting_e2e",
+        updated_by=args.updated_by,
+    )
+    _write_json_file(args.state_json_out, asdict(state))
+    _write_json_file(args.register_json_out, register_payload)
+    _write_text(args.state_comment_out, render_state_comment(state) + "\n")
+    _write_text(
+        args.register_comment_out,
+        render_registration_comment(RegistrationMetadata(**register_payload)) + "\n",
+    )
+    return 0
+
+
+def _command_prepare_fix_transition(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    if args.result == "changes_pushed":
+        if not args.new_head_sha:
+            raise SystemExit("--new-head-sha is required for changes_pushed")
+        next_state = apply_fixup_result(state, new_head_sha=args.new_head_sha)
+    else:
+        next_state = apply_no_change_fixup_result(state)
+    next_state = replace(
+        next_state,
+        fix_run_id=args.fix_run_id,
+        dispatch_token="" if args.clear_dispatch_token else next_state.dispatch_token,
+        workflow_error_count=0,
+        last_transition=args.last_transition,
+        updated_by=args.updated_by,
+    )
+    register_payload = _registration_payload_from_state(next_state)
+    _write_json_file(args.state_json_out, asdict(next_state))
+    _write_json_file(args.register_json_out, register_payload)
+    _write_text(args.state_comment_out, render_state_comment(next_state) + "\n")
+    _write_text(
+        args.register_comment_out,
+        render_registration_comment(RegistrationMetadata(**register_payload)) + "\n",
+    )
+    return 0
+
+
+def _command_prepare_bisect_payload(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    ci_analysis = _load_json(args.ci_analysis_file)
+    bisect_payload = prepare_bisect_payload(state, ci_analysis=ci_analysis)
+    if args.payload_json_out:
+        _write_json_file(args.payload_json_out, bisect_payload)
+    else:
+        _write_json(bisect_payload)
+    return 0
+
+
+def _command_prepare_fixing_state(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    next_state = prepare_fixing_state(
+        state,
+        fix_run_id=args.fix_run_id,
+        last_transition=args.last_transition,
+        updated_by=args.updated_by,
+    )
+    _write_json_file(args.state_json_out, asdict(next_state))
+    _write_text(args.state_comment_out, render_state_comment(next_state) + "\n")
+    return 0
+
+
+def _command_prepare_waiting_bisect(args: argparse.Namespace) -> int:
+    if not str(args.bisect_run_id or "").strip():
+        raise SystemExit("--bisect-run-id is required")
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    next_state = replace(
+        state,
+        status="waiting_bisect",
+        bisect_run_id=args.bisect_run_id,
+        fix_run_id=args.fix_run_id,
+        workflow_error_count=0,
+        last_transition=args.last_transition,
+        updated_by=args.updated_by,
+    )
+    _write_json_file(args.state_json_out, asdict(next_state))
+    _write_text(args.state_comment_out, render_state_comment(next_state) + "\n")
+    return 0
+
+
+def _command_prepare_manual_review_pending(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    next_state = replace(
+        state,
+        phase="done",
+        status="manual_review_pending",
+        terminal_reason=args.terminal_reason,
+        fix_run_id=args.fix_run_id,
+        workflow_error_count=0,
+        last_transition=args.last_transition,
+        updated_by=args.updated_by,
+    )
+    _write_json_file(args.state_json_out, asdict(next_state))
+    _write_json_file(args.register_json_out, _registration_payload_from_state(next_state))
+    _write_text(args.state_comment_out, render_state_comment(next_state) + "\n")
+    _write_text(
+        args.register_comment_out,
+        render_registration_comment(RegistrationMetadata(**_registration_payload_from_state(next_state))) + "\n",
+    )
+    return 0
+
+
+def _command_prepare_workflow_error_action(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    next_count = state.workflow_error_count + 1
+    action = "retry" if next_count <= args.max_retries else "manual_review"
+    next_state = replace(
+        state,
+        dispatch_token=args.next_dispatch_token,
+        terminal_reason=args.terminal_reason if action == "manual_review" else state.terminal_reason,
+        workflow_error_count=next_count,
+        last_transition=args.retry_transition if action == "retry" else args.terminal_transition,
+        updated_by=args.updated_by,
+    )
+    _write_json_file(args.state_json_out, asdict(next_state))
+    _write_text(args.state_comment_out, render_state_comment(next_state) + "\n")
+    _write_json({"action": action, "workflow_error_count": next_count, "dispatch_token": next_state.dispatch_token})
+    return 0
+
+
+def _command_prepare_workflow_error_recovery(args: argparse.Namespace) -> int:
+    payload = _load_json(args.state_file)
+    state = Main2MainState(**_normalize_state_payload(payload))
+    next_token = mint_dispatch_token()
+    next_count = state.workflow_error_count + 1
+    action = "retry" if next_count <= args.max_retries else "manual_review"
+    next_state = replace(
+        state,
+        dispatch_token=next_token,
+        terminal_reason=args.terminal_reason if action == "manual_review" else state.terminal_reason,
+        workflow_error_count=next_count,
+        last_transition=args.retry_transition if action == "retry" else args.terminal_transition,
+        updated_by=args.updated_by,
+    )
+    _write_json_file(args.state_json_out, asdict(next_state))
+    _write_text(args.state_comment_out, render_state_comment(next_state) + "\n")
+    _write_json({"action": action, "workflow_error_count": next_count, "dispatch_token": next_state.dispatch_token})
+    return 0
+
+
+def _command_extract_pr_comments(args: argparse.Namespace) -> int:
+    comments = _load_json(args.comments_file)
+    state_comment = select_latest_marker_comment(comments, STATE_MARKER)
+    register_comment = select_latest_marker_comment(comments, REGISTER_MARKER)
+
+    if args.state_comment_out:
+        if state_comment is None:
+            raise SystemExit("missing main2main-state comment")
+        _write_text(args.state_comment_out, state_comment.body)
+    if args.state_id_out:
+        if state_comment is None:
+            raise SystemExit("missing main2main-state comment")
+        _write_text(args.state_id_out, str(state_comment.id))
+    if args.register_comment_out:
+        if register_comment is None:
+            raise SystemExit("missing main2main-register comment")
+        _write_text(args.register_comment_out, register_comment.body)
+    if args.register_id_out:
+        if register_comment is None:
+            raise SystemExit("missing main2main-register comment")
+        _write_text(args.register_id_out, str(register_comment.id))
+    return 0
+
+
+def _command_select_bisect_run_id(args: argparse.Namespace) -> int:
+    runs = _load_json(args.runs_file)
+    run_id = select_bisect_run_id(
+        runs,
+        caller_run_id=args.caller_run_id,
+        dispatch_token=args.dispatch_token,
+    )
+    sys.stdout.write(run_id)
+    sys.stdout.write("\n")
+    return 0 if run_id else 1
+
+
+def _command_load_phase_context(args: argparse.Namespace) -> int:
+    pr = _gh_json(
+        [
+            "pr",
+            "view",
+            args.pr_number,
+            "--repo",
+            args.repo,
+            "--json",
+            "number,headRefName,headRefOid,body,url",
+        ]
+    )
+    comments = _gh_api_json(f"repos/{args.repo}/issues/{args.pr_number}/comments")
+    try:
+        context = load_phase_context(
+            pr,
+            comments,
+            expected_phase=args.expected_phase,
+            expected_status=args.expected_status,
+            allowed_statuses=args.allowed_statuses or None,
+            dispatch_token=args.dispatch_token,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if args.pr_json_out:
+        _write_json_file(args.pr_json_out, context.pr)
+    if args.state_json_out:
+        _write_json_file(args.state_json_out, asdict(context.state))
+    if args.registration_json_out:
+        _write_json_file(args.registration_json_out, asdict(context.registration))
+    if args.state_id_out:
+        _write_text(args.state_id_out, str(context.state_comment_id))
+    if args.register_id_out:
+        _write_text(args.register_id_out, str(context.register_comment_id))
+    if args.context_json_out:
+        _write_json_file(
+            args.context_json_out,
+            {
+                "pr_number": context.state.pr_number,
+                "branch": context.branch,
+                "head_sha": context.head_sha,
+                "state_comment_id": context.state_comment_id,
+                "register_comment_id": context.register_comment_id,
+                "pr_url": context.pr.get("url", ""),
+            },
+        )
+    return 0
+
+
+def _reconcile_pr(repo: str, pr_number: str) -> dict[str, Any]:
+    pr = _gh_json(
+        [
+            "pr",
+            "view",
+            pr_number,
+            "--repo",
+            repo,
+            "--json",
+            "number,headRefName,headRefOid,body,mergeable,mergeStateStatus,url,statusCheckRollup",
+        ]
+    )
+    comments = _gh_api_json(f"repos/{repo}/issues/{pr_number}/comments")
+    register_comment = select_latest_marker_comment(comments, REGISTER_MARKER)
+    state_comment = select_latest_marker_comment(comments, STATE_MARKER)
+
+    if state_comment is None:
+        token = mint_dispatch_token()
+        if register_comment is not None:
+            registration = parse_registration_comment(register_comment.body)
+            state = init_state_from_registration(
+                registration,
+                dispatch_token=token,
+                updated_by="schedule_main2main_reconcile.yaml/bootstrap",
+            )
+        else:
+            metadata = parse_pr_metadata(pr.get("body") or "")
+            state = Main2MainState(
+                pr_number=int(pr["number"]),
+                branch=pr["headRefName"],
+                head_sha=pr["headRefOid"],
+                old_commit=metadata.old_commit,
+                new_commit=metadata.new_commit,
+                phase="2",
+                status="waiting_e2e",
+                dispatch_token=token,
+                last_transition="reconcile/recover->waiting_e2e",
+                updated_by="schedule_main2main_reconcile.yaml/recover",
+            )
+        created = _gh_api_json(
+            f"repos/{repo}/issues/{pr_number}/comments",
+            method="POST",
+            payload={"body": render_state_comment(state)},
+        )
+        state_comment_id = int(created["id"])
+    else:
+        state = parse_state_comment(state_comment.body)
+        state_comment_id = state_comment.id
+
+    consistency = check_pr_consistency(
+        state,
+        branch=pr["headRefName"],
+        head_sha=pr["headRefOid"],
+    )
+    if not consistency.ok:
+        return {"action": "skip", "reason": consistency.reason}
+    if register_comment is not None:
+        registration = parse_registration_comment(register_comment.body)
+        registration_consistency = check_registration_consistency(state, registration)
+        if not registration_consistency.ok:
+            return {"action": "skip", "reason": registration_consistency.reason}
+    else:
+        _gh_api_json(
+            f"repos/{repo}/issues/{pr_number}/comments",
+            method="POST",
+            payload={
+                "body": render_registration_comment(
+                    RegistrationMetadata(**_registration_payload_from_state(state))
+                )
+            },
+        )
+
+    if state.status == "waiting_e2e":
+        resolved_e2e_run_id = resolve_e2e_run_id_from_status_checks(pr.get("statusCheckRollup") or [])
+        e2e_run_id = resolved_e2e_run_id or state.e2e_run_id
+        matched_run = None
+        if e2e_run_id:
+            try:
+                matched_run = _gh_json(
+                    [
+                        "run",
+                        "view",
+                        e2e_run_id,
+                        "--repo",
+                        repo,
+                        "--json",
+                        "databaseId,headSha,status,conclusion,createdAt,url",
+                    ]
+                )
+            except RuntimeError:
+                matched_run = None
+        if matched_run is None and not e2e_run_id:
+            runs = _gh_json(
+                [
+                    "run",
+                    "list",
+                    "--repo",
+                    repo,
+                    "--workflow",
+                    "pr_test_full.yaml",
+                    "-L",
+                    "50",
+                    "--json",
+                    "databaseId,headSha,status,conclusion,createdAt,url",
+                ]
+            )
+            matched_run = select_matching_e2e_run(runs or [], head_sha=state.head_sha)
+            if matched_run is not None:
+                e2e_run_id = str(matched_run.get("databaseId") or "")
+        if e2e_run_id and state.e2e_run_id != e2e_run_id:
+            state = replace(state, e2e_run_id=e2e_run_id, updated_by="schedule_main2main_reconcile.yaml/resolve_e2e")
+            _patch_state_comment(repo, state_comment_id, state)
+        decision = decide_reconcile_action(
+            state,
+            e2e_run=matched_run,
+            merge_state_status=pr.get("mergeStateStatus"),
+            mergeable=pr.get("mergeable"),
+        )
+    elif state.status == "waiting_bisect":
+        bisect_finished = False
+        if state.bisect_run_id:
+            try:
+                bisect_meta = _gh_json(
+                    ["run", "view", state.bisect_run_id, "--repo", repo, "--json", "status,conclusion"]
+                )
+            except RuntimeError:
+                bisect_meta = {}
+            bisect_finished = (bisect_meta or {}).get("status") == "completed"
+        decision = decide_reconcile_action(
+            state,
+            merge_state_status=pr.get("mergeStateStatus"),
+            mergeable=pr.get("mergeable"),
+            bisect_finished=bisect_finished,
+            finalize_missing=bisect_finished and state.last_transition != "reconcile->fix_phase3_finalize",
+        )
+    else:
+        decision = ReconcileDecision(action="ignore", reason=f"state {state.status} is not handled by reconcile")
+
+    if decision.action in {"wait", "ignore"}:
+        return {"action": decision.action, "reason": decision.reason}
+
+    token = mint_dispatch_token()
+    next_state = replace(state, dispatch_token=token, updated_by="schedule_main2main_reconcile.yaml")
+    if decision.run_id:
+        next_state = replace(next_state, e2e_run_id=decision.run_id)
+    if decision.action == "dispatch_fix_phase2":
+        next_state = replace(
+            next_state,
+            status="fixing",
+            phase="2",
+            workflow_error_count=0,
+            last_transition="reconcile->fix_phase2",
+        )
+    elif decision.action == "dispatch_fix_phase3_prepare":
+        next_state = replace(
+            next_state,
+            status="fixing",
+            phase="3",
+            workflow_error_count=0,
+            last_transition="reconcile->fix_phase3_prepare",
+        )
+    elif decision.action == "dispatch_manual_review":
+        next_state = replace(
+            next_state,
+            terminal_reason=decision.terminal_reason,
+            workflow_error_count=0,
+            last_transition="reconcile->manual_review",
+        )
+    elif decision.action == "dispatch_make_ready":
+        next_state = replace(next_state, workflow_error_count=0, last_transition="reconcile->make_ready")
+    elif decision.action == "dispatch_fix_phase3_finalize":
+        next_state = replace(next_state, workflow_error_count=0, last_transition="reconcile->fix_phase3_finalize")
+
+    _gh_api_json(
+        f"repos/{repo}/issues/comments/{state_comment_id}",
+        method="PATCH",
+        payload={"body": render_state_comment(next_state)},
+    )
+
+    if decision.action == "dispatch_fix_phase2":
+        _gh(
+            [
+                "workflow",
+                "run",
+                "schedule_main2main_auto.yaml",
+                "--repo",
+                repo,
+                "-f",
+                "mode=fix_phase2",
+                "-f",
+                f"pr_number={pr_number}",
+                "-f",
+                f"dispatch_token={token}",
+            ]
+        )
+    elif decision.action == "dispatch_fix_phase3_prepare":
+        _gh(
+            [
+                "workflow",
+                "run",
+                "schedule_main2main_auto.yaml",
+                "--repo",
+                repo,
+                "-f",
+                "mode=fix_phase3_prepare",
+                "-f",
+                f"pr_number={pr_number}",
+                "-f",
+                f"dispatch_token={token}",
+            ]
+        )
+    elif decision.action == "dispatch_fix_phase3_finalize":
+        _gh(
+            [
+                "workflow",
+                "run",
+                "schedule_main2main_auto.yaml",
+                "--repo",
+                repo,
+                "-f",
+                "mode=fix_phase3_finalize",
+                "-f",
+                f"pr_number={pr_number}",
+                "-f",
+                f"dispatch_token={token}",
+                "-f",
+                f"bisect_run_id={next_state.bisect_run_id}",
+            ]
+        )
+    elif decision.action == "dispatch_make_ready":
+        _gh(
+            [
+                "workflow",
+                "run",
+                "dispatch_main2main_terminal.yaml",
+                "--repo",
+                repo,
+                "-f",
+                "action=make_ready",
+                "-f",
+                f"pr_number={pr_number}",
+                "-f",
+                f"dispatch_token={token}",
+            ]
+        )
+    elif decision.action == "dispatch_manual_review":
+        _gh(
+            [
+                "workflow",
+                "run",
+                "dispatch_main2main_terminal.yaml",
+                "--repo",
+                repo,
+                "-f",
+                "action=manual_review",
+                "-f",
+                f"pr_number={pr_number}",
+                "-f",
+                f"dispatch_token={token}",
+                "-f",
+                f"terminal_reason={decision.terminal_reason}",
+            ]
+        )
+
+    return {"action": decision.action, "reason": decision.reason, "run_id": decision.run_id}
+
+
+def _command_reconcile_pr(args: argparse.Namespace) -> int:
+    result = _reconcile_pr(args.repo, args.pr_number)
+    _write_json(result)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Workflow-native main2main CI helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    mint = subparsers.add_parser("mint-dispatch-token")
+    mint.set_defaults(func=_command_mint_dispatch_token)
+
+    state_read = subparsers.add_parser("state-read")
+    state_read.add_argument("--comment-file", required=True)
+    state_read.set_defaults(func=_command_state_read)
+
+    state_write = subparsers.add_parser("state-write")
+    state_write.add_argument("--json-file", required=True)
+    state_write.set_defaults(func=_command_state_write)
+
+    register_read = subparsers.add_parser("registration-read")
+    register_read.add_argument("--comment-file", required=True)
+    register_read.set_defaults(func=_command_registration_read)
+
+    register_write = subparsers.add_parser("registration-write")
+    register_write.add_argument("--json-file", required=True)
+    register_write.set_defaults(func=_command_registration_write)
+
+    init_state = subparsers.add_parser("state-init-from-register")
+    init_state.add_argument("--comment-file", required=True)
+    init_state.add_argument("--dispatch-token", required=True)
+    init_state.add_argument("--updated-at", default="")
+    init_state.add_argument("--updated-by", default="")
+    init_state.set_defaults(func=_command_state_init_from_register)
+
+    guard = subparsers.add_parser("guard-check")
+    guard.add_argument("--state-file", required=True)
+    guard.add_argument("--expected-phase", default=None)
+    guard.add_argument("--expected-status", default=None)
+    guard.add_argument("--dispatch-token", default=None)
+    guard.set_defaults(func=_command_guard_check)
+
+    consistency = subparsers.add_parser("pr-consistency-check")
+    consistency.add_argument("--state-file", required=True)
+    consistency.add_argument("--branch", required=True)
+    consistency.add_argument("--head-sha", required=True)
+    consistency.set_defaults(func=_command_pr_consistency_check)
+
+    registration_consistency = subparsers.add_parser("registration-consistency-check")
+    registration_consistency.add_argument("--state-file", required=True)
+    registration_consistency.add_argument("--registration-file", required=True)
+    registration_consistency.set_defaults(func=_command_registration_consistency_check)
+
+    reconcile = subparsers.add_parser("reconcile-decision")
+    reconcile.add_argument("--state-file", required=True)
+    reconcile.add_argument("--e2e-run-file", default="")
+    reconcile.add_argument("--merge-state-status", default=None)
+    reconcile.add_argument("--mergeable", default=None)
+    reconcile.add_argument("--bisect-finished", action="store_true")
+    reconcile.add_argument("--finalize-missing", action="store_true")
+    reconcile.set_defaults(func=_command_reconcile_decision)
+
+    reconcile_pr = subparsers.add_parser("reconcile-pr")
+    reconcile_pr.add_argument("--repo", required=True)
+    reconcile_pr.add_argument("--pr-number", required=True)
+    reconcile_pr.set_defaults(func=_command_reconcile_pr)
+
+    select_run = subparsers.add_parser("select-e2e-run")
+    select_run.add_argument("--runs-file", required=True)
+    select_run.add_argument("--head-sha", required=True)
+    select_run.set_defaults(func=_command_select_e2e_run)
+
+    apply_fix = subparsers.add_parser("apply-fix-result")
+    apply_fix.add_argument("--state-file", required=True)
+    apply_fix.add_argument("--result", required=True, choices=["changes_pushed", "no_changes"])
+    apply_fix.add_argument("--new-head-sha", default="")
+    apply_fix.set_defaults(func=_command_apply_fix_result)
+
+    json_get = subparsers.add_parser("json-get")
+    json_get.add_argument("--json-file", required=True)
+    json_get.add_argument("--field", required=True)
+    json_get.set_defaults(func=_command_json_get)
+
+    upsert_section = subparsers.add_parser("upsert-pr-phase-section")
+    upsert_section.add_argument("--body-file", required=True)
+    upsert_section.add_argument("--heading", required=True)
+    upsert_section.add_argument("--content-file", required=True)
+    upsert_section.add_argument("--output-file", required=True)
+    upsert_section.set_defaults(func=_command_upsert_pr_phase_section)
+
+    detect_artifacts = subparsers.add_parser("prepare-detect-artifacts")
+    detect_artifacts.add_argument("--pr-number", required=True)
+    detect_artifacts.add_argument("--branch", required=True)
+    detect_artifacts.add_argument("--head-sha", required=True)
+    detect_artifacts.add_argument("--old-commit", required=True)
+    detect_artifacts.add_argument("--new-commit", required=True)
+    detect_artifacts.add_argument("--dispatch-token", required=True)
+    detect_artifacts.add_argument("--updated-by", default="schedule_main2main_auto.yaml/detect")
+    detect_artifacts.add_argument("--state-json-out", required=True)
+    detect_artifacts.add_argument("--register-json-out", required=True)
+    detect_artifacts.add_argument("--state-comment-out", required=True)
+    detect_artifacts.add_argument("--register-comment-out", required=True)
+    detect_artifacts.set_defaults(func=_command_prepare_detect_artifacts)
+
+    fix_transition = subparsers.add_parser("prepare-fix-transition")
+    fix_transition.add_argument("--state-file", required=True)
+    fix_transition.add_argument("--result", required=True, choices=["changes_pushed", "no_changes"])
+    fix_transition.add_argument("--new-head-sha", default="")
+    fix_transition.add_argument("--fix-run-id", required=True)
+    fix_transition.add_argument("--last-transition", required=True)
+    fix_transition.add_argument("--updated-by", required=True)
+    fix_transition.add_argument("--state-json-out", required=True)
+    fix_transition.add_argument("--register-json-out", required=True)
+    fix_transition.add_argument("--state-comment-out", required=True)
+    fix_transition.add_argument("--register-comment-out", required=True)
+    fix_transition.add_argument("--clear-dispatch-token", action="store_true")
+    fix_transition.set_defaults(func=_command_prepare_fix_transition)
+
+    bisect_payload = subparsers.add_parser("prepare-bisect-payload")
+    bisect_payload.add_argument("--state-file", required=True)
+    bisect_payload.add_argument("--ci-analysis-file", required=True)
+    bisect_payload.add_argument("--payload-json-out", required=False)
+    bisect_payload.set_defaults(func=_command_prepare_bisect_payload)
+
+    fixing_state = subparsers.add_parser("prepare-fixing-state")
+    fixing_state.add_argument("--state-file", required=True)
+    fixing_state.add_argument("--fix-run-id", required=True)
+    fixing_state.add_argument("--last-transition", required=True)
+    fixing_state.add_argument("--updated-by", required=True)
+    fixing_state.add_argument("--state-json-out", required=True)
+    fixing_state.add_argument("--state-comment-out", required=True)
+    fixing_state.set_defaults(func=_command_prepare_fixing_state)
+
+    waiting_bisect = subparsers.add_parser("prepare-waiting-bisect")
+    waiting_bisect.add_argument("--state-file", required=True)
+    waiting_bisect.add_argument("--bisect-run-id", required=True)
+    waiting_bisect.add_argument("--fix-run-id", required=True)
+    waiting_bisect.add_argument("--last-transition", required=True)
+    waiting_bisect.add_argument("--updated-by", required=True)
+    waiting_bisect.add_argument("--state-json-out", required=True)
+    waiting_bisect.add_argument("--state-comment-out", required=True)
+    waiting_bisect.set_defaults(func=_command_prepare_waiting_bisect)
+
+    manual_review_pending = subparsers.add_parser("prepare-manual-review-pending")
+    manual_review_pending.add_argument("--state-file", required=True)
+    manual_review_pending.add_argument("--terminal-reason", required=True)
+    manual_review_pending.add_argument("--fix-run-id", required=True)
+    manual_review_pending.add_argument("--last-transition", required=True)
+    manual_review_pending.add_argument("--updated-by", required=True)
+    manual_review_pending.add_argument("--state-json-out", required=True)
+    manual_review_pending.add_argument("--register-json-out", required=True)
+    manual_review_pending.add_argument("--state-comment-out", required=True)
+    manual_review_pending.add_argument("--register-comment-out", required=True)
+    manual_review_pending.set_defaults(func=_command_prepare_manual_review_pending)
+
+    workflow_error = subparsers.add_parser("prepare-workflow-error-action")
+    workflow_error.add_argument("--state-file", required=True)
+    workflow_error.add_argument("--next-dispatch-token", required=True)
+    workflow_error.add_argument("--max-retries", type=int, default=1)
+    workflow_error.add_argument("--terminal-reason", default="workflow_error")
+    workflow_error.add_argument("--retry-transition", required=True)
+    workflow_error.add_argument("--terminal-transition", required=True)
+    workflow_error.add_argument("--updated-by", required=True)
+    workflow_error.add_argument("--state-json-out", required=True)
+    workflow_error.add_argument("--state-comment-out", required=True)
+    workflow_error.set_defaults(func=_command_prepare_workflow_error_action)
+
+    workflow_error_recovery = subparsers.add_parser("prepare-workflow-error-recovery")
+    workflow_error_recovery.add_argument("--state-file", required=True)
+    workflow_error_recovery.add_argument("--max-retries", type=int, default=1)
+    workflow_error_recovery.add_argument("--terminal-reason", default="workflow_error")
+    workflow_error_recovery.add_argument("--retry-transition", required=True)
+    workflow_error_recovery.add_argument("--terminal-transition", required=True)
+    workflow_error_recovery.add_argument("--updated-by", required=True)
+    workflow_error_recovery.add_argument("--state-json-out", required=True)
+    workflow_error_recovery.add_argument("--state-comment-out", required=True)
+    workflow_error_recovery.set_defaults(func=_command_prepare_workflow_error_recovery)
+
+    extract_comments = subparsers.add_parser("extract-pr-comments")
+    extract_comments.add_argument("--comments-file", required=True)
+    extract_comments.add_argument("--state-comment-out", default="")
+    extract_comments.add_argument("--state-id-out", default="")
+    extract_comments.add_argument("--register-comment-out", default="")
+    extract_comments.add_argument("--register-id-out", default="")
+    extract_comments.set_defaults(func=_command_extract_pr_comments)
+
+    select_bisect = subparsers.add_parser("select-bisect-run-id")
+    select_bisect.add_argument("--runs-file", required=True)
+    select_bisect.add_argument("--caller-run-id", required=True)
+    select_bisect.add_argument("--dispatch-token", required=True)
+    select_bisect.set_defaults(func=_command_select_bisect_run_id)
+
+    load_phase = subparsers.add_parser("load-phase-context")
+    load_phase.add_argument("--repo", required=True)
+    load_phase.add_argument("--pr-number", required=True)
+    load_phase.add_argument("--expected-phase", default=None)
+    load_phase.add_argument("--expected-status", default=None)
+    load_phase.add_argument("--allowed-statuses", nargs="*", default=[])
+    load_phase.add_argument("--dispatch-token", default=None)
+    load_phase.add_argument("--pr-json-out", default="")
+    load_phase.add_argument("--state-json-out", default="")
+    load_phase.add_argument("--registration-json-out", default="")
+    load_phase.add_argument("--state-id-out", default="")
+    load_phase.add_argument("--register-id-out", default="")
+    load_phase.add_argument("--context-json-out", default="")
+    load_phase.set_defaults(func=_command_load_phase_context)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/scripts/main2main_ci.py
+++ b/.github/workflows/scripts/main2main_ci.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 import uuid
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any
+
+import regex as re
 
 STATE_MARKER = "main2main-state:v1"
 REGISTER_MARKER = "main2main-register"
@@ -266,7 +267,9 @@ def check_registration_consistency(
     if state.branch != registration.branch:
         return GuardResult(False, f"registration branch mismatch: expected {state.branch}, got {registration.branch}")
     if state.head_sha != registration.head_sha:
-        return GuardResult(False, f"registration head_sha mismatch: expected {state.head_sha}, got {registration.head_sha}")
+        return GuardResult(
+            False, f"registration head_sha mismatch: expected {state.head_sha}, got {registration.head_sha}"
+        )
     if state.old_commit != registration.old_commit or state.new_commit != registration.new_commit:
         return GuardResult(False, "registration commit range mismatch")
     if state.phase != registration.phase:
@@ -386,9 +389,7 @@ def normalize_conclusion(conclusion: str) -> str:
 def is_merge_conflict(*, merge_state_status: str | None = None, mergeable: str | None = None) -> bool:
     if mergeable and mergeable.upper() in _CONFLICT_MERGEABLES:
         return True
-    if merge_state_status and merge_state_status.upper() in _CONFLICT_MERGE_STATE_STATUSES:
-        return True
-    return False
+    return bool(merge_state_status and merge_state_status.upper() in _CONFLICT_MERGE_STATE_STATUSES)
 
 
 def decide_reconcile_action(
@@ -1045,9 +1046,7 @@ def _reconcile_pr(repo: str, pr_number: str) -> dict[str, Any]:
             f"repos/{repo}/issues/{pr_number}/comments",
             method="POST",
             payload={
-                "body": render_registration_comment(
-                    RegistrationMetadata(**_registration_payload_from_state(state))
-                )
+                "body": render_registration_comment(RegistrationMetadata(**_registration_payload_from_state(state)))
             },
         )
 


### PR DESCRIPTION
### What this PR does / why we need it?

Add the full `main2main` automation flow for upstream vLLM updates.

This PR introduces a GitHub Actions based control plane that:
- detects upstream vLLM commit drift and opens a `main2main` PR
- stores live workflow state in structured PR comments
- reconciles PR progress through scheduled polling
- runs automated phase 2 / phase 3 fix attempts
- dispatches bisect for phase 3 root-cause isolation
- performs terminal actions such as marking the PR ready or opening a manual review issue

## Core Components

- `schedule_main2main_auto.yaml`: main detect/fix workflow
- `schedule_main2main_reconcile.yaml`: scheduled state reconciliation and dispatch
- `dispatch_main2main_terminal.yaml`: ready/manual-review terminal actions
- `dispatch_main2main_bisect.yaml`: phase 3 bisect execution and result publishing
- `main2main_ci.py`: shared workflow state-machine helper

This introduces a complete workflow-driven `main2main` control plane that can create, track, repair, bisect, and finalize main2main PRs end to end.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
