### PR TITLE
[Feature][IR][1/N] Add RMSNorm IR kernel registration and op priority support

### DIFF
--- a/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
+++ b/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
@@ -6,10 +6,11 @@ import torch
 import torch.nn as nn
 import torchair
 import vllm.config
+from vllm import ir
 from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
 from vllm.utils.system_utils import update_environment_variables
-from vllm import ir
+
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.compilation.passes.qknorm_rope_fusion_pass import (
     QKNormRopeFusionPattern,

--- a/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
+++ b/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
@@ -78,11 +78,11 @@ class ModelQKNormRopeWithoutBias(nn.Module):
 
         # Q RMSNorm (per-head)
         q_by_head = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
-        q_norm_out, _ = ir.ops.rms_norm(q_by_head, self.q_weight, self.eps)
+        q_norm_out = ir.ops.rms_norm(q_by_head, self.q_weight, self.eps)
 
         # K RMSNorm (per-head)
         k_by_head = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
-        k_norm_out, _ = ir.ops.rms_norm(k_by_head, self.k_weight, self.eps)
+        k_norm_out = ir.ops.rms_norm(k_by_head, self.k_weight, self.eps)
 
         # Reshape for RoPE: [T, num_heads, head_dim] -> [1, T, num_heads, head_dim]
         q_flat = q_norm_out.view(q.shape)
@@ -125,12 +125,12 @@ class ModelQKNormRopeWithBias(nn.Module):
 
         # Q RMSNorm + Bias
         q_by_head = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
-        q_norm_out, _ = ir.ops.rms_norm(q_by_head, self.q_weight, self.eps)
+        q_norm_out = ir.ops.rms_norm(q_by_head, self.q_weight, self.eps)
         q_normed = q_norm_out + self.q_bias
 
         # K RMSNorm + Bias
         k_by_head = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
-        k_norm_out, _ = ir.ops.rms_norm(k_by_head, self.k_weight, self.eps)
+        k_norm_out = ir.ops.rms_norm(k_by_head, self.k_weight, self.eps)
         k_normed = k_norm_out + self.k_bias
 
         # Reshape for RoPE

--- a/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
+++ b/tests/e2e/singlecard/compile/test_graphex_qknorm_rope_fusion.py
@@ -9,7 +9,7 @@ import vllm.config
 from vllm.config import ModelConfig, VllmConfig
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
 from vllm.utils.system_utils import update_environment_variables
-
+from vllm import ir
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.compilation.passes.qknorm_rope_fusion_pass import (
     QKNormRopeFusionPattern,
@@ -77,11 +77,11 @@ class ModelQKNormRopeWithoutBias(nn.Module):
 
         # Q RMSNorm (per-head)
         q_by_head = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
-        q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, self.q_weight, self.eps)
+        q_norm_out, _ = ir.ops.rms_norm(q_by_head, self.q_weight, self.eps)
 
         # K RMSNorm (per-head)
         k_by_head = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
-        k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, self.k_weight, self.eps)
+        k_norm_out, _ = ir.ops.rms_norm(k_by_head, self.k_weight, self.eps)
 
         # Reshape for RoPE: [T, num_heads, head_dim] -> [1, T, num_heads, head_dim]
         q_flat = q_norm_out.view(q.shape)
@@ -124,12 +124,12 @@ class ModelQKNormRopeWithBias(nn.Module):
 
         # Q RMSNorm + Bias
         q_by_head = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
-        q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, self.q_weight, self.eps)
+        q_norm_out, _ = ir.ops.rms_norm(q_by_head, self.q_weight, self.eps)
         q_normed = q_norm_out + self.q_bias
 
         # K RMSNorm + Bias
         k_by_head = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
-        k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, self.k_weight, self.eps)
+        k_norm_out, _ = ir.ops.rms_norm(k_by_head, self.k_weight, self.eps)
         k_normed = k_norm_out + self.k_bias
 
         # Reshape for RoPE

--- a/vllm_ascend/_310p/ops/layernorm.py
+++ b/vllm_ascend/_310p/ops/layernorm.py
@@ -18,7 +18,7 @@ class AscendRMSNorm310(AscendRMSNorm):
                 x.add_(self.bias)
             return x, residual
 
-        x, _ = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
+        x = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
         if self.bias is not None:
             x.add_(self.bias)
         return x
@@ -34,10 +34,10 @@ class AscendGemmaRMSNorm310(AscendGemmaRMSNorm):
             orig_dtype = residual.dtype
             x = x + residual.to(x.dtype)
             residual = x.to(orig_dtype)
-            x, _ = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
+            x = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
             return x, residual
 
-        x, _ = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
+        x = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
         return x
 
 

--- a/vllm_ascend/_310p/ops/layernorm.py
+++ b/vllm_ascend/_310p/ops/layernorm.py
@@ -1,5 +1,6 @@
 import torch
 import torch_npu
