### PR TITLE
[Feature] Support step3p5 main model

### DIFF
--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 import torch
 
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
 from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
@@ -80,7 +82,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
 
         self.assertTrue(output is expected)
         mock_unquant.assert_called_once()
-        self.assertEqual(mock_unquant.call_args.kwargs["activation"], "silu")
+        self.assertEqual(mock_unquant.call_args.kwargs["activation"], MoEActivation.SILU)
         self.assertFalse(mock_unquant.call_args.kwargs["need_trans"])
         mock_quant.assert_not_called()
 

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -100,6 +100,7 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         query: Any,
         attn_metadata: AscendMetadata,
         output: Any | None = None,
+        layer_name: str | None = None,
     ) -> Any:
         """
         Executes Paged Attention (typically for the decode phase).
@@ -221,7 +222,7 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
 
         return output
 
-    def forward_impl(self, query, key, value, kv_cache, attn_metadata, output):
+    def forward_impl(self, query, key, value, kv_cache, attn_metadata, output, layer_name=None):
         """
         Main dispatch method for attention operations.
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -51,7 +51,9 @@ from vllm_ascend.attention.utils import (
 from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
     get_graph_params,
+    update_draft_graph_params_layer_name,
     update_draft_graph_params_workspaces,
+    update_graph_params_layer_name,
     update_graph_params_workspaces,
 )
 from vllm_ascend.device.device_op import DeviceOperator
@@ -302,12 +304,6 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         attn_mask = self.attn_mask_builder.get_attention_mask(self.model_config)
 
         swa_mask = None
-        is_swa = hasattr(self.model_config.hf_text_config, "sliding_window")
-        if self.model_config is not None and is_swa:
-            swa_mask = self.attn_mask_builder.get_swa_mask(
-                self.model_config.dtype, self.model_config.hf_text_config.sliding_window
-            )
-
         # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device
         query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)
 
@@ -409,9 +405,17 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 graph_params = get_draft_graph_params()
             else:
                 graph_params = get_graph_params()
+            # Use capture order layer names for correct replay ordering
+            # For hybrid models, attn_metadata.keys() order differs from capture order
+            captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+            if captured_layer_names:
+                attn_keys = captured_layer_names
+            else:
+                # Fallback to metadata keys if no captured names (backward compatibility)
+                attn_keys = list(forward_context.attn_metadata.keys())
             with torch.npu.stream(update_stream):
                 for key, param, handle, event in zip(
-                    forward_context.attn_metadata,
+                    attn_keys,
                     graph_params.attn_params[num_tokens],
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
@@ -460,11 +464,25 @@ class AscendAttentionBackendImpl(AttentionImpl):
             if _EXTRA_CTX.is_draft_model:
                 graph_params = get_draft_graph_params()
                 attn_metadata = draft_attn_metadatas
-                attn_keys = list(attn_metadata[0].keys())
+                # Use capture order layer names for correct replay ordering
+                # For hybrid models, attn_metadata.keys() order differs from capture order
+                captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+                if captured_layer_names:
+                    attn_keys = captured_layer_names
+                else:
+                    # Fallback to metadata keys if no captured names (backward compatibility)
+                    attn_keys = list(attn_metadata[0].keys())
             else:
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
-                attn_keys = list(attn_metadata.keys())
+                # Use capture order layer names for correct replay ordering
+                # For hybrid models, attn_metadata.keys() order differs from capture order
+                captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+                if captured_layer_names:
+                    attn_keys = captured_layer_names
+                else:
+                    # Fallback to metadata keys if no captured names (backward compatibility)
+                    attn_keys = list(attn_metadata.keys())
             # For Qwen3-next, since the kv_cache_config has already categorized
             # linear_attn and self_attn, the attn_metadata is first arranged with
             # self_attn followed by linear_attn. Therefore, using zip directly
@@ -497,6 +515,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         num_kv_heads,
                         num_heads,
                         scale,
+                        sliding_window,
                         attn_output,
                         softmax_lse,
                     ) = param
@@ -526,7 +545,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         num_key_value_heads=num_kv_heads,
                         num_heads=num_heads,
                         scale=scale,
-                        sparse_mode=3,
+                        sparse_mode=4 if sliding_window is not None else 3,
+                        pre_tokens=sliding_window - 1 if sliding_window is not None else SWA_INT_MAX,
+                        next_tokens=1 if sliding_window is not None else SWA_INT_MAX,
                         workspace=graph_params.workspaces.get(num_tokens),
                         out=[attn_output, softmax_lse],
                     )
@@ -546,6 +567,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        layer_name: str | None = None,
     ) -> torch.Tensor:
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(key, value, attn_metadata)
 
@@ -574,8 +596,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_seq_lengths_kv=actual_seq_lengths_kv,
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
-                sparse_mode=3,
+                sparse_mode=4 if self.sliding_window is not None else 3,
                 scale=self.scale,
+                pre_tokens=self.sliding_window - 1 if self.sliding_window is not None else SWA_INT_MAX,
+                next_tokens=1 if self.sliding_window is not None else SWA_INT_MAX,
             )
             if _EXTRA_CTX.is_draft_model:
                 update_draft_graph_params_workspaces(num_tokens, workspace)
