### PR TITLE
[Feature] The stateConv discontinuous function is added to the recurr…

### DIFF
--- a/csrc/attention/recurrent_gated_delta_rule/op_host/op_api/aclnn_recurrent_gated_delta_rule.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/op_api/aclnn_recurrent_gated_delta_rule.cpp
@@ -27,6 +27,7 @@
 #include "aclnn_kernels/transpose.h"
 #include "aclnn_kernels/contiguous.h"
 #include "aclnn_kernels/reshape.h"
+#include "aclnn/acl_meta.h"
 
 using namespace op;
 
@@ -40,6 +41,11 @@ constexpr size_t KEY_DIM_NUM = 3;
 constexpr size_t VALUE_DIM_NUM = 3;
 constexpr size_t BETA_DIM_NUM = 2;
 constexpr size_t STATE_DIM_NUM = 4;
+
+constexpr size_t STATE_DIM = 4;
+constexpr size_t STATE_STRIDE_0 = 0;
+constexpr size_t STATE_STRIDE_1 = 1;
+constexpr size_t STATE_STRIDE_2 = 2;
 
 struct RecurrentGatedDeltaRuleParams {
     // mandatory
@@ -176,10 +182,21 @@ aclnnStatus aclnnRecurrentGatedDeltaRuleGetWorkspaceSize(const aclTensor *query,
 
     auto out_ = l0op::Contiguous(out, uniqueExecutor.get());
 
+    int64_t* stateStridesValues = nullptr;
+    uint64_t stateStridesNum = 0;
+
+    ret = aclGetViewStrides(stateRef, &stateStridesValues, &stateStridesNum);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+    CHECK_COND(stateStridesNum == STATE_DIM, ACLNN_ERR_PARAM_INVALID, "stateStrideDim must be 4.");
+
+    int64_t stride0 = stateStridesValues[STATE_STRIDE_0];
+    int64_t stride1 = stateStridesValues[STATE_STRIDE_1];
+    int64_t stride2 = stateStridesValues[STATE_STRIDE_2];
+
     // 调用l0接口
     auto outRet =
         l0op::RecurrentGatedDeltaRule(query_, key_, value_, beta_, stateRef, actualSeqLengths_, ssmStateIndices_, g, gk,
-                                      numAcceptedTokens, scaleValue, uniqueExecutor.get());
+                                      numAcceptedTokens, scaleValue, stride0, stride1, stride2, uniqueExecutor.get());
     if (outRet == nullptr) {
         return ACLNN_ERR_INNER_NULLPTR;
     }
@@ -192,6 +209,7 @@ aclnnStatus aclnnRecurrentGatedDeltaRuleGetWorkspaceSize(const aclTensor *query,
     // 获取计算过程中需要使用的workspace大小。
     *workspaceSize = uniqueExecutor->GetWorkspaceSize();
     uniqueExecutor.ReleaseTo(executor);
+    delete[] stateStridesValues;
     return ACLNN_SUCCESS;
 }
 

--- a/csrc/attention/recurrent_gated_delta_rule/op_host/op_api/recurrent_gated_delta_rule.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/op_api/recurrent_gated_delta_rule.cpp
@@ -29,10 +29,11 @@ OP_TYPE_REGISTER(RecurrentGatedDeltaRule);
 const aclTensor *RecurrentGatedDeltaRule(const aclTensor *query, const aclTensor *key, const aclTensor *value,
                                          const aclTensor *beta, aclTensor *stateRef, const aclTensor *actualSeqLengths,
                                          const aclTensor *ssmStateIndices, const aclTensor *g, const aclTensor *gk,
-                                         const aclTensor *numAcceptedTokens, float scaleValue, aclOpExecutor *executor)
+                                         const aclTensor *numAcceptedTokens, float scaleValue, int64_t stride0,
+                                         int64_t stride1, int64_t stride2, aclOpExecutor *executor)
 {
     L0_DFX(RecurrentGatedDeltaRule, query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk,
-           numAcceptedTokens, scaleValue);
+           numAcceptedTokens, scaleValue, stride0, stride1, stride2);
 
     DataType outType = DataType::DT_BF16;
     Format format = Format::FORMAT_ND;
