### PR TITLE
[Ops][BugFix] Fix AttributeError in AscendYaRNRotaryEmbedding

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -280,6 +280,8 @@ class AscendYaRNRotaryEmbedding(YaRNScalingRotaryEmbedding):
         super().__init__(
             head_size, rotary_dim, max_position_embeddings, base, is_neox_style, scaling_factor, dtype, **extra_kwargs
         )
+        vllm_config = get_current_vllm_config()
+        self.use_mtp = vllm_config.speculative_config and vllm_config.speculative_config.method == "mtp"
         _record_cos_sin_cache(self.cos_sin_cache)
 
     def forward_oot(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an `AttributeError` in `AscendYaRNRotaryEmbedding` where the `use_mtp` attribute was not initialized. This attribute is required because `AscendYaRNRotaryEmbedding.forward_oot` delegates to `AscendRotaryEmbedding.forward_oot`, which expects `self.use_mtp` to be defined.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified that `AscendYaRNRotaryEmbedding` now correctly initializes `self.use_mtp` to match the implementation in `AscendRotaryEmbedding`.