### PR TITLE
[BugFix][Ascend950]  fix w8a8mxfp8 for moe

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -19,9 +19,9 @@ import torch
 import torch_npu
 
 from vllm_ascend.device.mxfp_compat import (
-    FLOAT4_E2M1FN_X2_DTYPE,
     FLOAT8_E8M0FNU_DTYPE,
-    HIFLOAT8_DTYPE,
+    QUANT_DTYPES,
+    SCALE_DTYPES,
 )
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -333,8 +333,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             quant_mode=2,
             dequant_dtype=torch.float32,
             quant_dtype=act_quant_type,
-            x_dtype=act_quant_type,
-            weight_dtype=weight_quant_type,
+            x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
+            weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
             weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
             x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
         )
@@ -362,9 +362,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 use_mxfp_quant=False,
             )
 
-        quant_dtypes = tuple(dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
-        scale_dtypes = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
-
         output_dtype = (
             input_dtype
             if input_dtype in [torch.bfloat16, torch.float16]
@@ -372,10 +369,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
 
         return {
-            "scale_dtype": scale_type if scale_type in scale_dtypes else None,
-            "per_token_scale_dtype": per_token_scale_type if per_token_scale_type in scale_dtypes else None,
-            "x_dtype": act_quant_type if act_quant_type in quant_dtypes else None,
-            "weight_dtype": weight_quant_type if weight_quant_type in quant_dtypes else None,
+            "scale_dtype": scale_type if scale_type in SCALE_DTYPES else None,
+            "per_token_scale_dtype": per_token_scale_type if per_token_scale_type in SCALE_DTYPES else None,
+            "x_dtype": act_quant_type if act_quant_type in QUANT_DTYPES else None,
+            "weight_dtype": weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
             "output_dtype": output_dtype,
         }
 

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -9,9 +9,9 @@ FLOAT4_E2M1FN_X2_DTYPE = getattr(torch_npu, "float4_e2m1fn_x2", getattr(torch, "
 HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 
 
-# TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, float4_e2m1fn_x2)
-# have to be specified for some operators like GMM in Ascend950, while float8_e4m3fn does not.
-# Remove these filterations when operators allow to pass data with these three dtypes directly.
+# TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, hifloat8) have to be
+# specified for some operators like GMM in Ascend950, while float8_e4m3fn does not. Remove these
+# filterations when operators allow to pass data with these three dtypes directly.
 QUANT_DTYPES = tuple(dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
 SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
 

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -9,6 +9,13 @@ FLOAT4_E2M1FN_X2_DTYPE = getattr(torch_npu, "float4_e2m1fn_x2", getattr(torch, "
 HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 
 
+# TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, float4_e2m1fn_x2)
+# have to be specified for some operators like GMM in Ascend950, while float8_e4m3fn does not.
+# Remove these filterations when operators allow to pass data with these three dtypes directly.
+QUANT_DTYPES = tuple(dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
+SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
+
+
 def _get_missing_symbols(symbols: tuple[str, ...]) -> list[str]:
     return [symbol for symbol in symbols if not hasattr(torch_npu, symbol)]
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR refactors the handling of quantization and scale data types by centralizing their definitions in `mxfp_compat.py`. It updates `device_op.py` to use these shared constants, ensuring consistent filtering for operators on Ascend950. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with existing tests.