### PR TITLE
[BugFix] Restrict Layer Sharding to PD-disaggregated mode‘s P node

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -156,7 +156,6 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V3.2-W8A8 \
 --no-enable-prefix-caching \
 --gpu-memory-utilization 0.92 \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"layer_sharding": ["q_b_proj", "o_proj"]}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 
 ```

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -43,7 +43,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_npugraph_ex`                | bool | `False` | Whether to enable npugraph_ex graph mode.                                                                 |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |
 | `enable_kv_nz`                      | bool | `False` | Whether to enable KV cache NZ layout. This option only takes effects on models using MLA (e.g., DeepSeek).                                      |
-| `layer_sharding`                    | dict | `{}`    | Configuration options for Layer Sharding Linear |
+| `layer_sharding`                    | dict | `{}`    | Configuration options for Layer Sharding Linear. Layer Sharding can only be enabled in PD-disaggregated's P node. |
 | `enable_sparse_c8`                  | bool | `False` | Whether to enable KV cache C8 in DSA models (e.g., DeepSeekV3.2 and GLM5). Not supported on A5 devices now |
 | `enable_mc2_hierarchy_comm`         | bool | `False` | Enable dispatch/combine op inter-node communication by ROCE. |
 

--- a/docs/source/user_guide/feature_guide/layer_sharding.md
+++ b/docs/source/user_guide/feature_guide/layer_sharding.md
@@ -37,11 +37,14 @@ To enable **Layer Shard Linear**, specify the target linear layers using the `--
 }'
 ```
 
+> **Restriction**
+> Layer Sharding can only be enabled in PD-disaggregated's **P node**.
+
 ---
 
 ## Supported Scenarios
 
-This feature can be enabled in any scenario, but delivers the greatest benefit in the following cases:
+This feature delivers the greatest benefit in the following cases:
 
 ### FlashComm2-enabled
 
