### PR TITLE
[BugFix][310P] Use CPU generator cache for sampling

### DIFF
--- a/tests/ut/_310p/sample/test_sampler_310.py
+++ b/tests/ut/_310p/sample/test_sampler_310.py
@@ -1,9 +1,36 @@
+import sys
+import unittest
 from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
 
-from vllm_ascend._310p.sample import sampler as sampler_310p
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+if "vllm" not in sys.modules:
+    vllm_module = ModuleType("vllm")
+    vllm_module.envs = SimpleNamespace(VLLM_BATCH_INVARIANT=False)
+    sys.modules["vllm"] = vllm_module
+    sys.modules["vllm.envs"] = vllm_module.envs
+
+if "vllm_ascend.sample.sampler" not in sys.modules:
+    sample_sampler_module = ModuleType("vllm_ascend.sample.sampler")
+    sample_sampler_module.DEFAULT_LOGPROBS_MODE = "raw_logprobs"
+    sample_sampler_module.AscendSampler = type("AscendSampler", (), {})
+    sample_sampler_module.AscendTopKTopPSampler = type("AscendTopKTopPSampler", (), {})
+    sys.modules["vllm_ascend.sample.sampler"] = sample_sampler_module
+
+if "vllm_ascend.utils" not in sys.modules:
+    utils_module = ModuleType("vllm_ascend.utils")
+    utils_module.global_stream = lambda: MagicMock()
+    utils_module.npu_stream_switch = lambda _: nullcontext()
+    sys.modules["vllm_ascend.utils"] = utils_module
+
+from vllm_ascend._310p.sample import sampler as sampler_310p  # noqa: E402
 
 
 class _FakeRow:
@@ -48,74 +75,87 @@ class _FakeCPUGenerator:
         self.seed = seed
 
 
-def test_random_sample_310p_reuse_cpu_generator_cache():
-    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
-    probs = MagicMock()
-    probs.div_.return_value = probs
-    probs.argmax.return_value = probs
-    probs.view.return_value = torch.tensor([0])
+class TestSampler310pStandalone(unittest.TestCase):
+    def tearDown(self):
+        sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
 
-    fake_q_first = _FakeQ(batch_size=2)
-    fake_q_second = _FakeQ(batch_size=2)
+    def test_random_sample_310p_reuse_cpu_generator_cache(self):
+        sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+        probs = MagicMock()
+        probs.div_.return_value = probs
+        probs.argmax.return_value = probs
+        probs.view.return_value = torch.tensor([0])
 
-    npu_stream = MagicMock()
-    generator = MagicMock()
-    generator.get_state.return_value = b"state"
-    generator.initial_seed.return_value = 7
-    generators = {1: generator}
+        fake_q_first = _FakeQ(batch_size=2)
+        fake_q_second = _FakeQ(batch_size=2)
 
-    with (
-        patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
-        patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-        patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
-        patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
-        patch.object(sampler_310p.torch.npu, "current_stream", return_value=npu_stream),
-    ):
-        sampler_310p._random_sample_310p(probs, generators)
-        sampler_310p._random_sample_310p(probs, generators)
+        npu_stream = MagicMock()
+        generator = MagicMock()
+        generator.get_state.return_value = b"state"
+        generator.initial_seed.return_value = 7
+        generators = {1: generator}
 
-    assert gen_ctor.call_count == 1
-    assert 1 in sampler_310p._CPU_GENERATOR_CACHE_310P
-    cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[1]
-    assert fake_q_first.rows[1].generators[0] is cached_cpu_generator
-    assert fake_q_second.rows[1].generators[0] is cached_cpu_generator
-    assert cached_cpu_generator.state == b"state"
-    assert cached_cpu_generator.seed is None
-    assert npu_stream.wait_stream.call_count == 2
+        with (
+            patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
+            patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
+            patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+            patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
+            patch.object(
+                sampler_310p.torch,
+                "npu",
+                SimpleNamespace(current_stream=MagicMock(return_value=npu_stream)),
+                create=True,
+            ),
+        ):
+            sampler_310p._random_sample_310p(probs, generators)
+            sampler_310p._random_sample_310p(probs, generators)
 
