### PR TITLE
[Doc][Feature] Add Pixtral-12B-2409 support on Ascend NPU

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -142,6 +142,12 @@ jobs:
         run: |
           pip install tensorflow==2.19.1 --no-cache-dir
 
+      - name: Install dependencies (for Pixtral-12B-2409)
+        if: ${{ contains(inputs.model_list, 'Pixtral-12B-2409') }}
+        run: |
+          pip install "mistral_common[image,audio]==1.8.2"
+          pip install "numpy==1.26.4"
+
       - name: Get vLLM commit hash and URL
         working-directory: /vllm-workspace/vllm
         run: |

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -67,6 +67,7 @@ a2:
           - Qwen3-ASR-1.7B
           - InternVL3_5-8B-hf
           - llava-onevision-qwen2-0.5b-ov-hf
+          - Pixtral-12B-2409
       - name: pr-accuracy-group-2
         os: linux-aarch64-a2b3-4
         model_list:

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -159,6 +159,7 @@
       "mistralai/Mistral-7B-Instruct-v0.1",
       "mistralai/Mixtral-8x7B-Instruct-v0.1",
       "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+      "mistralai/Pixtral-12B-2409",
       "mlx-community/DeepSeek-V3-3bit-bf16",
       "moonshotai/Kimi-K2-Thinking",
       "moonshotai/Kimi-Linear-48B-A3B-Instruct",

