### PR TITLE
[CI][BugFix] Increase /dev/shm size limit from 15Gi to 128Gi in multi-node LWS template

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -75,7 +75,7 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
-            sizeLimit: 15Gi
+            sizeLimit: 128Gi
         - name: shared-volume
           persistentVolumeClaim:
             claimName: {{ pvc_name | default("nv-action-vllm-benchmarks-v2") }}
@@ -137,7 +137,7 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
-            sizeLimit: 15Gi
+            sizeLimit: 128Gi
         - name: shared-volume
           persistentVolumeClaim:
             claimName: {{ pvc_name | default("nv-action-vllm-benchmarks-v2") }}


### PR DESCRIPTION

### What this PR does / why we need it?
Increase the `dshm` (tmpfs at `/dev/shm`) `sizeLimit` from 15Gi to 128Gi for both leader and worker containers in `lws.yaml.jinja2`.

Large-scale multi-node jobs (e.g., TP=8, DP=4, 32 NPUs total) use HCCL for collective communication. HCCL allocates shared memory buffers under `/dev/shm` for each communicator group (TP, EP, DP, etc.). With `HCCL_BUFFSIZE=1024` and multiple communicator domains, total SHM usage can exceed the previous 15Gi limit, causing HCCL to hang and triggering the EngineCore fatal error: [TimeoutError: RPC call to sample_tokens timed out](https://github.com/vllm-project/vllm-ascend/actions/runs/24900765575/job/72946650584#step:10:4693)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

https://github.com/vllm-project/vllm-ascend/actions/runs/24924577211/job/72992256649?pr=8693

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
