### PR TITLE
[Test] Add ASR model accuracy test

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -213,8 +213,16 @@ jobs:
           any_failure=0
           for model in $models; do
             echo "Running test for model: $model"
-            pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
-              --config "tests/e2e/models/configs/${model}.yaml" || {
+            config_path="./tests/e2e/models/configs/${model}.yaml"
+            model_type=$(python3 -c "import yaml,sys; c=yaml.safe_load(open('${config_path}')); print(c.get('model_type','vllm'))" 2>/dev/null || echo "vllm")
+            if [[ "$model_type" == "vllm-asr" ]]; then
+              test_script="./tests/e2e/models/test_asr_eval.py"
+            else
+              test_script="./tests/e2e/models/test_lm_eval_correctness.py"
+            fi
+            echo "  model_type=${model_type} → ${test_script}"
+            pytest -sv "${test_script}" \
+              --config "${config_path}" || {
               echo "Test failed for model: $model"
               any_failure=1
             }

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -217,6 +217,8 @@ jobs:
             model_type=$(python3 -c "import yaml,sys; c=yaml.safe_load(open('${config_path}')); print(c.get('model_type','vllm'))" 2>/dev/null || echo "vllm")
             if [[ "$model_type" == "vllm-asr" ]]; then
               test_script="./tests/e2e/models/test_asr_eval_correctness.py"
+            elif [[ "$model_type" == "vllm-rm" ]]; then
+              test_script="./tests/e2e/models/test_rm_eval_correctness.py"
             else
               test_script="./tests/e2e/models/test_lm_eval_correctness.py"
             fi

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -216,7 +216,7 @@ jobs:
             config_path="./tests/e2e/models/configs/${model}.yaml"
             model_type=$(python3 -c "import yaml,sys; c=yaml.safe_load(open('${config_path}')); print(c.get('model_type','vllm'))" 2>/dev/null || echo "vllm")
             if [[ "$model_type" == "vllm-asr" ]]; then
-              test_script="./tests/e2e/models/test_asr_eval.py"
+              test_script="./tests/e2e/models/test_asr_eval_correctness.py"
             else
               test_script="./tests/e2e/models/test_lm_eval_correctness.py"
             fi

--- a/mypy.ini
+++ b/mypy.ini
@@ -40,3 +40,4 @@ ignore_missing_imports = True
 
 [mypy-lmcache_ascend.*]
 ignore_missing_imports = True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ exclude = [
     "docs/source/tutorials/models/Kimi-K2.5.md",
     "docs/source/tutorials/models/LLaVA-OneVision-Qwen2-0.5B-OV.md",
     "docs/source/tutorials/models/MiniMax-M2.5.md",
-    "docs/source/tutorials/models/Minitron-8B-Base.md‎",
+    "docs/source/tutorials/models/Minitron-8B-Base.md",
     "docs/source/tutorials/models/PaddleOCR-VL.md",
     "docs/source/tutorials/models/Qwen-VL-Dense.md",
     "docs/source/tutorials/models/Qwen3-235B-A22B.md",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,4 @@ mindstudio-probe>=8.3.0
 arctic-inference==0.1.1
 xlite==0.1.0rc4
 uc-manager
+torchcodec

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,11 +15,12 @@ regex
 sentence_transformers
 ray>=2.47.1,<=2.48.0
 protobuf>3.20.0
-librosa 
+jiwer
+librosa
+scipy
 soundfile
 pytest_mock
 mindstudio-probe>=8.3.0
 arctic-inference==0.1.1
 xlite==0.1.0rc4
 uc-manager
-torchcodec

--- a/tests/e2e/models/configs/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/tests/e2e/models/configs/ERNIE-4.5-21B-A3B-PT.yaml
@@ -1,9 +1,18 @@
 model_name: "PaddlePaddle/ERNIE-4.5-21B-A3B-PT"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  trust_remote_code: true
+
 tasks:
 - name: "gsm8k"
   metrics:
   - name: "exact_match,flexible-extract"
     value: 0.71
+
 num_fewshot: 5
-trust_remote_code: True

--- a/tests/e2e/models/configs/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/tests/e2e/models/configs/ERNIE-4.5-21B-A3B-PT.yaml
@@ -16,3 +16,6 @@ tasks:
     value: 0.71
 
 num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/Hunyuan-A13B-Instruct.yaml
+++ b/tests/e2e/models/configs/Hunyuan-A13B-Instruct.yaml
@@ -1,6 +1,7 @@
 model_name: "Tencent-Hunyuan/Hunyuan-A13B-Instruct"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
-trust_remote_code: true
+
 test_cases:
   - model: "Tencent-Hunyuan/Hunyuan-A13B-Instruct"
     server_cmd:
@@ -15,18 +16,25 @@ test_cases:
       - --enforce-eager
       - --port
       - "8000"
+
+serve:
+  tensor_parallel_size: 4
+  dtype: auto
+  max_model_len: 32768
+  gpu_memory_utilization: 0.90
+  enforce_eager: true
+  trust_remote_code: true
+
 tasks:
-- name: "gsm8k"
-  metrics:
-  - name: "exact_match,strict-match"
-    value: 0.37
-  - name: "exact_match,flexible-extract"
-    value: 0.28
-tensor_parallel_size: 4
+  - name: "gsm8k"
+    metrics:
+      - name: "exact_match,strict-match"
+        value: 0.37
+      - name: "exact_match,flexible-extract"
+        value: 0.28
+
 num_fewshot: 5
-num_samples: 1000
-max_model_len: 32768
-max_num_batched_tokens: 32768
+limit: 1000
 apply_chat_template: false
 fewshot_as_multiturn: false
-gpu_memory_utilization: 0.90
+batch_size: "auto"

--- a/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
+++ b/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
@@ -1,10 +1,13 @@
 model_name: "OpenGVLab/InternVL3_5-8B-hf"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  max_model_len: 40960
+  trust_remote_code: true
+
 tasks:
   - name: "mmmu_val"
     metrics:
     - name: "acc,none"
       value: 0.58
-max_model_len: 40960
-trust_remote_code: True

--- a/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
+++ b/tests/e2e/models/configs/InternVL3_5-8B-hf.yaml
@@ -3,7 +3,10 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
+  tensor_parallel_size: 1
+  dtype: auto
   max_model_len: 40960
+  gpu_memory_utilization: 0.8
   trust_remote_code: true
 
 tasks:
@@ -11,3 +14,8 @@ tasks:
     metrics:
     - name: "acc,none"
       value: 0.58
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/Llama-3.2-3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Llama-3.2-3B-Instruct.yaml
@@ -1,5 +1,14 @@
 model_name: "LLM-Research/Llama-3.2-3B-Instruct"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  trust_remote_code: false
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -7,4 +16,5 @@ tasks:
     value: 0.71
   - name: "exact_match,flexible-extract"
     value: 0.76
+
 num_fewshot: 5

--- a/tests/e2e/models/configs/Llama-3.2-3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Llama-3.2-3B-Instruct.yaml
@@ -18,3 +18,6 @@ tasks:
     value: 0.76
 
 num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/Minitron-8B-Base.yaml
+++ b/tests/e2e/models/configs/Minitron-8B-Base.yaml
@@ -1,6 +1,7 @@
 model_name: "nv-community/Minitron-8B-Base"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
-trust_remote_code: true
+
 test_cases:
   - model: "nv-community/Minitron-8B-Base"
     server_cmd:
@@ -15,6 +16,15 @@ test_cases:
       - --enforce-eager
       - --port
       - "8000"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.9
+  enforce_eager: true
+  trust_remote_code: true
+
 tasks:
   - name: "gsm8k"
     metrics:
@@ -22,8 +32,8 @@ tasks:
         value: 0.5436
       - name: "exact_match,flexible-extract"
         value: 0.5451
-num_samples: 1000
-max_model_len: 4096
+
+limit: 1000
 apply_chat_template: false
 fewshot_as_multiturn: false
-gpu_memory_utilization: 0.9
+batch_size: "auto"

--- a/tests/e2e/models/configs/Molmo-7B-D-0924.yaml
+++ b/tests/e2e/models/configs/Molmo-7B-D-0924.yaml
@@ -3,9 +3,11 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
+  tensor_parallel_size: 1
+  dtype: auto
   max_model_len: 4096
-  trust_remote_code: true
   gpu_memory_utilization: 0.8
+  trust_remote_code: true
 
 tasks:
 - name: "ceval-valid"
@@ -13,5 +15,7 @@ tasks:
   - name: "acc,none"
     value: 0.71
 
+num_fewshot: 0
 apply_chat_template: false
 fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/Molmo-7B-D-0924.yaml
+++ b/tests/e2e/models/configs/Molmo-7B-D-0924.yaml
@@ -1,13 +1,17 @@
 model_name: "LLM-Research/Molmo-7B-D-0924"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  max_model_len: 4096
+  trust_remote_code: true
+  gpu_memory_utilization: 0.8
+
 tasks:
 - name: "ceval-valid"
   metrics:
   - name: "acc,none"
     value: 0.71
-max_model_len: 4096
-trust_remote_code: True
-apply_chat_template: False
-fewshot_as_multiturn: False
-gpu_memory_utilization: 0.8
+
+apply_chat_template: false
+fewshot_as_multiturn: false

--- a/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
@@ -1,5 +1,10 @@
 model_name: "Qwen/Qwen2-Audio-7B-Instruct"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  gpu_memory_utilization: 0.8
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -7,5 +12,5 @@ tasks:
     value: 0.44
   - name: "exact_match,flexible-extract"
     value: 0.45
+
 num_fewshot: 5
-gpu_memory_utilization: 0.8

--- a/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen2-Audio-7B-Instruct.yaml
@@ -3,7 +3,11 @@ model_type: "vllm"
 hardware: "Atlas A2 Series"
 
 serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
   gpu_memory_utilization: 0.8
+  trust_remote_code: false
 
 tasks:
 - name: "gsm8k"
@@ -14,3 +18,6 @@ tasks:
     value: 0.45
 
 num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-30B-A3B-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-30B-A3B-W8A8.yaml
@@ -1,5 +1,16 @@
 model_name: "vllm-ascend/Qwen3-30B-A3B-W8A8"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 2
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.7
+  trust_remote_code: false
+  enable_expert_parallel: true
+  quantization: ascend
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -7,10 +18,7 @@ tasks:
     value: 0.9
   - name: "exact_match,flexible-extract"
     value: 0.8
+
 num_fewshot: 5
-gpu_memory_utilization: 0.7
-enable_expert_parallel: True
-tensor_parallel_size: 2
-apply_chat_template: False
-fewshot_as_multiturn: False
-quantization: ascend
+apply_chat_template: false
+fewshot_as_multiturn: false

--- a/tests/e2e/models/configs/Qwen3-30B-A3B-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-30B-A3B-W8A8.yaml
@@ -22,3 +22,4 @@ tasks:
 num_fewshot: 5
 apply_chat_template: false
 fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-30B-A3B.yaml
+++ b/tests/e2e/models/configs/Qwen3-30B-A3B.yaml
@@ -25,3 +25,4 @@ tasks:
 num_fewshot: 5
 apply_chat_template: false
 fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-30B-A3B.yaml
+++ b/tests/e2e/models/configs/Qwen3-30B-A3B.yaml
@@ -1,5 +1,15 @@
 model_name: "Qwen/Qwen3-30B-A3B"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 2
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.6
+  trust_remote_code: false
+  enable_expert_parallel: true
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -11,9 +21,7 @@ tasks:
   metrics:
   - name: "acc,none"
     value: 0.84
+
 num_fewshot: 5
-gpu_memory_utilization: 0.6
-enable_expert_parallel: True
-tensor_parallel_size: 2
-apply_chat_template: False
-fewshot_as_multiturn: False
+apply_chat_template: false
+fewshot_as_multiturn: false

--- a/tests/e2e/models/configs/Qwen3-8B-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-8B-W8A8.yaml
@@ -20,3 +20,6 @@ tasks:
     value: 0.82
 
 num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-8B-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-8B-W8A8.yaml
@@ -1,5 +1,16 @@
 model_name: "vllm-ascend/Qwen3-8B-W8A8"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  trust_remote_code: false
+  quantization: ascend
+  enable_thinking: false
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -7,6 +18,5 @@ tasks:
     value: 0.80
   - name: "exact_match,flexible-extract"
     value: 0.82
+
 num_fewshot: 5
-enable_thinking: False
-quantization: ascend

--- a/tests/e2e/models/configs/Qwen3-8B.yaml
+++ b/tests/e2e/models/configs/Qwen3-8B.yaml
@@ -1,5 +1,15 @@
 model_name: "Qwen/Qwen3-8B"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  trust_remote_code: false
+  enable_thinking: false
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -7,5 +17,5 @@ tasks:
     value: 0.765
   - name: "exact_match,flexible-extract"
     value: 0.81
+
 num_fewshot: 5
-enable_thinking: False

--- a/tests/e2e/models/configs/Qwen3-8B.yaml
+++ b/tests/e2e/models/configs/Qwen3-8B.yaml
@@ -19,3 +19,6 @@ tasks:
     value: 0.81
 
 num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
+++ b/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
@@ -2,13 +2,6 @@ model_name: "Qwen/Qwen3-ASR-1.7B"
 model_type: "vllm-asr"
 hardware: "Atlas A2 Series"
 
-# === vllm serve configuration ===
-# Equivalent to running:
-#   vllm serve Qwen/Qwen3-ASR-1.7B \
-#     --tensor-parallel-size 1 \
-#     --dtype auto \
-#     --max-model-len 4096 \
-#     --gpu-memory-utilization 0.8
 serve:
   tensor_parallel_size: 1
   dtype: auto
@@ -16,9 +9,6 @@ serve:
   gpu_memory_utilization: 0.8
   trust_remote_code: false
 
-# === Open ASR Leaderboard evaluation tasks ===
-# Datasets from: https://github.com/huggingface/open_asr_leaderboard
-# Metric: WER (Word Error Rate, lower is better), validated with RTOL=0.10
 tasks:
   - name: "librispeech_test_clean"
     dataset: "librispeech_asr"
@@ -28,7 +18,7 @@ tasks:
     text_column: "text"
     metrics:
       - name: "wer"
-        value: 0.035   # Placeholder — measure on first run and lock in
+        value: 0.035
 
   - name: "librispeech_test_other"
     dataset: "librispeech_asr"
@@ -38,10 +28,9 @@ tasks:
     text_column: "text"
     metrics:
       - name: "wer"
-        value: 0.08    # Placeholder — measure on first run and lock in
+        value: 0.08 
 
-# Evaluation settings
-limit: 100           # Samples per dataset split; set to null for full evaluation
+limit: 100
 batch_size: 8
 language: "en"
-normalizer: "whisper"  # Text normalization: "whisper" uses EnglishTextNormalizer
+normalizer: "whisper" 

--- a/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
+++ b/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
@@ -1,6 +1,6 @@
 model_name: "Qwen/Qwen3-ASR-1.7B"
 model_type: "vllm-asr"
-hardware: "Atlas A3 Series"
+hardware: "Atlas A2 Series"
 
 serve:
   tensor_parallel_size: 1

--- a/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
+++ b/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
@@ -1,0 +1,47 @@
+model_name: "Qwen/Qwen3-ASR-1.7B"
+model_type: "vllm-asr"
+hardware: "Atlas A2 Series"
+
+# === vllm serve configuration ===
+# Equivalent to running:
+#   vllm serve Qwen/Qwen3-ASR-1.7B \
+#     --tensor-parallel-size 1 \
+#     --dtype auto \
+#     --max-model-len 4096 \
+#     --gpu-memory-utilization 0.8
+serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  trust_remote_code: false
+
+# === Open ASR Leaderboard evaluation tasks ===
+# Datasets from: https://github.com/huggingface/open_asr_leaderboard
+# Metric: WER (Word Error Rate, lower is better), validated with RTOL=0.10
+tasks:
+  - name: "librispeech_test_clean"
+    dataset: "librispeech_asr"
+    split: "test.clean"
+    dataset_config: "clean"
+    audio_column: "audio"
+    text_column: "text"
+    metrics:
+      - name: "wer"
+        value: 0.035   # Placeholder — measure on first run and lock in
+
+  - name: "librispeech_test_other"
+    dataset: "librispeech_asr"
+    split: "test.other"
+    dataset_config: "other"
+    audio_column: "audio"
+    text_column: "text"
+    metrics:
+      - name: "wer"
+        value: 0.08    # Placeholder — measure on first run and lock in
+
+# Evaluation settings
+limit: 100           # Samples per dataset split; set to null for full evaluation
+batch_size: 8
+language: "en"
+normalizer: "whisper"  # Text normalization: "whisper" uses EnglishTextNormalizer

--- a/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
+++ b/tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml
@@ -1,6 +1,6 @@
 model_name: "Qwen/Qwen3-ASR-1.7B"
 model_type: "vllm-asr"
-hardware: "Atlas A2 Series"
+hardware: "Atlas A3 Series"
 
 serve:
   tensor_parallel_size: 1
@@ -11,26 +11,11 @@ serve:
 
 tasks:
   - name: "librispeech_test_clean"
-    dataset: "librispeech_asr"
-    split: "test.clean"
+    dataset: "openslr/librispeech_asr"
+    split: "test"
     dataset_config: "clean"
-    audio_column: "audio"
-    text_column: "text"
     metrics:
       - name: "wer"
         value: 0.035
 
-  - name: "librispeech_test_other"
-    dataset: "librispeech_asr"
-    split: "test.other"
-    dataset_config: "other"
-    audio_column: "audio"
-    text_column: "text"
-    metrics:
-      - name: "wer"
-        value: 0.08 
-
-limit: 100
-batch_size: 8
-language: "en"
-normalizer: "whisper" 
+limit: 500

--- a/tests/e2e/models/configs/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -18,4 +18,6 @@ tasks:
     value: 0.98
 
 num_fewshot: 5
+apply_chat_template: true
+fewshot_as_multiturn: true
 batch_size: 1

--- a/tests/e2e/models/configs/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -1,15 +1,21 @@
 model_name: "Qwen/Qwen3-Next-80B-A3B-Instruct"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
-model: "vllm"
+
+serve:
+  tensor_parallel_size: 4
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.7
+  trust_remote_code: false
+  enable_expert_parallel: true
+  enforce_eager: true
+
 tasks:
 - name: "ceval-valid_accountant"
   metrics:
   - name: "acc,none"
     value: 0.98
-max_model_len: 4096
-tensor_parallel_size: 4
-gpu_memory_utilization: 0.7
-enable_expert_parallel: True
-enforce_eager: True
-batch_size: 1
+
 num_fewshot: 5
+batch_size: 1

--- a/tests/e2e/models/configs/Qwen3-Omni-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-Omni-30B-A3B-Instruct.yaml
@@ -3,8 +3,11 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
-  max_model_len: 8192
   tensor_parallel_size: 4
+  dtype: auto
+  max_model_len: 8192
+  gpu_memory_utilization: 0.7
+  trust_remote_code: false
   enable_expert_parallel: true
 
 tasks:
@@ -12,3 +15,8 @@ tasks:
   metrics:
   - name: "acc,none"
     value: 0.60
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-Omni-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-Omni-30B-A3B-Instruct.yaml
@@ -1,11 +1,14 @@
 model_name: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  max_model_len: 8192
+  tensor_parallel_size: 4
+  enable_expert_parallel: true
+
 tasks:
 - name: "mmmu_val"
   metrics:
   - name: "acc,none"
     value: 0.60
-max_model_len: 8192
-tensor_parallel_size: 4
-enable_expert_parallel: True

--- a/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -3,9 +3,11 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
-  max_model_len: 128000
   tensor_parallel_size: 2
+  dtype: auto
+  max_model_len: 128000
   gpu_memory_utilization: 0.7
+  trust_remote_code: false
   enable_expert_parallel: true
 
 tasks:
@@ -13,3 +15,8 @@ tasks:
   metrics:
   - name: "acc,none"
     value: 0.58
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -1,12 +1,15 @@
 model_name: "Qwen/Qwen3-VL-30B-A3B-Instruct"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  max_model_len: 128000
+  tensor_parallel_size: 2
+  gpu_memory_utilization: 0.7
+  enable_expert_parallel: true
+
 tasks:
 - name: "mmmu_val"
   metrics:
   - name: "acc,none"
     value: 0.58
-max_model_len: 128000
-tensor_parallel_size: 2
-gpu_memory_utilization: 0.7
-enable_expert_parallel: True

--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct-W8A8.yaml
@@ -1,12 +1,16 @@
 model_name: "vllm-ascend/Qwen3-VL-8B-Instruct-W8A8"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  max_model_len: 8192
+  gpu_memory_utilization: 0.8
+  quantization: ascend
+
 tasks:
 - name: "mmmu_val"
   metrics:
   - name: "acc,none"
     value: 0.52
-max_model_len: 8192
+
 batch_size: 32
-gpu_memory_utilization: 0.8
-quantization: ascend

--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct-W8A8.yaml
@@ -3,8 +3,11 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
+  tensor_parallel_size: 1
+  dtype: auto
   max_model_len: 8192
   gpu_memory_utilization: 0.8
+  trust_remote_code: false
   quantization: ascend
 
 tasks:
@@ -13,4 +16,7 @@ tasks:
   - name: "acc,none"
     value: 0.52
 
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
 batch_size: 32

--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
@@ -1,11 +1,15 @@
 model_name: "Qwen/Qwen3-VL-8B-Instruct"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  max_model_len: 8192
+  gpu_memory_utilization: 0.7
+
 tasks:
 - name: "mmmu_val"
   metrics:
   - name: "acc,none"
     value: 0.55
-max_model_len: 8192
+
 batch_size: 32
-gpu_memory_utilization: 0.7

--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
@@ -3,8 +3,11 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
+  tensor_parallel_size: 1
+  dtype: auto
   max_model_len: 8192
   gpu_memory_utilization: 0.7
+  trust_remote_code: false
 
 tasks:
 - name: "mmmu_val"
@@ -12,4 +15,7 @@ tasks:
   - name: "acc,none"
     value: 0.55
 
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
 batch_size: 32

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -11,3 +11,4 @@ internlm3-8b-instruct.yaml
 Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
+Qwen3-ASR-1.7B.yaml

--- a/tests/e2e/models/configs/accuracy_groups_a2.json
+++ b/tests/e2e/models/configs/accuracy_groups_a2.json
@@ -48,16 +48,9 @@
       "os": "linux-aarch64-a2b3-1",
       "model_list": [
         "gemma-3-4b-it",
-        "internlm3-8b-instruct"
-      ]
-    },
-    {
-      "name": "pr-accuracy-group-2",
-      "os": "linux-aarch64-a3-1",
-      "model_list": [
+        "internlm3-8b-instruct",
         "Qwen3-ASR-1.7B"
       ]
     }
-
   ]
 }