-    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+        self.assertEqual(gen_ctor.call_count, 1)
+        self.assertIn(1, sampler_310p._CPU_GENERATOR_CACHE_310P)
+        cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[1]
+        self.assertIs(fake_q_first.rows[1].generators[0], cached_cpu_generator)
+        self.assertIs(fake_q_second.rows[1].generators[0], cached_cpu_generator)
+        self.assertEqual(cached_cpu_generator.state, b"state")
+        self.assertIsNone(cached_cpu_generator.seed)
+        self.assertEqual(npu_stream.wait_stream.call_count, 2)
+
+    def test_random_sample_310p_fallback_to_initial_seed_when_set_state_failed(self):
+        sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+        probs = MagicMock()
+        probs.div_.return_value = probs
+        probs.argmax.return_value = probs
+        probs.view.return_value = torch.tensor([1])
+
+        fake_q = _FakeQ(batch_size=1)
+        npu_stream = MagicMock()
+        generator = MagicMock()
+        generator.get_state.side_effect = RuntimeError("state read failed")
+        generator.initial_seed.return_value = 1234
+        generators = {0: generator}
+
+        class _FailSetStateCPUGenerator(_FakeCPUGenerator):
+            def set_state(self, state):
+                raise RuntimeError("state set failed")
+
+        with (
+            patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
+            patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
+            patch.object(sampler_310p.torch, "empty_like", return_value=fake_q),
+            patch.object(sampler_310p.torch, "Generator", side_effect=_FailSetStateCPUGenerator),
+            patch.object(
+                sampler_310p.torch,
+                "npu",
+                SimpleNamespace(current_stream=MagicMock(return_value=npu_stream)),
+                create=True,
+            ),
+        ):
+            sampler_310p._random_sample_310p(probs, generators)
+
+        cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
+        self.assertEqual(cached_cpu_generator.seed, 1234)
+        self.assertIs(fake_q.rows[0].generators[0], cached_cpu_generator)
+        self.assertEqual(npu_stream.wait_stream.call_count, 1)
 
 
-def test_random_sample_310p_fallback_to_initial_seed_when_set_state_failed():
-    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
-    probs = MagicMock()
-    probs.div_.return_value = probs
-    probs.argmax.return_value = probs
-    probs.view.return_value = torch.tensor([1])
-
-    fake_q = _FakeQ(batch_size=1)
-    npu_stream = MagicMock()
-    generator = MagicMock()
-    generator.get_state.side_effect = RuntimeError("state read failed")
-    generator.initial_seed.return_value = 1234
-    generators = {0: generator}
-
-    class _FailSetStateCPUGenerator(_FakeCPUGenerator):
-        def set_state(self, state):
-            raise RuntimeError("state set failed")
-
-    with (
-        patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
-        patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-        patch.object(sampler_310p.torch, "empty_like", return_value=fake_q),
-        patch.object(sampler_310p.torch, "Generator", side_effect=_FailSetStateCPUGenerator),
-        patch.object(sampler_310p.torch.npu, "current_stream", return_value=npu_stream),
-    ):
-        sampler_310p._random_sample_310p(probs, generators)
-
-    cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
-    assert cached_cpu_generator.seed == 1234
-    assert fake_q.rows[0].generators[0] is cached_cpu_generator
-    assert npu_stream.wait_stream.call_count == 1
-
-    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/_310p/sample/test_sampler_310.py
+++ b/tests/ut/_310p/sample/test_sampler_310.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 from contextlib import nullcontext
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -13,21 +13,23 @@ if str(PROJECT_ROOT) not in sys.path:
 
 if "vllm" not in sys.modules:
     vllm_module = ModuleType("vllm")
-    vllm_module.envs = SimpleNamespace(VLLM_BATCH_INVARIANT=False)
+    vllm_envs_module = ModuleType("vllm.envs")
+    vllm_envs_module.VLLM_BATCH_INVARIANT = False  # type: ignore[attr-defined]
+    vllm_module.envs = vllm_envs_module  # type: ignore[attr-defined]
     sys.modules["vllm"] = vllm_module
-    sys.modules["vllm.envs"] = vllm_module.envs
+    sys.modules["vllm.envs"] = vllm_envs_module
 
 if "vllm_ascend.sample.sampler" not in sys.modules:
     sample_sampler_module = ModuleType("vllm_ascend.sample.sampler")
-    sample_sampler_module.DEFAULT_LOGPROBS_MODE = "raw_logprobs"
-    sample_sampler_module.AscendSampler = type("AscendSampler", (), {})
-    sample_sampler_module.AscendTopKTopPSampler = type("AscendTopKTopPSampler", (), {})
+    sample_sampler_module.DEFAULT_LOGPROBS_MODE = "raw_logprobs"  # type: ignore[attr-defined]
+    sample_sampler_module.AscendSampler = type("AscendSampler", (), {})  # type: ignore[attr-defined]
+    sample_sampler_module.AscendTopKTopPSampler = type("AscendTopKTopPSampler", (), {})  # type: ignore[attr-defined]
     sys.modules["vllm_ascend.sample.sampler"] = sample_sampler_module
 
 if "vllm_ascend.utils" not in sys.modules:
     utils_module = ModuleType("vllm_ascend.utils")
