### PR TITLE
[CI] Hot fix for nightly accuracy test and doc tests

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.vllm-ascend }}
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/labeled_doctest.yaml
+++ b/.github/workflows/labeled_doctest.yaml
@@ -44,7 +44,7 @@ jobs:
       # Each version should be tested
       fail-fast: false
       matrix:
-        vllm_version: [releases-v0.13.0, releases-v0.13.0-openeuler, main, main-openeuler]
+        vllm_version: [nightly-releases-v0.18.0, nightly-releases-v0.18.0-openeuler, nightly-main, nightly-main-openeuler]
     name: vLLM Ascend test
     runs-on: linux-aarch64-a2b3-1
     container:
@@ -76,6 +76,8 @@ jobs:
           # Overwrite e2e and examples
           cp -r tests/e2e /vllm-workspace/vllm-ascend/tests/
           cp -r examples /vllm-workspace/vllm-ascend/
+          # We are now maintain version policy in the main, so we need to copy docs to make sure the doctest can be run successfully.
+          cp -r docs /vllm-workspace/vllm-ascend/
 
           # Simulate container to enter directory
           cd /workspace

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -20,7 +20,6 @@ trap clean_venv EXIT
 
 function install_system_packages() {
     if command -v apt-get >/dev/null; then
-        sed -i 's|ports.ubuntu.com|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list
         apt-get update -y && apt-get install -y gcc g++ cmake libnuma-dev wget git curl jq
     elif command -v yum >/dev/null; then
         yum update -y && yum install -y gcc g++ cmake numactl-devel wget git curl jq
@@ -30,14 +29,16 @@ function install_system_packages() {
 }
 
 function config_pip_mirror() {
-    pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+    sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+    pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
 }
 
 function install_binary_test() {
 
+    config_pip_mirror
     install_system_packages
     create_vllm_venv
-    config_pip_mirror
 
     PIP_VLLM_VERSION=$(get_version pip_vllm_version)
     VLLM_VERSION=$(get_version vllm_version)
@@ -51,9 +52,6 @@ function install_binary_test() {
     pip install vllm=="${PIP_VLLM_VERSION}"
 
     pip install vllm-ascend=="${PIP_VLLM_ASCEND_VERSION}"
-    if [ "${PIP_VLLM_ASCEND_VERSION}" == "0.17.0rc1" ]; then
-        pip install torchvision==0.24.0 torchaudio==2.9.0
-    fi
 
     pip list | grep vllm
 

--- a/tests/e2e/doctests/002-pip-binary-installation-test.sh
+++ b/tests/e2e/doctests/002-pip-binary-installation-test.sh
@@ -39,6 +39,7 @@ function install_binary_test() {
     config_pip_mirror
     install_system_packages
     create_vllm_venv
+    pip install docutils
 
     PIP_VLLM_VERSION=$(get_version pip_vllm_version)
     VLLM_VERSION=$(get_version vllm_version)


### PR DESCRIPTION
### What this PR does / why we need it?
This patch:
1. Correct the nightly accuracy test's vllm-ascend version. in frankly, we should parameterize everything we actually need to pass in to avoid using the wrong version/branch. 
2. Upgrade doc test to latest.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
