### PR TITLE
[Doc][Bugfix] Fix po_translate script to preserve proper nouns (names)

### DIFF
--- a/.github/workflows/scripts/po_translate.py
+++ b/.github/workflows/scripts/po_translate.py
@@ -43,6 +43,7 @@ Rules:
 6. Use standard Chinese technical terminology
 7. For difficult parts, keep original English
 8. Remove "#, fuzzy" markers
+9. Do NOT translate proper nouns: person names, contributor names, author names must be kept as-is in msgstr
 
 Return ONLY the complete PO file content, no extra explanations.
 


### PR DESCRIPTION
### What this PR does / why we need it?
Add rule to po_translate.py to prevent translation of proper nouns (person names, contributor names, author names must be kept as-is in msgstr)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5af684c31912232e5c89484c2e8259e0fac6c55b
