### PR TITLE
[CI] Add toleration for dedicated=night taint in multi-node LWS template

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -13,6 +13,11 @@ spec:
         labels:
           role: leader
       spec:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "night"
+            effect: "NoSchedule"
         containers:
           - name: vllm-leader
             imagePullPolicy: Always
@@ -79,6 +84,11 @@ spec:
             path: /usr/local/Ascend/driver/tools
     workerTemplate:
       spec:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "night"
+            effect: "NoSchedule"
         containers:
           - name: vllm-worker
             imagePullPolicy: Always


### PR DESCRIPTION
### What this PR does / why we need it?

Add `tolerations` to the LeaderWorkerSet (LWS) pod spec so that both leader and worker pods can be scheduled onto nodes tainted with `dedicated=night:NoSchedule`.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/v0.19.0
