### PR TITLE
[MRV2][Spec Decoding][BugFix] fix mrv2 runtime error with speculative decoding

### DIFF
--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -1,11 +1,13 @@
 from vllm.v1.worker.gpu import model_runner
 from vllm.v1.worker.gpu.sample import penalties, sampler
+from vllm.v1.worker.gpu.spec_decode.eagle import speculator
 
 from vllm_ascend.worker.v2.input_batch import post_update
 from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
 from vllm_ascend.worker.v2.sample.penalties import apply_penalties
 
 penalties.apply_penalties = apply_penalties
-# because sampler.py is imported before this patch, it must be overridden
+# because sampler.py and speculator.py are imported before this patch, they must be overridden
 sampler.gumbel_sample = gumbel_sample
+speculator.gumbel_sample = gumbel_sample
 model_runner.post_update = post_update


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a runtime error in MRV2 when using speculative decoding (Eagle) by ensuring that the `gumbel_sample` function in the `speculator` module is correctly overridden with the Ascend-specific implementation. The root cause of this broken is that the patch of definition of `gumbel_sample` was removed in #8155.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified that speculative decoding works correctly on Ascend hardware without runtime errors.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
