### PR TITLE
[BugFix] Add compatibility guard for --enable-dbo on Ascend NPU

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -882,6 +882,15 @@ class NPUPlatform(Platform):
                 )
                 att_config.flash_attn_max_num_splits_for_cuda_graph = 32
 
+        # ==================== 9. Parallel Config ====================
+        if vllm_config.parallel_config:
+            if getattr(vllm_config.parallel_config, "enable_dbo", False):
+                logger.warning(
+                    "Parameter '--enable-dbo' is not yet supported on "
+                    "Ascend NPU. Resetting to False."
+                )
+                vllm_config.parallel_config.enable_dbo = False
+
     @classmethod
     def use_custom_op_collectives(cls) -> bool:
         return True

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -891,6 +891,14 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.parallel_config.enable_dbo = False
 
+            ubatch_size = getattr(vllm_config.parallel_config, "ubatch_size", 0)
+            if ubatch_size > 1:
+                logger.warning(
+                    "Parameter '--ubatch-size' relies on DBO which is not "
+                    "yet supported on Ascend NPU. Resetting to 0."
+                )
+                vllm_config.parallel_config.ubatch_size = 0
+
     @classmethod
     def use_custom_op_collectives(cls) -> bool:
         return True


### PR DESCRIPTION
### What this PR does / why we need it?

Add compatibility guards for DBO-related parameters in `_fix_incompatible_config()` (section 9: Parallel Config). DBO (Disaggregated Batch Orchestration) is not yet supported on Ascend NPU, so these parameters need to be intercepted and reset to safe defaults.

**Guarded parameters:**

| Parameter | Risk | Action |
|-----------|------|--------|
| `--enable-dbo` | Enables DBO code path, not supported on Ascend | Reset to `False` |
| `--ubatch-size` | When > 1, activates `use_ubatching` even without `enable_dbo`, triggering UBatch/microbatching path | Reset to `0` |
| `--dbo-decode-token-threshold` | Only read when `use_ubatching=True`; with both guards above it's never reached | No action needed |
| `--dbo-prefill-token-threshold` | Same as above | No action needed |

**Why `--ubatch-size` needs a separate guard:**

`ParallelConfig.use_ubatching` is defined as `enable_dbo or ubatch_size > 1`. Even after resetting `enable_dbo=False`, a user-supplied `--ubatch-size 128` would still make `use_ubatching=True`, activating `UBatchWrapper` instead of `CUDAGraphWrapper` and splitting batches into microbatches — which is untested on Ascend and could cause runtime issues.

### Does this PR introduce _any_ user-facing change?

Yes. Users who pass `--enable-dbo` or `--ubatch-size > 1` will see a warning log and the parameters will be silently reset on Ascend NPU.

### How was this patch tested?

Launched `vllm serve` with `--enable-dbo` on a 4-card Ascend NPU node (model: Qwen3.5-35B-A3B-w8a8-mtp, TP=4) and verified:

1. **Startup**: Service started successfully. Confirmed the warning log `"Parameter '--enable-dbo' is not yet supported on Ascend NPU. Resetting to False."` appeared, proving the guard triggered correctly.
2. **Endpoint verification**: All 9 API endpoints (`/health`, `/v1/models`, `/load`, `/version`, `/tokenize`, `/detokenize`, `/v1/chat/completions`, `/v1/completions`, `/v1/responses`) returned correct responses.
3. **Stress test**: 100 concurrent chat completion requests, 100/100 succeeded (p50=0.854s, p99=0.956s).