### PR TITLE
[SpecDecode][BugFix] Fix Eagle3 hidden states handling in PCP path

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -503,6 +503,16 @@ class SpecDecodeBaseProposer(EagleProposer):
 
         if self.method in ("eagle3", "dflash"):
             assert isinstance(self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM))
+            if self.method == "eagle3":
+                expected_input_dim = self.hidden_size * 3
+                if target_hidden_states.shape[-1] != expected_input_dim:
+                    logger.warning(
+                        "Eagle3 combine_hidden_states input dim mismatch: "
+                        "expected %d (3 * hidden_size), got %d. "
+                        "aux_hidden_states may not be captured correctly.",
+                        expected_input_dim,
+                        target_hidden_states.shape[-1],
+                    )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -951,7 +951,9 @@ def weak_ref_tensors(
     if isinstance(tensors, IntermediateTensors):
         ret = IntermediateTensors({key: weak_ref_tensor(val) for key, val in tensors.tensors.items()})
         return ret
-    raise ValueError("Invalid type for tensors")
+    # For non-tensor leaf nodes (e.g., None, int, metadata), return as-is.
+    # This handles nested structures from Eagle3 that may contain non-tensor elements.
+    return weak_ref_tensor(tensors)
 
 
 def npu_stream_switch(target_stream: torch.npu.Stream, *, enabled: bool = True):

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -944,9 +944,9 @@ def weak_ref_tensors(
     if isinstance(tensors, torch.Tensor):
         return weak_ref_tensor(tensors)
     if isinstance(tensors, list):
-        return [weak_ref_tensor(t) for t in tensors]
+        return [weak_ref_tensors(t) for t in tensors]
     if isinstance(tensors, tuple):
-        return tuple(weak_ref_tensor(t) for t in tensors)
+        return tuple(weak_ref_tensors(t) for t in tensors)
     # For IntermediateTensors used in pipeline parallelism
     if isinstance(tensors, IntermediateTensors):
         ret = IntermediateTensors({key: weak_ref_tensor(val) for key, val in tensors.tensors.items()})

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1160,9 +1160,10 @@ class NPUModelRunner(GPUModelRunner):
                     token_indices_to_sample = query_start_loc_pcp_full[1 : num_reqs + 1] - 1
                     target_token_ids = input_ids_pcp_full[:num_scheduled_tokens]
                     target_positions = self._get_positions(num_scheduled_tokens)
-                    target_hidden_states = hidden_states
                     if self.use_aux_hidden_state_outputs:
-                        target_hidden_states = torch.cat([h for h in aux_hidden_states], dim=-1)
+                        target_hidden_states = torch.cat([h[:num_scheduled_tokens] for h in aux_hidden_states], dim=-1)
+                    else:
+                        target_hidden_states = hidden_states[:num_scheduled_tokens]
                 else:
                     token_indices_to_sample = None
                     # input_ids can be None for multimodal models.
@@ -1197,9 +1198,10 @@ class NPUModelRunner(GPUModelRunner):
                 if self.pcp_size > 1:
                     target_token_ids = input_ids_pcp_full[token_indices]
                     target_positions = positions
-                    target_hidden_states = hidden_states
                     if self.use_aux_hidden_state_outputs:
-                        target_hidden_states = torch.cat([h for h in aux_hidden_states], dim=-1)
+                        target_hidden_states = torch.cat([h[token_indices] for h in aux_hidden_states], dim=-1)
+                    else:
+                        target_hidden_states = hidden_states[token_indices]
                 else:
                     target_token_ids = self.input_ids.gpu[token_indices]
                     target_positions = self._get_positions(token_indices)


### PR DESCRIPTION
### What this PR does / why we need it?

When Eagle3 speculative decoding is used with Prefill Context Parallel (PCP),
hidden states are not correctly indexed/sliced before being passed to the
Eagle3 proposer, causing garbled draft token outputs and zero acceptance rate.

Two bugs fixed in `model_runner_v1.py`:

1. **Prefill path** (`spec_decode_metadata is None`, `pcp_size > 1`):
   `aux_hidden_states` was not sliced with `[:num_scheduled_tokens]`,
   passing padded data to the proposer.

2. **Decode path** (`spec_decode_metadata is not None`, `pcp_size > 1`):
   `aux_hidden_states` was not indexed with `token_indices`,
   inconsistent with the `pcp_size <= 1` path.

Also fixes `utils.py` to recursively handle nested list/tuple structures
in `weak_ref_tensors`, which Eagle3 requires due to its nested hidden state output.

Adds dimension validation with warning logging in `eagle_proposer.py`.

Fixes #6187

### Does this PR introduce _any_ user-facing change?
Yes. Eagle3 speculative decoding with PCP now produces correct draft tokens
and non-zero acceptance rates.

### How was this patch tested?
- Existing unit tests pass
- Verified fix logic against the pcp_size <= 1 path which correctly uses
  `[:num_scheduled_tokens]` and `token_indices`
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
