### PR TITLE
[Test] Add unit tests for SpecDecodeBaseProposer.prepare_next_token_ids_padded

### DIFF
--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -788,3 +788,460 @@ class TestEagleProposerPropose():
             return True
         if flag_prefill_decode == "prefill":
             return False
+
+
+class MockCpuGpuBuffer:
+    """Mock CpuGpuBuffer for testing"""
+    def __init__(self, max_size, dtype, device="cpu", **kwargs):
+        self.max_size = max_size
+        self.dtype = dtype
+        self.device = device
+        self.cpu = torch.zeros(max_size, dtype=dtype, device="cpu")
+        self.np = self.cpu.numpy()
+        self.gpu = torch.zeros(max_size, dtype=dtype, device=device)
+    
+    def copy_to_gpu(self, size=None):
+        if size is None:
+            size = self.max_size
+        self.gpu[:size].copy_(self.cpu[:size])
+
+
+class MockCachedRequestState:
+    """Mock CachedRequestState for testing"""
+    def __init__(self, req_id, token_ids):
+        self.req_id = req_id
+        self.token_ids = token_ids
+    
+    def get_token_id(self, position):
+        if position < len(self.token_ids):
+            return self.token_ids[position]
+        return 0
+
+
+class MockInputBatch:
+    """Mock InputBatch for testing"""
+    def __init__(self, num_reqs, req_ids, vocab_size):
+        self.num_reqs = num_reqs
+        self.req_ids = req_ids
+        self.vocab_size = vocab_size
+
+
+class TestPrepareNextTokenIdsPadded(TestBase):
+    """Test prepare_next_token_ids_padded method with precision validation"""
+    
+    def setUp(self):
+        self.vllm_config = MagicMock(spec=VllmConfig)
+        self.vllm_config.speculative_config = MagicMock()
+        self.vllm_config.cache_config = MagicMock(spec=CacheConfig)
+        self.vllm_config.scheduler_config = MagicMock()
+        self.vllm_config.model_config = MagicMock()
+        self.vllm_config.model_config.hf_text_config = MagicMock(spec=[])
+        self.vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
+        self.vllm_config.compilation_config = MagicMock()
+        self.device = torch.device("cpu")
+        self.runner = MagicMock()
+        self.runner.pin_memory = False
+        self.runner.pcp_size = 1
+        self.runner.dcp_size = 1
+
+        self.vllm_config.cache_config.block_size = 16
+        self.vllm_config.scheduler_config.max_num_batched_tokens = 1024
+        self.vllm_config.scheduler_config.max_num_seqs = 32
+        self.vllm_config.model_config.dtype = torch.float16
+        self.vllm_config.model_config.max_model_len = 2048
+        self.vllm_config.model_config.uses_mrope = False
+        self.vllm_config.model_config.uses_xdrope_dim = 0
+        self.vllm_config.parallel_config.tensor_parallel_size = 1
+        self.vllm_config.parallel_config.data_parallel_rank = 0
+        self.vllm_config.parallel_config.data_parallel_size = 1
+        self.vllm_config.parallel_config.prefill_context_parallel_size = 1
+        self.vllm_config.parallel_config.enable_expert_parallel = False
+        self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
+        self.vllm_config.speculative_config.num_speculative_tokens = 4
+        self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(4)])
+        self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
+        self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
+        self.vllm_config.speculative_config.disable_padded_drafter_batch = False
+        self.vllm_config.additional_config = None
+        init_ascend_config(self.vllm_config)
+
+        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer", MockCpuGpuBuffer)
+        self.mock_cpugpubuffer.start()
+        self.mock_supports_multimodal_inputs = patch(
+            "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
+        )
+        self.mock_supports_multimodal_inputs.start()
+
+        set_current_vllm_config(self.vllm_config)
+        self.proposer = AscendEagleProposer(vllm_config=self.vllm_config, device=self.device, runner=self.runner)
+
+    def tearDown(self):
+        self.mock_cpugpubuffer.stop()
+        self.mock_supports_multimodal_inputs.stop()
+        set_current_vllm_config(None)
+
+    def test_all_valid_tokens(self):
+        """Test case where all requests have valid sampled tokens"""
+        num_reqs = 3
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [100, 101, 102, 103, 104],
+            [200, 201, 202, 203, 204],
+            [300, 301, 302, 303, 304],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(10))),
+            "req_1": MockCachedRequestState("req_1", list(range(15))),
+            "req_2": MockCachedRequestState("req_2", list(range(20))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1", "req_2"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([], dtype=torch.int64)
+        num_discarded_requests = 0
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        self.assertEqual(next_token_ids.shape[0], num_reqs)
+        self.assertEqual(valid_sampled_tokens_count.shape[0], num_reqs)
+        
+        expected_valid_counts = torch.tensor([5, 5, 5], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        expected_next_tokens = torch.tensor([104, 204, 304], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_partial_rejected_tokens(self):
+        """Test case where some tokens are rejected (marked as -1)"""
+        num_reqs = 3
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [100, 101, -1, -1, -1],
+            [200, 201, 202, 203, -1],
+            [300, 301, 302, 303, 304],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(10))),
+            "req_1": MockCachedRequestState("req_1", list(range(15))),
+            "req_2": MockCachedRequestState("req_2", list(range(20))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1", "req_2"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([], dtype=torch.int64)
+        num_discarded_requests = 0
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        expected_valid_counts = torch.tensor([2, 4, 5], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        expected_next_tokens = torch.tensor([101, 203, 304], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_all_rejected_tokens_with_backup(self):
+        """Test case where all tokens are rejected, should use backup token"""
+        num_reqs = 3
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [-1, -1, -1, -1, -1],
+            [-1, -1, -1, -1, -1],
+            [300, 301, 302, 303, 304],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(15))),
+            "req_1": MockCachedRequestState("req_1", list(range(20))),
+            "req_2": MockCachedRequestState("req_2", list(range(25))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1", "req_2"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([], dtype=torch.int64)
+        num_discarded_requests = 0
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        expected_valid_counts = torch.tensor([0, 0, 5], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        expected_backup_token_0 = requests["req_0"].get_token_id(10)
+        expected_backup_token_1 = requests["req_1"].get_token_id(15)
+        expected_next_tokens = torch.tensor([expected_backup_token_0, expected_backup_token_1, 304], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_discarded_requests(self):
+        """Test case with discarded requests"""
+        num_reqs = 3
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [100, 101, 102, 103, 104],
+            [200, 201, 202, 203, 204],
+            [300, 301, 302, 303, 304],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(15))),
+            "req_1": MockCachedRequestState("req_1", list(range(20))),
+            "req_2": MockCachedRequestState("req_2", list(range(25))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1", "req_2"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([0, 2], dtype=torch.int64)
+        num_discarded_requests = 2
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        expected_valid_counts = torch.tensor([0, 5, 0], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        expected_backup_token_0 = requests["req_0"].get_token_id(10)
+        expected_backup_token_2 = requests["req_2"].get_token_id(20)
+        expected_next_tokens = torch.tensor([expected_backup_token_0, 204, expected_backup_token_2], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_mixed_scenario(self):
+        """Test mixed scenario: some rejected tokens, some discarded requests, some all-rejected"""
+        num_reqs = 4
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10, 15, 20, 25], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [100, 101, -1, -1, -1],
+            [-1, -1, -1, -1, -1],
+            [300, 301, 302, 303, 304],
+            [400, 401, 402, -1, -1],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(15))),
+            "req_1": MockCachedRequestState("req_1", list(range(20))),
+            "req_2": MockCachedRequestState("req_2", list(range(25))),
+            "req_3": MockCachedRequestState("req_3", list(range(30))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1", "req_2", "req_3"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([1], dtype=torch.int64)
+        num_discarded_requests = 1
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        expected_valid_counts = torch.tensor([2, 0, 5, 3], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        expected_backup_token_1 = requests["req_1"].get_token_id(15)
+        expected_next_tokens = torch.tensor([101, expected_backup_token_1, 304, 402], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_single_request(self):
+        """Test with single request"""
+        num_reqs = 1
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([[100, 101, 102, 103, 104]], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(15))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([], dtype=torch.int64)
+        num_discarded_requests = 0
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        expected_valid_counts = torch.tensor([5], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        expected_next_tokens = torch.tensor([104], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_vocab_size_boundary(self):
+        """Test with tokens at vocab size boundary"""
+        num_reqs = 2
+        vocab_size = 100
+        
+        seq_lens_cpu = torch.tensor([10, 15], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [99, 100, 101, -1, -1],
+            [50, 51, 52, 53, 54],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(15))),
+            "req_1": MockCachedRequestState("req_1", list(range(20))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([], dtype=torch.int64)
+        num_discarded_requests = 0
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        # Token 100 and 101 are >= vocab_size (100), so they are invalid
+        # Only token 99 is valid for the first request
+        expected_valid_counts = torch.tensor([1, 5], dtype=torch.int64)
+        self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
+        
+        # Next token should be 99 (last valid token) for first request
+        # and 54 for second request
+        expected_next_tokens = torch.tensor([99, 54], dtype=torch.int64)
+        self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
+
+    def test_intermediate_variables_precision(self):
+        """Test to verify key variables that affect downstream computation"""
+        num_reqs = 2
+        vocab_size = 1000
+        
+        seq_lens_cpu = torch.tensor([10, 15], dtype=torch.int32)
+        
+        sampled_token_ids = torch.tensor([
+            [100, 101, -1, -1, -1],
+            [200, 201, 202, -1, -1],
+        ], dtype=torch.int64)
+        
+        requests = {
+            "req_0": MockCachedRequestState("req_0", list(range(15))),
+            "req_1": MockCachedRequestState("req_1", list(range(20))),
+        }
+        
+        gpu_input_batch = MockInputBatch(
+            num_reqs=num_reqs,
+            req_ids=["req_0", "req_1"],
+            vocab_size=vocab_size
+        )
+        
+        discard_request_indices = torch.tensor([], dtype=torch.int64)
+        num_discarded_requests = 0
+        
+        next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
+            seq_lens_cpu=seq_lens_cpu,
+            sampled_token_ids=sampled_token_ids,
+            requests=requests,
+            gpu_input_batch=gpu_input_batch,
+            discard_request_indices=discard_request_indices,
+            num_discarded_requests=num_discarded_requests,
+        )
+        
+        # Verify return values
+        self.assertEqual(next_token_ids[0].item(), 101, "next_token_ids[0] should be 101")
+        self.assertEqual(next_token_ids[1].item(), 202, "next_token_ids[1] should be 202")
+        self.assertEqual(valid_sampled_tokens_count[0].item(), 2, "valid_sampled_tokens_count[0] should be 2")
+        self.assertEqual(valid_sampled_tokens_count[1].item(), 3, "valid_sampled_tokens_count[1] should be 3")
+        
+        # Verify public member that affects downstream computation
+        expected_backup_0 = requests["req_0"].get_token_id(10)
+        expected_backup_1 = requests["req_1"].get_token_id(15)
+        self.assertEqual(
+            self.proposer.backup_next_token_ids.np[0], 
+            expected_backup_0,
+            f"backup_next_token_ids[0] should be {expected_backup_0}"
+        )
+        self.assertEqual(
+            self.proposer.backup_next_token_ids.np[1], 
+            expected_backup_1,
+            f"backup_next_token_ids[1] should be {expected_backup_1}"
+        )
+        
+        # Verify data types
+        self.assertEqual(next_token_ids.dtype, torch.int64, "next_token_ids dtype should be torch.int64")
+        self.assertEqual(valid_sampled_tokens_count.dtype, torch.int64, "valid_sampled_tokens_count dtype should be torch.int64")


### PR DESCRIPTION
### What this PR does / why we need it?

Added unit tests for `SpecDecodeBaseProposer.prepare_next_token_ids_padded` method.
This PR complements the test coverage for the core speculative decoding base proposer utility function, ensuring the correctness and stability of the `prepare_next_token_ids_padded` logic under different input scenarios (normal inputs, edge cases, padding behaviors, etc.).
Improves test robustness for the speculative decoding module and prevents potential regressions in future code changes.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added new dedicated unit tests for `SpecDecodeBaseProposer.prepare_next_token_ids_padded`.
All new and existing tests pass via CI.
Test cases cover normal execution, edge input conditions, tensor shape validation, and padding correctness to fully validate the method logic.