### PR TITLE
[Doc][Release] v0.19.0rc1 release note

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -31,11 +31,13 @@ on:
         type: choice
         options:
           - main
+          - v0.19.0rc1
           - v0.18.0rc1
           - v0.17.0rc1
           - v0.16.0rc1
           - v0.15.0rc1
           - v0.14.0rc1
+          - v0.18.0
           - v0.13.0
           - v0.13.0rc3
           - none

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -33,11 +33,13 @@ on:
         type: choice
         options:
           - main
+          - v0.19.0rc1
           - v0.18.0rc1
           - v0.17.0rc1
           - v0.16.0rc1
           - v0.15.0rc1
           - v0.14.0rc1
+          - v0.18.0
           - v0.13.0
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Please use the following recommended versions to get started quickly:
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-| v0.18.0rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) for more details |
+| v0.19.0rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) for more details |
+| v0.18.0rc1 | Previous release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.18.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html) for more details |
 | v0.13.0 | Latest stable version | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.13.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.13.0/installation.html) for more details |
 
 ## Contributing
@@ -86,7 +87,7 @@ Below are the maintained branches:
 
 | Branch     | Status       | Note                                 |
 |------------|--------------|--------------------------------------|
-| main       | Maintained   | CI commitment for vLLM main branch and vLLM v0.18.0 tag   |
+| main       | Maintained   | CI commitment for vLLM main branch and vLLM v0.19.1 tag   |
 | v0.7.1-dev | Unmaintained | Only doc fixes are allowed |
 | v0.7.3-dev | Maintained   | CI commitment for vLLM 0.7.3 version, only bug fixes are allowed, and no new release tags anymore. |
 | v0.9.1-dev | Maintained   | CI commitment for vLLM 0.9.1 version |

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,7 +57,8 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-|v0.18.0rc1| 最新RC版本 |请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)了解更多|
+|v0.19.0rc1| 最新RC版本 |请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)了解更多|
+|v0.18.0rc1| 上一RC版本 |请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.18.0/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html)了解更多|
 |v0.13.0| 最新正式/稳定版本 |[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.13.0/quick_start.html) and [安装指南](https://docs.vllm.ai/projects/ascend/en/v0.13.0/installation.html)了解更多|
 
 ## 贡献
@@ -80,7 +81,7 @@ vllm-ascend有主干分支和开发分支。
 
 | 分支         | 状态         | 备注                  |
 |------------|------------|---------------------|
-| main       | Maintained | 基于vLLM main分支和vLLM最新版本（v0.18.0）CI看护   |
+| main       | Maintained | 基于vLLM main分支和vLLM最新版本（v0.19.1）CI看护   |
 | v0.7.1-dev | Unmaintained | 只允许文档修复 |
 | v0.7.3-dev | Maintained | 基于vLLM v0.7.3版本CI看护, 只允许Bug修复，不会再发布新版本 |
 | v0.9.1-dev | Maintained | 基于vLLM v0.9.1版本CI看护 |

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -20,14 +20,23 @@
 | HeXiang Wang| [@whx-sjtu](https://github.com/whx-sjtu) | 2026/01 |
 
 ## Contributors
-<!-- last_commit: 8e3f8bab57cff0a98dc75ad43d8bf5bb4113f34e -->
+<!-- last_commit: 84bddfdccc9224dbb5af6bbd14db299ebc7d0b4d -->
 
 Every release of vLLM Ascend would not have been possible without the following contributors:
 
-Updated on 2026-03-25:
+Updated on 2026-04-21:
 
 | Number | Contributor | Date | Commit ID |
 |:------:|:-----------:|:-----:|:---------:|
+| 372 | [@lilinsiman](https://github.com/lilinsiman) | 2026/04/21 | [f75bfa2](https://github.com/vllm-project/vllm-ascend/commit/f75bfa2) |
+| 371 | [@MrZ20](https://github.com/MrZ20) | 2026/04/21 | [eb5e343](https://github.com/vllm-project/vllm-ascend/commit/eb5e343) |
+| 370 | [@realliujiaxu](https://github.com/realliujiaxu) | 2026/04/20 | [e14b89c](https://github.com/vllm-project/vllm-ascend/commit/e14b89c) |
+| 369 | [@freyfwt](https://github.com/freyfwt) | 2026/04/17 | [fed5c02](https://github.com/vllm-project/vllm-ascend/commit/fed5c02) |
+| 368 | [@Potabk](https://github.com/Potabk) | 2026/04/15 | [d2b6eb1](https://github.com/vllm-project/vllm-ascend/commit/d2b6eb1) |
+| 367 | [@gjc0824](https://github.com/gjc0824) | 2026/04/17 | [bec6314](https://github.com/vllm-project/vllm-ascend/commit/bec6314) |
+| 366 | [@skf-1999](https://github.com/skf-1999) | 2026/04/17 | [b7f92f3](https://github.com/vllm-project/vllm-ascend/commit/b7f92f3) |
+| 365 | [@sunshine202600](https://github.com/sunshine202600) | 2026/04/15 | [b414cff](https://github.com/vllm-project/vllm-ascend/commit/b414cff) |
+| 364 | [@triomino](https://github.com/triomino) | 2026/04/17 | [a837599](https://github.com/vllm-project/vllm-ascend/commit/a837599) |
 | 363 | [@GoMarck](https://github.com/GoMarck) | 2026/03/25 | [17da966](https://github.com/vllm-project/vllm-ascend/commit/17da96658f0b53a7e9b5932e64ced69a334f035c) |
 | 362 | [@drizzlezyk](https://github.com/drizzlezyk) | 2026/03/24 | [5487946](https://github.com/vllm-project/vllm-ascend/commit/54879467c41784a446aa5b486a391d9bfbf488fa) |
 | 361 | [@liuhy1213-cell](https://github.com/liuhy1213-cell) | 2026/03/23 | [fb283b5](https://github.com/vllm-project/vllm-ascend/commit/fb283b5820effe930d7f60952aca48177d710e94) |

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -20,7 +20,7 @@
 | HeXiang Wang| [@whx-sjtu](https://github.com/whx-sjtu) | 2026/01 |
 
 ## Contributors
-<!-- last_commit: 84bddfdccc9224dbb5af6bbd14db299ebc7d0b4d -->
+<!-- last_commit: aa8ac74984e2fbc07afbd19cb367b542ccc964b7 -->
 
 Every release of vLLM Ascend would not have been possible without the following contributors:
 

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -23,6 +23,7 @@ The table below is the release compatibility matrix for vLLM Ascend release.
 
 | vLLM Ascend | vLLM              | Python          | Stable CANN |        PyTorch/torch_npu        | Triton Ascend |
 |-------------|-------------------|-----------------|-------------|---------------------------------|---------------|
+| v0.19.0rc1  | v0.19.1          | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
 | v0.18.0rc1  | v0.18.0           | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
 | v0.17.0rc1  | v0.17.0           | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
 | v0.16.0rc1  | v0.16.0           | >= 3.10, < 3.12 | 8.5.1       | 2.9.0  / 2.9.0                  | 3.2.0         |
@@ -68,6 +69,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | Date       | Event                                     |
 |------------|-------------------------------------------|
+| 2026.04.22 | Release candidates, v0.19.0rc1            |
 | 2026.04.01 | Release candidates, v0.18.0rc1            |
 | 2026.03.15 | Release candidates, v0.17.0rc1            |
 | 2026.03.10 | Release candidates, v0.16.0rc1            |
@@ -128,7 +130,7 @@ Usually, each minor version of vLLM (such as 0.7) corresponds to a vLLM Ascend v
 
 | Branch     | State        | Note                                                     |
 | ---------- | ------------ | -------------------------------------------------------- |
-| main       | Maintained   | CI commitment for vLLM main branch and vLLM 0.18.0 tag |
+| main       | Maintained   | CI commitment for vLLM main branch and vLLM 0.19.1 tag |
 | releases/v0.13.0 | Maintained | CI commitment for vLLM 0.13.0 version                |
 | v0.11.0-dev| Maintained   | CI commitment for vLLM 0.11.0 version |
 | v0.9.1-dev | Maintained   | CI commitment for vLLM 0.9.1 version                     |

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,15 +68,15 @@ myst_substitutions = {
     # the branch of vllm, used in vllm clone
     # - main branch: 'main'
     # - vX.Y.Z branch: 'vX.Y.Z'
-    "vllm_version": "v0.18.0",
+    "vllm_version": "v0.19.1",
     # the branch of vllm-ascend, used in vllm-ascend clone and image tag
     # - main branch: 'main'
     # - vX.Y.Z branch: latest vllm-ascend release tag
-    "vllm_ascend_version": "v0.18.0rc1",
+    "vllm_ascend_version": "v0.19.0rc1",
     # the newest release version of vllm-ascend and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
-    "pip_vllm_ascend_version": "0.18.0rc1",
-    "pip_vllm_version": "0.18.0",
+    "pip_vllm_ascend_version": "0.19.0rc1",
+    "pip_vllm_version": "0.19.1",
     # CANN image tag
     "cann_image_tag": "8.5.1-910b-ubuntu22.04-py3.11",
     # vLLM commit hash for main branch

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,6 +2,7 @@
 
 ## Version Specific FAQs
 
+- [[v0.19.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/8477)
 - [[v0.18.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/7633)
 - [[v0.17.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/7173)
 - [[v0.13.0] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/6583)

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -7,50 +7,51 @@ Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest)
 
 ### Highlights
 
-- **Graph Capture Memory Planning**: Account for NPU graph capture memory in KV cache planning to avoid OOM
-- **Dynamic Chunk for Chunked Pipeline Parallelism**: Support dynamic chunk for CPP in model_runner_v2
-- **Hamming-based Sparse Attention**: New sparse attention operators for improved efficiency
+- **Graph Capture Memory Planning**: Account for NPU graph capture memory in KV cache planning to avoid OOM [#8289](https://github.com/vllm-project/vllm-ascend/pull/8289)
+- **Dynamic Chunk for Chunked Pipeline Parallelism**: Support dynamic chunk for CPP in model_runner_v2 [#7896](https://github.com/vllm-project/vllm-ascend/pull/7896)
+- **Hamming-based Sparse Attention**: New sparse attention operators for improved efficiency [#8346](https://github.com/vllm-project/vllm-ascend/pull/8346)
 
 ### Features
 
-- Qwen3VLMoe architecture support in xlite backend
-- DFlash support for model_runner_v2
-- Structured output support for model_runner_v2
-- EPLB Swift balancer policy supports mix placement
-- KV Pool hybrid alignment prefix cache support
+- Qwen3VLMoe architecture support in xlite backend [#8046](https://github.com/vllm-project/vllm-ascend/pull/8046)
+- DFlash support for model_runner_v2 [#8118](https://github.com/vllm-project/vllm-ascend/pull/8118)
+- Structured output support for model_runner_v2 [#8443](https://github.com/vllm-project/vllm-ascend/pull/8443)
+- EPLB Swift balancer policy supports mix placement [#8035](https://github.com/vllm-project/vllm-ascend/pull/8035)
+- KV Pool hybrid alignment prefix cache support [#8462](https://github.com/vllm-project/vllm-ascend/pull/8462)
 
 ### Hardware and Operator Support
 
-- Ascend 950 w8a8mxfp8 for MoE models
-- Conv3D to linear optimization when kernel size equals stride
+- Ascend 950 w8a8mxfp8 for MoE models [#8372](https://github.com/vllm-project/vllm-ascend/pull/8372)
+- Conv3D to linear optimization when kernel size equals stride [#8318](https://github.com/vllm-project/vllm-ascend/pull/8318)
 
 ### Performance
 
-- Reduce prefill KV all-gather communication for PCP/DCP
-- Optimize split_qkv_tp_rmsnorm_rope ops
-- Optimize _temperature_kernel and _topk_log_softmax_kernel (triton)
-- Initialize VLLM metrics in EPLB worker
+- Reduce prefill KV all-gather communication for PCP/DCP [#8043](https://github.com/vllm-project/vllm-ascend/pull/8043)
+- Optimize split_qkv_tp_rmsnorm_rope ops [#8059](https://github.com/vllm-project/vllm-ascend/pull/8059)
+- Optimize _temperature_kernel and _topk_log_softmax_kernel (triton) [#8083](https://github.com/vllm-project/vllm-ascend/pull/8083), [#8243](https://github.com/vllm-project/vllm-ascend/pull/8243)
+- Initialize VLLM metrics in EPLB worker [#8019](https://github.com/vllm-project/vllm-ascend/pull/8019)
 
 ### Bug Fixes
 
-- Fix compute_slot_mapping triton for pcp+eagle3
-- Handle num_cached_tokens/num_external_computed_tokens for different vllm versions
-- Fix w8a8 dispatch ffn combine bias param
-- Fix DSA-CP PD role gating for DeepSeek V3.2
-- Fix quant_bias missing in w8a8_static when flashcomm1 is enabled for GLM-5
-- Fix remote KV waiting promotion in patch balance scheduler
-- Resolve PD KV head count via ModelConfig.get_total_num_kv_heads()
-- Handle piecewise mode synchronization
+- Fix compute_slot_mapping triton for pcp+eagle3 [#8435](https://github.com/vllm-project/vllm-ascend/pull/8435)
+- Handle num_cached_tokens/num_external_computed_tokens for different vllm versions [#8426](https://github.com/vllm-project/vllm-ascend/pull/8426)
+- Fix w8a8 dispatch ffn combine bias param [#8465](https://github.com/vllm-project/vllm-ascend/pull/8465)
+- Gate recompute/balance/fused_mc2 by PD mode [#8373](https://github.com/vllm-project/vllm-ascend/pull/8373)
+- Fix DSA-CP PD role gating for DeepSeek V3.2 [#8290](https://github.com/vllm-project/vllm-ascend/pull/8290)
+- Fix quant_bias missing in w8a8_static when flashcomm1 is enabled for GLM-5 [#8220](https://github.com/vllm-project/vllm-ascend/pull/8220)
+- Fix remote KV waiting promotion in patch balance scheduler [#8279](https://github.com/vllm-project/vllm-ascend/pull/8279)
+- Resolve PD KV head count via ModelConfig.get_total_num_kv_heads() [#7997](https://github.com/vllm-project/vllm-ascend/pull/7997)
+- Handle piecewise mode synchronization [#8469](https://github.com/vllm-project/vllm-ascend/pull/8469)
 
 ### Dependencies
 
-- Upgrade vllm to v0.19.1
-- Mooncake version bump to v0.3.9
+- Upgrade vllm to v0.19.1 [#8448](https://github.com/vllm-project/vllm-ascend/pull/8448)
+- Mooncake version bump to v0.3.9 [#8445](https://github.com/vllm-project/vllm-ascend/pull/8445)
 
 ### Documentation
 
-- Update UCM documents
-- Merge npugraph_ex guide into graph_mode doc
+- Update UCM documents [#8475](https://github.com/vllm-project/vllm-ascend/pull/8475)
+- Merge npugraph_ex guide into graph_mode doc [#8464](https://github.com/vllm-project/vllm-ascend/pull/8464)
 
 ### Known Issues
 

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,5 +1,66 @@
 # Release Notes
 
+## v0.19.0rc1 - 2026.04.22
+
+This is the first release candidate of v0.19.0rc1 for vLLM Ascend.
+Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.
+
+### Highlights
+
+- **Graph Capture Memory Planning**: Account for NPU graph capture memory in KV cache planning to avoid OOM
+- **Dynamic Chunk for Chunked Pipeline Parallelism**: Support dynamic chunk for CPP in model_runner_v2
+- **Hamming-based Sparse Attention**: New sparse attention operators for improved efficiency
+
+### Features
+
+- Qwen3VLMoe architecture support in xlite backend
+- DFlash support for model_runner_v2
+- Structured output support for model_runner_v2
+- EPLB Swift balancer policy supports mix placement
+- KV Pool hybrid alignment prefix cache support
+
+### Hardware and Operator Support
+
+- Ascend 950 w8a8mxfp8 for MoE models
+- Conv3D to linear optimization when kernel size equals stride
+
+### Performance
+
+- Reduce prefill KV all-gather communication for PCP/DCP
+- Optimize split_qkv_tp_rmsnorm_rope ops
+- Optimize _temperature_kernel and _topk_log_softmax_kernel (triton)
+- Initialize VLLM metrics in EPLB worker
+
+### Bug Fixes
+
+- Fix compute_slot_mapping triton for pcp+eagle3
+- Handle num_cached_tokens/num_external_computed_tokens for different vllm versions
+- Fix w8a8 dispatch ffn combine bias param
+- Fix DSA-CP PD role gating for DeepSeek V3.2
+- Fix quant_bias missing in w8a8_static when flashcomm1 is enabled for GLM-5
+- Fix remote KV waiting promotion in patch balance scheduler
+- Resolve PD KV head count via ModelConfig.get_total_num_kv_heads()
+- Handle piecewise mode synchronization
+
+### Dependencies
+
+- Upgrade vllm to v0.19.1
+- Mooncake version bump to v0.3.9
+
+### Documentation
+
+- Update UCM documents
+- Merge npugraph_ex guide into graph_mode doc
+
+### Known Issues
+
+- Some issues identified in v0.18.0rc1 feedback remain under investigation:
+  - Qwen3.5 PD disaggregation accuracy
+  - Mooncake transfer self-healing precision
+  - MoE model accuracy bugs
+  - MTP drafter batchIdx crash
+  - Kimi K2.5 high concurrency + function call accuracy
+
 ## v0.18.0rc1 - 2026.04.01
 
 This is the first release candidate of v0.18.0 for vLLM Ascend. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.


### PR DESCRIPTION
## Summary
- align the v0.19.0rc1 release notes, version references, FAQ feedback link, contributors list, and manual release workflow options across the repo

## Does this PR introduce _any_ user-facing change?
Yes.
It updates the published v0.19.0rc1 release notes and the user-facing documentation/version references that point users at the current RC.

## How was this patch tested?
- created and updated the v0.19.0rc1 feedback issue and release checklist during release prep
- validated the modified workflow YAML files with `yaml.safe_load()`
- verified `docs/source/conf.py` substitutions by executing the file and checking the emitted version values
- manually reviewed the release note citations against the merged PRs used for this RC prep

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
