### PR TITLE
[Feature] add Dflash support for Qwen3.5

### DIFF
--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -32,6 +32,7 @@ _GDN_CUMSUM_WORKING_SET = 2**18
 
 _IS_PATCHED = False
 _ORIGINAL_BUILD = gdn_attn.GDNAttentionMetadataBuilder.build
+_ORIGINAL_INIT_THRESHOLD = gdn_attn.GDNAttentionMetadataBuilder._init_reorder_batch_threshold
 
 
 @dataclass
@@ -597,9 +598,33 @@ def _patched_build(
     return attn_metadata
 
 
+def _init_reorder_batch_threshold(
+    self,
+    reorder_batch_threshold: int | None = 1,
+    supports_spec_as_decode: bool = False,
+    supports_dcp_with_varlen: bool = False,
+) -> None:
+    _ORIGINAL_INIT_THRESHOLD(
+        self,
+        reorder_batch_threshold,
+        supports_spec_as_decode,
+        supports_dcp_with_varlen,
+    )
+    if self.reorder_batch_threshold != 1:
+        speculative_config = self.vllm_config.speculative_config
+        if (
+            speculative_config is not None
+            and speculative_config.num_speculative_tokens is not None
+            and hasattr(speculative_config, "method")
+            and speculative_config.method == "dflash"
+        ):
+            self.reorder_batch_threshold = 1 + speculative_config.num_speculative_tokens
+
+
 if not _IS_PATCHED and not is_310p():
     gdn_attn.GDNChunkedPrefillMetadata = GDNChunkedPrefillMetadata
     gdn_attn.GDNCausalConv1dHostMetadata = GDNCausalConv1dHostMetadata
     gdn_attn.GDNPrefillFallbackMeta = GDNPrefillFallbackMeta
     gdn_attn.GDNAttentionMetadataBuilder.build = _patched_build
+    gdn_attn.GDNAttentionMetadataBuilder._init_reorder_batch_threshold = _init_reorder_batch_threshold
     _IS_PATCHED = True

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -107,7 +107,7 @@ class AscendDflashProposer(AscendEagleProposer):
             num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.block_size,
+            block_size=self.kernel_block_size,
             num_query_per_req=num_query_per_req,
             num_speculative_tokens=self.num_speculative_tokens,
             total_input_tokens=num_context,
@@ -184,7 +184,9 @@ class AscendDflashProposer(AscendEagleProposer):
                 slot_mapping=self._slot_mapping_buffer[:num_query_total],
                 attn_state=AscendAttentionState.ChunkedPrefill,
                 causal=False,
-                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
+                block_table_tensor=self.runner.input_batch.block_table[self.kv_cache_gid].get_device_tensor()[
+                    :num_reqs
+                ],
             )
 
             attn_metadata_dflash = builder.build_for_graph_capture(
@@ -239,3 +241,6 @@ class AscendDflashProposer(AscendEagleProposer):
         return dict(
             input_ids=self.input_ids[:num_input_tokens], positions=self.positions[:num_input_tokens], inputs_embeds=None
         )
+
+    def _raise_if_multimodal(self):
+        pass

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -328,12 +328,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     def _maybe_share_lm_head(self, model: nn.Module) -> None:
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
-        if self.method in ("eagle", "dflash") and hasattr(model, "lm_head"):
+        if self.method in ("eagle", "dflash"):
             logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
-            if supports_multimodal(model):
+            if hasattr(model, "lm_head"):
+                self.model.lm_head = model.lm_head
+            elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
                 self.model.lm_head = model.get_language_model().lm_head
             else:
-                self.model.lm_head = model.lm_head
+                logger.warning("Target model has no accessible lm_head for sharing.")
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():


### PR DESCRIPTION

### What this PR does / why we need it?
Adapting to Qwen3.5 Series Models.
Test the accuracy and acceptance rate on the GSM8K dataset:
Qwen3.5-9B, DP1/TP1, output length 4096, data num 500, batch_size 16, temperature 0, spec_num 4
Accuracy: 93.40; Acceptance Rate: [0.91, 0.80, 0.69, 0.59]; Mean Acceptance Length: 4.00


### Does this PR introduce _any_ user-facing change?
Modify the speculative-config and compilation-config:
`--speculative-config '{"num_speculative_tokens": K, "method":"dflash","model":"dflash_weight_path"}'`
`--compilation-config '{"cudagraph_capture_sizes":[1 * (K+1), 2 * (K+1), ..., batch_size * (K+1)], "cudagraph_mode": "FULL_DECODE_ONLY"}'`

[!Attention!]
1. Solved ~~Since PR-[8055](https://github.com/vllm-project/vllm-ascend/pull/8055) modifies the GDN operator (Linear-Attention), when spec_num >= 8, it will face severe accuracy issues. This is not only an issue for dflash, but Qwen3.5's native MTP will also be affected. Therefore, before the issue is resolved, please limit spec_num to 1~7.~~
2. Solved ~~The full-attn-group sorting is incorrect, which causes the func updata_graph_fia error. Therefore, the FULL_DECODE_ONLY mode is not supported. We will provide another PR to fix this issue. Please use PIECEWISE now.~~

### How was this patch tested?
Coming Soon

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
