### PR TITLE
[Feature] DFlash + ACLGraph FDO/FULL mode support

### DIFF
--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -212,7 +212,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(result, "test_output")
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -227,7 +227,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method captures graph for the first time"""
@@ -270,7 +270,7 @@ class TestACLGraphWrapper(TestBase):
         result = wrapper(test_tensor, "arg2")
 
         # Verify graph capture happened
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
         self.mock_runnable.assert_called_once_with(test_tensor, "arg2")
@@ -288,7 +288,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(result, "test_output")
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -303,7 +303,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method replays graph when already captured"""
@@ -348,7 +348,7 @@ class TestACLGraphWrapper(TestBase):
         first_result = wrapper(test_tensor, "arg2")
 
         # Verify graph capture happened during first call
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once()
 
@@ -370,7 +370,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(second_result, "weak_ref_output")  # Weak ref output
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -383,7 +383,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method with debug mode input address checking"""
@@ -432,7 +432,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertTrue(True)
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -445,7 +445,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method with debug mode input address mismatch raises AssertionError"""
@@ -495,7 +495,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertIn("Input addresses for aclgraphs are different", str(context.exception))
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -512,7 +512,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method captures graph with gc_disable option enabled"""
@@ -569,7 +569,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertTrue(mock_patch.called)
 
         # Verify graph capture happened
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
 
@@ -577,7 +577,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(result, "test_output")
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -592,7 +592,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method captures graph with weak_ref_output option enabled"""
@@ -643,7 +643,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(mock_weak_ref_tensors.call_count, 2)
 
         # Verify graph capture happened
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
 
@@ -692,7 +692,7 @@ class TestACLGraphWrapper(TestBase):
                 mock_weak_ref_tensors.side_effect = ["inner_output", "weak_ref_output"]
 
                 # Mock validate_cudagraph_capturing_enabled
