### PR TITLE
[CI] repair ci custom op 

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -68,7 +68,7 @@ jobs:
     name: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     container:
       image: ${{ inputs.image }}
     env:


### PR DESCRIPTION
### What this PR does / why we need it?
repair ci custom op for timeout 
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
nightly
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
