### PR TITLE
[Feature] add npu_copy_and_expand_dflash_inputs AscendC Custom Op

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -23,7 +23,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     export CPATH=${ABSOLUTE_CATLASS_PATH}:${CPATH}
 
 
-    CUSTOM_OPS="moe_grouped_matmul;grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;copy_and_expand_eagle_inputs;causal_conv1d;lightning_indexer_quant;hamming_dist_top_k;reshape_and_cache_bnsd;recurrent_gated_delta_rule;"
+    CUSTOM_OPS="moe_grouped_matmul;grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;copy_and_expand_eagle_inputs;copy_and_expand_dflash_inputs;causal_conv1d;lightning_indexer_quant;hamming_dist_top_k;reshape_and_cache_bnsd;recurrent_gated_delta_rule;"
     SOC_ARG="ascend910b"
 elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
@@ -58,6 +58,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "apply_top_k_top_p_custom"
         "transpose_kv_cache_by_block"
         "copy_and_expand_eagle_inputs"
+        "copy_and_expand_dflash_inputs"
         "causal_conv1d"
         "moe_grouped_matmul"
         "lightning_indexer_quant"

--- a/csrc/copy_and_expand_dflash_inputs/op_host/CMakeLists.txt
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_ops_compile_options(
+        OP_NAME CopyAndExpandDflashInputs
+        OPTIONS --cce-auto-sync=on
+                -Wno-deprecated-declarations
+                -Werror
+)
+
+target_sources(op_host_aclnn PRIVATE
+        copy_and_expand_dflash_inputs_def.cpp
+)
+
+target_sources(optiling PRIVATE
+        copy_and_expand_dflash_inputs_tiling.cpp
+)
+
+target_include_directories(optiling PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_sources(opsproto PRIVATE
+        copy_and_expand_dflash_inputs_infershape.cpp
+)

--- a/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_def.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_def.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file copy_and_expand_dflash_inputs_def.cpp
+ * @brief CopyAndExpandDflashInputs OpDef registration
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+
+class CopyAndExpandDflashInputs : public OpDef {
+public:
+    explicit CopyAndExpandDflashInputs(const char* name) : OpDef(name)
+    {
+        // -------------------- Inputs --------------------
+        this->Input("next_token_ids")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("target_positions")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT64})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("query_start_loc")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("num_rejected_tokens")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("block_table")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+
+        // -------------------- In-place Outputs (as Inputs) --------------------
+        this->Input("out_input_ids")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("out_context_positions")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("out_query_positions")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("out_context_slot_mapping")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("out_query_slot_mapping")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("out_token_indices")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+
+        // -------------------- Outputs (empty for in-place) --------------------
+
+        // -------------------- Attributes --------------------
+        this->Attr("parallel_drafting_token_id").Int();
+        this->Attr("num_query_per_req").Int();
+        this->Attr("num_speculative_tokens").Int();
+        this->Attr("block_size").Int();
+        this->Attr("total_input_tokens").Int();
+        this->Attr("has_num_rejected").Bool();
+
+        // -------------------- Platform --------------------
+        this->AICore().AddConfig("ascend910b");
+        this->AICore().AddConfig("ascend910_93");
+    }
+};
+
+OP_ADD(CopyAndExpandDflashInputs);
+
+}  // namespace ops