@@ -46,13 +47,13 @@ const aclTensor *RecurrentGatedDeltaRule(const aclTensor *query, const aclTensor
     auto ret = INFER_SHAPE(
         RecurrentGatedDeltaRule,
         OP_INPUT(query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk, numAcceptedTokens),
-        OP_OUTPUT(out, stateRef), OP_ATTR(scaleValue));
+        OP_OUTPUT(out, stateRef), OP_ATTR(scaleValue, stride0, stride1, stride2));
     OP_CHECK_INFERSHAPE(ret != ACLNN_SUCCESS, return nullptr, "RecurrentGatedDeltaRule InferShape failed.");
 
     ret = ADD_TO_LAUNCHER_LIST_AICORE(
         RecurrentGatedDeltaRule,
         OP_INPUT(query, key, value, beta, stateRef, actualSeqLengths, ssmStateIndices, g, gk, numAcceptedTokens),
-        OP_OUTPUT(out, stateRef), OP_ATTR(scaleValue));
+        OP_OUTPUT(out, stateRef), OP_ATTR(scaleValue, stride0, stride1, stride2));
     OP_CHECK_ADD_TO_LAUNCHER_LIST_AICORE(ret != ACLNN_SUCCESS, return nullptr,
                                          "RecurrentGatedDeltaRule ADD_TO_LAUNCHER_LIST_AICORE failed.");
 

--- a/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.h
@@ -17,7 +17,8 @@ namespace l0op {
 const aclTensor *RecurrentGatedDeltaRule(const aclTensor *query, const aclTensor *key, const aclTensor *value,
                                          const aclTensor *beta, aclTensor *stateRef, const aclTensor *actualSeqLengths,
                                          const aclTensor *ssmStateIndices, const aclTensor *g, const aclTensor *gk,
-                                         const aclTensor *numAcceptedTokens, float scaleValue, aclOpExecutor *executor);
+                                         const aclTensor *numAcceptedTokens, float scaleValue, int64_t stride0,
+                                         int64_t stride1, int64_t stride2, aclOpExecutor *executor);
 }
 
 #endif // PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_RECURRENT_GETED_DELTA_RULE

--- a/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_def.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_def.cpp
@@ -42,7 +42,8 @@ public:
             .ParamType(REQUIRED)
             .DataType({ge::DT_BF16, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND})
+            .IgnoreContiguous();
         this->Input("actual_seq_lengths")
             .ParamType(REQUIRED)
             .DataType({ge::DT_INT32, ge::DT_INT32})
@@ -77,9 +78,13 @@ public:
             .ParamType(REQUIRED)
             .DataType({ge::DT_BF16, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND})
+            .IgnoreContiguous();
         this->Attr("scale_value").AttrType(OPTIONAL).Float(1.0);
-        
+        this->Attr("stride0").AttrType(REQUIRED).Int(0);
+        this->Attr("stride1").AttrType(REQUIRED).Int(0);
+        this->Attr("stride2").AttrType(REQUIRED).Int(0);
+
         OpAICoreConfig aicConfig;
         aicConfig.DynamicCompileStaticFlag(true)
             .DynamicFormatFlag(true)

--- a/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -49,6 +49,10 @@ const size_t DIM_1 = 1;
 const size_t DIM_2 = 2;
 const size_t DIM_3 = 3;
 
+const size_t ATTR_STATE_STRIDE_0 = 1;
+const size_t ATTR_STATE_STRIDE_1 = 2;
+const size_t ATTR_STATE_STRIDE_2 = 3;
+
 const size_t MAX_MTP = 8;
 
 template <typename T1, typename T2>
