### PR TITLE
[BugFix] Patch kv-init-related logic for model_runner_v2

### DIFF
--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -23,7 +23,7 @@ from vllm import SamplingParams
 
 from tests.e2e.conftest import VllmRunner
 
-MODELS = ["Qwen/Qwen3-0.6B"]
+MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
 
 MAIN_MODELS = ["LLM-Research/Meta-Llama-3.1-8B-Instruct"]
 EGALE_MODELS = ["vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B"]

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 
 import torch
+import vllm.model_executor.layers.attention.mla_attention
 import vllm.v1.kv_cache_interface
 from typing_extensions import Self
 from vllm.utils.torch_utils import get_dtype_size
@@ -140,3 +141,4 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
 
 
 vllm.v1.kv_cache_interface.MLAAttentionSpec = AscendMLAAttentionSpec
+vllm.model_executor.layers.attention.mla_attention.MLAAttentionSpec = AscendMLAAttentionSpec

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -53,3 +53,4 @@ import vllm_ascend.patch.worker.patch_v2.patch_model_state  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_block_table  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_c8  # noqa
 import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
+import vllm_ascend.patch.worker.patch_v2.patch_attn_utils  # noqa

--- a/vllm_ascend/patch/worker/patch_v2/patch_attn_utils.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_attn_utils.py
@@ -1,0 +1,6 @@
+import vllm
+
+from vllm_ascend.worker.v2.attn_utils import _allocate_kv_cache, _reshape_kv_cache
+
+vllm.v1.worker.gpu.attn_utils._allocate_kv_cache = _allocate_kv_cache
+vllm.v1.worker.gpu.attn_utils._reshape_kv_cache = _reshape_kv_cache

