### PR TITLE
[Ops][Misc] Refactor 310P W8A8 quantization methods to use a common base class

### DIFF
--- a/vllm_ascend/_310p/quantization/methods/w8a8_base.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_base.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from typing import Any
+
+import torch
+
+from vllm_ascend.quantization.methods.base import AscendLinearScheme
+
+
+class AscendW8A8Linear310pScheme(AscendLinearScheme):
+    def get_weight(
+        self,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype = torch.float16,
+    ) -> dict[str, Any]:
+        return {"weight": torch.empty(output_size, input_size, dtype=torch.int8)}
+
+    def get_pertensor_param(self, params_dtype: torch.dtype) -> dict[str, Any]:
+        return {
+            "input_scale": torch.empty(1, dtype=params_dtype),
+            "input_offset": torch.empty(1, dtype=torch.int8),
+        }
+
+    def get_perchannel_param(self, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
+        return {
+            "quant_bias": torch.empty(output_size, dtype=torch.int32),
+            "deq_scale": torch.empty(output_size, dtype=torch.int64),
+        }

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -27,10 +27,11 @@ from vllm_ascend._310p.fused_moe.experts_selector import select_experts
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
-from vllm_ascend.quantization.methods.base import AscendLinearScheme, AscendMoEScheme, QuantType
+from vllm_ascend.quantization.methods.base import AscendMoEScheme, QuantType
 from vllm_ascend.utils import maybe_trans_nz
 
 from .registry import register_scheme
+from .w8a8_base import AscendW8A8Linear310pScheme
 
 
 @register_scheme("W8A8_DYNAMIC", "moe")
@@ -160,20 +161,12 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
 
 
 @register_scheme("W8A8_DYNAMIC", "linear")
-class AscendW8A8DynamicLinearMethod310(AscendLinearScheme):
+class AscendW8A8DynamicLinearMethod310(AscendW8A8Linear310pScheme):
     """310P-only W8A8 dynamic linear scheme.
 
     Notes:
       - This scheme is discovered via 310P local registry.
     """
-
-    def get_weight(
-        self,
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype = torch.float16,
-    ) -> dict[str, Any]:
-        return {"weight": torch.empty(output_size, input_size, dtype=torch.int8)}
 
     def get_perchannel_param(
         self,

--- a/vllm_ascend/_310p/quantization/methods/w8a8_static.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_static.py
@@ -20,33 +20,19 @@ from typing import Any
 import torch
 import torch_npu
 
-from vllm_ascend.quantization.methods.base import AscendLinearScheme
 from vllm_ascend.utils import maybe_trans_nz
 
 from .registry import register_scheme
+from .w8a8_base import AscendW8A8Linear310pScheme
 
 
 @register_scheme("W8A8", "linear")
-class AscendW8A8LinearMethod310(AscendLinearScheme):
+class AscendW8A8LinearMethod310(AscendW8A8Linear310pScheme):
     """310P-only W8A8 static linear scheme.
 
     Notes:
       - This scheme is discovered via 310P local registry.
     """
-
-    def get_weight(
-        self,
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype = torch.float16,
-    ) -> dict[str, Any]:
-        return {"weight": torch.empty(output_size, input_size, dtype=torch.int8)}
-
-    def get_pertensor_param(self, params_dtype: torch.dtype) -> dict[str, Any]:
-        return {
-            "input_scale": torch.empty(1, dtype=params_dtype),
-            "input_offset": torch.empty(1, dtype=torch.int8),
-        }
 
     def get_perchannel_param(self, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
         params: dict[str, Any] = {}

--- a/vllm_ascend/_310p/quantization/methods/w8a8s.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8s.py
@@ -15,44 +15,23 @@
 # This file is a part of the vllm-ascend project.
 #
 
-from typing import Any
 
 import torch
 import torch_npu
 
-from vllm_ascend.quantization.methods.base import AscendLinearScheme
 from vllm_ascend.utils import maybe_trans_nz
 
 from .registry import register_scheme
+from .w8a8_base import AscendW8A8Linear310pScheme
 
 
 @register_scheme("W8A8S", "linear")
-class AscendW8A8SLinearMethod310(AscendLinearScheme):
+class AscendW8A8SLinearMethod310(AscendW8A8Linear310pScheme):
     """310P-only W8A8S Sparse linear scheme.
 
     Notes:
       - This scheme is discovered via 310P local registry.
     """
-
-    def get_weight(
-        self,
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype = torch.float16,
-    ) -> dict[str, Any]:
-        return {"weight": torch.empty(output_size, input_size, dtype=torch.int8)}
-
-    def get_pertensor_param(self, params_dtype: torch.dtype) -> dict[str, Any]:
-        return {
-            "input_scale": torch.empty(1, dtype=params_dtype),
-            "input_offset": torch.empty(1, dtype=torch.int8),
-        }
-
-    def get_perchannel_param(self, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        return {
-            "quant_bias": torch.empty(output_size, dtype=torch.int32),
-            "deq_scale": torch.empty(output_size, dtype=torch.int64),
-        }
 
     def apply(
         self,

--- a/vllm_ascend/_310p/quantization/methods/w8a8sc.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8sc.py
@@ -23,13 +23,13 @@ import torch_npu
 from vllm.distributed import get_tensor_model_parallel_rank
 
 from vllm_ascend.ops.linear import AscendRowParallelLinear
-from vllm_ascend.quantization.methods.base import AscendLinearScheme
 
 from .registry import register_scheme
+from .w8a8_base import AscendW8A8Linear310pScheme
 
 
 @register_scheme("W8A8SC", "linear")
-class AscendW8A8SCLinearMethod310(AscendLinearScheme):
+class AscendW8A8SCLinearMethod310(AscendW8A8Linear310pScheme):
     """310P-only W8A8SC static linear scheme.
 
     Notes:
@@ -67,18 +67,6 @@ class AscendW8A8SCLinearMethod310(AscendLinearScheme):
             "weight": torch.empty(input_size * output_size, dtype=torch.int8),
             "index": torch.empty(index_len, dtype=torch.int8),
             "info": torch.empty(5, dtype=torch.int64),
-        }
-
-    def get_pertensor_param(self, params_dtype: torch.dtype) -> dict[str, Any]:
-        return {
-            "input_scale": torch.empty(1, dtype=params_dtype),
-            "input_offset": torch.empty(1, dtype=torch.int8),
-        }
-
-    def get_perchannel_param(self, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
-        return {
-            "quant_bias": torch.empty(output_size, dtype=torch.int32),
-            "deq_scale": torch.empty(output_size, dtype=torch.int64),
         }
 
     def apply(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces `AscendW8A8Linear310pScheme` as a base class for 310P-specific W8A8 quantization schemes. It refactors `W8A8_DYNAMIC`, `W8A8` (static), `W8A8S`, and `W8A8SC` to inherit from this base class, removing redundant implementations of `get_weight`, `get_pertensor_param`, and `get_perchannel_param`. This improves code maintainability and reduces duplication across different quantization methods for the 310P hardware.

### Does this PR introduce _any_ user-facing change?

No. This is an internal refactoring of quantization schemes.

### How was this patch tested?

The changes are structural refactorings. Existing CI tests for 310P quantization should be used to verify that functionality remains unchanged.