### PR TITLE
[Attention][BugFix] Add wait_for_kv_layer_from_connector in mlapo branch in SFA

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1107,6 +1107,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 num_input_tokens=num_input_tokens,
             )
             k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+            wait_for_kv_layer_from_connector(layer_name)
         # native
         else:
             assert self.fused_qkv_a_proj is not None, "q lora is required for DSA."


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a bug in `AscendSFAImpl.forward` where the `wait_for_kv_layer_from_connector` call was missing in the `mlapo` execution path. 

In scenarios where the `mlapo` branch is active (e.g., with W8A8 quantization) and external KV cache loading is enabled (via the layerwise connector), the model could proceed with attention computation before the KV caches were fully loaded from external storage, leading to incorrect inference outputs. 

This PR adds the missing `wait_for_kv_layer_from_connector` call to the mlapo branch, ensuring that KV synchronization occurs before attention computation for both MLAPO and Native paths.

### Does this PR introduce _any_ user-facing change?

No. This is an internal logic fix to ensure correctness when external KV caches are involved.

### How was this patch tested?

  - Verified that `wait_for_kv_layer_from_connector` is now called in the mlapo branch (W8A8 models).
  - Confirmed inference correctness when external KV caches are loaded.
  - Checked logs to ensure no regression in standard scenarios.