### PR TITLE
[Feature] Fixed eagle's acceptance rate problem in graph mode for model_runner_v2

### DIFF
--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -69,13 +69,17 @@ def test_qwen3_dense_eager_mode(
 @pytest.mark.parametrize("model", MAIN_MODELS)
 @pytest.mark.parametrize("eagle_model", EGALE_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
-@pytest.mark.parametrize("enforce_eager", [True])
+@pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize(
+    "compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]}, {}]
+)
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 def test_egale_spec_decoding(
     model: str,
     eagle_model: str,
     max_tokens: int,
     enforce_eager: bool,
+    compilation_config: dict,
 ) -> None:
     prompts = [
         "Hello, my name is",
@@ -95,6 +99,7 @@ def test_egale_spec_decoding(
             "method": "eagle",
             "num_speculative_tokens": 3,
         },
+        compilation_config=compilation_config,
     ) as runner:
         runner.model.generate(prompts, sampling_params)
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -147,6 +147,7 @@ def set_ascend_forward_context(
         forward_context.prefetch_mlp_down_proj = False
         forward_context.model_instance = model_instance
         forward_context.is_draft_model = is_draft_model
+        forward_context.is_draft_model_prefill = False
 
         if num_tokens is None and attn_metadata is not None:
             num_tokens = attn_metadata.num_actual_tokens
@@ -317,6 +318,7 @@ class _ExtraForwardContextProxy:
         "num_tokens_across_dp",
         "mc2_mask",
         "is_draft_model",
+        "is_draft_model_prefill",
         "prefetch_mlp_gate_up_proj",
         "prefetch_mlp_down_proj",
         "model_instance",

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -50,6 +50,7 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
+    get_draft_graph_prefill_params,
     get_graph_params,
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
@@ -406,7 +407,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         if using_paged_attention(num_tokens, vllm_config):
             # Paged Attention update logic
             if _EXTRA_CTX.is_draft_model:
-                graph_params = get_draft_graph_params()
+                if _EXTRA_CTX.is_draft_model_prefill:
+                    graph_params = get_draft_graph_prefill_params()
+                else:
+                    graph_params = get_draft_graph_params()
             else:
                 graph_params = get_graph_params()
             with torch.npu.stream(update_stream):
@@ -458,7 +462,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         else:
             # FIA update logic
             if _EXTRA_CTX.is_draft_model:
-                graph_params = get_draft_graph_params()
+                if _EXTRA_CTX.is_draft_model_prefill:
+                    graph_params = get_draft_graph_prefill_params()
+                else:
+                    graph_params = get_draft_graph_params()
                 attn_metadata = draft_attn_metadatas
                 attn_keys = list(attn_metadata[0].keys())
             else:
@@ -554,7 +561,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
         if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
+            else:
+                graph_params = get_draft_graph_params()
         else:
             graph_params = get_graph_params()
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -39,7 +39,12 @@ from vllm_ascend.attention.context_parallel.common_cp import (
     _update_out_and_lse,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
-from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, update_graph_params_workspaces
+from vllm_ascend.compilation.acl_graph import (
+    get_draft_graph_params,
+    get_draft_graph_prefill_params,
+    get_graph_params,
+    update_graph_params_workspaces,
+)
 from vllm_ascend.utils import weak_ref_tensors
 
 MAX_O_PROJ_PREFETCH_SIZE = 16 * 1024 * 1024
@@ -298,7 +303,10 @@ class AscendMlaCPImpl(AscendMLAImpl):
         draft_attn_metadatas=None,
     ):
         if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
+            else:
+                graph_params = get_draft_graph_params()
             attn_metadata = draft_attn_metadatas
             attn_keys = list(attn_metadata[0].keys())
         else:
@@ -693,7 +701,10 @@ class AscendMlaCPImpl(AscendMLAImpl):
         }
 
         if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
+            else:
+                graph_params = get_draft_graph_params()
         else:
             graph_params = get_graph_params()
         if _EXTRA_CTX.capturing:

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -36,6 +36,7 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.compilation.acl_graph import (
     get_draft_graph_params,
+    get_draft_graph_prefill_params,
     get_graph_params,
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
@@ -780,7 +781,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         draft_attn_metadatas=None,
     ):
         if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
+            else:
+                graph_params = get_draft_graph_params()
             attn_metadata = draft_attn_metadatas
             attn_keys = list(attn_metadata[0].keys())
         else:
@@ -1456,7 +1460,10 @@ class AscendMLAImpl(MLAAttentionImpl):
             }
             common_kwargs.update(extra_fa_args)
         if _EXTRA_CTX.is_draft_model:
-            graph_params = get_draft_graph_params()
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
+            else:
+                graph_params = get_draft_graph_params()
         else:
             graph_params = get_graph_params()
         if _EXTRA_CTX.capturing:

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -165,8 +165,10 @@ class ACLGraphWrapper:
             # to save memory
             global _graph_params
             global _draft_graph_params
+            global _draft_graph_prefill_params
             weak_ref_workspaces(_graph_params)
             weak_ref_workspaces(_draft_graph_params)
+            weak_ref_workspaces(_draft_graph_prefill_params)
 
             # here we always use weak ref for the output
             # to save memory
@@ -291,3 +293,28 @@ def update_draft_graph_params_workspaces(num_tokens: int, workspace: Any):
 
 def get_draft_graph_params():
     return _draft_graph_params
+
+
+_draft_graph_prefill_params: GraphParams | None = None
+
+
+def set_draft_graph_prefill_params(aclgraph_capture_sizes: list[int]):
+    global _draft_graph_prefill_params
+    if _draft_graph_prefill_params is not None:
+        raise ValueError("DraftGraph preill parameters have already been set!")
+    _draft_graph_prefill_params = GraphParams(
+        {size: [] for size in aclgraph_capture_sizes},
+        {size: None for size in aclgraph_capture_sizes},
+        {size: [] for size in aclgraph_capture_sizes},
+        {size: [] for size in aclgraph_capture_sizes},
+    )
+
+
+def update_draft_graph_prefill_params_workspaces(num_tokens: int, workspace: Any):
+    global _draft_graph_prefill_params
+    if _draft_graph_prefill_params is not None:
+        _draft_graph_prefill_params.workspaces[num_tokens] = workspace
+
+
+def get_draft_graph_prefill_params():
+    return _draft_graph_prefill_params

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -699,6 +699,9 @@ class NPUPlatform(Platform):
 
         # is_draft_model will be removed later, so we set it to False temporarily.
         is_draft_model = False
+        # v2 has 2 graphs in eager, one for prefill, the other for decodes, this flag is aimed to distinguish them.
+        is_draft_model_prefill = False
+
         in_profile_run = get_mrv2_in_profile_run()
         moe_comm_type = select_moe_comm_method(
             num_tokens,
@@ -769,6 +772,7 @@ class NPUPlatform(Platform):
             "max_tokens_across_dp": max_tokens_across_dp,
             "mc2_mask": mc2_mask,
             "is_draft_model": is_draft_model,
+            "is_draft_model_prefill": is_draft_model_prefill,
             "in_profile_run": in_profile_run,
             "padded_num_tokens": padded_num_tokens,
         }

--- a/vllm_ascend/worker/v2/README.md
+++ b/vllm_ascend/worker/v2/README.md
@@ -25,8 +25,15 @@ to get specific plans.
 
     Location: `utils.torch_cuda_wrapper`, `utils.torch_npu_graph_wrapper`.
 
-- [ ] `graph_manager_wrapper`
+- [ ] `model_runner.graph_manager_wrapper`
 
     Why: ModelAclGraphManager needs model_runner's input_buffers and model_state.attn_metadata to update_full_graph_params, so model_runner should be passed into __init__ of ModelAclGraphManager.
 
     Location: `model_runner.NPUModelRunner.initialize_kv_cache`.
+
+- [ ] `speculator.graph_manager_wrapper`
+
+    Why: EagleAclGraphManager needs speculator's input_buffers and model_state.attn_metadata to update_full_graph_params, so speculator should be passed into __init
+    __ of EagleAclGraphManager.
+
+    Location: `speculator.AscendEagleSpeculator.init_cudagraph_manager`.

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -132,14 +132,27 @@ class ModelWithContext(nn.Module):
     so we can inherit vllm's CudaGraphManager._capture_full_graph.
     """
 
-    def __init__(self, original_model):
+    def __init__(self, original_model, is_draft_model=False, is_draft_model_prefill=False):
         super().__init__()
         self.original_model = original_model
+        self.is_draft_model = is_draft_model
+        self.is_draft_model_prefill = is_draft_model_prefill
 
     def forward(self, *args, **kwargs):
         # In warmup phase, capturing=False by default.
         # when capturing, we need to set capturing=True in forward context.
         if torch.npu.is_current_stream_capturing():
             _EXTRA_CTX.capturing = True
+        if self.is_draft_model:
+            _EXTRA_CTX.is_draft_model = True
+        if self.is_draft_model_prefill:
+            _EXTRA_CTX.is_draft_model_prefill = True
 
         return self.original_model(*args, **kwargs)
+
+    def get_original_model(self):
+        return self.original_model
+
+    def compute_logits(self, hidden_states: torch.Tensor):
+        # draft model has `compute_logits`, which is not in ModelWithContext
+        return self.original_model.compute_logits(hidden_states)

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.forward_context import get_forward_context, set_forward_context
+from vllm.logger import logger
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.input_batch import InputBuffers
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
+from vllm.v1.worker.utils import AttentionGroup
+
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.compilation.acl_graph import (
+    set_draft_graph_params,
+    set_draft_graph_prefill_params,
+    update_full_graph_params,
+)
+from vllm_ascend.worker.v2.aclgraph_utils import ModelWithContext
+from vllm_ascend.worker.v2.utils import communicator_switch
+
+
+class EagleAclGraphManager(EagleCudaGraphManager):
+    """AclGraphManager for Eagle speculative decoding."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        cudagraph_mode: CUDAGraphMode,
+        decode_query_len: int,
+        speculator: Any,
+    ):
+        super().__init__(vllm_config, device, cudagraph_mode, decode_query_len)
+
+        # set speculator attribute, so we can access attributes speculator
+        # when call `run_fullgraph` method in CudaGraphManager,
+        # then we don't need to # copy `propose` method in `AscendEagleSpeculator` class.
+        self.speculator = speculator
+        # capture_sizes sorts in ascending order.
+        self.capture_sizes = sorted(self.compilation_config.cudagraph_capture_sizes)
+        # vllm-ascend need to update draft graph params of attention backend.
+        # so we need to set draft graph params before capture full graph.
+        # `prefill` graph and `decodes` graph are different, `decode_query_len` can be used to distinguish them
+        self.is_draft_model_prefill = decode_query_len > 1
+        if super().needs_capture():
+            if self.is_draft_model_prefill:
+                set_draft_graph_prefill_params(self.capture_sizes)
+            else:
+                set_draft_graph_params(self.capture_sizes)
+
+    def capture(
+        self,
+        forward_fn: Callable,
+        model_state: ModelState,
+        input_buffers: InputBuffers,
+        block_tables: BlockTables,
+        attn_groups: list[list[AttentionGroup]],
+        kv_cache_config: KVCacheConfig,
+        progress_bar_desc: str = "Capturing CUDA graphs",
+    ) -> None:
+        """Capture ACL graphs for Eagle."""
+        with communicator_switch(), model_capture_wrapper(self.speculator, self.is_draft_model_prefill):
+            super().capture(
+                forward_fn,
+                model_state,
+                input_buffers,
+                block_tables,
+                attn_groups,
+                kv_cache_config,
+                progress_bar_desc,
+            )
+
+    def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+        """Override run_fullgraph to update full graph params in run_fullgraph."""
+        num_tokens = desc.num_tokens
+        if self.is_draft_model_prefill:
+            logger.info_once(f"draft prefill run_fullgraph with num_tokens={num_tokens}")
+        else:
+            logger.info_once(f"draft run_fullgraph with num_tokens={num_tokens}")
+
+        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
+
+        ret = super().run_fullgraph(desc)
+
+        positions = self.speculator.input_buffers.positions[:num_tokens]
+        # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
+        # calculate num_tokens_across_dp.
+        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens, device=self.device)
+        with set_forward_context(
+            self.speculator.model_state.attn_metadata,
+            self.vllm_config,
+            num_tokens=num_tokens,
+            cudagraph_runtime_mode=desc.cg_mode,
+            num_tokens_across_dp=num_tokens_across_dp,
+            batch_descriptor=None,  # Full graph model don't need batch_descriptor
+            slot_mapping=None,
+        ):
+            # decide to update draft graph params
+            _EXTRA_CTX.is_draft_model = True
+
+            # decide to run `prefill` graph or `decodes` graph
+            _EXTRA_CTX.is_draft_model_prefill = self.is_draft_model_prefill
+
+            forward_context = get_forward_context()
+            update_full_graph_params(
+                # FIXME(Ronald1995): support hybrid attn backend
+                list(self.speculator.attn_backends.values())[0],
+                self.speculator.update_stream,
+                forward_context,
+                num_tokens,
+                self.vllm_config,
+                self.speculator.speculative_config,
+                positions.shape[0],
+                draft_attn_metadatas=draft_attn_metadatas,
+            )
+        return ret
+
+
+@contextmanager
+def model_capture_wrapper(speculator, is_draft_model_prefill):
+    """Context manager to override speculator's model for speculator capturing."""
+    try:
+        speculator.model = ModelWithContext(speculator.model, True, is_draft_model_prefill)
+        yield
+    finally:
+        speculator.model = speculator.model.get_original_model()

