### PR TITLE
[Perf]Optimize multistream overlap with shared_experts

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -692,45 +692,57 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
-            original_dtype = hidden_states.dtype
-            # Execute dynamic quant concurrently with MoE gate.
-            torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-            quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-            # Execute the gate projection and activation concurrently with the
-            # dispatch communication.
-            maybe_wait_event(fused_moe_evts.before_dispatch)
-            hidden_states = torch_npu.npu_quant_matmul(
-                quantized_x,
-                self._shared_experts.gate_up_proj.weight,
-                self._shared_experts.gate_up_proj.weight_scale,
-                pertoken_scale=None,
-                bias=None,
-                output_dtype=torch.int32
-            )
-            # Execute activation concurrently with gmm2.
-            maybe_wait_event(fused_moe_evts.before_gmm2)
-            quantized_x, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
-                x=hidden_states,
-                weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
-                activation_scale=pertoken_scale,
-                bias=None,
-                quant_scale=None,
-                quant_offset=None,
-                group_index=None,
-                activate_left=True,
-                quant_mode=1
-            )
-            # Execute the down projection concurrently with the combine
-            # communication.
-            maybe_wait_event(fused_moe_evts.before_combine)
-            shared_out = torch_npu.npu_quant_matmul(
-                quantized_x,
-                self._shared_experts.down_proj.weight,
-                self._shared_experts.down_proj.weight_scale,
-                pertoken_scale=swiglu_out_scale,
-                bias=None,
-                output_dtype=original_dtype
-            )
+            if hasattr(self._shared_experts.gate_up_proj, "weight_scale"):
+                original_dtype = hidden_states.dtype
+                # Execute dynamic quant concurrently with MoE gate.
+                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+                quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
+                # Execute the gate projection and activation concurrently with the
+                # dispatch communication.
+                maybe_wait_event(fused_moe_evts.before_dispatch)
+                hidden_states = torch_npu.npu_quant_matmul(
+                    quantized_x,
+                    self._shared_experts.gate_up_proj.weight,
+                    self._shared_experts.gate_up_proj.weight_scale,
+                    pertoken_scale=None,
+                    bias=None,
+                    output_dtype=torch.int32,
+                )
+                # Execute activation concurrently with gmm2.
+                maybe_wait_event(fused_moe_evts.before_gmm2)
+                quantized_x, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
+                    x=hidden_states,
+                    weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
+                    activation_scale=pertoken_scale,
+                    bias=None,
+                    quant_scale=None,
+                    quant_offset=None,
+                    group_index=None,
+                    activate_left=True,
+                    quant_mode=1,
+                )
+                # Execute the down projection concurrently with the combine
+                # communication.
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out = torch_npu.npu_quant_matmul(
+                    quantized_x,
+                    self._shared_experts.down_proj.weight,
+                    self._shared_experts.down_proj.weight_scale,
+                    pertoken_scale=swiglu_out_scale,
+                    bias=None,
+                    output_dtype=original_dtype,
+                )
+            else:
+                # Ensure the shared experts wait for hidden_states to be ready.
+                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+                # Execute the gate projection and activation concurrently with the
+                # dispatch communication.
+                maybe_wait_event(fused_moe_evts.before_dispatch)
+                part1_out = self._shared_experts_part1(hidden_states)
+                # Execute the down projection concurrently with the combine
+                # communication.
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out = self._shared_experts_part2(hidden_states, part1_out)
 
         # Make sure the default stream waits for the shared experts stream to
         # finish.
@@ -755,7 +767,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
 
         before_routed_experts = torch.npu.current_stream().record_event()
         if self.multistream_overlap_shared_expert:
