### PR TITLE
[Attention][Feature]  adapt bailing_moe_linear on Ascend

### DIFF
--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,7 +111,18 @@ class AscendGemmaRMSNorm(GemmaRMSNorm):
 
 class LayerNormFn(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, weight, bias, z=None, eps=1e-6, group_size=None, norm_before_gate=True, is_rms_norm=False):
+    def forward(
+        ctx,
+        x,
+        weight,
+        bias,
+        z=None,
+        eps=1e-6,
+        group_size=None,
+        norm_before_gate=True,
+        is_rms_norm=False,
+        activation: str = "swish",
+    ):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
 
         x_shape_og = x.shape

--- a/vllm_ascend/ops/triton/fla/layernorm_guard.py
+++ b/vllm_ascend/ops/triton/fla/layernorm_guard.py
@@ -168,6 +168,7 @@ class LayerNormFn(torch.autograd.Function):
         group_size=None,
         norm_before_gate=True,
         is_rms_norm=False,
+        activation: str = "swish",
     ):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
 

--- a/vllm_ascend/ops/triton/mamba/lightning_attn.py
+++ b/vllm_ascend/ops/triton/mamba/lightning_attn.py
@@ -1,0 +1,615 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""NPU-compatible linear attention operators for BailingMoE.
+
+This module provides NPU-compatible replacements for GPU-only Triton kernels
+used in BailingMoELinearAttention:
+  - ``linear_decode_forward_npu``: replaces ``linear_decode_forward_triton``
+  - ``LightningAttentionKernelNPU``: replaces ``MiniMaxText01LinearKernel``
+"""
+
+import torch
+from einops import rearrange
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _fwd_diag_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    S,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n: tl.constexpr,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    CBLOCK: tl.constexpr,
+    NUM_BLOCK: tl.constexpr,
+):
+    # This kernel computes the diagonal blocks of the attention matrix
+    # Each diagonal block represents attention
+    # where queries attend to keys in the same block
+    off = tl.program_id(0)
+    off_bh = off // NUM_BLOCK  # batch-head index
+    off_block = off % NUM_BLOCK  # block index within the sequence
+    off_cblock = tl.program_id(1)  # sub-block index within a block
+
+    off_h = off_bh % h  # head index
+
+    # Calculate base offsets for the current batch and head
+    qk_offset = off_bh * n * d
+    v_offset = off_bh * n * e
+    o_offset = off_bh * n * e
+
+    # Calculate offsets for the current block
+    block_offset = off_block * BLOCK
+    qk_block_offset = block_offset * d
+    v_block_offset = block_offset * e
+    o_block_offset = block_offset * e
+
+    # Calculate offsets for the current sub-block
+    cblock_offset = off_cblock * CBLOCK
+    q_cblock_offset = cblock_offset * d
+    o_cblock_offset = cblock_offset * e
+
+    # Calculate pointers to the query, key, value, and output tensors
+    Q_block_ptr = (
+        Q + qk_offset + qk_block_offset + q_cblock_offset + tl.arange(0, CBLOCK)[:, None] * d + tl.arange(0, d)[None, :]
+    )
+    K_block_ptr = K + qk_offset + qk_block_offset + tl.arange(0, CBLOCK)[:, None] * d + tl.arange(0, d)[None, :]
+    V_block_ptr = V + v_offset + v_block_offset + tl.arange(0, CBLOCK)[:, None] * e + tl.arange(0, e)[None, :]
+    O_block_ptr = (
+        Out + o_offset + o_block_offset + o_cblock_offset + tl.arange(0, CBLOCK)[:, None] * e + tl.arange(0, e)[None, :]
+    )
+
+    # Load the decay rate for the current head
+    S_block_ptr = S + off_h
+    s = tl.load(S_block_ptr)
+
+    i = off_cblock
+    q_index = tl.arange(0, CBLOCK) + i * CBLOCK
+
+    # Load query values
+    q = tl.load(Q_block_ptr, mask=block_offset + q_index[:, None] < n, other=0.0).to(tl.float32)
+    # Initialize output accumulator
+    qkv = tl.zeros([CBLOCK, e], dtype=tl.float32)
+
+    # Process all sub-blocks up to and
+    # including the current one (causal attention)
+    for j in range(i + 1):
+        kv_index = tl.arange(0, CBLOCK) + j * CBLOCK
+        diff = q_index[:, None] - kv_index[None, :]
+        s_index = s * diff
+        # Apply causal mask: only attend to positions before the current one
+        s_index = tl.where(diff >= 0, -s_index, float("-inf"))
+        decay = tl.exp(s_index)
+
+        # Load key and value
+        k = tl.load(
+            K_block_ptr,
+            mask=block_offset + kv_index[:, None] < n,
+            other=0.0,
+        ).to(tl.float32)
+
+        v = tl.load(
+            V_block_ptr,
+            mask=block_offset + kv_index[:, None] < n,
+            other=0.0,
+        ).to(tl.float32)
+
+        # Compute attention scores and apply decay
+        qk = tl.dot(q, k.trans()) * decay
+        # Compute weighted values and accumulate
+        qkv += tl.dot(qk, v)
+
+        # Move to the next sub-block
+        K_block_ptr += CBLOCK * d
+        V_block_ptr += CBLOCK * e
+
+    tl.store(
+        O_block_ptr,
+        qkv.to(O_block_ptr.dtype.element_ty),
+        mask=block_offset + q_index[:, None] < n,
+    )
+
+
+@triton.jit
+def _fwd_kv_parallel(
+    K,
+    V,
+    K_decay,
+    KV,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n: tl.constexpr,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_BLOCK: tl.constexpr,
+    D_FBLOCK: tl.constexpr,
+    E_FBLOCK: tl.constexpr,
+    NUM_FBLOCK: tl.constexpr,
+    CBLOCK: tl.constexpr,
+    NUM_CBLOCK: tl.constexpr,
+):
+    # This kernel computes the key-value outer
+    # products for each block in parallel
+    off_bh = tl.program_id(0)  # batch-head index
+    off_block = tl.program_id(1)  # block index within the sequence
+    off_e = tl.program_id(2)  # e-dimension tile index for UB overflow prevention
+
+    off_h = off_bh % h  # head index
+
+    block_offset = off_block * BLOCK
+
+    # e-dimension tile offset: each program handles E_FBLOCK columns of e
+    e_offset = off_e * E_FBLOCK
+
+    # Calculate offsets for the current block
+    k_block_offset = block_offset * d
+    v_block_offset = block_offset * e
+    kv_block_offset = off_block * d * e
+
+    # Calculate base offsets for the current batch and head
+    k_offset = off_bh * n * d
+    v_offset = off_bh * n * e
+    kv_offset = off_bh * NUM_BLOCK * d * e
+
+    # Calculate pointers to the key, value, and key-value tensors
+    # K does not depend on e_offset (K is [n, d], not [n, e])
+    K_block_ptr = K + k_offset + k_block_offset + tl.arange(0, CBLOCK)[:, None] * d + tl.arange(0, D_FBLOCK)[None, :]
+    # V is offset by e_offset to select the current E_FBLOCK columns
+    V_block_ptr = (
+        V + v_offset + v_block_offset + tl.arange(0, CBLOCK)[:, None] * e + e_offset + tl.arange(0, E_FBLOCK)[None, :]
+    )
+    # KV is offset by e_offset to write into the correct E_FBLOCK columns
+    KV_block_ptr = (
+        KV
+        + kv_offset
+        + kv_block_offset
+        + tl.arange(0, D_FBLOCK)[:, None] * e
+        + e_offset
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+
+    # Load the decay factors for the current head and block
+    k_decay_ptr = K_decay + off_h * BLOCK + tl.arange(0, CBLOCK)
+
+    kv_index = tl.arange(0, CBLOCK)
+
+    # Initialize the key-value outer product accumulator
+    kv = tl.zeros([D_FBLOCK, E_FBLOCK], dtype=tl.float32)
+
+    # Handle the last block which might be smaller than BLOCK
+    split_n = n - (NUM_BLOCK - 1) * BLOCK if off_block == NUM_BLOCK - 1 else BLOCK
+    left_shift = tl.cdiv(split_n, CBLOCK) * CBLOCK - split_n
+    num_blocks = min(tl.cdiv(split_n, CBLOCK), NUM_CBLOCK)
+    k_decay_ptr += (NUM_CBLOCK - num_blocks) * CBLOCK
+
+    # Process all sub-blocks in the current block
+    for j in range(num_blocks):
+        left_bound = (1 - j) * left_shift
+        # Load key and value, handling boundary conditions
+        k_block = tl.load(
+            K_block_ptr - left_shift * d,
+            mask=(kv_index[:, None] >= left_bound),
+            other=0.0,
+        ).to(tl.float32)
+        v = tl.load(
+            V_block_ptr - left_shift * e,
+            mask=(kv_index[:, None] >= left_bound),
+            other=0.0,
+        ).to(tl.float32)
+
+        # Load decay factor and compute weighted key-value outer product
+        k_decay = tl.load(k_decay_ptr)
+        k_trans = tl.trans(k_block)
+        # NOTE: Need to add the extra dim here due to AMD MLIR lowering error.
+        # Please don't move it back until issue is resolved.
+        # Issue: https://github.com/ROCm/triton/issues/907
+        k_decay = k_decay[None, :]
+
+        kv += tl.dot(k_trans * k_decay, v)
+
+        # Move to the next sub-block
+        K_block_ptr += CBLOCK * d
+        V_block_ptr += CBLOCK * e
+        k_decay_ptr += CBLOCK
+    # Store the result
+    tl.store(KV_block_ptr, kv.to(KV_block_ptr.dtype.element_ty))
+
+
+@triton.jit
+def _fwd_kv_reduce(
+    S,
+    KV,
+    KV_HISTORY,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_BLOCK,
+    D_FBLOCK: tl.constexpr,
+    E_FBLOCK: tl.constexpr,
+):
+    # This kernel reduces the key-value outer products
+    # across blocks and updates the KV history
+    off_bh = tl.program_id(0)  # batch-head index
+    off_e = tl.program_id(1)  # e-dimension tile index for UB overflow prevention
+    off_h = off_bh % h  # head index
+
+    # e-dimension tile offset: each program handles E_FBLOCK columns of e
+    e_offset = off_e * E_FBLOCK
+
+    kv_offset = off_bh * NUM_BLOCK * d * e
+
+    # Calculate pointer to the key-value tensor, offset by e_offset
+    KV_block_ptr = KV + kv_offset + tl.arange(0, D_FBLOCK)[:, None] * e + e_offset + tl.arange(0, E_FBLOCK)[None, :]
+
+    # Load the decay rate for the current head
+    s_ptrs = S + off_h
+    s = tl.load(s_ptrs)
+
+    # Calculate pointer to the key-value history tensor, offset by e_offset
+    kv_history_offset = off_bh * d * e
+    KV_HISTORY_block_ptr = (
+        KV_HISTORY
+        + kv_history_offset
+        + tl.arange(0, D_FBLOCK)[:, None] * e
+        + e_offset
+        + tl.arange(0, E_FBLOCK)[None, :]
+    )
+
+    # Load the previous key-value history
+    kv_pre = tl.load(KV_HISTORY_block_ptr).to(tl.float32)
+
+    # Process all blocks in reverse order to compute the prefix sum
+    for i in range(NUM_BLOCK):
+        block_size = min(n - i * BLOCK, BLOCK)
+        # Compute decay factor for the current block
+        block_decay = tl.exp(-s.to(tl.float32) * block_size)
+
+        # Load the current key-value outer product
+        kv_cur = tl.load(KV_block_ptr).to(tl.float32)
+        # Store the previous key-value history to the current block
+        tl.store(KV_block_ptr, kv_pre.to(KV_block_ptr.dtype.element_ty))
+
+        # Update the key-value history with the current block
+        kv_pre = block_decay * kv_pre + kv_cur
+        KV_block_ptr += d * e
+    # Store the updated key-value history
+    tl.store(KV_HISTORY_block_ptr, kv_pre)
+
+
+@triton.jit
+def _fwd_none_diag_kernel(
+    Q,
+    Out,
+    S,
+    KV,
+    b: tl.constexpr,
+    h: tl.constexpr,
+    n,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_BLOCK,
+    E_FBLOCK: tl.constexpr,
+    CBLOCK: tl.constexpr,
+    NUM_CBLOCK: tl.constexpr,
+):
+    # This kernel computes the non-diagonal blocks of the attention matrix
+    # Each non-diagonal block represents attention
+    # where queries attend to keys in different blocks
+    off_bh = tl.program_id(0)  # batch-head index
+    off_h = off_bh % h  # head index
+
+    off_nc = tl.program_id(1)
+    off_n = off_nc // NUM_CBLOCK  # block index
+    off_c = off_nc % NUM_CBLOCK  # sub-block index
+    off_e = tl.program_id(2)  # output feature block index
+
+    n_offset = off_n * BLOCK
+    c_offset = off_c * CBLOCK
+    e_offset = off_e * E_FBLOCK
+    block_offset = n_offset + c_offset
+
+    # Calculate offsets for the current batch, head, and block
+    q_offset = off_bh * n * d + (n_offset + c_offset) * d
+    o_offset = off_bh * n * e + (n_offset + c_offset) * e + e_offset
+    kv_offset = off_bh * NUM_BLOCK * d * e + off_n * d * e + e_offset
+
+    # Calculate pointers to the query, output, and key-value tensors
+    Q_block_ptr = Q + q_offset + tl.arange(0, CBLOCK)[:, None] * d + tl.arange(0, d)[None, :]
+    O_block_ptr = Out + o_offset + tl.arange(0, CBLOCK)[:, None] * e + tl.arange(0, E_FBLOCK)[None, :]
+    KV_block_ptr = KV + kv_offset + tl.arange(0, d)[:, None] * e + tl.arange(0, E_FBLOCK)[None, :]
+
+    # Load the decay rate for the current head
+    S_block_ptr = S + off_h
+    s = tl.load(S_block_ptr)
+
+    c_array = tl.arange(0, CBLOCK)
+
+    # Load the key-value outer product for the current block
+    kv = tl.load(KV_block_ptr).to(tl.float32)
+    q_index = block_offset + tl.arange(0, CBLOCK)
+
+    # Load query values
+    q = tl.load(Q_block_ptr, mask=q_index[:, None] < n, other=0.0).to(tl.float32)
+
+    # Compute decay factors for the current sub-block
+    q_decay = tl.exp(-s.to(tl.float32) * (off_c * CBLOCK + c_array[:, None]))
+
+    # Compute non-diagonal attention output
+    qkv_none_diag = tl.dot(q, kv) * q_decay
+
+    # Load diagonal attention output (computed by _fwd_diag_kernel)
+    qkv_diag = tl.load(O_block_ptr, mask=q_index[:, None] < n, other=0.0).to(tl.float32)
+
+    # Combine diagonal and non-diagonal attention outputs
+    qkv = qkv_diag + qkv_none_diag
+    # Store the result
+    tl.store(O_block_ptr, qkv.to(O_block_ptr.dtype.element_ty), mask=q_index[:, None] < n)
+
+
+class _attention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, s, kv_history):
+        # Forward pass of the lightning attention algorithm
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        s = s.contiguous()
+
+        # Get input dimensions
+        b, h, n, d = q.shape
+        e = v.shape[-1]
+
+        # Initialize output tensor
+        o = torch.empty((b, h, n, e), dtype=q.dtype, device=q.device)
+
+        # ------------------------------------------------------------------ #
+        # Tiling parameters (NPU UB-safe, all kernels share the same BLOCK)  #
+        #                                                                     #
+        # BLOCK      = 256  : sequence tile size, unified across all kernels  #
+        #                     to keep diag / non-diag semantics consistent.   #
+        # CBLOCK_D   = 32   : sub-tile for _fwd_diag_kernel                  #
+        #                     UB ≈ 72 KB  (< 192 KB limit)                   #
+        # CBLOCK_KV  = 64   : sub-tile for _fwd_kv_parallel /                #
+        #                     _fwd_none_diag_kernel                           #
+        #                     UB ≈ 112 KB (< 192 KB limit)                   #
+        # E_FBLOCK   = e//2 : split the e-dimension into two tiles so that   #
+        #                     _fwd_kv_parallel UB stays within limits.        #
+        #                     The full e range is covered via grid dim-2      #
+        #                     (NUM_EFBLOCK tiles), NOT by truncation.         #
+        # ------------------------------------------------------------------ #
+        BLOCK = 256
+        NUM_BLOCK = triton.cdiv(n, BLOCK)
+
+        # Step 1: Compute diagonal blocks of attention
+        # Each program handles CBLOCK_D rows of Q within one BLOCK-sized tile.
+        # UB breakdown (fp32): q[32,d] + k[32,d] + v[32,e] +
+        #                      qk[32,32] + decay[32,32] + qkv[32,e]
+        #                    = 4*(2*32*128 + 2*32*128 + 2*32*32) ≈ 72 KB
+        CBLOCK_D = 32
+        NUM_CBLOCK_D = BLOCK // CBLOCK_D
+        assert BLOCK % CBLOCK_D == 0, "BLOCK must be a multiple of CBLOCK_D"
+
+        grid_diag = (b * h * NUM_BLOCK, NUM_CBLOCK_D)
+        _fwd_diag_kernel[grid_diag](
+            q,
+            k,
+            v,
+            o,
+            s,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            CBLOCK=CBLOCK_D,
+            NUM_BLOCK=NUM_BLOCK,
+            multibuffer=True,
+            limit_auto_multi_buffer_only_for_local_buffer=False,
+            set_workspace_multibuffer=4,
+            tile_mix_vector_loop=2,
+            tile_mix_cube_loop=2,
+        )
+
+        # Compute decay factors for keys (shape: [h, BLOCK])
+        array = torch.arange(0, BLOCK, device=q.device) + 1
+        k_decay = torch.exp(-s * (BLOCK - array.reshape(1, -1)))
+
+        # Feature-dimension tiling:
+        # D_FBLOCK covers the full d dimension (no split needed for d).
+        # E_FBLOCK splits e into NUM_EFBLOCK tiles; each tile is processed
+        # by a separate program (grid dim-2) so the full e is always covered.
+        D_FBLOCK = d  # process all d columns in one shot
+        E_FBLOCK = e // 2  # half of e per program instance
+        NUM_EFBLOCK = e // E_FBLOCK  # = 2 tiles to cover full e
+        assert e % E_FBLOCK == 0, "e must be divisible by E_FBLOCK"
+
+        CBLOCK_KV = 64
+        NUM_CBLOCK_KV = BLOCK // CBLOCK_KV
+        assert BLOCK % CBLOCK_KV == 0, "BLOCK must be a multiple of CBLOCK_KV"
+
+        # Step 2: Compute key-value outer products for each block in parallel.
+        # Grid dim-2 (NUM_EFBLOCK) ensures the full e dimension is covered
+        # without UB overflow.
+        # UB breakdown (fp32): kv[d,E_FBLOCK] + k[CBLOCK_KV,d] +
+        #                      v[CBLOCK_KV,E_FBLOCK] + k_trans*decay[d,CBLOCK_KV]
+        #                    = 4*(128*64 + 64*128 + 64*64 + 128*64) ≈ 112 KB
+        kv = torch.empty((b, h, NUM_BLOCK, d, e), dtype=torch.float32, device=q.device)
+        grid_kv = (b * h, NUM_BLOCK, NUM_EFBLOCK)
+        _fwd_kv_parallel[grid_kv](
+            k,
+            v,
+            k_decay,
+            kv,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            D_FBLOCK=D_FBLOCK,
+            E_FBLOCK=E_FBLOCK,
+            NUM_FBLOCK=NUM_EFBLOCK,
+            CBLOCK=CBLOCK_KV,
+            NUM_CBLOCK=NUM_CBLOCK_KV,
+        )
+
+        # Step 3: Reduce key-value outer products across blocks and update
+        # KV history. Grid dim-1 (NUM_EFBLOCK) covers the full e dimension.
+        # UB breakdown (fp32): kv_pre[d,E_FBLOCK] + kv_cur[d,E_FBLOCK]
+        #                    = 2*4*128*64 = 64 KB
+        grid_reduce = (b * h, NUM_EFBLOCK)
+        _fwd_kv_reduce[grid_reduce](
+            s,
+            kv,
+            kv_history,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            D_FBLOCK=D_FBLOCK,
+            E_FBLOCK=E_FBLOCK,
+        )
+
+        # Step 4: Compute non-diagonal blocks of attention.
+        # Grid dim-2 (NUM_EFBLOCK) covers the full e dimension.
+        # UB breakdown (fp32): kv[d,E_FBLOCK] + q[CBLOCK_KV,d] +
+        #                      qkv_none[CBLOCK_KV,E_FBLOCK] +
+        #                      qkv_diag[CBLOCK_KV,E_FBLOCK] + q_decay[CBLOCK_KV,1]
+        #                    = 4*(128*64 + 64*128 + 64*64 + 64*64 + 64) ≈ 96 KB
+        grid_none_diag = (b * h, NUM_BLOCK * NUM_CBLOCK_KV, NUM_EFBLOCK)
+        _fwd_none_diag_kernel[grid_none_diag](
+            q,
+            o,
+            s,
+            kv,
+            b,
+            h,
+            n,
+            d,
+            e,
+            BLOCK=BLOCK,
+            NUM_BLOCK=NUM_BLOCK,
+            E_FBLOCK=E_FBLOCK,
+            CBLOCK=CBLOCK_KV,
+            NUM_CBLOCK=NUM_CBLOCK_KV,
+        )
+
+        # Save tensors for backward pass
+        ctx.save_for_backward(q, k, v, s, kv)
+        ctx.BLOCK = BLOCK
+
+        return o, torch.cat([kv, kv_history.unsqueeze(2)], dim=2)
+
+
+lightning_attention_npu_ = _attention.apply
+
+
+def lightning_attention_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    ed: torch.Tensor,
+    block_size: int,
+    kv_history: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """lightning attention forward pass (NPU-friendly)."""
+    d = q.shape[-1]
+    e = v.shape[-1]
+
+    if ed.dim() == 1:
+        ed = ed.view(1, -1, 1, 1)
+
+    # Split the computation into chunks for better parallelism
+    m = 128 if d >= 128 else 64
+    arr = [m * i for i in range(d // m + 1)]
+    if arr[-1] != d:
+        arr.append(d)
+    n = len(arr)
+    output = 0
+
+    # Initialize or clone key-value history
+    if kv_history is None:
+        kv_history = torch.zeros((q.shape[0], q.shape[1], d, e), dtype=torch.float32, device=q.device)
+    else:
+        kv_history = kv_history.clone().contiguous()
+
+    # Process each chunk and accumulate results
+    for i in range(n - 1):
+        s = arr[i]
+        e = arr[i + 1]
+        q1 = q[..., s:e]
+        k1 = k[..., s:e]
+        o, kv = lightning_attention_npu_(q1, k1, v, ed, kv_history)
+        output = output + o
+    return output, kv
+
+
+class LightningAttentionKernelNPU:
+    """NPU-friendly lightning attention kernel for BailingMoE prefill.
+
+    Replaces ``MiniMaxText01LinearKernel`` by providing an NPU-friendly
+    implementation of the prefill forward pass
+    """
+
+    @staticmethod
+    def jit_linear_forward_prefix_npu(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        kv_caches: torch.Tensor,
+        slope_rate: torch.Tensor,
+        block_size: int,
+        layer_idx: int | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        slope_rate = slope_rate.to(torch.float32)
+        should_squeeze = q.dim() == 3
+        if should_squeeze:
+            q = q.unsqueeze(0)
+            k = k.unsqueeze(0)
+            v = v.unsqueeze(0)
+        b, h, n, d = q.shape
+        e = v.shape[-1]
+        kv_history = kv_caches.reshape(1, h, d, e).contiguous()
+        output, kv_history = lightning_attention_npu(
+            q,
+            k,
+            v,
+            slope_rate,
+            block_size=block_size,
+            kv_history=kv_history,
+        )
+        kv_caches.copy_(kv_history[:, :, -1, :, :].reshape(h, d, e))
+        assert output.shape[0] == 1, "batch size must be 1"
+        return rearrange(output.squeeze(0), "h n d -> n (h d)")

--- a/vllm_ascend/ops/triton/mamba/linear_attn.py
+++ b/vllm_ascend/ops/triton/mamba/linear_attn.py
@@ -1,0 +1,187 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""NPU-friendly method replacements for BailingMoELinearAttention.
+
+This module provides NPU-friendly drop-in replacements for the following
+methods of ``BailingMoELinearAttention``:
+
+- ``_prefill_and_mix_infer``: replaces the GPU Triton-based prefill path.
+- ``_decode_infer``: replaces the GPU Triton-based decode path.
+- ``_forward``: replaces the full forward pass to fix the group-norm branch.
+
+These functions are designed to be monkey-patched onto the class via
+``vllm_ascend/patch/worker/patch_bailing_linear_attn.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn.functional as F
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.fla.ops.layernorm_guard import layernorm_fn
+from vllm.model_executor.layers.mamba.linear_attn import (
+    clear_linear_attention_cache_for_new_sequences,
+    linear_attention_decode,
+    linear_attention_prefill_and_mix,
+)
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.attention.backends.linear_attn import LinearAttentionMetadata
+
+from vllm_ascend.ops.triton.mamba.lightning_attn import (
+    LightningAttentionKernelNPU,
+)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.models.bailing_moe_linear import BailingMoELinearAttention
+
+
+def _prefill_and_mix_infer_npu(
+    self: BailingMoELinearAttention,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kv_cache: torch.Tensor,
+    state_indices_tensor: torch.Tensor,
+    attn_metadata: LinearAttentionMetadata,
+) -> torch.Tensor:
+    return linear_attention_prefill_and_mix(
+        q=q,
+        k=k,
+        v=v,
+        kv_cache=kv_cache,
+        state_indices_tensor=state_indices_tensor,
+        attn_metadata=attn_metadata,
+        slope_rate=self.tp_slope,
+        block_size=self.BLOCK,
+        decode_fn=self._decode_infer,
+        prefix_fn=LightningAttentionKernelNPU.jit_linear_forward_prefix_npu,
+        layer_idx=self.layer_id,
+    )
+
+
+def _decode_infer_npu(self, q, k, v, kv_cache, state_indices_tensor, attn_metadata):
+    """Handle decode (single token per sequence)."""
+    hidden = linear_attention_decode(
+        q,
+        k,
+        v,
+        kv_cache,
+        self.tp_slope,
+        state_indices_tensor,
+        q_start=0,
+        q_end=attn_metadata.num_decode_tokens,
+        slot_start=0,
+        slot_end=attn_metadata.num_decodes,
+        block_size=32,
+    )
+    return hidden
+
+
+def _forward_npu(
+    self: BailingMoELinearAttention,
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    positions: torch.Tensor,
+) -> None:
+    forward_context = get_forward_context()
+    attn_metadata: AttentionMetadata = forward_context.attn_metadata
+    if attn_metadata is not None:
+        assert isinstance(attn_metadata, dict)
+        attn_metadata = attn_metadata[self.prefix]
+        assert isinstance(attn_metadata, LinearAttentionMetadata)
+        num_actual_tokens = attn_metadata.num_prefill_tokens + attn_metadata.num_decode_tokens
+    else:
+        num_actual_tokens = hidden_states.shape[0]
+
+    # QKV projection
+    qkv, _ = self.query_key_value(hidden_states[:num_actual_tokens])
+
+    qkv = qkv.to(torch.float32)
+    if self.linear_silu:
+        qkv = F.silu(qkv)
+
+    # Split q, k, v
+    q, k, v = torch.split(
+        qkv,
+        [self.q_size_per_rank, self.kv_size_per_rank, self.kv_size_per_rank],
+        dim=-1,
+    )
+
+    # Apply QK norm if needed
+    if self.use_qk_norm:
+        q = q.reshape(-1, self.tp_heads, self.head_dim)
+        k = k.reshape(-1, self.tp_kv_heads, self.head_dim)
+        q = layernorm_fn(
+            q,
+            self.query_layernorm.weight.data,
+            bias=None,
+            eps=self.rms_norm_eps,
+            is_rms_norm=True,
+        )
+        k = layernorm_fn(
+            k,
+            self.key_layernorm.weight.data,
+            bias=None,
+            eps=self.rms_norm_eps,
+            is_rms_norm=True,
+        )
+        q = q.reshape(-1, self.q_size_per_rank)
+        k = k.reshape(-1, self.kv_size_per_rank)
+
+    # Apply rotary embeddings
+    if self.linear_rope:
+        q, k = self.rotary_emb(positions[:num_actual_tokens], q, k)
+
+    # Reshape to [batch, heads, head_dim]
+    q = q.view((qkv.shape[0], self.tp_heads, self.head_dim))
+    k = k.view((qkv.shape[0], self.tp_kv_heads, self.head_dim))
+    v = v.view((qkv.shape[0], self.tp_kv_heads, self.head_dim))
+
+    # Apply scaling if using minimax backend
+    if self.linear_scale:
+        q = q * self.scaling
+
+    # Get KV cache and state indices
+    if attn_metadata is not None:
+        kv_cache = self.kv_cache[0]
+        state_indices_tensor = attn_metadata.state_indices_tensor
+        clear_linear_attention_cache_for_new_sequences(kv_cache, state_indices_tensor, attn_metadata)
+
+    # Compute attention
+    decode_only = getattr(attn_metadata, "num_prefills", 0) == 0
+    if attn_metadata is None:
+        hidden = torch.empty((q.shape[0], q.shape[1] * q.shape[2]), device=q.device, dtype=q.dtype)
+    else:
+        if not decode_only:
+            hidden = self._prefill_and_mix_infer(q, k, v, kv_cache, state_indices_tensor, attn_metadata)
+        else:
+            hidden = self._decode_infer(q, k, v, kv_cache, state_indices_tensor, attn_metadata)
+
+    # Apply group norm and gate (matching SGLang behavior).
+    gate, _ = self.g_proj(hidden_states[:num_actual_tokens])
+
+    hidden = self.g_norm(hidden)
+    hidden = F.sigmoid(gate) * hidden
+
+    hidden = hidden.to(hidden_states.dtype)
+
+    # Output projection
+    dense_out, _ = self.dense(hidden)
+    output[:num_actual_tokens] = dense_out

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -3,10 +3,11 @@ import math
 
 import vllm.model_executor.models.config
 from vllm.logger import logger
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateDtypeCalculator
 from vllm.model_executor.models import ModelRegistry
 from vllm.model_executor.models.config import MambaModelConfig
 from vllm.utils.math_utils import cdiv
-from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size
+from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size, get_kv_cache_torch_dtype
 
 
 @classmethod
@@ -34,11 +35,6 @@ def verify_and_update_config(cls, vllm_config) -> None:
         kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
 
     kernel_block_size = 128
-    # get attention block size
-    attn_num_kv_heads = model_config.get_num_kv_heads(parallel_config)
-    attn_head_size = model_config.get_head_size()
-    attn_single_token_k_page_size = attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
-
     model_cls, _ = ModelRegistry.resolve_model_cls(
         model_config.architecture,
         model_config=model_config,
@@ -52,9 +48,28 @@ def verify_and_update_config(cls, vllm_config) -> None:
         mamba_sizes.append(math.prod(shape) * get_dtype_size(dtype))
     ssm_block_page_size, conv_block_page_size = max(mamba_sizes), min(mamba_sizes)
 
+    # Pure linear attention models (e.g. bailing 2.5) have only SSM state,
+    # no conv block. Detected by a single 3-D mamba shape (ssm only, no conv).
+    # Example shape: MambaSpec(shapes=((8, 128, 128),), mamba_type='linear_attention')
+    if len(mamba_shapes) == 1 and len(mamba_shapes[0]) == 3:
+        conv_block_page_size = 0
+
     # NOTE(zxr): because of the limit of Ascend Hardware, we need to keep
     # all cache tensors contiguous, so we align the page size of ssm_block
     # and single attn_block
+    if model_config.use_mla:
+        attn_num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+        kv_lora_rank = model_config.hf_text_config.kv_lora_rank
+        qk_rope_head_dim = model_config.hf_text_config.qk_rope_head_dim
+        attn_single_token_k_page_size = kv_lora_rank * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+        attn_rope_token_page_size = qk_rope_head_dim * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+        attn_token_page_size = attn_single_token_k_page_size + attn_rope_token_page_size
+    else:
+        attn_num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+        attn_head_size = model_config.get_head_size()
+        attn_single_token_k_page_size = attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+        attn_token_page_size = 2 * attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+
     attn_block_size = kernel_block_size * cdiv(ssm_block_page_size, kernel_block_size * attn_single_token_k_page_size)
     assert attn_single_token_k_page_size * attn_block_size == ssm_block_page_size, (
         "Cannot align ssm_page_size and attn_page_size."
@@ -71,7 +86,7 @@ def verify_and_update_config(cls, vllm_config) -> None:
         )
 
     # compute new attention page size
-    attn_page_size = cache_config.block_size * 2 * attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+    attn_page_size = cache_config.block_size * attn_token_page_size
 
     # pad mamba page size for conv_blocks
     if (
@@ -93,3 +108,19 @@ def verify_and_update_config(cls, vllm_config) -> None:
 
 
 vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config = verify_and_update_config
+
+
+# =============================================================================
+# Patch: Remove float32 validation in linear_attention_state_dtype
+# =============================================================================
+# The original vLLM implementation raises ValueError when mamba_cache_dtype is
+# "float32" because it was not yet tested on GPU. Ascend NPU supports fp32
+# state for linear attention, so we replace the method with one that skips
+# this restriction.
+@classmethod  # type: ignore[misc]
+def _linear_attention_state_dtype_npu(cls, model_dtype, mamba_cache_dtype):
+    state_dtype = get_kv_cache_torch_dtype(mamba_cache_dtype, model_dtype)
+    return (state_dtype,)
+
+
+MambaStateDtypeCalculator.linear_attention_state_dtype = _linear_attention_state_dtype_npu

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -56,3 +56,4 @@ import vllm_ascend.patch.worker.patch_v2.patch_block_table  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
 import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_attn_utils  # noqa
+import vllm_ascend.patch.worker.patch_bailing_moe_linear  # noqa

--- a/vllm_ascend/patch/worker/patch_bailing_moe_linear.py
+++ b/vllm_ascend/patch/worker/patch_bailing_moe_linear.py
@@ -1,0 +1,134 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Patch for BailingMoELinear models to support Ascend NPU.
+
+This module provides NPU-fridendly patches for the following classes:
+- ``BailingMoeLinearMLA``
+- ``BailingMoELinearAttention``
+
+Patches include:
+
+1. **BF16 Rotary Embedding**: Forces BF16 dtype for rotary embedding cache
+   because NPU operators ``npu_interleave_rope`` and ``npu_kv_rmsnorm_rope_cache``
+   do not support FP32 input dtype.
+
+2. **NPU-fridendly Linear Attention Methods**: Replaces GPU-fridendly Triton kernel
+   calls with NPU-fridendly implementations:
+
+   - ``_prefill_and_mix_infer``: uses ``BailingLinearKernelNPU`` instead of
+     ``MiniMaxText01LinearKernel``
+   - ``_decode_infer``: uses ``linear_decode_forward_npu`` instead of
+     ``linear_decode_forward_triton``
+   - ``_forward``: fixes the group-norm branch, replacing it with
+     ``current_platform``-based dispatch.
+"""
+
+import torch
+
+# isort: off
+from vllm.model_executor.models.utils import maybe_prefix
+import vllm.model_executor.models.bailing_moe_linear as bailing_moe_linear
+from vllm_ascend.ops.triton.mamba.linear_attn import (
+    _forward_npu,
+    _prefill_and_mix_infer_npu,
+    _decode_infer_npu,
+)
+
+BailingMoELinearAttention = bailing_moe_linear.BailingMoELinearAttention
+BailingMoeMLAAttention = bailing_moe_linear.BailingMoeV25MLAAttention
+
+# =============================================================================
+# Patch 1: NPU-friendly Linear Attention Methods
+# =============================================================================
+BailingMoELinearAttention._prefill_and_mix_infer = _prefill_and_mix_infer_npu
+BailingMoELinearAttention._forward = _forward_npu
+BailingMoELinearAttention._decode_infer = _decode_infer_npu
+
+
+# =============================================================================
+# Patch 2: BF16 Rotary Embedding
+# =============================================================================
+def _patch_init_to_use_bf16_rope(cls):
+    """Patch a class's __init__ to force BF16 dtype for rotary embedding.
+
+    The NPU operators ``npu_interleave_rope`` and ``npu_kv_rmsnorm_rope_cache``
+    used by MLA/SFA attention backends do not support FP32 input dtype.
+    This patch ensures the rotary embedding cache is created with BF16 dtype.
+
+    The module-level ``get_rope`` is temporarily replaced during ``__init__``
+    and restored afterwards via ``try/finally``, so the patch is contained and
+    does not permanently mutate global state.
+    """
+    original_init = cls.__init__
+    original_get_rope = bailing_moe_linear.get_rope
+
+    def bf16_get_rope(*args, **kwargs):
+        kwargs["dtype"] = torch.bfloat16
+        return original_get_rope(*args, **kwargs)
+
+    def patched_init(self, *args, **kwargs):
+        bailing_moe_linear.get_rope = bf16_get_rope
+        try:
+            original_init(self, *args, **kwargs)
+        finally:
+            bailing_moe_linear.get_rope = original_get_rope
+
+    cls.__init__ = patched_init
+
+
+# Apply BF16 rotary embedding patch to both classes
+_patch_init_to_use_bf16_rope(BailingMoeMLAAttention)
+_patch_init_to_use_bf16_rope(BailingMoELinearAttention)
+
+# =============================================================================
+# Patch 3: Add prefix parameter to ParallelLMHead in BailingMoeV25ForCausalLM
+# =============================================================================
+BailingMoeV25ForCausalLM = bailing_moe_linear.BailingMoeV25ForCausalLM
+
+
+def _patch_causal_lm_lm_head_prefix(cls):
+    """Patch BailingMoeV25ForCausalLM.__init__ to pass prefix to ParallelLMHead.
+
+    The upstream ``BailingMoeV25ForCausalLM.__init__`` constructs ``lm_head``
+    without a ``prefix`` argument, which causes weight-loading key mismatches
+    on Ascend.
+    """
+    original_init = cls.__init__
+    original_parallel_lm_head = bailing_moe_linear.ParallelLMHead
+
+    def patched_init(self, *, vllm_config, prefix=""):
+        def _patched_lm_head_init(inner_self, vocab_size, hidden_size, **kw):
+            kw.setdefault("prefix", maybe_prefix(prefix, "lm_head"))
+            original_parallel_lm_head.__init__(inner_self, vocab_size, hidden_size, **kw)
+
+        _ParallelLMHeadWithPrefix = type(
+            "_ParallelLMHeadWithPrefix",
+            (original_parallel_lm_head,),
+            {"__init__": _patched_lm_head_init},
+        )
+        bailing_moe_linear.ParallelLMHead = _ParallelLMHeadWithPrefix
+        try:
+            original_init(self, vllm_config=vllm_config, prefix=prefix)
+        finally:
+            bailing_moe_linear.ParallelLMHead = original_parallel_lm_head
+
+    cls.__init__ = patched_init
+
+
+# Apply prefix patch to BailingMoeV25ForCausalLM
+_patch_causal_lm_lm_head_prefix(BailingMoeV25ForCausalLM)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -220,6 +220,31 @@ class NPUPlatform(Platform):
         return device_props.uuid
 
     @classmethod
