### PR TITLE
[Ops][BugFix] add null check for weight prefetch

### DIFF
--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -63,7 +63,8 @@ def select_experts(
     """
     # prefetch w1_w3_proj.weight preprocess
     weight_prefetch_method = get_weight_prefetch_method()
-    weight_prefetch_method.maybe_prefetch_moe_weight_preprocess(hidden_states, "gate_up")
+    if weight_prefetch_method:
+        weight_prefetch_method.maybe_prefetch_moe_weight_preprocess(hidden_states, "gate_up")
     is_support_npu_moe_gating_top_k = check_npu_moe_gating_top_k(
         hidden_states=hidden_states,
         top_k=top_k,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds a safety null check for the `weight_prefetch_method` in the `select_experts` function to prevent an `AttributeError` when prefetching is disabled or the method is not initialized.

### Does this PR introduce _any_ user-facing change?

No. This is an internal stability and code quality improvement.

### How was this patch tested?
Null-case Simulation: Mocked `get_weight_prefetch_method` to return `None` and confirmed that the expert selection logic proceeds without crashing.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
