### PR TITLE
[WIP][Feature]Using torch.float8_e8m0fnu instead of torch_npu.float8_e8m0fnu

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -19,7 +19,6 @@ import torch
 import torch_npu
 
 from vllm_ascend.device.mxfp_compat import (
-    FLOAT8_E8M0FNU_DTYPE,
     QUANT_DTYPES,
     SCALE_DTYPES,
 )
@@ -424,8 +423,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             quant_dtype=act_quant_type,
             x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
             weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
-            weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-            x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            weight_scale_dtype=torch.float8_e8m0fnu,
+            x_scale_dtype=torch.float8_e8m0fnu,
         )
         return out, A5DeviceAdaptor.maybe_normalize_mxfp_scale_layout(out_scale), None
 
@@ -573,10 +572,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             kv_cache=decode_k_nope,
             kr_cache=decode_k_pe,
             cache_index=attn_metadata.slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-            dequant_scale_x=dynamic_scale.view(FLOAT8_E8M0FNU_DTYPE),
-            dequant_scale_w_dq=atten_obj.weight_dq_scale.view(FLOAT8_E8M0FNU_DTYPE),
-            dequant_scale_w_uq_qr=atten_obj.weight_uq_qr_scale.view(FLOAT8_E8M0FNU_DTYPE),
-            dequant_scale_w_dkv_kr=atten_obj.weight_dkv_kr_scale.view(FLOAT8_E8M0FNU_DTYPE),
+            dequant_scale_x=dynamic_scale.view(torch.float8_e8m0fnu),
+            dequant_scale_w_dq=atten_obj.weight_dq_scale.view(torch.float8_e8m0fnu),
+            dequant_scale_w_uq_qr=atten_obj.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
+            dequant_scale_w_dkv_kr=atten_obj.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
             cache_mode="PA_BSND",
             query_quant_mode=0,
             weight_quant_mode=3,

--- a/vllm_ascend/device/mxfp_compat.py
+++ b/vllm_ascend/device/mxfp_compat.py
@@ -4,7 +4,6 @@ import torch_npu
 # TODO(linfeng): Temporary compatibility shim for MXFP4/MXFP8 because current torch_npu
 # releases do not expose the required dtype attributes yet. Simplify or remove this
 # file after the torch_npu release in March 2026 includes those dtype symbols.
-FLOAT8_E8M0FNU_DTYPE = getattr(torch_npu, "float8_e8m0fnu", getattr(torch, "float8_e8m0fnu", None))
 FLOAT4_E2M1FN_X2_DTYPE = getattr(torch_npu, "float4_e2m1fn_x2", getattr(torch, "float4_e2m1fn_x2", None))
 HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 
@@ -13,7 +12,7 @@ HIFLOAT8_DTYPE = getattr(torch_npu, "hifloat8", None)
 # specified for some operators like GMM in Ascend950, while float8_e4m3fn does not. Remove these
 # filterations when operators allow to pass data with these three dtypes directly.
 QUANT_DTYPES = tuple(dtype for dtype in (FLOAT4_E2M1FN_X2_DTYPE, HIFLOAT8_DTYPE) if dtype is not None)
-SCALE_DTYPES = tuple(dtype for dtype in (FLOAT8_E8M0FNU_DTYPE,) if dtype is not None)
+SCALE_DTYPES = tuple(dtype for dtype in (torch.float8_e8m0fnu,) if dtype is not None)
 
 
 def _get_missing_symbols(symbols: tuple[str, ...]) -> list[str]:

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -26,7 +26,6 @@ from vllm.distributed import get_ep_group
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.device.mxfp_compat import (
-    FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp4_linear_available,
     ensure_mxfp4_moe_available,
 )
@@ -87,9 +86,9 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
             quantized_x,
             layer.weight,
             layer.weight_scale,
-            scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            scale_dtype=torch.float8_e8m0fnu,
             pertoken_scale=pertoken_scale,
-            pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            pertoken_scale_dtype=torch.float8_e8m0fnu,
             bias=bias,
             output_dtype=output_dtype,
             x1_dtype=torch_npu.float4_e2m1fn_x2,
@@ -233,8 +232,8 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
                 activation=activation,
                 mxfp_act_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
-                mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-                mxfp_per_token_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                mxfp_scale_dtype=torch.float8_e8m0fnu,
+                mxfp_per_token_scale_dtype=torch.float8_e8m0fnu,
                 mxfp_use_bf16=(x.dtype == torch.bfloat16),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -26,7 +26,6 @@ from vllm.distributed import get_ep_group
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.device.mxfp_compat import (
-    FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp8_linear_available,
     ensure_mxfp8_moe_available,
 )
@@ -85,9 +84,9 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
             quantized_x,
             layer.weight,
             layer.weight_scale,
-            scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            scale_dtype=torch.float8_e8m0fnu,
             pertoken_scale=pertoken_scale,
-            pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+            pertoken_scale_dtype=torch.float8_e8m0fnu,
             bias=bias,
             output_dtype=output_dtype,
             group_sizes=[1, 1, self.group_size],
@@ -292,8 +291,8 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
                 activation=activation,
                 mxfp_act_quant_type=torch.float8_e4m3fn,
                 mxfp_weight_quant_type=torch.float8_e4m3fn,
-                mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-                mxfp_per_token_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                mxfp_scale_dtype=torch.float8_e8m0fnu,
+                mxfp_per_token_scale_dtype=torch.float8_e8m0fnu,
                 mxfp_use_bf16=(x.dtype == torch.bfloat16),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,

--- a/vllm_ascend/quantization/quant_parser.py
+++ b/vllm_ascend/quantization/quant_parser.py
@@ -2,7 +2,6 @@ import torch
 
 from vllm_ascend.device.mxfp_compat import (
     FLOAT4_E2M1FN_X2_DTYPE,
-    FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp4_dtype_available,
     ensure_mxfp8_scale_dtype_available,
 )
@@ -13,20 +12,20 @@ class QuantTypeMapping:
         "W8A8_MXFP8": {
             "act_quant_type": torch.float8_e4m3fn,
             "weight_quant_type": None,
-            "scale_dtype": FLOAT8_E8M0FNU_DTYPE,
-            "per_token_scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+            "scale_dtype": torch.float8_e8m0fnu,
+            "per_token_scale_dtype": torch.float8_e8m0fnu,
         },
         "W4A4_MXFP4": {
             "act_quant_type": FLOAT4_E2M1FN_X2_DTYPE,
             "weight_quant_type": FLOAT4_E2M1FN_X2_DTYPE,
-            "scale_dtype": FLOAT8_E8M0FNU_DTYPE,
-            "per_token_scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+            "scale_dtype": torch.float8_e8m0fnu,
+            "per_token_scale_dtype": torch.float8_e8m0fnu,
         },
         "W4A8_MXFP": {
             "act_quant_type": torch.float8_e4m3fn,
             "weight_quant_type": FLOAT4_E2M1FN_X2_DTYPE,
-            "scale_dtype": FLOAT8_E8M0FNU_DTYPE,
-            "per_token_scale_dtype": FLOAT8_E8M0FNU_DTYPE,
+            "scale_dtype": torch.float8_e8m0fnu,
+            "per_token_scale_dtype": torch.float8_e8m0fnu,
         },
     }
 


### PR DESCRIPTION
### What this PR does / why we need it?
- Replace torch_npu.float8_e8m0fnu dtype with torch.float8_e8m0fnu，which is more compatible with both PTA and torch.
-->

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
