### PR TITLE
[BugFix][Ops] Sync compatibility with CANN ops and fused_moe

### DIFF
--- a/csrc/add_rms_norm_bias/add_rms_norm_bias_torch_adpt.h
+++ b/csrc/add_rms_norm_bias/add_rms_norm_bias_torch_adpt.h
@@ -48,7 +48,7 @@ std::tuple<at::Tensor,at::Tensor, at::Tensor> npu_add_rms_norm_bias(
     at::Tensor x = at::empty(x1.sizes(), x1.options());
     EXEC_NPU_CMD(aclnnAddRmsNorm, x1, x2, gamma, epsilon, y, rstd, x);
     if (beta.has_value()) {
-    	y = at::add(y, beta.value());
+        y.add_(beta.value());
     }
     return std::tuple<at::Tensor, at::Tensor, at::Tensor>(y, rstd, x);
 }

--- a/csrc/add_rms_norm_bias/add_rms_norm_bias_torch_adpt.h
+++ b/csrc/add_rms_norm_bias/add_rms_norm_bias_torch_adpt.h
@@ -46,7 +46,10 @@ std::tuple<at::Tensor,at::Tensor, at::Tensor> npu_add_rms_norm_bias(
     rstd = at::empty(new_shape, x1.options().dtype(at::kFloat));
     at::Tensor y = at::empty(x1.sizes(), x1.options());
     at::Tensor x = at::empty(x1.sizes(), x1.options());
-    EXEC_NPU_CMD(aclnnAddRmsNormBias, x1, x2, gamma, beta, epsilon, y, rstd, x);
+    EXEC_NPU_CMD(aclnnAddRmsNorm, x1, x2, gamma, epsilon, y, rstd, x);
+    if (beta.has_value()) {
+    	y = at::add(y, beta.value());
+    }
     return std::tuple<at::Tensor, at::Tensor, at::Tensor>(y, rstd, x);
 }
 }

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -21,15 +21,14 @@ from functools import wraps
 import torch
 import torch.nn.functional as F
 import torch_npu
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group, tensor_model_parallel_all_reduce
 from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
-from vllm.model_executor.layers.fused_moe.fused_moe_method_base import FusedMoEMethodBase  # type: ignore
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFusedMoEMethod, get_compressed_expert_map
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
-from vllm.model_executor.layers.fused_moe.router.fused_moe_router import FusedMoERouter  # type: ignore
 from vllm.model_executor.layers.fused_moe.runner.default_moe_runner import DefaultMoERunner  # type: ignore
 from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
 
@@ -50,6 +49,7 @@ from vllm_ascend.utils import (
     npu_stream_switch,
     shared_expert_dp_enabled,
     shared_experts_calculation_stream,
+    vllm_version_is,
 )
 
 
@@ -67,10 +67,22 @@ class FusedMoEEvents:
     before_combine: torch.npu.Event | None = field(default=None)
 
 
+def mock_false():
+    return False
+
+
+def mock_true():
+    return True
+
+
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     def __init__(self, moe: FusedMoEConfig = None):
         super().__init__(moe=moe)
         self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
+
+    @property
+    def is_monolithic(self) -> bool:
+        return False
 
     def process_weights_after_loading(self, layer):
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
@@ -210,68 +222,20 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
 # Please remove this inheritance after extending vllm, todo(wxs)
 class AscendMoERunner(DefaultMoERunner):
