### PR TITLE
[Doc][Bugfix] Fix Doc test caused by missing `Hunyuan-A13B-Instruct.md` in index

### DIFF
--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -32,5 +32,6 @@ Kimi-K2-Thinking.md
 Kimi-K2.5.md
 PaddleOCR-VL.md
 MiniMax-M2.5.md
+Hunyuan-A13B-Instruct.md
 Minitron-8B-Base.md
 :::


### PR DESCRIPTION
### What this PR does / why we need it?

Fix Doc test because of  missing Hunyuan-A13B-Instruct.md in index, the error casused by https://github.com/vllm-project/vllm-ascend/pull/8157

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
