### PR TITLE
[Bugfix] Enforce C locale for CPU binding subprocess parsing

### DIFF
--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -55,12 +55,14 @@ class TestDeviceInfo(unittest.TestCase):
 
         self.assertEqual(output, 'command-output')
         self.assertEqual(return_code, 7)
-        mock_popen.assert_called_once_with(
-            ['dummy', 'cmd'],
-            shell=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        mock_popen.assert_called_once()
+        _, kwargs = mock_popen.call_args
+        self.assertEqual(kwargs["shell"], False)
+        self.assertEqual(kwargs["stdout"], subprocess.PIPE)
+        self.assertEqual(kwargs["stderr"], subprocess.PIPE)
+        self.assertEqual(kwargs["env"]["LC_ALL"], "C")
+        self.assertEqual(kwargs["env"]["LANG"], "C")
+        self.assertEqual(kwargs["env"]["LC_MESSAGES"], "C")
 
     @patch('vllm_ascend.cpu_binding.execute_command')
     def setUp(self, mock_execute_command):

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -37,7 +37,12 @@ def is_arm_cpu() -> bool:
 
 
 def execute_command(cmd: list[str]) -> tuple[str, int]:
-    with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
+    # Force a C locale so subprocess output remains parseable on localized OSes.
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+    env["LANG"] = "C"
+    env["LC_MESSAGES"] = "C"
+    with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env) as p:
         out, _ = p.communicate(timeout=1000)
     return out.decode(), p.returncode
 


### PR DESCRIPTION
## Summary
- bring over the CPU binding locale normalization from #7274 onto a fresh branch based on `main`
- address the review feedback by forcing `LC_ALL`, `LANG`, and `LC_MESSAGES` to `C`
- extend the existing unit test to assert the locale environment passed to `subprocess.Popen`

## Why
`LANG=C` alone can still be overridden by inherited `LC_ALL`/`LC_MESSAGES` settings, so the original change was not robust enough for localized environments.

## Testing
- attempted: `python -m pytest tests/ut/device_allocator/test_cpu_binding.py::TestDeviceInfo::test_execute_command -q`
- result: did not complete in this local environment, so the change was validated by targeted diff inspection and updated unit assertions only

## Attribution
- derived from the original work in #7274
- Co-authored-by: vLLM-Ascend Developer <developer@vllm-ascend.dev>
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
