### PR TITLE
[v0.18.0][CI] Remove hardcoded CANN version from wheel build config

### DIFF
--- a/.github/workflows/scripts/wheel/config.json
+++ b/.github/workflows/scripts/wheel/config.json
@@ -8,24 +8,21 @@
     {
       "variant_label": "310p",
       "properties": [
-        "ascend :: npu_type :: 310p",
-        "ascend :: cann_version :: 8.5.1"
+        "ascend :: npu_type :: 310p"
       ],
       "skip_plugin_validation": true
     },
     {
       "variant_label": "a2",
       "properties": [
-        "ascend :: npu_type :: a2",
-        "ascend :: cann_version :: 8.5.1"
+        "ascend :: npu_type :: a2"
       ],
       "skip_plugin_validation": true
     },
     {
       "variant_label": "a3",
       "properties": [
-        "ascend :: npu_type :: a3",
-        "ascend :: cann_version :: 8.5.1"
+        "ascend :: npu_type :: a3"
       ],
       "skip_plugin_validation": true
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

Each release branch targets a specific vLLM version, which corresponds to a different CANN version. Hardcoding `cann_version: 8.5.1` in the wheel build config means all branches share the same fixed CANN version regardless of their actual requirements. By removing this field, the CANN version is determined by the CI environment at build time, allowing each branch to naturally use the correct CANN version.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
