### PR TITLE
[SpecDecode][BugFix] Fix draft quarot model loading timeout due to float16 matmul bug on CPU

### DIFF
--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -111,7 +111,7 @@ def make_load_weights(target_model_path, rotation_path):
             if "fc." in name:
                 # anti-rotate fc
                 dtype = loaded_weight.dtype
-                loaded_weight = loaded_weight @ Q3.to(dtype)
+                loaded_weight = (loaded_weight.to(torch.float32) @ Q3.to(torch.float32)).to(dtype)
             if "embed_tokens" in name:
                 includes_embed_tokens = True
             model_weights[name] = loaded_weight
@@ -120,7 +120,9 @@ def make_load_weights(target_model_path, rotation_path):
         # process embedding if drafter does not have embedding
         if not includes_embed_tokens:
             name = "model.embed_tokens.weight"
-            loaded_weight = get_embedding_tensor(target_model_path).to(embed_dtype) @ Q.T.to(embed_dtype)
+            loaded_weight = (get_embedding_tensor(target_model_path).to(torch.float32) @ Q.T.to(torch.float32)).to(
+                embed_dtype
+            )
             model_weights[name] = loaded_weight
 
             includes_embed_tokens = True


### PR DESCRIPTION
### What this PR does / why we need it?
CPU-side float16 torch.matmul has a bug that causes loading timeout when loading EAGLE draft model for kimi QUAROT model. Cast tensors to float32 before matmul and cast back to original dtype afterward.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