@@ -602,10 +626,18 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.num_kv_heads,
                 self.num_heads,
                 self.scale,
+                self.sliding_window,
                 weak_ref_tensors(output),
                 weak_ref_tensors(softmax_lse),
             )
         )
+
+        # Record layer name in capture order for correct replay ordering
+        if layer_name is not None:
+            if _EXTRA_CTX.is_draft_model:
+                update_draft_graph_params_layer_name(num_tokens, layer_name)
+            else:
+                update_graph_params_layer_name(num_tokens, layer_name)
 
         torch.npu.graph_task_group_begin(stream)
         torch_npu.npu_fused_infer_attention_score.out(
@@ -620,8 +652,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_lengths_kv=actual_seq_lengths_kv,
             num_key_value_heads=self.num_kv_heads,
             num_heads=self.num_heads,
+            sparse_mode=4 if self.sliding_window is not None else 3,
             scale=self.scale,
-            sparse_mode=3,
+            pre_tokens=self.sliding_window - 1 if self.sliding_window is not None else SWA_INT_MAX,
+            next_tokens=1 if self.sliding_window is not None else SWA_INT_MAX,
             workspace=workspace,
             out=[output, softmax_lse],
         )
@@ -637,6 +671,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         query: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: torch.Tensor | None = None,
+        layer_name: str | None = None,
     ):
         graph_params = get_graph_params()
         num_tokens = query.shape[0]
@@ -677,6 +712,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     weak_ref_tensors(output),
                 )
             )
+
+            # Record layer name in capture order for correct replay ordering
+            if layer_name is not None:
+                update_graph_params_layer_name(num_tokens, layer_name)
 
             torch.npu.graph_task_group_begin(stream)
             torch_npu._npu_paged_attention(
@@ -757,28 +796,25 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
     def _forward_fia_slidingwindow(self, query: torch.Tensor, attn_metadata: AscendMetadata, output: torch.Tensor):
         batch_size = attn_metadata.seq_lens.shape[0]
-        block_size = 128
-        query = query.view(batch_size, 1, self.num_heads * self.head_size)
-        key = self.key_cache
-        value = self.value_cache
-        if self.key_cache is not None and self.value_cache is not None:
-            block_size = self.key_cache.shape[1]
-            key = self.key_cache.flatten(2, 3).contiguous()
-            value = self.value_cache.flatten(2, 3).contiguous()
-
+        num_block, block_size, _, _ = self.key_cache.shape
+        key = self.key_cache.view(num_block, block_size, -1)
+        value = self.value_cache.view(num_block, block_size, -1)
         attn_output, _ = torch_npu.npu_fused_infer_attention_score(
             query,
             key,
             value,
             num_heads=self.num_heads,
             num_key_value_heads=self.num_kv_heads,
-            input_layout="BSH",
+            input_layout="TND",
+            pre_tokens=self.sliding_window - 1,
+            next_tokens=1,
             block_size=block_size,
-            pre_tokens=self.sliding_window,
+            atten_mask=attn_metadata.attn_mask,
+            sparse_mode=4,
             scale=self.scale,
             block_table=attn_metadata.block_tables,
-            actual_seq_lengths=[1] * len(attn_metadata.seq_lens),
-            actual_seq_lengths_kv=attn_metadata.seq_lens,
+            actual_seq_lengths=attn_metadata.actual_seq_lengths_q,
+            actual_seq_lengths_kv=attn_metadata.seq_lens_list,
         )
 
         attn_output = attn_output.view(batch_size, self.num_heads, self.head_size)
@@ -792,13 +828,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        layer_name: str | None = None,
         kv_cache=None,
     ):
         # we inherit ForwardContext in model runner v2, when enable model
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
         if _EXTRA_CTX.capturing:
-            attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output)
+            attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output, layer_name)
             output[:num_tokens] = attn_output[:num_tokens]
             return output
         if (
@@ -853,6 +890,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 query=query,
                 key=key,
                 value=value,
+                pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
+                next_tokens=0 if self.sliding_window is not None else SWA_INT_MAX,
                 atten_mask=attn_metadata.attn_mask,
                 block_table=block_table,
                 input_layout="TND",
@@ -862,7 +901,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
                 scale=self.scale,
-                sparse_mode=3,
+                sparse_mode=4 if self.sliding_window is not None else 3,
             )
 
             attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
@@ -874,9 +913,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         query: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: torch.Tensor | None = None,
+        layer_name: str | None = None,
     ) -> torch.Tensor:
         if _EXTRA_CTX.capturing:
-            return self.full_graph_pa(query, attn_metadata, output)
+            return self.full_graph_pa(query, attn_metadata, output, layer_name)
         torch_npu._npu_paged_attention(
             query=query,
             key_cache=self.key_cache,
@@ -947,6 +987,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         kv_cache: tuple[torch.Tensor],
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        layer_name: str | None = None,
     ):
         num_tokens = query.shape[0]
         if (
@@ -954,9 +995,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             and using_paged_attention(num_tokens, self.vllm_config)
             and self.sliding_window is None
         ):
