### PR TITLE
[Doc][BugFix] Remove duplicate `--net=host` in DeepSeek-V4 guide

### DIFF
--- a/docs/source/tutorials/DeepSeek-V4.md
+++ b/docs/source/tutorials/DeepSeek-V4.md
@@ -41,7 +41,6 @@ docker run --rm \
     --name $NAME \
     --net=host \
     --shm-size=1g \
-    --net=host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
This PR removes a duplicated `--net=host` option from the DeepSeek-V4 Docker run command in `docs/source/tutorials/DeepSeek-V4.md`.

The command already sets `--net=host` before `--shm-size=1g`, so the second occurrence is redundant and may confuse users copying the deployment example.

<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