@@ -61,6 +64,8 @@ vllm serve \
 ### DSA-CP-enabled
 
 With [DSA-CP](https://github.com/vllm-project/vllm-ascend/pull/4702), both `q_b_proj` and `o_proj` layers require large weight matrices to be stored per layer. Sharding these layers across NPUs helps fit extremely deep models (e.g., 61-layer architectures) into limited device memory.
+
+Layer Sharding can only be enabled in PD-disaggregated's **P node**.
 
 **Example configuration:**
 

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -438,6 +438,36 @@ class TestNPUPlatform(TestBase):
 
         self.assertEqual(vllm_config.cache_config.block_size, 512)
 
+    def test_validate_layer_sharding_config_accepts_single_node(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.additional_config = {"layer_sharding": ["q_b_proj", "o_proj"]}
+        vllm_config.kv_transfer_config = None
+
+        self.platform._validate_layer_sharding_config(vllm_config)
+
+    def test_validate_layer_sharding_config_accepts_kv_producer(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.additional_config = {"layer_sharding": ["q_b_proj", "o_proj"]}
+        vllm_config.kv_transfer_config = MagicMock(is_kv_producer=True, kv_role="kv_producer")
+
+        self.platform._validate_layer_sharding_config(vllm_config)
+
+    def test_validate_layer_sharding_config_rejects_non_kv_producer(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.additional_config = {"layer_sharding": ["q_b_proj", "o_proj"]}
+        vllm_config.kv_transfer_config = MagicMock(is_kv_producer=False, kv_role="kv_consumer")
+
+        with pytest.raises(ValueError, match="layer_sharding can only be enabled in PD-disaggregated's P node"):
+            self.platform._validate_layer_sharding_config(vllm_config)
+
+    def test_validate_layer_sharding_config_rejects_kv_both(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.additional_config = {"layer_sharding": ["q_b_proj", "o_proj"]}
+        vllm_config.kv_transfer_config = MagicMock(is_kv_producer=True, kv_role="kv_both")
+
+        with pytest.raises(ValueError, match="layer_sharding can only be enabled in PD-disaggregated's P node"):
+            self.platform._validate_layer_sharding_config(vllm_config)
+
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -35,6 +35,7 @@ class TestUtils(TestBase):
 
         from vllm_ascend import platform
         importlib.reload(platform)
+        utils.enable_dsa_cp_with_layer_shard.cache_clear()
 
     def test_nd_to_nz_2d(self):
         # can be divided by 16
@@ -130,6 +131,30 @@ class TestUtils(TestBase):
     def test_current_stream(self):
         with mock.patch("torch.npu.current_stream") as mock_current_stream:
             self.assertEqual(utils.current_stream(), mock_current_stream())
+
+    def test_enable_dsa_cp_with_layer_shard_accepts_kv_producer(self):
+        mock_vllm_config = mock.MagicMock()
+        mock_vllm_config.kv_transfer_config = mock.MagicMock(kv_role="kv_producer")
+
+        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
+             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+            self.assertTrue(utils.enable_dsa_cp_with_layer_shard())
+
+    def test_enable_dsa_cp_with_layer_shard_rejects_kv_both(self):
+        mock_vllm_config = mock.MagicMock()
+        mock_vllm_config.kv_transfer_config = mock.MagicMock(kv_role="kv_both", is_kv_producer=True)
+
+        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
+             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+            self.assertFalse(utils.enable_dsa_cp_with_layer_shard())
+
+    def test_enable_dsa_cp_with_layer_shard_rejects_missing_kv_transfer(self):
+        mock_vllm_config = mock.MagicMock()
+        mock_vllm_config.kv_transfer_config = None
+
+        with mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config), \
+             mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True):
+            self.assertFalse(utils.enable_dsa_cp_with_layer_shard())
 
     def test_vllm_version_is(self):
         with mock.patch.dict(os.environ, {"VLLM_VERSION": "1.0.0"}):

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -242,10 +242,7 @@ class NPUPlatform(Platform):
 
         kv_transfer_config = vllm_config.kv_transfer_config
         if kv_transfer_config is not None and kv_transfer_config.kv_role != "kv_producer":
-            raise ValueError(
-                "additional_config.layer_sharding can only be enabled in "
-                "PD-disaggregated's P node."
-            )
+            raise ValueError("additional_config.layer_sharding can only be enabled in PD-disaggregated's P node.")
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -234,11 +234,27 @@ class NPUPlatform(Platform):
         torch.npu.set_device(device)
 
     @classmethod
+    def _validate_layer_sharding_config(cls, vllm_config: VllmConfig) -> None:
+        additional_config = vllm_config.additional_config or {}
+        layer_sharding = additional_config.get("layer_sharding") or []
+        if not layer_sharding:
+            return
+
+        kv_transfer_config = vllm_config.kv_transfer_config
+        if kv_transfer_config is not None and kv_transfer_config.kv_role != "kv_producer":
+            raise ValueError(
+                "additional_config.layer_sharding can only be enabled in "
+                "PD-disaggregated's P node."
+            )
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         from vllm_ascend.quantization.utils import maybe_auto_detect_quantization
 
         if vllm_config.model_config is not None:
             maybe_auto_detect_quantization(vllm_config)
+
+        cls._validate_layer_sharding_config(vllm_config)
 
         # initialize ascend config from vllm additional_config
         cls._fix_incompatible_config(vllm_config)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1269,7 +1269,9 @@ def enable_dsa_cp_with_layer_shard() -> bool:
     vllm_config = get_current_vllm_config()
     # because the broadcast in layer sharding needs to be overlapped with a heavy compute stream to be
     # effectively hidden, it is enabled only during the prefill stage.
-    is_prefill_instance = vllm_config.kv_transfer_config is not None and vllm_config.kv_transfer_config.is_kv_producer
+    is_prefill_instance = (
+        vllm_config.kv_transfer_config is not None and vllm_config.kv_transfer_config.kv_role == "kv_producer"
+    )
     return is_prefill_instance
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
- Introduce a check to restrict Layer Sharding to PD-disaggregated mode‘s P node
- Correct checks for P node (`kv_producer`) in PD-mix scenario.  
- This change prevents potential stream and event issues when operating in graph/capturing mode, ensuring safer communication practices.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
E2E test with dsv32 + FC1 + FULL_DECODE_ONLY + kv_transfer_config(kv_both) + layer_sharding

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
