### PR TITLE
[Ascend950][quant][Feature] Add W4A8 MXFP4 quantization support for Ascend950

### DIFF
--- a/tests/ut/ops/test_moe_runtime_args.py
+++ b/tests/ut/ops/test_moe_runtime_args.py
@@ -37,6 +37,8 @@ def _get_test_mxfp_dtype(quant_type: QuantType) -> torch.dtype | None:
         return torch.float8_e4m3fn
     if quant_type == QuantType.MXFP4:
         return MXFP4_TEST_DTYPE
+    if quant_type == QuantType.W4A8MXFP:
+        return torch.float8_e4m3fn
     return None
 
 
@@ -73,6 +75,7 @@ class TestMoERuntimeArgs(unittest.TestCase):
             QuantType.W8A8,
             QuantType.MXFP8,
             QuantType.MXFP4,
+            QuantType.W4A8MXFP,
         ):
             with self.subTest(quant_type=quant_type):
                 hidden_states = torch.randn(4, 8)
@@ -165,7 +168,7 @@ class TestMoERuntimeArgs(unittest.TestCase):
         self.assertIs(token_dispatch_input.topk_ids, routed_topk_ids)
 
     def test_build_fused_experts_input_requires_primitive_mxfp_params_for_mxfp_quant(self):
-        for quant_type in (QuantType.MXFP8, QuantType.MXFP4):
+        for quant_type in (QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP):
             with (
                 self.subTest(quant_type=quant_type),
                 self.assertRaisesRegex(ValueError, "primitive MXFP params are required"),
@@ -181,7 +184,11 @@ class TestMoERuntimeArgs(unittest.TestCase):
                 )
 
     def test_build_mlp_compute_input_derives_fusion_and_preserves_mxfp_params(self):
-        for quant_type, expected_fusion in ((QuantType.MXFP8, True), (QuantType.MXFP4, False)):
+        for quant_type, expected_fusion in (
+            (QuantType.MXFP8, True),
+            (QuantType.MXFP4, True),
+            (QuantType.W4A8MXFP, False),
+        ):
             with self.subTest(quant_type=quant_type):
                 mxfp_dtype = _get_test_mxfp_dtype(quant_type)
                 fused_experts_input = build_fused_experts_input(

--- a/tests/ut/ops/test_moe_runtime_args.py
+++ b/tests/ut/ops/test_moe_runtime_args.py
@@ -187,7 +187,7 @@ class TestMoERuntimeArgs(unittest.TestCase):
         for quant_type, expected_fusion in (
             (QuantType.MXFP8, True),
             (QuantType.MXFP4, True),
-            (QuantType.W4A8MXFP, False),
+            (QuantType.W4A8MXFP, True),
         ):
             with self.subTest(quant_type=quant_type):
                 mxfp_dtype = _get_test_mxfp_dtype(quant_type)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -531,7 +531,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             input_dtype=input_dtype,
             act_quant_type=act_quant_type,
             weight_quant_type=weight_quant_type,
-            scale_type=scale_type if mxfp_quant_dtype != QuantType.MXFP4 else None,
+            scale_type=scale_type if mxfp_quant_dtype != QuantType.W4A8MXFP else None,
             per_token_scale_type=per_token_scale_type,
             use_bf16=use_bf16,
             use_mxfp_quant=True,
@@ -545,7 +545,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
-        if mxfp_quant_dtype == QuantType.MXFP4:
+        if mxfp_quant_dtype == QuantType.W4A8MXFP:
             gmm2_scale = None
             antiquant_scale = weight_scale.reshape(
                 weight_scale.shape[0], weight_scale.shape[1] // 2 , 2, weight_scale.shape[2]

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -547,11 +547,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
             gmm2_scale = None
-            antiquant_scale = weight_scale.reshape(
-                weight_scale.shape[0], weight_scale.shape[1] // 2 , 2, weight_scale.shape[2]
-            ).transpose(-1, -2)
-            gmm2_kwargs.update({'antiquant_scale': [antiquant_scale]})
-        
+            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
+
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=gmm2_weight,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -452,7 +452,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 group_list=group_list,
                 x_dtype=torch.float8_e4m3fn,
                 weight_dtype=torch_npu.float4_e2m1fn_x2,
-                output_dtype=torch.bfloat16
+                output_dtype=torch.bfloat16,
             )[0]
             hidden_states = torch_npu.npu_swiglu(hidden_states)
             out, out_scale = torch_npu.npu_dynamic_mx_quant(

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -118,10 +118,11 @@ class BaseDeviceAdaptor:
         weight_scale: torch.Tensor,
         x_scale: torch.Tensor,
         bias=None,
-        swiglu_limit: int = 0,
         use_mxfp_quant: bool = False,
         act_quant_type: torch.dtype | int = torch.float8_e4m3fn,
         weight_quant_type: torch.dtype | int = torch.float8_e4m3fn,
+        swiglu_limit: int = 0,
+        mxfp_quant_dtype: QuantType | None = None,
     ):
         if use_mxfp_quant:
             raise RuntimeError("MXFP MoE quantization is only supported on Ascend A5.")
@@ -418,10 +419,11 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         weight_scale: torch.Tensor,
         x_scale: torch.Tensor,
         bias=None,
-        swiglu_limit: int = 0,
         use_mxfp_quant: bool = False,
         act_quant_type: torch.dtype | int = torch.float8_e4m3fn,
         weight_quant_type: torch.dtype | int = torch.float8_e4m3fn,
+        swiglu_limit: int = 0,
+        mxfp_quant_dtype: QuantType | None = None,
     ):
         if not use_mxfp_quant:
             return torch_npu.npu_grouped_matmul_swiglu_quant_v2(
@@ -435,21 +437,43 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 use_mxfp_quant=False,
             )
 
