### PR TITLE
[Feature] add FULL_DECODE_ONLY support for Dflash

### DIFF
--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -660,13 +660,12 @@ def test_dflash_acceptance(
     ]
 
     speculative_config = {
-        "method": "draft_model",
+        "method": "dflash",
         "model": spec_model_name,
         "num_speculative_tokens": num_speculative_tokens,
-        "enforce_eager": True,
     }
 
-    compilation_config = CompilationConfig(cudagraph_capture_sizes=[9])
+    compilation_config = CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[9, 18])
 
     with VllmRunner(
         main_model_name,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -501,12 +501,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         softmax_lse,
                     ) = param
 
+                    sparse_mode = 3
                     if _EXTRA_CTX.is_draft_model:
                         draft_step = attn_count // num_layers
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
                         block_tables = attn_metadata[draft_step][key].block_tables
                         attn_count = attn_count + 1
+                        if not attn_metadata[draft_step][key].causal:
+                            sparse_mode = 0
                     else:
                         seq_lens = attn_metadata[key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
@@ -526,7 +529,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         num_key_value_heads=num_kv_heads,
                         num_heads=num_heads,
                         scale=scale,
-                        sparse_mode=3,
+                        sparse_mode=sparse_mode,
                         workspace=graph_params.workspaces.get(num_tokens),
                         out=[attn_output, softmax_lse],
                     )
@@ -574,7 +577,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_seq_lengths_kv=actual_seq_lengths_kv,
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
-                sparse_mode=3,
+                sparse_mode=3 if attn_metadata.causal else 0,
                 scale=self.scale,
             )
             if _EXTRA_CTX.is_draft_model:
@@ -595,7 +598,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 weak_ref_tensors(key),
                 weak_ref_tensors(value),
                 weak_ref_tensors(block_table),
-                weak_ref_tensors(attn_metadata.attn_mask),
+                weak_ref_tensors(attn_metadata.attn_mask) if attn_metadata.attn_mask is not None else None,
                 block_size,
                 actual_seq_lengths_kv,
                 actual_seq_lengths_q,
@@ -621,7 +624,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             num_key_value_heads=self.num_kv_heads,
             num_heads=self.num_heads,
             scale=self.scale,
-            sparse_mode=3,
+            sparse_mode=3 if attn_metadata.causal else 0,
             workspace=workspace,
             out=[output, softmax_lse],
         )

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -2,10 +2,12 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.eagle_proposer import SpecDecodeBaseProposer
 
@@ -157,37 +159,71 @@ class AscendDflashProposer(SpecDecodeBaseProposer):
         num_query_tokens = min(num_tokens, self.max_query_tokens)
 
         (
-            num_query_tokens,
+            num_input_tokens,
             num_tokens_across_dp,
             _,
         ) = self.runner._sync_metadata_across_dp(num_query_tokens, is_draft_model=True)
 
-        num_input_tokens = num_query_tokens
+        num_query_per_req = 1 + self.num_speculative_tokens
+        num_query_total = num_reqs * num_query_per_req
 
-        num_context = num_tokens
-        context_positions = self._context_positions_buffer[:num_context]
-        context_states = self.hidden_states[:num_context]
+        context_positions = self._context_positions_buffer[:num_input_tokens]
+        context_states = self.hidden_states[:num_input_tokens]
 
-        input_ids = self.input_ids[:num_input_tokens]
-        positions = self.positions[:num_input_tokens]
+        multi_steps_attn_metadata = []
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
+            builder = self.draft_attn_groups[0].get_metadata_builder()
+            common_attn_metadata = AscendCommonAttentionMetadata(
+                query_start_loc=self.arange_dflash[: num_reqs + 1] * num_query_per_req,
+                query_start_loc_cpu=torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * num_query_per_req,
+                seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
+                seq_lens=self.runner.seq_lens[:num_reqs],
+                num_reqs=num_reqs,
+                num_actual_tokens=num_query_tokens,
+                max_query_len=num_query_per_req,
+                max_seq_len=0,
+                slot_mapping=self._slot_mapping_buffer[:num_query_total],
+                attn_state=AscendAttentionState.ChunkedPrefill,
+                causal=False,
+                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
+            )
+
+            attn_metadata_dflash = builder.build_for_graph_capture(
+                common_attn_metadata,
+                AscendAttentionState.ChunkedPrefill,
+            )
+
+            attn_metadata_dflash.attn_mask = None
+            attn_metadata_dflash.attn_state = AscendAttentionState.ChunkedPrefill
+
+            per_layer_attn_metadata = dict()
+            for layer_name in self.attn_layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata_dflash
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
-            num_actual_tokens=0,
+            num_actual_tokens=num_input_tokens,
             in_profile_run=is_profile,
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
+            draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             self.model.precompute_and_store_context_kv(context_states, context_positions)
+
             self.model(
-                input_ids=input_ids,
-                positions=positions,
+                input_ids=self.input_ids[:num_query_total],
+                positions=self._get_positions(num_query_total),
                 inputs_embeds=None,
             )