--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -17,17 +17,27 @@
 # This file is a part of the vllm-ascend project.
 #
 from contextlib import contextmanager
-from typing import Any
+from copy import copy
+from typing import Any, cast
 
 import torch
 import vllm
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.attn_utils import AttentionBackend
+from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.spec_decode.eagle import speculator as vllm_speculator
+from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator, gumbel_sample, update_eagle_inputs
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
+from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
+from vllm_ascend.worker.v2.spec_decode.eagle.aclgraph import EagleAclGraphManager
 
 
 class AscendEagleSpeculator(EagleSpeculator):
@@ -37,9 +47,36 @@ class AscendEagleSpeculator(EagleSpeculator):
         such as seq_lens_cpu from input_batch, so we need to override __init__.
         """
         super().__init__(vllm_config, device)
+
+        del self.input_buffers
+        # AscendInputBuffers has extra `seq_lens_cpu` attribute.
+        # so reinitialize input_buffers here.
+        self.input_buffers: AscendInputBuffers = AscendInputBuffers(
+            max_num_reqs=self.max_num_reqs,
+            max_num_tokens=self.max_num_tokens,
+            device=device,
+        )
+
+        # add more attributes for `input_buffers` in graph mode
+        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
+        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+            self.input_buffers.draft_seq_lens_cpus = [
+                torch.zeros(self.max_num_reqs, dtype=torch.int32, device="cpu")
+                for _ in range(self.num_speculative_steps - 1)
+            ]
+
+        # we need to update full graph params in run_fullgraph,
+        # so create a stream to update full graph params.
+        if cudagraph_mode.has_full_cudagraphs():
+            self.update_stream: torch.npu.Stream = torch.npu.Stream()
+
         # when in decode phase of eagle speculator, we need some value in
-        # main model's input_batch. so we keep a reference here.
+        # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
+
+    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        with graph_manager_wrapper(self):
+            super().init_cudagraph_manager(cudagraph_mode)
 
     def propose(
         self,
@@ -96,6 +133,32 @@ class AscendEagleSpeculator(EagleSpeculator):
                 is_profile=is_profile,
             )
 
+    def set_attn(
+        self,
+        model_state: ModelState,
+        kv_cache_config: KVCacheConfig,
+        block_tables: BlockTables,
+    ) -> None:
+        super().set_attn(model_state, kv_cache_config, block_tables)
+
+        # npu needs attn_backends to update graph params
+        attn_backends: dict[str, type[AttentionBackend]] = {}
+
+        active_layer_names = self.draft_attn_layer_names
+        for kv_cache_group_id, kv_cache_group_spec in enumerate(kv_cache_config.kv_cache_groups):
+            layer_names = kv_cache_group_spec.layer_names
+            if active_layer_names is not None:
+                layer_names = list(active_layer_names.intersection(layer_names))
+
+            layer_type = cast(type[Any], AttentionLayerBase)
+            attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type, layer_names)
+
+            for layer_name in layer_names:
+                attn_backend = attn_layers[layer_name].get_attn_backend()
+                attn_backends[layer_name] = attn_backend
+
+        self.attn_backends = attn_backends
+
     def generate_draft(
         self,
         num_reqs: int,
@@ -109,7 +172,8 @@ class AscendEagleSpeculator(EagleSpeculator):
         attn_metadata is created in super propose method, it does not have some
         attribute that Ascend attention backend needs, so we update it.
         """
