### PR TITLE
[Test] add E2E Test for Dflash

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -249,7 +249,8 @@
       "MiniMax/MiniMax-M2.5",
       "Eco-Tech/Qwen3.5-27B-w8a8-mtp",
       "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot",
-      "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+      "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp",
+      "z-lab/Qwen3-8B-DFlash-b16"
     ], 
     "datasets": [
       "vllm-ascend/GSM8K-in1024-bs210",

--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -35,12 +35,20 @@ DRAFT_PARALLEL_MODELS = {
     },
 }
 
+DFLASH = {
+    "dflash": {
+        "main": "Qwen/Qwen3-8B",
+        "spec": "z-lab/Qwen3-8B-DFlash-b16",
+    }
+}
+
 # NOTE: golden may change (eagle_proposer only runs in eager mode currently),
 # thus please update it if ci fails but you have better acceptance
 BASELINES = {
     "eagle": [0.74, 0.44, 0.29],
     "eagle3": [0.68, 0.40, 0.18],
     "draft_parallel": [0.83, 0.50, 0.33, 0.17, 0.17, 0.17, 0.17, 0.00],
+    "dflash": [0.67, 0.67, 0.44, 0.33, 0.11, 0.00, 0.00, 0.00],
 }
 
 
@@ -609,3 +617,97 @@ def test_eagle3_fia_pad_under_max_concurrency(
         compilation_config=compilation_config,
     ) as llm:
         _ = llm.generate_greedy(prompts, max_tokens=10)
+
+
+@pytest.mark.parametrize("method", DFLASH.keys())
+@pytest.mark.parametrize("num_speculative_tokens", [8])
+def test_dflash_acceptance(
+    method: str,
+    num_speculative_tokens: int,
+):
+    from vllm_ascend.utils import vllm_version_is
+
+    if vllm_version_is("0.19.0"):
+        pytest.skip("Dflash tests are not supported on vLLM version 0.19.0")
+
+    main_model_name = DFLASH[method]["main"]
+    spec_model_name = DFLASH[method]["spec"]
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        main_model_name,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    prompts = [
+        {
+            "role": "user",
+            "content": "Hello, your name is",
+        },
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [prompt],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        for prompt in prompts
+    ]
+
+    speculative_config = {
+        "method": "draft_model",
+        "model": spec_model_name,
+        "num_speculative_tokens": num_speculative_tokens,
+        "enforce_eager": True,
+    }
+
+    compilation_config = CompilationConfig(cudagraph_capture_sizes=[9])
+
+    with VllmRunner(
+        main_model_name,
+        max_model_len=4096,
+        disable_log_stats=False,
+        tensor_parallel_size=1,
+        max_num_seqs=256,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.8,
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        enable_prefix_caching=False,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"Output tokens: {output_tokens}")
+
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * num_speculative_tokens
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [num_accepted_tokens / num_drafts for num_accepted_tokens in num_accepted_tokens_per_pos]
+
+    golden = BASELINES[method]
+
+    match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
+    if not match:
+        print(f"acceptance_per_pos: {acceptance_per_pos}")
+        print(f"golden: {golden}")
+
+    assert match


### PR DESCRIPTION
Added E2E Test cases for the speculative method Dflash.
The vLLM v0.19.0 version is skipped because it does not support Dflash.
Only cases in Eager mode are used. Cases in FULL_DECODE_ONLY mode will be added later.
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
