### PR TITLE
[CI] Remove hardcoded CANN version from wheel build config

### DIFF
--- a/.github/workflows/scripts/wheel/config.json
+++ b/.github/workflows/scripts/wheel/config.json
@@ -8,24 +8,21 @@
     {
       "variant_label": "310p",
       "properties": [
-        "ascend :: npu_type :: 310p",
-        "ascend :: cann_version :: 8.5.1"
+        "ascend :: npu_type :: 310p"
       ],
       "skip_plugin_validation": true
     },
     {
       "variant_label": "a2",
       "properties": [
-        "ascend :: npu_type :: a2",
-        "ascend :: cann_version :: 8.5.1"
+        "ascend :: npu_type :: a2"
       ],
       "skip_plugin_validation": true
     },
     {
       "variant_label": "a3",
       "properties": [
-        "ascend :: npu_type :: a3",
-        "ascend :: cann_version :: 8.5.1"
+        "ascend :: npu_type :: a3"
       ],
       "skip_plugin_validation": true
     }


### PR DESCRIPTION
### What this PR does / why we need it?

Each release branch targets a specific vLLM version, which corresponds to a different CANN version. Hardcoding `cann_version: 8.5.1` in the wheel build config means all branches share the same fixed CANN version regardless of their actual requirements. By removing this field, the CANN version is determined by the CI environment at build time, allowing each branch to naturally use the correct CANN version.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
