### PR TITLE
[Feature] IndexCache support for DSA models

### DIFF
--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -7,7 +7,6 @@ from vllm.forward_context import ForwardContext
 from vllm.model_executor.layers.mla import MLAModules
 
 from tests.ut.base import TestBase
-from vllm_ascend.attention.sfa_v1 import AscendSFAImpl
 from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention, IndexerWrapper
 
 
@@ -74,7 +73,6 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         self.mock_mla_modules.kv_a_layernorm = MagicMock()
         self.mock_mla_modules.kv_b_proj = MagicMock()
         self.mock_mla_modules.o_proj = MagicMock()
-        self.mock_mla_modules.topk_indices_buffer = torch.empty(8, 4, dtype=torch.int32)
 
         self.mock_cache_config = MagicMock(spec=CacheConfig)
         self.mock_quant_config = MagicMock()
@@ -90,7 +88,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn) as mock_mla_cls:
+        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
             mock_tp_size.return_value = 2
             mock_ascend_config.return_value.enable_shared_expert_dp = True
             mock_vllm_config = MagicMock(spec=VllmConfig)
@@ -112,15 +110,11 @@ class TestAscendMultiHeadLatentAttention(TestBase):
                 cache_config=self.mock_cache_config,
                 quant_config=self.mock_quant_config,
                 prefix=self.prefix,
-                skip_topk=True,
             )
 
             self.assertEqual(attn.tp_size, 2)
             self.assertTrue(attn.enable_shared_expert_dp)
             self.assertIsNotNone(attn.mla_attn)
-            kwargs = mock_mla_cls.call_args.kwargs
-            self.assertTrue(kwargs["skip_topk"])
-            self.assertIs(kwargs["topk_indices_buffer"], self.mock_mla_modules.topk_indices_buffer)
 
     @patch("vllm_ascend.ops.mla.torch.ops.vllm.mla_forward")
     @patch("vllm_ascend.ops.mla.get_current_vllm_config")
@@ -173,42 +167,3 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         output = attn.forward(positions, hidden_states)
 
         self.assertEqual(output.shape, (3, self.hidden_size))
-
-
-class TestAscendSFAImplIndexCache(TestBase):
-
-    def test_get_indexcache_topk_indices(self):
-        impl = object.__new__(AscendSFAImpl)
-        impl.topk_indices_buffer = torch.arange(24, dtype=torch.int32).view(6, 4)
-
-        topk_indices = impl._get_indexcache_topk_indices(3)
-
-        self.assertEqual(topk_indices.shape, (3, 1, 4))
-        self.assertTrue(torch.equal(topk_indices.squeeze(1), impl.topk_indices_buffer[:3]))
-
-    def test_get_indexcache_topk_indices_requires_buffer(self):
-        impl = object.__new__(AscendSFAImpl)
-        impl.topk_indices_buffer = None
-
-        with self.assertRaisesRegex(RuntimeError, "topk_indices_buffer"):
-            impl._get_indexcache_topk_indices(3)
-
-    def test_update_indexcache_topk_indices(self):
-        impl = object.__new__(AscendSFAImpl)
-        impl.topk_indices_buffer = torch.full((6, 4), -1, dtype=torch.int32)
-        topk_indices = torch.arange(12, dtype=torch.int32).view(3, 4)
-
-        impl._update_indexcache_topk_indices(topk_indices)
-
-        self.assertTrue(torch.equal(impl.topk_indices_buffer[:3], topk_indices))
-        self.assertTrue(torch.equal(impl.topk_indices_buffer[3:], torch.full((3, 4), -1, dtype=torch.int32)))
-
-    def test_update_indexcache_topk_indices_from_npu_shape(self):
-        impl = object.__new__(AscendSFAImpl)
-        impl.topk_indices_buffer = torch.full((6, 4), -1, dtype=torch.int32)
-        topk_indices = torch.arange(12, dtype=torch.int32).view(3, 1, 4)
-
-        impl._update_indexcache_topk_indices(topk_indices)
-
-        self.assertTrue(torch.equal(impl.topk_indices_buffer[:3], topk_indices.squeeze(1)))
-        self.assertTrue(torch.equal(impl.topk_indices_buffer[3:], torch.full((3, 4), -1, dtype=torch.int32)))

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -7,6 +7,7 @@ from vllm.forward_context import ForwardContext
 from vllm.model_executor.layers.mla import MLAModules
 
 from tests.ut.base import TestBase
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl
 from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention, IndexerWrapper
 
 
@@ -73,6 +74,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         self.mock_mla_modules.kv_a_layernorm = MagicMock()
         self.mock_mla_modules.kv_b_proj = MagicMock()
         self.mock_mla_modules.o_proj = MagicMock()