--- a/vllm_ascend/worker/v2/README.md
+++ b/vllm_ascend/worker/v2/README.md
@@ -4,3 +4,17 @@ This directory contains the new model runner which is under active development.
 
 please see [Model Runner V2](https://github.com/vllm-project/vllm-ascend/issues/5208)
 to get specific plans.
+
+## Gaps with vLLM (To Be Addressed)
+
+- [ ] `set_cos_and_sin` & `update_cos_sin`
+
+    Why: DeepSeek-like models (mla) still need cos/sin setting and updating in model_runner. These should be removed when mla can solve cos/sin internally.
+
+    Location: `NPUModelRunner.__init__`, `NPUModelRunner.prepare_inputs`, `AscendInputBatch.make_dummy`.
+
+- [ ] `_allocate_kv_cache` & `_reshape_kv_cache`
+
+    Why: KV cache requires continuous space (thus divided as K cache and V cache separately) and PD disaggregation requires 2M-aligned tensors for KV cache, so custom KV cache initialization is needed. These should be removed when the above 2 requirements are no longer needed.
+
+    Location: `attn_utils._get_layer_kv_cache_specs`, `attn_utils._get_attention_kv_cache_dims`, `attn_utils._align_memory`, `attn_utils._allocate_kv_cache`, `attn_utils._reshape_kv_cache`.

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -22,13 +22,25 @@ from typing import Any
 
 import numpy as np
 import torch
-from vllm.config import VllmConfig
-from vllm.v1.kv_cache_interface import EncoderOnlyAttentionSpec, KVCacheConfig
+from vllm.config import VllmConfig, get_current_vllm_config, get_layers_from_vllm_config
+from vllm.model_executor.layers.attention import MLAAttention
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    EncoderOnlyAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, AscendPrefillContextParallelMetadata
+from vllm_ascend.quantization.utils import enable_fa_quant
+from vllm_ascend.utils import calc_split_factor
 
 _ATTENTION_MASK_BUILDER = None
 
@@ -148,3 +160,191 @@ def build_attn_state(
     else:
         attn_state = AscendAttentionState.PrefillCacheHit
     return attn_state
+
+
+def _get_layer_kv_cache_specs(kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
+    layer_kv_cache_spec: dict[str, KVCacheSpec] = {}
+    for group_kv_cache_spec in kv_cache_config.kv_cache_groups:
+        group_spec = group_kv_cache_spec.kv_cache_spec
+        for layer_name in group_kv_cache_spec.layer_names:
+            if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                layer_kv_cache_spec[layer_name] = group_spec.kv_cache_specs[layer_name]
+            else:
+                layer_kv_cache_spec[layer_name] = group_spec
+    return layer_kv_cache_spec
+
+
+def _get_attention_kv_cache_dims(layer_name: str, kv_cache_spec: AttentionSpec) -> tuple[int, int]:
+    if isinstance(kv_cache_spec, MLAAttentionSpec):
+        attn_layers = get_layers_from_vllm_config(get_current_vllm_config(), AttentionLayerBase, [layer_name])
+        attn_layer = attn_layers[layer_name]
+        if not isinstance(attn_layer, MLAAttention):
+            raise TypeError(f"Expected MLAAttention layer for {layer_name}, got {type(attn_layer).__name__}.")
+        return attn_layer.kv_lora_rank, attn_layer.qk_rope_head_dim
+
+    head_size_v = kv_cache_spec.head_size_v if hasattr(kv_cache_spec, "head_size_v") else kv_cache_spec.head_size
+    return kv_cache_spec.head_size, head_size_v
+
+
+def _align_memory(tensor: torch.Tensor, alignment: int) -> torch.Tensor:
+    data_ptr = tensor.data_ptr()
+    aligned_addr = (data_ptr + alignment - 1) // alignment * alignment
+    offset = (aligned_addr - data_ptr) // tensor.element_size()
+    return tensor[int(offset) :]
+
+
+def _allocate_kv_cache(
+    kv_cache_config: KVCacheConfig,
+    device: torch.device,
+) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+    """
+    Initialize the KV cache buffer with the correct size. The buffer needs to be
+    reshaped to the desired shape before being used by the models.
+
+    NOTE: To support prefill disaggregation, we need to split kvcache tensor
+    into k_cache and v_cache, and the addr of both are aligned by 2M.
+
+    Args:
+        kv_cache_config: The KV cache config
+        device: The device
+    Returns:
+        dict[str, tuple[torch.Tensor, torch.Tensor]]: A map between layer names
+            to their corresponding memory buffer for K cache and V cache
+    """
+    vllm_config = get_current_vllm_config()
+    is_kv_consumer = (
+        vllm_config.kv_transfer_config.is_kv_consumer if vllm_config.kv_transfer_config is not None else False
+    )
+
+    # init kv cache tensors
+    kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+    # prefill disaggregation need the addr of cache tensor be aligned with 2M
+    alignment = 2 * 1024 * 1024
+    layer_kv_cache_spec = _get_layer_kv_cache_specs(kv_cache_config)
+    for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+        if len(kv_cache_tensor.shared_by) == 0:
+            continue
+
+        # NOTE: We need to init k_cache tensor (nope cache tensor in mla) and
+        # v_cache tensor (rope cache tensor in mla) separately to support
+        # prefill disaggregation, as it only supports the 0-dim of kv_cache is
+        # `num_blocks`.
+        # For deepseek mla, we need to spilt cache tensor accrodding to the nope
+        # head dim and rope head dim.
+        example_layer_name = kv_cache_tensor.shared_by[0]
+        example_kv_cache_spec = layer_kv_cache_spec[example_layer_name]
+        assert isinstance(example_kv_cache_spec, AttentionSpec)
+
+        k_dim, v_dim = _get_attention_kv_cache_dims(example_layer_name, example_kv_cache_spec)
+        assert k_dim > 0 and v_dim > 0
+        kv_head_dim_list = [k_dim, v_dim]
+        if is_kv_consumer and enable_fa_quant(vllm_config):
+            k_tensor_split_factor, v_tensor_split_factor = vllm_config.quant_config.get_kv_quant_split_factor(
+                example_layer_name, kv_head_dim_list
+            )
+        else:
+            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
+        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
+        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+
+        if vllm_config.kv_transfer_config is None:
+            k_tensor = torch.zeros(k_tensor_size, dtype=torch.int8, device=device)
+            v_tensor = torch.zeros(v_tensor_size, dtype=torch.int8, device=device)
+        else:
+            k_tensor = torch.zeros(k_tensor_size + alignment, dtype=torch.int8, device=device)
+            v_tensor = torch.zeros(v_tensor_size + alignment, dtype=torch.int8, device=device)
+            k_tensor = _align_memory(k_tensor, alignment)[:k_tensor_size]
+            v_tensor = _align_memory(v_tensor, alignment)[:v_tensor_size]
+        for layer_name in kv_cache_tensor.shared_by:
+            kv_cache_raw_tensors[layer_name] = (k_tensor, v_tensor)
+
+    layer_names = set()
+    for group in kv_cache_config.kv_cache_groups:
+        for layer_name in group.layer_names:
+            layer_names.add(layer_name)
+    assert layer_names == set(kv_cache_raw_tensors.keys()), "Some layers are not correctly initialized"
+
+    return kv_cache_raw_tensors
+
+
+def _reshape_kv_cache(
+    kv_cache_config: KVCacheConfig,
+    kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]],
+    attn_backends: dict[str, AttentionBackend],
+    cache_dtype: str,
+) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+    """
+    Reshape the KV cache tensors to the desired shape and dtype.
+
+    Args:
+        kv_cache_config: The KV cache config
+        kv_cache_raw_tensors: The KV cache buffer of each layer, with correct
+            size but uninitialized shape
+    Returns:
+        dict[str, tuple[torch.Tensor, torch.Tensor]]: A map between layer names
+            to their corresponding memory buffer for KV cache
+    """
+    vllm_config = get_current_vllm_config()
+    is_kv_consumer = (
+        vllm_config.kv_transfer_config.is_kv_consumer if vllm_config.kv_transfer_config is not None else False
+    )
+
+    kv_caches: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+    for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
+        for layer_name in kv_cache_group_spec.layer_names:
+            kv_cache_spec = kv_cache_group_spec.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                kv_cache_spec = kv_cache_spec.kv_cache_specs[layer_name]
+            assert isinstance(kv_cache_spec, AttentionSpec)
+
+            if isinstance(kv_cache_spec, AttentionSpec):
+                raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name]
+                assert raw_k_tensor is not None
+                assert raw_v_tensor is not None
+                sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
+                assert sum_page_size_bytes % kv_cache_spec.page_size_bytes == 0
+                num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
+
+                # `num_blocks` is the number of blocks the model runner can use.
+                # `kv_cache_config.num_blocks` is the number of blocks that
+                # KVCacheManager may allocate.
+                # Since different GPUs may have different number of layers and
+                # different memory capacities, `num_blocks` can be different on
+                # different GPUs, and `kv_cache_config.num_blocks` is set to
+                # the min of all `num_blocks`. Verify it here.
+                assert num_blocks >= kv_cache_config.num_blocks
+
+                attn_backend = attn_backends[layer_name]
+                kv_cache_shape = attn_backend.get_kv_cache_shape(
+                    num_blocks,
+                    kv_cache_spec.block_size,
+                    kv_cache_spec.num_kv_heads,
+                    kv_cache_spec.head_size,
+                    cache_dtype,
+                )
+                if not isinstance(kv_cache_spec, MLAAttentionSpec):
+                    k_shape = kv_cache_shape[1:]
+                    if hasattr(kv_cache_spec, "head_size_v"):
+                        v_shape = (*kv_cache_shape[1:-1], kv_cache_spec.head_size_v)
+                    else:
+                        v_shape = k_shape
+                else:
+                    # k_cache: nope_cache    v_cache: rope_cache
+                    mla_num_blocks, mla_block_size, num_kv_heads, _ = kv_cache_shape
+                    k_dim, v_dim = _get_attention_kv_cache_dims(layer_name, kv_cache_spec)
+                    k_shape = (mla_num_blocks, mla_block_size, num_kv_heads, k_dim)
+                    v_shape = (mla_num_blocks, mla_block_size, num_kv_heads, v_dim)
+
+                k_cache_dtype = v_cache_dtype = kv_cache_spec.dtype
+                if is_kv_consumer and enable_fa_quant(vllm_config):
+                    k_cache_dtype, v_cache_dtype = vllm_config.quant_config.get_kv_quant_dtype(
+                        layer_name, kv_cache_spec.dtype, vllm_config.model_config
+                    )
+
+                k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
+                v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
+                kv_caches[layer_name] = (k_cache, v_cache)
+            else:
+                raise ValueError("Unknown KV cache spec type.")
+
+    return kv_caches

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -24,6 +24,7 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.ops.rotary_embedding import update_cos_sin
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
@@ -100,6 +101,8 @@ class AscendInputBatch(InputBatch):
         # attention metadata isn't needed,
         # we can also set attn_state to AscendAttentionState.DecodeOnly.
         input_batch.attn_state = AscendAttentionState.DecodeOnly
