### PR TITLE
[BugFix] Require kv producer for layer sharding

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -742,12 +742,13 @@ class TestNPUPlatform(TestBase):
 
         self.assertEqual(vllm_config.cache_config.block_size, 512)
 
-    def test_validate_layer_sharding_config_accepts_single_node(self):
+    def test_validate_layer_sharding_config_rejects_missing_kv_transfer_config(self):
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.additional_config = {"layer_sharding": ["q_b_proj", "o_proj"]}
         vllm_config.kv_transfer_config = None
 
-        self.platform._validate_layer_sharding_config(vllm_config)
+        with pytest.raises(ValueError, match="layer_sharding can only be enabled in PD-disaggregated's P node"):
+            self.platform._validate_layer_sharding_config(vllm_config)
 
     def test_validate_layer_sharding_config_accepts_kv_producer(self):
         vllm_config = TestNPUPlatform.mock_vllm_config()

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -241,7 +241,7 @@ class NPUPlatform(Platform):
             return
 
         kv_transfer_config = vllm_config.kv_transfer_config
-        if kv_transfer_config is not None and kv_transfer_config.kv_role != "kv_producer":
+        if kv_transfer_config is None or kv_transfer_config.kv_role != "kv_producer":
             raise ValueError("additional_config.layer_sharding can only be enabled in PD-disaggregated's P node.")
 
     @classmethod


### PR DESCRIPTION
### What this PR does / why we need it?

This PR tightens Ascend `additional_config.layer_sharding` validation so it is only accepted on PD-disaggregated P nodes with `kv_role="kv_producer"`.

### Does this PR introduce _any_ user-facing change?

Yes. Invalid `layer_sharding` configurations without `kv_transfer_config` now fail fast with `ValueError`.

### How was this patch tested?
