### PR TITLE
[BugFix] Fixed a bug when adapting latest vllm for model_runner_v2

### DIFF
--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -30,6 +30,7 @@ MAIN_MODELS = ["LLM-Research/Meta-Llama-3.1-8B-Instruct"]
 EGALE_MODELS = ["vllm-ascend/EAGLE-LLaMA3.1-Instruct-8B"]
 
 
+@pytest.mark.skipif(vllm_version_is("0.19.0"), reason="no need to support model_runner for v0.19.0")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [True])
@@ -98,6 +99,7 @@ def test_egale_spec_decoding(
         runner.model.generate(prompts, sampling_params)
 
 
+@pytest.mark.skipif(vllm_version_is("0.19.0"), reason="no need to support model_runner for v0.19.0")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [False])
@@ -125,4 +127,26 @@ def test_qwen3_dense_graph_mode(
         enforce_eager=enforce_eager,
         compilation_config=compilation_config,
     ) as runner:
-        runner.model.generate(prompts, sampling_params)
+        outputs = runner.model.generate(prompts, sampling_params)
+
+    if model != "Qwen/Qwen3-0.6B":
+        return
+
+    expected_outputs = [
+        " Lina. I'm a 22-year-old student from China.",
+        " the same as the president of the United Nations. This is because the president",
+        " Paris. The capital of France is also the capital of the Republic of France",
+        " not just about the technology itself but also about the human aspect-how we",
+    ]
+
+    matches = 0
+    misses = 0
+    for output, expected_output in zip(outputs, expected_outputs):
+        if output.outputs[0].text[:10] == expected_output[:10]:
+            matches += 1
+        else:
+            misses += 1
+            print(f"output: {output.outputs[0].text}")
+            print(f"expected_output: {expected_output}")
+
+    assert misses == 0

--- a/vllm_ascend/worker/v2/README.md
+++ b/vllm_ascend/worker/v2/README.md
@@ -18,3 +18,10 @@ to get specific plans.
     Why: KV cache requires continuous space (thus divided as K cache and V cache separately) and PD disaggregation requires 2M-aligned tensors for KV cache, so custom KV cache initialization is needed. These should be removed when the above 2 requirements are no longer needed.
 
     Location: `attn_utils._get_layer_kv_cache_specs`, `attn_utils._get_attention_kv_cache_dims`, `attn_utils._align_memory`, `attn_utils._allocate_kv_cache`, `attn_utils._reshape_kv_cache`.
+
+- [ ] `graph_manager_wrapper`
+
+    Why: ModelAclGraphManager needs model_runner's input_buffers and model_state.attn_metadata to update_full_graph_params, so model_runner should be passed into __init
+    __ of ModelAclGraphManager.
+
+    Location: `model_runner.NPUModelRunner.initialize_kv_cache`.

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -16,12 +16,15 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+from contextlib import contextmanager
 
 import numpy as np
 import torch
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu import model_runner as vllm_model_runner
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import (
@@ -73,19 +76,9 @@ class NPUModelRunner(GPUModelRunner):
 
         # because we will override these attribute, delete these attribute to
         # make sure it's collected by python gc immediately.
-        del self.cudagraph_manager
         del self.req_states
         del self.input_buffers
         del self.speculator
-
-        # NPU specific initializations can be added below.
-        self.cudagraph_manager: ModelAclGraphManager = ModelAclGraphManager(
-            self.vllm_config,
-            self.device,
-            self.compilation_config.cudagraph_mode,
-            decode_query_len=self.decode_query_len,
-            model_runner=self,
-        )
 
         # we define AscendEagleSpeculator in vllm_ascend.worker.v2.spec_decode.eagle.speculator
         # init_speculator will return AscendEagleSpeculator when eagle is used.
@@ -146,6 +139,10 @@ class NPUModelRunner(GPUModelRunner):
         # we need to use input_batch to set forward_context in run_fullgraph.
         # so we can inherit `execute_model` method.
         self.input_batch: AscendInputBatch | None = None
+
+    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        with graph_manager_wrapper(self):
+            super().initialize_kv_cache(kv_cache_config)
 
     @torch.inference_mode()
     def profile_run(self) -> None:
@@ -432,3 +429,18 @@ class NPUModelRunner(GPUModelRunner):
             num_reqs_padded = num_reqs_padded + 1
 
         return query_start_loc_np, num_reqs_padded
+
+
+@contextmanager
+def graph_manager_wrapper(model_runner):
+    """Context manager to override graph manager."""
+    original_graph_manager = vllm_model_runner.ModelCudaGraphManager
+
+    def factory(vllm_config: VllmConfig, device: torch.device, cudagraph_mode: CUDAGraphMode, decode_query_len: int):
+        return ModelAclGraphManager(vllm_config, device, cudagraph_mode, decode_query_len, model_runner)
+
+    try:
+        vllm_model_runner.ModelCudaGraphManager = factory
+        yield
+    finally:
+        vllm_model_runner.ModelCudaGraphManager = original_graph_manager


### PR DESCRIPTION
### What this PR does / why we need it?

- vllm move `graph_manager`'s __init__ into initialize_kv_cache.
- add an accuracy test.

outputs from `qwen3-0.6B`:
```text
Prompt: "Hello, my name is", Generated text: " Lina. I'm a 22-year-old student from China."
Prompt: "The president of the United States is", Generated text: " the same as the president of the United Nations. This is because the president"
Prompt: " Paris. The capital of France is also the capital of the Republic of France"
Prompt: "The future of AI is", Generated text: " not just about the technology itself but also about the human aspect-how we"
```

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

`e2e` for graph mode in `‎tests/e2e/singlecard/model_runner_v2/test_basic.py` covers it.

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