-        out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
-            x=x,
-            weight=[weight],
-            group_list=group_list,
-            weight_scale=[weight_scale],
-            x_scale=x_scale,
-            dequant_mode=2,
-            quant_mode=2,
-            dequant_dtype=torch.float32,
-            quant_dtype=act_quant_type,
-            x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
-            weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
-            weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-            x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-        )
+        # W4A8 mxfp
+        if mxfp_quant_dtype == QuantType.W4A8MXFP:
+            hidden_states = torch_npu.npu_grouped_matmul(
+                x=[x],
+                weight=[weight],
+                scale=None,
+                antiquant_scale=[weight_scale],
+                scale_dtype=None,
+                per_token_scale=[x_scale],
+                per_token_scale_dtype=torch.float8_e8m0fnu,
+                split_item=2,
+                group_type=0,
+                group_list=group_list,
+                x_dtype=torch.float8_e4m3fn,
+                weight_dtype=torch_npu.float4_e2m1fn_x2,
+                output_dtype=torch.bfloat16
+            )[0]
+            hidden_states = torch_npu.npu_swiglu(hidden_states)
+            out, out_scale = torch_npu.npu_dynamic_mx_quant(
+                hidden_states, dst_type=torch.float8_e4m3fn, round_mode="rint"
+            )
+        else:
+            out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
+                x=x,
+                weight=[weight],
+                group_list=group_list,
+                weight_scale=[weight_scale],
+                x_scale=x_scale,
+                dequant_mode=2,
+                quant_mode=2,
+                dequant_dtype=torch.float32,
+                quant_dtype=act_quant_type,
+                x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
+                weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
+                weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            )
         return out, A5DeviceAdaptor.maybe_normalize_mxfp_scale_layout(out_scale), None
 
     @staticmethod
@@ -532,7 +556,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             input_dtype=input_dtype,
             act_quant_type=act_quant_type,
             weight_quant_type=weight_quant_type,
-            scale_type=scale_type if mxfp_quant_dtype != QuantType.W4A8MXFP else None,
+            scale_type=scale_type,
             per_token_scale_type=per_token_scale_type,
             use_bf16=use_bf16,
             use_mxfp_quant=True,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -173,6 +173,7 @@ class BaseDeviceAdaptor:
         use_mxfp_quant: bool = False,
         bias=None,
         fallback_output_dtype: torch.dtype | None = None,
+        mxfp_quant_dtype: QuantType | None = None,
     ) -> torch.Tensor:
         if use_mxfp_quant:
             raise RuntimeError("MXFP MoE quantization is only supported on Ascend A5.")
