### PR TITLE
[Ops][Feature] Use int32 dtype for scatter_add_ in get_token_bin_counts_and_mask

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -364,6 +364,21 @@
 #    Future Plan:
 #       Remove this patch when vLLM support the operator as customop.
 #
+# ** 11a. File: worker/patch_token_bin_counts.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.layers.utils.get_token_bin_counts_and_mask`
+#    Why:
+#       On NPU, torch.long (int64) dtype in scatter_add_ falls back to AICPU,
+#       because AIVector and AICore do not support int64. Using torch.int32
+#       keeps the operation on AICore for better performance.
+#    How：
+#       Replace dtype from torch.long to torch.int32 for bin_counts tensor and
+#       cast tokens to torch.int32 before scatter_add_.
+#    Related PR (if no, explain why):
+#       No, this is an NPU-specific dtype limitation and optimization.
+#    Future Plan:
+#       Remove this patch when NPU AIVector supports scatter_add_ with torch.long dtype.
+#
 # ** 12. File: worker/patch_npugraph_ex_triton.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torchair.core._concrete_graph.ValuePack`,

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -28,6 +28,7 @@ if HAS_TRITON:
 import vllm_ascend.patch.worker.patch_weight_utils  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 import vllm_ascend.patch.worker.patch_unquantized_gemm  # noqa
+import vllm_ascend.patch.worker.patch_token_bin_counts  # noqa
 import vllm_ascend.patch.worker.patch_bert  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2  # noqa

--- a/vllm_ascend/patch/worker/patch_token_bin_counts.py
+++ b/vllm_ascend/patch/worker/patch_token_bin_counts.py
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+import vllm.model_executor.layers.utils
+
+
+def get_token_bin_counts_and_mask(
+    tokens: torch.Tensor,
+    vocab_size: int,
+    num_seqs: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # Compute the bin counts for the tokens.
+    # vocab_size + 1 for padding.
+    bin_counts = torch.zeros(
+        (num_seqs, vocab_size + 1), dtype=torch.int32, device=tokens.device
+    )
+    tokens = tokens.to(torch.int32)
+    bin_counts.scatter_add_(1, tokens, torch.ones_like(tokens))
+    bin_counts = bin_counts[:, :vocab_size]
+    mask = bin_counts > 0
+
+    return bin_counts, mask
+
+
+vllm.model_executor.layers.utils.get_token_bin_counts_and_mask = (
+    get_token_bin_counts_and_mask
+)


### PR DESCRIPTION
### What this PR does / why we need it?
On NPU, `torch.long` (int64) in `scatter_add_` falls back to AICPU because AIVector and AICore do not support int64. This PR replaces it with `torch.int32` to keep the operation on AICore, improving performance. When sample param with repetition_penalty，will cause performance lost
Blow is the profile detail
<img width="3020" height="1026" alt="image" src="https://github.com/user-attachments/assets/01c559a7-ac94-4d30-b47b-40b0fe3449d4" />

Fixes #

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested with vLLM v0.19.0 on NPU.