-            output = self.forward_paged_attention(query, attn_metadata, output)
+            output = self.forward_paged_attention(query, attn_metadata, output, layer_name)
         else:
-            output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, kv_cache)
+            output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, layer_name, kv_cache)
 
         return output
 
@@ -1017,10 +1058,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
             attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
             output[:num_tokens] = attn_output[:num_tokens]
             return output
+        layer_name = getattr(layer, "layer_name", None)
         if output_padded is not None:
-            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded)
+            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded, layer_name)
         else:
-            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output)
+            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output, layer_name)
         output[:num_tokens] = attn_output[:num_tokens]
         return output
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -795,6 +795,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         return key, value, block_size, block_table, actual_seq_lengths_kv
 
     def _forward_fia_slidingwindow(self, query: torch.Tensor, attn_metadata: AscendMetadata, output: torch.Tensor):
+        assert self.key_cache is not None
+        assert self.value_cache is not None
+        assert self.sliding_window is not None
         batch_size = attn_metadata.seq_lens.shape[0]
         num_block, block_size, _, _ = self.key_cache.shape
         key = self.key_cache.view(num_block, block_size, -1)

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -50,7 +50,11 @@ from vllm_ascend.attention.utils import (
     filter_chunked_req_indices,
     split_decodes_and_prefills,
 )
-from vllm_ascend.compilation.acl_graph import get_graph_params, update_graph_params_workspaces
+from vllm_ascend.compilation.acl_graph import (
+    get_graph_params,
+    update_graph_params_layer_name,
+    update_graph_params_workspaces,
+)
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import cp_chunkedprefill_comm_stream, weak_ref_tensors
 
@@ -296,11 +300,19 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         draft_attn_metadatas=None,
     ):
         graph_params = get_graph_params()
+        # Use capture order layer names for correct replay ordering
+        # For hybrid models, attn_metadata.keys() order differs from capture order
+        captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+        if captured_layer_names:
+            attn_keys = captured_layer_names
+        else:
+            # Fallback to metadata keys if no captured names (backward compatibility)
+            attn_keys = list(forward_context.attn_metadata.keys())
         # FIXME: Behold! We are using a temporary hack here to update the args
         # for each layer's attention op in the graph.
         with torch.npu.stream(update_stream):
             for key, param, handle, event in zip(
-                forward_context.attn_metadata,
+                attn_keys,
                 graph_params.attn_params[num_tokens],
                 graph_params.handles[num_tokens],
                 graph_params.events[num_tokens],
@@ -504,7 +516,17 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
             attn_lse = torch.index_select(torch.cat(lses, dim=0), 0, q_full_idx)
         return output, attn_lse
 
-    def _forward_decode_pcp_dcp(self, query: torch.Tensor, attn_metadata: AscendMetadata) -> torch.Tensor:
+    def _out_lse_reshape(self, attn_out: torch.Tensor, attn_lse: torch.Tensor) -> torch.Tensor:
+        attn_out = attn_out.contiguous().view(attn_out.shape[0] * attn_out.shape[1], attn_out.shape[2])
+        attn_lse = attn_lse.contiguous().view(attn_lse.shape[0] * attn_lse.shape[1] * attn_lse.shape[2])
+        return attn_out, attn_lse
+
+    def _forward_decode_pcp_dcp(
+        self,
+        query: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        layer_name: str | None = None,
+    ) -> torch.Tensor:
         assert self.key_cache is not None
         assert self.value_cache is not None
 
@@ -570,6 +592,9 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
                     self.dcp_rank,
                 )
             )
+            # Record layer name in capture order for correct replay ordering
+            if layer_name is not None:
+                update_graph_params_layer_name(num_tokens, layer_name)
             torch.npu.graph_task_group_begin(stream)
             torch_npu.npu_fused_infer_attention_score.out(
                 query, k_nope, value, **common_kwargs, workspace=workspace, out=[attn_out, attn_lse]
@@ -860,6 +885,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         kv_cache: tuple[torch.Tensor],
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        layer_name: str | None = None,
     ) -> torch.Tensor:
         assert attn_metadata is not None
         has_decode = attn_metadata.num_decodes > 0
@@ -871,7 +897,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
             pcp_use_hybrid_attn = attn_metadata.prefill.pcp_metadata.pcp_use_hybrid_attn
         if has_decode:
             decode_query = query[:num_decode_tokens].contiguous()
