### PR TITLE
[Performance] Add runner-level barrier for piecewise ACL graph replay

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -19,9 +19,42 @@ from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
 from vllm.platforms import current_platform
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
 from ..utils import weak_ref_tensors
+
+
+def piecewise_runner_barrier_enabled() -> bool:
+    enabled = envs_ascend.VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER
+    assert enabled in (0, 1), f"VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER must be 0 or 1, got {enabled}"
+    return enabled == 1
+
+
+def piecewise_runner_barrier_supports_spec_decode(
+    speculative_config: Any | None,
+) -> bool:
+    if speculative_config is None:
+        return True
+    return speculative_config.method in ("ngram", "suffix")
+
+
+def should_use_piecewise_runner_barrier(
+    cudagraph_mode: CUDAGraphMode,
+    enforce_eager: bool,
+    speculative_config: Any | None,
+) -> bool:
+    if not piecewise_runner_barrier_enabled():
+        return False
+    if not piecewise_runner_barrier_supports_spec_decode(speculative_config):
+        return False
+    assert not enforce_eager, (
+        "VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER requires graph mode, but enforce_eager is enabled."
+    )
+    assert cudagraph_mode == CUDAGraphMode.PIECEWISE, (
+        f"VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER only supports PIECEWISE cudagraph mode, got {cudagraph_mode}."
+    )
+    return True
 
 
 @dataclasses.dataclass
@@ -198,7 +231,17 @@ class ACLGraphWrapper:
         # If we do not in main model and in full-graph mode when using merge-eagle-graph,
         # we do not need to synchronize.
         use_eagle = self.vllm_config.speculative_config.use_eagle() if self.vllm_config.speculative_config else False
-        if self.runtime_mode != CUDAGraphMode.FULL or not _EXTRA_CTX.is_draft_model or not use_eagle:
+        runner_barrier_owns_sync = (
+            self.runtime_mode == CUDAGraphMode.PIECEWISE
+            and not _EXTRA_CTX.is_draft_model
+            and should_use_piecewise_runner_barrier(
+                self.runtime_mode,
+                self.vllm_config.model_config.enforce_eager,
+                self.vllm_config.speculative_config,
+            )
+        )
+        full_graph_eagle_skip_sync = self.runtime_mode == CUDAGraphMode.FULL and _EXTRA_CTX.is_draft_model and use_eagle
+        if not runner_barrier_owns_sync and not full_graph_eagle_skip_sync:
             torch.npu.current_stream().synchronize()
         entry.aclgraph.replay()
         return entry.output

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -107,6 +107,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Platform validation: only PD-mixed mode (`kv_role='kv_both'` or no kv_transfer_config).
     # Not supported in PD-disaggregated mode (`kv_producer` / `kv_consumer` only).
     "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),
+    # Whether to move the PIECEWISE aclgraph replay fence from each graph replay
+    # to the model runner input-preparation boundary. 0: disabled, 1: enabled.
+    "VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER": lambda: int(
+        os.getenv("VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER", "0")
+    ),
     # use fused op transpose_kv_cache_by_block, default is True
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -101,6 +101,7 @@ from vllm_ascend.compilation.acl_graph import (
     ACLGraphWrapper,
     set_draft_graph_params,
     set_graph_params,
+    should_use_piecewise_runner_barrier,
     update_full_graph_params,
 )
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
@@ -485,6 +486,14 @@ class NPUModelRunner(GPUModelRunner):
             and self.compilation_config.mode == CompilationMode.VLLM_COMPILE
             and not self.model_config.enforce_eager
         )
+
+    def _synchronize_before_piecewise_input_prep(self) -> None:
+        if should_use_piecewise_runner_barrier(
+            self.compilation_config.cudagraph_mode,
+            self.model_config.enforce_eager,
+            self.speculative_config,
+        ):
+            torch.npu.current_stream().synchronize()
 
     def _sync_metadata_across_dp(
         self,
@@ -1394,6 +1403,7 @@ class NPUModelRunner(GPUModelRunner):
             scheduler_output = deepcopy(scheduler_output)
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("prepare input"):
+            self._synchronize_before_piecewise_input_prep()
             with self.synchronize_input_prep():
                 # Update persistent batch states.
                 deferred_state_corrections_fn = self._update_states(scheduler_output)

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -44,6 +44,7 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_mask,
     set_mc2_tokens_capacity,
 )
+from vllm_ascend.compilation.acl_graph import should_use_piecewise_runner_barrier
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import set_weight_prefetch_method
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
@@ -140,6 +141,14 @@ class NPUModelRunner(GPUModelRunner):
         # so we can inherit `execute_model` method.
         self.input_batch: AscendInputBatch | None = None
 
+    def _synchronize_before_piecewise_input_prep(self) -> None:
+        if should_use_piecewise_runner_barrier(
+            self.compilation_config.cudagraph_mode,
+            self.model_config.enforce_eager,
+            self.speculative_config,
+        ):
+            torch.npu.current_stream().synchronize()
+
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         with graph_manager_wrapper(self):
             super().initialize_kv_cache(kv_cache_config)
