### PR TITLE
[BugFix] Fix conflicts between eagle and dflash about pcp

### DIFF
--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -621,7 +621,6 @@ def test_eagle3_fia_pad_under_max_concurrency(
 
 @pytest.mark.parametrize("method", DFLASH.keys())
 @pytest.mark.parametrize("num_speculative_tokens", [8])
-@pytest.mark.skipif(True, reason="Fix me, DFlash acceptance test is flaky, needs investigation")
 def test_dflash_acceptance(
     method: str,
     num_speculative_tokens: int,

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -381,7 +381,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
         # init block table tensor clone is only available after profile run and is only used for graph mode
-        if self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
+        if (
+            self.pcp_size * self.dcp_size > 1
+            and self.use_cuda_graph
+            and not is_profile
+            and self.block_table_tensor_clone is None
+        ):
             self.block_table_tensor_clone = torch.zeros(
                 (
                     self.runner.max_num_tokens + 2 * self.pcp_size * self.runner.max_num_reqs,
@@ -434,9 +439,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
                 common_attn_metadata.seq_lens = self.seq_lens_group[draft_step][:num_reqs]
                 common_attn_metadata.query_start_loc = self.query_start_loc_group[draft_step][: num_reqs + 1]
-                if draft_step > 0:
-                    slicing_length = num_reqs * self.decode_threshold if self.pcp_size * self.dcp_size > 1 else num_reqs
+                if self.pcp_size * self.dcp_size > 1 and draft_step > 0:
                     assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
+                    slicing_length = num_reqs * self.decode_threshold
                     common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:slicing_length]
                 attn_metadata_eagle = builder.build_for_graph_capture(
                     common_attn_metadata,
@@ -679,7 +684,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # Clone the data so that when calculating the data at position 2 and position 3
         # in the merged graph, it does not affect position 1
         # FIXME(lilinsiman)
-        if self.use_cuda_graph:
+        if self.pcp_size * self.dcp_size > 1 and self.use_cuda_graph:
             assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
             self.block_table_tensor_clone[: common_attn_metadata.block_table_tensor.shape[0]] = (
                 common_attn_metadata.block_table_tensor


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to fix conflicts between eagle and dflash when pcp is enabled. Since dflash rewrites `dummy_run` but reuse `_propose` in eagle, the `block_table_tensor_clone` variable created during `dummy_run` in eagle does not exist in dflash and thus incurs errors in `_propose`. We change this variable to be used only under pcp scenario.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