--- a/tests/e2e/models/configs/accuracy_groups_a2.json
+++ b/tests/e2e/models/configs/accuracy_groups_a2.json
@@ -50,6 +50,14 @@
         "gemma-3-4b-it",
         "internlm3-8b-instruct"
       ]
+    },
+    {
+      "name": "pr-accuracy-group-2",
+      "os": "linux-aarch64-a3-1",
+      "model_list": [
+        "Qwen3-ASR-1.7B"
+      ]
     }
+
   ]
 }

--- a/tests/e2e/models/configs/gemma-3-4b-it.yaml
+++ b/tests/e2e/models/configs/gemma-3-4b-it.yaml
@@ -1,5 +1,11 @@
 model_name: "LLM-Research/gemma-3-4b-it"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  gpu_memory_utilization: 0.7
+  enforce_eager: true
+
 tasks:
 - name: "gsm8k"
   metrics:
@@ -7,8 +13,7 @@ tasks:
     value: 0.59
   - name: "exact_match,flexible-extract"
     value: 0.59
+
 num_fewshot: 5
-apply_chat_template: False
-fewshot_as_multiturn: False
-gpu_memory_utilization: 0.7
-enforce_eager: True
+apply_chat_template: false
+fewshot_as_multiturn: false

--- a/tests/e2e/models/configs/gemma-3-4b-it.yaml
+++ b/tests/e2e/models/configs/gemma-3-4b-it.yaml
@@ -3,7 +3,11 @@ model_type: "vllm"
 hardware: "Atlas A2 Series"
 
 serve:
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
   gpu_memory_utilization: 0.7