@@ -100,6 +104,9 @@ ge::graphStatus RecurrentGatedDeltaRuleTiling::GetShapeAttrsInfo()
                 return ge::GRAPH_FAILED);
 
     OP_CHECK_IF(GetScale() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetScale."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetStateStrides() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetStateStrides."),
                 return ge::GRAPH_FAILED);
 
     OP_CHECK_IF(GetOptionalInput() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetOptionalInput."),
@@ -468,6 +475,27 @@ ge::graphStatus RecurrentGatedDeltaRuleTiling::GetScale()
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus RecurrentGatedDeltaRuleTiling::GetStateStrides()
+{
+    auto attrs = context_->GetAttrs();
+    const int64_t* stride0Ptr = attrs->GetAttrPointer<int64_t>(ATTR_STATE_STRIDE_0);
+    int64_t stride0 = (stride0Ptr == nullptr) ? 0 : *stride0Ptr;
+    OP_CHECK_IF(stride0 <= 0, OP_LOGE(context_->GetNodeName(), "stride0 only supports > 0"),
+                return ge::GRAPH_FAILED);
+    tilingData_.stateStride0 = stride0;
+    const int64_t* stride1Ptr = attrs->GetAttrPointer<int64_t>(ATTR_STATE_STRIDE_1);
+    int64_t stride1 = (stride1Ptr == nullptr) ? 0 : *stride1Ptr;
+    OP_CHECK_IF(stride1 <= 0, OP_LOGE(context_->GetNodeName(), "stride1 only supports > 0"),
+                return ge::GRAPH_FAILED);
+    tilingData_.stateStride1 = stride1;
+    const int64_t* stride2Ptr = attrs->GetAttrPointer<int64_t>(ATTR_STATE_STRIDE_2);
+    int64_t stride2 = (stride2Ptr == nullptr) ? 0 : *stride2Ptr;
+    OP_CHECK_IF(stride2 <= 0, OP_LOGE(context_->GetNodeName(), "stride2 only supports > 0"),
+                return ge::GRAPH_FAILED);
+    tilingData_.stateStride2 = stride2;
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus RecurrentGatedDeltaRuleTiling::GetOptionalInput()
 {
     if (context_->GetOptionalInputDesc(G_INDEX) == nullptr) {
@@ -602,7 +630,7 @@ ge::graphStatus RecurrentGatedDeltaRuleTiling::FinalizeVStepFromUb(int64_t ubSiz
             selected = profile;
         }
     }
-    
+
     OP_LOGD(context_->GetNodeName(), "selected profile: stateOutBufferNum=[%u], attnOutBufferNum=[%u], vStep=[%u], repeatTime=[%u], valid=[%d]",
             selected.stateOutBufferNum, selected.attnOutBufferNum, selected.vStep, selected.repeatTime, selected.valid);
 

--- a/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.h
@@ -94,6 +94,7 @@ protected:
     ge::graphStatus AnalyzeShapes();
     ge::graphStatus CalUbSize();
     ge::graphStatus GetScale();
+    ge::graphStatus GetStateStrides();
     ge::graphStatus GetOptionalInput();
     ge::graphStatus AnalyzeFormat();
     //Host tiling refactor helpers: split shape validation/fill and UB calculation.

--- a/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
@@ -62,6 +62,9 @@ public:
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         scale_ = tilingData->scale;
+        stateStride0_ = tilingData->stateStride0;
+        stateStride1_ = tilingData->stateStride1;
+        stateStride2_ = tilingData->stateStride2;
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasGama_ = (tilingData->hasGama == 1);
         hasGamaK_ = (tilingData->hasGamaK == 1);
@@ -323,7 +326,7 @@ private:
             ReduceSumBaseline(dstTensor, srcTensor, rows);
             return;
         }
-        
+
         if ((alignK_ & (alignK_ - 1)) != 0) {
             ReduceSumBaseline(dstTensor, srcTensor, rows);
             return;
@@ -452,7 +455,7 @@ private:
         }
         uint64_t nextVOffset = 0;
         uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
-        uint64_t nextStateOffset = ((stateOffset * NV_ + head_i) * realV_) * realK_;
+        uint64_t nextStateOffset = stateStride0_ * stateOffset + stateStride1_ * head_i;
         PrefetchState(nextStateOffset, nextSingleV);
         for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
             uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
@@ -460,7 +463,7 @@ private:
             nextVOffset = v_i + vStep_;
             if (nextVOffset < realV_) {
                 nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
-                nextStateOffset = ((stateOffset * NV_ + head_i) * realV_ + nextVOffset) * realK_;
+                nextStateOffset = stateStride0_ * stateOffset + stateStride1_ * head_i + stateStride2_ * nextVOffset;
                 PrefetchState(nextStateOffset, nextSingleV);
             }
             uint64_t pendingAttnOffset = 0;
@@ -473,7 +476,8 @@ private:
                 uint64_t curVOffset = (seq_i - seq0) * alignV_ + v_i;
                 uint64_t attnOffset = (seq_i * NV_ + head_i) * realV_ + v_i;
                 uint64_t curStateOutOffset =
-                    ((ssmStateIndicesGm_.GetValue(seq_i) * NV_ + head_i) * realV_ + v_i) * realK_;
+                    stateStride0_ * ssmStateIndicesGm_.GetValue(seq_i) +
+                    stateStride1_ * head_i + stateStride2_ * v_i;
                 gama_ = hasGama_ ? gamaInUb.GetValue(gbOffset) : 1;
                 beta_ = betaInUb.GetValue(gbOffset);
                 Compute(curSingleV, curQKOffset, curVOffset);
@@ -576,6 +580,9 @@ private:
     float beta_;
     float scale_;
     uint64_t blockIdx;
+    uint32_t stateStride0_;
+    uint32_t stateStride1_;
+    uint32_t stateStride2_;
 };
 } // namespace RecurrentGatedDeltaRule
 #endif

--- a/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h
+++ b/csrc/attention/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_tiling_data.h
@@ -36,6 +36,9 @@ struct alignas(8) RecurrentGatedDeltaRuleTilingData { // alignas(8)确保8字节
     uint32_t hasGama;
     uint32_t hasGamaK;
     uint32_t hasAcceptedTokens;
+    uint32_t stateStride0;
+    uint32_t stateStride1;
+    uint32_t stateStride2;
 };
 #pragma pack(pop)
 } // RecurrentGatedDeltaRule


### PR DESCRIPTION
…ent_gdn APIs.

### What this PR does / why we need it?
The method of processing the recurrent_gdn API is modified so that it can share the tensor with the conv1d API to process ssmstate and convstate.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