+from vllm import ir
 from vllm.model_executor.layers.layernorm import RMSNormGated
 
 from vllm_ascend.ops.layernorm import AscendGemmaRMSNorm, AscendRMSNorm
@@ -17,7 +18,7 @@ class AscendRMSNorm310(AscendRMSNorm):
                 x.add_(self.bias)
             return x, residual
 
-        x, _ = torch_npu.npu_rms_norm(x, self.weight, self.variance_epsilon)
+        x, _ = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
         if self.bias is not None:
             x.add_(self.bias)
         return x
@@ -33,10 +34,10 @@ class AscendGemmaRMSNorm310(AscendGemmaRMSNorm):
             orig_dtype = residual.dtype
             x = x + residual.to(x.dtype)
             residual = x.to(orig_dtype)
-            x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
+            x, _ = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
             return x, residual
 
-        x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
+        x, _ = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
         return x
 
 

--- a/vllm_ascend/_310p/ops/layernorm.py
+++ b/vllm_ascend/_310p/ops/layernorm.py
@@ -34,7 +34,7 @@ class AscendGemmaRMSNorm310(AscendGemmaRMSNorm):
             orig_dtype = residual.dtype
             x = x + residual.to(x.dtype)
             residual = x.to(orig_dtype)
-            x, _ = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
+            x, _ = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
             return x, residual
 
         x, _ = ir.ops.rms_norm(x, 1.0 + self.weight, self.variance_epsilon)

--- a/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
@@ -17,6 +17,7 @@
 #
 import torch
 from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
+from vllm import ir
 from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import Range
@@ -59,10 +60,10 @@ class QKNormRopeFusionPattern(BasePattern):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
             q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-            q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, q_weight, self.eps)
+            q_norm_out, _ = ir.ops.rms_norm(q_by_head, q_weight, self.eps)
 
             k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-            k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, k_weight, self.eps)
+            k_norm_out, _ = ir.ops.rms_norm(k_by_head, k_weight, self.eps)
 
             q_flat = q_norm_out.view(q.shape)
             k_flat = k_norm_out.view(k.shape)
@@ -138,11 +139,11 @@ class QKNormRopeFusionPatternWithBias(BasePattern):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
             q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-            q_norm_out, _ = torch.ops.npu.npu_rms_norm(q_by_head, q_weight, self.eps)
+            q_norm_out, _ = ir.ops.rms_norm(q_by_head, q_weight, self.eps)
             q_normed = q_norm_out + q_bias
 
             k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-            k_norm_out, _ = torch.ops.npu.npu_rms_norm(k_by_head, k_weight, self.eps)
+            k_norm_out, _ = ir.ops.rms_norm(k_by_head, k_weight, self.eps)
             k_normed = k_norm_out + k_bias
 
             q_flat = q_normed.view(q.shape)

--- a/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py
@@ -60,10 +60,10 @@ class QKNormRopeFusionPattern(BasePattern):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
             q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-            q_norm_out, _ = ir.ops.rms_norm(q_by_head, q_weight, self.eps)
+            q_norm_out = ir.ops.rms_norm(q_by_head, q_weight, self.eps)
 
             k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-            k_norm_out, _ = ir.ops.rms_norm(k_by_head, k_weight, self.eps)
+            k_norm_out = ir.ops.rms_norm(k_by_head, k_weight, self.eps)
 
             q_flat = q_norm_out.view(q.shape)
             k_flat = k_norm_out.view(k.shape)
@@ -139,11 +139,11 @@ class QKNormRopeFusionPatternWithBias(BasePattern):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
             q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-            q_norm_out, _ = ir.ops.rms_norm(q_by_head, q_weight, self.eps)
+            q_norm_out = ir.ops.rms_norm(q_by_head, q_weight, self.eps)
             q_normed = q_norm_out + q_bias
 
             k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-            k_norm_out, _ = ir.ops.rms_norm(k_by_head, k_weight, self.eps)
+            k_norm_out = ir.ops.rms_norm(k_by_head, k_weight, self.eps)
             k_normed = k_norm_out + k_bias
 
             q_flat = q_normed.view(q.shape)

