### PR TITLE
[BugFix][Scheduler] Sync the ProfileChunkScheduler with upstream vllm

### DIFF
--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -482,7 +482,6 @@ class ProfilingChunkScheduler(Scheduler):
                             step_skipped_waiting.prepend_request(request)
                             continue
 
-                        request.num_external_computed_tokens = ext_tokens
                         num_external_computed_tokens = ext_tokens
 
                         connector_prefix_cache_queries = request.num_tokens - num_new_local_computed_tokens
@@ -490,6 +489,15 @@ class ProfilingChunkScheduler(Scheduler):
 
                     num_computed_tokens = num_new_local_computed_tokens + num_external_computed_tokens
                     assert num_computed_tokens <= request.num_tokens
+
+                    # Track first scheduled prefill, not post-preemption repeat prefills
+                    if request.prefill_stats is not None:
+                        assert num_computed_tokens <= request.num_prompt_tokens
+                        request.prefill_stats.set(
+                            num_prompt_tokens=request.num_prompt_tokens,
+                            num_local_cached_tokens=num_new_local_computed_tokens,
+                            num_external_cached_tokens=num_external_computed_tokens,
+                        )
                 else:
                     new_computed_blocks = self.kv_cache_manager.empty_kv_cache_blocks
                     num_new_local_computed_tokens = 0
@@ -628,8 +636,6 @@ class ProfilingChunkScheduler(Scheduler):
                 time_budget -= self.profiling_chunk_manager.predict_time(num_new_tokens, request.num_computed_tokens)
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
-                if request.num_cached_tokens < 0:
-                    request.num_cached_tokens = num_computed_tokens
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
                     for i in encoder_inputs_to_schedule:


### PR DESCRIPTION
### What this PR does / why we need it?
Syncs the `ProfilingChunkScheduler` with upstream vLLM changes. Specifically, it updates the `Request` attribute handling (removing `num_external_computed_tokens` and `num_cached_tokens` assignments) and adds tracking for `prefill_stats` to align with the latest vLLM v1 scheduling logic. This ensures compatibility and correct behavior for chunked pipeline parallel execution.

### Does this PR introduce _any_ user-facing change?
No. This is an internal scheduler update to maintain compatibility with upstream vLLM.

### How was this patch tested?
The PR description indicates it was tested to ensure Chunked pipeline parallel is working.


- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