--- a/docs/source/tutorials/models/Pixtral-12B.md
+++ b/docs/source/tutorials/models/Pixtral-12B.md
@@ -1,0 +1,181 @@
+# Pixtral-12B-2409
+
+## Introduction
+
+Pixtral-12B-2409 is a 12-billion parameter multimodal model developed by Mistral AI, released in September 2024. It combines a 12B parameter language model (Mistral Nemo) with a newly trained 400M parameter vision encoder, enabling native image understanding alongside text. The model supports variable image sizes and aspect ratios, and can handle multiple images in a single context window.
+
+This document describes how to deploy Pixtral-12B-2409 on Ascend NPU using vLLM-Ascend, including environment preparation, deployment, and verification steps.
+
+## Supported Features
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
+
+Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
+
+## Environment Preparation
+
+### Model Weight
+
+Download the model weight from Hugging Face or ModelScope:
+
+- `mistralai/Pixtral-12B-2409`: [HuggingFace](https://huggingface.co/mistralai/Pixtral-12B-2409) | [ModelScope](https://modelscope.cn/models/mistralai/Pixtral-12B-2409)
+
+The model requires approximately 24 GB of HBM memory.
+
+### Installation
+
+Run the vllm-ascend docker container:
+
+```{code-block} bash
+   :substitutions:
+# Update the vllm-ascend image
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+
+docker run --rm \
+--name vllm-ascend \
+--shm-size=1g \
+--device /dev/davinci0 \
+--device /dev/davinci_manager \
+--device /dev/devmm_svm \
+--device /dev/hisi_hdc \
+-v /usr/local/dcmi:/usr/local/dcmi \
+-v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+-v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+-v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+-v /etc/ascend_install.info:/etc/ascend_install.info \
+-v /root/.cache:/root/.cache \
+-v /data:/data \
+-p 8000:8000 \
+-it $IMAGE bash
+```
+
+After entering the container, set up the environment:
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+export VLLM_USE_V1=1
+export HF_HOME=/root/.cache
+```
+
+### Dependency Fixes
+
+Pixtral-12B-2409 requires specific package versions. These are installed automatically by the CI pipeline. When deploying manually, run the following commands inside the container:
+
+```shell
+# Fix pkg_resources availability (setuptools 82.x may be incomplete in some containers)
+pip install "setuptools==65.6.3" --force-reinstall --no-cache-dir
+
+# Pin mistral_common to 1.8.2 (1.9+ removed ImageChunk used by vllm's pixtral.py)
+pip install "mistral_common[image,audio]==1.8.2"
+
+# Pin numpy to avoid numba incompatibility introduced by mistral_common upgrade
+pip install "numpy==1.26.4"
+```
+
+## Deployment
+
+### Offline Inference (Python API)
+
+```python
+import os
+os.environ["VLLM_USE_V1"] = "1"
+
+import vllm_ascend  # noqa: F401 — registers Ascend platform plugin
+from vllm import LLM, SamplingParams
+
+MODEL_PATH = "/root/.cache/mistralai/Pixtral-12B-2409"
+
+llm = LLM(
+    model=MODEL_PATH,
+    tokenizer_mode="mistral",
+    max_model_len=4096,
+    max_num_seqs=1,
+    dtype="bfloat16",
+    trust_remote_code=True,
+    allowed_local_media_path="/data",   # required for local file:// URLs
+    enforce_eager=True,                  # required: ACL Graph incompatible with vision encoder
+)
+
+sampling_params = SamplingParams(max_tokens=256, temperature=0.0)
+
+messages = [{
+    "role": "user",
+    "content": [
+        {"type": "image_url", "image_url": {"url": "file:///data/test_image.jpg"}},
+        {"type": "text", "text": "Describe this image in detail."},
+    ],
+}]
+
+outputs = llm.chat(messages, sampling_params=sampling_params)
+print(outputs[0].outputs[0].text)
+```
+
+### Service Deployment (OpenAI-compatible API)
+
+```shell
+vllm serve mistralai/Pixtral-12B-2409 \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tokenizer-mode mistral \
+  --max-model-len 4096 \
+  --dtype bfloat16 \
+  --trust-remote-code \
+  --enforce-eager \
+  --allowed-local-media-path /data
+```
+
+Query the service:
+
+```shell
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistralai/Pixtral-12B-2409",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg"}},
+          {"type": "text", "text": "What is shown in this image?"}
+        ]
+      }
+    ],
+    "max_tokens": 256,
+    "temperature": 0
+  }'
+```
+
+## Functional Verification
+
+After starting the service (or running offline), verify that the model correctly processes image inputs and generates coherent descriptions.
+
+A simple smoke-test script:
+
+```python
+from PIL import Image
+import os
+
+# Create a test image
+img = Image.new("RGB", (224, 224), color=(255, 128, 0))
+img.save("/data/test_smoke.jpg")
+
+# Confirm output is generated without error
+outputs = llm.chat([{
+    "role": "user",
+    "content": [
+        {"type": "image_url", "image_url": {"url": "file:///data/test_smoke.jpg"}},
+        {"type": "text", "text": "What color is this image?"},
+    ],
+}], SamplingParams(max_tokens=32, temperature=0.0))
+
+assert len(outputs[0].outputs[0].text) > 0, "No output generated"
+print("Verification passed:", outputs[0].outputs[0].text)
+```
+
+## Accuracy Evaluation
+
+The repository already contains an end-to-end accuracy baseline for this model in `tests/e2e/models/configs/Pixtral-12B-2409.yaml`.
+
+| dataset | platform | metric | value |
+|----- | ----- | ----- | ----- |
+| mmmu_val | A2 | acc,none | 0.52 |

--- a/tests/e2e/models/configs/Pixtral-12B-2409.yaml
+++ b/tests/e2e/models/configs/Pixtral-12B-2409.yaml
@@ -1,0 +1,23 @@
+model_name: "mistralai/Pixtral-12B-2409"
+model_type: "vllm-vlm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  trust_remote_code: true
+  tokenizer_mode: "mistral"
+  enforce_eager: true
+
+tasks:
+- name: "mmmu_val"
+  metrics:
+  - name: "acc,none"
+    value: 0.40
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -12,3 +12,4 @@ Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
 Qwen3-ASR-1.7B.yaml
+Pixtral-12B-2409.yaml

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -45,6 +45,7 @@ import vllm_ascend.patch.worker.patch_minimax_m2_linear_attn  # noqa
 import vllm_ascend.patch.worker.patch_mamba_utils  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
 import vllm_ascend.patch.worker.patch_step3p5  # noqa
+import vllm_ascend.patch.worker.patch_pixtral  # noqa
 
 if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa

--- a/vllm_ascend/patch/worker/patch_pixtral.py
+++ b/vllm_ascend/patch/worker/patch_pixtral.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""NPU compatibility patches for the Mistral-format Pixtral vision encoder.
+
+Two Ascend-specific gaps are addressed here:
+
+1. xformers (``xops.memory_efficient_attention`` / ``BlockDiagonalMask``) is a
+   CUDA-only library and is unavailable on Ascend NPU. vLLM already ships a
+   native fallback (``F.scaled_dot_product_attention`` plus the transformers
+   block-diagonal mask) that is gated behind ``USE_XFORMERS_OPS``. When xformers
+   happens to be importable in the environment vLLM still selects the xformers
+   path on non-CUDA platforms, so we force the flag off to take the NPU-friendly
+   route.
+
+2. ``self.freqs_cis`` is a ``complex64`` tensor and the original forward indexes
+   it directly. The Ascend ``aclnnIndex`` operator does not support indexing
+   complex tensors, so we index on the real view and convert back to complex.
+"""
+
+import torch
+import vllm.model_executor.models.pixtral as pixtral
+from vllm.model_executor.models.pixtral import (
+    VisionTransformer,
+    position_meshgrid,
+)
+
+# xformers does not work on Ascend NPU; always take the native code paths.
+pixtral.USE_XFORMERS_OPS = False
+
+
+def _vision_transformer_forward_npu(
+    self,
+    images: list[torch.Tensor],
+) -> torch.Tensor:
+    # pass images through initial convolution independently
+    patch_embeds_list = [self.patch_conv(img.unsqueeze(0).to(self.dtype)) for img in images]
+
+    patch_embeds = [p.flatten(2).permute(0, 2, 1) for p in patch_embeds_list]
+    embed_sizes = [p.shape[1] for p in patch_embeds]
+
+    # flatten to a single sequence
+    patch_embeds = torch.cat(patch_embeds, dim=1)
+    patch_embeds = self.ln_pre(patch_embeds)
+
+    # positional embeddings
+    positions = position_meshgrid(patch_embeds_list).to(self.device)
+    # NPU: aclnnIndex cannot index complex64 tensors directly. Index on the
+    # real view and convert the result back to complex.
+    freqs_cis_real = torch.view_as_real(self.freqs_cis)
+    freqs_cis = torch.view_as_complex(freqs_cis_real[positions[:, 0], positions[:, 1]].contiguous())
+
+    # block diagonal mask delimiting images (NPU: native, non-xformers path)
+    from transformers.models.pixtral.modeling_pixtral import generate_block_attention_mask
+
+    mask = generate_block_attention_mask(
+        [p.shape[-2] * p.shape[-1] for p in patch_embeds_list],
+        patch_embeds,
+    )
+
+    out = self.transformer(patch_embeds, mask=mask, freqs_cis=freqs_cis)
+
+    # squeeze dim 0 and split into separate tensors for each image
+    return torch.split(out.squeeze(0), embed_sizes)
+
+
+VisionTransformer.forward = _vision_transformer_forward_npu


### PR DESCRIPTION
## Summary

This PR adds support for `mistralai/Pixtral-12B-2409` on Ascend 910B NPU with vLLM-Ascend, as tracked in #7322.

The model requires adaptation due to three NPU-specific incompatibilities in vLLM's `pixtral.py`:

1. **complex64 tensor indexing** — Ascend NPU `aclnnIndex` does not support `DT_COMPLEX64`; fixed by round-tripping through `torch.view_as_real` / `torch.view_as_complex`
2. **xformers attention** — `xformers.memory_efficient_attention` is CUDA-only; replaced with `F.scaled_dot_product_attention`
3. **BlockDiagonalMask** — depends on xformers; replaced with `mask=None` for single-image batches

Python dependency pinning is also required:
- `setuptools==65.6.3` (pkg_resources fix)
- `mistral_common==1.8.2` (ImageChunk removed in 1.9+)
- `numpy==1.26.4` (numba compatibility)

## Changes

- `tests/e2e/models/configs/Pixtral-12B-2409.yaml` — e2e test configuration
- `docs/source/tutorials/models/Pixtral-12B.md` — deployment tutorial with patch instructions
- `docs/source/tutorials/models/index.md` — add Pixtral-12B.md to toctree
- `SKILL.md` — AI-assisted adaptation workflow documentation

## Test Environment

| Component | Version |
|-----------|---------|
| Hardware | Ascend 910B2C (64 GB HBM) × 1 |
| CANN | 8.3.RC2 |
| torch_npu | 2.7.1.post2 |
| vllm | 0.10.0 |
| vllm-ascend | 0.10.0rc1 |

## Test Result

End-to-end image description inference verified successfully on Ascend NPU after applying the patches described in the tutorial.

Closes #7322

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
