### PR TITLE
[BugFix] Validate shared experts existence before enabling multistream overlap

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -49,7 +49,9 @@ class TestAscendConfig(TestBase):
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
     @patch("vllm_ascend.utils.has_shared_experts", return_value=True)
-    def test_init_ascend_config_with_additional_config(self, mock_has_shared_experts, mock_fix_incompatible_config):
+    def test_init_ascend_config_with_additional_config(
+        self, mock_has_shared_experts, mock_fix_incompatible_config
+    ):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "ascend_compilation_config": {
@@ -79,7 +81,9 @@ class TestAscendConfig(TestBase):
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
     @patch("vllm_ascend.utils.has_shared_experts", return_value=False)
-    def test_multistream_overlap_disabled_without_shared_experts(self, mock_has_shared_experts, mock_fix_incompatible_config):
+    def test_multistream_overlap_disabled_without_shared_experts(
+        self, mock_has_shared_experts, mock_fix_incompatible_config
+    ):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "multistream_overlap_shared_expert": True,

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -49,9 +49,7 @@ class TestAscendConfig(TestBase):
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
     @patch("vllm_ascend.utils.has_shared_experts", return_value=True)
-    def test_init_ascend_config_with_additional_config(
-        self, mock_has_shared_experts, mock_fix_incompatible_config
-    ):
+    def test_init_ascend_config_with_additional_config(self, mock_has_shared_experts, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "ascend_compilation_config": {
@@ -81,9 +79,7 @@ class TestAscendConfig(TestBase):
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
     @patch("vllm_ascend.utils.has_shared_experts", return_value=False)
-    def test_multistream_overlap_disabled_without_shared_experts(
-        self, mock_has_shared_experts, mock_fix_incompatible_config
-    ):
+    def test_multistream_overlap_disabled_without_shared_experts(self, mock_has_shared_experts, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "multistream_overlap_shared_expert": True,

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -49,9 +49,7 @@ class TestAscendConfig(TestBase):
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
     @patch("vllm_ascend.utils.has_shared_experts", return_value=True)
-    def test_init_ascend_config_with_additional_config(
-        self, mock_has_shared_experts, mock_fix_incompatible_config
-    ):
+    def test_init_ascend_config_with_additional_config(self, mock_has_shared_experts, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "ascend_compilation_config": {

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -48,7 +48,10 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
-    def test_init_ascend_config_with_additional_config(self, mock_fix_incompatible_config):
+    @patch("vllm_ascend.utils.has_shared_experts", return_value=True)
+    def test_init_ascend_config_with_additional_config(
+        self, mock_has_shared_experts, mock_fix_incompatible_config
+    ):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "ascend_compilation_config": {
@@ -74,6 +77,22 @@ class TestAscendConfig(TestBase):
 
         ascend_fusion_config = ascend_config.ascend_fusion_config
         self.assertFalse(ascend_fusion_config.fusion_ops_gmmswigluquant)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
+    @patch("vllm_ascend.utils.has_shared_experts", return_value=False)
+    def test_multistream_overlap_disabled_without_shared_experts(
+        self, mock_has_shared_experts, mock_fix_incompatible_config
+    ):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "multistream_overlap_shared_expert": True,
+            "multistream_overlap_gate": True,
+            "refresh": True,
+        }
+        ascend_config = init_ascend_config(test_vllm_config)
+        self.assertFalse(ascend_config.multistream_overlap_shared_expert)
+        self.assertFalse(ascend_config.multistream_overlap_gate)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -103,6 +103,17 @@ class AscendConfig:
                 )
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
+        
+        if self.multistream_overlap_shared_expert or self.multistream_overlap_gate:
+            from vllm_ascend.utils import has_shared_experts
+            
+            if not has_shared_experts(vllm_config):
+                logger.warning_once(
+                    "multistream_overlap_shared_expert or multistream_overlap_gate is enabled, "
+                    "but the model does not have shared experts. These configurations will be "
+                    "ignored and may cause performance degradation. Please disable them."
+                )
+        
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -103,17 +103,19 @@ class AscendConfig:
                 )
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
-        
+
         if self.multistream_overlap_shared_expert or self.multistream_overlap_gate:
             from vllm_ascend.utils import has_shared_experts
-            
+
             if not has_shared_experts(vllm_config):
                 logger.warning_once(
                     "multistream_overlap_shared_expert or multistream_overlap_gate is enabled, "
                     "but the model does not have shared experts. These configurations will be "
                     "ignored and may cause performance degradation. Please disable them."
                 )
-        
+                self.multistream_overlap_shared_expert = False
+                self.multistream_overlap_gate = False
+
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -523,12 +523,21 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
     )
 
     if os.getenv("HCCL_OP_EXPANSION_MODE") == "AIV":
+        multistream_overlap_shared_expert = vllm_config.additional_config.get(
+            "multistream_overlap_shared_expert", False
+        )
+        has_shared = has_shared_experts(vllm_config)
+        if multistream_overlap_shared_expert and not has_shared:
+            logger.warning(
+                "multistream_overlap_shared_expert is enabled but the model does not have "
+                "shared experts. This configuration will be ignored."
+            )
         # TODO: Find out whether we need to take into account the pp_size
         parallel_factor = (
             1
             + num_comm_groups
             + int(parallel_config.enable_expert_parallel)
-            + int(vllm_config.additional_config.get("multistream_overlap_shared_expert", False))
+            + int(multistream_overlap_shared_expert and has_shared)
         )
         if is_moe_model(vllm_config):
             parallel_factor += parallel_config.data_parallel_size > 1
@@ -824,6 +833,19 @@ def shared_expert_dp_enabled() -> bool:
 
 def prefill_context_parallel_enable() -> bool:
     return envs_ascend.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL
+
+
+_HAS_SHARED_EXPERTS: bool | None = None
+
+
+def has_shared_experts(vllm_config: VllmConfig) -> bool:
+    """Checks if the MoE model has shared experts by config"""
+    global _HAS_SHARED_EXPERTS
+    if _HAS_SHARED_EXPERTS is None:
+        hf_text_config = vllm_config.model_config.hf_text_config
+        n_shared_experts = getattr(hf_text_config, "n_shared_experts", 0)
+        _HAS_SHARED_EXPERTS = n_shared_experts is not None and n_shared_experts > 0
+    return _HAS_SHARED_EXPERTS
 
 
 def is_moe_model(vllm_config: VllmConfig):

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -842,7 +842,11 @@ def has_shared_experts(vllm_config: VllmConfig) -> bool:
     """Checks if the MoE model has shared experts by config"""
     global _HAS_SHARED_EXPERTS
     if _HAS_SHARED_EXPERTS is None:
-        hf_text_config = vllm_config.model_config.hf_text_config
+        if vllm_config.model_config is None:
+            return False
+        hf_text_config = getattr(vllm_config.model_config, "hf_text_config", None)
+        if hf_text_config is None:
+            return False
         n_shared_experts = getattr(hf_text_config, "n_shared_experts", 0)
         _HAS_SHARED_EXPERTS = n_shared_experts is not None and n_shared_experts > 0
     return _HAS_SHARED_EXPERTS


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a performance issue where `multistream_overlap_shared_expert` configuration could negatively impact models without shared experts (e.g., MiniMax-M2.5).
When users enable `multistream_overlap_shared_expert` for models without shared experts:
1. The configuration is accepted without validation
2. The `parallel_factor` calculation incorrectly increases, reducing maximum supported batch sizes
3. This leads to performance degradation instead of improvement
4. No warning is given to users about the misconfiguration

### Does this PR introduce _any_ user-facing change?
Yes, this PR introduces user-facing changes:
**For models WITHOUT shared experts (e.g., MiniMax-M2.5):**
- **Before**: Enabling `multistream_overlap_shared_expert` would silently reduce performance
- **After**: Users will see clear warning messages:
  ```
  WARNING: multistream_overlap_shared_expert or multistream_overlap_gate is enabled, 
  but the model does not have shared experts. These configurations will be ignored 
  and may cause performance degradation. Please disable them.
  ```
- The configuration will be automatically ignored, preventing performance degradation

**For models WITH shared experts (e.g., DeepSeek-V3, GLM-5, Qwen3.5-397B-A17B):**
- **No behavior change**: The optimization works as expected when enabled
- **No performance impact**: The validation adds minimal overhead

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
