### PR TITLE
[Misc] Capitalize author field in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -505,7 +505,7 @@ setup(
     # Follow:
     # https://packaging.python.org/en/latest/specifications/version-specifiers
     version=VERSION,
-    author="vLLM-Ascend team",
+    author="vLLM-Ascend Team",
     license="Apache 2.0",
     description="vLLM Ascend backend plugin",
     long_description=read_readme(),


### PR DESCRIPTION
### What this PR does / why we need it?

- Capitalize the "T" in "team" to "Team" in the `author` field of `setup.py` for consistent naming style.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No test needed. This is a trivial metadata change.
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
