### PR TITLE
[Doc][v0.13.0] remove duplicate --net=host flag in DeepSeek-V4 tutorial

### DIFF
--- a/docs/source/tutorials/DeepSeek-V4.md
+++ b/docs/source/tutorials/DeepSeek-V4.md
@@ -41,7 +41,6 @@ docker run --rm \
     --name $NAME \
     --net=host \
     --shm-size=1g \
-    --net=host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes a duplicated `--net=host` argument from the `docker run` command in the DeepSeek-V4 tutorial documentation (`docs/source/tutorials/DeepSeek-V4.md`).

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

N/A. This is a trivial markdown fix.
