### PR TITLE
[Doc][BugFix] Fix Chinese documentation preview URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,4 @@ python -m http.server -d _build/html/
 Launch your browser and open:
 
 - English version: <http://localhost:8000>
-- Chinese version: <http://localhost:8000/zh_CN>
+- Chinese version: <http://localhost:8000/zh-cn>


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the Chinese documentation preview URL in `docs/README.md`.
- https://github.com/vllm-project/vllm-ascend/issues/8692

The generated Chinese docs path uses `zh-cn`, but the README previously pointed to `zh_CN`, which could lead contributors to open the wrong local preview URL.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