-    utils_module.global_stream = lambda: MagicMock()
-    utils_module.npu_stream_switch = lambda _: nullcontext()
+    utils_module.global_stream = lambda: MagicMock()  # type: ignore[attr-defined]
+    utils_module.npu_stream_switch = lambda _: nullcontext()  # type: ignore[attr-defined]
     sys.modules["vllm_ascend.utils"] = utils_module
 
 from vllm_ascend._310p.sample import sampler as sampler_310p  # noqa: E402
@@ -103,10 +105,11 @@ class TestSampler310pStandalone(unittest.TestCase):
             patch.object(
                 sampler_310p.torch,
                 "npu",
-                SimpleNamespace(current_stream=MagicMock(return_value=npu_stream)),
+                ModuleType("torch.npu"),
                 create=True,
             ),
         ):
+            sampler_310p.torch.npu.current_stream = MagicMock(return_value=npu_stream)
             sampler_310p._random_sample_310p(probs, generators)
             sampler_310p._random_sample_310p(probs, generators)
 
@@ -146,10 +149,11 @@ class TestSampler310pStandalone(unittest.TestCase):
             patch.object(
                 sampler_310p.torch,
                 "npu",
-                SimpleNamespace(current_stream=MagicMock(return_value=npu_stream)),
+                ModuleType("torch.npu"),
                 create=True,
             ),
         ):
+            sampler_310p.torch.npu.current_stream = MagicMock(return_value=npu_stream)
             sampler_310p._random_sample_310p(probs, generators)
 
         cached_cpu_generator, source_generator_id = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
@@ -185,10 +189,11 @@ class TestSampler310pStandalone(unittest.TestCase):
             patch.object(
                 sampler_310p.torch,
                 "npu",
-                SimpleNamespace(current_stream=MagicMock(return_value=npu_stream)),
+                ModuleType("torch.npu"),
                 create=True,
             ),
         ):
+            sampler_310p.torch.npu.current_stream = MagicMock(return_value=npu_stream)
             sampler_310p._random_sample_310p(probs, {0: generator_first})
             sampler_310p._random_sample_310p(probs, {0: generator_second})
 

--- a/tests/ut/_310p/sample/test_sampler_310.py
+++ b/tests/ut/_310p/sample/test_sampler_310.py
@@ -1,0 +1,121 @@
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend._310p.sample import sampler as sampler_310p
+
+
+class _FakeRow:
+    def __init__(self):
+        self.generators = []
+
+    def exponential_(self, generator=None):
+        self.generators.append(generator)
+        return self
+
+
+class _FakeQ:
+    def __init__(self, batch_size):
+        self.shape = (batch_size, 4)
+        self.default_exponential_called = False
+        self.rows = {idx: _FakeRow() for idx in range(batch_size)}
+
+    def cpu(self):
+        return self
+
+    def npu(self):
+        return self
+
+    def exponential_(self):
+        self.default_exponential_called = True
+        return self
+
+    def __getitem__(self, idx):
+        return self.rows[idx]
+
+
+class _FakeCPUGenerator:
+    def __init__(self, device=None):
+        self.device = device
+        self.state = None
+        self.seed = None
+
+    def set_state(self, state):
+        self.state = state
+
+    def manual_seed(self, seed):
+        self.seed = seed
+
+
+def test_random_sample_310p_reuse_cpu_generator_cache():
+    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+    probs = MagicMock()
+    probs.div_.return_value = probs
+    probs.argmax.return_value = probs
+    probs.view.return_value = torch.tensor([0])
+
+    fake_q_first = _FakeQ(batch_size=2)
+    fake_q_second = _FakeQ(batch_size=2)
+
+    npu_stream = MagicMock()
+    generator = MagicMock()
+    generator.get_state.return_value = b"state"
+    generator.initial_seed.return_value = 7
+    generators = {1: generator}
+
+    with (
+        patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
+        patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
+        patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+        patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
+        patch.object(sampler_310p.torch.npu, "current_stream", return_value=npu_stream),
+    ):
+        sampler_310p._random_sample_310p(probs, generators)
+        sampler_310p._random_sample_310p(probs, generators)
+
+    assert gen_ctor.call_count == 1
+    assert 1 in sampler_310p._CPU_GENERATOR_CACHE_310P
+    cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[1]
+    assert fake_q_first.rows[1].generators[0] is cached_cpu_generator
+    assert fake_q_second.rows[1].generators[0] is cached_cpu_generator
+    assert cached_cpu_generator.state == b"state"
+    assert cached_cpu_generator.seed is None
+    assert npu_stream.wait_stream.call_count == 2
+
+    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+
+
+def test_random_sample_310p_fallback_to_initial_seed_when_set_state_failed():
+    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+    probs = MagicMock()
+    probs.div_.return_value = probs
+    probs.argmax.return_value = probs
+    probs.view.return_value = torch.tensor([1])
+
+    fake_q = _FakeQ(batch_size=1)
+    npu_stream = MagicMock()
+    generator = MagicMock()
+    generator.get_state.side_effect = RuntimeError("state read failed")
+    generator.initial_seed.return_value = 1234
+    generators = {0: generator}
+
+    class _FailSetStateCPUGenerator(_FakeCPUGenerator):
+        def set_state(self, state):
+            raise RuntimeError("state set failed")
+
+    with (
+        patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
+        patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
+        patch.object(sampler_310p.torch, "empty_like", return_value=fake_q),
+        patch.object(sampler_310p.torch, "Generator", side_effect=_FailSetStateCPUGenerator),
+        patch.object(sampler_310p.torch.npu, "current_stream", return_value=npu_stream),
+    ):
+        sampler_310p._random_sample_310p(probs, generators)
+
+    cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
+    assert cached_cpu_generator.seed == 1234
+    assert fake_q.rows[0].generators[0] is cached_cpu_generator
+    assert npu_stream.wait_stream.call_count == 1
+
+    sampler_310p._CPU_GENERATOR_CACHE_310P.clear()

