### PR TITLE
[Doc][KV Pool]Fix typo in KV Cache Pool Guide documentation

### DIFF
--- a/docs/source/developer_guide/Design_Documents/KV_Cache_Pool_Guide.md
+++ b/docs/source/developer_guide/Design_Documents/KV_Cache_Pool_Guide.md
@@ -33,7 +33,7 @@ When combined with vLLM's Prefix Caching mechanism, the pool enables efficient c
 Prefix Caching with on-chip memory is already supported by the vLLM V1 Engine.
 By introducing KV Connector V1, users can seamlessly combine on-chip memory-based Prefix Caching with Mooncake-backed KV Pool.
 
- The user can enable both features simply by enabling Prefix Caching, which is enabled by default in vLLM V1 unless the `--no_enable_prefix_caching` flag is set, and setting up the KV Connector for KV Pool (e.g., the MooncakeStoreConnector).
+ The user can enable both features simply by enabling Prefix Caching, which is enabled by default in vLLM V1 unless the `--no-enable-prefix-caching` flag is set, and setting up the KV Connector for KV Pool (e.g., the MooncakeStoreConnector).
 
 **Workflow**:
 


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