-    """
-    Default implementation of the MoE runner for executing Mixture of Experts layers.
-
-    This class provides a comprehensive implementation for running MoE computations
-    with support for:
-    - Expert routing and token dispatching
-    - Shared experts computation with optional parallel execution using CUDA streams
-    - Data parallel (DP) chunking for large batch processing
-    - Tensor model parallel and expert parallel operations
-    - Various quantization methods and custom operators
-    - Both monolithic and decomposed expert execution paths
-
-    The runner handles the complete MoE forward pass including routing tokens to
-    experts, executing expert computations, and combining results. It supports
-    advanced features like overlapped execution of shared experts and optimized
-    kernels for different parallel execution modes.
-
-    Eventually, this class will be split up and specialized for different
-    configurations, e.g. the presence or absence of shared experts, a gate, etc.
-    """
-
-    def __init__(
-        self,
-        layer: torch.nn.Module,
-        moe_config: FusedMoEConfig,
-        router: FusedMoERouter,
-        routed_input_transform: torch.nn.Module | None,
-        gate: torch.nn.Module | None,
-        shared_experts: torch.nn.Module | None,
-        quant_method: FusedMoEMethodBase,
-        reduce_results: bool,
-        enable_dbo: bool,
-    ):
-        super().__init__(
-            layer,
-            moe_config,
-            router,
-            routed_input_transform,
-            gate,
-            shared_experts,
-            quant_method,
-            reduce_results,
-            enable_dbo,
-        )
-        if self.shared_experts is None:
-            self.moe_forward = torch.ops.vllm.moe_forward
-        else:
-            self.moe_forward = torch.ops.vllm.moe_forward_shared
-
     @property
     def use_dp_chunking(self) -> bool:
         """Ascend uses its own forward_impl path, not the FlashInfer Cutlass
         chunked path. Always return False to stay on forward_impl."""
         return False
 