+        # For mla/sfa, update cos/sin. Here is for _dummy_run.
+        update_cos_sin(input_batch.positions)
         return cls(**asdict(input_batch), seq_lens_np=seq_lens_np)
 
 

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -41,6 +41,7 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_mask,
     set_mc2_tokens_capacity,
 )
+from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import set_weight_prefetch_method
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
@@ -127,6 +128,8 @@ class NPUModelRunner(GPUModelRunner):
         # set _WEIGHT_PREFETCH_METHOD, _mc2_tokens_capacity and _reserved_mc2_mask which
         # is necessary for weight_prfetching function, and MoE communication optimization.
         set_weight_prefetch_method(self.ascend_config.weight_prefetch_config)
+        # TODO: remove set_cos_and_sin (together with update_cos_sin) when mla can properly handle cos/sin internally
+        set_cos_and_sin(vllm_config, self.max_num_reqs, self.decode_query_len, self.dtype, self.device)
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
 
@@ -330,6 +333,10 @@ class NPUModelRunner(GPUModelRunner):
             seq_lens_np=self.input_buffers.seq_lens_np,
             attn_state=attn_state,
         )
+
+        # For mla/sfa, update cos/sin. Here is for execute_model.
+        update_cos_sin(self.input_batch.positions)
+
         return self.input_batch
 
     def postprocess(

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -70,6 +70,7 @@ class AscendModelState(DefaultModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             # extra attributes for ascend npus.
             seq_lens_np=input_batch.seq_lens_np,
+            positions=input_batch.positions,
             attn_state=input_batch.attn_state,
         )
         return self.attn_metadata


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to patch `_allocate_kv_cache` and `_reshape_kv_cache` for model_runner_v2. Since the different organization of kv cache tensors, it is non-trivial to reuse related code in vllm. This PR simply copies them from model_runner_v1 and deletes branches about sfa/hybrid, because they may be supported later with refactoring.

At the same time, add cos/sin setting and updating back since currently mla still needs them. Now it should be ok to run dsv31 in model_runner_v2 in basic configuration. Related e2e is also added.

Additionally, update README for recording gaps with vllm.

BTW, ut is on the way.

RFC: #5208

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
