### PR TITLE
[Feature] support structure output for model runner v2

### DIFF
--- a/tests/e2e/singlecard/test_guided_decoding.py
+++ b/tests/e2e/singlecard/test_guided_decoding.py
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 import json
+import os
 from typing import Any
+from unittest.mock import patch
 
 import jsonschema
 import pytest
@@ -26,10 +28,21 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 from tests.e2e.conftest import VllmRunner
+from vllm_ascend.utils import vllm_version_is
 
 MODEL_NAME = "Qwen/Qwen3-0.6B"
 
 GuidedDecodingBackend = ["xgrammar", "guidance", "outlines"]
+
+
+@pytest.fixture(params=[False, True], ids=["v1", "v2"])
+def model_runner_env(request):
+    use_v2_model_runner = request.param
+    if use_v2_model_runner and vllm_version_is("0.20.1"):
+        pytest.skip("No need to support v2 model runner for vLLM tag version.")
+
+    with patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1" if use_v2_model_runner else "0"}):
+        yield
 
 
 @pytest.fixture(scope="module")
@@ -66,7 +79,7 @@ def sample_json_schema():
 
 
 @pytest.mark.parametrize("guided_decoding_backend", GuidedDecodingBackend)
-def test_guided_json_completion(guided_decoding_backend: str, sample_json_schema):
+def test_guided_json_completion(guided_decoding_backend: str, sample_json_schema, model_runner_env):
     runner_kwargs: dict[str, Any] = {}
     sampling_params = SamplingParams(
         temperature=1.0, max_tokens=500, structured_outputs=StructuredOutputsParams(json=sample_json_schema)
@@ -96,7 +109,7 @@ def test_guided_json_completion(guided_decoding_backend: str, sample_json_schema
 
 
 @pytest.mark.parametrize("guided_decoding_backend", GuidedDecodingBackend)
-def test_guided_regex(guided_decoding_backend: str, sample_regex):
+def test_guided_regex(guided_decoding_backend: str, sample_regex, model_runner_env):
     if guided_decoding_backend == "outlines":
         pytest.skip("Outlines doesn't support regex-based guided decoding.")
     runner_kwargs: dict[str, Any] = {}

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -2,6 +2,7 @@ from vllm.v1.worker.gpu import input_batch, model_runner
 from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, penalties, prompt_logprob, sampler, states
 from vllm.v1.worker.gpu.spec_decode import probabilistic_rejection_sampler_utils, rejection_sampler
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 
 from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.input_batch import post_update
@@ -10,6 +11,7 @@ from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 from vllm_ascend.worker.v2.sample.logprob import compute_token_logprobs, compute_topk_logprobs
 from vllm_ascend.worker.v2.sample.min_p import apply_min_p
 from vllm_ascend.worker.v2.sample.penalties import apply_penalties, bincount
+from vllm_ascend.worker.v2.structured_outputs import apply_grammar_bitmask
 
 penalties.apply_penalties = apply_penalties
 # because sampler.py and speculator.py are imported before this patch, they must be overridden
@@ -26,6 +28,7 @@ bad_words.apply_bad_words = apply_bad_words
 gumbel.apply_temperature = apply_temperature
 states.apply_temperature = apply_temperature
 logprob.compute_token_logprobs = compute_token_logprobs
+StructuredOutputsWorker.apply_grammar_bitmask = apply_grammar_bitmask
 
 if not vllm_version_is("0.20.1"):
     from vllm_ascend.worker.v2.spec_decode.probabilistic_rejection_sampler_utils import (

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -1,8 +1,7 @@
-from vllm.v1.worker.gpu import input_batch, model_runner
+from vllm.v1.worker.gpu import input_batch, model_runner, structured_outputs
 from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, penalties, prompt_logprob, sampler, states
 from vllm.v1.worker.gpu.spec_decode import probabilistic_rejection_sampler_utils, rejection_sampler
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator
-from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 
 from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.input_batch import post_update
@@ -11,7 +10,7 @@ from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 from vllm_ascend.worker.v2.sample.logprob import compute_token_logprobs, compute_topk_logprobs
 from vllm_ascend.worker.v2.sample.min_p import apply_min_p
 from vllm_ascend.worker.v2.sample.penalties import apply_penalties, bincount
-from vllm_ascend.worker.v2.structured_outputs import apply_grammar_bitmask
+from vllm_ascend.worker.v2.structured_outputs import _apply_grammar_bitmask_kernel
 
 penalties.apply_penalties = apply_penalties
 # because sampler.py and speculator.py are imported before this patch, they must be overridden
@@ -28,7 +27,7 @@ bad_words.apply_bad_words = apply_bad_words
 gumbel.apply_temperature = apply_temperature
 states.apply_temperature = apply_temperature
 logprob.compute_token_logprobs = compute_token_logprobs
-StructuredOutputsWorker.apply_grammar_bitmask = apply_grammar_bitmask
+structured_outputs._apply_grammar_bitmask_kernel = _apply_grammar_bitmask_kernel
 
 if not vllm_version_is("0.20.1"):
     from vllm_ascend.worker.v2.spec_decode.probabilistic_rejection_sampler_utils import (

--- a/vllm_ascend/worker/v2/structured_outputs.py
+++ b/vllm_ascend/worker/v2/structured_outputs.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+# NPU-compatible structured output bitmask kernel and apply method.
+#
+# Upstream cannot be used directly on Ascend NPU: `BLOCK_SIZE=8192` overflows
+# UB, while a smaller `BLOCK_SIZE` makes the grid unstable. We therefore keep
+# `BLOCK_SIZE=8192` and split each block with `BLOCK_SIZE_SUB=1024`.
+#
+#
+
+
+import torch
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+
+_NPU_BLOCK_SIZE = 8192
+_NPU_BLOCK_SIZE_SUB = 1024
+
+
+def apply_grammar_bitmask(self, logits, input_batch, grammar_req_ids, grammar_bitmask):
+    """NPU-compatible apply_grammar_bitmask for StructuredOutputsWorker.
+
+    Differences from the upstream implementation:
+      - Uses BLOCK_SIZE_SUB tiling (gather_kernel pattern) to avoid UB
+        overflow while keeping BLOCK_SIZE=8192 for a small grid.
+
+    """
+    if not grammar_req_ids:
+        return
+
+    # Asynchronously copy the bitmask to NPU.
+    with torch.cuda.stream(self.copy_stream):
+        bitmask = async_copy_to_gpu(
+            grammar_bitmask,
+            out=self.grammar_bitmask[: grammar_bitmask.shape[0]],
+        )
+
+    # Construct bitmask -> logits mapping
+    mapping: list[int] = []
+    req_ids = input_batch.req_ids
+    cu_num_logits = input_batch.cu_num_logits_np.tolist()
+    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+    for grammar_req_id in grammar_req_ids:
+        req_idx = req_id_to_idx[grammar_req_id]
+        logits_start_idx = cu_num_logits[req_idx]
+        logits_end_idx = cu_num_logits[req_idx + 1]
+        mapping.extend(range(logits_start_idx, logits_end_idx))
+
+    num_masks = bitmask.shape[0]
+    assert num_masks == len(mapping), f"num_masks={num_masks} != len(mapping)={len(mapping)}"
+
+    # Asynchronously copy the mapping to NPU.
+    with torch.cuda.stream(self.copy_stream):
+        logits_indices_cpu = torch.tensor(mapping, dtype=torch.int32, device="cpu", pin_memory=True)
+        logits_indices = self.logits_indices[: len(mapping)].copy_(logits_indices_cpu, non_blocking=True)
+    # ensure copies finish before kernel launch
+    current_stream = torch.cuda.current_stream()
+    current_stream.wait_stream(self.copy_stream)
+
+    vocab_size = logits.shape[-1]
+    BLOCK_SIZE = _NPU_BLOCK_SIZE
+    BLOCK_SIZE_SUB = _NPU_BLOCK_SIZE_SUB
+    grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))
+    _apply_grammar_bitmask_kernel[grid](
+        logits,
+        logits.stride(0),
+        logits_indices,
+        bitmask,
+        bitmask.stride(0),
+        vocab_size,
+        BLOCK_SIZE=BLOCK_SIZE,
+        BLOCK_SIZE_SUB=BLOCK_SIZE_SUB,
+    )
+
+    # Ensure the copy stream waits for the device tensors to finish being used
+    # before it reuses or deallocates them
+    self.copy_stream.wait_stream(current_stream)
+
+
+# Adapted from
+# https://github.com/mlc-ai/xgrammar/blob/main/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+# Ascend NPU bitmask kernel (BLOCK_SIZE_SUB tiling)
+@triton.jit
+def _apply_grammar_bitmask_kernel(
+    logits_ptr,
+    logits_stride,
+    logits_indices_ptr,
+    bitmask_ptr,
+    bitmask_stride,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE_SUB: tl.constexpr,
+):
+    bitmask_idx = tl.program_id(0)
+    block_id = tl.program_id(1)
+    logits_idx = tl.load(logits_indices_ptr + bitmask_idx)
+
+    # Sub-block tiling loop: process BLOCK_SIZE_SUB tokens per iteration
+    for sub_offset in tl.range(0, BLOCK_SIZE, BLOCK_SIZE_SUB):
+        global_token_offset = block_id * BLOCK_SIZE + sub_offset
+        bitmask_word_start = global_token_offset // 32
+        bitmask_offset = bitmask_word_start + tl.arange(0, BLOCK_SIZE_SUB // 32)
+        packed_bitmask = tl.load(
+            bitmask_ptr + bitmask_idx * bitmask_stride + bitmask_offset,
+            mask=bitmask_offset < bitmask_stride,
+            other=0,
+        )
+        # Unpack: each int32 word → 32 bool values (0 = blocked)
+        bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
+        bitmask = bitmask.reshape(BLOCK_SIZE_SUB)
+
+        # Apply: set blocked positions to -inf
+        block_offset = global_token_offset + tl.arange(0, BLOCK_SIZE_SUB)
+        tl.store(
+            logits_ptr + logits_idx * logits_stride + block_offset,
+            -float("inf"),
+            mask=bitmask & (block_offset < vocab_size),
+        )

--- a/vllm_ascend/worker/v2/structured_outputs.py
+++ b/vllm_ascend/worker/v2/structured_outputs.py
@@ -45,7 +45,7 @@ def apply_grammar_bitmask(self, logits, input_batch, grammar_req_ids, grammar_bi
         return
 
     # Asynchronously copy the bitmask to NPU.
-    with torch.cuda.stream(self.copy_stream):
+    with torch.npu.stream(self.copy_stream):
         bitmask = async_copy_to_gpu(
             grammar_bitmask,
             out=self.grammar_bitmask[: grammar_bitmask.shape[0]],
@@ -66,11 +66,11 @@ def apply_grammar_bitmask(self, logits, input_batch, grammar_req_ids, grammar_bi
     assert num_masks == len(mapping), f"num_masks={num_masks} != len(mapping)={len(mapping)}"
 
     # Asynchronously copy the mapping to NPU.
-    with torch.cuda.stream(self.copy_stream):
+    with torch.npu.stream(self.copy_stream):
         logits_indices_cpu = torch.tensor(mapping, dtype=torch.int32, device="cpu", pin_memory=True)
         logits_indices = self.logits_indices[: len(mapping)].copy_(logits_indices_cpu, non_blocking=True)
     # ensure copies finish before kernel launch
-    current_stream = torch.cuda.current_stream()
+    current_stream = torch.npu.current_stream()
     current_stream.wait_stream(self.copy_stream)
 
     vocab_size = logits.shape[-1]

--- a/vllm_ascend/worker/v2/structured_outputs.py
+++ b/vllm_ascend/worker/v2/structured_outputs.py
@@ -30,6 +30,7 @@ from vllm.triton_utils import tl, triton
 # Adapted from
 # https://github.com/mlc-ai/xgrammar/blob/main/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
 # Ascend NPU bitmask kernel (BLOCK_SIZE_SUB tiling)
+# TODO: Optimize the kernel performance with NPU profiling data.
 @triton.jit
 def _apply_grammar_bitmask_kernel(
     logits_ptr,

--- a/vllm_ascend/worker/v2/structured_outputs.py
+++ b/vllm_ascend/worker/v2/structured_outputs.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-# NPU-compatible structured output bitmask kernel and apply method.
+# NPU-compatible structured output bitmask kernel.
 #
 # Upstream cannot be used directly on Ascend NPU: `BLOCK_SIZE=8192` overflows
 # UB, while a smaller `BLOCK_SIZE` makes the grid unstable. We therefore keep
@@ -24,73 +24,7 @@
 #
 #
 
-
-import torch
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
-
-_NPU_BLOCK_SIZE = 8192
-_NPU_BLOCK_SIZE_SUB = 1024
-
-
-def apply_grammar_bitmask(self, logits, input_batch, grammar_req_ids, grammar_bitmask):
-    """NPU-compatible apply_grammar_bitmask for StructuredOutputsWorker.
-
-    Differences from the upstream implementation:
-      - Uses BLOCK_SIZE_SUB tiling (gather_kernel pattern) to avoid UB
-        overflow while keeping BLOCK_SIZE=8192 for a small grid.
-
-    """
-    if not grammar_req_ids:
-        return
-
-    # Asynchronously copy the bitmask to NPU.
-    with torch.npu.stream(self.copy_stream):
-        bitmask = async_copy_to_gpu(
-            grammar_bitmask,
-            out=self.grammar_bitmask[: grammar_bitmask.shape[0]],
-        )
-
-    # Construct bitmask -> logits mapping
-    mapping: list[int] = []
-    req_ids = input_batch.req_ids
-    cu_num_logits = input_batch.cu_num_logits_np.tolist()
-    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
-    for grammar_req_id in grammar_req_ids:
-        req_idx = req_id_to_idx[grammar_req_id]
-        logits_start_idx = cu_num_logits[req_idx]
-        logits_end_idx = cu_num_logits[req_idx + 1]
-        mapping.extend(range(logits_start_idx, logits_end_idx))
-
-    num_masks = bitmask.shape[0]
-    assert num_masks == len(mapping), f"num_masks={num_masks} != len(mapping)={len(mapping)}"
-
-    # Asynchronously copy the mapping to NPU.
-    with torch.npu.stream(self.copy_stream):
-        logits_indices_cpu = torch.tensor(mapping, dtype=torch.int32, device="cpu", pin_memory=True)
-        logits_indices = self.logits_indices[: len(mapping)].copy_(logits_indices_cpu, non_blocking=True)
-    # ensure copies finish before kernel launch
-    current_stream = torch.npu.current_stream()
-    current_stream.wait_stream(self.copy_stream)
-
-    vocab_size = logits.shape[-1]
-    BLOCK_SIZE = _NPU_BLOCK_SIZE
-    BLOCK_SIZE_SUB = _NPU_BLOCK_SIZE_SUB
-    grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))
-    _apply_grammar_bitmask_kernel[grid](
-        logits,
-        logits.stride(0),
-        logits_indices,
-        bitmask,
-        bitmask.stride(0),
-        vocab_size,
-        BLOCK_SIZE=BLOCK_SIZE,
-        BLOCK_SIZE_SUB=BLOCK_SIZE_SUB,
-    )
-
-    # Ensure the copy stream waits for the device tensors to finish being used
-    # before it reuses or deallocates them
-    self.copy_stream.wait_stream(current_stream)
 
 
 # Adapted from
@@ -105,8 +39,8 @@ def _apply_grammar_bitmask_kernel(
     bitmask_stride,
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
-    BLOCK_SIZE_SUB: tl.constexpr,
 ):
+    BLOCK_SIZE_SUB: tl.constexpr = 1024
     bitmask_idx = tl.program_id(0)
     block_id = tl.program_id(1)
     logits_idx = tl.load(logits_indices_ptr + bitmask_idx)
@@ -121,7 +55,6 @@ def _apply_grammar_bitmask_kernel(
             mask=bitmask_offset < bitmask_stride,
             other=0,
         )
-        # Unpack: each int32 word → 32 bool values (0 = blocked)
         bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
         bitmask = bitmask.reshape(BLOCK_SIZE_SUB)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Ascend NPU support for structured outputs in model runner v2.

Upstream `StructuredOutputsWorker.apply_grammar_bitmask` cannot be used directly on Ascend because the original Triton kernel with `BLOCK_SIZE=8192` may exceed UB capacity.  Reducing `BLOCK_SIZE` avoids UB overflow, but increases the number of work-groups and may lead to unstable scheduling behavior on NPU.

To address this, this PR adds an Ascend-specific `_apply_grammar_bitmask_kernel` implementation that:
- introduces `BLOCK_SIZE_SUB=1024` tiling inside each block to reduce UB usage
- applies the grammar bitmask to logits with an NPU-compatible Triton kernel
- patches `_apply_grammar_bitmask_kernel` for model runner v2

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