+    # TODO: Remove this after drop v0.19.0 support
     def forward_impl(
         self,
         layer: torch.nn.Module,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         shared_input: torch.Tensor | None,
-    ):
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """
         Override the default forward_impl to use Ascend-specific implementation.
         This delegates to the layer's forward_impl method which contains the
@@ -283,6 +247,21 @@ class AscendMoERunner(DefaultMoERunner):
         # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
         return result
 
+    def forward_dispatch(
+        self,
+        layer: torch.nn.Module,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        with self._sequence_parallel_context():
+            return self.forward_impl(
+                layer,
+                hidden_states,
+                router_logits,
+                shared_experts_input,
+            )
+
 
 class AscendFusedMoE(FusedMoE):
     moe_counter = -1
@@ -293,6 +272,7 @@ class AscendFusedMoE(FusedMoE):
 
         num_experts = kwargs["num_experts"]
         intermediate_size = kwargs["intermediate_size"]
+        num_shared_experts = kwargs.get("n_shared_experts", 0)
 
         AscendFusedMoE.moe_counter += 1
         self.moe_instance_id = AscendFusedMoE.moe_counter
@@ -325,8 +305,12 @@ class AscendFusedMoE(FusedMoE):
 
         # init moe
         eplb_config = ascend_config.eplb_config
+        self.mix_placement = getattr(ascend_config, "mix_placement", False)
+        self.n_shared_experts = num_shared_experts
+        num_experts += num_shared_experts if self.mix_placement else 0
+        self.moe_config.num_experts = num_experts
         self.global_expert_map, self._expert_map, self.log2phy, self.global_redundant_expert_num = init_eplb_config(
-            eplb_config, self.moe_instance_id, self.moe_config
+            eplb_config, self.moe_instance_id, self.moe_config, self.mix_placement, num_shared_experts
         )
         self.global_num_experts = num_experts + self.global_redundant_expert_num
         self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)
@@ -372,22 +356,18 @@ class AscendFusedMoE(FusedMoE):
 
         setup_moe_comm_method(self.moe_config)
         self.quant_type = self._get_quant_type()
-        self.runner = self._init_runner()
 
-    def _init_runner(self):
-        # Storing the runner in the FusedMoE is an intermediate state, eventually
-        # the runner will own the FusedMoE layer and provide the execution interface
-        # for MoE ops.
-        return AscendMoERunner(
-            layer=self,
-            moe_config=self.moe_config,
-            router=self.router,
-            routed_input_transform=self._routed_input_transform,
-            gate=self.gate,
-            shared_experts=self.shared_experts,
-            quant_method=self.quant_method,
-            reduce_results=self.reduce_results,
-            enable_dbo=self.vllm_config.parallel_config.enable_dbo,
+        is_legacy = vllm_version_is("0.19.0")
+        self.runner = AscendMoERunner(
+            self if is_legacy else self.layer_name,
+            self.moe_config,
+            self.router,
+            self._routed_input_transform,
+            self.gate if is_legacy else kwargs.pop("gate", None),
+            self.shared_experts if is_legacy else kwargs.pop("shared_experts", None),
+            self.quant_method,
+            self.reduce_results,
+            self.vllm_config.parallel_config.enable_dbo,
         )
 
     def _get_quant_type(self) -> QuantType:
@@ -575,24 +555,46 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         routed_input_transform: torch.nn.Module | None = None,
         **kwargs,
     ):
+        ascend_config = get_ascend_config()
+        # TODO: Enabling the mix placement in deepseek_v2.py
+        # remove this part after the mix placement merged into vllm
+        # https://github.com/vllm-project/vllm/pull/31256
+        if ascend_config.mix_placement:
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_false
+            rocm_aiter_ops.is_fused_moe_enabled = mock_false
         AscendFusedMoE.__init__(self, **kwargs)
+        if ascend_config.mix_placement:
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_true
+            rocm_aiter_ops.is_fused_moe_enabled = mock_true
 
         self._routed_input_transform = routed_input_transform
         self._shared_experts = shared_experts
         self.use_overlapped = use_overlapped
         self.shared_expert_stream = None
-        ascend_config = get_ascend_config()
-        self.multistream_overlap_shared_expert = (
-            ascend_config.multistream_overlap_shared_expert and self._shared_experts is not None
-        )
-        self.multistream_overlap_gate = ascend_config.multistream_overlap_gate and self._shared_experts is not None
+        has_shared_experts = shared_experts is not None
+        self.multistream_overlap_shared_expert = ascend_config.multistream_overlap_shared_expert and has_shared_experts
+        self.multistream_overlap_gate = ascend_config.multistream_overlap_gate and has_shared_experts
         if enable_sp():
             logger.info_once("Sequence parallelism is enabled, shared experts are replicated for best performance.")
 
         self._gate = gate
-        # Recreate the runner with the correct shared_experts parameter
-        # The parent class created the runner before self._shared_experts was set
-        self.runner = self._init_runner()
+        # Recreate the runner with the correct shared_experts parameter.
+        # The parent class created the runner before self._shared_experts was set.
+        # NOTE: must use self._shared_experts here, not self.shared_experts —
+        # FusedMoE.shared_experts is a property that reads self.runner.shared_experts,
+        # which at this point is still the stale runner built with shared_experts=None.
+        is_legacy = vllm_version_is("0.19.0")
+        self.runner = AscendMoERunner(
+            self if is_legacy else self.layer_name,
+            self.moe_config,
+            self.router,
+            self._routed_input_transform,
+            self.gate,
+            self._shared_experts,
+            self.quant_method,
+            self.reduce_results,
+            self.vllm_config.parallel_config.enable_dbo,
+        )
 
         if self.multistream_overlap_shared_expert:
             # Wrap the quant_method's process_weights_after_loading to validate that
@@ -610,16 +612,8 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
 
     def _shared_experts_part1(self, hidden_states: torch.Tensor):
-        if hasattr(self._shared_experts, "gate_up_proj"):
-            shared_proj, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
-        elif hasattr(self._shared_experts, "up_proj"):
-            shared_proj, _ = self._shared_experts.up_proj(hidden_states)
-        else:
-            raise AttributeError(
-                    f"{type(self._shared_experts)} has neither "
-                    "'gate_up_proj' nor 'up_proj'; cannot split shared expert computation."
-                )
-        return shared_proj
+        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
+        return shared_gate_up
 
     def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
         shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore
@@ -675,20 +669,16 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self._shared_experts is None:
-            fused_out = AscendFusedMoE.forward(
-                self,
-                hidden_states=hidden_states,
-                router_logits=router_logits,
-            )
-            shared_out = None
-            return shared_out, fused_out
-        shared_out, fused_out = AscendFusedMoE.forward(
+        result = AscendFusedMoE.forward(
             self,
             hidden_states=hidden_states,
             router_logits=router_logits,
         )
-        return shared_out, fused_out
+        # When shared experts are absent, the parent returns only fused_out;
+        # otherwise it returns a (shared_out, fused_out) tuple.
+        if self._shared_experts is None:
+            return None, result
+        return result
 
     def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
         if self._shared_experts is None:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -612,8 +612,16 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
 
     def _shared_experts_part1(self, hidden_states: torch.Tensor):
-        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
-        return shared_gate_up
+        if hasattr(self._shared_experts, "gate_up_proj"):
+            shared_proj, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
+        elif hasattr(self._shared_experts, "up_proj"):
+            shared_proj, _ = self._shared_experts.up_proj(hidden_states)
+        else:
+            raise AttributeError(
+                    f"{type(self._shared_experts)} has neither "
+                    "'gate_up_proj' nor 'up_proj'; cannot split shared expert computation."
+                )
+        return shared_proj
 
     def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
         shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -21,14 +21,15 @@ from functools import wraps
 import torch
 import torch.nn.functional as F
 import torch_npu
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group, tensor_model_parallel_all_reduce
 from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.fused_moe_method_base import FusedMoEMethodBase  # type: ignore
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFusedMoEMethod, get_compressed_expert_map
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
+from vllm.model_executor.layers.fused_moe.router.fused_moe_router import FusedMoERouter  # type: ignore
 from vllm.model_executor.layers.fused_moe.runner.default_moe_runner import DefaultMoERunner  # type: ignore
 from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
 
@@ -49,7 +50,6 @@ from vllm_ascend.utils import (
     npu_stream_switch,
     shared_expert_dp_enabled,
     shared_experts_calculation_stream,
-    vllm_version_is,
 )
 
 
@@ -67,22 +67,10 @@ class FusedMoEEvents:
     before_combine: torch.npu.Event | None = field(default=None)
 
 
-def mock_false():
-    return False
-
-
-def mock_true():
-    return True
-
-
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     def __init__(self, moe: FusedMoEConfig = None):
         super().__init__(moe=moe)
         self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
-
-    @property
-    def is_monolithic(self) -> bool:
-        return False
 
     def process_weights_after_loading(self, layer):
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
@@ -222,20 +210,68 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
 # Please remove this inheritance after extending vllm, todo(wxs)
 class AscendMoERunner(DefaultMoERunner):
+    """
+    Default implementation of the MoE runner for executing Mixture of Experts layers.
+
+    This class provides a comprehensive implementation for running MoE computations
+    with support for:
+    - Expert routing and token dispatching
+    - Shared experts computation with optional parallel execution using CUDA streams
+    - Data parallel (DP) chunking for large batch processing
+    - Tensor model parallel and expert parallel operations
+    - Various quantization methods and custom operators
+    - Both monolithic and decomposed expert execution paths
+
+    The runner handles the complete MoE forward pass including routing tokens to
+    experts, executing expert computations, and combining results. It supports
+    advanced features like overlapped execution of shared experts and optimized
+    kernels for different parallel execution modes.
+
+    Eventually, this class will be split up and specialized for different
+    configurations, e.g. the presence or absence of shared experts, a gate, etc.
+    """
+
+    def __init__(
+        self,
+        layer: torch.nn.Module,
+        moe_config: FusedMoEConfig,
+        router: FusedMoERouter,
+        routed_input_transform: torch.nn.Module | None,
+        gate: torch.nn.Module | None,
+        shared_experts: torch.nn.Module | None,
+        quant_method: FusedMoEMethodBase,
+        reduce_results: bool,
+        enable_dbo: bool,
+    ):
+        super().__init__(
+            layer,
+            moe_config,
+            router,
+            routed_input_transform,
+            gate,
+            shared_experts,
+            quant_method,
+            reduce_results,
+            enable_dbo,
+        )
+        if self.shared_experts is None:
+            self.moe_forward = torch.ops.vllm.moe_forward
+        else:
+            self.moe_forward = torch.ops.vllm.moe_forward_shared
+
     @property
     def use_dp_chunking(self) -> bool:
         """Ascend uses its own forward_impl path, not the FlashInfer Cutlass
         chunked path. Always return False to stay on forward_impl."""
         return False
 
-    # TODO: Remove this after drop v0.19.0 support
     def forward_impl(
         self,
         layer: torch.nn.Module,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         shared_input: torch.Tensor | None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ):
         """
         Override the default forward_impl to use Ascend-specific implementation.
         This delegates to the layer's forward_impl method which contains the