+    def num_compute_units(cls, device_id: int = 0) -> int:
+        """Return the number of Cube Cores on the NPU device.
+        This is the NPU equivalent of CUDA's ``multi_processor_count``
+        (SM count).  On Ascend hardware the closest concept is
+        ``cube_core_num`` exposed by ``torch.npu.get_device_properties``,
+        which represents the matrix-compute units (analogous to CUDA SMs).
+        This value is consumed by vLLM's
+        ``layernorm_guard.calc_rows_per_block`` to size the Triton kernel
+        launch grid.  Note that the result is clamped to 4 by that
+        function, so the exact value has minimal impact on correctness;
+        it only affects kernel occupancy heuristics.
+        """
+        props = torch.npu.get_device_properties(device_id)
+        # cube_core_num is the matrix-compute unit count, semantically
+        # closest to CUDA's multi_processor_count (SM count).
+        cube_core_num = getattr(props, "cube_core_num", None)
+        if cube_core_num is not None and cube_core_num > 0:
+            return int(cube_core_num)
+        # Fallback for older torch-npu versions that may not expose cube_core_num
+        vector_core_num = getattr(props, "vector_core_num", None)
+        if vector_core_num is not None and vector_core_num > 0:
+            return int(vector_core_num)
+        return 24  # safe default (24 Cube Cores)
+
+    @classmethod
     def inference_mode(cls):
         return torch.inference_mode()
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3232,13 +3232,26 @@ class NPUModelRunner(GPUModelRunner):
                             current_kv_cache_spec.head_size,
                         )
                         if self.hybrid_with_attn_and_mamba:
