### PR TITLE
[Bugfix][Sample] Preserve logprobs mode in Ascend sampler backend

### DIFF
--- a/tests/ut/sample/test_sampler.py
+++ b/tests/ut/sample/test_sampler.py
@@ -7,5 +7,16 @@ class TestAscendSampler(TestBase):
     def test_init_with_raw_logprobs(self):
         sampler = AscendSampler(logprobs_mode="raw_logprobs")
         self.assertEqual(sampler.logprobs_mode, "raw_logprobs")
-        self.assertTrue(hasattr(sampler, 'topk_topp_sampler'))
+        self.assertTrue(hasattr(sampler, "topk_topp_sampler"))
         self.assertIsInstance(sampler.topk_topp_sampler, AscendTopKTopPSampler)
+        self.assertEqual(sampler.topk_topp_sampler.logprobs_mode, "raw_logprobs")
+
+    def test_init_with_processed_logits(self):
+        sampler = AscendSampler(logprobs_mode="processed_logits")
+        self.assertEqual(sampler.logprobs_mode, "processed_logits")
+        self.assertEqual(sampler.topk_topp_sampler.logprobs_mode, "processed_logits")
+
+    def test_init_with_processed_logprobs(self):
+        sampler = AscendSampler(logprobs_mode="processed_logprobs")
+        self.assertEqual(sampler.logprobs_mode, "processed_logprobs")
+        self.assertEqual(sampler.topk_topp_sampler.logprobs_mode, "processed_logprobs")

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -62,9 +62,8 @@ class AscendSampler(Sampler):
         )
 
     def __init__(self, logprobs_mode=DEFAULT_LOGPROBS_MODE):
-        # TODO: support logprobs_mode in vllm-ascend
         super().__init__(logprobs_mode=logprobs_mode)
-        self.topk_topp_sampler = AscendTopKTopPSampler()
+        self.topk_topp_sampler = AscendTopKTopPSampler(logprobs_mode=logprobs_mode)
         self.async_exponential_event = torch.npu.Event()
 
     def set_q_event(self, q, event):


### PR DESCRIPTION
### What this PR does / why we need it?
`AscendSampler` passes `logprobs_mode` into the upstream sampler constructor, but then overwrites `self.topk_topp_sampler` with an `AscendTopKTopPSampler` instance built with default arguments.

That causes `processed_logits` and `processed_logprobs` requests to silently fall back to the default mode in the Ascend top-k/top-p path.

This PR forwards the configured `logprobs_mode` into `AscendTopKTopPSampler` and adds regression coverage for the supported modes.

### Does this PR introduce _any_ user-facing change?
Yes. Requests that rely on `processed_logits` or `processed_logprobs` now receive the requested mode instead of silently using the default behavior.

### How was this patch tested?
- Added regression coverage in `tests/ut/sample/test_sampler.py`
- Ran `python -m py_compile vllm_ascend\sample\sampler.py tests\ut\sample\test_sampler.py`
- Ran a stub-based import validation that constructs `AscendSampler` with `processed_logits` and `processed_logprobs` and verifies the Ascend top-k/top-p backend preserves the requested mode

Local `pytest -sv tests\ut\sample\test_sampler.py` is currently blocked because the active environment does not include `regex`, `vllm`, and `torch-npu`.
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
