### PR TITLE
[BugFix] Revert change of `balance_flag` to fix DSV3.1 W4A8 TTFT degradation

### DIFF
--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -268,7 +268,7 @@ class BalanceScheduler(Scheduler):
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
-                balance_flag = max(t.item() for t in self.balance_queue) >= self.max_num_running_reqs - 1
+                balance_flag = max(t.item() for t in self.balance_queue) == self.max_num_running_reqs
                 if balance_flag:
                     break
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fix TTFT degradation on Deepseek-V3.1-W4A8. Revert changes of `balance_flag` in https://github.com/vllm-project/vllm-ascend/pull/7611.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