-                with patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled"):
+                with patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled"):
                     wrapper = ACLGraphWrapper(
                         runnable=self.mock_runnable,
                         vllm_config=self.mock_vllm_config,

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1263,6 +1263,7 @@ class TestEagleProposerPropose:
 
 class MockCpuGpuBuffer:
     """Mock CpuGpuBuffer for testing"""
+
     def __init__(self, max_size, dtype, device="cpu", **kwargs):
         self.max_size = max_size
         self.dtype = dtype
@@ -1270,7 +1271,7 @@ class MockCpuGpuBuffer:
         self.cpu = torch.zeros(max_size, dtype=dtype, device="cpu")
         self.np = self.cpu.numpy()
         self.gpu = torch.zeros(max_size, dtype=dtype, device=device)
-    
+
     def copy_to_gpu(self, size=None):
         if size is None:
             size = self.max_size
@@ -1279,10 +1280,11 @@ class MockCpuGpuBuffer:
 
 class MockCachedRequestState:
     """Mock CachedRequestState for testing"""
+
     def __init__(self, req_id, token_ids):
         self.req_id = req_id
         self.token_ids = token_ids
-    
+
     def get_token_id(self, position):
         if position < len(self.token_ids):
             return self.token_ids[position]
@@ -1291,6 +1293,7 @@ class MockCachedRequestState:
 
 class MockInputBatch:
     """Mock InputBatch for testing"""
+
     def __init__(self, num_reqs, req_ids, vocab_size):
         self.num_reqs = num_reqs
         self.req_ids = req_ids
@@ -1299,7 +1302,7 @@ class MockInputBatch:
 
 class TestPrepareNextTokenIdsPadded(TestBase):
     """Test prepare_next_token_ids_padded method with precision validation"""
-    
+
     def setUp(self):
         self.vllm_config = MagicMock(spec=VllmConfig)
         self.vllm_config.speculative_config = MagicMock()
@@ -1355,30 +1358,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case where all requests have valid sampled tokens"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, 102, 103, 104],
-            [200, 201, 202, 203, 204],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, 102, 103, 104],
+                [200, 201, 202, 203, 204],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(10))),
             "req_1": MockCachedRequestState("req_1", list(range(15))),
             "req_2": MockCachedRequestState("req_2", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1387,13 +1389,13 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         self.assertEqual(next_token_ids.shape[0], num_reqs)
         self.assertEqual(valid_sampled_tokens_count.shape[0], num_reqs)
-        
+
         expected_valid_counts = torch.tensor([5, 5, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_next_tokens = torch.tensor([104, 204, 304], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
 
@@ -1401,30 +1403,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case where some tokens are rejected (marked as -1)"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, -1, -1, -1],
-            [200, 201, 202, 203, -1],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, -1, -1, -1],
+                [200, 201, 202, 203, -1],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(10))),
             "req_1": MockCachedRequestState("req_1", list(range(15))),
             "req_2": MockCachedRequestState("req_2", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1433,10 +1434,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([2, 4, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_next_tokens = torch.tensor([101, 203, 304], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
 
@@ -1444,30 +1445,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case where all tokens are rejected, should use backup token"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [-1, -1, -1, -1, -1],
-            [-1, -1, -1, -1, -1],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
             "req_2": MockCachedRequestState("req_2", list(range(25))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1476,10 +1476,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([0, 0, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_backup_token_0 = requests["req_0"].get_token_id(10)
         expected_backup_token_1 = requests["req_1"].get_token_id(15)
         expected_next_tokens = torch.tensor([expected_backup_token_0, expected_backup_token_1, 304], dtype=torch.int64)
@@ -1489,30 +1489,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case with discarded requests"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, 102, 103, 104],
-            [200, 201, 202, 203, 204],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, 102, 103, 104],
+                [200, 201, 202, 203, 204],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
             "req_2": MockCachedRequestState("req_2", list(range(25))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([0, 2], dtype=torch.int64)
         num_discarded_requests = 2
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1521,10 +1520,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([0, 5, 0], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_backup_token_0 = requests["req_0"].get_token_id(10)
         expected_backup_token_2 = requests["req_2"].get_token_id(20)
         expected_next_tokens = torch.tensor([expected_backup_token_0, 204, expected_backup_token_2], dtype=torch.int64)
@@ -1534,32 +1533,33 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test mixed scenario: some rejected tokens, some discarded requests, some all-rejected"""
         num_reqs = 4
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20, 25], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, -1, -1, -1],
-            [-1, -1, -1, -1, -1],
-            [300, 301, 302, 303, 304],
-            [400, 401, 402, -1, -1],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [300, 301, 302, 303, 304],
+                [400, 401, 402, -1, -1],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
             "req_2": MockCachedRequestState("req_2", list(range(25))),
             "req_3": MockCachedRequestState("req_3", list(range(30))),
         }
-        
+
         gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2", "req_3"],
-            vocab_size=vocab_size
+            num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2", "req_3"], vocab_size=vocab_size
         )
-        
+
         discard_request_indices = torch.tensor([1], dtype=torch.int64)
         num_discarded_requests = 1
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1568,10 +1568,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([2, 0, 5, 3], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_backup_token_1 = requests["req_1"].get_token_id(15)
         expected_next_tokens = torch.tensor([101, expected_backup_token_1, 304, 402], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
@@ -1580,24 +1580,20 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test with single request"""
         num_reqs = 1
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10], dtype=torch.int32)
-        
+
         sampled_token_ids = torch.tensor([[100, 101, 102, 103, 104]], dtype=torch.int64)
-        
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1606,10 +1602,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_next_tokens = torch.tensor([104], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
 
@@ -1617,28 +1613,27 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test with tokens at vocab size boundary"""
         num_reqs = 2
         vocab_size = 100
-        
+
         seq_lens_cpu = torch.tensor([10, 15], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [99, 100, 101, -1, -1],
-            [50, 51, 52, 53, 54],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [99, 100, 101, -1, -1],
+                [50, 51, 52, 53, 54],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1647,12 +1642,12 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         # Token 100 and 101 are >= vocab_size (100), so they are invalid
         # Only token 99 is valid for the first request
         expected_valid_counts = torch.tensor([1, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         # Next token should be 99 (last valid token) for first request
         # and 54 for second request
         expected_next_tokens = torch.tensor([99, 54], dtype=torch.int64)
@@ -1662,28 +1657,27 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test to verify key variables that affect downstream computation"""
         num_reqs = 2
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, -1, -1, -1],
-            [200, 201, 202, -1, -1],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, -1, -1, -1],
+                [200, 201, 202, -1, -1],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1692,27 +1686,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         # Verify return values
         self.assertEqual(next_token_ids[0].item(), 101, "next_token_ids[0] should be 101")
         self.assertEqual(next_token_ids[1].item(), 202, "next_token_ids[1] should be 202")
         self.assertEqual(valid_sampled_tokens_count[0].item(), 2, "valid_sampled_tokens_count[0] should be 2")
         self.assertEqual(valid_sampled_tokens_count[1].item(), 3, "valid_sampled_tokens_count[1] should be 3")
-        
+
         # Verify public member that affects downstream computation
         expected_backup_0 = requests["req_0"].get_token_id(10)
         expected_backup_1 = requests["req_1"].get_token_id(15)
         self.assertEqual(
-            self.proposer.backup_next_token_ids.np[0], 
+            self.proposer.backup_next_token_ids.np[0],
             expected_backup_0,
-            f"backup_next_token_ids[0] should be {expected_backup_0}"
+            f"backup_next_token_ids[0] should be {expected_backup_0}",
         )
         self.assertEqual(
-            self.proposer.backup_next_token_ids.np[1], 
+            self.proposer.backup_next_token_ids.np[1],
             expected_backup_1,
-            f"backup_next_token_ids[1] should be {expected_backup_1}"
+            f"backup_next_token_ids[1] should be {expected_backup_1}",
         )
-        
+
         # Verify data types
         self.assertEqual(next_token_ids.dtype, torch.int64, "next_token_ids dtype should be torch.int64")
-        self.assertEqual(valid_sampled_tokens_count.dtype, torch.int64, "valid_sampled_tokens_count dtype should be torch.int64")
+        self.assertEqual(
+            valid_sampled_tokens_count.dtype, torch.int64, "valid_sampled_tokens_count dtype should be torch.int64"
+        )

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -509,13 +509,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         scale,
                         attn_output,
                         softmax_lse,
+                        sparse_mode,
                         c8_k_aq_scale,
                         c8_k_aq_offset,
                         c8_v_aq_scale,
                         c8_v_aq_offset,
                     ) = param
 
-                    sparse_mode = 3
                     if _EXTRA_CTX.is_draft_model:
                         draft_step = attn_count // num_layers
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
@@ -528,6 +528,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         seq_lens = attn_metadata[key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
                         block_tables = attn_metadata[key].block_tables
+
+                    # TND layout constraint: queryT must equal
+                    # actual_seq_lengths_q[-1]. When the graph was captured
+                    # with a padded num_tokens (e.g. 16) but the live batch
+                    # produces fewer actual tokens (e.g. 9), the mismatch
+                    # causes FIA kernel validation failure.
+                    if actual_seq_lengths_q and actual_seq_lengths_q[-1] != num_tokens:
+                        actual_seq_lengths_q = list(actual_seq_lengths_q)
+                        actual_seq_lengths_q[-1] = num_tokens
 
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
@@ -597,7 +606,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         workspace = graph_params.workspaces.get(num_tokens)
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
-        attn_mask = attn_metadata.attn_mask
+        attn_mask = attn_metadata.attn_mask if attn_metadata.causal else None
         sparse_mode = 3 if attn_metadata.causal else 0
         extra_args = {}
         if self.enable_c8_quant:
@@ -658,6 +667,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             self.scale,
             weak_ref_tensors(output),
             weak_ref_tensors(softmax_lse),
+            sparse_mode,
         )
         if self.enable_c8_quant:
             attn_params = attn_params + (

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+from collections import defaultdict
 from collections.abc import Callable
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -13,7 +14,7 @@ import torch_npu
 import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphOptions
-from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
@@ -134,8 +135,8 @@ class ACLGraphWrapper:
                 # shape. E.g. we only log it for the first subgraph in
                 # piecewise mode.
                 logger.debug("Capturing a aclgraph on (%s,%s)", self.runtime_mode.name, entry.batch_descriptor)
-            # validate that aclgraph capturing is legal at this point.
-            validate_cudagraph_capturing_enabled()
+            # enable aclgraph capturing for lazy capture path (draft model)
+            set_cudagraph_capturing_enabled(True)
 
             input_addresses = [x.data_ptr() for x in args if isinstance(x, torch.Tensor)]
             entry.input_addresses = input_addresses
@@ -246,10 +247,10 @@ def update_full_graph_params(
 
 @dataclass
 class GraphParams:
-    events: dict[int, list[torch.npu.ExternalEvent]]
+    events: defaultdict[int, list[torch.npu.ExternalEvent]]
     workspaces: dict[int, torch.Tensor]
-    handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
-    attn_params: dict[int, list[tuple]]
+    handles: defaultdict[int, list[torch_npu._C._NPUTaskGroupHandle]]
+    attn_params: defaultdict[int, list[tuple]]
 
 
 _graph_params: GraphParams | None = None
@@ -260,10 +261,10 @@ def set_graph_params(aclgraph_capture_sizes: list[int]):
     if _graph_params is not None:
         raise ValueError("Graph parameters have already been set!")
     _graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
         {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
     )
 
 
@@ -285,10 +286,10 @@ def set_draft_graph_params(aclgraph_capture_sizes: list[int]):
     if _draft_graph_params is not None:
         raise ValueError("DraftGraph parameters have already been set!")
     _draft_graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
         {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
     )
 
 
@@ -310,10 +311,10 @@ def set_draft_graph_prefill_params(aclgraph_capture_sizes: list[int]):
     if _draft_graph_prefill_params is not None:
         raise ValueError("DraftGraph preill parameters have already been set!")
     _draft_graph_prefill_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
         {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
     )
 
 

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -166,35 +166,61 @@ class AscendDflashProposer(AscendEagleProposer):
         num_query_per_req = 1 + self.num_speculative_tokens
         num_query_total = num_reqs * num_query_per_req
 
+        # init block table tensor clone is only available after profile run
+        # and is only used for graph mode
+        if self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
+            self.block_table_tensor_clone = torch.zeros(
+                (
+                    self.runner.max_num_tokens + 2 * self.pcp_size * self.runner.max_num_reqs,
+                    self.runner.input_batch.block_table[0].get_device_tensor().shape[1],
+                ),
+                dtype=torch.int32,
+                device=self.device,
+                pin_memory=self.runner.pin_memory,
+            )
+
         context_positions = self._context_positions_buffer[:num_input_tokens]
         context_states = self.hidden_states[:num_input_tokens]
 
+        # Build attn_metadata for FULL graph capture so that FIA operators
+        # are properly included in the captured graph (DFlash needs non-causal attention).
         multi_steps_attn_metadata = []
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
-            builder = self.draft_attn_groups[0].get_metadata_builder()
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.draft_attn_groups) > 0:
+            # DFlash uses num_query_per_req tokens per request
+            num_query_per_req = 1 + self.num_speculative_tokens
+            batch_size = max(num_input_tokens // num_query_per_req, 1)
+
+            # Build correct DFlash query_start_loc: [0, nq, 2*nq, ...]
+            dflash_qsl = self.arange_dflash[: batch_size + 1] * num_query_per_req
+            dflash_qsl_cpu = torch.arange(batch_size + 1, dtype=torch.int32) * num_query_per_req
+            # Correct actual_seq_lengths_q for DFlash: cumulative query lengths
+            dflash_actual_seq_q = self.arange_dflash[1 : batch_size + 1] * num_query_per_req
+
             common_attn_metadata = AscendCommonAttentionMetadata(
-                query_start_loc=self.arange_dflash[: num_reqs + 1] * num_query_per_req,
-                query_start_loc_cpu=torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * num_query_per_req,
+                query_start_loc=dflash_qsl,
+                query_start_loc_cpu=dflash_qsl_cpu,
                 seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
-                seq_lens=self.runner.seq_lens[:num_reqs],
-                num_reqs=num_reqs,
-                num_actual_tokens=num_query_tokens,
+                seq_lens=self.runner.seq_lens[:batch_size],
+                num_reqs=batch_size,
+                num_actual_tokens=num_input_tokens,
+                num_input_tokens=num_input_tokens,
                 max_query_len=num_query_per_req,
-                max_seq_len=0,
-                slot_mapping=self._slot_mapping_buffer[:num_query_total],
+                num_computed_tokens_cpu=None,
+                actual_seq_lengths_q=dflash_actual_seq_q,
+                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:batch_size],
+                slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
+                positions=self.runner.positions,
                 attn_state=AscendAttentionState.ChunkedPrefill,
+                decode_token_per_req=num_query_per_req,
+                max_seq_len=0,
                 causal=False,
-                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
             )
 
+            builder = self.draft_attn_groups[0].get_metadata_builder()
             attn_metadata_dflash = builder.build_for_graph_capture(
                 common_attn_metadata,
                 AscendAttentionState.ChunkedPrefill,
             )
-
-            attn_metadata_dflash.attn_mask = None
-            attn_metadata_dflash.attn_state = AscendAttentionState.ChunkedPrefill
-
             per_layer_attn_metadata = dict()
             for layer_name in self.attn_layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata_dflash
@@ -210,7 +236,7 @@ class AscendDflashProposer(AscendEagleProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=multi_steps_attn_metadata,
+            draft_attn_metadatas=multi_steps_attn_metadata if multi_steps_attn_metadata else None,
         ):
             self.model.precompute_and_store_context_kv(context_states, context_positions)
 
@@ -219,23 +245,54 @@ class AscendDflashProposer(AscendEagleProposer):
                 positions=self._get_positions(num_query_total),
                 inputs_embeds=None,
             )
+            if multi_steps_attn_metadata:
+                forward_context = get_forward_context()
+                if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                    self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
-            forward_context = get_forward_context()
-            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
-                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
+        # Clear ALL draft_graph_params stored during dummy_run warmup.
+        # Issues with keeping dummy_run's params:
+        # 1. attn_params: duplicate entries when real call uses same key
+        # 2. workspaces: computed with stale seq_lens (near 0), too small for
+        #    real inference (e.g. seq_lens=118) → NPU buffer overflow (error 507057)
+        # 3. events/handles: stale references
+        # The first real ACLGraphWrapper capture will re-populate everything correctly.
+        if multi_steps_attn_metadata:
+            from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, get_draft_graph_params
 
-    def build_model_inputs_first_pass(
-        self,
-        num_input_tokens: int,
-    ) -> dict[str, Any]:
+            draft_gp = get_draft_graph_params()
+            if draft_gp is not None:
+                for key in list(draft_gp.attn_params.keys()):
+                    draft_gp.attn_params[key] = []
+                    draft_gp.events[key] = []
+                    draft_gp.handles[key] = []
+                for key in list(draft_gp.workspaces.keys()):
+                    draft_gp.workspaces[key] = None
+            # Invalidate ACLGraphWrapper's captured graph entries so the first
+            # real _propose() call re-captures with correct runtime params.
+            # During dummy_run, self.model (ACLGraphWrapper) captured a graph
+            # with stale dummy values. Without clearing, the first real call
+            # would replay that stale graph instead of re-capturing.
+            if isinstance(self.model, ACLGraphWrapper):
+                self.model.concrete_aclgraph_entries.clear()
+
+    def prepare_context_kv(self) -> None:
+        """Precompute and store context KV OUTSIDE the graph boundary.
+
+        This must run eagerly (before graph replay) because num_context varies
+        between calls, making it incompatible with fixed-shape graph replay.
+        """
         num_context = self._dflash_num_context
-
         self.model.precompute_and_store_context_kv(
             self._dflash_hidden_states,
             self._context_positions_buffer[:num_context],
             self._context_slot_mapping_buffer[:num_context],
         )
 
+    def build_model_inputs_first_pass(
+        self,
+        num_input_tokens: int,
+    ) -> dict[str, Any]:
         return dict(
             input_ids=self.input_ids[:num_input_tokens], positions=self.positions[:num_input_tokens], inputs_embeds=None
         )

--- a/vllm_ascend/spec_decode/draft_proposer.py
+++ b/vllm_ascend/spec_decode/draft_proposer.py
@@ -1,5 +1,5 @@
 import torch
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 
 from vllm_ascend.spec_decode.eagle_proposer import AscendSpecDecodeBaseProposer
@@ -15,3 +15,11 @@ class AscendDraftModelProposer(DraftModelProposer, AscendSpecDecodeBaseProposer)
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, False, runner=runner)
         self._raise_if_vocab_size_mismatch()
         self._raise_if_draft_tp_mismatch()
+
+    def _maybe_share_lm_head(self, target_language_model) -> None:
+        # Draft models don't share lm_head with the target model.
+        # But we still need to initialize full graph support if enabled.
+        if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
+            from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
+            self.update_stream = torch.npu.Stream()
+            self._runnable = ACLGraphWrapper(self._run_merged_draft, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)

--- a/vllm_ascend/spec_decode/draft_proposer.py
+++ b/vllm_ascend/spec_decode/draft_proposer.py
@@ -21,5 +21,6 @@ class AscendDraftModelProposer(DraftModelProposer, AscendSpecDecodeBaseProposer)
         # But we still need to initialize full graph support if enabled.
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
             from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
+
             self.update_stream = torch.npu.Stream()
             self._runnable = ACLGraphWrapper(self._run_merged_draft, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -58,129 +58,6 @@ else:
 _PREPARE_INPUTS_BLOCK_SIZE = 4
 
 
-def _copy_and_expand_eagle_inputs_fallback(
-    target_token_ids: "torch.Tensor",
-    target_positions: "torch.Tensor",
-    next_token_ids: "torch.Tensor",
-    query_start_loc: "torch.Tensor",
-    query_end_loc: "torch.Tensor",
-    padding_token_id: int,
-    parallel_drafting_token_id: int,
-    num_padding_slots: int,
-    shift_input_ids: bool,
-    total_draft_tokens: int,
-) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]":
-    """Pure-Python fallback for npu_copy_and_expand_eagle_inputs.
-    Uses caller's total_draft_tokens for output size with bounds checking."""
-    device = target_token_ids.device
-    tid = target_token_ids.cpu().numpy()
-    target_pos = target_positions.cpu().numpy()
-    ntid = next_token_ids.cpu().numpy()
-    qsl = query_start_loc.cpu().numpy()
-    qel = query_end_loc.cpu().numpy()
-
-    num_reqs = len(qsl) - 1
-    total_input_tokens = len(tid)
-
-    out_ids = np.zeros(total_draft_tokens, dtype=np.int32)
-    out_pos = np.zeros(total_draft_tokens, dtype=np.int32)
-    out_rej = np.zeros(total_draft_tokens, dtype=np.int8)
-    out_msk = np.zeros(total_draft_tokens, dtype=np.int8)
-    out_nti = np.zeros(num_reqs * num_padding_slots, dtype=np.int32)
-    out_hsm = np.zeros(total_input_tokens, dtype=np.int32)
-
-    for r in range(num_reqs):
-        qs = int(qsl[r])
-        nqs = int(qsl[r + 1])
-        qe = int(qel[r])
-
-        num_rejected = max(nqs - qe - 1, 0)
-
-        if shift_input_ids:
-            num_valid = max(qe - qs, 0)
-            output_start = qs + r * (num_padding_slots - 1)
-        else:
-            num_valid = max(qe - qs + 1, 0)
-            output_start = qs + r * num_padding_slots
-
-        start_pos = int(target_pos[qs]) if qs < len(target_pos) else 0
-        next_token_id = int(ntid[r]) if r < len(ntid) else 0
-
-        # Valid region
-        if shift_input_ids:
-            read_start = qs + 1
-            read_count = min(num_valid, total_input_tokens - read_start)
-            if read_count < 0:
-                read_count = 0
-            for j in range(num_valid):
-                w = output_start + j
-                if w >= total_draft_tokens:
-                    break
-                idx = min(j, read_count - 1) if read_count > 0 else 0
-                out_ids[w] = tid[read_start + idx] if read_count > 0 else 0
-                out_pos[w] = start_pos + j
-        else:
-            num_input = nqs - qs
-            for j in range(num_valid):
-                w = output_start + j
-                if w >= total_draft_tokens:
-                    break
-                idx = min(j, num_input - 1)
-                out_ids[w] = tid[qs + idx]
-                out_pos[w] = start_pos + j
-
-        # Bonus token
-        w = output_start + num_valid
-        if w < total_draft_tokens:
-            out_ids[w] = next_token_id
-            out_pos[w] = start_pos + num_valid
-
-        # Parallel draft tokens
-        for k in range(1, num_padding_slots):
-            j = num_valid + k
-            w = output_start + j
-            if w >= total_draft_tokens:
-                break
-            out_ids[w] = parallel_drafting_token_id
-            out_pos[w] = start_pos + j
-            out_msk[w] = 1
-
-        # Rejected tokens
-        for k in range(num_rejected):
-            j = num_valid + num_padding_slots + k
-            w = output_start + j
-            if w >= total_draft_tokens:
-                break
-            out_ids[w] = padding_token_id
-            out_pos[w] = 0
-            out_rej[w] = 1
-
-        # New token indices
-        for k in range(num_padding_slots):
-            nti_w = output_start + num_valid + k
-            if nti_w >= total_draft_tokens:
-                nti_w = total_draft_tokens - 1
-            out_nti[r * num_padding_slots + k] = nti_w
-
-        # Hidden state mapping
-        if shift_input_ids:
-            num_input = nqs - qs
-            for j in range(num_input):
-                hsm_w = output_start + j
-                if hsm_w >= total_draft_tokens:
-                    hsm_w = total_draft_tokens - 1
-                out_hsm[qs + j] = hsm_w
-
-    return (
-        torch.from_numpy(out_ids).to(device),
-        torch.from_numpy(out_pos).to(device),
-        torch.from_numpy(out_rej).to(device),
-        torch.from_numpy(out_msk).to(device),
-        torch.from_numpy(out_nti).to(device),
-        torch.from_numpy(out_hsm).to(device),
-    )
-
-
 # TODO: Remove it when the bug of fx-graph is solved
 # patch vllm_config to be in CompilationMode.NONE temporarily
 @contextmanager
@@ -1322,46 +1199,25 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if num_rejected_tokens_gpu is not None:
                 query_end_loc = query_end_loc - num_rejected_tokens_gpu
 
-            try:
-                (
-                    out_input_ids,
-                    out_positions,
-                    out_is_rejected_token_mask,
-                    out_is_masked_token_mask,
-                    token_indices_to_sample,
-                    out_hidden_state_mapping,
-                ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
-                    target_token_ids,
-                    target_positions.to(torch.int32),
-                    next_token_ids,
-                    query_start_loc,
-                    query_end_loc,
-                    0,  # padding_token_id
-                    self.parallel_drafting_token_id,
-                    self.extra_slots_per_request,
-                    self.pass_hidden_states_to_model,
-                    total_num_output_tokens,
-                )
-            except (AttributeError, RuntimeError):
-                (
-                    out_input_ids,
-                    out_positions,
-                    out_is_rejected_token_mask,
-                    out_is_masked_token_mask,
-                    token_indices_to_sample,
-                    out_hidden_state_mapping,
-                ) = _copy_and_expand_eagle_inputs_fallback(
-                    target_token_ids,
-                    target_positions.to(torch.int32),
-                    next_token_ids,
-                    query_start_loc,
-                    query_end_loc,
-                    0,  # padding_token_id
-                    self.parallel_drafting_token_id,
-                    self.extra_slots_per_request,
-                    self.pass_hidden_states_to_model,
-                    total_num_output_tokens,
-                )
+            (
+                out_input_ids,
+                out_positions,
+                out_is_rejected_token_mask,
+                out_is_masked_token_mask,
+                token_indices_to_sample,
+                out_hidden_state_mapping,
+            ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
+                target_token_ids,
+                target_positions.to(torch.int32),
+                next_token_ids,
+                query_start_loc,
+                query_end_loc,
+                0,  # padding_token_id
+                self.parallel_drafting_token_id,
+                self.extra_slots_per_request,
+                self.pass_hidden_states_to_model,
+                total_num_output_tokens,
+            )
 
             # Copy returned tensors into pre-allocated buffers
             self.input_ids[:total_num_output_tokens].copy_(out_input_ids)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -728,6 +728,16 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # is run in eager mode currently, which means `_pad_query_start_loc_for_fia` is not called,
             # while draft model is run in graph model, which means we should pad the `query_start_loc`.
             # Need to be fixed in the future.
+            #
+            # For DFlash: sync proposer's query_start_loc into runner's buffer before padding,
+            # because DFlash rebuilds query_start_loc in set_inputs_first_pass with different
+            # values (num_query_per_req per request) than what the target model runner has.
+            # Without this, _pad_query_start_loc_for_fia operates on stale target model values.
+            if self.method == "dflash":
+                num_reqs = common_attn_metadata.num_reqs
+                self.runner.query_start_loc.np[: num_reqs + 1] = common_attn_metadata.query_start_loc_cpu[
+                    : num_reqs + 1
+                ].numpy()
             num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
                 num_input_tokens,
                 batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
@@ -946,6 +956,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
 
+            # DFlash: precompute context KV OUTSIDE graph boundary because
+            # num_context varies between calls (incompatible with graph replay).
+            if self.method == "dflash":
+                self.prepare_context_kv()
+
             model_inputs: dict[str, Any] = {
                 "num_input_tokens": num_input_tokens,
                 "batch_size": batch_size,
@@ -964,6 +979,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+
+            # NPU graph capture does not execute kernels — only records
+            # operations. The first ACLGraphWrapper call (capture) returns
+            # uninitialized garbage in the output tensor. Clamp token IDs
+            # to valid vocabulary range to prevent OOB embedding access
+            # in the target model (which would cause NPU error 507057).
+            vocab_size = self.vllm_config.model_config.get_vocab_size()
+            if draft_token_ids is not None and isinstance(draft_token_ids, torch.Tensor):
+                draft_token_ids.clamp_(0, vocab_size - 1)
         return draft_token_ids
 
     def _run_merged_draft(
@@ -1278,7 +1302,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 target_positions = target_positions[0]
 
             self._set_positions(num_tokens, target_positions)
-            self.hidden_states[:num_tokens] = target_hidden_states
+            if self.pass_hidden_states_to_model:
+                self.hidden_states[:num_tokens] = target_hidden_states
 
             return num_tokens, token_indices_to_sample, cad, (query_lens_d, ori_token_indices_to_sample)
         else:

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -58,6 +58,129 @@ else:
 _PREPARE_INPUTS_BLOCK_SIZE = 4
 
 
+def _copy_and_expand_eagle_inputs_fallback(
+    target_token_ids: "torch.Tensor",
+    target_positions: "torch.Tensor",
+    next_token_ids: "torch.Tensor",
+    query_start_loc: "torch.Tensor",
+    query_end_loc: "torch.Tensor",
+    padding_token_id: int,
+    parallel_drafting_token_id: int,
+    num_padding_slots: int,
+    shift_input_ids: bool,
+    total_draft_tokens: int,
+) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]":
+    """Pure-Python fallback for npu_copy_and_expand_eagle_inputs.
+    Uses caller's total_draft_tokens for output size with bounds checking."""
+    device = target_token_ids.device
+    tid = target_token_ids.cpu().numpy()
+    target_pos = target_positions.cpu().numpy()
+    ntid = next_token_ids.cpu().numpy()
+    qsl = query_start_loc.cpu().numpy()
+    qel = query_end_loc.cpu().numpy()
+
+    num_reqs = len(qsl) - 1
+    total_input_tokens = len(tid)
+
+    out_ids = np.zeros(total_draft_tokens, dtype=np.int32)
+    out_pos = np.zeros(total_draft_tokens, dtype=np.int32)
+    out_rej = np.zeros(total_draft_tokens, dtype=np.int8)
+    out_msk = np.zeros(total_draft_tokens, dtype=np.int8)
+    out_nti = np.zeros(num_reqs * num_padding_slots, dtype=np.int32)
+    out_hsm = np.zeros(total_input_tokens, dtype=np.int32)
+
+    for r in range(num_reqs):
+        qs = int(qsl[r])
+        nqs = int(qsl[r + 1])
+        qe = int(qel[r])
+
+        num_rejected = max(nqs - qe - 1, 0)
+
+        if shift_input_ids:
+            num_valid = max(qe - qs, 0)
+            output_start = qs + r * (num_padding_slots - 1)
+        else:
+            num_valid = max(qe - qs + 1, 0)
+            output_start = qs + r * num_padding_slots
+
+        start_pos = int(target_pos[qs]) if qs < len(target_pos) else 0
+        next_token_id = int(ntid[r]) if r < len(ntid) else 0
+
+        # Valid region
+        if shift_input_ids:
+            read_start = qs + 1
+            read_count = min(num_valid, total_input_tokens - read_start)
+            if read_count < 0:
+                read_count = 0
+            for j in range(num_valid):
+                w = output_start + j
+                if w >= total_draft_tokens:
+                    break
+                idx = min(j, read_count - 1) if read_count > 0 else 0
+                out_ids[w] = tid[read_start + idx] if read_count > 0 else 0
+                out_pos[w] = start_pos + j
+        else:
+            num_input = nqs - qs
+            for j in range(num_valid):
+                w = output_start + j
+                if w >= total_draft_tokens:
+                    break
+                idx = min(j, num_input - 1)
+                out_ids[w] = tid[qs + idx]
+                out_pos[w] = start_pos + j
+
+        # Bonus token
+        w = output_start + num_valid
+        if w < total_draft_tokens:
+            out_ids[w] = next_token_id
+            out_pos[w] = start_pos + num_valid
+
+        # Parallel draft tokens
+        for k in range(1, num_padding_slots):
+            j = num_valid + k
+            w = output_start + j
+            if w >= total_draft_tokens:
+                break
+            out_ids[w] = parallel_drafting_token_id
+            out_pos[w] = start_pos + j
+            out_msk[w] = 1
+
+        # Rejected tokens
+        for k in range(num_rejected):
+            j = num_valid + num_padding_slots + k
+            w = output_start + j
+            if w >= total_draft_tokens:
+                break
+            out_ids[w] = padding_token_id
+            out_pos[w] = 0
+            out_rej[w] = 1
+
+        # New token indices
+        for k in range(num_padding_slots):
+            nti_w = output_start + num_valid + k
+            if nti_w >= total_draft_tokens:
+                nti_w = total_draft_tokens - 1
+            out_nti[r * num_padding_slots + k] = nti_w
+
+        # Hidden state mapping
+        if shift_input_ids:
+            num_input = nqs - qs
+            for j in range(num_input):
+                hsm_w = output_start + j
+                if hsm_w >= total_draft_tokens:
+                    hsm_w = total_draft_tokens - 1
+                out_hsm[qs + j] = hsm_w
+
+    return (
+        torch.from_numpy(out_ids).to(device),
+        torch.from_numpy(out_pos).to(device),
+        torch.from_numpy(out_rej).to(device),
+        torch.from_numpy(out_msk).to(device),
+        torch.from_numpy(out_nti).to(device),
+        torch.from_numpy(out_hsm).to(device),
+    )
+
+
 # TODO: Remove it when the bug of fx-graph is solved
 # patch vllm_config to be in CompilationMode.NONE temporarily
 @contextmanager
@@ -1174,25 +1297,46 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if num_rejected_tokens_gpu is not None:
                 query_end_loc = query_end_loc - num_rejected_tokens_gpu
 
-            (
-                out_input_ids,
-                out_positions,
-                out_is_rejected_token_mask,
-                out_is_masked_token_mask,
-                token_indices_to_sample,
-                out_hidden_state_mapping,
-            ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
-                target_token_ids,
-                target_positions.to(torch.int32),
-                next_token_ids,
-                query_start_loc,
-                query_end_loc,
-                0,  # padding_token_id
-                self.parallel_drafting_token_id,
-                self.extra_slots_per_request,
-                self.pass_hidden_states_to_model,
-                total_num_output_tokens,
-            )
+            try:
+                (
+                    out_input_ids,
+                    out_positions,
+                    out_is_rejected_token_mask,
+                    out_is_masked_token_mask,
+                    token_indices_to_sample,
+                    out_hidden_state_mapping,
+                ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
+                    target_token_ids,
+                    target_positions.to(torch.int32),
+                    next_token_ids,
+                    query_start_loc,
+                    query_end_loc,
+                    0,  # padding_token_id
+                    self.parallel_drafting_token_id,
+                    self.extra_slots_per_request,
+                    self.pass_hidden_states_to_model,
+                    total_num_output_tokens,
+                )
+            except (AttributeError, RuntimeError):
+                (
+                    out_input_ids,
+                    out_positions,
+                    out_is_rejected_token_mask,
+                    out_is_masked_token_mask,
+                    token_indices_to_sample,
+                    out_hidden_state_mapping,
+                ) = _copy_and_expand_eagle_inputs_fallback(
+                    target_token_ids,
+                    target_positions.to(torch.int32),
+                    next_token_ids,
+                    query_start_loc,
+                    query_end_loc,
+                    0,  # padding_token_id
+                    self.parallel_drafting_token_id,
+                    self.extra_slots_per_request,
+                    self.pass_hidden_states_to_model,
+                    total_num_output_tokens,
+                )
 
             # Copy returned tensors into pre-allocated buffers
             self.input_ids[:total_num_output_tokens].copy_(out_input_ids)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -469,7 +469,7 @@ class NPUWorker(WorkerBase):
         with context, set_current_vllm_config(self.vllm_config):
             self.model_runner.load_model()
 
-    def compile_or_warm_up_model(self) -> float:
+    def compile_or_warm_up_model(self):
         # Note: need to adapt for graph mode.
         warmup_sizes = (self.vllm_config.compilation_config.compile_sizes or []).copy()
         if not self.model_config.enforce_eager:
@@ -549,7 +549,12 @@ class NPUWorker(WorkerBase):
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)
-        return self.vllm_config.compilation_config.compilation_time
+        from vllm.v1.worker.worker_base import CompilationTimes
+
+        return CompilationTimes(
+            language_model=self.vllm_config.compilation_config.compilation_time,
+            encoder=getattr(self.vllm_config.compilation_config, "encoder_compilation_time", 0.0),
+        )
 
     def _warm_up_atb(self):
         x = torch.rand((2, 4), dtype=torch.float16).npu()


### PR DESCRIPTION
## Summary

Enable DFlash speculative decoding to work correctly with ACLGraph compilation modes (FULL_DECODE_ONLY / FULL) on Ascend NPU.

DFlash is a block-level diffusion-based speculative decoding method ([vllm PR #36847](https://github.com/vllm-project/vllm/pull/36847)) that generates k draft tokens in parallel. Combined with FULL_DECODE_ONLY graph mode, it achieves **5.8x** throughput speedup (175 tok/s vs 30 tok/s baseline) on Qwen3-8B.

### Changes

1. **CompilationTimes + eagle inputs fallback** (`worker.py`, `eagle_proposer.py`)
   - Wrap `compile_or_warm_up_model` return value as `CompilationTimes` namedtuple
   - Add pure Python fallback for `npu_copy_and_expand_eagle_inputs`

2. **update_stream initialization** (`draft_proposer.py`)
   - Initialize `update_stream` + `ACLGraphWrapper` in `_maybe_share_lm_head` for FULL_DECODE_ONLY/FULL mode

3. **DFlash + ACLGraph core fixes** (`attention_v1.py`, `dflash_proposer.py`, `eagle_proposer.py`)
   - Dynamic `sparse_mode` for non-causal cross-attention (fixes acceptance 0.62% -> 30%)
   - Build DFlash-specific non-causal `attn_metadata` for FULL graph capture
   - Move `prepare_context_kv` outside graph boundary (variable-length input incompatible with graph replay)
   - Sync DFlash `query_start_loc` to runner buffer before FIA padding
   - Fix TND dimension constraint (`actual_seq_lengths_q` vs `num_tokens`)
   - Clamp garbage token IDs after first graph capture (prevents NPU error 507057)
   - Clear `draft_graph_params` after `dummy_run` warmup

4. **hidden_states guard** (`eagle_proposer.py`)
   - Guard `hidden_states` copy with `pass_hidden_states_to_model` check

5. **ACLGraphWrapper lazy capture fix** (`acl_graph.py`)
   - Replace `validate_cudagraph_capturing_enabled()` with `set_cudagraph_capturing_enabled(True)` for draft model's lazy capture path
   - Use `defaultdict(list)` for `GraphParams` to prevent `KeyError`

### Performance (Qwen3-8B, MATH-500, 50 prompts, concurrency=1)

| Mode | Throughput | TTFT | TPOT | Acceptance | Speedup |
|------|-----------|------|------|-----------|---------|
| No spec (baseline) | 30.33 tok/s | 119.23 ms | 32.62 ms | - | 1.0x |
| DFlash + PIECEWISE (spec=15) | 142.23 tok/s | 100.33 ms | 6.75 ms | 38.30% | 4.7x |
| **DFlash + FULL_DECODE_ONLY (spec=15)** | **175.23 tok/s** | 96.35 ms | **5.39 ms** | 29.99% | **5.8x** |
| DFlash + FULL (spec=15) | 171.61 tok/s | **45.40 ms** | 5.72 ms | 27.62% | 5.7x |
| Eagle3 + PIECEWISE (spec=3) | 45.30 tok/s | 72.00 ms | 21.91 ms | 36.43% | 1.5x |
| Eagle3 + FULL_DECODE_ONLY (spec=3) | 74.40 tok/s | 98.46 ms | 13.13 ms | 36.66% | 2.5x |
| Eagle3 + FULL (spec=3) | 74.80 tok/s | 52.46 ms | 13.25 ms | 36.50% | 2.5x |

### Compatibility

Verified no regression on non-speculative serving, Eagle3, and EAGLE draft_model:

| Scenario | Model | Method | Mode | Result |
|----------|-------|--------|------|--------|
| No spec (baseline) | Qwen3-8B | - | PIECEWISE | Pass |
| Eagle3 | Qwen3-8B | eagle3, spec=3 | FULL | Pass |
| EAGLE draft_model | LLaMA-3.1-8B | draft_model, spec=8 | FULL | Pass |
| DFlash | Qwen3-8B | dflash, spec=15 | FULL_DECODE_ONLY | Pass |
| DFlash | Qwen3-8B | dflash, spec=15 | FULL | Pass |

## Test plan

- [x] DFlash + Qwen3-8B with PIECEWISE / FULL_DECODE_ONLY / FULL modes
- [x] Eagle3 + Qwen3-8B with FULL mode
- [x] EAGLE draft_model + LLaMA-8B with FULL mode
- [x] Non-speculative baseline serving
