### PR TITLE
[BugFix][KV Pool]MooncakeBackend handles protocol besides ascend

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -61,10 +61,10 @@ class MooncakeBackend(Backend):
                     self.config.master_server_address,
                 )
 
-        if ret != 0:
-            msg = "Initialize mooncake failed."
-            logger.error(msg)
-            raise RuntimeError(msg)
+            if ret != 0:
+                msg = "Initialize mooncake failed."
+                logger.error(msg)
+                raise RuntimeError(msg)
 
     def set_device(self):
         local_rank = get_world_group().local_rank

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -65,6 +65,8 @@ class MooncakeBackend(Backend):
                 msg = "Initialize mooncake failed."
                 logger.error(msg)
                 raise RuntimeError(msg)
+        else:
+            raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
 
     def set_device(self):
         local_rank = get_world_group().local_rank


### PR DESCRIPTION
### What this PR does / why we need it?
ref:https://github.com/vllm-project/vllm-ascend/issues/8482
Currently `mooncake_backend` does not handle protocols besides ascend correctly and will raise UnboundLocalError. This PR provides a quick fix that handles this error. 

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
