### PR TITLE
[BugFix](Worker): Fix routed experts capture for hybrid MoE models

### DIFF
--- a/tests/ut/patch/worker/patch_common/test_patch_routed_experts_capturer.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_routed_experts_capturer.py
@@ -1,13 +1,14 @@
-from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 import uuid
 
 import torch
 
 from tests.ut.base import TestBase
-from vllm_ascend.patch.worker.patch_routed_experts_capturer import RoutedExpertsCapturer
-from vllm.config import ModelConfig, VllmConfig
-from vllm.config.parallel import ParallelConfig
-from transformers import PretrainedConfig
+from vllm_ascend.patch.worker.patch_routed_experts_capturer import (
+    RoutedExpertsCapturer,
+    init_routed_experts_capturer,
+)
 from vllm.platforms import current_platform
 
 
@@ -52,6 +53,53 @@ class TestPatchRoutedExpertsCapturer(TestBase):
             )
             self.assertEqual(self.capturer._device_buffer.dtype, torch.int32)
             self.assertEqual(self.capturer._device_buffer.device.type, current_platform.device_name)
+
+    def test_init_routed_experts_capturer_uses_full_attention_capacity(self):
+        class FakeAttentionSpec:
+            def __init__(self, block_size):
+                self.block_size = block_size
+
+        class FakeMambaSpec:
+            def __init__(self, block_size):
+                self.block_size = block_size
+
+        runner = SimpleNamespace(
+            model_config=SimpleNamespace(enable_return_routed_experts=True),
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=32),
+            vllm_config=SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    decode_context_parallel_size=1,
+                    prefill_context_parallel_size=1,
+                )
+            ),
+            kv_cache_config=SimpleNamespace(
+                num_blocks=16,
+                kv_cache_groups=[
+                    SimpleNamespace(kv_cache_spec=FakeMambaSpec(block_size=262144)),
+                    SimpleNamespace(kv_cache_spec=FakeAttentionSpec(block_size=128)),
+                ],
+            ),
+            _bind_routed_experts_capturer=MagicMock(),
+        )
+        capturer = MagicMock()
+
+        with patch(
+            "vllm_ascend.patch.worker.patch_routed_experts_capturer.RoutedExpertsCapturer.create",
+            return_value=capturer,
+        ), patch(
+            "vllm_ascend.patch.worker.patch_routed_experts_capturer.GPUModelRunner._get_attention_kv_cache_gid",
+            return_value=1,
+        ):
+            init_routed_experts_capturer(runner)
+
+        self.assertEqual(runner.routed_experts_attn_gid, 1)
+        self.assertEqual(runner.max_num_kv_tokens, 16 * 128)
+        self.assertTrue(runner.routed_experts_initialized)
+        capturer.init_buffer.assert_called_once_with(
+            max_num_batched_tokens=32,
+            max_num_kv_tokens=16 * 128,
+            vllm_config=runner.vllm_config,
+        )
 
     def tearDown(self):
         self.capturer.clear_buffer()

--- a/tests/ut/worker/test_routed_experts_hybrid.py
+++ b/tests/ut/worker/test_routed_experts_hybrid.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tests.ut.base import TestBase
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.worker import NPUWorker
+
+
+class FakeAttentionSpec:
+
+    def __init__(self, block_size):
+        self.block_size = block_size
+
+
+class FakeMambaSpec:
+
+    def __init__(self, block_size):
+        self.block_size = block_size
+
+
+class TestRoutedExpertsHybrid(TestBase):
+
+    def test_get_attention_kv_cache_gid_prefers_attention_group(self):
+        runner = object.__new__(NPUModelRunner)
+        runner.kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(kv_cache_spec=FakeMambaSpec(block_size=262144)),
+                SimpleNamespace(kv_cache_spec=FakeAttentionSpec(block_size=128)),
+            ]
+        )
+
+        with patch("vllm_ascend.worker.model_runner_v1.AttentionSpec", FakeAttentionSpec):
+            self.assertEqual(runner._get_attention_kv_cache_gid(), 1)
+
+    def test_npu_model_runner_reuses_parent_init_routed_experts_capturer(self):
+        self.assertNotIn("init_routed_experts_capturer", NPUModelRunner.__dict__)
+
+    def test_worker_initializes_routed_experts_after_kv_cache(self):
+        worker = object.__new__(NPUWorker)
+        worker.vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(enable_sleep_mode=False)
+        )
+        worker.model_config = SimpleNamespace(enable_return_routed_experts=True)
+        worker.model_runner = MagicMock()
+
+        with patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized"), patch.object(
+            GPUModelRunner,
+            "init_routed_experts_capturer",
+        ) as mock_parent_init:
+            worker.initialize_from_config(kv_cache_config=MagicMock())
+
+        worker.model_runner.initialize_kv_cache.assert_called_once()
+        mock_parent_init.assert_called_once_with(worker.model_runner)

