### PR TITLE
[BugFix] Fix sliding window attention computation and improve throughput

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -286,6 +286,7 @@ class TestAscendAttentionBackendImpl(TestBase):
         metadata = self.attn_metadata
         metadata.attn_state = AscendAttentionState.DecodeOnly
         metadata.seq_lens = torch.tensor([10] * 10)
+        metadata.actual_seq_lengths_q = [10]
         metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
         metadata.num_actual_tokens = 100
         metadata.slot_mapping = torch.zeros(10, dtype=torch.long)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -619,14 +619,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
 
+        # next_tokens only takes effect when sparse_mode=4 (sliding window attention);
+        # for other sparse modes it is ignored, so we set it to 0 by default.
+        next_tokens = 0
         if self.sliding_window is not None:
             sparse_mode = 4
             pre_tokens = self.sliding_window
-            next_tokens = 0
+
         else:
             sparse_mode = 3 if attn_metadata.causal else 0
             pre_tokens = SWA_INT_MAX
-            next_tokens = 0
 
         extra_args = {}
         if self.enable_c8_quant:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -620,7 +620,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         attn_mask = attn_metadata.attn_mask
         sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
         pre_tokens = self.sliding_window or SWA_INT_MAX
-        next_tokens= 0 if self.sliding_window else SWA_INT_MAX
+        next_tokens = 0 if self.sliding_window else SWA_INT_MAX
 
         extra_args = {}
         if self.enable_c8_quant:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -618,16 +618,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
-
-        if self.sliding_window is not None:
-            sparse_mode = 4
-            pre_tokens = self.sliding_window
-            next_tokens = 0
-
-        else:
-            sparse_mode = 3 if attn_metadata.causal else 0
-            pre_tokens = SWA_INT_MAX
-            next_tokens = SWA_INT_MAX
+        sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
+        pre_tokens = self.sliding_window or SWA_INT_MAX
+        next_tokens= 0 if self.sliding_window else SWA_INT_MAX
 
         extra_args = {}
         if self.enable_c8_quant:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -509,13 +509,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         scale,
                         attn_output,
                         softmax_lse,
+                        sparse_mode,
+                        pre_tokens,
+                        next_tokens,
                         c8_k_aq_scale,
                         c8_k_aq_offset,
                         c8_v_aq_scale,
                         c8_v_aq_offset,
                     ) = param
 
