### PR TITLE
[BugFix]Correct MLAPO

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1492,7 +1492,7 @@ class TestAscendMLAImpl(TestBase):
         self.impl.q_proj.weight_scale.data = torch.randn(128, 128, 128)
         self.impl.q_lora_rank = 32
 
-        self.impl.process_weights_for_fused_mlapo_a5(torch.float16)
+        self.impl._process_weights_for_fused_mlapo_a5(torch.float16)
         self.assertTrue(hasattr(self.impl, "weight_dq"))
         self.assertTrue(hasattr(self.impl, "weight_uq_qr"))
         self.assertTrue(hasattr(self.impl, "weight_dkv_kr"))
@@ -1625,11 +1625,11 @@ class TestAscendMLAImpl(TestBase):
 
         mock_get_ascend_device_type.return_value = AscendDeviceType.A5
 
-        self.impl.process_weights_for_fused_mlapo_a5 = MagicMock()
+        self.impl._process_weights_for_fused_mlapo_a5 = MagicMock()
 
         self.impl.process_weights_after_loading(torch.bfloat16)
 
-        self.impl.process_weights_for_fused_mlapo_a5.assert_called_once_with(torch.bfloat16)
+        self.impl._process_weights_for_fused_mlapo_a5.assert_called_once_with(torch.bfloat16)
 
         self.assertEqual(self.impl.W_UK_T.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UK_T.shape[1], self.impl.qk_nope_head_dim)
@@ -1667,11 +1667,11 @@ class TestAscendMLAImpl(TestBase):
 
         mock_get_ascend_device_type.return_value = AscendDeviceType.A2
 
-        self.impl.process_weights_for_fused_mlapo = MagicMock()
+        self.impl._process_weights_for_fused_mlapo = MagicMock()
 
         self.impl.process_weights_after_loading(torch.bfloat16)
 
-        self.impl.process_weights_for_fused_mlapo.assert_called_once_with(torch.bfloat16)
+        self.impl._process_weights_for_fused_mlapo.assert_called_once_with(torch.bfloat16)
 
         self.assertEqual(self.impl.W_UK_T.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UK_T.shape[1], self.impl.qk_nope_head_dim)

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -968,9 +968,9 @@ class AscendMLAImpl(MLAAttentionImpl):
                 )
         if self.enable_mlapo:
             if get_ascend_device_type() == AscendDeviceType.A5:
-                self.process_weights_for_fused_mlapo_a5(act_dtype)
+                self._process_weights_for_fused_mlapo_a5(act_dtype)
             else:
-                self.process_weights_for_fused_mlapo(act_dtype)
+                self._process_weights_for_fused_mlapo(act_dtype)
         elif self.fa_quant_layer:
             self._process_weights_for_fused_fa_quant()
         else:
@@ -1079,7 +1079,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.q_proj.quant_bias = None
             torch.npu.empty_cache()
 
-    def process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
+    def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
         assert self.fused_qkv_a_proj is not None
 
         weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
@@ -1671,7 +1671,11 @@ class AscendMLAImpl(MLAAttentionImpl):
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
         # MLA Preprocess
-        if self.fa_quant_layer or (self.enable_mlapo and attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS):
+        if self.fa_quant_layer or (
+            self.enable_mlapo
+            and attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+            and attn_metadata.num_prefills == 0
+        ):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                 hidden_states.contiguous(), need_gather_q_kv
             )


### PR DESCRIPTION
### What this PR does / why we need it?
- Fixes a bug where mlapo was incorrectly being used during the chunked prefill process on A5 devices.
- Add missing underscore to the call of _process_weights_for_fused_mlapo.
- Add underscore to function name process_weights_for_fused_mlapo_A5 for consistency

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
