### PR TITLE
[CI]add Qwen3.5-35B-A3B-w8a8 to model list

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -20,6 +20,7 @@
       "Eco-Tech/Kimi-K2.5-W4A8",
       "Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot",
       "Eco-Tech/Qwen3-VL-32B-Instruct-w8a8-QuaRot",
+      "Eco-Tech/Qwen3.5-35B-A3B-w8a8-mtp",
       "Howeee/Qwen2.5-1.5B-apeach",
       "IntervitensInc/pangu-pro-moe-model",
       "IntervitensInc/pangu-pro-moe-modelt",


### PR DESCRIPTION
### What this PR does / why we need it?
310p add Qwen3.5-35B-A3B-w8a8 to modellist
### Does this PR introduce _any_ user-facing change?
NA
### How was this patch tested?
NA
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