--- a/vllm_ascend/kernels/__init__.py
+++ b/vllm_ascend/kernels/__init__.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Kernel implementations for vllm-ascend."""
+
+from . import npu_ops
+
+__all__ = ["npu_ops"]

--- a/vllm_ascend/kernels/npu_ops.py
+++ b/vllm_ascend/kernels/npu_ops.py
@@ -31,11 +31,11 @@ def rms_norm(
     weight: Tensor | None,
     epsilon: float,
     variance_size: int | None = None,
-) -> tuple[Tensor, Tensor]:
+) -> Tensor:
     import torch_npu
 
     if weight is None:
         weight = torch.ones(x.shape[-1], device=x.device, dtype=x.dtype)
     assert variance_size is None
     x, _ = torch_npu.npu_rms_norm(x, weight, epsilon)
-    return x, _
+    return x

--- a/vllm_ascend/kernels/npu_ops.py
+++ b/vllm_ascend/kernels/npu_ops.py
@@ -31,7 +31,7 @@ def rms_norm(
     weight: Tensor | None,
     epsilon: float,
     variance_size: int | None = None,
-) -> Tensor:
+) -> tuple[Tensor, Tensor]:
     import torch_npu
 
     if weight is None:

--- a/vllm_ascend/kernels/npu_ops.py
+++ b/vllm_ascend/kernels/npu_ops.py
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import torch
+from torch import Tensor
+from vllm import ir
+
+rms_no_var_size = lambda x, weight, epsilon, variance_size=None: variance_size is None  # noqa: E731
+
+
+@ir.ops.rms_norm.register_impl(
+    "npu_kernels",
+    supports_args=rms_no_var_size,
+    supported=True,
+)
+def rms_norm(
+    x: Tensor,
+    weight: Tensor | None,
+    epsilon: float,
+    variance_size: int | None = None,
+) -> Tensor:
+    import torch_npu
+
+    if weight is None:
+        weight = torch.ones(x.shape[-1], device=x.device, dtype=x.dtype)
+    assert variance_size is None
+    x, _ = torch_npu.npu_rms_norm(x, weight, epsilon)
+    return x, _

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -80,7 +80,7 @@ class AscendRMSNorm(RMSNorm):
                     x.add_(self.bias)
             return x, residual
 
-        x, residual = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
+        x = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
         if self.bias_loaded:
             x.add_(self.bias)
 

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -18,6 +18,7 @@
 
 import torch
 from torch import nn
+from vllm import ir
 from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 
@@ -79,7 +80,7 @@ class AscendRMSNorm(RMSNorm):
                     x.add_(self.bias)
             return x, residual
 
-        x, residual = torch_npu.npu_rms_norm(x, self.weight, self.variance_epsilon)
+        x, residual = ir.ops.rms_norm(x, self.weight, self.variance_epsilon)
         if self.bias_loaded:
             x.add_(self.bias)
 

--- a/vllm_ascend/ops/qwen2_decoder.py
+++ b/vllm_ascend/ops/qwen2_decoder.py
@@ -17,6 +17,7 @@ from transformers.models.qwen2.modeling_qwen2 import (
 )
 from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs
+from vllm import ir
 from vllm.model_executor.models.deepencoder2 import CustomQwen2Decoder
 
 
@@ -353,4 +354,4 @@ class AscendQwen2RMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return torch_npu.npu_rms_norm(hidden_states, self.weight, epsilon=self.variance_epsilon)[0]
+        return ir.ops.rms_norm(hidden_states, self.weight, epsilon=self.variance_epsilon)[0]

--- a/vllm_ascend/ops/qwen2_decoder.py
+++ b/vllm_ascend/ops/qwen2_decoder.py
@@ -354,4 +354,4 @@ class AscendQwen2RMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return ir.ops.rms_norm(hidden_states, self.weight, epsilon=self.variance_epsilon)[0]
+        return ir.ops.rms_norm(hidden_states, self.weight, epsilon=self.variance_epsilon)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -52,10 +52,12 @@ from vllm_ascend.utils import (
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
+    from vllm.config.kernel import IrOpPriorityConfig
     from vllm.utils import FlexibleArgumentParser
 else:
     ModelConfig = None
     VllmConfig = None
+    IrOpPriorityConfig = None
     FlexibleArgumentParser = None
 
 _CUSTOM_OP_REGISTERED = False
@@ -129,6 +131,19 @@ class NPUPlatform(Platform):
         To use graph fusion operations, we defined our own backend compiler.
         """
         return "vllm_ascend.compilation.compiler_interface.AscendCompiler"
+
+    @classmethod
+    def import_ir_kernels(cls) -> None:
+        """Import vllm_ascend.kernels to trigger NPU custom op registration."""
+        import vllm_ascend.kernels  # noqa: F401
+
+    @classmethod
+    def get_default_ir_op_priority(cls, vllm_config: VllmConfig) -> IrOpPriorityConfig:
+        """Return the default IR op priority for NPU, preferring npu_kernels over native."""
+        from vllm.config.kernel import IrOpPriorityConfig
+
+        default = ["npu_kernels", "native"]
+        return IrOpPriorityConfig.with_default(default)
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces the initial infrastructure for vLLM IR support on Ascend NPU. It implements `import_ir_kernels` to enable NPU custom operator registration and `get_default_ir_op_priority` to set the IR dispatch priority (preferring `npu_kernels` over `native`). Additionally, it registers the `RMSNorm` IR kernel implementation using `torch_npu`.


### Does this PR introduce _any_ user-facing change?
N/A
### How was this patch tested?
CI passed with new added/existing test.

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
