### PR TITLE
[Doc] Update vllm main version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ myst_substitutions = {
     "ci_vllm_version": "v0.18.0",
     # main branch compatibility matrix - updated dynamically
     # vLLM commit hash for main branch
-    "main_vllm_commit": "",
+    "main_vllm_commit": "5af684c31912232e5c89484c2e8259e0fac6c55b",
     # vLLM tag for main branch
     "main_vllm_tag": "v0.19.0",
     # Python version for main branch


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the `main_vllm_commit` hash in `docs/source/conf.py` to `5af684c31912232e5c89484c2e8259e0fac6c55b`. This ensures the documentation for the main branch points to a specific, verified commit of the upstream vLLM repository.

### Does this PR introduce _any_ user-facing change?
No, this is a documentation configuration update.

### How was this patch tested?
Verified the commit hash corresponds to the intended version.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
