### PR TITLE
[CI][Bugfix] Fix auto-translation PO file corruption and improve PR title

### DIFF
--- a/.github/workflows/schedule_doc_translate.yaml
+++ b/.github/workflows/schedule_doc_translate.yaml
@@ -33,9 +33,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  translate:
+  check:
     runs-on: linux-amd64-cpu-8-hk
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+      pr_title: ${{ steps.check.outputs.pr_title }}
+    steps:
+      - name: Check for existing open PR
+        id: check
+        uses: actions/github-script@v8
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const base = process.env.TARGET_BRANCH;
+            const branchLabel = base.split('/').pop();
+            const prTitle = '[' + branchLabel + '][Doc] Translated Doc files';
+            core.setOutput('pr_title', prTitle);
+
+            const existingPRs = await github.rest.pulls.list({
+              owner: 'vllm-project', repo: 'vllm-ascend',
+              base: base, state: 'open', per_page: 100
+            });
+            const duplicate = existingPRs.data.find(pr => pr.title === prTitle);
+            if (duplicate) {
+              core.notice('PR #' + duplicate.number + ' for base "' + base + '" is still open, skipping this run.');
+              core.setOutput('skip', 'true');
+            } else {
+              core.setOutput('skip', 'false');
+            }
+
+  translate:
+    needs: check
+    if: needs.check.outputs.skip != 'true'
+    runs-on: linux-amd64-cpu-8-hk
+    timeout-minutes: 400
     permissions:
       contents: read
     env:
@@ -154,6 +188,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_HEAD: vllm-ascend-ci:${{ env.BRANCH_NAME }}
           PR_BASE: ${{ env.TARGET_BRANCH }}