@@ -247,21 +283,6 @@ class AscendMoERunner(DefaultMoERunner):
         # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
         return result
 
-    def forward_dispatch(
-        self,
-        layer: torch.nn.Module,
-        hidden_states: torch.Tensor,
-        router_logits: torch.Tensor,
-        shared_experts_input: torch.Tensor | None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        with self._sequence_parallel_context():
-            return self.forward_impl(
-                layer,
-                hidden_states,
-                router_logits,
-                shared_experts_input,
-            )
-
 
 class AscendFusedMoE(FusedMoE):
     moe_counter = -1
@@ -272,7 +293,6 @@ class AscendFusedMoE(FusedMoE):
 
         num_experts = kwargs["num_experts"]
         intermediate_size = kwargs["intermediate_size"]
-        num_shared_experts = kwargs.get("n_shared_experts", 0)
 
         AscendFusedMoE.moe_counter += 1
         self.moe_instance_id = AscendFusedMoE.moe_counter
@@ -305,12 +325,8 @@ class AscendFusedMoE(FusedMoE):
 
         # init moe
         eplb_config = ascend_config.eplb_config
-        self.mix_placement = getattr(ascend_config, "mix_placement", False)
-        self.n_shared_experts = num_shared_experts
-        num_experts += num_shared_experts if self.mix_placement else 0
-        self.moe_config.num_experts = num_experts
         self.global_expert_map, self._expert_map, self.log2phy, self.global_redundant_expert_num = init_eplb_config(
-            eplb_config, self.moe_instance_id, self.moe_config, self.mix_placement, num_shared_experts
+            eplb_config, self.moe_instance_id, self.moe_config
         )
         self.global_num_experts = num_experts + self.global_redundant_expert_num
         self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)
