### PR TITLE
[BugFix][EPLB] Validation logic optimization for EPLB and MTP support redundant experts

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -505,10 +505,10 @@ class EplbConfig:
 
     def _validate_config(self):
         if self.expert_map_path is not None:
-            logger.info(f"The expert_map is {self.config['dynamic_eplb']}")
+            logger.info(f"The expert_map is {self.expert_map_path}")
             if self.expert_map_path[-5:] != ".json":
                 raise TypeError("The expert_map is not json.")
-            if not os.path.exists(self.expert_map_path):
+            if not (os.path.exists(self.expert_map_path) and os.access(self.expert_map_path, os.R_OK)):
                 raise ValueError("The expert_map is not exist.")
         if self.expert_map_record_path is not None:
             self.config["dynamic_eplb"] = True
@@ -527,7 +527,7 @@ class EplbConfig:
             assert (
                 os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
                 or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
-            ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the ePLB must be set to true."
+            ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
 
         logger.info(f"Dynamic EPLB is {self.config['dynamic_eplb']}")
         logger.info(f"The number of redundant experts is {self.config['num_redundant_experts']}")

--- a/vllm_ascend/eplb/core/eplb_utils.py
+++ b/vllm_ascend/eplb/core/eplb_utils.py
@@ -16,7 +16,6 @@
 #
 # Todo: Once https://github.com/vllm-project/vllm/issues/22246 is merged in vllm. Remove eplb utils.
 import json
-import os.path
 from collections import defaultdict
 
 import numpy as np
@@ -34,7 +33,9 @@ def expert_file_to_tensor(expert_map_path, layer_id):
         raise ValueError("Invalid EPLB Table")
     if layer_id == data["moe_layer_count"]:
         logger.warning("Init expert map of mtp/eagle when using sample.")
-        return None, None
+        for device in data["layer_list"][0]["device_list"]:
+            physical_count += len(device["device_expert"])
+        return None, physical_count
     for device in data["layer_list"][layer_id]["device_list"]:
         physical_count += len(device["device_expert"])
         device_data.append(device["device_expert"])
@@ -44,6 +45,8 @@ def expert_file_to_tensor(expert_map_path, layer_id):
 
 def generate_global_placement(n_expert, ep_size, n_redundant, num_shared_experts):
     n_expert -= num_shared_experts
+    if (n_expert + n_redundant) % ep_size != 0:
+        raise ValueError("(n_expert + n_redundant) % ep_size must be 0")
     all_experts = np.arange(n_expert)
     groups = np.array_split(all_experts, ep_size)
     for i in range(n_redundant):
@@ -72,16 +75,9 @@ def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num
         return None, None, None, n_redundant
 
     if expert_map_path:
-        if not (os.path.exists(expert_map_path) and os.access(expert_map_path, os.R_OK)):
-            raise ValueError("Invalid EPLB path")
         eplb_enable = True
         global_placement, physical_count = expert_file_to_tensor(expert_map_path, layer_id)
-        if physical_count is not None:
-            n_redundant = physical_count - n_experts
-            if not moe_config.supports_eplb:
-                raise ValueError("Eplb supports only w8a8_dynamic quantization.")
-        else:
-            eplb_enable = False
+        n_redundant = physical_count - n_experts
     elif not eplb_enable:
         _, expert_map, _ = determine_expert_map(ep_size, moe_config.ep_rank, n_experts)
         return None, expert_map, None, 0


### PR DESCRIPTION
### What this PR does / why we need it?
1. The parameter path and quantization type of EPLB are checked for duplicate verification. The subsequent verification is deleted.
2. When the current static load balancing table does not include draft models, the draft models do not use EPLB. However, if the number of redundant experts in each layer is inconsistent, an error will be reported. We ensure that the number of redundant experts in the draft models is consistent with that in the main model.
3. Add a check to ensure that the number of experts actually deployed per card is consistent.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
Test deepseekv3 with `--speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}'`
Sever start success.
<img width="998" height="106" alt="Snipaste_2026-04-25_16-41-34" src="https://github.com/user-attachments/assets/2a88cab8-4930-4e5f-8403-6850c1b4e334" />

The verification takes effect
<img width="918" height="163" alt="Snipaste_2026-04-27_16-18-13" src="https://github.com/user-attachments/assets/e6bfeb77-ffba-4f29-83a3-3a38e25293b9" />



- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