+        self.mock_mla_modules.topk_indices_buffer = torch.empty(8, 4, dtype=torch.int32)
 
         self.mock_cache_config = MagicMock(spec=CacheConfig)
         self.mock_quant_config = MagicMock()
@@ -88,7 +90,7 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         mock_mla_attn.impl = MagicMock()
         mock_mla_attn.impl.process_weights_after_loading = MagicMock()
 
-        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
+        with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn) as mock_mla_cls:
             mock_tp_size.return_value = 2
             mock_ascend_config.return_value.enable_shared_expert_dp = True
             mock_vllm_config = MagicMock(spec=VllmConfig)
@@ -110,11 +112,15 @@ class TestAscendMultiHeadLatentAttention(TestBase):
                 cache_config=self.mock_cache_config,
                 quant_config=self.mock_quant_config,
                 prefix=self.prefix,
+                skip_topk=True,
             )
 
             self.assertEqual(attn.tp_size, 2)
             self.assertTrue(attn.enable_shared_expert_dp)
             self.assertIsNotNone(attn.mla_attn)
+            kwargs = mock_mla_cls.call_args.kwargs
+            self.assertTrue(kwargs["skip_topk"])
+            self.assertIs(kwargs["topk_indices_buffer"], self.mock_mla_modules.topk_indices_buffer)
 
     @patch("vllm_ascend.ops.mla.torch.ops.vllm.mla_forward")
     @patch("vllm_ascend.ops.mla.get_current_vllm_config")
@@ -167,3 +173,42 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         output = attn.forward(positions, hidden_states)
 
         self.assertEqual(output.shape, (3, self.hidden_size))
+
+
+class TestAscendSFAImplIndexCache(TestBase):
+
+    def test_get_indexcache_topk_indices(self):
+        impl = object.__new__(AscendSFAImpl)
+        impl.topk_indices_buffer = torch.arange(24, dtype=torch.int32).view(6, 4)
+
+        topk_indices = impl._get_indexcache_topk_indices(3)
+
+        self.assertEqual(topk_indices.shape, (3, 1, 4))
+        self.assertTrue(torch.equal(topk_indices.squeeze(1), impl.topk_indices_buffer[:3]))
+
+    def test_get_indexcache_topk_indices_requires_buffer(self):
+        impl = object.__new__(AscendSFAImpl)
+        impl.topk_indices_buffer = None
+
+        with self.assertRaisesRegex(RuntimeError, "topk_indices_buffer"):
+            impl._get_indexcache_topk_indices(3)
+
+    def test_update_indexcache_topk_indices(self):
+        impl = object.__new__(AscendSFAImpl)
+        impl.topk_indices_buffer = torch.full((6, 4), -1, dtype=torch.int32)
+        topk_indices = torch.arange(12, dtype=torch.int32).view(3, 4)
+
+        impl._update_indexcache_topk_indices(topk_indices)
+
+        self.assertTrue(torch.equal(impl.topk_indices_buffer[:3], topk_indices))
+        self.assertTrue(torch.equal(impl.topk_indices_buffer[3:], torch.full((3, 4), -1, dtype=torch.int32)))
+
+    def test_update_indexcache_topk_indices_from_npu_shape(self):
+        impl = object.__new__(AscendSFAImpl)
+        impl.topk_indices_buffer = torch.full((6, 4), -1, dtype=torch.int32)
+        topk_indices = torch.arange(12, dtype=torch.int32).view(3, 1, 4)
+
+        impl._update_indexcache_topk_indices(topk_indices)
+
+        self.assertTrue(torch.equal(impl.topk_indices_buffer[:3], topk_indices.squeeze(1)))
+        self.assertTrue(torch.equal(impl.topk_indices_buffer[3:], torch.full((3, 4), -1, dtype=torch.int32)))

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -418,7 +418,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.tp_rank = get_tp_group().rank_in_group
         self.q_b_proj = kwargs["q_b_proj"]
         self.skip_topk = kwargs.get("skip_topk", False)
-        self.use_index_cache = self.skip_topk
         self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
 
         ascend_config = get_ascend_config()
@@ -1260,7 +1259,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         topk_num_tokens = num_input_tokens or hidden_states.shape[0]
         if self.skip_topk:
             topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