--- a/tests/ut/_310p/sample/test_sampler_310.py
+++ b/tests/ut/_310p/sample/test_sampler_310.py
@@ -112,9 +112,10 @@ class TestSampler310pStandalone(unittest.TestCase):
 
         self.assertEqual(gen_ctor.call_count, 1)
         self.assertIn(1, sampler_310p._CPU_GENERATOR_CACHE_310P)
-        cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[1]
+        cached_cpu_generator, source_generator_id = sampler_310p._CPU_GENERATOR_CACHE_310P[1]
         self.assertIs(fake_q_first.rows[1].generators[0], cached_cpu_generator)
         self.assertIs(fake_q_second.rows[1].generators[0], cached_cpu_generator)
+        self.assertEqual(source_generator_id, id(generator))
         self.assertEqual(cached_cpu_generator.state, b"state")
         self.assertIsNone(cached_cpu_generator.seed)
         self.assertEqual(npu_stream.wait_stream.call_count, 2)
@@ -151,10 +152,55 @@ class TestSampler310pStandalone(unittest.TestCase):
         ):
             sampler_310p._random_sample_310p(probs, generators)
 
-        cached_cpu_generator = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
+        cached_cpu_generator, source_generator_id = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
+        self.assertEqual(source_generator_id, id(generator))
         self.assertEqual(cached_cpu_generator.seed, 1234)
         self.assertIs(fake_q.rows[0].generators[0], cached_cpu_generator)
         self.assertEqual(npu_stream.wait_stream.call_count, 1)
+
+    def test_random_sample_310p_rebuild_cache_when_generator_identity_changes(self):
+        sampler_310p._CPU_GENERATOR_CACHE_310P.clear()
+        probs = MagicMock()
+        probs.div_.return_value = probs
+        probs.argmax.return_value = probs
+        probs.view.return_value = torch.tensor([0])
+
+        fake_q_first = _FakeQ(batch_size=1)
+        fake_q_second = _FakeQ(batch_size=1)
+        npu_stream = MagicMock()
+
+        generator_first = MagicMock()
+        generator_first.get_state.return_value = b"state-1"
+        generator_first.initial_seed.return_value = 11
+
+        generator_second = MagicMock()
+        generator_second.get_state.return_value = b"state-2"
+        generator_second.initial_seed.return_value = 22
+
+        with (
+            patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
+            patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
+            patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+            patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
+            patch.object(
+                sampler_310p.torch,
+                "npu",
+                SimpleNamespace(current_stream=MagicMock(return_value=npu_stream)),
+                create=True,
+            ),
+        ):
+            sampler_310p._random_sample_310p(probs, {0: generator_first})
+            sampler_310p._random_sample_310p(probs, {0: generator_second})
+
+        self.assertEqual(gen_ctor.call_count, 2)
+        first_cpu_generator = fake_q_first.rows[0].generators[0]
+        second_cpu_generator = fake_q_second.rows[0].generators[0]
+        self.assertIsNot(first_cpu_generator, second_cpu_generator)
+        self.assertEqual(first_cpu_generator.state, b"state-1")
+        self.assertEqual(second_cpu_generator.state, b"state-2")
+        cached_cpu_generator, source_generator_id = sampler_310p._CPU_GENERATOR_CACHE_310P[0]
+        self.assertIs(cached_cpu_generator, second_cpu_generator)
+        self.assertEqual(source_generator_id, id(generator_second))
 
 
 if __name__ == "__main__":