@@ -171,6 +180,7 @@ class NPUModelRunner(GPUModelRunner):
         npu attention backends need seq_lens_cpu to work.
         so we need to prepare seq_lens_cpu here.
         """
+        self._synchronize_before_piecewise_input_prep()
         num_tokens = scheduler_output.total_num_scheduled_tokens
         num_tokens_after_padding = batch_desc.num_tokens
         assert num_tokens > 0


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds an opt-in runner-level barrier for Ascend PIECEWISE ACL graph replay.

Today, PIECEWISE graph replay synchronizes before every sub-graph replay. For piecewise decode, this introduces repeated fixed synchronization overhead. This PR moves the synchronization boundary to the model runner side, so input/metadata updates are still ordered before graph replay, while avoiding a full stream synchronization before every piecewise sub-graph replay.

The optimization is guarded by a new environment variable and is disabled by default:

```bash
VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER=1
```

The optimization is intentionally conservative:
- Only applies to `CUDAGraphMode.PIECEWISE`.
- Disabled by default.
- Does not apply when `enforce_eager=True`.
- Does not apply to draft-model graph replay.
- Allows normal decoding and suffix/ngram speculative decoding.
- Keeps the original per-replay synchronization path for EAGLE / EAGLE-3 / Medusa / MTP / draft-model style speculative decoding.

### Does this PR introduce _any_ user-facing change?

No behavior changes by default.

This PR only adds an optional environment variable:

```bash
VLLM_ASCEND_ENABLE_PIECEWISE_RUNNER_BARRIER=1
```

When the env var is not set, the original synchronization behavior is preserved.

### How was this patch tested?

Accuracy test - GSM8K:

Baseline:

|   Tasks   |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_local|      3|flexible-extract|     5|exact_match|↑  |0.9121|±  |0.0078|
|           |       |strict-match    |     5|exact_match|↑  |0.9022|±  |0.0082|

With this PR:

|   Tasks   |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_local|      3|flexible-extract|     5|exact_match|↑  |0.9151|±  |0.0077|
|           |       |strict-match    |     5|exact_match|↑  |0.9022|±  |0.0082|

Accuracy test - CEval:

Baseline:

| dataset | version | metric | mode | vllm-api-general-chat |
|---|---|---|---|---:|
| ceval-stem | - | accuracy | gen | 90.48 |
| ceval-stem | - | naive_average | gen | 90.48 |
| ceval-social-science | - | accuracy | gen | 92.22 |
| ceval-social-science | - | naive_average | gen | 92.22 |
| ceval-humanities | - | accuracy | gen | 82.53 |
| ceval-humanities | - | naive_average | gen | 82.53 |
| ceval-other | - | accuracy | gen | 83.38 |
| ceval-other | - | naive_average | gen | 83.38 |
| ceval-hard | - | accuracy | gen | 89.64 |
| ceval-hard | - | naive_average | gen | 89.64 |
| ceval | - | accuracy | gen | 87.63 |
| ceval | - | naive_average | gen | 87.63 |
| ceval-weighted | - | accuracy | gen | 86.26 |
| ceval-weighted | - | weighted_average | gen | 86.26 |

With this PR:

| dataset | version | metric | mode | vllm-api-general-chat |
|---|---|---|---|---:|
| ceval-stem | - | accuracy | gen | 89.69 |
| ceval-stem | - | naive_average | gen | 89.69 |
| ceval-social-science | - | accuracy | gen | 91.56 |
| ceval-social-science | - | naive_average | gen | 91.56 |
| ceval-humanities | - | accuracy | gen | 86.21 |
| ceval-humanities | - | naive_average | gen | 86.21 |
| ceval-other | - | accuracy | gen | 82.80 |
| ceval-other | - | naive_average | gen | 82.80 |
| ceval-hard | - | accuracy | gen | 89.04 |
| ceval-hard | - | naive_average | gen | 89.04 |
| ceval | - | accuracy | gen | 87.85 |
| ceval | - | naive_average | gen | 87.85 |
| ceval-weighted | - | accuracy | gen | 86.70 |
| ceval-weighted | - | weighted_average | gen | 86.70 |

Baseline serving benchmark:

```text
============ Serving Benchmark Result ============
Successful requests:                     10
Failed requests:                         0
Maximum request concurrency:             5
Benchmark duration (s):                  36.59
Total input tokens:                      435400
Total generated tokens:                  2280
Request throughput (req/s):              0.27
Output token throughput (tok/s):         62.32
Peak output token throughput (tok/s):    110.00
Peak concurrent requests:                10.00
Total token throughput (tok/s):          11962.40
---------------Time to First Token----------------
Mean TTFT (ms):                          5848.34
Median TTFT (ms):                        6188.57
P99 TTFT (ms):                           8789.83
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          54.69
Median TPOT (ms):                        52.17
P99 TPOT (ms):                           67.99
---------------Inter-token Latency----------------
Mean ITL (ms):                           54.45
Median ITL (ms):                         45.53
P99 ITL (ms):                            55.76
----------------End-to-end Latency----------------
Mean E2EL (ms):                          18262.12
Median E2EL (ms):                        18245.61
P99 E2EL (ms):                           19354.62
==================================================
```

With this PR:

```text
============ Serving Benchmark Result ============
Successful requests:                     10
Failed requests:                         0
Maximum request concurrency:             5
Benchmark duration (s):                  33.81
Total input tokens:                      435400
Total generated tokens:                  2280
Request throughput (req/s):              0.30
Output token throughput (tok/s):         67.44
Peak output token throughput (tok/s):    125.00
Peak concurrent requests:                10.00
Total token throughput (tok/s):          12945.43
---------------Time to First Token----------------
Mean TTFT (ms):                          5724.19
Median TTFT (ms):                        6274.70
P99 TTFT (ms):                           8471.88
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          49.13
Median TPOT (ms):                        46.59
P99 TPOT (ms):                           62.80
---------------Inter-token Latency----------------
Mean ITL (ms):                           48.92
Median ITL (ms):                         40.38
P99 ITL (ms):                            47.63
----------------End-to-end Latency----------------
Mean E2EL (ms):                          16877.05
Median E2EL (ms):                        16860.60
P99 E2EL (ms):                           17704.29
==================================================
```

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