-            logger.info("--- skip topk_indices --- ")
         else:
             topk_indices = self.indexer_select_post_process(
                 x=hidden_states,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -417,6 +417,9 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tp_group().rank_in_group
         self.q_b_proj = kwargs["q_b_proj"]
+        self.skip_topk = kwargs.get("skip_topk", False)
+        self.use_index_cache = self.skip_topk
+        self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
 
         ascend_config = get_ascend_config()
         self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
@@ -429,6 +432,11 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         self.local_num_heads = self.num_heads
         self.vllm_config = get_current_vllm_config()
+        self.use_index_cache = self.skip_topk or getattr(
+            self.vllm_config.model_config.hf_config,
+            "use_index_cache",
+            False,
+        )
         self.is_kv_producer = (
             self.vllm_config.kv_transfer_config is not None and self.vllm_config.kv_transfer_config.is_kv_producer
         )
@@ -1027,6 +1035,26 @@ class AscendSFAImpl(MLAAttentionImpl):
             )
         return topk_indices
 
+    def _get_indexcache_topk_indices(self, num_tokens: int) -> torch.Tensor:
+        if self.topk_indices_buffer is None:
+            raise RuntimeError("IndexCache requires topk_indices_buffer when skip_topk is enabled.")
+        topk_indices = self.topk_indices_buffer[:num_tokens]
+        if topk_indices.dim() == 2:
+            topk_indices = topk_indices.unsqueeze(1)
+        return topk_indices
+
+    def _update_indexcache_topk_indices(self, topk_indices: torch.Tensor) -> None:
+        if self.topk_indices_buffer is None:
+            return
+        num_tokens = topk_indices.shape[0]
+        topk_tokens = topk_indices.shape[-1]
+        topk_indices_to_cache = topk_indices
+        topk_indices_buffer = self.topk_indices_buffer[:num_tokens, :topk_tokens]
+        if topk_indices_to_cache.dim() == 3 and topk_indices_buffer.dim() == 2:
+            assert topk_indices_to_cache.shape[1] == 1
+            topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
+        topk_indices_buffer.copy_(topk_indices_to_cache)
+
     def _execute_sparse_flash_attention_process(
         self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
     ):
@@ -1229,16 +1257,23 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 
-        topk_indices = self.indexer_select_post_process(
-            x=hidden_states,
-            q_c=q_c,
-            kv_cache=kv_cache,
-            attn_metadata=attn_metadata,
-            cos=cos,
-            sin=sin,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_key=actual_seq_lengths_key,
-        )
+        topk_num_tokens = num_input_tokens or hidden_states.shape[0]
+        if self.skip_topk:
+            topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
+            logger.info("--- skip topk_indices --- ")
+        else:
+            topk_indices = self.indexer_select_post_process(
+                x=hidden_states,
+                q_c=q_c,
+                kv_cache=kv_cache,
+                attn_metadata=attn_metadata,
+                cos=cos,
+                sin=sin,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+            )
+            if self.use_index_cache:
+                self._update_indexcache_topk_indices(topk_indices)
 
         attn_output = self._execute_sparse_flash_attention_process(
             ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -80,6 +80,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        skip_topk: bool = False,
     ) -> None:
         nn.Module.__init__(self)
         self.hidden_size = hidden_size
@@ -90,6 +91,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.v_head_dim = v_head_dim
         self.prefix = prefix
+        self.skip_topk = skip_topk
         hf_config = get_current_vllm_config().model_config.hf_text_config
         self.enable_shared_expert_dp = get_ascend_config().enable_shared_expert_dp
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -112,6 +114,8 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             prefix=f"{prefix}.attn",
             use_sparse=mla_modules.is_sparse,
             indexer=ascend_indexer,
+            skip_topk=skip_topk,
+            topk_indices_buffer=getattr(mla_modules, "topk_indices_buffer", None),
             # extra args
             rotary_emb=mla_modules.rotary_emb,
             fused_qkv_a_proj=mla_modules.fused_qkv_a_proj,


### PR DESCRIPTION
## Motivation

Implemented the corresponding NPU adaptation based on upstream IndexCache work.
**This is an optimization for DSA models on NPU, which can significantly improve throughput and reduce E2E latency.**

This PR adds **Ascend NPU adaptation for IndexCache in vLLM-Ascend**, based on:

- upstream vLLM PR: https://github.com/vllm-project/vllm/pull/37735
- upstream issue implemented by that PR: https://github.com/vllm-project/vllm/issues/37684
- IndexCache integration reference: https://github.com/THUDM/IndexCache?tab=readme-ov-file#step-1-clone-sglang--vllm

## Modifications

This PR includes NPU-oriented integration and adaptation for IndexCache in vLLM-Ascend.

IndexCache can be enabled through HF overrides, for example:

```bash
--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'
```

## Accuracy Tests

I evaluated accuracy on the C-Eval dataset. The baseline score is `0.9008`, while `indexCache=4` (reusing 3/4 of the indices) achieves `0.9063`.

| Setting | Description | C-Eval Score |
|---|---|---:|
| Baseline | IndexCache disabled | 0.9008 |
| IndexCache = 4 | Reuse 3/4 of indices | 0.9063 |