+
+            forward_context = get_forward_context()
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
 
     def build_model_inputs_first_pass(
         self,

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -339,7 +339,12 @@ class SpecDecodeBaseProposer(EagleProposer):
 
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
             self.update_stream = torch.npu.Stream()
-            self._runnable = ACLGraphWrapper(self._run_merged_draft, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)
+            if self.method == "dflash":
+                self.model = ACLGraphWrapper(self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)
+            else:
+                self._runnable = ACLGraphWrapper(
+                    self._run_merged_draft, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
+                )
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.
@@ -569,10 +574,13 @@ class SpecDecodeBaseProposer(EagleProposer):
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, num_reqs_padded
             )
-            common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
-            common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
-                self.runner.optimistic_seq_lens_cpu, num_reqs_padded
-            )
+            if self.method == "dflash":
+                common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+            else:
+                common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
+                common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
+                    self.runner.optimistic_seq_lens_cpu, num_reqs_padded
+                )
             if common_attn_metadata.num_computed_tokens_cpu is not None:
                 common_attn_metadata.num_computed_tokens_cpu = self._adjust_tensor(
                     common_attn_metadata.num_computed_tokens_cpu, num_reqs_padded
@@ -619,6 +627,9 @@ class SpecDecodeBaseProposer(EagleProposer):
         assert len(self.draft_attn_groups) > 0
         builder = self.draft_attn_groups[0].get_metadata_builder()
         attn_metadata = builder.build(0, common_attn_metadata, self.runner.get_model())
+
+        if hasattr(attn_metadata, "causal") and not attn_metadata.causal:
+            attn_metadata.attn_mask = None
 
         if self.uses_mrope:
             used_update_positions = self.mrope_positions[:, token_indices_to_sample]
@@ -786,12 +797,12 @@ class SpecDecodeBaseProposer(EagleProposer):
                 "inputs_embeds": inputs_embeds,
             }
 
-        if self.pass_hidden_states_to_model and self.method != "dflash":
-            model_hidden_states = self.hidden_states[:num_input_tokens]
-            model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
-            model_kwargs["hidden_states"] = model_hidden_states
-            if self.method == "mtp":
-                model_kwargs["positions"] = model_positions
+            if self.pass_hidden_states_to_model:
+                model_hidden_states = self.hidden_states[:num_input_tokens]
+                model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
+                model_kwargs["hidden_states"] = model_hidden_states
+                if self.method == "mtp":
+                    model_kwargs["positions"] = model_positions
 
         ret_hidden_states = self.model(**model_kwargs)
         if not self.model_returns_tuple():


### PR DESCRIPTION
### What this PR does / why we need it?
Support the FULL_DECODE_ONLY feature of the speculative method "Dflash"(PR-[8118](https://github.com/vllm-project/vllm-ascend/pull/8118)).

The performance is further improved compared with PIECEWISE mode:
Qwen3-8B, DP1/TP1, constructing gsm8k dataset to repeat the input length to 3.5K/output length 1.5K, data num 400, batch_size 16, temperature 0
| Method | Graph Mode | Spec Num | Mean Acceptance Length |  TOPT(ms) | Output Token Throughput(token/s)| 
|-----|-----|-----|-----|-----|-----|
| Eagle3 | FULL_DECODE_ONLY | 3 | 2.81 | 16.4 | 943.60(baseline) |
| Eagle3 | FULL_DECODE_ONLY | 8 | 3.60 | 19.5 | 795.34(↓15.7%) |
| Dflash | PIECEWISE  | 8 | 5.25 | 12.4 | 1248.93(↑32.4%) |
| Dflash | FULL_DECODE_ONLY | 8 | 5.25 | 11.5 | 1347.84(↑42.8%) |

### Does this PR introduce _any_ user-facing change?
Modify the speculative-config and compilation-config:
`--speculative-config '{"num_speculative_tokens": K, "method":"dflash","model":"dflash_weight_path"}'`
`--compilation-config '{"cudagraph_capture_sizes":[1 * (K+1), 2 * (K+1), ..., batch_size * (K+1)], "cudagraph_mode": "FULL_DECODE_ONLY"}'`


### How was this patch tested?
Add FULL_DECODE_ONLY test cases `test_dflash_acceptance`  in the single-card CI.

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