-            router_logits = F.linear(hidden_states.float(), self.gate.weight)
+            router_logits = F.linear(hidden_states, self.gate.weight)
 
         fused_moe_results = AscendFusedMoE.forward_impl(
             self,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -57,6 +57,7 @@ from vllm_ascend.utils import (
 class FusedMoEResult:
     routed_out: torch.Tensor
     before_dispatch_evt: torch.npu.Event | None = None
+    before_gmm2_evt: torch.npu.Event | None = None
     before_combine_evt: torch.npu.Event | None = None
 
 
@@ -64,6 +65,7 @@ class FusedMoEResult:
 class FusedMoEEvents:
     before_routed_experts: torch.npu.Event
     before_dispatch: torch.npu.Event | None = field(default=None)
+    before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
 
 
@@ -539,6 +541,7 @@ class AscendFusedMoE(FusedMoE):
             return FusedMoEResult(
                 routed_out=routed_out,
                 before_dispatch_evt=fused_experts_results.before_dispatch_evt,
+                before_gmm2_evt=fused_experts_results.before_gmm2_evt,
                 before_combine_evt=fused_experts_results.before_combine_evt,
             )
         else:
@@ -655,7 +658,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
 
     @property
     def is_internal_router(self) -> bool:
-        return False
+        return self.multistream_overlap_shared_expert
 
     @property
     def use_dp_chunking(self) -> bool:
@@ -689,16 +692,45 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
-            # Ensure the shared experts wait for hidden_states to be ready.
+            original_dtype = hidden_states.dtype
+            # Execute dynamic quant concurrently with MoE gate.
             torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+            quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
             # Execute the gate projection and activation concurrently with the
             # dispatch communication.
             maybe_wait_event(fused_moe_evts.before_dispatch)
-            part1_out = self._shared_experts_part1(hidden_states)
+            hidden_states = torch_npu.npu_quant_matmul(
+                quantized_x,
+                self._shared_experts.gate_up_proj.weight,
+                self._shared_experts.gate_up_proj.weight_scale,
+                pertoken_scale=None,
+                bias=None,
+                output_dtype=torch.int32
+            )
+            # Execute activation concurrently with gmm2.
+            maybe_wait_event(fused_moe_evts.before_gmm2)
+            quantized_x, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
+                x=hidden_states,
+                weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
+                activation_scale=pertoken_scale,
+                bias=None,
+                quant_scale=None,
+                quant_offset=None,
+                group_index=None,
+                activate_left=True,
+                quant_mode=1
+            )
             # Execute the down projection concurrently with the combine
             # communication.
             maybe_wait_event(fused_moe_evts.before_combine)
-            shared_out = self._shared_experts_part2(hidden_states, part1_out)
+            shared_out = torch_npu.npu_quant_matmul(
+                quantized_x,
+                self._shared_experts.down_proj.weight,
+                self._shared_experts.down_proj.weight_scale,
+                pertoken_scale=swiglu_out_scale,
+                bias=None,
+                output_dtype=original_dtype
+            )
 
         # Make sure the default stream waits for the shared experts stream to
         # finish.
@@ -722,6 +754,9 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             set_flash_common3_context(shared_experts=self._shared_experts)
 
         before_routed_experts = torch.npu.current_stream().record_event()
+        if self.multistream_overlap_shared_expert:
+            router_logits = F.linear(hidden_states.float(), self.gate.weight)
+
         fused_moe_results = AscendFusedMoE.forward_impl(
             self,
             hidden_states=hidden_states,
@@ -743,6 +778,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 FusedMoEEvents(
                     before_routed_experts=before_routed_experts,
                     before_dispatch=fused_moe_results.before_dispatch_evt,
+                    before_gmm2=fused_moe_results.before_gmm2_evt,
                     before_combine=fused_moe_results.before_combine_evt,
                 ),
             )

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -692,7 +692,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
-            if hasattr(self._shared_experts.gate_up_proj, "weight_scale"):
+            if self.quant_type == QuantType.W8A8:
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -73,6 +73,7 @@ class FusedExpertsResult:
     # communication method that supports shared experts in parallel with routed
     # experts.
     before_dispatch_evt: torch.npu.Event | None = None
+    before_gmm2_evt: torch.npu.Event | None = None
     before_combine_evt: torch.npu.Event | None = None
     # For dynamic_eplb
     group_list_type: int = 1
@@ -141,7 +142,7 @@ class MoECommMethod(ABC):
             use_fusion_ops=self.use_fusion_ops,
         )
 
-        mlp_output = self._apply_mlp(mlp_compute_input)
+        mlp_output, before_gmm2_evt = self._apply_mlp(mlp_compute_input)
 
         before_combine_evt = torch.npu.current_stream().record_event()
         routed_out = self.token_dispatcher.token_combine(
@@ -152,6 +153,7 @@ class MoECommMethod(ABC):
         return FusedExpertsResult(
             routed_out=routed_out,
             before_dispatch_evt=before_dispatch_evt,
+            before_gmm2_evt=before_gmm2_evt,
             before_combine_evt=before_combine_evt,
             group_list_type=token_dispatch_output.group_list_type,
             expert_tokens=token_dispatch_output.group_list,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -192,6 +192,7 @@ def quant_apply_mlp(
                 activate_left=True,
                 quant_mode=1,
             )
+        before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
@@ -226,6 +227,7 @@ def quant_apply_mlp(
         dispose_tensor(unquantized_hidden_states)
         # act_fn: swiglu
         hidden_states = torch_npu.npu_swiglu(hidden_states)
+        before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
@@ -299,6 +301,7 @@ def quant_apply_mlp(
             else:
                 hidden_states = torch_npu.npu_swiglu(hidden_states)
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
+        before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
@@ -317,7 +320,7 @@ def quant_apply_mlp(
             bias=bias2,
             fallback_output_dtype=_output_dtype,
         )
-    return hidden_states
+    return hidden_states, before_gmm2_evt
 
 
 def unquant_apply_mlp(
@@ -366,7 +369,7 @@ def unquant_apply_mlp(
         group_type=0,
         group_list=group_list,
     )[0]
-    return hidden_states
+    return hidden_states, None
 
 
 def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:


### PR DESCRIPTION
### What this PR does / why we need it?
|   Path    |  |  |  |  |  |
| ---- | ---- | ---- | ---- | ---- | ---- |
|   shared_experts    |    DynamicQuant  |  GateUpProj |  |  DequantSwigluQuant  |  DownProj  |
|   routed_experts    |   Gate  |  Dispatch | GroupedMatmulSwigluQuant | GroupedMatmul | Combine

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