+  trust_remote_code: false
   enforce_eager: true
 
 tasks:
@@ -17,3 +21,4 @@ tasks:
 num_fewshot: 5
 apply_chat_template: false
 fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/internlm3-8b-instruct.yaml
+++ b/tests/e2e/models/configs/internlm3-8b-instruct.yaml
@@ -3,9 +3,11 @@ model_type: "vllm"
 hardware: "Atlas A2 Series"
 
 serve:
-  max_model_len: 2048
-  trust_remote_code: true
+  tensor_parallel_size: 1
   dtype: "bfloat16"
+  max_model_len: 2048
+  gpu_memory_utilization: 0.8
+  trust_remote_code: true
 
 tasks:
 - name: "ceval-valid"
@@ -16,3 +18,4 @@ tasks:
 num_fewshot: 5
 apply_chat_template: false
 fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/internlm3-8b-instruct.yaml
+++ b/tests/e2e/models/configs/internlm3-8b-instruct.yaml
@@ -1,13 +1,18 @@
 model_name: "Shanghai_AI_Laboratory/internlm3-8b-instruct"
+model_type: "vllm"
 hardware: "Atlas A2 Series"
+
+serve:
+  max_model_len: 2048
+  trust_remote_code: true
+  dtype: "bfloat16"
+
 tasks:
 - name: "ceval-valid"
   metrics:
   - name: "acc,none"
     value: 0.42
