### PR TITLE
[Feature] Xlite MiniMaxM2 Support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,5 +20,5 @@ soundfile
 pytest_mock
 mindstudio-probe>=8.3.0
 arctic-inference==0.1.1
-xlite==0.1.0rc4
+xlite==0.1.0rc5
 uc-manager

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -24,6 +24,7 @@ from typing import Any, TypeAlias, cast
 
 import torch
 import torch.nn as nn
+import torch_npu
 from transformers import PretrainedConfig
 from vllm.config import VllmConfig
 from vllm.distributed import get_ep_group, get_tensor_model_parallel_world_size, get_world_group
@@ -35,6 +36,7 @@ from xlite._C import AttnMeta, AttnMHA, Model, ModelConfig, Runtime, ScoringFunc
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState, AscendMetadata
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
 from vllm_ascend.xlite.utils import _get_nested_attr
 
 XliteInitResult: TypeAlias = tuple[Model, torch.Tensor, int, torch.dtype]
@@ -369,6 +371,11 @@ class QwenMoeXliteModel(LlamaXliteModel):
             for weight in w2_weight[: _get_nested_attr(layer, "mlp", "experts", "local_num_experts", default=0)]
         ]
 
+        if xlite_model.re_up_gate:
+            self.xlite_config.experts_weight_nz = (
+                torch_npu.get_npu_format(xlite_model.re_up_gate[0]) == ACL_FORMAT_FRACTAL_NZ
+            )
+
 
 class Glm4MoeXliteModel(LlamaXliteModel):
     """xlite adapter for GLM4 MoE architectures."""
@@ -435,6 +442,74 @@ class Glm4MoeXliteModel(LlamaXliteModel):
             for w2_weight_i in w2_weight[: _get_nested_attr(layer, "mlp", "experts", "local_num_experts", default=0)]
         ]
 
+        if xlite_model.re_up_gate:
+            self.xlite_config.experts_weight_nz = (
+                torch_npu.get_npu_format(xlite_model.re_up_gate[0]) == ACL_FORMAT_FRACTAL_NZ
+            )
+
+
+class MiniMaxM2XliteModel(LlamaXliteModel):
+    """xlite adapter for MiniMax M2 architectures."""
+
+    def _build_model_config(self) -> None:
+        super()._build_model_config()
+
+        vllm_config = self.vllm_config
+        hf_config = self.hf_text_config
+        xlite_config = self.xlite_config
+
+        ep_group = get_ep_group()
+        xlite_config.rope_head_dim = hf_config.rotary_dim
+        xlite_config.n_dense_layers = 0
+        xlite_config.n_routed_experts = hf_config.num_local_experts
+        xlite_config.n_shared_experts = 0
+        xlite_config.n_act_experts = hf_config.num_experts_per_tok
+        xlite_config.def_dp_size = vllm_config.parallel_config.data_parallel_size
+        xlite_config.moe_ep_size = ep_group.world_size if vllm_config.parallel_config.enable_expert_parallel else 1
+        xlite_config.moe_tp_size = 1 if vllm_config.parallel_config.enable_expert_parallel else ep_group.world_size
+        xlite_config.experts_weight_transpose = True
+        xlite_config.moe_intermediate_size = hf_config.intermediate_size
+        xlite_config.norm_topk_prob = True
+        xlite_config.qk_norm_full = True
+        xlite_config.scoring_func = ScoringFuncSigmoid
+
+    def _build_model(self) -> None:
+        super()._build_model()
+
+        layers, _ = self._get_layers_and_model_prefix()
+        xlite_model = self.xlite_model
+        xlite_model.gate = [
+            weight
+            for layer in layers
+            if (weight := _get_nested_attr(layer, "block_sparse_moe", "gate", "weight")) is not None
+        ]
+        xlite_model.gate_bias = [
+            bias.to(torch.float32)  # NOTE: type conversion for numerical stability in xlite's implementation
+            for layer in layers
+            if (bias := _get_nested_attr(layer, "block_sparse_moe", "e_score_correction_bias")) is not None
+        ]
+        xlite_model.re_up_gate = [
+            w13_weight_i
+            for layer in layers
+            if (w13_weight := _get_nested_attr(layer, "block_sparse_moe", "experts", "w13_weight")) is not None
+            for w13_weight_i in w13_weight[
+                : _get_nested_attr(layer, "block_sparse_moe", "experts", "local_num_experts", default=0)
+            ]
+        ]
+        xlite_model.re_down = [
+            w2_weight_i
+            for layer in layers
+            if (w2_weight := _get_nested_attr(layer, "block_sparse_moe", "experts", "w2_weight")) is not None
+            for w2_weight_i in w2_weight[
+                : _get_nested_attr(layer, "block_sparse_moe", "experts", "local_num_experts", default=0)
+            ]
+        ]
+
+        if xlite_model.re_up_gate:
+            self.xlite_config.experts_weight_nz = (
+                torch_npu.get_npu_format(xlite_model.re_up_gate[0]) == ACL_FORMAT_FRACTAL_NZ
+            )
+
 
 def xlite_model_init(runnable: nn.Module, vllm_config: VllmConfig) -> XliteInitResult:
     """Construct and initialize an architecture-specific xlite model adapter.
@@ -457,6 +532,7 @@ def xlite_model_init(runnable: nn.Module, vllm_config: VllmConfig) -> XliteInitR
         "Qwen3MoeForCausalLM": QwenMoeXliteModel,
         "Qwen3VLMoeForConditionalGeneration": QwenMoeXliteModel,
         "Glm4MoeForCausalLM": Glm4MoeXliteModel,
+        "MiniMaxM2ForCausalLM": MiniMaxM2XliteModel,
     }
 
     architecture = vllm_config.model_config.architectures[0]


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds support for the MiniMaxM2 architecture in the Xlite runtime adapter. It includes:
- Implementation of `MiniMaxM2XliteModel` to map MiniMaxM2 configuration and weights (gate, experts) to Xlite.
- Enabling `experts_weight_nz` for MoE models (Qwen, GLM4, MiniMaxM2).
- Registration of `MiniMaxM2ForCausalLM` in the Xlite model initialization strategy map.

### Does this PR introduce _any_ user-facing change?
Yes, it enables Xlite acceleration for MiniMaxM2 models on Ascend NPUs.

### How was this patch tested?
- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
