### PR TITLE
[BugFix][PCP] Fix incorrect slot mapping for DeepSeek 3.2 PCP+MTP decode path

### DIFF
--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -140,6 +140,10 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             elif self.speculative_config is not None and num_decodes > 0:
                 # when mtp, pcp_allgather_restore_idx=[696,-1,697,-1,560,-1,561,-1,100,101,102],
                 # slot_mapping should be [696,697,-1,-1,560,561,-1,-1,100,101,102]
+                # corner case: decode requests in the same MTP batch can have
+                # different query lengths when some drafts are clipped near
+                # max_model_len, so compact slot_mapping by per-request length
+                # instead of assuming each request has decode_threshold tokens.
                 decode_query_lens = long_seq_metadata.query_lens_pcp_full_cpu[:num_decodes]
                 decode_slot_mapping = self.slot_mapping_buf[: num_decode_tokens * self.pcp_size]
                 self._compact_varlen_decode_slot_mapping(

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -58,6 +58,33 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
         )
         self.block_arange_buffer = torch.arange(self.pcp_size * self.dcp_size, dtype=torch.int32, device=device)
 
+    def _compact_varlen_decode_slot_mapping(
+        self,
+        decode_slot_mapping: torch.Tensor,
+        decode_query_lens: torch.Tensor,
+    ) -> None:
+        device = decode_slot_mapping.device
+        decode_query_lens_cpu = decode_query_lens.to(device="cpu", dtype=torch.int64, non_blocking=True)
+        total_valid_tokens = int(decode_query_lens_cpu.sum().item())
+        if total_valid_tokens == 0:
+            return
+        decode_query_lens = decode_query_lens_cpu.to(device=device, dtype=torch.int64, non_blocking=True)
+
+        req_spans = decode_query_lens * self.pcp_size
+        req_starts = torch.cumsum(req_spans, dim=0) - req_spans
+
+        token_offsets = torch.arange(total_valid_tokens, device=device, dtype=torch.int64)
+        token_base = torch.cumsum(decode_query_lens, dim=0) - decode_query_lens
+        token_offsets = token_offsets - torch.repeat_interleave(token_base, decode_query_lens)
+
+        expanded_req_starts = torch.repeat_interleave(req_starts, decode_query_lens)
+        valid_in_idx = expanded_req_starts + token_offsets * self.pcp_size
+        valid_out_idx = expanded_req_starts + token_offsets
+
+        valid_slots = decode_slot_mapping[valid_in_idx]
+        decode_slot_mapping.fill_(-1)
+        decode_slot_mapping.index_copy_(0, valid_out_idx, valid_slots)
+
     def build(
         self,
         common_prefix_len: int,
@@ -113,15 +140,12 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             elif self.speculative_config is not None and num_decodes > 0:
                 # when mtp, pcp_allgather_restore_idx=[696,-1,697,-1,560,-1,561,-1,100,101,102],
                 # slot_mapping should be [696,697,-1,-1,560,561,-1,-1,100,101,102]
-                num_tokens_per_request = num_decode_tokens // num_decodes
-                decode_slot_mapping = self.slot_mapping_buf[: num_decode_tokens * self.pcp_size].reshape(
-                    num_decodes, -1
+                decode_query_lens = long_seq_metadata.query_lens_pcp_full_cpu[:num_decodes]
+                decode_slot_mapping = self.slot_mapping_buf[: num_decode_tokens * self.pcp_size]
+                self._compact_varlen_decode_slot_mapping(
+                    decode_slot_mapping,
+                    decode_query_lens,
                 )
-                decode_slot_mapping[:, :num_tokens_per_request] = decode_slot_mapping[
-                    :, : num_tokens_per_request * self.pcp_size : self.pcp_size
-                ]
-                decode_slot_mapping[:, num_tokens_per_request : num_tokens_per_request * self.pcp_size].fill_(-1)
-                self.slot_mapping_buf[: num_decode_tokens * self.pcp_size] = decode_slot_mapping.flatten()
             metadata_cls.slot_mapping = self.slot_mapping_buf[:num_actual_tokens_pcp_padded]
         metadata_cls.sfa_cp_metadata = sfa_cp_metadata
         return metadata_cls


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a bug in certain corner cases when PCP and MTP are enabled together for DeepSeek 3.2.
In the original decode + PCP + MTP branch, the code assumes that every request has the same number of decode tokens. In special cases, this assumption does not hold, which can cause the decode slot mapping to be computed incorrectly.
The fix is to compute the decode slot mapping using the actual decode token count of each request.

### How was this patch tested?


- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
