### PR TITLE
[BugFix] fix dsv3.1 service failed to start

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3412,7 +3412,7 @@ class NPUModelRunner(GPUModelRunner):
                     kv_cache_spec[layer_name] = spec
                     attn_layer_names.add(layer_name)
 
-            elif isinstance(attn_module, MLAAttention): 
+            elif isinstance(attn_module, MLAAttention):
                 if self.use_sparse:
                     # `MLAAttentionSpec` is temporarily patched to `AscendMLAAttentionSpec`.
                     # Re-importing it at runtime will therefore resolve to the patched class.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3412,7 +3412,7 @@ class NPUModelRunner(GPUModelRunner):
                     kv_cache_spec[layer_name] = spec
                     attn_layer_names.add(layer_name)
 
-            elif isinstance(attn_module, MLAAttention):
+            elif isinstance(attn_module, MLAAttention): 
                 if self.use_sparse:
                     # `MLAAttentionSpec` is temporarily patched to `AscendMLAAttentionSpec`.
                     # Re-importing it at runtime will therefore resolve to the patched class.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3430,7 +3430,6 @@ class NPUModelRunner(GPUModelRunner):
                         cache_sparse_c8=self.ascend_config.is_sparse_c8_layer(layer_name),
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
-                    assert isinstance(spec, MLAAttentionSpec)
                     from vllm.v1.kv_cache_interface import MLAAttentionSpec as AscendMLAAttentionSpec
                     if getattr(attn_module.impl, "fa_quant_layer", False):
                         head_size = attn_module.head_size + attn_module.qk_rope_head_dim


### PR DESCRIPTION

### What this PR does / why we need it?
This PR fixes a service startup failure for DeepSeek-V3.1 models by removing a strict type assertion for MLAAttentionSpec in NPUModelRunner.get_kv_cache_spec. The assertion was failing due to class identity mismatches caused by the runtime patching of MLAAttentionSpec with AscendMLAAttentionSpec.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Verified that the service starts correctly for DSV3.1 models.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
