### PR TITLE
[BugFix] [P/D] In scenarios where TP is not equal, the KV cache at the MTP layer is not handled.

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -587,7 +587,7 @@ class KVCacheRecvingThread(threading.Thread):
         head_dim = self.model_config.hf_text_config.head_dim
         block_size = self.vllm_config.cache_config.block_size
         num_kv_head = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
-        layers = self.model_config.hf_text_config.num_hidden_layers
+        layers = len(self.kv_caches)
         flat_block_ids = [item for sublist in block_ids for item in sublist]
         block_ids_tensor = torch.tensor(flat_block_ids, dtype=torch.int64, device=device)
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the issue where the Mooncake connector does not handle the MTP layer KV cache when TP is unbalanced.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
by nightly

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
