### PR TITLE
[BugFix][310p][0.18.0] remove triton-ascend's installation of 310p

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-# Should be mirrored in requirements.txt
+# Should be mirrored in requirements.txt, except triton-ascend
+# triton-ascend is handlesd in setup.py and skipped for 310P SOC version.
 requires = [
     "attrs",
     "cmake>=3.26",
@@ -29,8 +30,7 @@ requires = [
     "fastapi<0.124.0",
     "opencv-python-headless<=4.11.0.86", # Required to avoid numpy version conflict with vllm
     "compressed_tensors>=0.11.0",
-    "arctic-inference==0.1.1",
-    "triton-ascend==3.2.0"
+    "arctic-inference==0.1.1"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -471,15 +471,20 @@ def read_readme() -> str:
 
 def get_requirements() -> list[str]:
     """Get Python package dependencies from requirements.txt."""
+    soc_version = (envs.SOC_VERSION or "").lower()
+    skip_triton_ascend = soc_version.startswith("ascend310p")
 
     def _read_requirements(filename: str) -> list[str]:
         with open(get_path(filename)) as f:
-            requirements = f.read().strip().split("\n")
+            requirements = f.read().splitlines()
         resolved_requirements = []
         for line in requirements:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
             if line.startswith("-r "):
                 resolved_requirements += _read_requirements(line.split()[1])
-            elif line.startswith("--"):
+            elif line.startswith("--") or skip_triton_ascend and line.startswith("triton-ascend"):
                 continue
             else:
                 resolved_requirements.append(line)


### PR DESCRIPTION
### What this PR does / why we need it?
The triton-ascend dependency has been removed from the pyproject.toml build requirements to prevent its installation on 310p, because the triton-ascend cannot use by 310p, when it install by default cause some error in spec and fusion pass.
cherrypick from #7238 
### Does this PR introduce _any_ user-facing change?
NO
### How was this patch tested?
the ci and local tests

- vLLM version: v0.18.0