--- a/vllm_ascend/_310p/sample/sampler.py
+++ b/vllm_ascend/_310p/sample/sampler.py
@@ -25,7 +25,7 @@ from vllm_ascend.sample.sampler import (
 )
 from vllm_ascend.utils import global_stream, npu_stream_switch
 
-_CPU_GENERATOR_CACHE_310P: dict[int, torch.Generator] = {}
+_CPU_GENERATOR_CACHE_310P: dict[int, tuple[torch.Generator, int]] = {}
 
 
 def _random_sample_310p(
@@ -40,15 +40,17 @@ def _random_sample_310p(
             q.exponential_()
         if generators:
             for i, generator in generators.items():
-                cpu_generator = _CPU_GENERATOR_CACHE_310P.get(i)
-                if cpu_generator is None:
+                cache_entry = _CPU_GENERATOR_CACHE_310P.get(i)
+                if cache_entry is None or cache_entry[1] != id(generator):
                     cpu_generator = torch.Generator(device="cpu")
                     try:
                         # Keep RNG stream consistent with the original generator.
                         cpu_generator.set_state(generator.get_state())
                     except Exception:
                         cpu_generator.manual_seed(generator.initial_seed())
-                    _CPU_GENERATOR_CACHE_310P[i] = cpu_generator
+                    cache_entry = (cpu_generator, id(generator))
+                    _CPU_GENERATOR_CACHE_310P[i] = cache_entry
+                cpu_generator, _ = cache_entry
                 q[i].exponential_(generator=cpu_generator)
         q = q.npu()
     torch.npu.current_stream().wait_stream(global_stream())

--- a/vllm_ascend/_310p/sample/sampler.py
+++ b/vllm_ascend/_310p/sample/sampler.py
@@ -25,6 +25,8 @@ from vllm_ascend.sample.sampler import (
 )
 from vllm_ascend.utils import global_stream, npu_stream_switch
 
+_CPU_GENERATOR_CACHE_310P: dict[int, torch.Generator] = {}
+
 
 def _random_sample_310p(
     probs: torch.Tensor,
@@ -38,7 +40,16 @@ def _random_sample_310p(
             q.exponential_()
         if generators:
             for i, generator in generators.items():
-                q[i].exponential_(generator=generator)
+                cpu_generator = _CPU_GENERATOR_CACHE_310P.get(i)
+                if cpu_generator is None:
+                    cpu_generator = torch.Generator(device="cpu")
+                    try:
+                        # Keep RNG stream consistent with the original generator.
+                        cpu_generator.set_state(generator.get_state())
+                    except Exception:
+                        cpu_generator.manual_seed(generator.initial_seed())
+                    _CPU_GENERATOR_CACHE_310P[i] = cpu_generator
+                q[i].exponential_(generator=cpu_generator)
         q = q.npu()
     torch.npu.current_stream().wait_stream(global_stream())
     return probs.div_(q).argmax(dim=-1).view(-1)


### PR DESCRIPTION
What this PR does / why we need it?
This PR ports the 310P sampling fix to use a CPU generator cache during exponential_ sampling, avoiding direct dependency on non-CPU generator execution in this path and keeping RNG behavior aligned with the original generator state.

It also adds targeted UT coverage for this logic, including cache reuse and fallback seeding behavior, and ensures the new UT can run in environments without torch_npu by using local test stubs (without modifying global UT conftest behavior).

Does this PR introduce any user-facing change?
No user-facing API change.
This is a backend bugfix and test improvement for 310P sampling behavior.

How was this patch tested?
Added UT: tests/ut/_310p/sample/test_sampler_310.py

verifies CPU generator cache creation + reuse
verifies fallback to initial_seed when state sync fails
Local checks:

python tests/ut/_310p/sample/test_sampler_310.py
ruff check vllm_ascend/_310p/sample/sampler.py tests/ut/_310p/sample/test_sampler_310.py
vLLM version:

vLLM main:
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
