### PR TITLE
[Ops][BugFix] Add None guard for all_moe_layers in fused_moe

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -419,7 +419,7 @@ class AscendFusedMoE(FusedMoE):
         forward_context = get_forward_context()
         # When static kernels are enabled, the forward pass runs twice (compilation + capture),
         # causing moe_layer_index to overflow. Wrap the index to prevent out-of-bounds errors.
-        if self.enable_npugraph_ex_static_kernel:
+        if self.enable_npugraph_ex_static_kernel and forward_context.all_moe_layers:
             moe_layer_index = forward_context.moe_layer_index % (len(forward_context.all_moe_layers))
             forward_context.moe_layer_index = moe_layer_index
 


### PR DESCRIPTION
### What this PR does / why we need it?
When `fast_moe_cold_start` is `False` (triggered by PyTorch ≥ 2.11 with `HAS_OPAQUE_TYPE=True`, or speculative decoding enabled), `forward_context.all_moe_layers` is set to `None` by upstream vLLM. The current code in `fused_moe.py` calls `len(forward_context.all_moe_layers)` without a None check, causing a `TypeError`.
This PR adds a truthiness guard to skip the index-wrapping logic when `all_moe_layers` is `None` or empty, also preventing `ZeroDivisionError` on empty list.
Fixes #8620
### Does this PR introduce _any_ user-facing change?
No. This is a crash fix — previously crashing configurations will now work correctly.
### How was this patch tested?
- Code review against upstream vLLM's None guard in `default_moe_runner.py`
- Verified the change is a single-line condition addition with no behavioral difference when `all_moe_layers` is not None