--- a/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_infershape.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_infershape.cpp
@@ -94,10 +94,10 @@ static ge::graphStatus InferDataType4CopyAndExpandDflashInputs(gert::InferDataTy
 {
     // out_input_ids: INT32
     context->SetOutputDataType(OUT_INPUT_IDS, DT_INT32);
-    // out_context_positions: INT64
-    context->SetOutputDataType(OUT_CONTEXT_POSITIONS, DT_INT64);
-    // out_query_positions: INT64
-    context->SetOutputDataType(OUT_QUERY_POSITIONS, DT_INT64);
+    // out_context_positions: INT32
+    context->SetOutputDataType(OUT_CONTEXT_POSITIONS, DT_INT32);
+    // out_query_positions: INT32
+    context->SetOutputDataType(OUT_QUERY_POSITIONS, DT_INT32);
     // out_context_slot_mapping: INT32
     context->SetOutputDataType(OUT_CONTEXT_SLOT_MAPPING, DT_INT32);
     // out_query_slot_mapping: INT32

--- a/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_infershape.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_infershape.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file copy_and_expand_dflash_inputs_infershape.cpp
+ * @brief InferShape and InferDataType for CopyAndExpandDflashInputs
+ */
+
+#include "register/op_def_registry.h"
+#include "log/ops_log.h"
+
+#define unlikely(x) __builtin_expect((x), 0)
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                                                           \
+    do {                                                                                                   \
+        if (unlikely((ptr) == nullptr)) {                                                                  \
+            const char* name = (unlikely(((context) == nullptr) || (context)->GetNodeName() == nullptr)) ? \
+                                   "nil" :                                                                 \
+                                   (context)->GetNodeName();                                               \
+            OPS_LOG_E(name, "%s is nullptr!", #ptr);                                                       \
+            return ge::GRAPH_FAILED;                                                                       \
+        }                                                                                                  \
+    } while (0)
+
+// Inputs
+static constexpr int IDX_NEXT_TOKEN_IDS = 0;
+static constexpr int IDX_TARGET_POSITIONS = 1;
+static constexpr int IDX_QUERY_START_LOC = 2;
+static constexpr int IDX_NUM_REJECTED_TOKENS = 3;
+static constexpr int IDX_BLOCK_TABLE = 4;
+
+// Outputs
+static constexpr int OUT_INPUT_IDS = 0;
+static constexpr int OUT_CONTEXT_POSITIONS = 1;
+static constexpr int OUT_QUERY_POSITIONS = 2;
+static constexpr int OUT_CONTEXT_SLOT_MAPPING = 3;
+static constexpr int OUT_QUERY_SLOT_MAPPING = 4;
+static constexpr int OUT_TOKEN_INDICES = 5;
+static constexpr int OUTPUT_NUM = 6;
+
+// Attributes
+static constexpr int ATTR_NUM_QUERY_PER_REQ = 1;
+
+using namespace ge;
+
+namespace ops {
+
+static ge::graphStatus InferShape4CopyAndExpandDflashInputs(gert::InferShapeContext* context)
+{
+    // Get input shapes
+    const gert::Shape* targetPositionsShape = context->GetInputShape(IDX_TARGET_POSITIONS);
+    OP_CHECK_NULL_WITH_CONTEXT(context, targetPositionsShape);
+    const gert::Shape* queryStartLocShape = context->GetInputShape(IDX_QUERY_START_LOC);
+    OP_CHECK_NULL_WITH_CONTEXT(context, queryStartLocShape);
+
+    // Derive dimensions from input shapes
+    int64_t totalInputTokens = targetPositionsShape->GetDim(0);
+    int64_t numReqs = queryStartLocShape->GetDim(0) - 1;
+
+    // Get num_query_per_req from attributes
+    auto attrs = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrs);
+    int64_t numQueryPerReq = *(attrs->GetAttrPointer<int64_t>(ATTR_NUM_QUERY_PER_REQ));
+
+    // Compute total_query_tokens
+    int64_t totalQueryTokens = numReqs * numQueryPerReq;
+
+    // Get and validate all output shapes
+    gert::Shape* outShapes[OUTPUT_NUM];
+    for (int i = 0; i < OUTPUT_NUM; ++i) {
+        outShapes[i] = context->GetOutputShape(i);
+        OP_CHECK_NULL_WITH_CONTEXT(context, outShapes[i]);
+        outShapes[i]->SetDimNum(1);
+    }
+
+    // out_input_ids: [total_query_tokens]
+    outShapes[OUT_INPUT_IDS]->SetDim(0, totalQueryTokens);
+
+    // out_context_positions: [total_input_tokens]
+    outShapes[OUT_CONTEXT_POSITIONS]->SetDim(0, totalInputTokens);
+
+    // out_query_positions: [total_query_tokens]
+    outShapes[OUT_QUERY_POSITIONS]->SetDim(0, totalQueryTokens);
+
+    // out_context_slot_mapping: [total_input_tokens]
+    outShapes[OUT_CONTEXT_SLOT_MAPPING]->SetDim(0, totalInputTokens);
+
+    // out_query_slot_mapping: [total_query_tokens]
+    outShapes[OUT_QUERY_SLOT_MAPPING]->SetDim(0, totalQueryTokens);
+
+    // out_token_indices: [num_reqs * (num_query_per_req - 1)] (skip bonus token)
+    outShapes[OUT_TOKEN_INDICES]->SetDim(0, numReqs * (numQueryPerReq - 1));
+
+    return GRAPH_SUCCESS;
+}
+
+static ge::graphStatus InferDataType4CopyAndExpandDflashInputs(gert::InferDataTypeContext* context)
+{
+    // out_input_ids: INT32
+    context->SetOutputDataType(OUT_INPUT_IDS, DT_INT32);
+    // out_context_positions: INT64
+    context->SetOutputDataType(OUT_CONTEXT_POSITIONS, DT_INT64);
+    // out_query_positions: INT64
+    context->SetOutputDataType(OUT_QUERY_POSITIONS, DT_INT64);
+    // out_context_slot_mapping: INT32
+    context->SetOutputDataType(OUT_CONTEXT_SLOT_MAPPING, DT_INT32);
+    // out_query_slot_mapping: INT32
+    context->SetOutputDataType(OUT_QUERY_SLOT_MAPPING, DT_INT32);
+    // out_token_indices: INT32
+    context->SetOutputDataType(OUT_TOKEN_INDICES, DT_INT32);
+
+    return GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(CopyAndExpandDflashInputs)
+    .InferShape(InferShape4CopyAndExpandDflashInputs)
+    .InferDataType(InferDataType4CopyAndExpandDflashInputs);
+
+} // namespace ops

--- a/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_tiling.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_tiling.cpp
@@ -84,11 +84,11 @@ static ge::graphStatus TilingFunc(gert::TilingContext* context)
     // ========== 4. Get operator attributes ==========
     auto attrs = context->GetAttrs();
 
-    int32_t parallelDraftingTokenId = *(attrs->GetAttrPointer<int32_t>(0));
-    int32_t numQueryPerReq = *(attrs->GetAttrPointer<int32_t>(1));
-    int32_t numSpeculativeTokens = *(attrs->GetAttrPointer<int32_t>(2));
-    int32_t blockSize = *(attrs->GetAttrPointer<int32_t>(3));
-    int32_t totalInputTokens = *(attrs->GetAttrPointer<int32_t>(4));
+    int64_t parallelDraftingTokenId = *(attrs->GetAttrPointer<int64_t>(0));
+    int64_t numQueryPerReq = *(attrs->GetAttrPointer<int64_t>(1));
+    int64_t numSpeculativeTokens = *(attrs->GetAttrPointer<int64_t>(2));
+    int64_t blockSize = *(attrs->GetAttrPointer<int64_t>(3));
+    int64_t totalInputTokens = *(attrs->GetAttrPointer<int64_t>(4));
     bool hasNumRejected = *(attrs->GetAttrPointer<bool>(5));
 
     // ========== 5. Compute core distribution ==========
@@ -130,10 +130,10 @@ static ge::graphStatus TilingFunc(gert::TilingContext* context)
 
     OPS_LOG_I(context, "Block Dim: %u", usedCoreNum);
     OPS_LOG_I(context,
-        "numReqs: %u, numQueryPerReq: %u, numSpeculativeTokens: %u, totalInputTokens: %d, totalQueryTokens: %u",
+        "numReqs: %u, numQueryPerReq: %ld, numSpeculativeTokens: %ld, totalInputTokens: %ld, totalQueryTokens: %u",
         numReqs, numQueryPerReq, numSpeculativeTokens, totalInputTokens, totalQueryTokens);
     OPS_LOG_I(context,
-        "blockTableStride: %u, blockSize: %u, hasNumRejected: %d",
+        "blockTableStride: %u, blockSize: %ld, hasNumRejected: %d",
         blockTableStride, blockSize, hasNumRejected ? 1 : 0);
 
     return ge::GRAPH_SUCCESS;

--- a/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_tiling.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_tiling.cpp
@@ -1,0 +1,161 @@
+/**
+ * @file copy_and_expand_dflash_inputs_tiling.cpp
+ * @brief CopyAndExpandDflashInputs TilingFunc implementation
+ */
+
+#include "copy_and_expand_dflash_inputs_tiling.h"
+#include "register/op_def_registry.h"
+#include "log/ops_log.h"
+
+#include <algorithm>
+
+namespace optiling {
+
+static void GetCompileParameters(
+    gert::TilingContext* context, uint32_t& coreNum)
+{
+    auto ptrCompileInfo = reinterpret_cast<const CopyAndExpandDflashInputsCompileInfo*>(context->GetCompileInfo());
+    if (ptrCompileInfo == nullptr) {
+        auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+        coreNum = ascendcPlatform.GetCoreNum();
+    } else {
+        coreNum = ptrCompileInfo->totalCoreNum;
+    }
+}
+
+static ge::graphStatus TilingFunc(gert::TilingContext* context)
+{
+    OPS_LOG_I(context, "Enter TilingFunc for CopyAndExpandDflashInputs");
+    OPS_LOG_D(context, "TilingFunc running.");
+
+    // ========== 1. Get hardware core count ==========
+    uint32_t coreNum;
+    GetCompileParameters(context, coreNum);
+
+    // ========== 2. Derive num_reqs from query_start_loc shape ==========
+    // query_start_loc is the 3rd input (index 2), shape [num_reqs + 1]
+    auto queryStartLocShape = context->GetInputShape(2);
+    if (queryStartLocShape == nullptr) {
+        OPS_LOG_E(context, "Failed to get query_start_loc shape (input index 2)");
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    if (queryStartLocShape->GetStorageShape().GetDimNum() == 0) {
+        OPS_LOG_E(context, "query_start_loc has no dimensions");
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    int64_t dim0 = queryStartLocShape->GetStorageShape().GetDim(0);
+    if (dim0 <= 1) {
+        OPS_LOG_E(context, "query_start_loc first dimension must be > 1, got %ld", dim0);
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    uint32_t numReqs = static_cast<uint32_t>(dim0 - 1);
+    OPS_LOG_I(context, "Derived numReqs: %u from query_start_loc shape [%ld]", numReqs, dim0);
+
+    // ========== 3. Get block_table stride from input shape ==========
+    // block_table is the 5th input (index 4), shape [num_reqs, max_blocks]
+    // The stride is the second dimension (max_blocks)
+    auto blockTableShape = context->GetInputShape(4);
+    if (blockTableShape == nullptr) {
+        OPS_LOG_E(context, "Failed to get block_table shape (input index 4)");
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    if (blockTableShape->GetStorageShape().GetDimNum() < 2) {
+        OPS_LOG_E(context, "block_table must have at least 2 dimensions, got %d",
+                  blockTableShape->GetStorageShape().GetDimNum());
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    int64_t blockTableDim0 = blockTableShape->GetStorageShape().GetDim(0);
+    int64_t blockTableDim1 = blockTableShape->GetStorageShape().GetDim(1);
+    if (blockTableDim0 != static_cast<int64_t>(numReqs)) {
+        OPS_LOG_E(context, "block_table first dimension (%ld) must equal numReqs (%u)",
+                  blockTableDim0, numReqs);
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    if (blockTableDim1 <= 0) {
+        OPS_LOG_E(context, "block_table second dimension (max_blocks) must be > 0, got %ld",
+                  blockTableDim1);
+        return ge::GRAPH_PARAM_INVALID;
+    }
+    uint32_t blockTableStride = static_cast<uint32_t>(blockTableDim1);
+    OPS_LOG_I(context, "blockTable shape dims: num_reqs=%ld, max_blocks=%ld",
+              blockTableDim0, blockTableDim1);
+    OPS_LOG_I(context, "Final blockTableStride: %u", blockTableStride);
+
+    // ========== 4. Get operator attributes ==========
+    auto attrs = context->GetAttrs();
+
+    int32_t parallelDraftingTokenId = *(attrs->GetAttrPointer<int32_t>(0));
+    int32_t numQueryPerReq = *(attrs->GetAttrPointer<int32_t>(1));
+    int32_t numSpeculativeTokens = *(attrs->GetAttrPointer<int32_t>(2));
+    int32_t blockSize = *(attrs->GetAttrPointer<int32_t>(3));
+    int32_t totalInputTokens = *(attrs->GetAttrPointer<int32_t>(4));
+    bool hasNumRejected = *(attrs->GetAttrPointer<bool>(5));
+
+    // ========== 5. Compute core distribution ==========
+    uint32_t usedCoreNum = std::min(coreNum, numReqs);
+    if (usedCoreNum == 0) {
+        usedCoreNum = 1;
+    }
+    uint32_t reqsPerCore   = numReqs / usedCoreNum;
+    uint32_t remainderReqs = numReqs % usedCoreNum;
+
+    // ========== 6. Set tiling_key ==========
+    context->SetTilingKey(1);
+
+    // ========== 7. Get output shape ==========
+    uint32_t totalQueryTokens = numReqs * numQueryPerReq;
+
+    // ========== 8. Fill TilingData ==========
+    CopyAndExpandDflashInputsTilingData tiling;
+    tiling.set_usedCoreNum(usedCoreNum);
+    tiling.set_numReqs(numReqs);
+    tiling.set_reqsPerCore(reqsPerCore);
+    tiling.set_remainderReqs(remainderReqs);
+    tiling.set_parallelDraftingTokenId(parallelDraftingTokenId);
+    tiling.set_numQueryPerReq(static_cast<uint32_t>(numQueryPerReq));
+    tiling.set_numSpeculativeTokens(static_cast<uint32_t>(numSpeculativeTokens));
+    tiling.set_blockSize(static_cast<uint32_t>(blockSize));
+    tiling.set_totalInputTokens(static_cast<uint32_t>(totalInputTokens));
+    tiling.set_hasNumRejected(hasNumRejected ? 1 : 0);
+    tiling.set_blockTableStride(blockTableStride);
+    tiling.set_totalQueryTokens(totalQueryTokens);
+
+    tiling.SaveToBuffer(
+        context->GetRawTilingData()->GetData(),
+        context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+
+    // ========== 9. Set block_dim ==========
+    context->SetBlockDim(usedCoreNum);
+
+    OPS_LOG_I(context, "Block Dim: %u", usedCoreNum);
+    OPS_LOG_I(context,
+        "numReqs: %u, numQueryPerReq: %u, numSpeculativeTokens: %u, totalInputTokens: %d, totalQueryTokens: %u",
+        numReqs, numQueryPerReq, numSpeculativeTokens, totalInputTokens, totalQueryTokens);
+    OPS_LOG_I(context,
+        "blockTableStride: %u, blockSize: %u, hasNumRejected: %d",
+        blockTableStride, blockSize, hasNumRejected ? 1 : 0);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus TilingPrepare4CopyAndExpandDflashInputs(gert::TilingParseContext* context)
+{
+    OPS_LOG_D(context, "TilingPrepare4CopyAndExpandDflashInputs running.");
+    OPS_LOG_I(context, "TilingPrepare4CopyAndExpandDflashInputs running.");
+    auto compileInfo = context->GetCompiledInfo<CopyAndExpandDflashInputsCompileInfo>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, compileInfo);
+    auto platformInfo = context->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context, platformInfo);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+
+    compileInfo->totalCoreNum = ascendcPlatform.GetCoreNum();
+
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(CopyAndExpandDflashInputs)
+    .Tiling(TilingFunc)
+    .TilingParse<CopyAndExpandDflashInputsCompileInfo>(TilingPrepare4CopyAndExpandDflashInputs);
+
+}  // namespace optiling

--- a/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_tiling.h
+++ b/csrc/copy_and_expand_dflash_inputs/op_host/copy_and_expand_dflash_inputs_tiling.h
@@ -1,0 +1,39 @@
+#ifndef COPY_AND_EXPAND_DFLASH_INPUTS_TILING_H
+#define COPY_AND_EXPAND_DFLASH_INPUTS_TILING_H
+
+#include "register/tilingdata_base.h"
+#include "error_log.h"
+#include "register/op_impl_registry.h"
+#include "tiling/platform/platform_ascendc.h"
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(CopyAndExpandDflashInputsTilingData)
+    // ---- 分核参数 ----
+    TILING_DATA_FIELD_DEF(uint32_t, usedCoreNum);            // 实际使用的核数
+    TILING_DATA_FIELD_DEF(uint32_t, numReqs);                // 总请求数
+    TILING_DATA_FIELD_DEF(uint32_t, reqsPerCore);            // 每核基础请求数
+    TILING_DATA_FIELD_DEF(uint32_t, remainderReqs);          // 余数（前 remainder 个核多处理 1 个请求）
+
+    // ---- 算子属性 ----
+    TILING_DATA_FIELD_DEF(int32_t, parallelDraftingTokenId); // 并行推测解码 mask token ID
+    TILING_DATA_FIELD_DEF(uint32_t, numQueryPerReq);         // 每个请求的 query token 数 (1 + num_speculative_tokens)
+    TILING_DATA_FIELD_DEF(uint32_t, numSpeculativeTokens);   // 投机 token 数
+    TILING_DATA_FIELD_DEF(uint32_t, blockSize);              // KV cache block size
+    TILING_DATA_FIELD_DEF(uint32_t, totalInputTokens);       // 输入 context token 总数
+    TILING_DATA_FIELD_DEF(int32_t, hasNumRejected);          // 是否有 rejected tokens (0/1)
+    TILING_DATA_FIELD_DEF(uint32_t, blockTableStride);       // block_table步长（每个请求的block数量）
+
+    // ---- 输出尺寸 ----
+    TILING_DATA_FIELD_DEF(uint32_t, totalQueryTokens);       // 输出 query token 总数
+END_TILING_DATA_DEF;
+
+struct CopyAndExpandDflashInputsCompileInfo {
+    uint32_t totalCoreNum = 0;
+};
+
+REGISTER_TILING_DATA_CLASS(CopyAndExpandDflashInputs, CopyAndExpandDflashInputsTilingData)
+
+}  // namespace optiling
+
+#endif  // COPY_AND_EXPAND_DFLASH_INPUTS_TILING_H

--- a/csrc/copy_and_expand_dflash_inputs/op_kernel/copy_and_expand_dflash_inputs.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_kernel/copy_and_expand_dflash_inputs.cpp
@@ -162,47 +162,79 @@ private:
 
         int32_t queryOffset = r * numQueryPerReq;
 
-        // 读取所有 context positions，确保不超过totalInputTokens
-        LocalTensor<int64_t> ctxPosLocal = inputBuf.Get<int64_t>();
-        if (numCtxTokens > 0) {
-            for (int32_t i = 0; i < numCtxTokens; i++) {
-                int32_t ctxPosIdx = ctxStart + i;
-                // 限制索引不超过 totalInputTokens - 1
-                ctxPosIdx = (ctxPosIdx < static_cast<int32_t>(totalInputTokens)) ? ctxPosIdx : static_cast<int32_t>(totalInputTokens) - 1;
-                int64_t pos = (ctxPosIdx >= 0 && ctxPosIdx < static_cast<int32_t>(totalInputTokens)) ?
-                              gmTargetPositions.GetValue(ctxPosIdx) : 0;
-                ctxPosLocal.SetValue(i, pos);
-            }
-            pipe_barrier(PIPE_ALL);
-        }
-
-        // 获取最后一个有效的 context position（排除 rejected tokens）
-        // 用于计算 query positions 的起始点
+        // 获取最后一个有效的 context position（排除 rejected tokens），用于计算 query positions
+        // 只需要读取最后一个有效token，不需要读取所有tokens
         int64_t lastCtxPos = 0;
         if (validCtxEnd > ctxStart) {
-            // 如果有有效的 context tokens，使用最后一个有效 token 的 position
-            lastCtxPos = ctxPosLocal.GetValue(validCtxEnd - ctxStart - 1);
+            int32_t lastValidIdx = validCtxEnd - 1;
+            // 限制索引不超过 totalInputTokens - 1
+            lastValidIdx = (lastValidIdx < static_cast<int32_t>(totalInputTokens)) ? lastValidIdx : static_cast<int32_t>(totalInputTokens) - 1;
+            if (lastValidIdx >= 0) {
+                lastCtxPos = gmTargetPositions.GetValue(lastValidIdx);
+            }
         }
 
-        // 输出 context positions
+        // 分批处理 context tokens 以避免缓冲区溢出
+        constexpr uint32_t BATCH_SIZE = 4096;  // 保持原有缓冲区大小
+        LocalTensor<int64_t> ctxPosLocal = inputBuf.Get<int64_t>();
         LocalTensor<int32_t> outCtxPos = outCtxPosBuf.Get<int32_t>();
-        for (int32_t i = 0; i < numCtxTokens; i++) {
-            outCtxPos.SetValue(i, static_cast<int32_t>(ctxPosLocal.GetValue(i)));
-        }
-        DataCopyOut_int32(gmOutContextPositions, outCtxPos, ctxStart, numCtxTokens);
-
-        // 计算 context slot mapping
         LocalTensor<int32_t> outCtxSlot = outCtxSlotBuf.Get<int32_t>();
-        for (int32_t i = 0; i < numCtxTokens; i++) {
-            int64_t pos = ctxPosLocal.GetValue(i);
-            int32_t blockNum = static_cast<int32_t>(pos / blockSize);
-            // clamp blockNum避免OOB
-            blockNum = (blockNum < static_cast<int32_t>(blockTableStride)) ? blockNum : static_cast<int32_t>(blockTableStride) - 1;
-            int32_t blockId = gmBlockTable.GetValue(r * blockTableStride + blockNum);
-            int32_t blockOffset = static_cast<int32_t>(pos % blockSize);
-            outCtxSlot.SetValue(i, blockId * blockSize + blockOffset);
+
+        int32_t processedTokens = 0;
+        while (processedTokens < numCtxTokens) {
+            int32_t currentBatchSize = numCtxTokens - processedTokens;
+            if (currentBatchSize > static_cast<int32_t>(BATCH_SIZE)) {
+                currentBatchSize = static_cast<int32_t>(BATCH_SIZE);
+            }
+
+            // 使用 DataCopy 批量读取当前批次的 context positions，避免 scalar Global Memory reads
+            int32_t ctxPosIdx = ctxStart + processedTokens;
+            // 确保索引范围合法
+            ctxPosIdx = (ctxPosIdx < 0) ? 0 : ctxPosIdx;
+            ctxPosIdx = (ctxPosIdx >= static_cast<int32_t>(totalInputTokens)) ? static_cast<int32_t>(totalInputTokens) - 1 : ctxPosIdx;
+
+            // 检查是否会越界，如果会则调整当前批次大小
+            int32_t remainingGlobalTokens = static_cast<int32_t>(totalInputTokens) - ctxPosIdx;
+            if (currentBatchSize > remainingGlobalTokens) {
+                currentBatchSize = remainingGlobalTokens;
+            }
+
+            if (currentBatchSize > 0) {
+                // 使用 DataCopy 批量读取，性能更好
+                constexpr int32_t ELEMS_PER_BLK = ONE_BLK_SIZE / (int32_t)sizeof(int64_t);
+                int32_t aligned = (currentBatchSize + ELEMS_PER_BLK - 1) / ELEMS_PER_BLK * ELEMS_PER_BLK;
+                DataCopy(ctxPosLocal, gmTargetPositions[ctxPosIdx], aligned);
+                pipe_barrier(PIPE_ALL);
+
+                // 如果实际读取的数据少于需要的，用 0 填充
+                for (int32_t i = currentBatchSize; i < aligned; i++) {
+                    ctxPosLocal.SetValue(i, 0);
+                }
+            }
+
+            // 处理当前批次的输出
+            if (currentBatchSize > 0) {
+                for (int32_t i = 0; i < currentBatchSize; i++) {
+                    int32_t outIdx = processedTokens + i;
+                    // 输出 context positions
+                    outCtxPos.SetValue(i, static_cast<int32_t>(ctxPosLocal.GetValue(i)));
+                    // 计算 context slot mapping
+                    int64_t pos = ctxPosLocal.GetValue(i);
+                    int32_t blockNum = static_cast<int32_t>(pos / blockSize);
+                    // clamp blockNum避免OOB
+                    blockNum = (blockNum < static_cast<int32_t>(blockTableStride)) ? blockNum : static_cast<int32_t>(blockTableStride) - 1;
+                    int32_t blockId = gmBlockTable.GetValue(r * blockTableStride + blockNum);
+                    int32_t blockOffset = static_cast<int32_t>(pos % blockSize);
+                    outCtxSlot.SetValue(i, blockId * blockSize + blockOffset);
+                }
+
+                // 输出当前批次的结果
+                DataCopyOut_int32(gmOutContextPositions, outCtxPos, ctxStart + processedTokens, currentBatchSize);
+                DataCopyOut_int32(gmOutContextSlotMapping, outCtxSlot, ctxStart + processedTokens, currentBatchSize);
+            }
+
+            processedTokens += currentBatchSize;
         }
-        DataCopyOut_int32(gmOutContextSlotMapping, outCtxSlot, ctxStart, numCtxTokens);
 
         // 计算 query positions 和 input_ids
         LocalTensor<int32_t> queryPosLocal = outQueryPosBuf.Get<int32_t>();

--- a/csrc/copy_and_expand_dflash_inputs/op_kernel/copy_and_expand_dflash_inputs.cpp
+++ b/csrc/copy_and_expand_dflash_inputs/op_kernel/copy_and_expand_dflash_inputs.cpp
@@ -1,0 +1,301 @@
+/**
+ * CopyAndExpandDflashInputs 算子 Kernel 实现
+ *
+ * 主要功能：
+ * - 复制 context positions
+ * - 计算 query positions (last_context_pos + 1 + offset)
+ * - 设置 input_ids (next_token + mask tokens)
+ * - 计算 context 和 query 的 slot_mapping
+ * - 输出 token_indices_to_sample (跳过 bonus token)
+ */
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+
+class CopyAndExpandDflashInputsKernel {
+public:
+    __aicore__ inline CopyAndExpandDflashInputsKernel() {}
+
+    __aicore__ inline void Init(
+        GM_ADDR nextTokenIds,        // [num_reqs]
+        GM_ADDR targetPositions,     // [num_context]
+        GM_ADDR queryStartLoc,       // [num_reqs + 1]
+        GM_ADDR numRejectedTokens,   // [num_reqs] or null
+        GM_ADDR blockTable,          // [num_reqs, max_blocks]
+        GM_ADDR outInputIds,         // [total_query_tokens] (in-place output)
+        GM_ADDR outContextPositions, // [num_context] (in-place output)
+        GM_ADDR outQueryPositions,   // [total_query_tokens] (in-place output)
+        GM_ADDR outContextSlotMapping, // [num_context] (in-place output)
+        GM_ADDR outQuerySlotMapping, // [total_query_tokens] (in-place output)
+        GM_ADDR outTokenIndices,     // [num_reqs * num_speculative_tokens] (in-place output)
+        const CopyAndExpandDflashInputsTilingData* tilingData)
+    {
+        usedCoreNum = tilingData->usedCoreNum;
+        numReqs = tilingData->numReqs;
+        reqsPerCore = tilingData->reqsPerCore;
+        remainderReqs = tilingData->remainderReqs;
+        parallelDraftingTokenId = tilingData->parallelDraftingTokenId;
+        numQueryPerReq = tilingData->numQueryPerReq;
+        numSpeculativeTokens = tilingData->numSpeculativeTokens;
+        blockSize = tilingData->blockSize;
+        totalInputTokens = tilingData->totalInputTokens;
+        hasNumRejected = tilingData->hasNumRejected;
+        blockTableStride = tilingData->blockTableStride;
+        totalQueryTokens = tilingData->totalQueryTokens;
+
+        uint32_t coreId = GetBlockIdx();
+        if (coreId < remainderReqs) {
+            myStartReq = coreId * (reqsPerCore + 1);
+            myNumReqs = reqsPerCore + 1;
+        } else {
+            myStartReq = remainderReqs * (reqsPerCore + 1) + (coreId - remainderReqs) * reqsPerCore;
+            myNumReqs = reqsPerCore;
+        }
+
+        // 绑定 GM Tensor
+        gmNextTokenIds.SetGlobalBuffer((__gm__ int32_t*)nextTokenIds, numReqs);
+        gmTargetPositions.SetGlobalBuffer((__gm__ int64_t*)targetPositions, totalInputTokens);
+        gmQueryStartLoc.SetGlobalBuffer((__gm__ int32_t*)queryStartLoc, numReqs + 1);
+        if (hasNumRejected && numRejectedTokens != nullptr) {
+            gmNumRejectedTokens.SetGlobalBuffer((__gm__ int32_t*)numRejectedTokens, numReqs);
+        }
+        gmBlockTable.SetGlobalBuffer((__gm__ int32_t*)blockTable, numReqs * blockTableStride);
+        gmOutInputIds.SetGlobalBuffer((__gm__ int32_t*)outInputIds, totalQueryTokens);
+        gmOutContextPositions.SetGlobalBuffer((__gm__ int32_t*)outContextPositions, totalInputTokens);
+        gmOutQueryPositions.SetGlobalBuffer((__gm__ int32_t*)outQueryPositions, totalQueryTokens);
+        gmOutContextSlotMapping.SetGlobalBuffer((__gm__ int32_t*)outContextSlotMapping, totalInputTokens);
+        gmOutQuerySlotMapping.SetGlobalBuffer((__gm__ int32_t*)outQuerySlotMapping, totalQueryTokens);
+        gmOutTokenIndices.SetGlobalBuffer((__gm__ int32_t*)outTokenIndices, numReqs * numSpeculativeTokens);
+
+        // 分配 UB 缓冲区
+        constexpr uint32_t MAX_PER_REQ = 4096;
+        pipe.InitBuffer(qsBuf, AlignUp((myNumReqs + 1) * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(ntBuf, AlignUp(myNumReqs * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(nrBuf, AlignUp(myNumReqs * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(inputBuf, AlignUp(MAX_PER_REQ * sizeof(int64_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(outCtxPosBuf, AlignUp(MAX_PER_REQ * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(outQueryPosBuf, AlignUp(numQueryPerReq * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(outCtxSlotBuf, AlignUp(MAX_PER_REQ * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(outQuerySlotBuf, AlignUp(numQueryPerReq * sizeof(int32_t), ONE_BLK_SIZE));
+        pipe.InitBuffer(tmpBuf, AlignUp(64 * sizeof(int32_t), ONE_BLK_SIZE));
+
+        // DataCopy 元数据到 UB
+        if (myNumReqs > 0) {
+            LocalTensor<int32_t> lqs = qsBuf.Get<int32_t>();
+            DataCopyIn(lqs, gmQueryStartLoc, (int32_t)myStartReq, (int32_t)(myNumReqs + 1));
+
+            LocalTensor<int32_t> lnt = ntBuf.Get<int32_t>();
+            DataCopyIn(lnt, gmNextTokenIds, (int32_t)myStartReq, (int32_t)myNumReqs);
+
+            if (hasNumRejected) {
+                LocalTensor<int32_t> lnr = nrBuf.Get<int32_t>();
+                DataCopyIn(lnr, gmNumRejectedTokens, (int32_t)myStartReq, (int32_t)myNumReqs);
+            }
+        }
+    }
+
+    __aicore__ inline void Process()
+    {
+        for (uint32_t rLocal = 0; rLocal < myNumReqs; rLocal++) {
+            ProcessOneRequest(myStartReq + rLocal, rLocal);
+        }
+    }
+
+private:
+    static __aicore__ inline uint32_t AlignUp(uint32_t x, uint32_t a)
+    {
+        return (x + a - 1) / a * a;
+    }
+
+    __aicore__ inline void DataCopyIn(LocalTensor<int32_t>& dst,
+                                       GlobalTensor<int32_t>& src,
+                                       int32_t gmOffset, int32_t count)
+    {
+        if (count <= 0) return;
+        constexpr int32_t ELEMS_PER_BLK = ONE_BLK_SIZE / (int32_t)sizeof(int32_t);
+        int32_t aligned = (count + ELEMS_PER_BLK - 1) / ELEMS_PER_BLK * ELEMS_PER_BLK;
+        DataCopy(dst, src[gmOffset], aligned);
+        pipe_barrier(PIPE_ALL);
+    }
+
+
+    __aicore__ inline void DataCopyOut_int32(GlobalTensor<int32_t>& dst,
+                                              LocalTensor<int32_t>& src,
+                                              int32_t gmOffset, int32_t count)
+    {
+        if (count <= 0) return;
+        uint32_t totalBytes = static_cast<uint32_t>(count) * static_cast<uint32_t>(sizeof(int32_t));
+        pipe_barrier(PIPE_ALL);
+        DataCopyPad(dst[gmOffset], src, DataCopyExtParams(1, totalBytes, 0, 0, 0));
+        pipe_barrier(PIPE_ALL);
+    }
+
+    __aicore__ inline int32_t ReadQS(uint32_t rLocal) {
+        return qsBuf.Get<int32_t>().GetValue(rLocal);
+    }
+    __aicore__ inline int32_t ReadNextQS(uint32_t rLocal) {
+        return qsBuf.Get<int32_t>().GetValue(rLocal + 1);
+    }
+    __aicore__ inline int32_t ReadNT(uint32_t rLocal) {
+        return ntBuf.Get<int32_t>().GetValue(rLocal);
+    }
+    __aicore__ inline int32_t ReadNR(uint32_t rLocal) {
+        if (hasNumRejected) {
+            return nrBuf.Get<int32_t>().GetValue(rLocal);
+        }
+        return 0;
+    }
+
+    __aicore__ inline void ProcessOneRequest(uint32_t r, uint32_t rLocal)
+    {
+        int32_t ctxStart = ReadQS(rLocal);
+        int32_t ctxEnd = ReadNextQS(rLocal);
+        int32_t numRejected = ReadNR(rLocal);
+
+        // 处理所有 context tokens（包括 rejected tokens），用于输出
+        int32_t numCtxTokens = ctxEnd - ctxStart;
+
+        // 有效 context 结束位置（排除 rejected tokens），仅用于计算 last position
+        int32_t validCtxEnd = ctxEnd - numRejected;
+        if (validCtxEnd < ctxStart) validCtxEnd = ctxStart;
+
+        int32_t queryOffset = r * numQueryPerReq;
+
+        // 读取所有 context positions，确保不超过totalInputTokens
+        LocalTensor<int64_t> ctxPosLocal = inputBuf.Get<int64_t>();
+        if (numCtxTokens > 0) {
+            for (int32_t i = 0; i < numCtxTokens; i++) {
+                int32_t ctxPosIdx = ctxStart + i;
+                // 限制索引不超过 totalInputTokens - 1
+                ctxPosIdx = (ctxPosIdx < static_cast<int32_t>(totalInputTokens)) ? ctxPosIdx : static_cast<int32_t>(totalInputTokens) - 1;
+                int64_t pos = (ctxPosIdx >= 0 && ctxPosIdx < static_cast<int32_t>(totalInputTokens)) ?
+                              gmTargetPositions.GetValue(ctxPosIdx) : 0;
+                ctxPosLocal.SetValue(i, pos);
+            }
+            pipe_barrier(PIPE_ALL);
+        }
+
+        // 获取最后一个有效的 context position（排除 rejected tokens）
+        // 用于计算 query positions 的起始点
+        int64_t lastCtxPos = 0;
+        if (validCtxEnd > ctxStart) {
+            // 如果有有效的 context tokens，使用最后一个有效 token 的 position
+            lastCtxPos = ctxPosLocal.GetValue(validCtxEnd - ctxStart - 1);
+        }
+
+        // 输出 context positions
+        LocalTensor<int32_t> outCtxPos = outCtxPosBuf.Get<int32_t>();
+        for (int32_t i = 0; i < numCtxTokens; i++) {
+            outCtxPos.SetValue(i, static_cast<int32_t>(ctxPosLocal.GetValue(i)));
+        }
+        DataCopyOut_int32(gmOutContextPositions, outCtxPos, ctxStart, numCtxTokens);
+
+        // 计算 context slot mapping
+        LocalTensor<int32_t> outCtxSlot = outCtxSlotBuf.Get<int32_t>();
+        for (int32_t i = 0; i < numCtxTokens; i++) {
+            int64_t pos = ctxPosLocal.GetValue(i);
+            int32_t blockNum = static_cast<int32_t>(pos / blockSize);
+            // clamp blockNum避免OOB
+            blockNum = (blockNum < static_cast<int32_t>(blockTableStride)) ? blockNum : static_cast<int32_t>(blockTableStride) - 1;
+            int32_t blockId = gmBlockTable.GetValue(r * blockTableStride + blockNum);
+            int32_t blockOffset = static_cast<int32_t>(pos % blockSize);
+            outCtxSlot.SetValue(i, blockId * blockSize + blockOffset);
+        }
+        DataCopyOut_int32(gmOutContextSlotMapping, outCtxSlot, ctxStart, numCtxTokens);
+
+        // 计算 query positions 和 input_ids
+        LocalTensor<int32_t> queryPosLocal = outQueryPosBuf.Get<int32_t>();
+        LocalTensor<int32_t> inputIdsLocal = tmpBuf.Get<int32_t>();
+        int32_t nextTokenId = ReadNT(rLocal);
+
+        for (uint32_t qIdx = 0; qIdx < numQueryPerReq; qIdx++) {
+            int64_t queryPos = lastCtxPos + 1 + qIdx;
+            int32_t queryGlobalIdx = queryOffset + qIdx;
+
+            queryPosLocal.SetValue(qIdx, static_cast<int32_t>(queryPos));
+
+            // Input ID: next_token for first query, mask token for rest
+            if (qIdx == 0) {
+                inputIdsLocal.SetValue(qIdx, nextTokenId);
+            } else {
+                inputIdsLocal.SetValue(qIdx, parallelDraftingTokenId);
+            }
+        }
+
+        DataCopyOut_int32(gmOutQueryPositions, queryPosLocal, queryOffset, numQueryPerReq);
+        DataCopyOut_int32(gmOutInputIds, inputIdsLocal, queryOffset, numQueryPerReq);
+
+        // 计算 query slot mapping
+        LocalTensor<int32_t> querySlotLocal = outQuerySlotBuf.Get<int32_t>();
+        for (uint32_t qIdx = 0; qIdx < numQueryPerReq; qIdx++) {
+            int64_t queryPos = static_cast<int64_t>(queryPosLocal.GetValue(qIdx));
+            int32_t queryGlobalIdx = queryOffset + qIdx;
+
+            int32_t blockNum = static_cast<int32_t>(queryPos / blockSize);
+            // clamp blockNum避免OOB
+            blockNum = (blockNum < static_cast<int32_t>(blockTableStride)) ? blockNum : static_cast<int32_t>(blockTableStride) - 1;
+            int32_t blockId = gmBlockTable.GetValue(r * blockTableStride + blockNum);
+            int32_t blockOffset = static_cast<int32_t>(queryPos % blockSize);
+            querySlotLocal.SetValue(qIdx, blockId * blockSize + blockOffset);
+        }
+        DataCopyOut_int32(gmOutQuerySlotMapping, querySlotLocal, queryOffset, numQueryPerReq);
+
+        // Token indices to sample (跳过 bonus token at qIdx=0)
+        LocalTensor<int32_t> tokenIndicesLocal = tmpBuf.Get<int32_t>();
+        for (uint32_t specIdx = 0; specIdx < numSpeculativeTokens; specIdx++) {
+            tokenIndicesLocal.SetValue(specIdx, queryOffset + 1 + specIdx);
+        }
+        DataCopyOut_int32(gmOutTokenIndices, tokenIndicesLocal, r * numSpeculativeTokens, numSpeculativeTokens);
+    }
+
+private:
+    GlobalTensor<int32_t> gmNextTokenIds, gmQueryStartLoc, gmNumRejectedTokens, gmBlockTable;
+    GlobalTensor<int64_t> gmTargetPositions;
+    GlobalTensor<int32_t> gmOutInputIds, gmOutTokenIndices;
+    GlobalTensor<int32_t> gmOutContextPositions, gmOutQueryPositions;
+    GlobalTensor<int32_t> gmOutContextSlotMapping, gmOutQuerySlotMapping;
+
+    uint32_t usedCoreNum, numReqs, reqsPerCore, remainderReqs;
+    int32_t parallelDraftingTokenId;
+    uint32_t numQueryPerReq, numSpeculativeTokens, blockSize;
+    uint32_t totalInputTokens, hasNumRejected, blockTableStride, totalQueryTokens;
+    uint32_t myStartReq, myNumReqs;
+
+    TPipe pipe;
+    TBuf<QuePosition::VECCALC> qsBuf, ntBuf, nrBuf;
+    TBuf<QuePosition::VECCALC> inputBuf;
+    TBuf<QuePosition::VECCALC> outCtxPosBuf, outQueryPosBuf;  // Separate buffers for positions
+    TBuf<QuePosition::VECCALC> outCtxSlotBuf, outQuerySlotBuf;  // Separate buffers for slot mappings
+    TBuf<QuePosition::VECCALC> tmpBuf;
+};
+
+extern "C" __global__ __aicore__ void copy_and_expand_dflash_inputs(
+    GM_ADDR nextTokenIds,
+    GM_ADDR targetPositions,
+    GM_ADDR queryStartLoc,
+    GM_ADDR numRejectedTokens,
+    GM_ADDR blockTable,
+    GM_ADDR outInputIds,
+    GM_ADDR outContextPositions,
+    GM_ADDR outQueryPositions,
+    GM_ADDR outContextSlotMapping,
+    GM_ADDR outQuerySlotMapping,
+    GM_ADDR outTokenIndices,
+    GM_ADDR workspace,
+    GM_ADDR tiling)
+{
+    GET_TILING_DATA(tilingData, tiling);
+
+    if (GetBlockIdx() >= tilingData.usedCoreNum) {
+        return;
+    }
+
+    if (TILING_KEY_IS(1)) {
+        CopyAndExpandDflashInputsKernel op;
+        op.Init(nextTokenIds, targetPositions, queryStartLoc, numRejectedTokens, blockTable,
+                outInputIds, outContextPositions, outQueryPositions,
+                outContextSlotMapping, outQuerySlotMapping, outTokenIndices, &tilingData);
+        op.Process();
+    }
+}

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -923,6 +923,50 @@ npu_copy_and_expand_eagle_inputs(
             out_new_token_indices, out_hidden_state_mapping};
 }
 
+std::tuple<at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&>
+npu_copy_and_expand_dflash_inputs(
+    const at::Tensor &next_token_ids,
+    const at::Tensor &target_positions,
+    const at::Tensor &query_start_loc,
+    const c10::optional<at::Tensor> &num_rejected_tokens_opt,
+    const at::Tensor &block_table,
+    int64_t parallel_drafting_token_id,
+    int64_t num_query_per_req,
+    int64_t num_speculative_tokens,
+    int64_t block_size,
+    at::Tensor &out_input_ids,
+    at::Tensor &out_context_positions,
+    at::Tensor &out_query_positions,
+    at::Tensor &out_context_slot_mapping,
+    at::Tensor &out_query_slot_mapping,
+    at::Tensor &out_token_indices)
+{
+    int64_t total_input_tokens = target_positions.size(0);
+    int64_t num_reqs = query_start_loc.size(0) - 1;
+    int64_t total_query_tokens = num_reqs * num_query_per_req;
+
+    // Validate output tensor shapes - allow larger tensors for buffer reuse
+    TORCH_CHECK(out_input_ids.size(0) >= total_query_tokens, "out_input_ids size too small");
+    TORCH_CHECK(out_context_positions.size(0) >= total_input_tokens, "out_context_positions size too small");
+    TORCH_CHECK(out_query_positions.size(0) >= total_query_tokens, "out_query_positions size too small");
+    TORCH_CHECK(out_context_slot_mapping.size(0) >= total_input_tokens, "out_context_slot_mapping size too small");
+    TORCH_CHECK(out_query_slot_mapping.size(0) >= total_query_tokens, "out_query_slot_mapping size too small");
+    TORCH_CHECK(out_token_indices.size(0) >= num_reqs * num_speculative_tokens, "out_token_indices size too small");
+
+    bool has_num_rejected = num_rejected_tokens_opt.has_value();
+    at::Tensor num_rejected_tokens = has_num_rejected ? num_rejected_tokens_opt.value() : at::empty({0}, at::dtype(at::kInt).device(next_token_ids.device()));
+
+    EXEC_NPU_CMD(aclnnCopyAndExpandDflashInputs,
+        next_token_ids, target_positions, query_start_loc, num_rejected_tokens, block_table,
+        out_input_ids, out_context_positions, out_query_positions,
+        out_context_slot_mapping, out_query_slot_mapping, out_token_indices,
+        parallel_drafting_token_id, num_query_per_req, num_speculative_tokens, block_size,
+        total_input_tokens, has_num_rejected);
+
+    return {out_input_ids, out_context_positions, out_query_positions,
+            out_context_slot_mapping, out_query_slot_mapping, out_token_indices};
+}
+
 at::Tensor npu_causal_conv1d_custom(
     const at::Tensor& x,
     const at::Tensor& weight,
@@ -1230,7 +1274,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     ops.impl("npu_sign_bits_pack", torch::kPrivateUse1, &vllm_ascend::npu_sign_bits_pack);
 
     ops.def(
-        "transpose_kv_cache_by_block(Tensor[] kCache, Tensor[] vCache, Tensor blockIDs, int blockSize, int headNum, int headDim, int splitNum, int layerNum) -> ()"
+        "transpose_kv_cache_by_block(Tensor[] kCache, Tensor[] "
+        "vCache, Tensor blockIDs, int blockSize, int headNum, int headDim, int splitNum, int layerNum) -> ()"
     );
     ops.impl("transpose_kv_cache_by_block", torch::kPrivateUse1, &vllm_ascend::transpose_kv_cache_by_block);
 
@@ -1243,6 +1288,16 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "Tensor out_is_masked_token_mask, Tensor out_new_token_indices, Tensor out_hidden_state_mapping)"
     );
     ops.impl("npu_copy_and_expand_eagle_inputs", torch::kPrivateUse1, &vllm_ascend::npu_copy_and_expand_eagle_inputs);
+    ops.def(
+        "npu_copy_and_expand_dflash_inputs(Tensor next_token_ids, Tensor target_positions, "
+        "Tensor query_start_loc, Tensor? num_rejected_tokens, Tensor block_table, "
+        "int parallel_drafting_token_id, int num_query_per_req, int num_speculative_tokens, "
+        "int block_size, Tensor! out_input_ids, Tensor! out_context_positions, Tensor! out_query_positions, "
+        "Tensor! out_context_slot_mapping, Tensor! out_query_slot_mapping, Tensor! out_token_indices) -> "
+        "(Tensor out_input_ids, Tensor out_context_positions, Tensor out_query_positions, "
+        "Tensor out_context_slot_mapping, Tensor out_query_slot_mapping, Tensor out_token_indices)"
+    );
+    ops.impl("npu_copy_and_expand_dflash_inputs", torch::kPrivateUse1, &vllm_ascend::npu_copy_and_expand_dflash_inputs);
     ops.def(
         "npu_causal_conv1d_custom(Tensor x, "
         "                         Tensor weight, "

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -544,6 +544,40 @@ npu_copy_and_expand_eagle_inputs_meta(
             out_new_token_indices, out_hidden_state_mapping};
 }
 
+std::tuple<at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&>
+npu_copy_and_expand_dflash_inputs_meta(
+    const at::Tensor &next_token_ids,
+    const at::Tensor &target_positions,
+    const at::Tensor &query_start_loc,
+    const c10::optional<at::Tensor> &num_rejected_tokens_opt,
+    const at::Tensor &block_table,
+    int64_t parallel_drafting_token_id,
+    int64_t num_query_per_req,
+    int64_t num_speculative_tokens,
+    int64_t block_size,
+    at::Tensor &out_input_ids,
+    at::Tensor &out_context_positions,
+    at::Tensor &out_query_positions,
+    at::Tensor &out_context_slot_mapping,
+    at::Tensor &out_query_slot_mapping,
+    at::Tensor &out_token_indices)
+{
+    int64_t total_input_tokens = target_positions.size(0);
+    int64_t num_reqs = query_start_loc.size(0) - 1;
+    int64_t total_query_tokens = num_reqs * num_query_per_req;
+
+    // Validate output tensor shapes for meta implementation - allow larger tensors for buffer reuse
+    TORCH_CHECK(out_input_ids.size(0) >= total_query_tokens, "out_input_ids size too small");
+    TORCH_CHECK(out_context_positions.size(0) >= total_input_tokens, "out_context_positions size too small");
+    TORCH_CHECK(out_query_positions.size(0) >= total_query_tokens, "out_query_positions size too small");
+    TORCH_CHECK(out_context_slot_mapping.size(0) >= total_input_tokens, "out_context_slot_mapping size too small");
+    TORCH_CHECK(out_query_slot_mapping.size(0) >= total_query_tokens, "out_query_slot_mapping size too small");
+    TORCH_CHECK(out_token_indices.size(0) >= num_reqs * num_speculative_tokens, "out_token_indices size too small");
+
+    return {out_input_ids, out_context_positions, out_query_positions,
+            out_context_slot_mapping, out_query_slot_mapping, out_token_indices};
+}
+
 at::Tensor npu_causal_conv1d_custom_meta(
     const at::Tensor& x,
     const at::Tensor& weight,
@@ -729,6 +763,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_sign_bits_pack", &vllm_ascend::meta::npu_sign_bits_pack_meta);
     // CopyAndExpandEagleInputs
     ops.impl("npu_copy_and_expand_eagle_inputs", &vllm_ascend::meta::npu_copy_and_expand_eagle_inputs_meta);
+    // CopyAndExpandDflashInputs
+    ops.impl("npu_copy_and_expand_dflash_inputs", &vllm_ascend::meta::npu_copy_and_expand_dflash_inputs_meta);
     // causal_conv1d_fn
     ops.impl("npu_causal_conv1d_custom", &vllm_ascend::meta::npu_causal_conv1d_custom_meta);
     // moe_grouped_matmul

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_copy_and_expand_dflash_inputs.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_copy_and_expand_dflash_inputs.py
@@ -106,25 +106,20 @@ def golden_copy_and_expand_dflash_inputs_torch(
                 query_out = req_idx * num_query_per_req + (j - num_ctx)
                 out_query_slot_mapping[query_out] = slot
 
-def generate_test_case(num_reqs, num_speculative_tokens, block_size, max_tokens_per_req=64):
+def generate_test_case(num_reqs, num_speculative_tokens, block_size, min_tokens_per_req=1, max_tokens_per_req=64):
     rng = np.random.default_rng(42)
-
-    num_reqs_prefill = num_reqs // 2
-    num_reqs_decode = num_reqs - num_reqs_prefill
 
     next_token_ids = rng.integers(1, 50000, size=num_reqs, dtype=np.int32)
 
-    query_lens = rng.integers(1, max_tokens_per_req, size=num_reqs)
-    query_lens[:num_reqs_decode] = 1 + num_speculative_tokens
+    query_lens = rng.integers(min_tokens_per_req, max_tokens_per_req, size=num_reqs)
     query_start_loc = np.zeros(num_reqs + 1, dtype=np.int32)
     query_start_loc[1:] = np.cumsum(query_lens)
 
-    seq_lens = rng.integers(1, max_tokens_per_req, size=num_reqs)
+    seq_lens = rng.integers(min_tokens_per_req, max_tokens_per_req, size=num_reqs)
     seq_lens = np.maximum(seq_lens, query_lens)
 
     num_rejected_tokens = rng.integers(0, num_speculative_tokens, size=num_reqs)
-    num_rejected_tokens[num_reqs_decode: ] = 0
-    num_rejected_tokens = np.minimum(num_rejected_tokens, query_lens)
+    num_rejected_tokens = np.minimum(num_rejected_tokens, query_lens - 1)
 
     total_input_tokens = query_start_loc[-1]
     target_positions = np.zeros(total_input_tokens, dtype=np.int32)
@@ -137,6 +132,11 @@ def generate_test_case(num_reqs, num_speculative_tokens, block_size, max_tokens_
     max_blocks = (np.max(seq_lens) + block_size - 1) // block_size
     num_blocks = num_reqs * max_blocks
     block_table_tensor = np.arange(0, num_blocks, dtype=np.int32).reshape(num_reqs, max_blocks)
+
+    # print(f"query_lens: {query_lens}")
+    # print(f"seq_lens: {seq_lens}")
+    # print(f"num_rejected_tokens: {num_rejected_tokens}")
+    # print(f"target_positions: {target_positions}")
 
     return (
             torch.from_numpy(next_token_ids).to(torch.int32).npu(),
@@ -153,10 +153,9 @@ def test_copy_and_expand_dflash_inputs(num_reqs, num_speculative_tokens):
     block_size = 128
 
     next_token_ids, target_positions, query_start_loc, num_rejected_tokens, block_table_tensor = generate_test_case(
-        num_reqs, num_speculative_tokens, block_size, 64)
+        num_reqs, num_speculative_tokens, block_size, min_tokens_per_req=1, max_tokens_per_req=64)
 
     parallel_drafting_token_id = 151669
-    num_speculative_tokens = 15
 
     num_query_per_req = num_speculative_tokens + 1
 
@@ -227,6 +226,97 @@ def test_copy_and_expand_dflash_inputs(num_reqs, num_speculative_tokens):
     )
 
     # Check if outputs are equal
+    input_ids_match = torch.equal(out_input_ids, torch_out_input_ids)
+    context_positions_match = torch.equal(out_context_positions, torch_out_context_positions)
+    query_positions_match = torch.equal(out_query_positions, torch_out_query_positions)
+    context_slot_mapping_match = torch.equal(out_context_slot_mapping, torch_out_context_slot_mapping)
+    query_slot_mapping_match = torch.equal(out_query_slot_mapping, torch_out_query_slot_mapping)
+    token_indices_match = torch.equal(out_token_indices, torch_out_token_indices)
+
+    all_match = (input_ids_match and context_positions_match and
+                 query_positions_match and context_slot_mapping_match and
+                 query_slot_mapping_match and token_indices_match)
+
+@pytest.mark.parametrize("num_reqs", [1, 2])
+@pytest.mark.parametrize("num_speculative_tokens", [3])
+def test_copy_and_expand_dflash_inputs_large_context(num_reqs, num_speculative_tokens):
+    block_size = 128
+
+    # Generate a test case with more than 4096 context tokens per request
+    next_token_ids, target_positions, query_start_loc, num_rejected_tokens, block_table_tensor = generate_test_case(
+        num_reqs, num_speculative_tokens, block_size, min_tokens_per_req=4500, max_tokens_per_req=5000)  # 5000 >
+
+    parallel_drafting_token_id = 151669
+
+    num_query_per_req = num_speculative_tokens + 1
+
+    num_query_total = num_reqs * (1 + num_speculative_tokens)
+    num_context = query_start_loc[-1]
+
+    # Prepare output tensors for Ascend C operator (in-place)
+    out_input_ids = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    out_context_positions = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    out_query_positions = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    out_context_slot_mapping = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    out_query_slot_mapping = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    out_token_indices = torch.zeros(num_reqs * num_speculative_tokens, device='npu:0', dtype=torch.int32)
+
+    # Call Ascend C operator - this should trigger the batch processing code path
+    torch.ops._C_ascend.npu_copy_and_expand_dflash_inputs(
+        # Inputs
+        next_token_ids,
+        target_positions,
+        query_start_loc,
+        num_rejected_tokens,
+        block_table_tensor,
+        # Scalars
+        parallel_drafting_token_id,
+        num_query_per_req,
+        num_speculative_tokens,
+        block_size,
+        # In-place outputs
+        out_input_ids,
+        out_context_positions,
+        out_query_positions,
+        out_context_slot_mapping,
+        out_query_slot_mapping,
+        out_token_indices
+    )
+
+    torch_out_input_ids = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    torch_out_context_positions = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    torch_out_query_positions = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    torch_out_context_slot_mapping = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    torch_out_query_slot_mapping = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    torch_out_token_indices = torch.zeros(num_reqs * num_speculative_tokens, device='npu:0', dtype=torch.int32)
+
+    # Call PyTorch native implementation
+    golden_copy_and_expand_dflash_inputs_torch(
+        # Inputs
+        next_token_ids,
+        target_positions,
+        # Outputs
+        torch_out_input_ids,
+        torch_out_context_positions,
+        torch_out_query_positions,
+        torch_out_context_slot_mapping,
+        torch_out_query_slot_mapping,
+        torch_out_token_indices,
+        # Block table
+        block_table_tensor,
+        # Metadata
+        query_start_loc,
+        num_rejected_tokens,
+        # Scalars
+        parallel_drafting_token_id,
+        block_size,
+        num_query_per_req,
+        num_speculative_tokens,
+        num_context,
+        num_reqs
+    )
+
+    # Check if outputs are equal - this verifies that the batch processing works correctly
     input_ids_match = torch.equal(out_input_ids, torch_out_input_ids)
     context_positions_match = torch.equal(out_context_positions, torch_out_context_positions)
     query_positions_match = torch.equal(out_query_positions, torch_out_query_positions)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_copy_and_expand_dflash_inputs.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_copy_and_expand_dflash_inputs.py
@@ -1,0 +1,241 @@
+import numpy as np
+import pytest
+import torch
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+def golden_copy_and_expand_dflash_inputs_torch(
+    # Inputs
+    next_token_ids,  # [num_reqs]
+    target_positions,  # [num_context]
+    # Outputs
+    out_input_ids,  # [num_query_total] (output)
+    out_context_positions,  # [num_context] (output)
+    out_query_positions,  # [num_query_total] (output)
+    out_context_slot_mapping,  # [num_context] (output)
+    out_query_slot_mapping,  # [num_query_total] (output)
+    out_token_indices,  # [num_reqs * num_speculative_tokens] (output)
+    # Block table
+    block_table,  # [max_reqs, max_blocks]
+    # Metadata
+    query_start_loc,  # [num_reqs + 1]
+    num_rejected_tokens,  # [num_reqs] or None when not padded
+    # Scalars
+    parallel_drafting_token_id,  # int
+    block_size,  # int
+    num_query_per_req,  # int
+    num_speculative_tokens,  # int
+    total_input_tokens,  # int
+    batch_size,  # int
+):
+    """Golden reference pytorch native implementation of copy_and_expand_dflash_inputs."""
+
+    # Initialize metadata
+    has_num_rejected = num_rejected_tokens is not None
+
+    for req_idx in range(batch_size):
+        # Load context token range for this request
+        ctx_start = query_start_loc[req_idx]
+        ctx_end = query_start_loc[req_idx + 1]
+        num_ctx = ctx_end - ctx_start
+        total_tokens = num_ctx + num_query_per_req
+
+        # Process each token in the sequence
+        for j in range(total_tokens):
+            in_bounds = True
+            is_ctx = j < num_ctx
+            is_query = not is_ctx
+
+            if is_ctx:
+                # --- Context positions ---
+                ctx_pos_idx = min(ctx_start + j, total_input_tokens - 1)
+                ctx_pos = target_positions[ctx_pos_idx]
+                positions = ctx_pos
+
+                # Store context position
+                out_context_positions[ctx_start + j] = ctx_pos
+
+            else:
+                # --- Query positions ---
+                query_off = j - num_ctx  # offset within query portion (0-indexed)
+
+                # Query: last_valid_pos + 1 + query_off
+                # In padded mode, ctx_end includes rejected tokens; use valid_ctx_end
+                # to find the last accepted context position.
+                if has_num_rejected:
+                    num_rejected = num_rejected_tokens[req_idx]
+                    valid_ctx_end = ctx_end - num_rejected
+                else:
+                    valid_ctx_end = ctx_end
+
+                last_pos = target_positions[valid_ctx_end - 1]
+                query_pos = last_pos + 1 + query_off
+                positions = query_pos
+
+                # Store query position
+                query_out = req_idx * num_query_per_req + query_off
+                out_query_positions[query_out] = query_pos
+
+                # --- Input IDs (query tokens only) ---
+                bonus_token = next_token_ids[req_idx]
+                is_bonus = query_off == 0
+                if is_bonus:
+                    input_id = bonus_token
+                else:
+                    input_id = parallel_drafting_token_id
+
+                out_input_ids[query_out] = input_id
+
+                # --- Token indices to sample (mask tokens, skip the bonus token) ---
+                is_sample = query_off > 0
+                if is_sample:
+                    sample_out_idx = req_idx * num_speculative_tokens + (query_off - 1)
+                    out_token_indices[sample_out_idx] = query_out
+
+            # --- Slot mapping (block_table lookup for all positions) ---
+            block_num = positions // block_size
+            # Clamp block_number to avoid OOB when position is at max
+            block_num = min(block_num, block_table.size(1) - 1)
+            block_id = block_table[req_idx, block_num]
+            slot = block_id * block_size + (positions % block_size)
+
+            if is_ctx:
+                out_context_slot_mapping[ctx_start + j] = slot
+            else:
+                query_out = req_idx * num_query_per_req + (j - num_ctx)
+                out_query_slot_mapping[query_out] = slot
+
+def generate_test_case(num_reqs, num_speculative_tokens, block_size, max_tokens_per_req=64):
+    rng = np.random.default_rng(42)
+
+    num_reqs_prefill = num_reqs // 2
+    num_reqs_decode = num_reqs - num_reqs_prefill
+
+    next_token_ids = rng.integers(1, 50000, size=num_reqs, dtype=np.int32)
+
+    query_lens = rng.integers(1, max_tokens_per_req, size=num_reqs)
+    query_lens[:num_reqs_decode] = 1 + num_speculative_tokens
+    query_start_loc = np.zeros(num_reqs + 1, dtype=np.int32)
+    query_start_loc[1:] = np.cumsum(query_lens)
+
+    seq_lens = rng.integers(1, max_tokens_per_req, size=num_reqs)
+    seq_lens = np.maximum(seq_lens, query_lens)
+
+    num_rejected_tokens = rng.integers(0, num_speculative_tokens, size=num_reqs)
+    num_rejected_tokens[num_reqs_decode: ] = 0
+    num_rejected_tokens = np.minimum(num_rejected_tokens, query_lens)
+
+    total_input_tokens = query_start_loc[-1]
+    target_positions = np.zeros(total_input_tokens, dtype=np.int32)
+
+    for i in range(num_reqs):
+        last_pos = seq_lens[i]
+        first_pos = seq_lens[i] - query_lens[i]
+        target_positions[query_start_loc[i]: query_start_loc[i+1]] = np.arange(first_pos, last_pos, dtype=np.int32)
+
+    max_blocks = (np.max(seq_lens) + block_size - 1) // block_size
+    num_blocks = num_reqs * max_blocks
+    block_table_tensor = np.arange(0, num_blocks, dtype=np.int32).reshape(num_reqs, max_blocks)
+
+    return (
+            torch.from_numpy(next_token_ids).to(torch.int32).npu(),
+            torch.from_numpy(target_positions).to(torch.int64).npu(),
+            torch.from_numpy(query_start_loc).to(torch.int32).npu(),
+            torch.from_numpy(num_rejected_tokens).to(torch.int32).npu(),
+            torch.from_numpy(block_table_tensor).to(torch.int32).npu()
+            )
+
+
+@pytest.mark.parametrize("num_reqs", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("num_speculative_tokens", [3, 7, 15])
+def test_copy_and_expand_dflash_inputs(num_reqs, num_speculative_tokens):
+    block_size = 128
+
+    next_token_ids, target_positions, query_start_loc, num_rejected_tokens, block_table_tensor = generate_test_case(
+        num_reqs, num_speculative_tokens, block_size, 64)
+
+    parallel_drafting_token_id = 151669
+    num_speculative_tokens = 15
+
+    num_query_per_req = num_speculative_tokens + 1
+
+    num_query_total = num_reqs * (1 + num_speculative_tokens)
+    num_context = query_start_loc[-1]
+
+    # Prepare output tensors for Ascend C operator (in-place)
+    out_input_ids = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    out_context_positions = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    out_query_positions = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    out_context_slot_mapping = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    out_query_slot_mapping = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    out_token_indices = torch.zeros(num_reqs * num_speculative_tokens, device='npu:0', dtype=torch.int32)
+
+    # Call Ascend C operator
+    torch.ops._C_ascend.npu_copy_and_expand_dflash_inputs(
+        # Inputs
+        next_token_ids,
+        target_positions,
+        query_start_loc,
+        num_rejected_tokens,
+        block_table_tensor,
+        # Scalars
+        parallel_drafting_token_id,
+        num_query_per_req,
+        num_speculative_tokens,
+        block_size,
+        # In-place outputs
+        out_input_ids,
+        out_context_positions,
+        out_query_positions,
+        out_context_slot_mapping,
+        out_query_slot_mapping,
+        out_token_indices
+    )
+
+    torch_out_input_ids = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    torch_out_context_positions = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    torch_out_query_positions = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    torch_out_context_slot_mapping = torch.zeros(num_context, device='npu:0', dtype=torch.int32)
+    torch_out_query_slot_mapping = torch.zeros(num_query_total, device='npu:0', dtype=torch.int32)
+    torch_out_token_indices = torch.zeros(num_reqs * num_speculative_tokens, device='npu:0', dtype=torch.int32)
+
+    # Call PyTorch native implementation
+    golden_copy_and_expand_dflash_inputs_torch(
+        # Inputs
+        next_token_ids,
+        target_positions,
+        # Outputs
+        torch_out_input_ids,
+        torch_out_context_positions,
+        torch_out_query_positions,
+        torch_out_context_slot_mapping,
+        torch_out_query_slot_mapping,
+        torch_out_token_indices,
+        # Block table
+        block_table_tensor,
+        # Metadata
+        query_start_loc,
+        num_rejected_tokens,
+        # Scalars
+        parallel_drafting_token_id,
+        block_size,
+        num_query_per_req,
+        num_speculative_tokens,
+        num_context,
+        num_reqs
+    )
+
+    # Check if outputs are equal
+    input_ids_match = torch.equal(out_input_ids, torch_out_input_ids)
+    context_positions_match = torch.equal(out_context_positions, torch_out_context_positions)
+    query_positions_match = torch.equal(out_query_positions, torch_out_query_positions)
+    context_slot_mapping_match = torch.equal(out_context_slot_mapping, torch_out_context_slot_mapping)
+    query_slot_mapping_match = torch.equal(out_query_slot_mapping, torch_out_query_slot_mapping)
+    token_indices_match = torch.equal(out_token_indices, torch_out_token_indices)
+
+    all_match = (input_ids_match and context_positions_match and
+                 query_positions_match and context_slot_mapping_match and
+                 query_slot_mapping_match and token_indices_match)
+
+    assert all_match

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -86,31 +86,25 @@ class AscendDflashProposer(AscendEagleProposer):
 
         has_num_rejected = num_rejected_tokens_gpu is not None
 
-        copy_and_expand_dflash_inputs_kernel_single_grid[1,](
+        torch.ops._C_ascend.npu_copy_and_expand_dflash_inputs(
             # Inputs
-            next_token_ids_ptr=next_token_ids,
-            target_positions_ptr=target_positions,
-            # Outputs
-            out_input_ids_ptr=self.input_ids,
-            out_context_positions_ptr=self._context_positions_buffer,
-            out_query_positions_ptr=self.positions,
-            out_context_slot_mapping_ptr=self._context_slot_mapping_buffer,
-            out_query_slot_mapping_ptr=self._slot_mapping_buffer,
-            out_token_indices_ptr=token_indices_to_sample,
-            # Block table
-            block_table_ptr=cad.block_table_tensor,
-            block_table_stride=cad.block_table_tensor.stride(0),
-            # Metadata
-            query_start_loc_ptr=cad.query_start_loc,
-            num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
+            next_token_ids,
+            target_positions,
+            cad.query_start_loc,
+            num_rejected_tokens_gpu,
+            cad.block_table_tensor,
             # Scalars
-            parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.block_size,
-            num_query_per_req=num_query_per_req,
-            num_speculative_tokens=self.num_speculative_tokens,
-            total_input_tokens=num_context,
-            batch_size=batch_size,
-            HAS_NUM_REJECTED=has_num_rejected,
+            self.parallel_drafting_token_id,
+            num_query_per_req,
+            self.num_speculative_tokens,
+            self.block_size,
+            # In-place outputs
+            self.input_ids,
+            self._context_positions_buffer,
+            self.positions,
+            self._context_slot_mapping_buffer,
+            self._slot_mapping_buffer,
+            token_indices_to_sample
         )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]


### PR DESCRIPTION
### What this PR does / why we need it?
 Add a new AscendC custom operator npu_copy_and_expand_dflash_inputs to replace the existing Triton kernel copy_and_expand_dflash_inputs_kernel_single_grid. This change addresses multi-core utilization limitations in the original implementation.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
