### PR TITLE
[Refactor][main] Migrate from deprecated torchair reduce-overhead to …

### DIFF
--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_matmul_allreduce_add_rmsnorm.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_matmul_allreduce_add_rmsnorm.py
@@ -6,13 +6,12 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch_npu
-import torchair
+import npugraph_ex as nge
 
 from vllm_ascend.utils import enable_custom_op
 
-config = torchair.CompilerConfig()
-config.mode = "reduce-overhead"
-npu_backend = torchair.get_npu_backend(compiler_config=config)
+config = nge.CompilerConfig()
+npu_backend = nge.get_npu_backend(compiler_config=config)
 torch_npu.npu.config.allow_internal_format = True
 enable_custom_op()
 

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_gmm_combine_decode.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_gmm_combine_decode.py
@@ -9,7 +9,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch_npu
-import torchair
+import npugraph_ex as nge
 
 from vllm_ascend.utils import enable_custom_op
 
@@ -478,9 +478,8 @@ def run_once(local_rank_id,
     fused_ops = FusionOp(*weight_datas, ep_hcomm_info_fused, *parameter,
                          dynamic_eplb, w8a8_dynamic, is_nz).npu()  # type: ignore
     if test_graph:
-        config = torchair.CompilerConfig()
-        config.mode = "reduce-overhead"
-        npu_backend = torchair.get_npu_backend(compiler_config=config)
+        config = nge.CompilerConfig()
+        npu_backend = nge.get_npu_backend(compiler_config=config)
         fused_ops = torch.compile(fused_ops, backend=npu_backend)
     
     # test performance

--- a/tests/e2e/singlecard/compile/test_graphex_norm_quant_fusion.py
+++ b/tests/e2e/singlecard/compile/test_graphex_norm_quant_fusion.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_npu
-import torchair
+import npugraph_ex as nge
 import vllm.config
 from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
@@ -25,7 +25,7 @@ def find_op(gm, op_default):
 
 
 def create_pattern_wrapper(assert_func):
-    original_func = torchair.npu_fx_compiler._optimize_fx
+    original_func = nge.npu_fx_compiler._optimize_fx
 
     def wrapper(gm, example_inputs=None, config=None):
         ret = original_func(gm, example_inputs, config)

--- a/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
+++ b/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import torch
 import torch.nn as nn
-import torchair
+import npugraph_ex as nge
 import vllm.config
 from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
@@ -25,7 +25,7 @@ def find_op(gm, op_default):
 
 
 def create_pattern_wrapper(assert_func):
-    original_func = torchair.npu_fx_compiler._optimize_fx
+    original_func = nge.npu_fx_compiler._optimize_fx
 
     def wrapper(gm, example_inputs=None, config=None):
         ret = original_func(gm, example_inputs, config)
@@ -216,8 +216,8 @@ def test_rmsnorm_quant_fusion(
         )
 
         with torch.no_grad():
-            original_optimize = torchair.npu_fx_compiler._optimize_fx
-            torchair.npu_fx_compiler._optimize_fx = create_pattern_wrapper(
+            original_optimize = nge.npu_fx_compiler._optimize_fx
+            nge.npu_fx_compiler._optimize_fx = create_pattern_wrapper(
                 lambda gm: assert_qknorm_rope_fusion(gm, expect_fused=True, use_bias=use_bias)
             )
 
@@ -225,4 +225,4 @@ def test_rmsnorm_quant_fusion(
 
             compiled_model(qkv, cos_sin_cache, positions)
 
-            torchair.npu_fx_compiler._optimize_fx = original_optimize
+            nge.npu_fx_compiler._optimize_fx = original_optimize

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -76,12 +76,10 @@ def npugraph_ex_compile(
     compile_range: Range,
     key: str | None = None,
 ) -> tuple[Callable | None, Any | None]:
-    import torchair
+    import npugraph_ex as nge
 
     torch.npu.set_compile_mode(jit_compile=False)
-    config = torchair.CompilerConfig()
-    # use aclgraph mode, avoid the transformation from fx graph to Ascend IR.
-    config.mode = "reduce-overhead"
+    config = nge.CompilerConfig()
     # execute FX graph in eager mode before graph mode to optimize FX graph.
     config.debug.run_eagerly = True
     # This is a temporary fix to resolve issues with inplace operations in some testcases like test_whisper.
@@ -107,7 +105,7 @@ def npugraph_ex_compile(
         ]
         config.experimental_config.aclgraph._aclnn_static_shape_kernel_sym_value_range = decode_cudagraph_batch_sizes
 
-    npugraph_ex = torchair.get_npu_backend(compiler_config=config)
+    npugraph_ex = nge.get_npu_backend(compiler_config=config)
 
     # torch.compile requires the output of the fx graph to be a tuple
     if not graph_returns_tuple(graph):

--- a/vllm_ascend/compilation/passes/base_pattern.py
+++ b/vllm_ascend/compilation/passes/base_pattern.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 
 import torch
 import torch._inductor.pattern_matcher as pm
-import torchair
+import npugraph_ex as nge
 from torch._inductor.pattern_matcher import PatternMatcherPass
 from vllm.config import VllmConfig
 
@@ -48,7 +48,7 @@ class BasePattern(ABC):
 
         pm.register_replacement(pattern_fn, replacement_fn, example_inputs, pm.fwd_only, pm_pass)
 
-        torchair.register_replacement(
+        nge.register_replacement(
             search_fn=pattern_fn,
             replace_fn=replacement_fn,
             example_inputs=example_inputs,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -366,9 +366,9 @@
 #
 # ** 12. File: worker/patch_npugraph_ex_triton.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `torchair.core._concrete_graph.ValuePack`,
-#      `torchair.npu_fx_compiler._unpack_meta`,
-#      `torchair.npu_fx_compiler._NpuGraphConverter._unpack_npu`
+#   1. `npugraph_ex.core._concrete_graph.ValuePack`,
+#      `npugraph_ex.npu_fx_compiler._unpack_meta`,
+#      `npugraph_ex.npu_fx_compiler._NpuGraphConverter._unpack_npu`
 #    Why:
 #       In the Triton scenario, npugraph_ex backend needs to process the value pack of the input parameters.
 #    How：

--- a/vllm_ascend/patch/worker/patch_npugraph_ex_triton.py
+++ b/vllm_ascend/patch/worker/patch_npugraph_ex_triton.py
@@ -19,10 +19,10 @@ import importlib
 import sys
 
 import torch
-import torchair
+import npugraph_ex as nge
 from torch._subclasses.fake_tensor import FakeTensor
-from torchair.core._concrete_graph import _is_symlist
-from torchair.npu_fx_compiler import _unpack_meta_list
+from npugraph_ex.core._concrete_graph import _is_symlist
+from npugraph_ex.npu_fx_compiler import _unpack_meta_list
 
 
 class ValuePack:
@@ -108,9 +108,8 @@ def _unpack_npu(self, args, kwargs):
     return unpacked, unpacked_kwargs
 
 
-torchair.core._concrete_graph.ValuePack = ValuePack
-# The ValuePack class is referenced in these two modules, and after the patch, these two modules need to be reloaded.
-importlib.reload(sys.modules["torchair.fx_summary"])
-importlib.reload(sys.modules["torchair.npu_fx_compiler"])
-torchair.npu_fx_compiler._unpack_meta = _unpack_meta
-torchair.npu_fx_compiler._NpuGraphConverter._unpack_npu = _unpack_npu
+nge.core._concrete_graph.ValuePack = ValuePack
+# The ValuePack class is referenced in the npu_fx_compiler module, and after the patch, it needs to be reloaded.
+importlib.reload(sys.modules["npugraph_ex.npu_fx_compiler"])
+nge.npu_fx_compiler._unpack_meta = _unpack_meta
+nge.npu_fx_compiler._NpuGraphConverter._unpack_npu = _unpack_npu


### PR DESCRIPTION
### What this PR does / why we need it?
Migrate from the deprecated `torchair` `reduce-overhead` mode to the `npugraph_ex` backend directly.
The `reduce-overhead` mode in `torchair.CompilerConfig` has been marked as deprecated with a `DeprecationWarning`, recommending migration to the `npugraph_ex` backend. Both paths ultimately create `AclConcreteGraph` and share identical nested config structures (`debug.*`, `experimental_config.*`, etc.), so this is a drop-in replacement with no behavioral change.
**Changes:**
- Replace `import torchair` with `import npugraph_ex as nge` across all production and test files
- Remove `config.mode = "reduce-overhead"` (npugraph_ex.CompilerConfig defaults to `"npugraph_ex"`)
- Update monkey-patch targets in `patch_npugraph_ex_triton.py` from `torchair.*` internals to `npugraph_ex.*`
- Update `register_replacement` calls to use `npugraph_ex` API
- Update documentation comments in `patch/__init__.py` to reflect new module paths
**Files changed (8):**
- `vllm_ascend/compilation/compiler_interface.py`
- `vllm_ascend/compilation/passes/base_pattern.py`
- `vllm_ascend/patch/worker/patch_npugraph_ex_triton.py`
- `vllm_ascend/patch/__init__.py`
- `tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py`
- `tests/e2e/singlecard/compile/test_graphex_norm_quant_fusion.py`
- `tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_matmul_allreduce_add_rmsnorm.py`
- `tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_gmm_combine_decode.py`
### Does this PR introduce _any_ user-facing change?
No. This is an internal refactor. The `npugraph_ex` backend has the same config paths, same compilation behavior, and same runtime semantics as the `torchair` `reduce-overhead` mode. No user-visible API, configuration, or behavior changes.
### How was this patch tested?
- Verified all `torchair` references (import, API calls, monkey-patches) are fully migrated with zero residual `torchair` code dependencies
- Confirmed that all referenced `npugraph_ex` internal APIs (`_optimize_fx`, `ValuePack`, `_is_symlist`, `_unpack_meta_list`, `_NpuGraphConverter`, `register_replacement`) exist in the `npugraph_ex` package with matching signatures
- Existing CI tests (`test_graphex_qknorm_rope_fusion`, `test_graphex_norm_quant_fusion`, nightly multicard tests) cover the affected compilation paths
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5af684c31912232e5c89484c2e8259e0fac6c55b