+
 num_fewshot: 5
-max_model_len: 2048
-trust_remote_code: True
-dtype: "bfloat16"
-apply_chat_template: False
-fewshot_as_multiturn: False
+apply_chat_template: false
+fewshot_as_multiturn: false

--- a/tests/e2e/models/configs/llava-onevision-qwen2-0.5b-ov-hf.yaml
+++ b/tests/e2e/models/configs/llava-onevision-qwen2-0.5b-ov-hf.yaml
@@ -1,10 +1,13 @@
 model_name: "llava-hf/llava-onevision-qwen2-0.5b-ov-hf"
+model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
-model: "vllm-vlm"
+
+serve:
+  trust_remote_code: true
+  gpu_memory_utilization: 0.8
+
 tasks:
 - name: "ceval-valid"
   metrics:
   - name: "acc,none"
     value: 0.42
-trust_remote_code: True
-gpu_memory_utilization: 0.8

--- a/tests/e2e/models/configs/llava-onevision-qwen2-0.5b-ov-hf.yaml
+++ b/tests/e2e/models/configs/llava-onevision-qwen2-0.5b-ov-hf.yaml
@@ -3,11 +3,19 @@ model_type: "vllm-vlm"
 hardware: "Atlas A2 Series"
 
 serve:
-  trust_remote_code: true
+  tensor_parallel_size: 1
+  dtype: auto
+  max_model_len: 4096
   gpu_memory_utilization: 0.8
+  trust_remote_code: true
 
 tasks:
 - name: "ceval-valid"
   metrics:
   - name: "acc,none"
     value: 0.42
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/report_template.md
+++ b/tests/e2e/models/report_template.md
@@ -6,6 +6,7 @@
 - **Parallel mode**: {{ parallel_mode }}
 - **Execution mode**: {{ execution_model }}
 
+{% if show_command is not defined or show_command %}
 **Command**:  
 
 ```bash
@@ -26,6 +27,7 @@ lm_eval --model {{ model_type }} --model_args $MODEL_ARGS \
 {%- endif %}
   --batch_size {{ batch_size }}
 ```