@@ -356,18 +372,22 @@ class AscendFusedMoE(FusedMoE):
 
         setup_moe_comm_method(self.moe_config)
         self.quant_type = self._get_quant_type()
+        self.runner = self._init_runner()
 
-        is_legacy = vllm_version_is("0.19.0")
-        self.runner = AscendMoERunner(
-            self if is_legacy else self.layer_name,
-            self.moe_config,
-            self.router,
-            self._routed_input_transform,
-            self.gate if is_legacy else kwargs.pop("gate", None),
-            self.shared_experts if is_legacy else kwargs.pop("shared_experts", None),
-            self.quant_method,
-            self.reduce_results,
-            self.vllm_config.parallel_config.enable_dbo,
+    def _init_runner(self):
+        # Storing the runner in the FusedMoE is an intermediate state, eventually
+        # the runner will own the FusedMoE layer and provide the execution interface
+        # for MoE ops.
+        return AscendMoERunner(
+            layer=self,
+            moe_config=self.moe_config,
+            router=self.router,
+            routed_input_transform=self._routed_input_transform,
+            gate=self.gate,
+            shared_experts=self.shared_experts,
+            quant_method=self.quant_method,
+            reduce_results=self.reduce_results,
+            enable_dbo=self.vllm_config.parallel_config.enable_dbo,
         )
 
     def _get_quant_type(self) -> QuantType:
@@ -555,46 +575,24 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         routed_input_transform: torch.nn.Module | None = None,
         **kwargs,
     ):
-        ascend_config = get_ascend_config()
-        # TODO: Enabling the mix placement in deepseek_v2.py
-        # remove this part after the mix placement merged into vllm
-        # https://github.com/vllm-project/vllm/pull/31256
-        if ascend_config.mix_placement:
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_false
-            rocm_aiter_ops.is_fused_moe_enabled = mock_false
         AscendFusedMoE.__init__(self, **kwargs)
-        if ascend_config.mix_placement:
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_true
-            rocm_aiter_ops.is_fused_moe_enabled = mock_true
 
         self._routed_input_transform = routed_input_transform
         self._shared_experts = shared_experts
         self.use_overlapped = use_overlapped
         self.shared_expert_stream = None
-        has_shared_experts = shared_experts is not None
-        self.multistream_overlap_shared_expert = ascend_config.multistream_overlap_shared_expert and has_shared_experts
-        self.multistream_overlap_gate = ascend_config.multistream_overlap_gate and has_shared_experts
+        ascend_config = get_ascend_config()
+        self.multistream_overlap_shared_expert = (
+            ascend_config.multistream_overlap_shared_expert and self._shared_experts is not None
+        )
+        self.multistream_overlap_gate = ascend_config.multistream_overlap_gate and self._shared_experts is not None
         if enable_sp():
             logger.info_once("Sequence parallelism is enabled, shared experts are replicated for best performance.")
 
         self._gate = gate
