### PR TITLE
[Misc] Cleanup  useless utils

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -95,23 +95,6 @@ class TestUtils(TestBase):
         )
         self.assertTrue(torch.allclose(output, expected))
 
-    def test_aligned_16(self):
-        # align to 16
-        input_tensor = torch.randn(15, 64)
-        output_tensor = utils.aligned_16(input_tensor)
-        self.assertEqual(output_tensor.shape[0], 16)
-
-        # align to 16
-        input_tensor = torch.randn(16, 64)
-        output_tensor = utils.aligned_16(input_tensor)
-        self.assertEqual(output_tensor.shape[0], 16)
-        self.assertTrue(torch.equal(input_tensor, output_tensor))
-
-        # align to 32
-        input_tensor = torch.randn(17, 64)
-        output_tensor = utils.aligned_16(input_tensor)
-        self.assertEqual(output_tensor.shape[0], 32)
-
     @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_enable_custom_op(self):
         result = utils.enable_custom_op()

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# from collections.abc import Iterable
 # mypy: ignore-errors
 
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -12,6 +12,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.triton_utils import HAS_TRITON
+from vllm.utils.math_utils import round_up
 from vllm.v1.attention.backend import (
     AttentionBackend,  # type: ignore
     AttentionCGSupport,
@@ -48,7 +49,6 @@ from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
 from vllm_ascend.quantization.methods import AscendW8A8LinearMethod
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
-    _round_up,
     dispose_layer,
     enable_dsa_cp,
     enable_dsa_cp_with_layer_shard,
@@ -256,7 +256,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         if self.enable_dsa_cp:
             global_tp_size = get_tp_group().world_size
             num_tokens = num_input_tokens
-            num_tokens_pad = _round_up(num_tokens, global_tp_size)
+            num_tokens_pad = round_up(num_tokens, global_tp_size)
             num_tokens_per_device = num_tokens_pad // global_tp_size
             local_start = get_tp_group().rank_in_group * num_tokens_per_device
             local_end_with_pad = local_start + num_tokens_per_device

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group, is_v1_kv_transfer_group
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.utils.math_utils import round_up
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
 from vllm_ascend import envs
@@ -304,12 +305,6 @@ def maybe_save_kv_layer_to_connector(
         return
     # TODO: assert ascendMetadata
     connector.save_kv_layer(layer_name, kv_cache_layer, attn_metadata)
-
-
-def round_up(val: int, align: int) -> int:
-    if align == 0:
-        return 0
-    return -(val // -align) * align
 
 
 def trans_rope_weight(weight, rope_dim):

--- a/vllm_ascend/patch/worker/patch_huanyuan_vl.py
+++ b/vllm_ascend/patch/worker/patch_huanyuan_vl.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# from collections.abc import Iterable
 
 from vllm.transformers_utils.processors.hunyuan_vl import HunYuanVLProcessor
 

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# from collections.abc import Iterable
 # mypy: ignore-errors
 
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -33,6 +33,7 @@ import torch_npu  # noqa: F401
 from packaging.version import InvalidVersion, Version
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
+from vllm.utils.math_utils import round_up
 
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import WeightPrefetchConfig, get_ascend_config
@@ -51,6 +52,7 @@ REGISTERED_ASCEND_OPS = {}
 ACL_FORMAT_FRACTAL_ND = 2
 ACL_FORMAT_FRACTAL_NZ = 29
 
+_ASCEND_DEVICE_TYPE = None
 _CUSTOM_OP_ENABLED = None
 _DEVICE_PRINT_OP_REGISTERED = False
 _CURRENT_STREAM = None
@@ -59,7 +61,7 @@ _WEIGHT_PREFETCH_METHOD = None
 _GLOBAL_STREAM = None
 _SHARED_EXPERTS_CALCULATION_STREAM = None
 _CP_CHUNKEDPREFILL_COMM_STREAM = None
-_ASCEND_CUSTOMOP_IS_REIGISTERED = False
+_ASCEND_CUSTOMOP_IS_REGISTERED = False
 _DEFAULT_BUFFER_SIZE = 200
 _MIN_DP_BUFFER_SIZE = 50
 _DYNAMIC_EPLB_BUFFER_SIZE = 100
@@ -185,16 +187,6 @@ def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
     return torch_npu.npu_format_cast(weight, ACL_FORMAT_FRACTAL_NZ)
 
 
-def _round_up(x: int, align: int):
-    # round up x to align, for example, if align is 16, x will be rounded up to 16, 32, 48, etc.
-    # input: 15, 16 -> output: 16
-    # input: 17, 16 -> output: 32
-    # input: 30, 16 -> output: 32
-    # input: 33, 16 -> output: 48
-    # ...
-    return (x + align - 1) // align * align
-
-
 def _custom_pad(x, pad_dims):
     # pad the input tensor to the shape of pad_dims
     # input: (13, 30), pad_dims: [0, 2, 0, 3]
@@ -220,17 +212,17 @@ def nd_to_nz_2d(in_tensor: torch.Tensor) -> torch.Tensor:
     # in_tensor: (13, 30)
     aux_dims = [1, 0, 0, 16]
     # aux_dims[1]: 16
-    aux_dims[1] = _round_up(in_tensor.size(0), 16)
+    aux_dims[1] = round_up(in_tensor.size(0), 16)
     # aux_dims[2]: 2
-    aux_dims[2] = _round_up(in_tensor.size(1), 16) // 16
+    aux_dims[2] = round_up(in_tensor.size(1), 16) // 16
 
     # after: aux_dims: [1, 16, 2, 16]
 
     pad_dims = [0, 0, 0, 0]
     # pad_dims[1]: 2
-    pad_dims[1] = _round_up(in_tensor.size(1), 16) - in_tensor.size(1)
+    pad_dims[1] = round_up(in_tensor.size(1), 16) - in_tensor.size(1)
     # pad_dims[3]: 3
-    pad_dims[3] = _round_up(in_tensor.size(0), 16) - in_tensor.size(0)
+    pad_dims[3] = round_up(in_tensor.size(0), 16) - in_tensor.size(0)
 
     # after: pad_dims: [0, 2, 0, 3]
 
@@ -249,28 +241,6 @@ def nd_to_nz_spec(mask_tensor: torch.Tensor) -> torch.Tensor:
     mask_tensor_pad[0][:num_tokens, :max_seq_len] = mask_tensor
     mask = mask_tensor_pad.reshape((1, tokens_pad, max_seq_len_pad // 16, 16)).permute(0, 2, 1, 3)
     return mask
-
-
-def aligned_16(tensor: torch.Tensor):
-    """Aligned tensor for 310P"""
-
-    # Get the size of the current 0th dimension
-    n = tensor.size(0)
-
-    # Calculate the aligned size
-    n_aligned = ((n + 15) // 16) * 16
-
-    # If already aligned, return the original tensor
-    if n == n_aligned:
-        return tensor
-
-    # Create a new tensor with shape (n_aligned, H, W) and fill it with zeros
-    new_tensor = torch.zeros(n_aligned, *tensor.shape[1:], dtype=tensor.dtype, device=tensor.device)
-
-    # Copy the original tensor to the first N positions of the new tensor
-    new_tensor[:n] = tensor
-
-    return new_tensor
 
 
 def enable_custom_op():
@@ -617,8 +587,8 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     NOTE: if the register branch requires model type, please use `vllm.config.get_current_vllm_config`,
     and ensure this will execute after model config is initilazed.
     """
-    global _ASCEND_CUSTOMOP_IS_REIGISTERED
-    if _ASCEND_CUSTOMOP_IS_REIGISTERED:
+    global _ASCEND_CUSTOMOP_IS_REGISTERED
+    if _ASCEND_CUSTOMOP_IS_REGISTERED:
         return
     from vllm.model_executor.custom_op import CustomOp
 
@@ -722,7 +692,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)
 
     # NOTE: Keep this at last to ensure all custom actions are registered
-    _ASCEND_CUSTOMOP_IS_REIGISTERED = True
+    _ASCEND_CUSTOMOP_IS_REGISTERED = True
 
 
 class AscendDeviceType(Enum):
@@ -732,19 +702,16 @@ class AscendDeviceType(Enum):
     A5 = 3
 
 
-_ascend_device_type = None
-
-
 def _init_ascend_device_type():
-    global _ascend_device_type
+    global _ASCEND_DEVICE_TYPE
     from vllm_ascend import _build_info  # type: ignore
 
-    _ascend_device_type = AscendDeviceType[_build_info.__device_type__]
+    _ASCEND_DEVICE_TYPE = AscendDeviceType[_build_info.__device_type__]
 
 
 def check_ascend_device_type():
-    global _ascend_device_type
-    if _ascend_device_type is None:
+    global _ASCEND_DEVICE_TYPE
+    if _ASCEND_DEVICE_TYPE is None:
         _init_ascend_device_type()
 
     soc_version = torch_npu.npu.get_soc_version()
@@ -759,17 +726,17 @@ def check_ascend_device_type():
     else:
         raise RuntimeError(f"Can not support soc_version: {soc_version}.")
 
-    assert _ascend_device_type == cur_device_type, (
+    assert cur_device_type == _ASCEND_DEVICE_TYPE, (
         f"Current device type: {cur_device_type} does not match the installed version's device type: "
-        f"{_ascend_device_type}, please check your installation package."
+        f"{_ASCEND_DEVICE_TYPE}, please check your installation package."
     )
 
 
 def get_ascend_device_type():
-    global _ascend_device_type
-    if _ascend_device_type is None:
+    global _ASCEND_DEVICE_TYPE
+    if _ASCEND_DEVICE_TYPE is None:
         _init_ascend_device_type()
-    return _ascend_device_type
+    return _ASCEND_DEVICE_TYPE
 
 
 def lmhead_tp_enable() -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR cleans up unused utility functions (such as `aligned_16`) and standardizes the use of `round_up` by importing it from `vllm.utils.math_utils` instead of maintaining multiple local implementations. It also renames the internal global `_ascend_device_type` to `_ASCEND_DEVICE_TYPE` for better naming consistency across the codebase.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests were updated to reflect the removal of deleted utilities, and CI was used to verify the changes.

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
