### PR TITLE
[BugFix] handle enum-based MoE activation in fuse_moe/moe_mlp unquant_apply_mlp

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -336,6 +336,8 @@ def unquant_apply_mlp(
         w1 = w1.transpose(1, 2)
         w2 = w2.transpose(1, 2)
 
+    act_name = getattr(activation, "value", activation)
+
     gate_up_out = torch_npu.npu_grouped_matmul(
         x=[hidden_states],
         weight=[w1],
@@ -346,7 +348,7 @@ def unquant_apply_mlp(
         group_list=group_list,
     )[0]
 
-    if activation == "swigluoai":
+    if act_name == "swigluoai":
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
     else:


### PR DESCRIPTION
  ### What this PR does / why we need it?

  This PR fixes a compatibility issue in `vllm_ascend/ops/fused_moe/moe_mlp.py` for newer vLLM versions and will fix https://github.com/vllm-project/vllm-ascend/issues/8463 

  In older versions, `activation` passed into `unquant_apply_mlp` is a plain string such as `"swigluoai"`. In newer vLLM versions, the same field
  is passed as a `MoEActivation` enum. The previous implementation compared `activation` directly against the string `"swigluoai"`, so on newer
  versions the check always failed and the code fell back to the generic `torch_npu.npu_swiglu(...)` path instead of the intended
  `AscendSwigluOAIAndMul.swiglu_oai_forward(...)` path.

  This especially affects `gpt-oss`, which uses `activation="swigluoai"` in its MoE MLP. As a result, the wrong activation path was selected
  during inference and outputs could become incorrect / garbled.

  This patch keeps backward compatibility with both calling conventions:

  - old vLLM versions: `activation` is a string
  - newer vLLM versions: `activation` is a `MoEActivation` enum

  The change is intentionally minimal and only normalizes `activation` inside `unquant_apply_mlp` before checking whether it is `swigluoai`.

  ### Does this PR introduce _any_ user-facing change?

  This changes inference behavior for affected models on newer vLLM versions. In particular, `gpt-oss` now correctly takes the `swigluoai` path in the unquantized fused MoE MLP instead of the generic SwiGLU path, which fixes incorrect / garbled outputs.

  There is no API or interface change.

  ### How was this patch tested?

  Tested manually on an Ascend A2 environment with real inference regression checks. End-to-end regression with gpt-oss-120b served by vLLM:

```
export VLLM_PLUGINS=ascend
vllm serve /path/to/gpt-oss-120b-bf16  \
  --served-model-name gpt-oss-120b-bf16 \
  --port 9350 \
  --max-model-len 131072 \
  --max-num-seqs 128 \
  --tensor-parallel-size 8 \
  --max-num-batched-tokens 32768 \
  --enforce-eager \
  --enable-chunked-prefill \
  --gpu-memory-utilization 0.9
```

Then sent:

```
curl http://127.0.0.1:9350/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "Say this is a test",
    "max_tokens": 7,
    "temperature": 0
  }'
```

Observed normal output:

```json
{
  "choices": [
    {
      "text": ". This is only a test."
    }
  ]
}
```

3. Sanity check:

python -m py_compile vllm_ascend/ops/fused_moe/moe_mlp.py

No dedicated unit test was added in this PR because the issue is caused by an integration-level behavior difference between older and newer vLLM
activation types (string vs enum), and the most reliable validation is real model inference on Ascend.


- vLLM version: v0.17.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b31e9326a7d9394aab8c767f8ebe225c65594b60
