### PR TITLE
[Ops][Feature] Support Bailing quantization

### DIFF
--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -243,6 +243,15 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
             "up_proj",
         ],
     },
+    "bailing_hybrid": {
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        "o_proj": ["dense"],
+    },
 }
 
 
@@ -478,7 +487,10 @@ class AscendModelSlimConfig(QuantizationConfig):
         # TODO: remove it when vllm fixes the WeightsMapper bug of qwen3-vl.
         if model_type in ["qwen3_vl"] and prefix == "lm_head":
             prefix = "language_model.lm_head"
-
+        if model_type in ["bailing_hybrid"]:
+            # Adapt to bailing_hybrid architecture: update layer names to MoE convention
+            prefix = prefix.replace("linear_attn", "attention")
+            prefix = prefix.replace("self_attn", "attention")
         if model_type in packed_modules_model_mapping:
             self.packed_modules_mapping = packed_modules_model_mapping[model_type]
         prefix = self.quant_prefix_mapper(model_type, prefix)


### PR DESCRIPTION
### What this PR does / why we need it?

Add ModelSlim quantization configuration support for `bailing_hybrid` model architecture:
- Add `bailing_hybrid` module mapping in `packed_modules_model_mapping`, including:
  - `gate_up_proj`: MoE gate/up projection layers
  - `experts`: expert layer gate/up/down projections
  - `fused_qkv_a_proj`: fused QKV projection
  - `o_proj`: output projection layer
- Fix layer name mapping by unifying `linear_attn` and `self_attn` to `attention` to match quantization weight naming conventions

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
- Verified quantization inference on BaLing 2.5/2.6 series models
