### PR TITLE
[Ops][Feature] Optimize AscendTopKTopPSampler with fast path and NPU operators

### DIFF
--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -18,57 +18,63 @@ class AscendSampler(Sampler):
 
 class AscendTopKTopPSampler(TopKTopPSampler):
 
-    def _apply_top_k_top_p(
+     def _apply_top_k_top_p(
         self,
         logits: torch.Tensor,
         k: torch.Tensor,
         p: torch.Tensor,
     ) -> torch.Tensor:
+        # npu_top_k_top_p uses the operator aclnnApplyTopKTopP, but 
+aclnnApplyTopKTopP currently does not support 310P
+        if not is_310p() and p is not None and k is not None and 1 <= int(
+                k.max()) <= 1024:
+            # npu_top_k_top_p's parameter order is (logits, p, k), not (logits, 
+k, p)
+            return torch_npu.npu_top_k_top_p(logits, p, k)
         if p is None and k is None:
             return logits
-        # npu_top_k_top_p uses the operator aclnnApplyTopKTopP, but aclnnApplyTopKTopP currently does not support 310P
-        if not is_310p():
-            # npu_top_k_top_p requires parameter k ranged from 1 to 1024
-            if k is None or 1 <= int(k.max()) <= 1024:
-                # npu_top_k_top_p's parameter order is (logits, p, k), not (logits, k, p)
-                return torch_npu.npu_top_k_top_p(logits, p, k)
-
         probs = logits.softmax(dim=-1)
         probs_sort, _ = probs.sort(dim=-1, descending=False)
-
         if k is not None:
             top_k_count = probs_sort.size(1) - k.to(
                 torch.long)  # shape: (batch, )
             top_k_count = top_k_count.unsqueeze(dim=1)
             top_k_cutoff = probs_sort.gather(-1, top_k_count)
-
             # Make sure the no top-k rows are no-op.
             no_top_k_mask = (k == logits.shape[1]).unsqueeze(dim=1)
             top_k_cutoff.masked_fill_(no_top_k_mask, -float("inf"))
-
             elements_to_discard = probs < top_k_cutoff
             logits.masked_fill_(elements_to_discard, -float("inf"))
 
-        if p is not None:
+         if p is not None:
             cumprob = torch.cumsum(probs_sort, dim=-1)
             top_p_mask = cumprob <= 1 - p.unsqueeze(dim=1)
             top_p_mask[:, -1] = False  # at least one
-
             top_p_count = top_p_mask.sum(dim=-1).unsqueeze(1)
             top_p_cutoff = probs_sort.gather(-1, top_p_count)
             elements_to_discard = probs < top_p_cutoff
             logits.masked_fill_(elements_to_discard, -float("inf"))
-
         return logits
 
-    def forward_native(self, logits, generators, k, p):
+   def forward_native(self, logits, generators, k, p):
         """Override pytorch native implementation to torch_npu"""
-        logits = self._apply_top_k_top_p(logits, k, p)
+        print(self.logprobs_mode)
         logits_to_return = None
+        if (not is_310p() 
+            and p is not None 
+            and k is not None 
+            and 1 <= int(k.max()) <= 1024
+            and self.logprobs_mode != "processed_logits" 
+            and self.logprobs_mode != "processed_logprobs"):
+            probs = torch_npu.top_k_top_p_softmax(logits, p, k)
+            return random_sample(probs, generators), logits_to_return
+        
+        logits = self._apply_top_k_top_p(logits, k, p)
         if self.logprobs_mode == "processed_logits":
             logits_to_return = logits
         elif self.logprobs_mode == "processed_logprobs":
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
-
+    
         probs = logits.softmax(dim=-1, dtype=torch.float32)
         return random_sample(probs, generators), logits_to_return
+

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -24,12 +24,10 @@ class AscendTopKTopPSampler(TopKTopPSampler):
         k: torch.Tensor,
         p: torch.Tensor,
     ) -> torch.Tensor:
-        # npu_top_k_top_p uses the operator aclnnApplyTopKTopP, but 
-aclnnApplyTopKTopP currently does not support 310P
+        # npu_top_k_top_p uses the operator aclnnApplyTopKTopP, but aclnnApplyTopKTopP currently does not support 310P
         if not is_310p() and p is not None and k is not None and 1 <= int(
                 k.max()) <= 1024:
-            # npu_top_k_top_p's parameter order is (logits, p, k), not (logits, 
-k, p)
+            # npu_top_k_top_p's parameter order is (logits, p, k), not (logits, k, p)
             return torch_npu.npu_top_k_top_p(logits, p, k)
         if p is None and k is None:
             return logits
@@ -58,7 +56,6 @@ k, p)
 
    def forward_native(self, logits, generators, k, p):
         """Override pytorch native implementation to torch_npu"""
-        print(self.logprobs_mode)
         logits_to_return = None
         if (not is_310p() 
             and p is not None 


### PR DESCRIPTION
新增自定义算子替换: top_k_top_p_softmax

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://github.com/vllm-project/vllm-ascend/issues/8244

### What this PR does / why we need it?
This PR optimizes the `AscendTopKTopPSampler` by introducing a fast path using `torch_npu.top_k_top_p_softmax` and refining the `_apply_top_k_top_p` logic. These changes improve performance on Ascend NPU by utilizing optimized operators.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Not specified.