-            output_decode = self._forward_decode_pcp_dcp(decode_query, attn_metadata)
+            output_decode = self._forward_decode_pcp_dcp(decode_query, attn_metadata, layer_name)
             output[:num_decode_tokens] = output_decode
         if has_prefill:
             assert attn_metadata.prefill is not None

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -39,7 +39,12 @@ from vllm_ascend.attention.context_parallel.common_cp import (
     _update_out_and_lse,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
-from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, update_graph_params_workspaces
+from vllm_ascend.compilation.acl_graph import (
+    get_draft_graph_params,
+    get_graph_params,
+    update_graph_params_layer_name,
+    update_graph_params_workspaces,
+)
 from vllm_ascend.utils import weak_ref_tensors
 
 MAX_O_PROJ_PREFETCH_SIZE = 16 * 1024 * 1024
@@ -301,11 +306,19 @@ class AscendMlaCPImpl(AscendMLAImpl):
             graph_params = get_draft_graph_params()
         else:
             graph_params = get_graph_params()
+        # Use capture order layer names for correct replay ordering
+        # For hybrid models, attn_metadata.keys() order differs from capture order
+        captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+        if captured_layer_names:
+            attn_keys = captured_layer_names
+        else:
+            # Fallback to metadata keys if no captured names (backward compatibility)
+            attn_keys = list(forward_context.attn_metadata.keys())
         # FIXME: Behold! We are using a temporary hack here to update the args
         # for each layer's attention op in the graph.
         with torch.npu.stream(update_stream):
             for key, param, handle, event in zip(
-                forward_context.attn_metadata,
+                attn_keys,
                 graph_params.attn_params[num_tokens],
                 graph_params.handles[num_tokens],
                 graph_params.events[num_tokens],
@@ -619,6 +632,7 @@ class AscendMlaCPImpl(AscendMLAImpl):
         block_size: int,
         attn_metadata: AscendMLAMetadata,
         dequant_scale_q_nope=None,
+        layer_name: str | None = None,
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
@@ -721,6 +735,12 @@ class AscendMlaCPImpl(AscendMLAImpl):
                     weak_ref_tensors(softmax_lse),
                 )
             )
