### PR TITLE
[BugFix] MTP recurrent batch size after lmhead TP logits truncation

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -940,6 +940,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             return torch.stack(draft_token_ids_list, dim=1)
 
         # Generate the remaining draft tokens.
+        batch_size = draft_token_ids.shape[0]
         draft_token_ids_tensor = torch.zeros(
             (self.num_speculative_tokens, *draft_token_ids.shape), dtype=draft_token_ids.dtype, device=self.device
         )

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -944,7 +944,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # However, when lmhead_tp_enable() is disabled, the batch size uses the length after padding.
         # To decouple the scenarios, a judgment is required.
         # That is, the batch size needs to be modified only when lmhead_tp_enable() is enabled.
-        if lmhead_tp_enable():
+        if lmhead_tp_enable() and self.method == "mtp":
             batch_size = draft_token_ids.shape[0]
 
         # Generate the remaining draft tokens.

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -499,13 +499,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
 
-            # The logits are split and then merged only when lmhead_tp_enable() is enabled.
-            # As a result, the batch size length becomes the actual length 32.
-            # However, when lmhead_tp_enable() is disabled, the batch size uses the length after padding.
-            # To decouple the scenarios, a judgment is required. That is, the batch size needs to be modified only when lmhead_tp_enable() is enabled.
-            if lmhead_tp_enable():
-                batch_size = draft_token_ids.shape[0]
-
             self._runnable(
                 num_input_tokens=num_tokens,
                 batch_size=batch_size,
@@ -946,6 +939,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 draft_token_ids_list.append(draft_token_ids)
             return torch.stack(draft_token_ids_list, dim=1)
 
+        # The logits are split and then merged only when lmhead_tp_enable() is enabled.
+        # As a result, the batch size length becomes the actual length 32.
+        # However, when lmhead_tp_enable() is disabled, the batch size uses the length after padding.
+        # To decouple the scenarios, a judgment is required.
+        # That is, the batch size needs to be modified only when lmhead_tp_enable() is enabled.
+        if lmhead_tp_enable():
+            batch_size = draft_token_ids.shape[0]
+                
         # Generate the remaining draft tokens.
         draft_token_ids_tensor = torch.zeros(
             (self.num_speculative_tokens, *draft_token_ids.shape), dtype=draft_token_ids.dtype, device=self.device

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -947,7 +947,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             return torch.stack(draft_token_ids_list, dim=1)
 
         # Generate the remaining draft tokens.
-        batch_size = draft_token_ids.shape[0]
         draft_token_ids_tensor = torch.zeros(
             (self.num_speculative_tokens, *draft_token_ids.shape), dtype=draft_token_ids.dtype, device=self.device
         )

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -499,6 +499,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
 
+            # The logits are split and then merged only when lmhead_tp_enable() is enabled.
+            # As a result, the batch size length becomes the actual length 32.
+            # However, when lmhead_tp_enable() is disabled, the batch size uses the length after padding.
+            # To decouple the scenarios, a judgment is required. That is, the batch size needs to be modified only when lmhead_tp_enable() is enabled.
+            if lmhead_tp_enable():
+                batch_size = draft_token_ids.shape[0]
+
             self._runnable(
                 num_input_tokens=num_tokens,
                 batch_size=batch_size,

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -946,7 +946,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # That is, the batch size needs to be modified only when lmhead_tp_enable() is enabled.
         if lmhead_tp_enable():
             batch_size = draft_token_ids.shape[0]
-                
+
         # Generate the remaining draft tokens.
         draft_token_ids_tensor = torch.zeros(
             (self.num_speculative_tokens, *draft_token_ids.shape), dtype=draft_token_ids.dtype, device=self.device


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

-  With mtp and lmhead_tensor_parallel_size enabled together, real requests can fail with an error like:
```
RuntimeError: The expanded size of the tensor (1024) must match the 
existing size (32) at non-singleton dimension 0.
Target sizes: [1024]. Tensor sizes: [32]
```
- The failure happens in the recurrent draft loop at:
file

```
self.input_ids[:batch_size] = input_ids
```
- In this path:
  - the incoming batch_size still reflects the graph/padded drafter batch
  - but after compute_logits() under lmhead_tp , draft_token_ids reflects only the real valid sample count
- As a result, the recurrent writeback path can try to write a smaller tensor into a larger slice.

- In _run_merged_draft() , the first sampling step computes:
```
draft_token_ids = logits.argmax(dim=-1)
```
- Under lmhead_tp , logits can be padded for parallel computation and then truncated back to the real valid sample count.
- However, the recurrent draft loop still reuses the original batch_size from the function input, which may represent the padded graph batch rather than the effective sampled token count.
- This creates a semantic mismatch:
  - batch_size : padded/graph batch size
  - draft_token_ids.shape[0] : real effective recurrent batch size
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->