+          PR_TITLE: ${{ needs.check.outputs.pr_title }}
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
@@ -165,7 +200,7 @@ jobs:
               const pr = await github.rest.pulls.create({
                 owner: 'vllm-project', repo: 'vllm-ascend',
                 head: process.env.PR_HEAD, base: process.env.PR_BASE,
-                title: '[Doc] Translated Doc files', body: prBody
+                title: process.env.PR_TITLE, body: prBody
               });
               core.info('Created PR #' + pr.data.number);
             } catch (error) {

--- a/.github/workflows/schedule_doc_translate.yaml
+++ b/.github/workflows/schedule_doc_translate.yaml
@@ -33,43 +33,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  translate:
     runs-on: linux-amd64-cpu-8-hk
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-      pr_title: ${{ steps.check.outputs.pr_title }}
-    steps:
-      - name: Check for existing open PR
-        id: check
-        uses: actions/github-script@v8
-        env:
-          TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
-        with:
-          github-token: ${{ secrets.PAT_TOKEN }}
-          script: |
-            const base = process.env.TARGET_BRANCH;
-            const branchLabel = base.split('/').pop();
-            const prTitle = '[' + branchLabel + '][Doc] Translated Doc files';
-            core.setOutput('pr_title', prTitle);
-
-            const existingPRs = await github.rest.pulls.list({
-              owner: 'vllm-project', repo: 'vllm-ascend',
-              base: base, state: 'open', per_page: 100
-            });
-            const duplicate = existingPRs.data.find(pr => pr.title === prTitle);
-            if (duplicate) {
-              core.notice('PR #' + duplicate.number + ' for base "' + base + '" is still open, skipping this run.');
-              core.setOutput('skip', 'true');
-            } else {
-              core.setOutput('skip', 'false');
-            }
-
-  translate:
-    needs: check
-    if: needs.check.outputs.skip != 'true'
-    runs-on: linux-amd64-cpu-8-hk
-    timeout-minutes: 400
     permissions:
       contents: read
     env:
@@ -188,11 +154,15 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_HEAD: vllm-ascend-ci:${{ env.BRANCH_NAME }}
           PR_BASE: ${{ env.TARGET_BRANCH }}
-          PR_TITLE: ${{ needs.check.outputs.pr_title }}
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             try {
+              const branchLabel = process.env.PR_BASE.split('/').pop();
+              const date = new Date().toISOString().slice(0, 10);
+              const prTitle = branchLabel === 'main'
+                ? '[Doc] Translated Doc files ' + date
+                : '[' + branchLabel + '][Doc] Translated Doc files ' + date;
               const prBody = '## Auto-Translation Summary\n\n' +
                 'Translated **' + process.env.FILE_COUNT + '** file(s):\n\n' +
                 process.env.FILE_LIST + '\n---\n\n' +
@@ -200,7 +170,7 @@ jobs:
               const pr = await github.rest.pulls.create({
                 owner: 'vllm-project', repo: 'vllm-ascend',
                 head: process.env.PR_HEAD, base: process.env.PR_BASE,
-                title: process.env.PR_TITLE, body: prBody
+                title: prTitle, body: prBody
               });
               core.info('Created PR #' + pr.data.number);
             } catch (error) {

--- a/.github/workflows/scripts/po_translate.py
+++ b/.github/workflows/scripts/po_translate.py
@@ -19,12 +19,12 @@ import argparse
 import asyncio
 import json
 import os
-import re
 import shutil
 import sys
 import time
 from pathlib import Path
 
+import regex as re
 from openai import AsyncOpenAI
 
 SYSTEM_PROMPT = (
@@ -120,22 +120,22 @@ class POTranslator:
         orphaned msgstr lines.  This method keeps each entry intact.
         """
         # PO entries are separated by one or more blank lines.
-        entries = re.split(r'\n{2,}', content.strip())
+        entries = re.split(r"\n{2,}", content.strip())
         chunks: list[str] = []
         current: list[str] = []
         current_lines = 0
 
         for entry in entries:
-            entry_lines = entry.count('\n') + 1
+            entry_lines = entry.count("\n") + 1
             if current_lines + entry_lines > max_lines and current:
-                chunks.append('\n\n'.join(current) + '\n')
+                chunks.append("\n\n".join(current) + "\n")
                 current = []
                 current_lines = 0
             current.append(entry)
             current_lines += entry_lines
 
         if current:
-            chunks.append('\n\n'.join(current) + '\n')
+            chunks.append("\n\n".join(current) + "\n")
 
         return chunks if len(chunks) > 1 else [content]
 
@@ -167,7 +167,7 @@ class POTranslator:
             translated[idx] = chunk_text
 
         # Write result: join chunks with a single blank line between them
-        final = '\n\n'.join(t.strip('\n') for t in translated) + '\n'
+        final = "\n\n".join(t.strip("\n") for t in translated) + "\n"
         Path(po_path).write_text(final, encoding="utf-8")
         return True
 

--- a/.github/workflows/scripts/po_translate.py
+++ b/.github/workflows/scripts/po_translate.py
@@ -19,6 +19,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import shutil
 import sys
 import time
@@ -45,7 +46,6 @@ Rules:
 
 Return ONLY the complete PO file content, no extra explanations.
 
-{chunk_info}
 {content}"""
 
 
@@ -56,11 +56,14 @@ class POTranslator:
 
     async def _call_api(self, content: str, chunk_info: str = "") -> str | None:
         """Make a single translation API call."""
-        prompt = TRANSLATION_PROMPT.format(content=content, chunk_info=chunk_info)
+        prompt = TRANSLATION_PROMPT.format(content=content)
+        system = SYSTEM_PROMPT
+        if chunk_info:
+            system = f"{SYSTEM_PROMPT} ({chunk_info})"
         response = await self.client.chat.completions.create(
             model="deepseek-chat",
             messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "system", "content": system},
                 {"role": "user", "content": prompt},
             ],
             max_tokens=8000,
@@ -84,8 +87,9 @@ class POTranslator:
             lines = content.split("\n")
             print(f"  {path.name} ({len(lines)} lines)", end=" ", flush=True)
 
-            if len(lines) > 500:
-                success = await self._translate_chunked(po_path, lines)
+            chunks = self._split_po_entries(content)
+            if len(chunks) > 1:
+                success = await self._translate_chunked(po_path, chunks)
             else:
                 result = await self._call_api(content)
                 if result:
@@ -107,23 +111,47 @@ class POTranslator:
         finally:
             Path(backup).unlink(missing_ok=True)
 
-    async def _translate_chunked(self, po_path: str, lines: list[str]) -> bool:
-        """Translate large file in parallel chunks."""
-        chunk_size = 300
-        total = (len(lines) + chunk_size - 1) // chunk_size
+    @staticmethod
+    def _split_po_entries(content: str, max_lines: int = 300) -> list[str]:
+        """Split PO content into chunks on entry boundaries (blank-line separated).
+
+        Splitting on raw line numbers can cut a msgid/msgstr pair in half,
+        causing the LLM to see an incomplete entry and produce duplicate or
+        orphaned msgstr lines.  This method keeps each entry intact.
+        """
+        # PO entries are separated by one or more blank lines.
+        entries = re.split(r'\n{2,}', content.strip())
+        chunks: list[str] = []
+        current: list[str] = []
+        current_lines = 0
+
+        for entry in entries:
+            entry_lines = entry.count('\n') + 1
+            if current_lines + entry_lines > max_lines and current:
+                chunks.append('\n\n'.join(current) + '\n')
+                current = []
+                current_lines = 0
+            current.append(entry)
+            current_lines += entry_lines
+
+        if current:
+            chunks.append('\n\n'.join(current) + '\n')
+
+        return chunks if len(chunks) > 1 else [content]
+
+    async def _translate_chunked(self, po_path: str, chunks: list[str]) -> bool:
+        """Translate large file in parallel entry-aligned chunks."""
+        total = len(chunks)
         sem = asyncio.Semaphore(self.max_concurrent)
 
-        async def do_chunk(idx: int) -> tuple[int, list[str] | None, str | None]:
+        async def do_chunk(idx: int) -> tuple[int, str | None, str | None]:
             async with sem:
-                start = idx * chunk_size
-                end = min((idx + 1) * chunk_size, len(lines))
-                chunk = "\n".join(lines[start:end])
-                info = f"[Chunk {idx + 1}/{total}]"
+                info = f"chunk {idx + 1}/{total}"
                 try:
-                    result = await self._call_api(chunk, chunk_info=info)
+                    result = await self._call_api(chunks[idx], chunk_info=info)
                     if result is None:
                         return (idx, None, "empty response")
-                    return (idx, result.split("\n"), None)
+                    return (idx, result, None)
                 except Exception as e:
                     return (idx, None, str(e)[:50])
 
@@ -131,15 +159,15 @@ class POTranslator:
         results = await asyncio.gather(*[do_chunk(i) for i in range(total)])
 
         # Check for failures
-        translated = [None] * total
-        for idx, chunk_lines, error in results:
+        translated: list[str | None] = [None] * total
+        for idx, chunk_text, error in results:
             if error:
                 print(f"\n    Chunk {idx + 1} failed: {error}")
                 return False
-            translated[idx] = chunk_lines
+            translated[idx] = chunk_text
 
-        # Write result
-        final = "\n".join(line for chunk in translated for line in chunk)
+        # Write result: join chunks with a single blank line between them
+        final = '\n\n'.join(t.strip('\n') for t in translated) + '\n'
         Path(po_path).write_text(final, encoding="utf-8")
         return True
 

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -9,3 +9,4 @@ msgspec
 sphinx-substitution-extensions
 sphinx-intl
 openai
+regex


### PR DESCRIPTION
### What this PR does / why we need it?


Fix two bugs in the auto doc translation workflow that caused corrupted PO files (duplicate `msgstr`, orphaned entries, and stray chunk markers), and improve the generated PR title to include branch label and date.

### `po_translate.py` — fix PO file corruption on large files

The previous implementation split PO files by raw line count (`chunk_size=300`), which could cut a `msgid`/`msgstr` pair across two chunks. This caused:
- **Duplicate `msgstr`**: LLM completes the truncated entry in chunk N, while the original `msgstr` at the start of chunk N+1 becomes a second entry.
- **Broken PO syntax**: chunk N+1 starting with `msgstr` without a preceding `msgid`.
- **Stray chunk markers** (`[Chunk 2/4]`): `chunk_info` was injected into the user message body, and the LLM echoed it into the translated output.

Fixes:
- Add `_split_po_entries()`: splits content on blank-line entry boundaries instead of raw line numbers, keeping each `msgid`/`msgstr` block intact.
- Move `chunk_info` from the user prompt body to the system message, so the LLM never includes it in the translation output.
- `_translate_chunked()` now receives pre-split entry-aligned chunks and joins them with a single blank line, avoiding double blank lines or missing separators.

### `schedule_doc_translate.yaml` — improve auto-generated PR title

- PR title now includes the target branch label (skipped for `main`) and the creation date, e.g. `[v0.8.x][Doc] Translated Doc files 2026-04-13`.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