-        self._update_decode_attn_metadata(attn_metadata, num_reqs)
+        self._init_decode_attn_metadata(attn_metadata, num_reqs)
+        self._increment_decode_attn_metadata(attn_metadata)
 
         # NOTE(drslark): following lines (from 145 to 184) come from raw gpu's generate_draft logic
         pos = self.input_buffers.positions[:num_reqs]
@@ -154,7 +218,7 @@ class AscendEagleSpeculator(EagleSpeculator):
                     self.block_tables.compute_slot_mappings(idx_mapping, query_start_loc, pos, num_tokens_padded)
 
                     # npu's own update logic
-                    self._update_decode_attn_metadata(attn_metadata, num_reqs)
+                    self._increment_decode_attn_metadata(attn_metadata)
 
     @torch.inference_mode()
     def run_model(
@@ -187,28 +251,93 @@ class AscendEagleSpeculator(EagleSpeculator):
                 attn_meta.seq_len_list = attn_meta.seq_lens.tolist()
         return last_hidden_states, hidden_states
 
-    def _update_decode_attn_metadata(self, attn_metadata: dict[str, Any], num_reqs: int):
-        """Update attention metadata for decode phase on Ascend NPUs."""
+    def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
+        """Build draft_attn_metadatas for partial-merged draft graph."""
+        attn_metadata = self.model_state.attn_metadata
+        attn_metadata = {
+            name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names
+        }
+
+        if is_draft_model_prefill:
+            return [attn_metadata]
+
+        draft_attn_metadatas = self._init_decode_draft_attn_metadatas(attn_metadata, num_reqs_padded)
+
+        for i, per_step_attn_metadata in enumerate(draft_attn_metadatas):
+            step = i + 1
+            assert self.input_batch is not None
+            self._update_decode_attn_metadata(per_step_attn_metadata, step, self.input_batch.num_reqs)
+
+        return draft_attn_metadatas
+
+    def _init_decode_attn_metadata(self, attn_metadata: dict[str, Any], num_reqs: int):
+        """Initialize attention metadata for decode phase on Ascend NPUs."""
         if attn_metadata is None:
             return
 
         attn_state = AscendAttentionState.DecodeOnly
-        seq_lens_cpu = self._get_seq_lens_cpu()
+        seq_lens_cpu = self._get_seq_lens_cpu()[:num_reqs]
 
-        # NOTE(drslark) to achieve fully alignment with vllm, `num_rejected` should be subtracted from `seq_lens`
-        # to avoid extra sync overhead, `v2` is currently aligned with NPU `v1` only
-
-        # follows the logic in `prepare_eagle_decode` and `update_eagle_inputs`
-        seq_lens_cpu[:num_reqs] = torch.clamp(seq_lens_cpu[:num_reqs] + 1, max=self.max_model_len)
-        seq_lens_cpu[num_reqs:].fill_(0)
-
-        seq_lens_list = seq_lens_cpu.tolist()
         # attn_metadata is build in vllm's super class.
         # We need to update attn_state for each layer's metadata.
         for metadata in attn_metadata.values():
             metadata.attn_state = attn_state
             metadata.seq_lens_cpu = seq_lens_cpu
+
+    def _init_decode_draft_attn_metadatas(self, attn_metadata: dict[str, Any], num_reqs_padded: int):
+        """Initialize attention metadata for decode phase in graph mode on Ascend NPUs."""
+        if attn_metadata is None:
+            return
+
+        attn_state = AscendAttentionState.DecodeOnly
+
+        draft_attn_metadatas = []
+        # attn_metadata is build in vllm's super class.
+        # We need to update attn_state for each layer's metadata.
+        for seq_lens_cpu in self.input_buffers.draft_seq_lens_cpus:
+            per_step_attn_metadata = {k: copy(v) for k, v in attn_metadata.items()}
+
+            seq_lens_cpu = seq_lens_cpu[:num_reqs_padded]
+            for metadata in per_step_attn_metadata.values():
+                metadata.attn_state = attn_state
+                metadata.seq_lens_cpu = seq_lens_cpu
+            draft_attn_metadatas.append(per_step_attn_metadata)
+
+        return draft_attn_metadatas
+
+    def _increment_decode_attn_metadata(self, attn_metadata: dict[str, Any]):
+        """Increment attention metadata for decode phase on Ascend NPUs."""
+        # in eager mode, attn_metadata's seq_lens_cpu and input_buffers's seq_lens_cpu shares the memory
+        self._update_decode_attn_metadata(attn_metadata, 1)
+
+    def _update_decode_attn_metadata(self, attn_metadata: dict[str, Any], step: int, num_reqs: int | None = None):
+        """Update attention metadata for decode phase on Ascend NPUs."""
+        if attn_metadata is None:
+            return
+
+        num_reqs_padded = next(iter(attn_metadata.values())).seq_lens_cpu.shape[0]
+        seq_lens_cpu = self._get_seq_lens_cpu()[:num_reqs_padded]
+        if num_reqs is None:
+            num_reqs = num_reqs_padded
+        next_seq_lens_cpu = self._calc_next_seq_lens_cpu(seq_lens_cpu, num_reqs, num_reqs_padded, step)
+
+        query_lens_list = [i for i in range(1, num_reqs_padded + 1)]
+        seq_lens_list = next_seq_lens_cpu.tolist()
+        # attn_metadata is build in vllm's super class.
+        # We need to update attn_state for each layer's metadata.
+        for metadata in attn_metadata.values():
+            metadata.actual_seq_lengths_q = query_lens_list
+            metadata.seq_lens_cpu.copy_(next_seq_lens_cpu)
             metadata.seq_lens_list = seq_lens_list
+
+    def _calc_next_seq_lens_cpu(self, seq_lens_cpu, num_reqs, num_reqs_padded, step):
+        # NOTE(drslark) to achieve fully alignment with vllm, `num_rejected` should be subtracted from `seq_lens`
+        # to avoid extra sync overhead, `v2` is currently aligned with NPU `v1` only
+
+        # follows the logic in `prepare_eagle_decode` and `update_eagle_inputs`
+        next_seqs_cpu = torch.clamp(seq_lens_cpu[:num_reqs_padded] + step, max=self.max_model_len)
+        next_seqs_cpu[num_reqs:].fill_(0)
+        return next_seqs_cpu
 
     def _get_seq_lens_cpu(self) -> torch.Tensor:
         """Get seq_lens_cpu from input_batch."""
@@ -251,3 +380,18 @@ def torch_gather_wrapper():
         yield
     finally:
         torch.gather = original_gather
+
+
+@contextmanager
+def graph_manager_wrapper(speculator):
+    """Context manager to override graph manager."""
+    original_graph_manager = EagleCudaGraphManager
+
+    def factory(vllm_config: VllmConfig, device: torch.device, cudagraph_mode: CUDAGraphMode, decode_query_len: int):
+        return EagleAclGraphManager(vllm_config, device, cudagraph_mode, decode_query_len, speculator)
+
+    try:
+        vllm_speculator.EagleCudaGraphManager = factory
+        yield
+    finally:
+        vllm_speculator.EagleCudaGraphManager = original_graph_manager


### PR DESCRIPTION
### What this PR does / why we need it?

Enable eagle's graph mode for model_runner_v2.

* Make decodes of speculator be correctly captured.
* Make prefill of speculator be correctly captured.
* Make graph params of decodes be correctly updated.
* Add one more group graph params.
* Add a new flag to determine if in draft's prefill graph.
  If `is_draft_model` and `is_draft_model_prefill`, then it is in draft's prefill graph, otherwise, it is in draft's decodes graph or v1's merged graph.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

For prompts:

```text
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
```

`eager` mode's output:

```text
--------------------------------------------------
total_num_output_tokens: 800
num_drafts: 461
num_draft_tokens: 1383
num_accepted_tokens: 338
mean acceptance length: 1.73
--------------------------------------------------
acceptance at token 0: 0.39
acceptance at token 1: 0.21
acceptance at token 2: 0.13
acceptance at token 3: 0.00
acceptance at token 4: 0.00
acceptance at token 5: 0.00
```

`FULL_DECODE_ONLY` mode's output:

```text
--------------------------------------------------
total_num_output_tokens: 800
num_drafts: 463
num_draft_tokens: 1389
num_accepted_tokens: 336
mean acceptance length: 1.73
--------------------------------------------------
acceptance at token 0: 0.39
acceptance at token 1: 0.21
acceptance at token 2: 0.13
acceptance at token 3: 0.00
acceptance at token 4: 0.00
acceptance at token 5: 0.00
```

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