+{% endif %}
 
 | Task                  | Metric      | Value     | Stderr |
 |-----------------------|-------------|----------:|-------:|

--- a/tests/e2e/models/test_asr_eval.py
+++ b/tests/e2e/models/test_asr_eval.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ASR (Automatic Speech Recognition) accuracy evaluation using Open ASR Leaderboard datasets.
+
+Evaluates WER (Word Error Rate) on speech datasets (LibriSpeech, etc.) by:
+1. Starting vllm serve with the ASR model via RemoteOpenAIServer
+2. Transcribing audio samples via POST /v1/audio/transcriptions
+3. Normalising hypotheses and references with the Whisper EnglishTextNormalizer
+4. Computing WER with jiwer and comparing against ground-truth thresholds
+
+Runs with the same --config / --config-list-file CLI options as test_lm_eval_correctness.py.
+Only processes configs that have model_type: "vllm-asr"; other configs are skipped.
+
+Usage:
+    pytest tests/e2e/models/test_asr_eval.py \
+        --config=tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml \
+        --tp-size=1 \
+        --report-dir=./benchmarks/accuracy
+
+Reference: https://github.com/huggingface/open_asr_leaderboard
+"""
+
+import io
+import os
+from dataclasses import dataclass
+
+import jiwer
+import numpy as np
+import pytest
+import scipy.io.wavfile as wav_io
+import yaml
+from datasets import load_dataset
+from jinja2 import Environment, FileSystemLoader
+from whisper.normalizers import EnglishTextNormalizer
+
+from tests.e2e.conftest import RemoteOpenAIServer
+
+# Allow up to 10% relative deviation from the declared ground-truth WER.
+# ASR results have higher variance than classification tasks, so we use a
+# more generous tolerance than the 5% used in test_lm_eval_correctness.py.
+RTOL = 0.10
+
+TEST_DIR = os.path.dirname(__file__)
+
+_NORMALIZER = EnglishTextNormalizer()
+
+
+@dataclass
+class EnvConfig:
+    vllm_version: str
+    vllm_commit: str
+    vllm_ascend_version: str
+    vllm_ascend_commit: str
+    cann_version: str
+    torch_version: str
+    torch_npu_version: str
+
+
+@pytest.fixture
+def env_config() -> EnvConfig:
+    return EnvConfig(
+        vllm_version=os.getenv("VLLM_VERSION", "unknown"),
+        vllm_commit=os.getenv("VLLM_COMMIT", "unknown"),
+        vllm_ascend_version=os.getenv("VLLM_ASCEND_VERSION", "unknown"),
+        vllm_ascend_commit=os.getenv("VLLM_ASCEND_COMMIT", "unknown"),
+        cann_version=os.getenv("CANN_VERSION", "unknown"),
+        torch_version=os.getenv("TORCH_VERSION", "unknown"),
+        torch_npu_version=os.getenv("TORCH_NPU_VERSION", "unknown"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def build_serve_args(eval_config: dict) -> list[str]:
+    """Convert the serve: section of the YAML into a vllm serve CLI args list.
+
+    Example — serve: {tensor_parallel_size: 2, dtype: auto} becomes:
+        ["--tensor-parallel-size", "2", "--dtype", "auto"]
+    """
+    serve_cfg = eval_config.get("serve", {})
+    flag_map = {
+        "tensor_parallel_size": "--tensor-parallel-size",
+        "dtype": "--dtype",
+        "max_model_len": "--max-model-len",
+        "gpu_memory_utilization": "--gpu-memory-utilization",
+        "trust_remote_code": "--trust-remote-code",
+        "enforce_eager": "--enforce-eager",
+        "quantization": "--quantization",
+    }
+    args: list[str] = []
+    for key, flag in flag_map.items():
+        value = serve_cfg.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            if value:
+                args.append(flag)
+        else:
+            args.extend([flag, str(value)])
+    return args
+
+
+def audio_to_wav_bytes(audio_array: np.ndarray, sample_rate: int) -> bytes:
+    """Convert a numpy audio array to in-memory WAV bytes at the given sample rate."""
+    buf = io.BytesIO()
+    # Ensure int16 encoding for maximum API compatibility.
+    if audio_array.dtype != np.int16:
+        if np.issubdtype(audio_array.dtype, np.floating):
+            audio_array = np.clip(audio_array, -1.0, 1.0)
+            audio_array = (audio_array * 32767).astype(np.int16)
+        else:
+            audio_array = audio_array.astype(np.int16)
+    wav_io.write(buf, sample_rate, audio_array)
+    return buf.getvalue()
+
+
+def normalize_text(text: str) -> str:
+    """Apply Whisper's EnglishTextNormalizer (lowercase + strip punctuation)."""
+    return _NORMALIZER(text)
+
+
+def transcribe_batch(client, model_name: str, audio_items: list[dict], language: str) -> list[str]:
+    """Call /v1/audio/transcriptions for a list of audio items.
+
+    Each item in audio_items must have keys: audio_array (np.ndarray), sample_rate (int).
+    Returns the raw transcription strings in the same order.
+    """
+    hypotheses: list[str] = []
+    for item in audio_items:
+        wav_bytes = audio_to_wav_bytes(item["audio_array"], item["sample_rate"])
+        response = client.audio.transcriptions.create(
+            model=model_name,
+            file=("audio.wav", wav_bytes, "audio/wav"),
+            language=language,
+        )
+        hypotheses.append(response.text)
+    return hypotheses
+
+
+def generate_asr_report(
+    eval_config: dict,
+    report_data: dict,
+    report_dir: str,
+    env_config: EnvConfig,
+) -> None:
+    """Write a Markdown accuracy report using the same Jinja2 template as lm_eval tests."""
+    env = Environment(loader=FileSystemLoader(TEST_DIR))
+    template = env.get_template("report_template.md")
+
+    serve_cfg = eval_config.get("serve", {})
+    tp_size = serve_cfg.get("tensor_parallel_size", 1)
+    ep_enabled = serve_cfg.get("enable_expert_parallel", False)
+    enforce_eager = serve_cfg.get("enforce_eager", False)
+
+    parallel_mode = f"TP{tp_size}"
+    if ep_enabled:
+        parallel_mode += " + EP"
+    execution_model = "Eager" if enforce_eager else "ACLGraph"
+
+    model_args_str = ",".join(f"{k}={v}" for k, v in serve_cfg.items())
+
+    report_content = template.render(
+        vllm_version=env_config.vllm_version,
+        vllm_commit=env_config.vllm_commit,
+        vllm_ascend_version=env_config.vllm_ascend_version,
+        vllm_ascend_commit=env_config.vllm_ascend_commit,
+        cann_version=env_config.cann_version,
+        torch_version=env_config.torch_version,
+        torch_npu_version=env_config.torch_npu_version,
+        hardware=eval_config.get("hardware", "unknown"),
+        model_name=eval_config["model_name"],
+        model_args=f"'{model_args_str}'",
+        model_type=eval_config.get("model_type", "vllm-asr"),
+        datasets=",".join(t["name"] for t in eval_config["tasks"]),
+        apply_chat_template=False,
+        fewshot_as_multiturn=False,
+        limit=eval_config.get("limit", "N/A"),
+        batch_size=eval_config.get("batch_size", 8),
+        num_fewshot="N/A",
+        rows=report_data["rows"],
+        parallel_mode=parallel_mode,
+        execution_model=execution_model,
+    )
+
+    report_path = os.path.join(report_dir, f"{os.path.basename(eval_config['model_name'])}.md")
+    os.makedirs(os.path.dirname(report_path), exist_ok=True)
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report_content)
+
+
+# ---------------------------------------------------------------------------
+# Main test
+# ---------------------------------------------------------------------------
+
+def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
+    """Parametrised ASR accuracy test driven by a YAML config file.
+
+    Skips automatically when the config's model_type is not "vllm-asr".
+    """
+    eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
+
+    model_name: str = eval_config["model_name"]
+    language: str = eval_config.get("language", "en")
+    limit: int | None = eval_config.get("limit", None)
+    batch_size: int = eval_config.get("batch_size", 8)
+
+    # Build serve args, letting --tp-size CLI flag override the YAML value.
+    serve_args = build_serve_args(eval_config)
+    if tp_size and tp_size != "1":
+        # Remove any tensor-parallel-size already in serve_args and use CLI value.
+        filtered = []
+        skip_next = False
+        for arg in serve_args:
+            if skip_next:
+                skip_next = False
+                continue
+            if arg == "--tensor-parallel-size":
+                skip_next = True
+                continue
+            filtered.append(arg)
+        serve_args = filtered + ["--tensor-parallel-size", str(tp_size)]
+
+    print(f"\nStarting vllm serve for {model_name}")
+    print(f"  serve args: {serve_args}")
+
+    success = True
+    report_data: dict[str, list[dict]] = {"rows": []}
+
+    with RemoteOpenAIServer(model_name, serve_args) as server:
+        client = server.get_client()
+
+        for task in eval_config["tasks"]:
+            task_name: str = task["name"]
+            dataset_name: str = task["dataset"]
+            split: str = task["split"]
+            dataset_config_name: str | None = task.get("dataset_config")
+            audio_col: str = task.get("audio_column", "audio")
+            text_col: str = task.get("text_column", "text")
+
+            print(f"\nLoading dataset: {dataset_name} / {dataset_config_name} ({split})")
+            ds = load_dataset(
+                dataset_name,
+                dataset_config_name,
+                split=split,
+                trust_remote_code=False,
+            )
+            if limit is not None:
+                ds = ds.select(range(min(limit, len(ds))))
+
+            print(f"  {len(ds)} samples to evaluate")
+
+            # Collect audio items and references in batches.
+            all_hypotheses: list[str] = []
+            all_references: list[str] = []
+
+            for batch_start in range(0, len(ds), batch_size):
+                batch = ds.select(range(batch_start, min(batch_start + batch_size, len(ds))))
+                audio_items = [
+                    {
+                        "audio_array": sample[audio_col]["array"],
+                        "sample_rate": sample[audio_col]["sampling_rate"],
+                    }
+                    for sample in batch
+                ]
+                references = [sample[text_col] for sample in batch]
+
+                hypotheses = transcribe_batch(client, model_name, audio_items, language)
+                all_hypotheses.extend(hypotheses)
+                all_references.extend(references)
+
+                if (batch_start // batch_size + 1) % 5 == 0:
+                    print(f"  processed {batch_start + len(batch)}/{len(ds)} samples …")
+
+            # Normalise both sides before WER calculation.
+            norm_hypotheses = [normalize_text(h) for h in all_hypotheses]
+            norm_references = [normalize_text(r) for r in all_references]
+
+            measured_wer = round(jiwer.wer(norm_references, norm_hypotheses), 4)
+            print(f"\n{task_name} WER = {measured_wer:.4f}")
+
+            for metric in task["metrics"]:
+                if metric["name"] != "wer":
+                    continue
+                ground_truth = metric["value"]
+                task_success = bool(np.isclose(ground_truth, measured_wer, rtol=RTOL))
+                success = success and task_success
+
+                status = "✅" if task_success else "❌"
+                print(
+                    f"{task_name} | wer: ground_truth={ground_truth} | "
+                    f"measured={measured_wer} | {status}"
+                )
+
+                report_data["rows"].append(
+                    {
+                        "task": task_name,
+                        "metric": "wer",
+                        "value": f"{status}{measured_wer}",
+                        "stderr": "N/A",
+                    }
+                )
+
+    generate_asr_report(eval_config, report_data, report_dir, env_config)
+    assert success, "One or more ASR tasks exceeded the WER tolerance. See output above."

--- a/tests/e2e/models/test_asr_eval.py
+++ b/tests/e2e/models/test_asr_eval.py
@@ -201,6 +201,9 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
     """
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
 
+    if eval_config.get("model_type", "vllm") != "vllm-asr":
+        pytest.skip(f"Skipping non-ASR config (model_type={eval_config.get('model_type', 'vllm')})")
+
     model_name: str = eval_config["model_name"]
     language: str = eval_config.get("language", "en")
     limit: int | None = eval_config.get("limit", None)

--- a/tests/e2e/models/test_asr_eval_correctness.py
+++ b/tests/e2e/models/test_asr_eval_correctness.py
@@ -1,48 +1,32 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""ASR (Automatic Speech Recognition) accuracy evaluation using Open ASR Leaderboard datasets.
-
-Evaluates WER (Word Error Rate) on speech datasets (LibriSpeech, etc.) by:
-1. Starting vllm serve with the ASR model via RemoteOpenAIServer
-2. Transcribing audio samples via POST /v1/audio/transcriptions
-3. Normalising hypotheses and references with the Whisper EnglishTextNormalizer
-4. Computing WER with jiwer and comparing against ground-truth thresholds
-
-Runs with the same --config / --config-list-file CLI options as test_lm_eval_correctness.py.
-Only processes configs that have model_type: "vllm-asr"; other configs are skipped.
-
-Usage:
-    pytest tests/e2e/models/test_asr_eval.py \
-        --config=tests/e2e/models/configs/Qwen3-ASR-1.7B.yaml \
-        --tp-size=1 \
-        --report-dir=./benchmarks/accuracy
-
-Reference: https://github.com/huggingface/open_asr_leaderboard
-"""
-
 import io
 import os
 from dataclasses import dataclass
+
+import string
 
 import jiwer
 import numpy as np
 import pytest
 import scipy.io.wavfile as wav_io
+import soundfile as sf
 import yaml
-from datasets import load_dataset
+from datasets import Audio
+from modelscope.msdatasets import MsDataset
+import huggingface_hub.constants as hf_constants
+import datasets.config as ds_config
 from jinja2 import Environment, FileSystemLoader
-from whisper.normalizers import EnglishTextNormalizer
 
 from tests.e2e.conftest import RemoteOpenAIServer
+from vllm.utils.network_utils import get_open_port
 
 # Allow up to 10% relative deviation from the declared ground-truth WER.
 # ASR results have higher variance than classification tasks, so we use a
 # more generous tolerance than the 5% used in test_lm_eval_correctness.py.
-RTOL = 0.10
+RTOL = 0.03
 
 TEST_DIR = os.path.dirname(__file__)
 
-_NORMALIZER = EnglishTextNormalizer()
+_PUNCT_TABLE = str.maketrans("", "", string.punctuation)
 
 
 @dataclass
@@ -68,10 +52,6 @@ def env_config() -> EnvConfig:
         torch_npu_version=os.getenv("TORCH_NPU_VERSION", "unknown"),
     )
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def build_serve_args(eval_config: dict) -> list[str]:
     """Convert the serve: section of the YAML into a vllm serve CLI args list.
@@ -117,8 +97,11 @@ def audio_to_wav_bytes(audio_array: np.ndarray, sample_rate: int) -> bytes:
 
 
 def normalize_text(text: str) -> str:
-    """Apply Whisper's EnglishTextNormalizer (lowercase + strip punctuation)."""
-    return _NORMALIZER(text)
+    """Normalize text for WER calculation: lowercase, strip punctuation, collapse whitespace."""
+    text = text.lower()
+    text = text.translate(_PUNCT_TABLE)
+    text = " ".join(text.split())
+    return text
 
 
 def transcribe_batch(client, model_name: str, audio_items: list[dict], language: str) -> list[str]:
@@ -190,10 +173,6 @@ def generate_asr_report(
         f.write(report_content)
 
 
-# ---------------------------------------------------------------------------
-# Main test
-# ---------------------------------------------------------------------------
-
 def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
     """Parametrised ASR accuracy test driven by a YAML config file.
 
@@ -212,18 +191,11 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
     # Build serve args, letting --tp-size CLI flag override the YAML value.
     serve_args = build_serve_args(eval_config)
     if tp_size and tp_size != "1":
-        # Remove any tensor-parallel-size already in serve_args and use CLI value.
-        filtered = []
-        skip_next = False
-        for arg in serve_args:
-            if skip_next:
-                skip_next = False
-                continue
-            if arg == "--tensor-parallel-size":
-                skip_next = True
-                continue
-            filtered.append(arg)
-        serve_args = filtered + ["--tensor-parallel-size", str(tp_size)]
+        # Drop any --tensor-parallel-size already in serve_args, then append
+        # the CLI-supplied value so it takes precedence over the YAML setting.
+        it = iter(serve_args)
+        serve_args = [a for a in it if a != "--tensor-parallel-size" or not next(it, None)]
+        serve_args += ["--tensor-parallel-size", str(tp_size)]
 
     print(f"\nStarting vllm serve for {model_name}")
     print(f"  serve args: {serve_args}")
@@ -231,7 +203,9 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
     success = True
     report_data: dict[str, list[dict]] = {"rows": []}
 
-    with RemoteOpenAIServer(model_name, serve_args) as server:
+    server_port = get_open_port()
+    serve_args = serve_args + ["--port", str(server_port)]
+    with RemoteOpenAIServer(model_name, serve_args, server_port=server_port, auto_port=False) as server:
         client = server.get_client()
 
         for task in eval_config["tasks"]:
@@ -242,15 +216,30 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
             audio_col: str = task.get("audio_column", "audio")
             text_col: str = task.get("text_column", "text")
 
-            print(f"\nLoading dataset: {dataset_name} / {dataset_config_name} ({split})")
-            ds = load_dataset(
-                dataset_name,
-                dataset_config_name,
-                split=split,
-                trust_remote_code=False,
-            )
+            split_expr = f"{split}[:{limit}]" if limit is not None else split
+            print(f"\nLoading dataset via modelscope: {dataset_name} / {dataset_config_name} ({split_expr})")
+            # MsDataset accesses ModelScope (not HuggingFace), but datasets/huggingface_hub
+            # cache HF_HUB_OFFLINE at import time and block all HTTP. Patch temporarily.
+            _orig_hf_offline = hf_constants.HF_HUB_OFFLINE
+            _orig_ds_offline = ds_config.HF_DATASETS_OFFLINE
+            hf_constants.HF_HUB_OFFLINE = False
+            ds_config.HF_DATASETS_OFFLINE = False
+            try:
+                ds = MsDataset.load(
+                    dataset_name,
+                    subset_name=dataset_config_name,
+                    split=split_expr,
+                )
+            finally:
+                hf_constants.HF_HUB_OFFLINE = _orig_hf_offline
+                ds_config.HF_DATASETS_OFFLINE = _orig_ds_offline
             if limit is not None:
                 ds = ds.select(range(min(limit, len(ds))))
+
+            # Disable automatic audio decoding so we can use soundfile instead
+            # of torchcodec (which requires CUDA libs unavailable on Ascend NPU).
+            if hasattr(ds, "cast_column"):
+                ds = ds.cast_column(audio_col, Audio(decode=False))
 
             print(f"  {len(ds)} samples to evaluate")
 
@@ -260,13 +249,18 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
 
             for batch_start in range(0, len(ds), batch_size):
                 batch = ds.select(range(batch_start, min(batch_start + batch_size, len(ds))))
-                audio_items = [
-                    {
-                        "audio_array": sample[audio_col]["array"],
-                        "sample_rate": sample[audio_col]["sampling_rate"],
-                    }
-                    for sample in batch
-                ]
+                audio_items = []
+                for sample in batch:
+                    raw = sample[audio_col]
+                    if isinstance(raw, dict) and "bytes" in raw and raw["bytes"] is not None:
+                        audio_array, sample_rate = sf.read(io.BytesIO(raw["bytes"]))
+                    elif isinstance(raw, dict) and "path" in raw and raw["path"] is not None:
+                        audio_array, sample_rate = sf.read(raw["path"])
+                    else:
+                        # Already decoded (e.g. MsDataset with native decoding)
+                        audio_array = raw["array"]
+                        sample_rate = raw["sampling_rate"]
+                    audio_items.append({"audio_array": audio_array, "sample_rate": sample_rate})
                 references = [sample[text_col] for sample in batch]
 
                 hypotheses = transcribe_batch(client, model_name, audio_items, language)
@@ -287,7 +281,9 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
                 if metric["name"] != "wer":
                     continue
                 ground_truth = metric["value"]
-                task_success = bool(np.isclose(ground_truth, measured_wer, rtol=RTOL))
+                # Pass if measured WER is at or below the threshold (better is OK);
+                # allow up to RTOL relative degradation above the threshold.
+                task_success = measured_wer <= ground_truth * (1 + RTOL)
                 success = success and task_success
 
                 status = "✅" if task_success else "❌"

--- a/tests/e2e/models/test_asr_eval_correctness.py
+++ b/tests/e2e/models/test_asr_eval_correctness.py
@@ -1,23 +1,20 @@
 import io
 import os
+import string
 from dataclasses import dataclass
 
-import string
-
-import jiwer
+import jiwer  # type: ignore[import-untyped]
 import numpy as np
 import pytest
-import scipy.io.wavfile as wav_io
-import soundfile as sf
+import scipy.io.wavfile as wav_io  # type: ignore[import-untyped]
+import soundfile as sf  # type: ignore[import-untyped]
 import yaml
 from datasets import Audio
-from modelscope.msdatasets import MsDataset
-import huggingface_hub.constants as hf_constants
-import datasets.config as ds_config
 from jinja2 import Environment, FileSystemLoader
+from modelscope.msdatasets import MsDataset  # type: ignore[import-untyped]
+from vllm.utils.network_utils import get_open_port
 
 from tests.e2e.conftest import RemoteOpenAIServer
-from vllm.utils.network_utils import get_open_port
 
 # Allow up to 10% relative deviation from the declared ground-truth WER.
 # ASR results have higher variance than classification tasks, so we use a
@@ -165,6 +162,7 @@ def generate_asr_report(
         rows=report_data["rows"],
         parallel_mode=parallel_mode,
         execution_model=execution_model,
+        show_command=False,
     )
 
     report_path = os.path.join(report_dir, f"{os.path.basename(eval_config['model_name'])}.md")
@@ -218,21 +216,11 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
 
             split_expr = f"{split}[:{limit}]" if limit is not None else split
             print(f"\nLoading dataset via modelscope: {dataset_name} / {dataset_config_name} ({split_expr})")
-            # MsDataset accesses ModelScope (not HuggingFace), but datasets/huggingface_hub
-            # cache HF_HUB_OFFLINE at import time and block all HTTP. Patch temporarily.
-            _orig_hf_offline = hf_constants.HF_HUB_OFFLINE
-            _orig_ds_offline = ds_config.HF_DATASETS_OFFLINE
-            hf_constants.HF_HUB_OFFLINE = False
-            ds_config.HF_DATASETS_OFFLINE = False
-            try:
-                ds = MsDataset.load(
-                    dataset_name,
-                    subset_name=dataset_config_name,
-                    split=split_expr,
-                )
-            finally:
-                hf_constants.HF_HUB_OFFLINE = _orig_hf_offline
-                ds_config.HF_DATASETS_OFFLINE = _orig_ds_offline
+            ds = MsDataset.load(
+                dataset_name,
+                subset_name=dataset_config_name,
+                split=split_expr,
+            )
             if limit is not None:
                 ds = ds.select(range(min(limit, len(ds))))
 
@@ -287,10 +275,7 @@ def test_asr_eval_param(config_filename, tp_size, report_dir, env_config):
                 success = success and task_success
 
                 status = "✅" if task_success else "❌"
-                print(
-                    f"{task_name} | wer: ground_truth={ground_truth} | "
-                    f"measured={measured_wer} | {status}"
-                )
+                print(f"{task_name} | wer: ground_truth={ground_truth} | measured={measured_wer} | {status}")
 
                 report_data["rows"].append(
                     {

--- a/tests/e2e/models/test_lm_eval_correctness.py
+++ b/tests/e2e/models/test_lm_eval_correctness.py
@@ -36,9 +36,10 @@ def env_config() -> EnvConfig:
 
 
 def build_model_args(eval_config, tp_size):
-    trust_remote_code = eval_config.get("trust_remote_code", False)
-    max_model_len = eval_config.get("max_model_len", 4096)
-    dtype = eval_config.get("dtype", "auto")
+    serve_cfg = eval_config.get("serve", {})
+    trust_remote_code = serve_cfg.get("trust_remote_code", False)
+    max_model_len = serve_cfg.get("max_model_len", 4096)
+    dtype = serve_cfg.get("dtype", "auto")
     model_args = {
         "pretrained": eval_config["model_name"],
         "tensor_parallel_size": tp_size,
@@ -55,7 +56,7 @@ def build_model_args(eval_config, tp_size):
         "enable_thinking",
         "quantization",
     ]:
-        val = eval_config.get(s, None)
+        val = serve_cfg.get(s, None)
         if val is not None:
             model_args[s] = val
 
@@ -87,7 +88,7 @@ def generate_report(tp_size, eval_config, report_data, report_dir, env_config):
         hardware=eval_config.get("hardware", "unknown"),
         model_name=eval_config["model_name"],
         model_args=f"'{','.join(f'{k}={v}' for k, v in model_args.items())}'",
-        model_type=eval_config.get("model", "vllm"),
+        model_type=eval_config.get("model_type", "vllm"),
         datasets=",".join([task["name"] for task in eval_config["tasks"]]),
         apply_chat_template=eval_config.get("apply_chat_template", True),
         fewshot_as_multiturn=eval_config.get("fewshot_as_multiturn", True),
@@ -108,12 +109,15 @@ def generate_report(tp_size, eval_config, report_data, report_dir, env_config):
 def test_lm_eval_correctness_param(config_filename, tp_size, report_dir, env_config):
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
 
+    if eval_config.get("model_type", "vllm") == "vllm-asr":
+        pytest.skip("Skipping ASR config, use test_asr_eval.py instead")
+
     model_args = build_model_args(eval_config, tp_size)
     success = True
     report_data: dict[str, list[dict]] = {"rows": []}
 
     eval_params = {
-        "model": eval_config.get("model", "vllm"),
+        "model": eval_config.get("model_type", "vllm"),
         "model_args": model_args,
         "tasks": [task["name"] for task in eval_config["tasks"]],
         "apply_chat_template": eval_config.get("apply_chat_template", True),

--- a/tests/e2e/models/test_lm_eval_correctness.py
+++ b/tests/e2e/models/test_lm_eval_correctness.py
@@ -107,6 +107,7 @@ def generate_report(tp_size, eval_config, report_data, report_dir, env_config):
 
 def test_lm_eval_correctness_param(config_filename, tp_size, report_dir, env_config):
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
+
     model_args = build_model_args(eval_config, tp_size)
     success = True
     report_data: dict[str, list[dict]] = {"rows": []}


### PR DESCRIPTION
### What this PR does / why we need it?

Adds an end-to-end accuracy evaluation framework for ASR (Automatic Speech Recognition) models on Ascend NPU, along with a configuration for Qwen3-ASR-1.7B.


- **New test file** `tests/e2e/models/test_asr_eval_correctness.py`: A pytest-based ASR accuracy evaluator that:
  - Starts a `vllm serve` instance via `RemoteOpenAIServer`
  - Transcribes audio samples using the `/v1/audio/transcriptions` API
  - Normalises transcriptions with Whisper's `EnglishTextNormalizer`
  - Computes WER with `jiwer` and validates against ground-truth thresholds (10% relative tolerance)
  - Generates a Markdown accuracy report using the shared `report_template.md`

- **CI integration** `.github/workflows/_e2e_nightly_single_node_models.yaml`: Wired the new ASR test into the nightly single-node pipeline.

- **Unified YAML format**: Standardised `hardware`, `serve`, `tasks`, `limit`, `batch_size` fields across all existing accuracy test configs for consistency.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5af684c31912232e5c89484c2e8259e0fac6c55b
