### PR TITLE
[Doc] Clarify irqbalance service management

### DIFF
--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -71,7 +71,8 @@ For best results, if you run inside a Docker container where `systemctl` is like
 
 - **Stop `irqbalance` service**:
 
-    For example, on Ubuntu system, you can run the following command to stop irqbalance:
+    For example, on Ubuntu and other systemd-based Linux distributions, you can stop irqbalance with:
+
     ```bash
     sudo systemctl stop irqbalance
     ```
@@ -81,6 +82,8 @@ For best results, if you run inside a Docker container where `systemctl` is like
     ```bash
     sudo systemctl start irqbalance
     ```
+
+    Note: On systems that do not use systemd, use the corresponding service-management command provided by the distribution.
 
 - **Permissions**:
     - Read access to `/proc/self/status` and `/proc/interrupts`


### PR DESCRIPTION
### What this PR does / why we need it?

This PR clarifies the CPU binding documentation for managing the `irqbalance` service.

The previous wording only mentioned Ubuntu while the command shown is specific to systemd-based Linux distributions. This update describes the command as applicable to Ubuntu and other systemd-based distributions, and adds a note for non-systemd systems to use the distribution-specific service-management command.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update and does not change vLLM or vllm-ascend runtime behavior.

### How was this patch tested?
