### PR TITLE
[CI] fix ut caused by num_cached_tokens

### DIFF
--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -41,6 +41,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_ascend.core.profiling_chunk_predictor import ProfilingChunkManager
+from vllm_ascend.utils import vllm_version_is
 
 
 class ProfilingChunkScheduler(Scheduler):
@@ -628,8 +629,15 @@ class ProfilingChunkScheduler(Scheduler):
                 time_budget -= self.profiling_chunk_manager.predict_time(num_new_tokens, request.num_computed_tokens)
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
-                if request.num_cached_tokens < 0:
-                    request.num_cached_tokens = num_computed_tokens
+                if vllm_version_is("0.19.0"):
+                    if request.num_cached_tokens < 0:
+                        request.num_cached_tokens = num_computed_tokens
+                elif request.prefill_stats is not None:
+                    request.prefill_stats.set(
+                        num_prompt_tokens=request.num_prompt_tokens,
+                        num_local_cached_tokens=num_new_local_computed_tokens,
+                        num_external_cached_tokens=num_external_computed_tokens,
+                    )
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
                     for i in encoder_inputs_to_schedule:


### PR DESCRIPTION
### What this PR does / why we need it?

fix ut caused by `AttributeError: 'Request' object has no attribute 'num_cached_tokens'`
https://github.com/vllm-project/vllm-ascend/actions/runs/24570008301/job/71840866803?pr=8362#step:8:2499
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