## Benchmarking and Profiling

Benchmark model:

```text
/nas/disk1/GLM-5-w8a8
```

IndexCache configuration:

```bash
--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'
```

### Concurrency 1

Command summary:

```bash
vllm bench serve \
  --backend openai-chat \
  --model glm-5 \
  --served-model-name glm-5 \
  --tokenizer /nas/disk1/GLM-5-w8a8 \
  --dataset-name random \
  --max-concurrency 1 \
  --num-prompts 10 \
  --random-input-len 20480 \
  --random-output-len 100
```

| Metric | Baseline | IndexCache freq=4 | Change |
|---|---:|---:|---:|
| Successful requests | 10 | 10 | - |
| Failed requests | 0 | 0 | - |
| Benchmark duration | 158.08 s | 135.64 s | -14.20% |
| Request throughput | 0.06 req/s | 0.07 req/s | +16.67% |
| Output token throughput | 5.62 tok/s | 6.55 tok/s | +16.55% |
| Total token throughput | 1289.57 tok/s | 1502.87 tok/s | +16.54% |
| Mean TTFT | 10757.46 ms | 8922.62 ms | -17.06% |
| Median TTFT | 10733.79 ms | 9207.87 ms | -14.22% |
| P99 TTFT | 14907.90 ms | 12111.08 ms | -18.76% |
| Mean TPOT | 57.53 ms | 52.86 ms | -8.12% |
| Median TPOT | 57.31 ms | 52.70 ms | -8.04% |
| P99 TPOT | 59.28 ms | 54.47 ms | -8.11% |
| Mean ITL | 56.87 ms | 52.27 ms | -8.09% |
| Median ITL | 57.49 ms | 52.79 ms | -8.18% |
| P99 ITL | 59.28 ms | 54.34 ms | -8.33% |
| Mean E2EL | 15807.51 ms | 13563.86 ms | -14.19% |
| Median E2EL | 15465.32 ms | 13375.34 ms | -13.51% |
| P99 E2EL | 20480.54 ms | 17271.27 ms | -15.67% |

### Concurrency 3

Command summary:

```bash
vllm bench serve \
  --backend openai-chat \
  --model glm-5 \
  --served-model-name glm-5 \
  --tokenizer /nas/disk1/GLM-5-w8a8 \
  --dataset-name random \
  --max-concurrency 3 \
  --num-prompts 30 \
  --random-input-len 20480 \
  --random-output-len 100
```

| Metric | Baseline | IndexCache freq=4 | Change |
|---|---:|---:|---:|
| Successful requests | 30 | 30 | - |
| Failed requests | 0 | 0 | - |
| Benchmark duration | 373.53 s | 319.61 s | -14.44% |
| Request throughput | 0.08 req/s | 0.09 req/s | +12.50% |
| Output token throughput | 8.34 tok/s | 9.74 tok/s | +16.79% |
| Total token throughput | 1645.72 tok/s | 1923.37 tok/s | +16.87% |
| Mean TTFT | 13091.83 ms | 11148.76 ms | -14.84% |
| Median TTFT | 11481.13 ms | 9499.50 ms | -17.26% |
| P99 TTFT | 31325.00 ms | 26006.29 ms | -16.98% |
| Mean TPOT | 247.58 ms | 210.51 ms | -14.97% |
| Median TPOT | 228.46 ms | 195.56 ms | -14.40% |
| P99 TPOT | 578.27 ms | 476.18 ms | -17.65% |
| Mean ITL | 231.70 ms | 198.65 ms | -14.26% |
| Median ITL | 60.78 ms | 55.68 ms | -8.39% |
| P99 ITL | 2300.33 ms | 1783.22 ms | -22.48% |
| Mean E2EL | 37142.37 ms | 31768.29 ms | -14.47% |
| Median E2EL | 35100.75 ms | 30648.91 ms | -12.68% |
| P99 E2EL | 61257.49 ms | 51345.84 ms | -16.18% |

### Benchmark Summary

With `use_index_cache=true` and `index_topk_freq=4`, the GLM-5 W8A8 workload shows consistent performance improvement:

- Concurrency 1:
  - total token throughput improves by **16.54%**
  - mean TTFT improves by **17.06%**
  - mean E2E latency improves by **14.19%**
  - mean TPOT improves by **8.12%**

- Concurrency 3:
  - total token throughput improves by **16.87%**
  - mean TTFT improves by **14.84%**
  - mean E2E latency improves by **14.47%**
  - mean TPOT improves by **14.97%**
  - P99 ITL improves by **22.48%**

No failed requests were observed in either baseline or IndexCache runs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(if required)*
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