@@ -546,7 +547,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            gmm2_scale = None
+            gmm2_scale = None  # type: ignore[assignment]
             gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
 
         return torch_npu.npu_grouped_matmul(

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -23,6 +23,7 @@ from vllm_ascend.device.mxfp_compat import (
     QUANT_DTYPES,
     SCALE_DTYPES,
 )
+from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
@@ -505,6 +506,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         use_mxfp_quant: bool = False,
         bias=None,
         fallback_output_dtype: torch.dtype | None = None,
+        mxfp_quant_dtype: QuantType | None = None,
     ) -> torch.Tensor:
         if not use_mxfp_quant:
             return BaseDeviceAdaptor.npu_grouped_matmul_gmm2(
@@ -529,7 +531,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             input_dtype=input_dtype,
             act_quant_type=act_quant_type,
             weight_quant_type=weight_quant_type,
-            scale_type=scale_type,
+            scale_type=scale_type if mxfp_quant_dtype != QuantType.MXFP4 else None,
             per_token_scale_type=per_token_scale_type,
             use_bf16=use_bf16,
             use_mxfp_quant=True,
@@ -543,6 +545,13 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
+        if mxfp_quant_dtype == QuantType.MXFP4:
+            gmm2_scale = None
+            antiquant_scale = weight_scale.reshape(
+                weight_scale.shape[0], weight_scale.shape[1] // 2 , 2, weight_scale.shape[2]
+            ).transpose(-1, -2)
+            gmm2_kwargs.update({'antiquant_scale': [antiquant_scale]})
+        
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=gmm2_weight,

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -5,6 +5,7 @@ import torch_npu
 # releases do not expose the required dtype attributes yet. Simplify or remove this
 # file after the torch_npu release in March 2026 includes those dtype symbols.
 FLOAT8_E8M0FNU_DTYPE = getattr(torch_npu, "float8_e8m0fnu", getattr(torch, "float8_e8m0fnu", None))
+FLOAT8_E4M3FN_DTYPE = getattr(torch_npu, "float8_e4m3fn", getattr(torch, "float8_e4m3fn", None))
 FLOAT4_E2M1FN_X2_DTYPE = getattr(torch_npu, "float4_e2m1fn_x2", getattr(torch, "float4_e2m1fn_x2", None))
 HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 
@@ -12,7 +13,7 @@ HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 # TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, hifloat8) have to be
 # specified for some operators like GMM in Ascend950, while float8_e4m3fn does not. Remove these
 # filterations when operators allow to pass data with these three dtypes directly.
-QUANT_DTYPES = tuple(dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
+QUANT_DTYPES = tuple(dtype for dtype in (FLOAT8_E4M3FN_DTYPE, FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
 SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
 
 

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -13,7 +13,9 @@ HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 # TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, hifloat8) have to be
 # specified for some operators like GMM in Ascend950, while float8_e4m3fn does not. Remove these
 # filterations when operators allow to pass data with these three dtypes directly.
-QUANT_DTYPES = tuple(dtype for dtype in (FLOAT8_E4M3FN_DTYPE, FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
+QUANT_DTYPES = tuple(
+    dtype for dtype in (FLOAT8_E4M3FN_DTYPE, FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None
+)
 SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
 
 

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -5,7 +5,6 @@ import torch_npu
 # releases do not expose the required dtype attributes yet. Simplify or remove this
 # file after the torch_npu release in March 2026 includes those dtype symbols.
 FLOAT8_E8M0FNU_DTYPE = getattr(torch_npu, "float8_e8m0fnu", getattr(torch, "float8_e8m0fnu", None))
-FLOAT8_E4M3FN_DTYPE = getattr(torch_npu, "float8_e4m3fn", getattr(torch, "float8_e4m3fn", None))
 FLOAT4_E2M1FN_X2_DTYPE = getattr(torch_npu, "float4_e2m1fn_x2", getattr(torch, "float4_e2m1fn_x2", None))
 HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 
@@ -14,7 +13,7 @@ HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 # specified for some operators like GMM in Ascend950, while float8_e4m3fn does not. Remove these
 # filterations when operators allow to pass data with these three dtypes directly.
 QUANT_DTYPES = tuple(
-    dtype for dtype in (FLOAT8_E4M3FN_DTYPE, FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None
+    dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None
 )
 SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
 

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -12,9 +12,7 @@ HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 # TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, hifloat8) have to be
 # specified for some operators like GMM in Ascend950, while float8_e4m3fn does not. Remove these
 # filterations when operators allow to pass data with these three dtypes directly.
-QUANT_DTYPES = tuple(
-    dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None
-)
+QUANT_DTYPES = tuple(dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
 SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
 
 

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -28,7 +28,6 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.activation import AscendSwigluOAIAndMul
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.quantization.quant_type import QuantType
-
 from vllm_ascend.utils import (
     dispose_tensor,
     enable_custom_op,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -168,6 +168,7 @@ def quant_apply_mlp(
                 act_quant_type=act_quant_type,
                 weight_quant_type=weight_quant_type,
                 swiglu_limit=swiglu_limit,
+                mxfp_quant_dtype=mxfp_quant_dtype,
             )
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
@@ -292,6 +293,7 @@ def quant_apply_mlp(
                 act_quant_type=act_quant_type,
                 weight_quant_type=weight_quant_type,
                 swiglu_limit=swiglu_limit,
+                mxfp_quant_dtype=mxfp_quant_dtype,
             )
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
@@ -448,8 +450,6 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         assert mxfp is not None, "mlp_compute_input.quant.mxfp is required for MXFP quant types."
         act_quant_type = mxfp.act_quant_type or act_quant_type
         weight_quant_type = mxfp.weight_quant_type or weight_quant_type
-        if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            weight_quant_type = mxfp.weight_quant_type
         scale_type = mxfp.scale_dtype
         per_token_scale_type = mxfp.per_token_scale_dtype
         use_bf16 = mxfp.use_bf16

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -27,6 +27,8 @@ from vllm_ascend.device.mxfp_compat import (
 )
 from vllm_ascend.ops.activation import AscendSwigluOAIAndMul
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
+from vllm_ascend.quantization.quant_type import QuantType
+
 from vllm_ascend.utils import (
     dispose_tensor,
     enable_custom_op,
@@ -96,6 +98,7 @@ def quant_apply_mlp(
     fusion: bool = False,
     dynamic_eplb: bool = False,
     use_mxfp_quant: bool = False,
+    mxfp_quant_dtype: QuantType | None = None,
     act_quant_type: torch.dtype = torch.float8_e4m3fn,
     weight_quant_type: torch.dtype | None = None,
     scale_type: torch.dtype | None = None,
@@ -214,6 +217,7 @@ def quant_apply_mlp(
             use_mxfp_quant=use_mxfp_quant,
             bias=None,
             fallback_output_dtype=w2_scale[0].dtype if isinstance(w2_scale, list) else w2_scale.dtype,
+            mxfp_quant_dtype=mxfp_quant_dtype,
         )
     elif w1_offset is not None:
         # gmm1: gate_up_proj
@@ -337,6 +341,7 @@ def quant_apply_mlp(
             use_mxfp_quant=use_mxfp_quant,
             bias=bias2,
             fallback_output_dtype=_output_dtype,
+            mxfp_quant_dtype=mxfp_quant_dtype,
         )
     return hidden_states, before_gmm2_evt
 
@@ -437,12 +442,15 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     per_token_scale_type = None
     use_bf16 = hidden_states.dtype == torch.bfloat16
     use_mxfp_quant = mlp_compute_input.quant.is_mxfp
+    mxfp_quant_dtype = mlp_compute_input.quant.quant_type
 
     if use_mxfp_quant:
         mxfp = mlp_compute_input.quant.mxfp
         assert mxfp is not None, "mlp_compute_input.quant.mxfp is required for MXFP quant types."
         act_quant_type = mxfp.act_quant_type or act_quant_type
         weight_quant_type = mxfp.weight_quant_type or weight_quant_type
+        if mxfp_quant_dtype == QuantType.W4A8MXFP:
+            weight_quant_type = mxfp.weight_quant_type
         scale_type = mxfp.scale_dtype
         per_token_scale_type = mxfp.per_token_scale_dtype
         use_bf16 = mxfp.use_bf16
@@ -463,6 +471,7 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         fusion=fusion,
         dynamic_eplb=dynamic_eplb,
         use_mxfp_quant=use_mxfp_quant,
+        mxfp_quant_dtype=mxfp_quant_dtype,
         act_quant_type=act_quant_type,
         weight_quant_type=weight_quant_type,
         scale_type=scale_type,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -88,7 +88,7 @@ def _build_mxfp_params(
     mxfp_per_token_scale_dtype: torch.dtype | None = None,
     mxfp_use_bf16: bool | None = None,
 ) -> _stage_params.MoEMxfpParams | None:
-    if quant_type not in [QuantType.MXFP8, QuantType.MXFP4]:
+    if quant_type not in [QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP]:
         return None
 
     has_explicit_mxfp_args = any(

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -222,7 +222,8 @@ def build_mlp_compute_input(
         topk_scales=token_dispatch_output.topk_scales,
         weights=fused_experts_input.weights,
         quant=fused_experts_input.quant,
-        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4) and use_fusion_ops,
+        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4)
+        and use_fusion_ops,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -222,7 +222,7 @@ def build_mlp_compute_input(
         topk_scales=token_dispatch_output.topk_scales,
         weights=fused_experts_input.weights,
         quant=fused_experts_input.quant,
-        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8) and use_fusion_ops,
+        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4) and use_fusion_ops,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -222,7 +222,7 @@ def build_mlp_compute_input(
         topk_scales=token_dispatch_output.topk_scales,
         weights=fused_experts_input.weights,
         quant=fused_experts_input.quant,
-        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4)
+        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
         and use_fusion_ops,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -222,7 +222,8 @@ def build_mlp_compute_input(
         topk_scales=token_dispatch_output.topk_scales,
         weights=fused_experts_input.weights,
         quant=fused_experts_input.quant,
-        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
+        fusion=fused_experts_input.quant.quant_type
+        in (QuantType.W8A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
         and use_fusion_ops,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -81,8 +81,6 @@ class MoEQuantParams:
 
     @property
     def dispatch_with_quant(self) -> bool:
-        # MXFP4 currently quantizes activations in the MoE MLP path, so
-        # MC2 dispatch must remain unquantized for that mode.
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
 
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -69,7 +69,7 @@ class MoEQuantParams:
 
     @property
     def is_mxfp(self) -> bool:
-        return self.quant_type in (QuantType.MXFP8, QuantType.MXFP4)
+        return self.quant_type in (QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
 
     @property
     def is_int_quant(self) -> bool:
@@ -81,7 +81,9 @@ class MoEQuantParams:
 
     @property
     def dispatch_with_quant(self) -> bool:
-        return self.quant_type in (QuantType.W8A8, QuantType.W4A8, QuantType.MXFP8, QuantType.MXFP4)
+        # MXFP4 currently quantizes activations in the MoE MLP path, so
+        # MC2 dispatch must remain unquantized for that mode.
+        return self.quant_type in (QuantType.W8A8, QuantType.W4A8, QuantType.MXFP8, QuantType.MXFP4, QuantType.W4A8MXFP)
 
 
 __all__ = [

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -368,12 +368,8 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
         elif quant_type == QuantType.MXFP8:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
-        elif quant_type == QuantType.MXFP4:
-            # W4A4MXFP4 with AllGather+EP currently does not pre-quantize
-            # per-token activations in prepare. Keep quantization in the MoE MLP path.
-            pass
-        elif quant_type == QuantType.W4A8MXFP:
-            # W4A8MXFP4 with AllGather+EP currently does not pre-quantize
+        elif quant_type in [QuantType.MXFP4, QuantType.W4A8MXFP]:
+            # W4A4MXFP4 and  W4A8MXFP4 with AllGather+EP currently does not pre-quantize
             # per-token activations in prepare. Keep quantization in the MoE MLP path.
             pass
 

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -369,7 +369,11 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         elif quant_type == QuantType.MXFP8:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
         elif quant_type == QuantType.MXFP4:
-            # MXFP4 with AllGather+EP currently does not pre-quantize
+            # W4A4MXFP4 with AllGather+EP currently does not pre-quantize
+            # per-token activations in prepare. Keep quantization in the MoE MLP path.
+            pass
+        elif quant_type == QuantType.W4A8MXFP:
+            # W4A8MXFP4 with AllGather+EP currently does not pre-quantize
             # per-token activations in prepare. Keep quantization in the MoE MLP path.
             pass
 

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -42,6 +42,7 @@ from .w4a4_laos_dynamic import AscendW4A4LaosDynamicLinearMethod
 from .w4a4_mxfp4 import AscendW4A4MXFP4DynamicFusedMoEMethod, AscendW4A4MXFP4DynamicLinearMethod
 from .w4a4_mxfp4_flatquant import AscendW4A4MXFP4FlatQuantDynamicLinearMethod
 from .w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
+from .w4a8_mxfp4 import AscendW4A8MXFPDynamicLinearMethod, AscendW4A8MXFPDynamicFusedMoEMethod
 from .w4a16 import AscendW4A16FusedMoEMethod
 from .w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod, AscendW8A8DynamicLinearMethod
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
@@ -57,6 +58,8 @@ def is_mx_quant_type(instance: Any) -> bool:
         AscendW4A4MXFP4DynamicLinearMethod,
         AscendW4A4MXFP4DynamicFusedMoEMethod,
         AscendW4A4MXFP4FlatQuantDynamicLinearMethod,
+        AscendW4A8MXFPDynamicLinearMethod,
+        AscendW4A8MXFPDynamicFusedMoEMethod,
     )
     return isinstance(instance, MX_QUANT_TYPES)
 
@@ -88,5 +91,4 @@ __all__ = [
     "AscendFAQuantAttentionMethod",
     "AscendW4A4MXFP4DynamicLinearMethod",
     "AscendW4A4MXFP4DynamicFusedMoEMethod",
-    "AscendW4A4MXFP4FlatQuantDynamicLinearMethod",
 ]

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -42,7 +42,7 @@ from .w4a4_laos_dynamic import AscendW4A4LaosDynamicLinearMethod
 from .w4a4_mxfp4 import AscendW4A4MXFP4DynamicFusedMoEMethod, AscendW4A4MXFP4DynamicLinearMethod
 from .w4a4_mxfp4_flatquant import AscendW4A4MXFP4FlatQuantDynamicLinearMethod
 from .w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
-from .w4a8_mxfp4 import AscendW4A8MXFPDynamicLinearMethod, AscendW4A8MXFPDynamicFusedMoEMethod
+from .w4a8_mxfp4 import AscendW4A8MXFPDynamicFusedMoEMethod, AscendW4A8MXFPDynamicLinearMethod
 from .w4a16 import AscendW4A16FusedMoEMethod
 from .w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod, AscendW8A8DynamicLinearMethod
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -33,7 +33,7 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, QuantType
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
 
 
@@ -81,7 +81,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         x2_scale = (
             layer.weight_scale.transpose(-1, -2).reshape(-1, layer.weight_scale.shape[0] // 2, 2).transpose(-3, -2)
         )
-        output_dtype = x.dtype
+        output_dtype = x.dtype if not isinstance(x, tuple) else x[0].dtype
 
         output = torch_npu.npu_quant_matmul(
             quantized_x,
@@ -107,7 +107,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
 
 
 @register_scheme("W4A8_MXFP", "moe")
-class AscendW4A8MXFPDynamicFusedMoEMethod:
+class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
     """FusedMoe method for Ascend W4A8_DYNAMIC."""
 
     quant_type: QuantType = QuantType.W4A8MXFP
@@ -123,10 +123,6 @@ class AscendW4A8MXFPDynamicFusedMoEMethod:
             and not vllm_config.model_config.enforce_eager
         )
         self.dynamic_eplb = ascend_config.eplb_config.dynamic_eplb
-        self.additional_quant_config = None
-
-    def update_additional_quant_config(self, additional_quant_config: dict):
-        self.additional_quant_config = additional_quant_config
 
     @staticmethod
     def get_weight(
@@ -162,7 +158,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod:
         top_k: int,
         renormalize: bool,
         use_grouped_topk: bool = False,
-        global_num_experts: int = -1,
+        num_experts: int = -1,
         expert_map: torch.Tensor | None = None,
         topk_group: int | None = None,
         num_expert_group: int | None = None,
@@ -179,9 +175,16 @@ class AscendW4A8MXFPDynamicFusedMoEMethod:
         apply_router_weight_on_input: bool = False,
         mc2_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert router_logits.shape[1] == global_num_experts - global_redundant_expert_num, (
-            "Number of global experts mismatch (excluding redundancy)"
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
         )
+        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
             router_logits=router_logits,
@@ -193,16 +196,14 @@ class AscendW4A8MXFPDynamicFusedMoEMethod:
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
-            global_num_experts=global_num_experts,
+            num_experts=num_logical_experts,
         )
 
         # this is a naive implementation for experts load balance so as
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.
         if enable_force_load_balance:
-            random_matrix = torch.rand(
-                topk_ids.size(0), global_num_experts - global_redundant_expert_num, device=topk_ids.device
-            )
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         topk_weights = topk_weights.to(x.dtype)

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -244,5 +244,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod:
         )
         layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
         layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
-        layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2)
-        layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2)
+        g, n, k = layer.w13_weight_scale.shape
+        layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g, n, k // 2, 2).transpose(-3, -2)
+        g, n, k = layer.w2_weight_scale.shape
+        layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g, n, k // 2, 2).transpose(-3, -2)

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -1,0 +1,248 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch_npu
+from vllm.config import CompilationMode, get_current_vllm_config
+from vllm.distributed import get_ep_group
+from vllm.forward_context import get_forward_context
+
+from vllm_ascend.ascend_config import get_ascend_config
+
+from vllm_ascend.device.mxfp_compat import (
+    FLOAT8_E8M0FNU_DTYPE,
+    ensure_mxfp4_linear_available,
+)
+from vllm_ascend.ops.fused_moe.experts_selector import select_experts
+from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+
+from .base import AscendLinearScheme, QuantType
+from .registry import register_scheme
+
+
+@register_scheme("W4A8_MXFP", "linear")
+class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
+    """Linear method for Ascend W4A8_MXFP (Microscaling) quantization."""
+    def __init__(self):
+        ensure_mxfp4_linear_available("W8A8_MXFP8 linear quantization")
+        vllm_config = get_current_vllm_config()
+        self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)
+
+
+    @staticmethod
+    def get_weight(input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
+        
+        params_dict = {"weight": torch.empty(output_size, input_size // 2, dtype=torch.uint8)}
+        
+        return params_dict
+
+    @staticmethod
+    def get_pertensor_param(params_dtype: torch.dtype) -> dict[str, Any]:
+        return {}
+
+    @staticmethod
+    def get_perchannel_param(
+            output_size: int,
+            params_dtype: torch.dtype,
+    ) -> dict[str, Any]:
+        return {}
+
+    def get_pergroup_param(
+        self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
+    ) -> dict[str, Any]:
+        params_dict = {}
+        params_dict["weight_scale"] = torch.empty(output_size, input_size // self.group_size, dtype=torch.uint8)
+        return params_dict
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        bias: torch.Tensor | None = None,
+        tp_rank: int | None = 0,
+    ) -> torch.Tensor:
+
+        quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
+
+        x2_scale = (
+            layer.weight_scale.transpose(-1, -2).reshape(-1, layer.weight_scale.shape[0] // 2, 2).transpose(-3, -2)
+        )
+        output_dtype = x.dtype
+
+        output = torch_npu.npu_quant_matmul(
+            quantized_x,
+            layer.weight,
+            x2_scale,
+            scale_dtype=torch_npu.float8_e8m0fnu,
+            pertoken_scale=dynamic_scale, 
+            pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
+            bias=bias,
+            output_dtype=output_dtype,
+            x2_dtype=torch_npu.float4_e2m1fn_x2,
+            group_sizes=[0, 0, self.group_size],
+        )
+
+        return output
+
+    def process_weights_after_loading(self, layer):
+        layer.weight.data = layer.weight.data.transpose(0, 1)
+        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+
+
+@register_scheme("W4A8_MXFP", "moe")
+class AscendW4A8MXFPDynamicFusedMoEMethod:
+    """FusedMoe method for Ascend W4A8_DYNAMIC."""
+    quant_type: QuantType = QuantType.MXFP4
+
+    def __init__(self):
+        self.ep_group = get_ep_group()
+
+        vllm_config = get_current_vllm_config()
+        self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)
+        ascend_config = get_ascend_config()
+        self.use_aclgraph = (
+            vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+            and not vllm_config.model_config.enforce_eager
+        )
+        self.dynamic_eplb = ascend_config.eplb_config.dynamic_eplb
+        self.additional_quant_config = None
+
+    def update_addtional_quant_config(self, addtional_quant_config: dict):
+        self.additional_quant_config = addtional_quant_config
+
+
+    @staticmethod
+    def get_weight(
+        num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
+    ) -> dict[str, Any]:
+        param_dict = {}
+        param_dict["w13_weight"] = torch.empty(
+            num_experts, 2 * intermediate_size_per_partition, hidden_sizes // 2, dtype=torch.uint8
+        )
+        param_dict["w2_weight"] = torch.empty(
+            num_experts, hidden_sizes, intermediate_size_per_partition // 2, dtype=torch.uint8
+        )
+        return param_dict
+
+    def get_dynamic_quant_param(
+        self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
+    ) -> dict[str, Any]:
+        param_dict = {}
+        param_dict["w13_weight_scale"] = torch.empty(
+            num_experts, 2 * intermediate_size_per_partition, hidden_sizes // self.group_size, dtype=torch.uint8
+        )
+
+        param_dict["w2_weight_scale"] = torch.empty(
+            num_experts, hidden_sizes, intermediate_size_per_partition // self.group_size, dtype=torch.uint8
+        )
+        return param_dict
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        renormalize: bool,
+        use_grouped_topk: bool = False,
+        global_num_experts: int = -1,
+        expert_map: torch.Tensor | None = None,
+        topk_group: int | None = None,
+        num_expert_group: int | None = None,
+        custom_routing_function: Callable | None = None,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        e_score_correction_bias: torch.Tensor | None = None,
+        is_prefill: bool = True,
+        enable_force_load_balance: bool = True,
+        log2phy: torch.Tensor = None,
+        global_redundant_expert_num: int = 0,
+        pertoken_scale: Any | None = None,
+        activation: str = "silu",
+        apply_router_weight_on_input: bool = False,
+        mc2_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert router_logits.shape[1] == global_num_experts - global_redundant_expert_num, (
+            "Number of global experts mismatch (excluding redundancy)"
+        )
+        topk_weights, topk_ids = select_experts(
+            hidden_states=x,
+            router_logits=router_logits,
+            top_k=top_k,
+            use_grouped_topk=use_grouped_topk,
+            renormalize=renormalize,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            e_score_correction_bias=e_score_correction_bias,
+            global_num_experts=global_num_experts,
+        )
+
+        # this is a naive implementation for experts load balance so as
+        # to avoid accumulating too much tokens on a single rank.
+        # currently it is only activated when doing profile runs.
+        if enable_force_load_balance:
+            random_matrix = torch.rand(
+                topk_ids.size(0), global_num_experts - global_redundant_expert_num, device=topk_ids.device
+            )
+            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
+
+        topk_weights = topk_weights.to(x.dtype)
+
+        moe_comm_method = get_forward_context().moe_comm_method
+        return moe_comm_method.fused_experts(
+            fused_experts_input=build_fused_experts_input(
+                hidden_states=x,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                quant_type=self.quant_type,
+                dynamic_eplb=self.dynamic_eplb,
+                expert_map=expert_map,
+                global_redundant_expert_num=global_redundant_expert_num,
+                mc2_mask=mc2_mask,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                log2phy=log2phy,
+                pertoken_scale=pertoken_scale,
+                activation=activation,
+                mxfp_act_quant_type=torch.float8_e4m3fn,
+                mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
+                mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                mxfp_per_token_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                mxfp_use_bf16=(x.dtype == torch.bfloat16),
+                w1_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+            )
+        )
+
+    def process_weights_after_loading(self, layer):
+        layer.w13_weight.data = torch_npu.npu_format_cast(
+            layer.w13_weight.data, 29, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
+        )
+        layer.w2_weight.data = torch_npu.npu_format_cast(
+            layer.w2_weight.data, 29, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
+        )
+        layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
+        layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
+        layer.w13_weight_scale.data = layer.w13_weight_scale.data.transpose(1, 2)
+        layer.w2_weight_scale.data = layer.w2_weight_scale.data.transpose(1, 2)

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -110,7 +110,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
 @register_scheme("W4A8_MXFP", "moe")
 class AscendW4A8MXFPDynamicFusedMoEMethod:
     """FusedMoe method for Ascend W4A8_DYNAMIC."""
-    quant_type: QuantType = QuantType.MXFP4
+    quant_type: QuantType = QuantType.W4A8MXFP
 
     def __init__(self):
         self.ep_group = get_ep_group()

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -26,7 +26,6 @@ from vllm.distributed import get_ep_group
 from vllm.forward_context import get_forward_context
 
 from vllm_ascend.ascend_config import get_ascend_config
-
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp4_linear_available,
@@ -41,17 +40,15 @@ from .registry import register_scheme
 @register_scheme("W4A8_MXFP", "linear")
 class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
     """Linear method for Ascend W4A8_MXFP (Microscaling) quantization."""
+
     def __init__(self):
         ensure_mxfp4_linear_available("W8A8_MXFP8 linear quantization")
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)
 
-
     @staticmethod
     def get_weight(input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        
         params_dict = {"weight": torch.empty(output_size, input_size // 2, dtype=torch.uint8)}
-        
         return params_dict
 
     @staticmethod
@@ -60,8 +57,8 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
 
     @staticmethod
     def get_perchannel_param(
-            output_size: int,
-            params_dtype: torch.dtype,
+        output_size: int,
+        params_dtype: torch.dtype,
     ) -> dict[str, Any]:
         return {}
 
@@ -79,7 +76,6 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
-
         quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
 
         x2_scale = (
@@ -92,7 +88,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
             layer.weight,
             x2_scale,
             scale_dtype=torch_npu.float8_e8m0fnu,
-            pertoken_scale=dynamic_scale, 
+            pertoken_scale=dynamic_scale,
             pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
             bias=bias,
             output_dtype=output_dtype,
@@ -103,6 +99,9 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         return output
 
     def process_weights_after_loading(self, layer):
+        layer.weight.data = torch_npu.npu_format_cast(
+            layer.weight.data, 29, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
+        )
         layer.weight.data = layer.weight.data.transpose(0, 1)
         layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 
@@ -110,6 +109,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
 @register_scheme("W4A8_MXFP", "moe")
 class AscendW4A8MXFPDynamicFusedMoEMethod:
     """FusedMoe method for Ascend W4A8_DYNAMIC."""
+
     quant_type: QuantType = QuantType.W4A8MXFP
 
     def __init__(self):
@@ -125,9 +125,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod:
         self.dynamic_eplb = ascend_config.eplb_config.dynamic_eplb
         self.additional_quant_config = None
 
-    def update_addtional_quant_config(self, addtional_quant_config: dict):
-        self.additional_quant_config = addtional_quant_config
-
+    def update_additional_quant_config(self, additional_quant_config: dict):
+        self.additional_quant_config = additional_quant_config
 
     @staticmethod
     def get_weight(

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -51,17 +51,6 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         params_dict = {"weight": torch.empty(output_size, input_size // 2, dtype=torch.uint8)}
         return params_dict
 
-    @staticmethod
-    def get_pertensor_param(params_dtype: torch.dtype) -> dict[str, Any]:
-        return {}
-
-    @staticmethod
-    def get_perchannel_param(
-        output_size: int,
-        params_dtype: torch.dtype,
-    ) -> dict[str, Any]:
-        return {}
-
     def get_pergroup_param(
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
@@ -78,15 +67,12 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
     ) -> torch.Tensor:
         quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
 
-        x2_scale = (
-            layer.weight_scale.transpose(-1, -2).reshape(-1, layer.weight_scale.shape[0] // 2, 2).transpose(-3, -2)
-        )
         output_dtype = x.dtype if not isinstance(x, tuple) else x[0].dtype
 
         output = torch_npu.npu_quant_matmul(
             quantized_x,
             layer.weight,
-            x2_scale,
+            layer.weight_scale,
             scale_dtype=torch_npu.float8_e8m0fnu,
             pertoken_scale=dynamic_scale,
             pertoken_scale_dtype=torch_npu.float8_e8m0fnu,
@@ -102,8 +88,9 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
         layer.weight.data = torch_npu.npu_format_cast(
             layer.weight.data, 29, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
         )
-        layer.weight.data = layer.weight.data.transpose(0, 1)
-        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
+        layer.weight.data = layer.weight.data.transpose(-1, -2)
+        n, k = layer.weight_scale.shape
+        layer.weight_scale.data = layer.weight_scale.data.reshape(n, k // 2, 2).transpose(-3, -2)
 
 
 @register_scheme("W4A8_MXFP", "moe")
@@ -174,6 +161,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         activation: str = "silu",
         apply_router_weight_on_input: bool = False,
         mc2_mask: torch.Tensor | None = None,
+        tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
         num_shared_experts = getattr(layer, "n_shared_experts", 0)
         if num_shared_experts is None:
@@ -197,6 +185,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
             num_experts=num_logical_experts,
+            tid2eid=tid2eid,
         )
 
         # this is a naive implementation for experts load balance so as

--- a/vllm_ascend/quantization/quant_type.py
+++ b/vllm_ascend/quantization/quant_type.py
@@ -32,3 +32,4 @@ class QuantType(Enum):
     MXFP8 = 3
     W4A16 = 4
     MXFP4 = 5
+    W4A8MXFP = 6


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request introduces support for W4A8 MXFP4  quantization on Ascend devices. Key changes include the implementation of AscendW4A8MXFP4DynamicLinearMethod and AscendW4A48MXFP4DynamicFusedMoEMethod
### Does this PR introduce _any_ user-facing change?
Users can now utilize the W4A8_MXFP4 quantization scheme for models running on Ascend hardware

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
