### PR TITLE
[Doc][Bugfix] Fix numbered list translation not displayed in Sphinx

### DIFF
--- a/.github/workflows/scripts/po_translate.py
+++ b/.github/workflows/scripts/po_translate.py
@@ -44,6 +44,8 @@ Rules:
 7. For difficult parts, keep original English
 8. Remove "#, fuzzy" markers
 9. Do NOT translate proper nouns: person names, contributor names, author names must be kept as-is in msgstr
+10. In list items, no space between marker and Chinese text: "1.中文" not "1. 中文"
+    (space causes Sphinx to ignore the translation)
 
 Return ONLY the complete PO file content, no extra explanations.
 


### PR DESCRIPTION
### What this PR does / why we need it?

Add prompt rule to prevent spaces between list markers and Chinese text in translated msgstr (e.g., use "1.中文" instead of "1. 中文"), which caused Sphinx to ignore the translation and fall back to English.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
