### PR TITLE
[BugFix] Fix incorrect DeprecationWarning usage

### DIFF
--- a/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
+++ b/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import torch
 import torch.nn.functional as F
 
@@ -199,10 +197,9 @@ def chunk_gated_delta_rule_pytorch(
     Internal math follows Transformers torch_chunk_gated_delta_rule flow.
     """
     if head_first:
-        warnings.warn(
-            "head_first=True is not supported in 310P fallback.",
-            DeprecationWarning,
-            stacklevel=2,
+        raise NotImplementedError(
+            "head_first=True is not supported in 310P fallback. "
+            "Please use head_first=False."
         )
     q, k, v, g, beta, input_was_tnd = _normalize_chunk_inputs(q, k, v, g, beta, cu_seqlens)
 

--- a/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
+++ b/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import torch
 import torch.nn.functional as F
 
@@ -197,7 +199,11 @@ def chunk_gated_delta_rule_pytorch(
     Internal math follows Transformers torch_chunk_gated_delta_rule flow.
     """
     if head_first:
-        raise DeprecationWarning("head_first=True is not supported in 310P fallback.")
+        warnings.warn(
+            "head_first=True is not supported in 310P fallback.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     q, k, v, g, beta, input_was_tnd = _normalize_chunk_inputs(q, k, v, g, beta, cu_seqlens)
 
     if cu_seqlens is not None and q.shape[0] != 1:

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -278,9 +278,10 @@ def chunk_gated_delta_rule(
     assert len(beta.shape) == 3, "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
 
     if head_first:
-        raise DeprecationWarning(
+        warnings.warn(
             "head_first is deprecated and will be removed in a future version. "
             "Please use head_first=False for now instead.",
+            DeprecationWarning,
             stacklevel=2,
         )
         q, k, v, beta, g = map(lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g))


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes incorrect usage of DeprecationWarning.

### Does this PR introduce _any_ user-facing change?
Users who call the function with head_first=True will now receive a proper deprecation warning instead of a crash. The program will continue to execute instead of being interrupted.

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