--- a/vllm_ascend/patch/worker/patch_routed_experts_capturer.py
+++ b/vllm_ascend/patch/worker/patch_routed_experts_capturer.py
@@ -10,6 +10,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     logger,
 )
 from vllm.platforms import current_platform
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
 def init_buffer(
@@ -62,7 +63,32 @@ def init_buffer(
         shape,
     )
 
+def init_routed_experts_capturer(self) -> None:
+    logger.info(
+        "Initializing routed experts capturer, enable_return_routed_experts: %s",
+        self.model_config.enable_return_routed_experts,
+    )
+    routed_experts_capturer = RoutedExpertsCapturer.create()
+
+    self.routed_experts_attn_gid = GPUModelRunner._get_attention_kv_cache_gid(self)
+    attn_group = self.kv_cache_config.kv_cache_groups[self.routed_experts_attn_gid]
+    self.max_num_kv_tokens = self.kv_cache_config.num_blocks * attn_group.kv_cache_spec.block_size
+
+    dcp_size = self.vllm_config.parallel_config.decode_context_parallel_size
+    pcp_size = self.vllm_config.parallel_config.prefill_context_parallel_size
+    if pcp_size * dcp_size > 1:
+        self.max_num_kv_tokens *= pcp_size * dcp_size
+
+    routed_experts_capturer.init_buffer(
+        max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+        max_num_kv_tokens=self.max_num_kv_tokens,
+        vllm_config=self.vllm_config,
+    )
+    self._bind_routed_experts_capturer(routed_experts_capturer)
+    self.routed_experts_initialized = True
+
 
 # Patch for _device_buffer's initialization(device="cuda" -> device=current_platform.device_name).
 # TODO Remove this patch when pr(https://github.com/vllm-project/vllm/pull/34336) is merged.
 RoutedExpertsCapturer.init_buffer = init_buffer
+GPUModelRunner.init_routed_experts_capturer = init_routed_experts_capturer

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -422,6 +422,8 @@ class NPUModelRunner(GPUModelRunner):
         self.long_seq_metadata = None
         self.query_lens: torch.Tensor | None = None
         self.cpu_slot_mapping = None
+        self.routed_experts_attn_gid = 0
+        self.routed_experts_initialized = False
         self.sampling_done_event: torch.npu.Event | None = None
 
         # self.cudagraph_batch_sizes sorts in ascending order.
@@ -1238,7 +1240,7 @@ class NPUModelRunner(GPUModelRunner):
         scheduler_output: "SchedulerOutput",
         intermediate_tensors: IntermediateTensors | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
-        if self.vllm_config.model_config.enable_return_routed_experts:
+        if self.routed_experts_initialized:
             capturer = RoutedExpertsCapturer.get_instance()
             if capturer is not None:
                 capturer.clear_buffer()
@@ -1714,7 +1716,7 @@ class NPUModelRunner(GPUModelRunner):
             if self.speculative_config is not None:
                 self.finalize_kv_connector()
 
-        if self.model_config.enable_return_routed_experts:
+        if self.routed_experts_initialized:
             capturer = RoutedExpertsCapturer.get_instance()
             if capturer is not None:
                 capturer.save_captured_experts(indices=self.cpu_slot_mapping)
@@ -2233,7 +2235,7 @@ class NPUModelRunner(GPUModelRunner):
                     slot_mapping,
                     kv_cache_gid,
                 )
-            if self.model_config.enable_return_routed_experts and kv_cache_gid == 0:
+            if self.routed_experts_initialized and kv_cache_gid == self.routed_experts_attn_gid:
                 self.cpu_slot_mapping = slot_mapping.cpu().numpy()
             return blk_table_tensor, slot_mapping
 
@@ -2782,9 +2784,6 @@ class NPUModelRunner(GPUModelRunner):
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)
-
-        if self.model_config.enable_return_routed_experts:
-            self.init_routed_experts_capturer()
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -42,6 +42,7 @@ from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 from vllm.v1.worker.worker_base import WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -524,6 +525,9 @@ class NPUWorker(WorkerBase):
             context = nullcontext()  # type: ignore
         with context:
             self.model_runner.initialize_kv_cache(kv_cache_config)
+
+        if self.model_config.enable_return_routed_experts:
+            GPUModelRunner.init_routed_experts_capturer(self.model_runner)
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None):
         # Check if profiling is enabled (RFC #6954 - align with upstream vLLM)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aligns the routed experts capture path in `vllm-ascend` with the upstream fix(https://github.com/vllm-project/vllm/pull/35744) for hybrid KV cache models.

For hybrid MoE models such as Qwen3.5, routed experts capture should use the attention KV cache group instead of assuming KV cache group `0`. In hybrid models, group `0` may correspond to the Mamba KV cache group with a much larger block size, which can produce incorrect slot mapping for routed experts capture.

This change makes the Ascend worker reuse the parent `GPUModelRunner.init_routed_experts_capturer()` implementation instead of maintaining a duplicated local implementation. The Ascend side only keeps the minimal state gating needed for capture and save timing.

### How was this patch tested?

- Added unit test:
  - `tests/ut/worker/test_routed_experts_hybrid.py`
---
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
