### PR TITLE
[CI] Fix the nightly pip binary install doc test fail

### DIFF
--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -48,7 +48,7 @@ function install_binary_test() {
     pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/"
 
     # The vLLM version already in pypi, we install from pypi.
-    pip install vllm=="${PIP_VLLM_VERSION}"
+    pip install --default-timeout=300 --retries 3 vllm=="${PIP_VLLM_VERSION}"
 
     pip install vllm-ascend=="${PIP_VLLM_ASCEND_VERSION}"
     if [ "${PIP_VLLM_ASCEND_VERSION}" == "0.17.0rc1" ]; then


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the nightly pip binary install doc test fail.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Nightly doc test

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