+            # Record layer name in capture order for correct replay ordering
+            if layer_name is not None:
+                if _EXTRA_CTX.is_draft_model:
+                    update_graph_params_layer_name(num_tokens, layer_name)
+                else:
+                    update_graph_params_layer_name(num_tokens, layer_name)
             torch.npu.graph_task_group_begin(stream)
             torch_npu.npu_fused_infer_attention_score.out(
                 q_nope, k_nope, k_nope, **common_kwargs, workspace=workspace, out=[attn_output, softmax_lse]

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -37,7 +37,9 @@ from vllm_ascend.attention.utils import (
 from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
     get_graph_params,
+    update_draft_graph_params_layer_name,
     update_draft_graph_params_workspaces,
+    update_graph_params_layer_name,
     update_graph_params_workspaces,
 )
 from vllm_ascend.device.device_op import DeviceOperator
@@ -774,11 +776,25 @@ class AscendMLAImpl(MLAAttentionImpl):
         if _EXTRA_CTX.is_draft_model:
             graph_params = get_draft_graph_params()
             attn_metadata = draft_attn_metadatas
-            attn_keys = list(attn_metadata[0].keys())
+            # Use capture order layer names for correct replay ordering
+            # For hybrid models, attn_metadata.keys() order differs from capture order
+            captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+            if captured_layer_names:
+                attn_keys = captured_layer_names
+            else:
+                # Fallback to metadata keys if no captured names (backward compatibility)
+                attn_keys = list(attn_metadata[0].keys())
         else:
             graph_params = get_graph_params()
             attn_metadata = forward_context.attn_metadata
-            attn_keys = list(attn_metadata.keys())
+            # Use capture order layer names for correct replay ordering
+            # For hybrid models, attn_metadata.keys() order differs from capture order
+            captured_layer_names = graph_params.attn_layer_names.get(num_tokens, [])
+            if captured_layer_names:
+                attn_keys = captured_layer_names
+            else:
+                # Fallback to metadata keys if no captured names (backward compatibility)
+                attn_keys = list(attn_metadata.keys())
         # FIXME: Behold! We are using a temporary hack here to update the args
         # for each layer's attention op in the graph.
         num_layers = len(attn_keys)
@@ -1312,6 +1328,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         block_size: int,
         attn_metadata: AscendMLAMetadata,
         dequant_scale_q_nope=None,
+        layer_name: str | None = None,
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
@@ -1466,6 +1483,13 @@ class AscendMLAImpl(MLAAttentionImpl):
                     update_graph_params_workspaces(num_tokens, workspace)
 
             graph_params.attn_params[num_tokens].append(attn_params)
+
+            # Record layer name in capture order for correct replay ordering
+            if layer_name is not None:
+                if _EXTRA_CTX.is_draft_model:
+                    update_draft_graph_params_layer_name(num_tokens, layer_name)
+                else:
+                    update_graph_params_layer_name(num_tokens, layer_name)
 
             torch.npu.graph_task_group_begin(stream)
             torch_npu.npu_fused_infer_attention_score_v2.out(
@@ -1731,6 +1755,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 kv_cache[0].shape[1],
                 attn_metadata,
                 decode_preprocess_res.dequant_scale_q_nope,
+                layer_name,
             )
 
             o_proj_input[:num_decode_tokens] = output_decode

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -241,6 +241,9 @@ class GraphParams:
     workspaces: dict[int, torch.Tensor]
     handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
     attn_params: dict[int, list[tuple]]
+    # Record layer names in capture order to ensure correct replay order
+    # for hybrid models with mixed full/swa attention types
+    attn_layer_names: dict[int, list[str]]
 
 
 _graph_params: GraphParams | None = None
@@ -255,6 +258,7 @@ def set_graph_params(aclgraph_capture_sizes: list[int]):
         {size: None for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
+        {size: [] for size in aclgraph_capture_sizes},
     )
 
 
@@ -262,6 +266,12 @@ def update_graph_params_workspaces(num_tokens: int, workspace: torch.Tensor):
     global _graph_params
     if _graph_params is not None:
         _graph_params.workspaces[num_tokens] = workspace
+
+
+def update_graph_params_layer_name(num_tokens: int, layer_name: str):
+    global _graph_params
+    if _graph_params is not None:
+        _graph_params.attn_layer_names[num_tokens].append(layer_name)
 
 
 def get_graph_params():
@@ -280,6 +290,7 @@ def set_draft_graph_params(aclgraph_capture_sizes: list[int]):
         {size: None for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
         {size: [] for size in aclgraph_capture_sizes},
+        {size: [] for size in aclgraph_capture_sizes},
     )
 
 
@@ -287,6 +298,12 @@ def update_draft_graph_params_workspaces(num_tokens: int, workspace: Any):
     global _draft_graph_params
     if _draft_graph_params is not None:
         _draft_graph_params.workspaces[num_tokens] = workspace
+
+
+def update_draft_graph_params_layer_name(num_tokens: int, layer_name: str):
+    global _draft_graph_params
+    if _draft_graph_params is not None:
+        _draft_graph_params.attn_layer_names[num_tokens].append(layer_name)
 
 
 def get_draft_graph_params():

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -58,5 +58,16 @@ class AscendSwigluOAIAndMul:
 
 class AscendSwigluStepAndMul:
     def swiglu_step_forward(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
-        layer = SwigluStepAndMul(limit=limit)
-        return SwigluStepAndMul.forward_native(layer, x)
+        """Out-variant of swiglustep activation.
+
+        Writes into `out`:
+        silu(x[:d]).clamp(max=limit) * x[d:].clamp(-limit, limit)
+        """
+        import torch.nn.functional as F
+
+        gate, up = x.chunk(2, dim=-1)
+        gate = F.silu(gate)
+        gate = gate.clamp(max=limit)
+        up = up.clamp(min=-limit, max=limit)
+        out = gate * up
+        return out

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -16,8 +16,12 @@
 #
 
 import torch
-import torch.nn.functional as F
-from vllm.model_executor.layers.activation import QuickGELU, SiluAndMul, SwigluOAIAndMul
+from vllm.model_executor.layers.activation import (
+    QuickGELU,
+    SiluAndMul,
+    SwigluOAIAndMul,
+    SwigluStepAndMul,
+)
 
 from vllm_ascend.utils import get_weight_prefetch_method
 
@@ -52,15 +56,7 @@ class AscendSwigluOAIAndMul:
         return SwigluOAIAndMul.forward_native(layer, x)
 
 
-def swiglustep_and_mul(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
-    """Out-variant of swiglustep activation.
-
-    Writes into `out`:
-      silu(x[:d]).clamp(max=limit) * x[d:].clamp(-limit, limit)
-    """
-    gate, up = x.chunk(2, dim=-1)
-    gate = F.silu(gate)
-    gate = gate.clamp(max=limit)
-    up = up.clamp(min=-limit, max=limit)
-    out = gate * up
-    return out
+class AscendSwigluStepAndMul:
+    def swiglu_step_forward(x: torch.Tensor, limit: float = 7.0) -> torch.Tensor:
+        layer = SwigluStepAndMul(limit=limit)
+        return SwigluStepAndMul.forward_native(layer, x)

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -101,6 +101,7 @@ def select_experts(
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
             global_num_experts=global_num_experts,
+            routed_scaling_factor=routed_scaling_factor,
         )
     if mix_placement:
         shared_expert_routing_factor = 1.0 if is_support_npu_moe_gating_top_k else (1 / routed_scaling_factor)
@@ -182,7 +183,7 @@ def _renormalize_topk_weights(
     renormalize: bool,
 ):
     if renormalize:
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-20)
     return topk_weights
 
 
@@ -266,6 +267,7 @@ def _native_select_experts(
     scoring_func: str = "softmax",
     e_score_correction_bias: torch.Tensor | None = None,
     global_num_experts: torch.Tensor | None = None,
+    routed_scaling_factor=1.0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Select top-k experts based on router logits.
@@ -289,7 +291,7 @@ def _native_select_experts(
     Raises:
         ValueError: If an unsupported scoring function is provided.
     """
-
+    router_logits = router_logits.float()
     if scoring_func == "softmax":
         topk_weights = router_logits.softmax(dim=-1)
     elif scoring_func == "sigmoid":
@@ -319,12 +321,18 @@ def _native_select_experts(
         topk_ids = topk_ids.to(torch.int32)
         return topk_weights, topk_ids
 
-    topk_weights, topk_ids = topk_weights.topk(top_k, dim=-1)
+    gate_prob_with_bias = topk_weights + e_score_correction_bias.unsqueeze(0)
+    _, topk_ids = gate_prob_with_bias.topk(top_k, dim=-1)
+    topk_weights = torch.gather(topk_weights, 1, topk_ids)
     topk_weights = topk_weights.to(hidden_states.dtype)
 
     # Required by npu_moe_init_routing
     topk_ids = topk_ids.to(torch.int32)
-    topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
+
+    if routed_scaling_factor != 1.0:
+        topk_weights = _renormalize_topk_weights(topk_weights, renormalize) * routed_scaling_factor
+    else:
+        topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
 
     return topk_weights, topk_ids
 

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -321,10 +321,12 @@ def _native_select_experts(
         topk_ids = topk_ids.to(torch.int32)
         return topk_weights, topk_ids
 
-    assert e_score_correction_bias is not None
-    gate_prob_with_bias = topk_weights + e_score_correction_bias.unsqueeze(0)
-    _, topk_ids = gate_prob_with_bias.topk(top_k, dim=-1)
-    topk_weights = torch.gather(topk_weights, 1, topk_ids)
+    if e_score_correction_bias is not None:
+        gate_prob_with_bias = topk_weights + e_score_correction_bias.unsqueeze(0)
+        _, topk_ids = gate_prob_with_bias.topk(top_k, dim=-1)
+        topk_weights = torch.gather(topk_weights, 1, topk_ids)
+    else:
+        topk_weights, topk_ids = topk_weights.topk(top_k, dim=-1)
     topk_weights = topk_weights.to(hidden_states.dtype)
 
     # Required by npu_moe_init_routing

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -321,6 +321,7 @@ def _native_select_experts(
         topk_ids = topk_ids.to(torch.int32)
         return topk_weights, topk_ids
 
+    assert e_score_correction_bias is not None
     gate_prob_with_bias = topk_weights + e_score_correction_bias.unsqueeze(0)
     _, topk_ids = gate_prob_with_bias.topk(top_k, dim=-1)
     topk_weights = torch.gather(topk_weights, 1, topk_ids)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -26,7 +26,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp8_moe_available,
 )
-from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, swiglustep_and_mul
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.utils import (
     dispose_tensor,
@@ -361,7 +361,7 @@ def apply_moe_activation(
         gate_up_out = torch_npu.npu_swiglu(gate_up_out)
 
     elif activation == MoEActivation.SWIGLUSTEP:
-        gate_up_out = swiglustep_and_mul(gate_up_out, limit=7.0)
+        gate_up_out = AscendSwigluStepAndMul.swiglu_step_forward(gate_up_out)
 
     else:
         raise ValueError(f"Unsupported FusedMoE activation: {activation}")

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,6 +18,7 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -25,7 +26,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp8_moe_available,
 )
-from vllm_ascend.ops.activation import AscendSwigluOAIAndMul
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, swiglustep_and_mul
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.utils import (
     dispose_tensor,
@@ -101,9 +102,14 @@ def quant_apply_mlp(
     scale_type: torch.dtype | None = None,
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
+    activation: MoEActivation | None = None,
+    **kwargs,
 ) -> torch.Tensor:
+    # TODO(linfeng): Current massive parameter passing is quite severe; parameter differences introduced by different
+    # quantization modes will be consolidated into a dataclass in a follow-up.
     input_hidden_dtype = hidden_states.dtype
     use_gmm_swiglu_quant_fusion = use_mxfp_quant or (fusion and not dynamic_eplb)
+    act: MoEActivation = activation or MoEActivation.SILU
 
     if use_mxfp_quant:
         ensure_mxfp8_moe_available("MXFP MoE MLP path")
@@ -127,6 +133,12 @@ def quant_apply_mlp(
         dispose_tensor(unquantized_hidden_states)
         quantized_hidden_states = None
     else:
+        if use_mxfp_quant and dynamic_scale.ndim == 2:
+            dynamic_scale = dynamic_scale.reshape(
+                dynamic_scale.shape[0],
+                dynamic_scale.shape[1] // 2,
+                2,
+            )
         unquantized_hidden_states = None
         pertoken_scale = (
             DeviceOperator.maybe_normalize_mxfp_scale_layout(dynamic_scale) if use_mxfp_quant else dynamic_scale
@@ -225,7 +237,7 @@ def quant_apply_mlp(
         )[0]
         dispose_tensor(unquantized_hidden_states)
         # act_fn: swiglu
-        hidden_states = torch_npu.npu_swiglu(hidden_states)
+        hidden_states = apply_moe_activation(act, hidden_states)
         # gmm2: down_proj
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
@@ -258,7 +270,7 @@ def quant_apply_mlp(
                 group_list=cumsum_group_list(group_list, group_list_type, 0),
                 bias=bias1,
             )
-        elif use_gmm_swiglu_quant_fusion:
+        elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP:
             hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
                 weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
@@ -291,13 +303,14 @@ def quant_apply_mlp(
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
             if HAS_TRITON:
-                from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
-
-                hidden_states, swiglu_out_scale = swiglu_quant(
-                    hidden_states, group_list=group_list, group_list_type=group_list_type
+                hidden_states, swiglu_out_scale = apply_moe_activation_triton(
+                    act,
+                    hidden_states,
+                    group_list=group_list,
+                    group_list_type=group_list_type,
                 )
             else:
-                hidden_states = torch_npu.npu_swiglu(hidden_states)
+                hidden_states = apply_moe_activation(act, hidden_states)
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
@@ -320,6 +333,50 @@ def quant_apply_mlp(
     return hidden_states
 
 
+def apply_moe_activation_triton(
+    activation: MoEActivation,
+    hidden_states: torch.Tensor,
+    group_list,
+    group_list_type,
+) -> torch.Tensor:
+    if activation == MoEActivation.SILU:
+        from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
+
+        hidden_states, swiglu_out_scale = swiglu_quant(
+            hidden_states,
+            group_list=group_list,
+            group_list_type=group_list_type,
+        )
+    elif activation == MoEActivation.SWIGLUSTEP:
+        from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
+
+        hidden_states, swiglu_out_scale = swiglu_quant(
+            hidden_states,
+            group_list=group_list,
+            group_list_type=group_list_type,
+            use_step=True,
+            limit=7.0,
+        )
+    else:
+        raise ValueError(f"Unsupported FusedMoE activation: {activation}")
+    return hidden_states, swiglu_out_scale
+
+
+def apply_moe_activation(
+    activation: MoEActivation,
+    gate_up_out: torch.Tensor,
+) -> torch.Tensor:
+    if activation == MoEActivation.SILU:
+        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+
+    elif activation == MoEActivation.SWIGLUSTEP:
+        gate_up_out = swiglustep_and_mul(gate_up_out, limit=7.0)
+
+    else:
+        raise ValueError(f"Unsupported FusedMoE activation: {activation}")
+    return gate_up_out
+
+
 def unquant_apply_mlp(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -327,7 +384,7 @@ def unquant_apply_mlp(
     group_list: torch.Tensor,
     w1_bias: torch.Tensor = None,
     w2_bias: torch.Tensor = None,
-    activation: str | None = None,
+    activation: MoEActivation | None = None,
     group_list_type: int = 1,
     topk_scales: torch.Tensor | None = None,
     need_trans: bool = True,
@@ -346,11 +403,15 @@ def unquant_apply_mlp(
         group_list=group_list,
     )[0]
 
-    if activation == "swigluoai":
+    # apply_moe_activation expects `str`, but `activation` can be None.
+    # Default to "silu" to match fused_moe default behavior.
+    act: MoEActivation = activation or MoEActivation.SILU
+
+    if act == "swigluoai":
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
     else:
-        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+        gate_up_out = apply_moe_activation(act, gate_up_out)
 
     if topk_scales is not None:
         gate_up_out *= topk_scales
@@ -444,4 +505,5 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         scale_type=scale_type,
         per_token_scale_type=per_token_scale_type,
         use_bf16=use_bf16,
+        activation=activation,
     )

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -103,10 +103,7 @@ def quant_apply_mlp(
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
     activation: MoEActivation | None = None,
-    **kwargs,
 ) -> torch.Tensor:
-    # TODO(linfeng): Current massive parameter passing is quite severe; parameter differences introduced by different
-    # quantization modes will be consolidated into a dataclass in a follow-up.
     input_hidden_dtype = hidden_states.dtype
     use_gmm_swiglu_quant_fusion = use_mxfp_quant or (fusion and not dynamic_eplb)
     act: MoEActivation = activation or MoEActivation.SILU
@@ -133,12 +130,6 @@ def quant_apply_mlp(
         dispose_tensor(unquantized_hidden_states)
         quantized_hidden_states = None
     else:
-        if use_mxfp_quant and dynamic_scale.ndim == 2:
-            dynamic_scale = dynamic_scale.reshape(
-                dynamic_scale.shape[0],
-                dynamic_scale.shape[1] // 2,
-                2,
-            )
         unquantized_hidden_states = None
         pertoken_scale = (
             DeviceOperator.maybe_normalize_mxfp_scale_layout(dynamic_scale) if use_mxfp_quant else dynamic_scale

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -407,7 +407,7 @@ def unquant_apply_mlp(
     # Default to "silu" to match fused_moe default behavior.
     act: MoEActivation = activation or MoEActivation.SILU
 
-    if act == "swigluoai":
+    if act == MoEActivation.SWIGLUOAI:
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
     else:
@@ -449,6 +449,8 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     w1_offset = mlp_compute_input.weights.w1_offset
     w2_offset = mlp_compute_input.weights.w2_offset
     activation = mlp_compute_input.activation
+    if isinstance(activation, str):
+        activation = MoEActivation(activation)
     need_trans = mlp_compute_input.need_trans
     dynamic_eplb = mlp_compute_input.dynamic_eplb
     fusion = mlp_compute_input.fusion

--- a/vllm_ascend/ops/triton/activation/swiglu_quant.py
+++ b/vllm_ascend/ops/triton/activation/swiglu_quant.py
@@ -19,6 +19,8 @@ def _swiglu_quant_kernel(
     NUM_CORES: tl.constexpr,
     DTYPE_MAX: tl.constexpr,
     SCALE: tl.constexpr,
+    USE_STEP: tl.constexpr,
+    LIMIT: tl.constexpr,
 ):
     # calc real total_rows
     if GROUP_LIST_TYPE == 0:  # cusum
@@ -42,7 +44,13 @@ def _swiglu_quant_kernel(
         cur_x = tl.load(x_ptr + x_offsets)
         x1 = extract_slice(cur_x, offsets=(0,), sizes=(HALF_COLS,), strides=(1,))
         x2 = extract_slice(cur_x, offsets=(HALF_COLS,), sizes=(HALF_COLS,), strides=(1,))
-        out = x1 * tl.sigmoid(x1) * x2
+        if USE_STEP:
+            gate = x1 * tl.sigmoid(x1)
+            gate = tl.minimum(gate, LIMIT)
+            up = tl.maximum(tl.minimum(x2, LIMIT), -LIMIT)
+            out = gate * up
+        else:
+            out = x1 * tl.sigmoid(x1) * x2
 
         # quant
         if SCALE:
@@ -63,7 +71,7 @@ def _swiglu_quant_kernel(
             tl.store(out_ptr + o_offsets, out.to(out_ptr.dtype.element_ty))
 
 
-def swiglu_quant(x, group_list, group_list_type, need_quant=True):
+def swiglu_quant(x, group_list, group_list_type, need_quant=True, use_step=False, limit=7.0):
     # group_list_type must be 0 cusum or 1 count
     if group_list_type not in [0, 1]:
         raise ValueError(f"group_list_type must be 0 or 1, but got {group_list_type}")
@@ -95,6 +103,8 @@ def swiglu_quant(x, group_list, group_list_type, need_quant=True):
         NUM_CORES=num_vectorcore,
         DTYPE_MAX=127,
         SCALE=need_quant,
+        USE_STEP=use_step,
+        LIMIT=limit,
         multibuffer=True,
     )
     return out, scale


### PR DESCRIPTION
### What this PR does / why we need it?
                                                                                                                                                                     
  This PR adds support for the step3p5 model on Ascend NPU. The step3p5 model is a hybrid architecture with mixed full-attention and sliding-window-attention (SWA)
  layers, and uses MoE with the SWIGLUSTEP activation function. The following changes are required:                                                                  
                                                                                                                                                                     
#### Attention:                                                                                                                                                         
  - Add sliding window attention support by configuring sparse_mode=4, pre_tokens, and next_tokens in npu_fused_infer_attention_score calls (both graph capture and
  eager paths).                                                                                                                                                      
  - Fix _forward_fia_slidingwindow to use proper TND layout, correct actual_seq_lengths / seq_lens_list parameters, and sparse_mode=4 instead of the previous BSH
  layout with hardcoded values.                                                                                                                                      
  - Introduce attn_layer_names tracking in GraphParams to record layer names during ACL graph capture in execution order. During replay, use this capture-order list 
  instead of attn_metadata.keys() to ensure correct parameter-to-layer mapping for hybrid models where metadata key order differs from capture order.               
  - Propagate layer_name parameter through forward_impl, forward_fused_infer_attention, forward_paged_attention, full_graph_fia, full_graph_pa, and their            
  context-parallel equivalents (attention_cp, mla_cp, mla_v1).                                                                                           
  - Remove unused swa_mask building in AscendAttentionMetadataBuilder.build.                                                                                         
                                                                            
  #### MoE / Activation:                                                                                                                                                  
  - Add Ascend wrapper for SwiGLU-step activation.                                                              
  - Extend the Triton swiglu_quant kernel with USE_STEP and LIMIT compile-time constants to support the step activation variant.                                     
  - Add apply_moe_activation and apply_moe_activation_triton dispatchers to route between SILU and SWIGLUSTEP in both quantized and unquantized MoE MLP paths.       
                                                                                                                                                                     
#### Expert Selector:                                                                                                                                                   
  - Add e_score_correction_bias handling in _native_select_experts with proper null check, using gate_prob_with_bias for top-k selection when bias is present.       
  - Add routed_scaling_factor parameter propagation through the expert selection pipeline, applying it after weight renormalization.                                 
  - Add epsilon (1e-20) to top-k weight renormalization denominator for numerical stability.                                                                         
  - Cast router_logits to float32 before scoring for numerical precision.                                                                                            
                                                                                                                                                                     
#### 310P:                                                                                                                                                              
  - Add layer_name parameter to 310P attention forward_paged_attention and forward_impl for interface consistency.                                                   
                                                                                                                                                                     
### Does this PR introduce any user-facing change?                                                                                                                     
                                                                                                                                                                     
  Yes. This PR adds support for running the step3p5 model on Ascend NPU, including sliding window attention and the SWIGLUSTEP MoE activation function. No breaking  
  changes to existing model support.                                                                                                                                 
                                                                                                                                                                     
### How was this patch tested?                                                                                                                                         
   
  - Unit test updated to expect MoEActivation enum instead of string in test_moe_mlp.py.                                                                             
  - Step3.5-Flash is loaded successfully and returns the correct answer.                                                                                                                           
                                                                                                                                                                     
### vLLM version:                                                                                                                                                      
                                                                                                                                                                     
  vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0   
