### PR TITLE
[Ops][BugFix] : NPU MoE layers support TP only.

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -289,8 +289,9 @@ class AscendFusedMoE(FusedMoE):
 
         self.moe_config.tp_group = get_tp_group()
         self.moe_config.dp_group = get_dp_group()
-        self.moe_config.ep_group = get_ep_group()
-        self.moe_config.mc2_group = get_mc2_group()
+        if self.moe_config.ep_size > 1:
+            self.moe_config.ep_group = get_ep_group()
+            self.moe_config.mc2_group = get_mc2_group()
         self.moe_config.supports_eplb = self.quant_method.supports_eplb
         ascend_config = get_ascend_config()
         # flashcommon3 gate stream

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -53,10 +53,13 @@ def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | No
 
 
 def setup_moe_comm_method(moe_config):
-    _MoECommMethods[MoECommType.ALLTOALL] = AlltoAllCommImpl(moe_config)
-    _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
-    _MoECommMethods[MoECommType.MC2] = MC2CommImpl(moe_config)
-    _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(moe_config)
+    if moe_config.ep_size > 1:
+        _MoECommMethods[MoECommType.ALLTOALL] = AlltoAllCommImpl(moe_config)
+        _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
+        _MoECommMethods[MoECommType.MC2] = MC2CommImpl(moe_config)
+        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(moe_config)
+    else:
+        _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
 
 
 def set_gmmswigluquant_method():


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the MoE (Mixture of Experts) initialization failure on Ascend NPU when **only Tensor Parallelism is enabled** without Expert Parallelism.
- Only assign `self.moe_config.ep_group = get_ep_group()` when `ep_size > 1`.
- Only register `AlltoAllCommImpl` in `setup_moe_comm_method()` when `ep_size > 1`.
- This aligns with vLLM upstream's convention (`ep_size == 1` means no EP) and keeps the code robust across vLLM versions.

### Does this PR introduce _any_ user-facing change?
No. This is a bug fix that restores expected behavior for TP-only MoE inference on NPU. No API, CLI flag, or model interface is changed.

### How was this patch tested?
- [x] Manually tested on Ascend A3/A5 with `tensor-parallel-size 4` using HunyuanImage-3.0 (MoE model). The model now initializes and runs inference successfully instead of crashing during worker startup.
- [x] Verified that `enable-expert-parallel` paths remain intact and still initialize EP groups correctly.
- [x] `pre-commit` hooks passed (ruff format).

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
