### PR TITLE
[Misc] Relocate debugger start logic in model runner

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1258,6 +1258,14 @@ class NPUModelRunner(GPUModelRunner):
         ):
             scheduler_output = deepcopy(scheduler_output)
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+        # prevent debugger is None
+        if self.debugger is not None:
+            dbg_cfg = getattr(self.debugger, "config", None)
+            dump_level = str(getattr(dbg_cfg, "level", "L1")).upper() if dbg_cfg is not None else "L1"
+            if dump_level in ("L0", "MIX"):
+                self.debugger.start(model=self.model)
+            else:
+                self.debugger.start()
         with record_function_or_nullcontext("prepare input"):
             with self.synchronize_input_prep():
                 # Update persistent batch states.
@@ -1467,14 +1475,7 @@ class NPUModelRunner(GPUModelRunner):
             cudagraph_mode = CUDAGraphMode.NONE
             # Mark KV scales as calculated after the first forward pass
             self.calculate_kv_scales = False  # type: ignore[has-type]
-        # prevent debugger is None
-        if self.debugger is not None:
-            dbg_cfg = getattr(self.debugger, "config", None)
-            dump_level = str(getattr(dbg_cfg, "level", "L1")).upper() if dbg_cfg is not None else "L1"
-            if dump_level in ("L0", "MIX"):
-                self.debugger.start(model=self.model)
-            else:
-                self.debugger.start()
+        
         if self.ascend_config.enable_async_exponential:
             self.sampler.do_async_exponential(
                 b_s=logits_indices.shape[0],


### PR DESCRIPTION
### What this PR does / why we need it?

Start msprobe before preparing input for multi model profiling.

- dump result before
<img width="1628" height="496" alt="img_v3_0210o_f485028c-ff94-4e54-9b59-713d25558acg" src="https://github.com/user-attachments/assets/105283e0-d945-4086-bab9-d9f943f40387" />

- dump result after
<img width="1632" height="1064" alt="img_v3_0210o_98fd388a-8123-47cd-9d09-06499243a2ag" src="https://github.com/user-attachments/assets/9f060be2-539f-4fc1-a7d0-7f64480de087" />

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