-                            attn_tensor_page_size = int(np.prod(kv_cache_shape[1:])) * get_dtype_size(
-                                current_kv_cache_spec.dtype
-                            )
-                            conv_block_padding_size = raw_k_tensor.numel() - attn_tensor_page_size * 2
-                            raw_kv_tensor = raw_k_tensor[conv_block_padding_size:]
-                            raw_k_tensor = raw_kv_tensor[:attn_tensor_page_size]
-                            raw_v_tensor = raw_kv_tensor[attn_tensor_page_size:]
+                            if not isinstance(current_kv_cache_spec, MLAAttentionSpec):
+                                attn_tensor_page_size = int(np.prod(kv_cache_shape[1:])) * get_dtype_size(
+                                    current_kv_cache_spec.dtype
+                                )
+                                conv_block_padding_size = raw_k_tensor.numel() - attn_tensor_page_size * 2
+                                raw_kv_tensor = raw_k_tensor[conv_block_padding_size:]
+                                raw_k_tensor = raw_kv_tensor[:attn_tensor_page_size]
+                                raw_v_tensor = raw_kv_tensor[attn_tensor_page_size:]
+                            else:
+                                k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
+                                nope_page_size = int(np.prod(kv_cache_shape[:-1])) * k_dim * get_dtype_size(
+                                    current_kv_cache_spec.dtype
+                                )
+                                rope_page_size = int(np.prod(kv_cache_shape[:-1])) * v_dim * get_dtype_size(
+                                    current_kv_cache_spec.dtype
+                                )
+                                conv_block_padding_size = raw_k_tensor.numel() - nope_page_size - rope_page_size
+                                raw_kv_tensor = raw_k_tensor[conv_block_padding_size:]
+                                raw_k_tensor = raw_kv_tensor[:nope_page_size]
+                                raw_v_tensor = raw_kv_tensor[nope_page_size:]
                     else:
                         kv_cache_shape = attn_backend.get_kv_cache_shape(
                             num_blocks,
@@ -3604,6 +3617,7 @@ class NPUModelRunner(GPUModelRunner):
                         dtype=dtype,
                         cache_dtype_str=cache_dtype_str,
                     )
+                    attn_layer_names.add(layer_name)
 
             elif isinstance(attn_module, MambaBase):
                 mamba_layers[layer_name] = attn_module


### PR DESCRIPTION
### Note
This PR will be removed in the near future, and this issue will track the progress: https://github.com/vllm-project/vllm-ascend/issues/8677

### What this PR does / why we need it?
Adapt BaLing 2.5/2.6 series models:
1. Aligned pagesize padding between linear attention and MLA
2. Fixed NPU incompatibility in upstream vLLM lightning_attn implementation:
   - Resolved UB overflow issues
   - Optimized tiling strategy and Triton kernel implementation for better performance
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
ling-2.6-flash

```bash
# High concurrency GSM8K evaluation
evalscope eval \
  --model auto \
  --model-id auto \
  --datasets gsm8k \
  --dataset-dir /datasets/gsm8k\
  --chat-template true \
  --api-url http://localhost:${PORT}/v1\
  --eval-batch-size 32
```
<img width="607" height="92" alt="image" src="https://github.com/user-attachments/assets/8971cd78-855b-4bb6-9794-1bd5d113424e" />