-                    sparse_mode = 3
                     if _EXTRA_CTX.is_draft_model:
                         draft_step = attn_count // num_layers
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
@@ -527,7 +529,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     else:
                         seq_lens = attn_metadata[key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
-                        block_tables = attn_metadata[key].block_tables
+                        # NOTE:
+                        # For models with sliding-window attention on the FIA full-graph replay path,
+                        # rebinding `block_tables` to the latest metadata tensor causes corrupted /
+                        # repeated outputs in our repro on Ascend NPU.
+                        #
+                        # Keep the captured block_tables tensor on this affected path.
+                        # Non-SWA models preserve the original behavior and continue to refresh
+                        # block_tables from attn_metadata.
+                        if not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
+                            block_tables = attn_metadata[key].block_tables
 
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
@@ -557,6 +568,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         num_heads=num_heads,
                         scale=scale,
                         sparse_mode=sparse_mode,
+                        pre_tokens=pre_tokens,
+                        next_tokens=next_tokens,
                         **extra_args,
                         workspace=graph_params.workspaces.get(num_tokens),
                         out=[attn_output, softmax_lse],
@@ -605,7 +618,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
-        sparse_mode = 3 if attn_metadata.causal else 0
+
+        if self.sliding_window is not None:
+            sparse_mode = 4
+            pre_tokens = self.sliding_window
+            next_tokens = 0
+        else:
+            sparse_mode = 3 if attn_metadata.causal else 0
+            pre_tokens = SWA_INT_MAX
+            next_tokens = 0
+
         extra_args = {}
         if self.enable_c8_quant:
             extra_args = {
@@ -636,6 +658,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
                 sparse_mode=sparse_mode,
+                pre_tokens=pre_tokens,
+                next_tokens=next_tokens,
                 scale=self.scale,
                 **extra_args,
             )
@@ -665,6 +689,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             self.scale,
             weak_ref_tensors(output),
             weak_ref_tensors(softmax_lse),
+            sparse_mode,
+            pre_tokens,
+            next_tokens,
         )
         if self.enable_c8_quant:
             attn_params = attn_params + (
@@ -692,6 +719,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
             num_heads=self.num_heads,
             scale=self.scale,
             sparse_mode=sparse_mode,
+            pre_tokens=pre_tokens,
+            next_tokens=next_tokens,
             workspace=workspace,
             out=[output, softmax_lse],
             **extra_args,
@@ -826,35 +855,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         return key, value, block_size, block_table, actual_seq_lengths_kv
 
-    def _forward_fia_slidingwindow(self, query: torch.Tensor, attn_metadata: AscendMetadata, output: torch.Tensor):
-        batch_size = attn_metadata.seq_lens.shape[0]
-        block_size = 128
-        query = query.view(batch_size, 1, self.num_heads * self.head_size)
-        key = self.key_cache
-        value = self.value_cache
-        if self.key_cache is not None and self.value_cache is not None:
-            block_size = self.key_cache.shape[1]
-            key = self.key_cache.flatten(2, 3).contiguous()
-            value = self.value_cache.flatten(2, 3).contiguous()
-
-        attn_output, _ = torch_npu.npu_fused_infer_attention_score(
-            query,
-            key,
-            value,
-            num_heads=self.num_heads,
-            num_key_value_heads=self.num_kv_heads,
-            input_layout="BSH",
-            block_size=block_size,
-            pre_tokens=self.sliding_window,
-            scale=self.scale,
-            block_table=attn_metadata.block_tables,
-            actual_seq_lengths=[1] * len(attn_metadata.seq_lens),
-            actual_seq_lengths_kv=attn_metadata.seq_lens,
-        )
-
-        attn_output = attn_output.view(batch_size, self.num_heads, self.head_size)
-        output[:batch_size] = attn_output[:batch_size]
-        return output
 
     def forward_fused_infer_attention(
         self,
@@ -872,13 +872,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output)
             output[:num_tokens] = attn_output[:num_tokens]
             return output
-        if (
-            attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-            and self.sliding_window is not None
-            and attn_metadata.seq_lens.shape[0] == query.size(0)
-            and self.sinks is None
-        ):
-            return self._forward_fia_slidingwindow(query, attn_metadata, output)
+
         passed_key = key
         key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(
             key, value, attn_metadata, kv_cache
@@ -939,6 +933,24 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     num_heads=self.num_heads,
                     scale=self.scale,
                     sparse_mode=0,
+                )
+            elif self.sliding_window is not None:
+                attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+                    query=query,
+                    key=key,
+                    value=value,
+                    atten_mask=attn_metadata.attn_mask,
+                    block_table=block_table,
+                    input_layout="TND",
+                    block_size=block_size,
+                    actual_seq_lengths=attn_metadata.actual_seq_lengths_q,
+                    actual_seq_lengths_kv=actual_seq_lengths_kv,
+                    num_key_value_heads=self.num_kv_heads,
+                    num_heads=self.num_heads,
+                    scale=self.scale,
+                    pre_tokens=self.sliding_window,
+                    next_tokens=0,
+                    sparse_mode=4,
                 )
             else:
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -855,7 +855,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         return key, value, block_size, block_table, actual_seq_lengths_kv
 
-
     def forward_fused_infer_attention(
         self,
         query: torch.Tensor,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -619,16 +619,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
 
-        # next_tokens only takes effect when sparse_mode=4 (sliding window attention);
-        # for other sparse modes it is ignored, so we set it to 0 by default.
-        next_tokens = 0
         if self.sliding_window is not None:
             sparse_mode = 4
             pre_tokens = self.sliding_window
+            next_tokens = 0
 
         else:
             sparse_mode = 3 if attn_metadata.causal else 0
             pre_tokens = SWA_INT_MAX
+            next_tokens = SWA_INT_MAX
 
         extra_args = {}
         if self.enable_c8_quant:


### PR DESCRIPTION
### What this PR does / why we need it?

The original sliding window attention implementation has two critical issues:

1. **Output corruption in full-graph replay path**: Rebinding `block_tables` to the latest metadata tensor causes corrupted/garbled outputs on Ascend NPU for SWA models.

2. **Repetition issues**: Using `sparse_mode=3` and the `_forward_fia_slidingwindow` method both lead to repeated outputs, affecting model quality.

This PR fixes the above issues with the following changes:

- Fix block_tables handling in full-graph replay path: keep captured block_tables tensor for SWA models to avoid output corruption
- Fix SWA attention parameters: use `sparse_mode=4` with `pre_tokens=sliding_window` and `next_tokens=0`
- Add sliding window support in graph capture mode (full_graph_fia): pass `sparse_mode`, `pre_tokens`, `next_tokens` to graph params
- Remove deprecated `_forward_fia_slidingwindow` method, consolidate SWA handling into unified TND layout path
- Add missing `actual_seq_lengths_q` in test fixture

### Does this PR introduce any user-facing change?

No. This PR only fixes internal implementation issues without changing any public API.

### How was this patch tested?


- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
