### PR TITLE
[Misc] remove weak_ref_tensor C code

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -37,22 +37,6 @@ namespace vllm_ascend {
     const int64_t size,
     const uint32_t loop_cnt,
     const uint32_t aiv_num);
-    
-  torch::Tensor weak_ref_tensor(torch::Tensor& tensor) {
-    if (!tensor.is_privateuseone()) {
-      throw std::runtime_error("Tensor must be on NPU device");
-    }
-    // Get the raw data pointer
-    void* data_ptr = tensor.data_ptr();
-    // Get tensor sizes and strides
-    std::vector<int64_t> sizes = tensor.sizes().vec();
-    std::vector<int64_t> strides = tensor.strides().vec();
-    // Get tensor options (dtype, device)
-    auto options = tensor.options();
-    // Create a new tensor from the raw data pointer
-    auto new_tensor = at_npu::native::from_blob(data_ptr, sizes, strides, options);
-    return new_tensor;
-  }
 
   extern void bgmv_shrink_impl(
         AscendType type,

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1035,8 +1035,6 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "-> (Tensor y ,Tensor rstd)"
         );
     ops.impl("npu_gemma_rms_norm", torch::kPrivateUse1, &vllm_ascend::npu_gemma_rms_norm);
-    ops.def("weak_ref_tensor(Tensor input) -> Tensor");
-    ops.impl("weak_ref_tensor", torch::kPrivateUse1, &vllm_ascend::weak_ref_tensor);
 
     ops.def(
         "get_masked_input_and_mask(Tensor input, "


### PR DESCRIPTION
we use `torch_npu._C._weak_ref_tensor` instead of custom op, the `weak_ref_tensor` custom op is useless now.

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
