### PR TITLE
[Performance]Remove a redundant cast in MC2

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 import torch
 
 import vllm_ascend.ops.fused_moe.moe_stage_params as _stage_params
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.fused_moe.moe_stage_contracts import (
     MoEAllGatherCombineMetadata,
     MoEAllToAllCombineMetadata,
@@ -196,9 +197,13 @@ def build_token_dispatch_input(
     fused_experts_input: MoEFusedExpertsInput,
     topk_ids: torch.Tensor | None = None,
 ) -> MoETokenDispatchInput:
+    topk_weights = fused_experts_input.topk_weights
+    if _EXTRA_CTX.moe_comm_type is MoECommType.MC2:
+        topk_weights = topk_weights.to(torch.float32)
+
     return MoETokenDispatchInput(
         hidden_states=fused_experts_input.hidden_states,
-        topk_weights=fused_experts_input.topk_weights,
+        topk_weights=topk_weights,
         topk_ids=fused_experts_input.topk_ids if topk_ids is None else topk_ids,
         routing=fused_experts_input.routing,
         quant=fused_experts_input.quant,


### PR DESCRIPTION

### What this PR does / why we need it?
In the MC2 (Multi-Communication Combine) MoE dispatch path, `topk_weights` needs to be in float32
precision. Before this change, each downstream consumer (e.g., `npu_moe_init_comm`,
`npu_grouped_matmul_gmm2` callers in `token_dispatcher.py` and `moe_comm_method.py`) independently called
`.to(torch.float32)` on `topk_weights`. This resulted in redundant cast kernels being launched
every time the tensor was consumed.

This PR moves the float32 cast upstream into `build_token_dispatch_input`, right where the
`MoETokenDispatchInput` is constructed. When an `mc2_mask` is present, `topk_weights` is converted
to float32 once, and all downstream consumers receive an already-float32 tensor. PyTorch skips
the subsequent `.to(torch.float32)` calls as no-ops, eliminating redundant kernel launches in
the MC2 dispatch hot path.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Verified on A5 devices with MC2-enabled workloads

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