-        # Recreate the runner with the correct shared_experts parameter.
-        # The parent class created the runner before self._shared_experts was set.
-        # NOTE: must use self._shared_experts here, not self.shared_experts —
-        # FusedMoE.shared_experts is a property that reads self.runner.shared_experts,
-        # which at this point is still the stale runner built with shared_experts=None.
-        is_legacy = vllm_version_is("0.19.0")
-        self.runner = AscendMoERunner(
-            self if is_legacy else self.layer_name,
-            self.moe_config,
-            self.router,
-            self._routed_input_transform,
-            self.gate,
-            self._shared_experts,
-            self.quant_method,
-            self.reduce_results,
-            self.vllm_config.parallel_config.enable_dbo,
-        )
+        # Recreate the runner with the correct shared_experts parameter
+        # The parent class created the runner before self._shared_experts was set
+        self.runner = self._init_runner()
 
         if self.multistream_overlap_shared_expert:
             # Wrap the quant_method's process_weights_after_loading to validate that
@@ -612,8 +610,16 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
 
     def _shared_experts_part1(self, hidden_states: torch.Tensor):
-        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
-        return shared_gate_up
+        if hasattr(self._shared_experts, "gate_up_proj"):
+            shared_proj, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
+        elif hasattr(self._shared_experts, "up_proj"):
+            shared_proj, _ = self._shared_experts.up_proj(hidden_states)
+        else:
+            raise AttributeError(
+                    f"{type(self._shared_experts)} has neither "
+                    "'gate_up_proj' nor 'up_proj'; cannot split shared expert computation."
+                )
+        return shared_proj
 
     def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
         shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore
@@ -669,16 +675,20 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        result = AscendFusedMoE.forward(
+        if self._shared_experts is None:
+            fused_out = AscendFusedMoE.forward(
+                self,
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
+            shared_out = None
+            return shared_out, fused_out
+        shared_out, fused_out = AscendFusedMoE.forward(
             self,
             hidden_states=hidden_states,
             router_logits=router_logits,
         )
-        # When shared experts are absent, the parent returns only fused_out;
-        # otherwise it returns a (shared_out, fused_out) tuple.
-        if self._shared_experts is None:
-            return None, result
-        return result
+        return shared_out, fused_out
 
     def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
         if self._shared_experts is None:

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -19,7 +19,6 @@ import torch
 import torch_npu
 from torch.nn.functional import pad
 from vllm.triton_utils import HAS_TRITON
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
@@ -347,34 +346,11 @@ def unquant_apply_mlp(
         group_list=group_list,
     )[0]
 
-    if activation.is_gated:
-        # Activations with gated multiplication (gate × activation(up))
-        assert w2.size(-1) * 2 == gate_up_out.size(-1), (
-            f"{activation.value} expects 2x ratio: "
-            f"{w2.size(-1) * 2} vs {gate_up_out.size(-1)}"
-        )
-        if activation == MoEActivation.SWIGLUOAI:
-            num_experts, _, hidden_size = w1.shape
-            gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
-        else:
-            gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+    if activation == "swigluoai":
+        num_experts, _, hidden_size = w1.shape
+        gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
     else:
-        # Activations without gated multiplication
-        assert w2.size(-1) == gate_up_out.size(-1), (
-            f"{activation.value} expects equal sizes: "
-            f"{w2.size(-1)} vs {gate_up_out.size(-1)}"
-        )
-        if activation == MoEActivation.SILU_NO_MUL:
-            gate_up_out = torch_npu.npu_silu(gate_up_out)
-        elif activation == MoEActivation.GELU_NO_MUL:
-            gate_up_out = torch_npu.npu_gelu(gate_up_out, approximate="none")
-        elif activation == MoEActivation.RELU2_NO_MUL:
-            gate_up_out = torch.relu(gate_up_out)
-            gate_up_out = torch.square(gate_up_out)
-        else:
-            raise ValueError(
-                    f"Unsupported FusedMoE activation: {activation}"
-                )         
+        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
 
     if topk_scales is not None:
         gate_up_out *= topk_scales

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -19,6 +19,7 @@ import torch
 import torch_npu
 from torch.nn.functional import pad
 from vllm.triton_utils import HAS_TRITON
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
@@ -346,11 +347,34 @@ def unquant_apply_mlp(
         group_list=group_list,
     )[0]
 
-    if activation == "swigluoai":
-        num_experts, _, hidden_size = w1.shape
-        gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
+    if activation.is_gated:
+        # Activations with gated multiplication (gate × activation(up))
+        assert w2.size(-1) * 2 == gate_up_out.size(-1), (
+            f"{activation.value} expects 2x ratio: "
+            f"{w2.size(-1) * 2} vs {gate_up_out.size(-1)}"
+        )
+        if activation == MoEActivation.SWIGLUOAI:
+            num_experts, _, hidden_size = w1.shape
+            gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
+        else:
+            gate_up_out = torch_npu.npu_swiglu(gate_up_out)
     else:
-        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+        # Activations without gated multiplication
+        assert w2.size(-1) == gate_up_out.size(-1), (
+            f"{activation.value} expects equal sizes: "
+            f"{w2.size(-1)} vs {gate_up_out.size(-1)}"
+        )
+        if activation == MoEActivation.SILU_NO_MUL:
+            gate_up_out = torch_npu.npu_silu(gate_up_out)
+        elif activation == MoEActivation.GELU_NO_MUL:
+            gate_up_out = torch_npu.npu_gelu(gate_up_out, approximate="none")
+        elif activation == MoEActivation.RELU2_NO_MUL:
+            gate_up_out = torch.relu(gate_up_out)
+            gate_up_out = torch.square(gate_up_out)
+        else:
+            raise ValueError(
+                    f"Unsupported FusedMoE activation: {activation}"
+                )         
 
     if topk_scales is not None:
         gate_up_out *= topk_scales

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -19,6 +19,7 @@ import torch
 import torch_npu
 from torch.nn.functional import pad
 from vllm.triton_utils import HAS_TRITON
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
@@ -346,11 +347,34 @@ def unquant_apply_mlp(
         group_list=group_list,
     )[0]
 
-    if activation == "swigluoai":
-        num_experts, _, hidden_size = w1.shape
-        gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
+    if activation.is_gated:
+        # Activations with gated multiplication (gate × activation(up))
+        assert w2.size(-1) * 2 == gate_up_out.size(-1), (
+            f"{activation.value} expects 2x ratio: "
+            f"{w2.size(-1) * 2} vs {gate_up_out.size(-1)}"
+        )
+        if activation == MoEActivation.SWIGLUOAI:
+            num_experts, _, hidden_size = w1.shape
+            gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
+        else:
+            gate_up_out = torch_npu.npu_swiglu(gate_up_out)
     else:
-        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+        # Activations without gated multiplication
+        assert w2.size(-1) == gate_up_out.size(-1), (
+            f"{activation.value} expects equal sizes: "
+            f"{w2.size(-1)} vs {gate_up_out.size(-1)}"
+        )
+        if activation == MoEActivation.SILU_NO_MUL:
+            gate_up_out = torch_npu.npu_silu(gate_up_out)
+        elif activation == MoEActivation.GELU_NO_MUL:
+            gate_up_out = torch_npu.npu_gelu(gate_up_out, approximate="none")
+        elif activation == MoEActivation.RELU2_NO_MUL:
+            gate_up_out = torch.relu(gate_up_out)
+            gate_up_out = torch.square(gate_up_out)
+        else:
+            raise ValueError(
+                    f"Unsupported FusedMoE activation: {activation}"
+                )     
 
     if topk_scales is not None:
         gate_up_out *= topk_scales

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,8 +18,8 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
-from vllm.triton_utils import HAS_TRITON
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
@@ -79,6 +79,14 @@ def _require_single_tensor_for_swiglu_quant(
             raise ValueError(f"{name} must be a tensor or a single-element list, but got {len(tensor_or_list)}.")
         return tensor_or_list[0]
     return tensor_or_list
+
+
+def _normalize_moe_activation(activation: MoEActivation | str | None) -> MoEActivation:
+    if activation is None:
+        return MoEActivation.SILU
+    if isinstance(activation, MoEActivation):
+        return activation
+    return MoEActivation.from_str(activation)
 
 
 def quant_apply_mlp(
@@ -328,11 +336,13 @@ def unquant_apply_mlp(
     group_list: torch.Tensor,
     w1_bias: torch.Tensor = None,
     w2_bias: torch.Tensor = None,
-    activation: str | None = None,
+    activation: MoEActivation | str | None = None,
     group_list_type: int = 1,
     topk_scales: torch.Tensor | None = None,
     need_trans: bool = True,
 ) -> torch.Tensor:
+    activation = _normalize_moe_activation(activation)
+
     if need_trans:
         w1 = w1.transpose(1, 2)
         w2 = w2.transpose(1, 2)
@@ -372,9 +382,7 @@ def unquant_apply_mlp(
             gate_up_out = torch.relu(gate_up_out)
             gate_up_out = torch.square(gate_up_out)
         else:
-            raise ValueError(
-                    f"Unsupported FusedMoE activation: {activation}"
-                )     
+            raise ValueError(f"Unsupported FusedMoE activation: {activation}")
 
     if topk_scales is not None:
         gate_up_out *= topk_scales

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -57,6 +57,8 @@ dataclass directly.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import torch
 
 import vllm_ascend.ops.fused_moe.moe_stage_params as _stage_params
@@ -77,6 +79,9 @@ from vllm_ascend.ops.fused_moe.moe_stage_params import (
     MoERoutingParams,
 )
 from vllm_ascend.quantization.quant_type import QuantType
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 
 def _build_mxfp_params(
@@ -128,7 +133,7 @@ def build_fused_experts_input(
     apply_router_weight_on_input: bool = False,
     log2phy: torch.Tensor | None = None,
     pertoken_scale: torch.Tensor | None = None,
-    activation: str = "silu",
+    activation: MoEActivation | str | None = "silu",
     need_trans: bool = False,
     w1_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -17,12 +17,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
 import torch
 
 from vllm_ascend.ops.fused_moe.moe_stage_params import MoEQuantParams, MoERoutingParams
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 TMoECombineMetadata = TypeVar("TMoECombineMetadata")
 
@@ -65,7 +68,7 @@ class MoEFusedExpertsInput:
     weights: MoEWeights
     routing: MoERoutingParams
     quant: MoEQuantParams
-    activation: str = "silu"
+    activation: MoEActivation | str | None = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
 
@@ -136,7 +139,7 @@ class MoEMlpComputeInput:
     weights: MoEWeights
     quant: MoEQuantParams
     fusion: bool
-    activation: str = "silu"
+    activation: MoEActivation | str | None = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR combines two compatibility fixes needed to keep vLLM Ascend aligned with the latest upstream and dependency changes.

1. Fix the startup failure reported in [`#7095`](https://github.com/vllm-project/vllm-ascend/issues/7095). The latest CANN ops package no longer exports `aclnnAddRmsNormBias` / `aclnnAddRmsNormBiasGetWorkspaceSize`, which causes affected models such as Kimi 2.5 to fail during initialization with a missing-symbol error from `libopapi.so`. To address this, this PR replaces the direct `aclnnAddRmsNormBias` call with `aclnnAddRmsNorm` and applies `beta` afterward in the adapter, preserving the expected behavior while removing the dependency on the removed op.

2. Update the Ascend fused MoE path to match the latest upstream `fused_moe` implementation. This includes:
    - adapting the Ascend MoE runner to the current upstream runner/router/quant-method API
    - selecting the correct `torch.ops.vllm.moe_forward` variant depending on whether shared experts are present
    - rebuilding the shared-expert runner after shared modules are attached
    - supporting newer shared-expert module layouts with either `gate_up_proj` or `up_proj`
    - switching the MLP activation path to `MoEActivation` and handling both gated and non-gated activation variants used by the latest upstream implementation

Fixes #7095

### Does this PR introduce _any_ user-facing change?
There is no API or configuration change in this PR.

Users on newer CANN ops packages should no longer hit the missing `aclnnAddRmsNormBias` symbol error during startup, and models using the newer upstream fused MoE implementation should work correctly on Ascend with the updated shared-expert and activation handling.

### How was this patch tested?
Local sanity check:
```bash
python -m py_compile ops/fused_moe/fused_moe.py ops/fused_moe/moe_mlp.py

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/5af684c31912232e5c89484c2e8259e0fac6c55b
