### PR TITLE
[Refactor][Misc] Use lazy formatting for log

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -270,8 +270,10 @@ def parse_args():
     )
     args = parser.parse_args()
     logger.info(
-        f"Decoder hosts will access Proxy host:port/metaserver, ensure that {set(args.decoder_hosts)} "
-        f"can access {args.host}:{args.port}/metaserver"
+        "Decoder hosts will access Proxy host:port/metaserver, ensure that %s can access %s:%s/metaserver",
+        set(args.decoder_hosts),
+        args.host,
+        args.port,
     )
     # Wildcard address is not allowed for layerwise connector
     if args.host in ["0.0.0.0", "::", "0:0:0:0:0:0:0:0"]:
@@ -356,12 +358,12 @@ async def send_request_to_service(
                 result_future.set_result(response.json()["kv_transfer_params"])
             return
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning(f"Attempt {attempt} failed for {endpoint}: {str(e)}")
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for {endpoint}.")
+                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
                 raise last_exc
 
 
@@ -385,22 +387,22 @@ async def stream_service_response_with_retry(
                 return  # Success, exit after streaming
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             if attempt < max_retries:
-                logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise e
         except Exception as e:
             # If any chunk has been sent, do not retry, just log and drop
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error(f"Streaming to client interrupted after response started: {str(e)}")
+                logger.error("Streaming to client interrupted after response started: %s", e)
                 return
             else:
                 if attempt < max_retries:
-                    logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                     await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
                 else:
-                    logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                     raise e
 
 
@@ -478,7 +480,7 @@ async def _handle_completions(api: str, request: Request):
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
-                            logger.debug(f"Skipping chunk: {chunk}")
+                            logger.debug("Skipping chunk: %s", chunk)
                             yield chunk
                             continue
                         if not chunk_str:
@@ -489,7 +491,7 @@ async def _handle_completions(api: str, request: Request):
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
                             # if chunk is [done], skip it.
-                            logger.debug(f"Skipping chunk: {chunk_str}")
+                            logger.debug("Skipping chunk: %s", chunk_str)
                             yield chunk
                             continue
                         choices = chunk_json.get("choices", [])
@@ -528,9 +530,11 @@ async def _handle_completions(api: str, request: Request):
                         yield chunk
             except Exception as e:
                 logger.error(
-                    f"Error during streaming from decoder {decoder.url}: {str(e)} "
-                    f"the aborted request {request_id} will be routing to the target "
-                    "prefiller when new request is ready to dispatch to it"
+                    "Error during streaming from decoder %s: %s the aborted request %s "
+                    "will be routing to the target prefiller when new request is ready to dispatch to it",
+                    decoder.url,
+                    e,
+                    request_id,
                 )
 
             # After streaming done, release tokens
@@ -582,12 +586,12 @@ async def metaserver(request: Request):
         request_id = get_origin_request_id(api, request_id)
         req_data["kv_transfer_params"] = kv_transfer_params
         prefiller_score = proxy_state.calculate_prefill_scores(request_length)
-        logger.debug(f"Request length: {request_length}, Prefiller score: {prefiller_score}")
+        logger.debug("Request length: %s, Prefiller score: %s", request_length, prefiller_score)
 
         # Select prefiller
         prefiller_idx = proxy_state.select_prefiller(prefiller_score)
         prefiller = proxy_state.prefillers[prefiller_idx]
-        logger.debug(f"Using prefill {prefiller.url=} {req_data=}")
+        logger.debug("Using prefill prefiller.url=%r req_data=%r", prefiller.url, req_data)
         # Send request to prefiller
         await send_request_to_service(
             prefiller.client,
@@ -602,7 +606,7 @@ async def metaserver(request: Request):
         proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 
     except Exception as e:
-        logger.error(f"Post metaserver failed with: {str(e)}")
+        logger.error("Post metaserver failed with: %s", e)
         proxy_state.release_prefiller(prefiller_idx, prefiller_score)
         proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -373,7 +373,7 @@ class ProxyState:
             return False
 
         if self.request_num > 0:
-            logger.warning(f"Start to taint prefill instances {instances}.")
+            logger.warning("Start to taint prefill instances %s.", instances)
             self._taint_prefillers(instances)
             return True
 
@@ -399,7 +399,7 @@ class ProxyState:
             return False
 
         if self.request_num > 0:
-            logger.warning(f"Start to taint decode instances {instances}.")
+            logger.warning("Start to taint decode instances %s.", instances)
             self._taint_decoders(instances)
             return True
 
@@ -608,12 +608,12 @@ async def send_request_to_service(
             response.raise_for_status()
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning(f"Attempt {attempt} failed for {endpoint}: {str(e)}")
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for {endpoint}.")
+                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
                 raise last_exc
 
 
@@ -637,28 +637,28 @@ async def stream_service_response_with_retry(
                 return  # Success, exit after streaming
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             if attempt < max_retries:
-                logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise e
         except Exception as e:
             # If any chunk has been sent, do not retry, just log and drop
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error(f"Streaming to client interrupted after response started: {str(e)}")
+                logger.error("Streaming to client interrupted after response started: %s", e)
                 return
             else:
                 if attempt < max_retries:
-                    logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                     await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
                 else:
-                    logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                     raise e
 
 
 async def _handle_select_instance(api: str, req_data: Any, request_length: int):
     prefiller_score = proxy_state.calculate_prefill_scores(request_length)
-    logger.debug(f"Request length: {request_length}, Prefiller score: {prefiller_score}")
+    logger.debug("Request length: %s, Prefiller score: %s", request_length, prefiller_score)
     request_id = await proxy_state.next_req_id()
     # Select prefiller
     prefiller_idx = proxy_state.select_prefiller(prefiller_score)
@@ -752,7 +752,7 @@ async def _handle_completions(api: str, request: Request):
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
-                            logger.debug(f"Skipping chunk: {chunk}")
+                            logger.debug("Skipping chunk: %s", chunk)
                             yield chunk
                             continue
                         if not chunk_str:
@@ -763,7 +763,7 @@ async def _handle_completions(api: str, request: Request):
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
                             # if chunk is [done], skip it.
-                            logger.debug(f"Skipping chunk: {chunk_str}")
+                            logger.debug("Skipping chunk: %s", chunk_str)
                             yield chunk
                             continue
                         choices = chunk_json.get("choices", [])
@@ -804,9 +804,11 @@ async def _handle_completions(api: str, request: Request):
                         yield chunk
             except Exception as e:
                 logger.error(
-                    f"Error during streaming from decoder {instance_info.decoder.url}: {str(e)} "
-                    f"the aborted request {instance_info.request_id} will be routing to the target "
-                    "prefiller when new request is ready to dispatch to it"
+                    "Error during streaming from decoder %s: %s the aborted request %s "
+                    "will be routing to the target prefiller when new request is ready to dispatch to it",
+                    instance_info.decoder.url,
+                    e,
+                    instance_info.request_id,
                 )
                 proxy_state.abort_prefiller_request(instance_info.prefiller_idx, instance_info.request_id)
                 proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
@@ -866,7 +868,7 @@ async def _handle_adjust_instances(adjust_mode: str, request: Request):
             "current_decode_instances": [str(decoder) for decoder in proxy_state.decoders],
         }
     except Exception as e:
-        logger.error(f"Failed to {adjust_mode} instances: {e}")
+        logger.error("Failed to %s instances: %s", adjust_mode, e)
         raise e
 
 

--- a/examples/epd_disaggregated/epd_load_balance_proxy_layerwise_server_example.py
+++ b/examples/epd_disaggregated/epd_load_balance_proxy_layerwise_server_example.py
@@ -384,12 +384,12 @@ async def send_request_to_encode_service(
             response.raise_for_status()
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning(f"Attempt {attempt} failed for {endpoint}: {str(e)}")
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for {endpoint}.")
+                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
                 raise last_exc
 
 
@@ -413,21 +413,21 @@ async def stream_service_response_with_retry(
                 return
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             if attempt < max_retries:
-                logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise e
         except Exception as e:
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error(f"Streaming to client interrupted after response started: {str(e)}")
+                logger.error("Streaming to client interrupted after response started: %s", e)
                 return
             else:
                 if attempt < max_retries:
-                    logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                     await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
                 else:
-                    logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                     raise e
 
 
@@ -623,7 +623,7 @@ async def _handle_completions(api: str, request: Request):
                     ):
                         yield chunk
                 except Exception as e:
-                    logger.error(f"Error during streaming from pd {pd.url}: {str(e)}")
+                    logger.error("Error during streaming from pd %s: %s", pd.url, e)
                     proxy_state.abort_pd_request(pd_idx, request_id)
                 finally:
                     proxy_state.release_pd(pd_idx, token_score)
@@ -662,8 +662,11 @@ async def _handle_completions(api: str, request: Request):
                         yield chunk
                 except Exception as e:
                     logger.error(
-                        f"Error during streaming from decoder {decoder.url}: {str(e)} the aborted request {request_id} \
-                            will be routing to the target prefiller when new request is ready to dispatch to it"
+                        "Error during streaming from decoder %s: %s the aborted request %s "
+                        "will be routing to the target prefiller when new request is ready to dispatch to it",
+                        decoder.url,
+                        e,
+                        request_id,
                     )
 
                 # After streaming done, release tokens
@@ -732,12 +735,12 @@ async def send_request_to_service(
                 result_future.set_result(response.json()["kv_transfer_params"])
             return
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning(f"Attempt {attempt} failed for {endpoint}: {str(e)}")
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for {endpoint}.")
+                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
                 raise last_exc
 
 
@@ -752,12 +755,12 @@ async def metaserver(request: Request):
         req_data, token_score, api = proxy_state.req_data_dict[request_id]
         request_id = get_origin_request_id(api, request_id)
         req_data["kv_transfer_params"] = kv_transfer_params
-        logger.debug(f"Prefiller score: {token_score}")
+        logger.debug("Prefiller score: %s", token_score)
 
         # Select prefiller
         prefiller_idx = proxy_state.select_prefiller(token_score)
         prefiller = proxy_state.prefillers[prefiller_idx]
-        logger.debug(f"Using prefill {prefiller.url=} {req_data=}")
+        logger.debug("Using prefill prefiller.url=%r req_data=%r", prefiller.url, req_data)
         # Send request to prefiller
         _ = await send_request_to_service(
             prefiller.client,
@@ -772,7 +775,7 @@ async def metaserver(request: Request):
         proxy_state.release_prefiller_kv(prefiller_idx, token_score)
 
     except Exception as e:
-        logger.error(f"Post metaserver failed with: {str(e)}")
+        logger.error("Post metaserver failed with: %s", e)
         proxy_state.release_prefiller(prefiller_idx, token_score)
         proxy_state.release_prefiller_kv(prefiller_idx, token_score)
 

--- a/examples/external_online_dp/dp_load_balance_proxy_server.py
+++ b/examples/external_online_dp/dp_load_balance_proxy_server.py
@@ -252,22 +252,22 @@ async def stream_service_response_with_retry(
                 return  # Success, exit after streaming
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             if attempt < max_retries:
-                logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise e
         except Exception as e:
             # If any chunk has been sent, do not retry, just log and drop
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error(f"Streaming to client interrupted after response started: {str(e)}")
+                logger.error("Streaming to client interrupted after response started: %s", e)
                 return
             else:
                 if attempt < max_retries:
-                    logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                     await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
                 else:
-                    logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                     raise e
 
 
@@ -277,14 +277,17 @@ async def _select_instance(api: str, req_data: Any, request_length: int):
     ignore_eos = req_data.get("ignore_eos", False)
     priority_score = proxy_state.calculate_request_score(request_length, max_tokens=max_tokens, ignore_eos=ignore_eos)
     logger.debug(
-        f"Request length: {request_length}, max tokens: {max_tokens}, "
-        f"ignore_eos: {ignore_eos}, Priority score: {priority_score}"
+        "Request length: %s, max tokens: %s, ignore_eos: %s, Priority score: %s",
+        request_length,
+        max_tokens,
+        ignore_eos,
+        priority_score,
     )
     request_id = await proxy_state.next_req_id()
     # Select dp server based on priority score
     server_idx = proxy_state.select_server(priority_score)
     chosen_server = proxy_state.dp_servers[server_idx]
-    logger.debug(f"Choose server {chosen_server.url} to process request {request_id}")
+    logger.debug("Choose server %s to process request %s", chosen_server.url, request_id)
     return InstanceInfo(
         request_id=request_id, server_idx=server_idx, priority_score=priority_score, server_state=chosen_server
     )
@@ -320,8 +323,10 @@ async def _handle_completions(api: str, request: Request):
                     yield chunk
             except Exception as e:
                 logger.error(
-                    f"Error during streaming from server {instance_info.server_state.url}: {str(e)}, "
-                    f"the aborted request is: {instance_info.request_id}."
+                    "Error during streaming from server %s: %s, the aborted request is: %s.",
+                    instance_info.server_state.url,
+                    e,
+                    instance_info.request_id,
                 )
 
             # After streaming done, release tokens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,12 +81,11 @@ ignore = [
     "B007",
     # f-string format
     "UP032",
-    # TODO: FIE ME
-    "G004",
     "B904",
     "SIM108",
     "SIM102"
 ]
+logger-objects = ["vllm.logger.logger"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,15 @@ logger = logging.getLogger(__name__)
 def check_or_set_default_env(cmake_args, env_name, env_variable, default_path=""):
     if env_variable is None:
         logging.warning(
-            f"No {env_name} found in your environment, pleause try to set {env_name} "
-            "if you customize the installation path of this library, otherwise default "
-            "path will be adapted during build this project"
+            "No %s found in your environment, pleause try to set %s if you customize the installation path of this "
+            "library, otherwise default path will be adapted during build this project",
+            env_name,
+            env_name,
         )
-        logging.warning(f"Set default {env_name}: {default_path}")
+        logging.warning("Set default %s: %s", env_name, default_path)
         env_variable = default_path
     else:
-        logging.info(f"Found existing {env_name}: {env_variable}")
+        logging.info("Found existing %s: %s", env_name, env_variable)
     # cann package seems will check this environments in cmake, need write this env variable back.
     if env_name == "ASCEND_HOME_PATH":
         os.environ["ASCEND_HOME_PATH"] = env_variable
@@ -186,7 +187,7 @@ def gen_build_info():
     with open(package_dir, "w+") as f:
         f.write("# Auto-generated file\n")
         f.write(f"__device_type__ = '{device_type}'\n")
-    logging.info(f"Generated _build_info.py with SOC version: {soc_version}")
+    logging.info("Generated _build_info.py with SOC version: %s", soc_version)
 
 
 class CMakeExtension(Extension):
@@ -350,7 +351,7 @@ class cmake_build_ext(build_ext):
         # Default build tool to whatever cmake picks.
 
         cmake_args += [source_dir]
-        logging.info(f"cmake config command: {cmake_args}")
+        logging.info("cmake config command: %s", cmake_args)
         try:
             subprocess.check_call(cmake_args, cwd=self.build_temp)
         except subprocess.CalledProcessError as e:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -234,7 +234,7 @@ class RemoteOpenAIServer:
         env["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
         if env_dict is not None:
             env.update(env_dict)
-        logger.info(f"Starting server with command: {' '.join(server_cmd)}")
+        logger.info("Starting server with command: %s", " ".join(server_cmd))
         self.proc: subprocess.Popen = subprocess.Popen(
             server_cmd,
             env=env,
@@ -376,11 +376,11 @@ class RemoteOpenAIServer:
                     resp = client.get(url)
                     if resp.status_code == 200:
                         ready[node_ip] = True
-                        logger.info(f"[READY] Node {node_ip}: {url} is ready.")
+                        logger.info("[READY] Node %s: %s is ready.", node_ip, url)
                 except RequestException:
                     all_ready = False
                     if should_log:
-                        logger.debug(f"[WAIT] {url}: connection failed")
+                        logger.debug("[WAIT] %s: connection failed", url)
 
                     # check unexpected exit
                     result = self._poll()

--- a/tools/vllm_bench.py
+++ b/tools/vllm_bench.py
@@ -112,16 +112,16 @@ class VllmbenchRunner:
         stdout, stderr = self.proc.communicate()
 
         if self.proc.returncode != 0:
-            logging.error(f"vllm bench command failed, return code: {self.proc.returncode}")
-            logging.error(f"Standard output: {stdout}")
-            logging.error(f"Standard error: {stderr}")
+            logging.error("vllm bench command failed, return code: %s", self.proc.returncode)
+            logging.error("Standard output: %s", stdout)
+            logging.error("Standard error: %s", stderr)
             raise RuntimeError(f"vllm bench command execution failed: {stderr}")
 
-        logging.info(f"vllm bench command completed, return code: {self.proc.returncode}")
+        logging.info("vllm bench command completed, return code: %s", self.proc.returncode)
         if stdout:
             lines = stdout.split("\n")
             last_lines = lines[-100:] if len(lines) > 100 else lines
-            logging.info(f"Last {len(last_lines)} lines of standard output:")
+            logging.info("Last %s lines of standard output:", len(last_lines))
             for line in last_lines:
                 logging.info(line)
         else:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -72,9 +72,10 @@ class AscendConfig:
         self.layer_sharding = additional_config.get("layer_sharding", None)
         if self.layer_sharding:
             logger.info_once(
-                f"Linear layer sharding enabled with config: {self.layer_sharding}. "
+                "Linear layer sharding enabled with config: %s. "
                 "Note: This feature works optimally with FLASHCOMM2 and DSA-CP enabled; "
-                "using it without these features may result in significant performance degradation."
+                "using it without these features may result in significant performance degradation.",
+                self.layer_sharding,
             )
 
         self.enable_shared_expert_dp = (
@@ -97,9 +98,10 @@ class AscendConfig:
                     cdiv(vllm_config.scheduler_config.max_num_batched_tokens, tp_pcp_size) * tp_pcp_size
                 )
                 logger.warning_once(
-                    f"When using FLASHCOMM1, the max_num_batched_tokens should be divisible"
-                    f"by tp_size * pcp_size ({tp_pcp_size}). It has been adjusted to"
-                    f"{vllm_config.scheduler_config.max_num_batched_tokens}."
+                    "When using FLASHCOMM1, the max_num_batched_tokens should be divisible "
+                    "by tp_size * pcp_size (%s). It has been adjusted to %s.",
+                    tp_pcp_size,
+                    vllm_config.scheduler_config.max_num_batched_tokens,
                 )
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
@@ -323,7 +325,7 @@ class FinegrainedTPConfig:
             if module_tp_size > 0 and vllm_config.parallel_config.data_parallel_size % module_tp_size != 0:
                 raise AssertionError("module tp sizes must divide data_parallel_size")
         if any(size > 0 for size in module_tp_sizes) and enabled_configs:
-            logger.info(f"finegrained_tp_config enabled: {', '.join(enabled_configs)}")
+            logger.info("finegrained_tp_config enabled: %s", ", ".join(enabled_configs))
 
 
 class AscendCompilationConfig:
@@ -416,8 +418,9 @@ class XliteGraphConfig:
                 )
             if vllm_config.cache_config.block_size != 128:
                 logger.warning(
-                    f"Current cache block size is {vllm_config.cache_config.block_size}, which may not be optimal or "
-                    f"compatible with xlite graph mode. The recommended block size for xlite graph mode is 128."
+                    "Current cache block size is %s, which may not be optimal or compatible with xlite graph mode. "
+                    "The recommended block size for xlite graph mode is 128.",
+                    vllm_config.cache_config.block_size,
                 )
 
 
@@ -505,7 +508,7 @@ class EplbConfig:
 
     def _validate_config(self):
         if self.expert_map_path is not None:
-            logger.info(f"The expert_map is {self.expert_map_path}")
+            logger.info("The expert_map is %s", self.expert_map_path)
             if self.expert_map_path[-5:] != ".json":
                 raise TypeError("The expert_map is not json.")
             if not (os.path.exists(self.expert_map_path) and os.access(self.expert_map_path, os.R_OK)):
@@ -529,8 +532,8 @@ class EplbConfig:
                 or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
             ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
 
-        logger.info(f"Dynamic EPLB is {self.config['dynamic_eplb']}")
-        logger.info(f"The number of redundant experts is {self.config['num_redundant_experts']}")
+        logger.info("Dynamic EPLB is %s", self.config["dynamic_eplb"])
+        logger.info("The number of redundant experts is %s", self.config["num_redundant_experts"])
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/compilation/passes/sequence_parallelism.py
+++ b/vllm_ascend/compilation/passes/sequence_parallelism.py
@@ -209,10 +209,10 @@ class SequenceParallelismPass(VllmInductorPass):
     def __call__(self, graph: torch.fx.Graph):
         self.begin()
         self.noop_cleanup(graph)  # Eliminate redundant view-like operations
-        logger.debug(f"after noop_cleanup {graph.graph}")
+        logger.debug("after noop_cleanup %s", graph.graph)
         self.matched_count = self.patterns.apply(graph)
         logger.debug("Replaced %s patterns", self.matched_count)
-        logger.debug(f"after apply replacement {graph.graph}")
+        logger.debug("after apply replacement %s", graph.graph)
 
         from torch._inductor.pattern_matcher import PatternPrettyPrinter
 
@@ -230,5 +230,5 @@ class SequenceParallelismPass(VllmInductorPass):
         Check if the pass is applicable for the current configuration.
         """
         applicable = compile_range.start >= self.min_tokens
-        logger.debug(f"SequenceParallelismPass {compile_range=} {applicable=}")
+        logger.debug("SequenceParallelismPass compile_range=%r applicable=%r", compile_range, applicable)
         return applicable

--- a/vllm_ascend/compilation/passes/sequence_parallelism_moe.py
+++ b/vllm_ascend/compilation/passes/sequence_parallelism_moe.py
@@ -186,9 +186,9 @@ class SequenceParallelismMoePass(VllmInductorPass):
 
     def __call__(self, graph: torch.fx.Graph):
         self.begin()
-        logger.debug(f"before apply replacement {graph}")
+        logger.debug("before apply replacement %s", graph)
         self.matched_count = self.patterns.apply(graph)
-        logger.debug(f"after apply replacement {graph}")
+        logger.debug("after apply replacement %s", graph)
         logger.debug("SequenceParallelismMoePass replaced %s patterns", self.matched_count)
         pattern_idx = 0
         for pattern_entry in self.patterns.patterns.values():
@@ -200,5 +200,5 @@ class SequenceParallelismMoePass(VllmInductorPass):
 
     def is_applicable_for_range(self, compile_range: Range) -> bool:
         applicable = compile_range.start >= self.min_tokens
-        logger.debug(f"SequenceParallelismMoePass {compile_range=} {applicable=}")
+        logger.debug("SequenceParallelismMoePass compile_range=%r applicable=%r", compile_range, applicable)
         return applicable

--- a/vllm_ascend/compilation/passes/utils/npugraph_ex_utils_check.py
+++ b/vllm_ascend/compilation/passes/utils/npugraph_ex_utils_check.py
@@ -36,17 +36,17 @@ def extra_stream_scope_check(match: Match) -> bool:
                 non_default_streams.add(current_stream)
                 if len(non_default_streams) > 1:
                     logger.debug(
-                        f"Cross-stream operation detected in pattern match for AddRMSNormQuant. "
-                        f"Multiple streams found: {non_default_streams}. "
-                        f"Fusion is not supported for cross-stream operations."
+                        "Cross-stream operation detected in pattern match for AddRMSNormQuant. "
+                        "Multiple streams found: %s. Fusion is not supported for cross-stream operations.",
+                        non_default_streams,
                     )
                     return False
 
     if has_default and len(non_default_streams) > 0:
         logger.debug(
-            f"Cross-stream operation detected in pattern match for AddRMSNormQuant. "
-            f"Multiple streams found: {non_default_streams}. "
-            f"Fusion is not supported for cross-stream operations."
+            "Cross-stream operation detected in pattern match for AddRMSNormQuant. "
+            "Multiple streams found: %s. Fusion is not supported for cross-stream operations.",
+            non_default_streams,
         )
         return False
 
@@ -69,7 +69,7 @@ def check_and_register_fusion_pass(pattern_class: type, **kwargs):
         _register_patterns.add(pattern_key)
     except RuntimeError as e:
         if "Duplicate pattern" in str(e):
-            logger.warning(f"Pattern {pattern_class.__name__} eps {eps} has been registered")
+            logger.warning("Pattern %s eps %s has been registered", pattern_class.__name__, eps)
             _register_patterns.add(pattern_key)
         else:
             raise e

--- a/vllm_ascend/core/scheduler_dynamic_batch.py
+++ b/vllm_ascend/core/scheduler_dynamic_batch.py
@@ -43,8 +43,9 @@ class BudgetRefiner:
         if not self.enabled:
             return
         logger.info(
-            "Dynamic batch is enabled with SLO limit: {}, and chunked prefill is "
-            "forced to be activated because dynamic batch relies on it".format(str(slo_limit))
+            "Dynamic batch is enabled with SLO limit: %s, and chunked prefill is "
+            "forced to be activated because dynamic batch relies on it",
+            slo_limit,
         )
         self.lookup: dict[tuple[int, int], int] = {}
         self.context_keys: set[int] = set()
@@ -96,7 +97,7 @@ class BudgetRefiner:
             return self.default_budget
         budget = self.lookup.get((aligned_ctx, aligned_dnum), None)
         if budget is None:
-            logger.warn(f"Table miss for ctx,dnum{aligned_ctx, aligned_dnum}")
+            logger.warning("Table miss for ctx,dnum%s", (aligned_ctx, aligned_dnum))
             budget = self.default_budget
         # For debug.
         # logger.info(

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -32,7 +32,7 @@ def is_arm_cpu() -> bool:
         return False
     if arch in {"aarch64", "arm64"} or arch.startswith("arm"):
         return True
-    logger.warning(f"Unknown CPU architecture '{arch}', CPU binding will be disabled.")
+    logger.warning("Unknown CPU architecture '%s', CPU binding will be disabled.", arch)
     return False
 
 
@@ -279,9 +279,17 @@ class CpuAlloc:
         extra = total_cpu % total_npus
 
         logger.debug(
-            f"[cpu_global_slice] rank:{self.rank_id} ASCEND_RT_VISIBLE_DEVICES={ASCEND_RT_VISIBLE_DEVICES} "
-            f"running_npu_list:{running} total_npus:{total_npus} allowed_cpus:{total_cpu} "
-            f"base:{base} extra:{extra} allowed_cpus_head:{allowed[:16]} allowed_cpus_tail:{allowed[-16:]}"
+            "[cpu_global_slice] rank:%s ASCEND_RT_VISIBLE_DEVICES=%s running_npu_list:%s total_npus:%s "
+            "allowed_cpus:%s base:%s extra:%s allowed_cpus_head:%s allowed_cpus_tail:%s",
+            self.rank_id,
+            ASCEND_RT_VISIBLE_DEVICES,
+            running,
+            total_npus,
+            total_cpu,
+            base,
+            extra,
+            allowed[:16],
+            allowed[-16:],
         )
 
         # Enforce per-NPU slice length >= 5.
@@ -317,7 +325,9 @@ class CpuAlloc:
         self.build_cpu_node_map()
 
         mode = self._binding_mode()
-        logger.info(f"[cpu_bind_mode] mode={mode} rank={self.rank_id} visible_npus={self.device_info.running_npu_list}")
+        logger.info(
+            "[cpu_bind_mode] mode=%s rank=%s visible_npus=%s", mode, self.rank_id, self.device_info.running_npu_list
+        )
         if mode == GLOBAL_SLICE_MODE:
             self.build_global_slice_cpu_pool()
             return
@@ -369,7 +379,7 @@ class CpuAlloc:
         main = " ".join(map(str, self.assign_main[current_npu]))
         acl = " ".join(map(str, self.assign_acl[current_npu]))
         rel = str(self.assign_rel[current_npu]) if self.assign_rel[current_npu] else ""
-        logger.info(f"NPU{current_npu}: main=[{main}]  acl=[{acl}]  release=[{rel}]")
+        logger.info("NPU%s: main=[%s]  acl=[%s]  release=[%s]", current_npu, main, acl, rel)
 
     def bind_memory(self, pid: str, npu: int) -> None:
         def _get_npu_numa_node(npu_id: int) -> int | None:
@@ -384,14 +394,14 @@ class CpuAlloc:
             return
         target_numa = _get_npu_numa_node(npu)
         if target_numa is None:
-            logger.warning(f"[migrate] rank:{self.rank_id} -> NPU{npu} has no CPU pool, skip memory binding.")
+            logger.warning("[migrate] rank:%s -> NPU%s has no CPU pool, skip memory binding.", self.rank_id, npu)
             return
         all_numa_nodes = sorted(self.numa_to_cpu_map.keys())
         if target_numa not in all_numa_nodes:
-            logger.warning(f"[migrate] NPU:{npu} -> NUMA {target_numa} not found, skip memory binding.")
+            logger.warning("[migrate] NPU:%s -> NUMA %s not found, skip memory binding.", npu, target_numa)
             return
         # Bind memory to the NPU's NUMA node only to minimize cross-NUMA traffic.
-        logger.info(f"[migrate] NPU:{npu} -> NUMA [{target_numa}]")
+        logger.info("[migrate] NPU:%s -> NUMA [%s]", npu, target_numa)
         execute_command(
             [
                 "migratepages",
@@ -421,7 +431,7 @@ class CpuAlloc:
         # Only bind IRQ for current rank's NPU to avoid multi-process overwrite.
         current_npu = self.device_info.running_npu_list[self.rank_id]
         if current_npu not in self.npu_cpu_pool:
-            logger.warning(f"[irq] rank:{self.rank_id} -> NPU{current_npu} has no cpu pool, skip irq binding.")
+            logger.warning("[irq] rank:%s -> NPU%s has no cpu pool, skip irq binding.", self.rank_id, current_npu)
             return
 
         if shutil.which("systemctl"):
@@ -445,7 +455,7 @@ class CpuAlloc:
         npu = current_npu
         cpus = self.npu_cpu_pool[npu]
         if len(cpus) < 2:
-            logger.warning(f"[irq] NPU{npu} cpu pool too small (<2), skip irq binding.")
+            logger.warning("[irq] NPU%s cpu pool too small (<2), skip irq binding.", npu)
             return
 
         sq_cpu, cq_cpu = cpus[0], cpus[1]  # Reserved for IRQ binding
@@ -467,13 +477,13 @@ class CpuAlloc:
                 break
 
         if not pci_addr:
-            logger.warning(f"Can't find pci address of NPU{npu} .")
+            logger.warning("Can't find pci address of NPU%s .", npu)
             return
 
         try:
             npu_irq_list = sorted(os.listdir(f"/sys/bus/pci/devices/{pci_addr}/msi_irqs/"), key=lambda x: int(x))
         except FileNotFoundError:
-            logger.warning(f"The msi_irqs folder cannot be found under /sys/bus/pci/devices/{pci_addr} .")
+            logger.warning("The msi_irqs folder cannot be found under /sys/bus/pci/devices/%s .", pci_addr)
             return
 
         sq_irq, cq_irq = "", ""
@@ -483,12 +493,17 @@ class CpuAlloc:
                 cq_irq = str(int(irq) + 1)
                 break
         if not sq_irq:
-            logger.warning(f"The sq_send_trigger_irq of NPU{npu} is not found.")
+            logger.warning("The sq_send_trigger_irq of NPU%s is not found.", npu)
             return
 
         logger.info(
-            f"NPU{npu}(PCI {pci_addr}): sq_send_trigger_irq IRQ_ID={sq_irq} -> CPU{sq_cpu}, "
-            f"cq_update_irq IRQ_ID={cq_irq} -> CPU{cq_cpu}"
+            "NPU%s(PCI %s): sq_send_trigger_irq IRQ_ID=%s -> CPU%s, cq_update_irq IRQ_ID=%s -> CPU%s",
+            npu,
+            pci_addr,
+            sq_irq,
+            sq_cpu,
+            cq_irq,
+            cq_cpu,
         )
         with open(f"/proc/irq/{sq_irq}/smp_affinity", "w") as f:
             f.write(self.cpu_to_mask(sq_cpu))

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -2,6 +2,7 @@
 import contextlib
 import copy
 import hashlib
+import logging
 import math
 import os
 import queue
@@ -243,13 +244,14 @@ class KVCacheSendingThread(threading.Thread):
                 self.ready_event.set()
                 self.run_busy_loop(sock)
         except Exception as e:
-            logger.error("Mooncake KVCacheSendingThread exception: %s", e, exc_info=True)
+            logger.exception("Mooncake KVCacheSendingThread exception: %s", e)
 
     def run_busy_loop(self, sock: zmq.Socket):  # type: ignore
         encoder = msgspec.msgpack.Encoder()
         encoded_data = encoder.encode(self.metadata)
         size_in_bytes = len(encoded_data)
-        logger.debug("Size of encoded MooncakeAgentMetadata: %s bytes", str(size_in_bytes))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Size of encoded MooncakeAgentMetadata: %s bytes", str(size_in_bytes))
 
         decoder = msgspec.msgpack.Decoder(type=tuple)
         while True:
@@ -386,7 +388,7 @@ class KVCacheRecvingThread(threading.Thread):
         """Add a new request to the queue for processing."""
         if remote_port_send_num is None:
             remote_port_send_num = {}
-        logger.debug(f"Adding request {request_id} to the queue.")
+        logger.debug("Adding request %s to the queue.", request_id)
         self.request_queue.put(
             {
                 "request_id": request_id,
@@ -423,7 +425,7 @@ class KVCacheRecvingThread(threading.Thread):
                     continue
                 self._handle_request(request_data)
             except Exception as e:
-                logger.error(f"Error in KVCacheTransferThread: {e}")
+                logger.error("Error in KVCacheTransferThread: %s", e)
 
     def _handle_request(self, req_meta: dict[str, Any]):
         request_id = req_meta["request_id"]
@@ -434,11 +436,11 @@ class KVCacheRecvingThread(threading.Thread):
         all_task_done = req_meta["all_task_done"]
 
         try:
-            logger.debug(f"Starting to transfer KV cache for request {remote_request_id}.")
+            logger.debug("Starting to transfer KV cache for request %s.", remote_request_id)
             self._transfer_kv_cache(req_meta)
-            logger.debug(f"Finished transferring KV cache for request {remote_request_id}.")
+            logger.debug("Finished transferring KV cache for request %s.", remote_request_id)
         except Exception as e:
-            logger.error(f"Failed to transfer KV cache for request {remote_request_id}: {e}", exc_info=True)
+            logger.exception("Failed to transfer KV cache for request %s: %s", remote_request_id, e)
         finally:
             self._send_done_signal_to_free_remote_port(remote_request_id, remote_host, remote_port_send_num)
             if all_task_done:
@@ -522,7 +524,7 @@ class KVCacheRecvingThread(threading.Thread):
         local_kv_caches_base_addrs = self.kv_caches_base_addr[self.local_engine_id][self.local_handshake_port][
             first_layer_index * num_cache_per_layer : end_layer_index * num_cache_per_layer
         ]
-        logger.debug(f"transfer kv cache first_layer_index:{first_layer_index} , end_layer_index:{end_layer_index}")
+        logger.debug("transfer kv cache first_layer_index:%s , end_layer_index:%s", first_layer_index, end_layer_index)
         remote_transfer_port = self.remote_te_port[remote_engine_id][remote_handshake_port]
         num_blocks = len(local_block_ids)
         session_id = f"{remote_host}:{remote_transfer_port}"
@@ -730,7 +732,8 @@ class KVCacheRecvingThread(threading.Thread):
             resp = ensure_zmq_recv(
                 sock, self.remote_poller, f"{remote_host}:{remote_handshake_port}", timeout=self.timeout
             )
-            logger.debug(f"Received response for request {request_id}: {resp.decode('utf-8')}")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Received response for request %s: %s", request_id, resp.decode("utf-8"))
             if resp != b"ACK":
                 logger.error(
                     "Failed to receive ACK for request %s from %s:%d", request_id, remote_host, remote_handshake_port
@@ -740,7 +743,7 @@ class KVCacheRecvingThread(threading.Thread):
             if isinstance(sock, zmq.Socket):  # type: ignore
                 sock.close()
                 sock = None
-                logger.warning(f"Unexpected error occurred in socket, {e}, closing the original channel")
+                logger.warning("Unexpected error occurred in socket, %s, closing the original channel", e)
         finally:
             if sock is not None:
                 self._return_remote_socket(sock, remote_host, remote_handshake_port)
@@ -1299,11 +1302,12 @@ class MooncakeConnectorWorker:
             else set()
         )
         if self.tp_rank == 0:
-            logger.debug(
-                "Number of completed KV cache send requests: %d, receive requests: %d",
-                len(done_sending),
-                len(done_recving),
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Number of completed KV cache send requests: %d, receive requests: %d",
+                    len(done_sending),
+                    len(done_recving),
+                )
         return done_sending, done_recving
 
     def _get_kv_split_metadata(
@@ -1520,14 +1524,15 @@ class MooncakeConnectorWorker:
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""
         for req_id, meta in metadata.requests.items():
-            logger.debug(
-                "start_load_kv for request %s from remote engine %s. "
-                "Num local_block_ids: %s. Num remote_block_ids: %s. ",
-                req_id,
-                meta.remote_engine_id,
-                len(meta.local_block_ids),
-                len(meta.remote_block_ids),
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "start_load_kv for request %s from remote engine %s. "
+                    "Num local_block_ids: %s. Num remote_block_ids: %s. ",
+                    req_id,
+                    meta.remote_engine_id,
+                    len(meta.local_block_ids),
+                    len(meta.remote_block_ids),
+                )
 
             prefill_tp_size = meta.remote_ptp_size if getattr(meta, "remote_ptp_size", None) else self._prefill_tp_size
             tp_num_need_pulls = self._get_tp_num_need_pulls(prefill_tp_size)
@@ -1767,10 +1772,10 @@ def ensure_zmq_send(
         except zmq.ZMQError as e:  # type: ignore
             retries_left -= 1
             if retries_left > 0:
-                logger.warning(f"Send failed: {e}, retrying... ({retries_left} attempts left)")
+                logger.warning("Send failed: %s, retrying... (%s attempts left)", e, retries_left)
                 time.sleep(0.1)
             else:
-                logger.error(f"Send failed after all retries: {e}")
+                logger.error("Send failed after all retries: %s", e)
                 raise RuntimeError(f"Failed to send data to {path} after {max_retries} retries: {e}")
 
 
@@ -1792,10 +1797,10 @@ def ensure_zmq_recv(
         except zmq.ZMQError as e:  # type: ignore
             retries_left -= 1
             if retries_left > 0:
-                logger.warning(f"Receive failed: {e}, retrying... ({retries_left} attempts left)")
+                logger.warning("Receive failed: %s, retrying... (%s attempts left)", e, retries_left)
                 time.sleep(0.1)
             else:
-                logger.error(f"Receive failed from {path} after all retries: {e}")
+                logger.error("Receive failed from %s after all retries: %s", path, e)
                 raise RuntimeError(f"Failed to receive data after {max_retries} retries: {e}")
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -1715,7 +1715,7 @@ class MooncakeLayerwiseConnectorWorker:
                 agent_meta: MooncakeAgentMetadata = self.decoder.decode(metadata_bytes)
             except Exception as e:
                 logger.error(
-                    "Query to port and kv base addr for request %sfrom %s:%sfail with error: %s",
+                    "Query to port and kv base addr for request %s from %s:%s fail with error: %s",
                     req_id,
                     req_meta.remote_host,
                     req_meta.remote_port,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -3,6 +3,7 @@
 import contextlib
 import copy
 import hashlib
+import logging
 import math
 import os
 import queue
@@ -270,7 +271,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         try:
             self._transfer_kv_cache(send_task)
         except Exception as e:
-            logger.error(f"Failed to transfer KV cache for layer idx {send_task.layer_idx}, {e}")
+            logger.error("Failed to transfer KV cache for layer idx %s, %s", send_task.layer_idx, e)
 
     def get_transfer_meta(self, send_task: SendTask, req_id: str, req_meta: ReqMeta, layer_group_idx: int):
         src_list: list[int] = []
@@ -482,7 +483,9 @@ class KVCacheSendingLayerThread(threading.Thread):
                 )
                 if ret < 0:
                     logger.error(
-                        f"Mooncake transfer failed for send requests {transfer_meta.req_ids} kv cache to {session_id}"
+                        "Mooncake transfer failed for send requests %s kv cache to %s",
+                        transfer_meta.req_ids,
+                        session_id,
                     )
                     if send_task.layer_idx == (self.total_layers - 1):
                         for req_id in transfer_meta.req_ids:
@@ -813,7 +816,7 @@ class MooncakeLayerwiseConnectorScheduler:
             remote_cached_tokens = request.num_computed_tokens
             # Get unhashed blocks to pull from remote.
             logger.debug(
-                f"MooncakeLayerwiseConnector update_state_after_alloc: add {request.request_id} to need recv queue"
+                "MooncakeLayerwiseConnector update_state_after_alloc: add %s to need recv queue", request.request_id
             )
             self._reqs_need_recv[request.request_id] = (
                 request,
@@ -823,7 +826,7 @@ class MooncakeLayerwiseConnectorScheduler:
 
             params["do_remote_prefill"] = False
 
-            logger.info(f"Send request: {request.request_id} to proxy metaserver: {params.get('metaserver', None)}")
+            logger.info("Send request: %s to proxy metaserver: %s", request.request_id, params.get("metaserver", None))
             # All parameters here should appear in the returned dict of
             # request_finished in the scheduler side except "request_id".
             # change the format of request_id if vllm-version >= 0.14.0
@@ -850,7 +853,7 @@ class MooncakeLayerwiseConnectorScheduler:
 
                 def handle_exception(future):
                     if future.exception():
-                        logger.error(f"Access metaserver fail: {future.exception()}")
+                        logger.error("Access metaserver fail: %s", future.exception())
 
                 future.add_done_callback(handle_exception)
 
@@ -858,7 +861,7 @@ class MooncakeLayerwiseConnectorScheduler:
         if params is not None and params.get("do_remote_decode"):
             local_block_ids = list(blocks.get_block_ids())
             logger.debug(
-                f"MooncakeLayerwiseConnector update_state_after_alloc: add {request.request_id} to need send queue"
+                "MooncakeLayerwiseConnector update_state_after_alloc: add %s to need send queue", request.request_id
             )
             remote_cache_tokens = params["remote_cached_tokens"]
             local_transferred_tokens = remote_cache_tokens
@@ -936,14 +939,20 @@ class MooncakeLayerwiseConnectorScheduler:
                             local_computed_tokens=local_computed_tokens,
                             local_transed_tokens=local_transed_tokens,
                         )
-                        logger.debug(
-                            f"MooncakeLayerwiseConnector build_connector_meta: {req_id=}"
-                            f"prompt_len={len(request.all_token_ids)} {local_computed_tokens=}"
-                            f"{local_transed_tokens=}"
-                            f"remote_cache_tokens={request.kv_transfer_params.get('remote_cached_tokens')}"
-                            f"{chunk_finish=} {local_block_ids=}"
-                            f"remote_block_ids={request.kv_transfer_params.get('remote_block_ids')}"
-                        )
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "MooncakeLayerwiseConnector build_connector_meta: req_id=%r prompt_len=%s "
+                                "local_computed_tokens=%r local_transed_tokens=%r remote_cache_tokens=%s "
+                                "chunk_finish=%r local_block_ids=%r remote_block_ids=%s",
+                                req_id,
+                                len(request.all_token_ids),
+                                local_computed_tokens,
+                                local_transed_tokens,
+                                request.kv_transfer_params.get("remote_cached_tokens"),
+                                chunk_finish,
+                                local_block_ids,
+                                request.kv_transfer_params.get("remote_block_ids"),
+                            )
 
                     # whether chunk finish
                     chunk_finish = send_req_info.local_computed_tokens >= len(send_req_info.request.all_token_ids)
@@ -962,7 +971,7 @@ class MooncakeLayerwiseConnectorScheduler:
                 self.metaserver_client.post(url, json=message)
                 success = True
             except Exception as e:
-                logger.error(f"Failed to connect to metaserver: {url}, retry {retry} time.")
+                logger.error("Failed to connect to metaserver: %s, retry %s time.", url, retry)
                 if retry == 3:
                     raise e
 
@@ -1103,7 +1112,7 @@ class MooncakeLayerwiseConnectorWorker:
         for tensor in (self.k_buffer, self.v_buffer):
             assert tensor.data_ptr() % alignment == 0, "The address of the registered kv cache should be aligned to 2M"
             ret_value = self.engine.register_memory(tensor.data_ptr(), tensor.numel() * tensor.element_size())
-            logger.info(f"Register memory buffer for transfer, buffer size:{tensor.numel() * tensor.element_size()}")
+            logger.info("Register memory buffer for transfer, buffer size:%s", tensor.numel() * tensor.element_size())
             if ret_value != 0:
                 raise RuntimeError("Mooncake memory registration failed. ")
 
@@ -1172,7 +1181,7 @@ class MooncakeLayerwiseConnectorWorker:
                     lengths.append(
                         num_blocks * single_kv_cache.element_size() * math.prod(block_shape) * block_size_scale
                     )
-                logger.info(f"layer: {layer_name}, num_blocks: {num_blocks}, block_shape: {block_shape}")
+                logger.info("layer: %s, num_blocks: %s, block_shape: %s", layer_name, num_blocks, block_shape)
             self.layer_metadata[layer_name] = single_layer_meta
 
         if self.use_attn_mamba_hybrid:
@@ -1266,7 +1275,7 @@ class MooncakeLayerwiseConnectorWorker:
             self.request_map.pop(req_id, None)
         if len(done_recving) > 0:
             logger.info(
-                f"Number of completed KV cache recv requests: {len(done_recving)}, receive requests: {done_recving}"
+                "Number of completed KV cache recv requests: %s, receive requests: %s", len(done_recving), done_recving
             )
         return set(), done_recving
 
@@ -1315,7 +1324,7 @@ class MooncakeLayerwiseConnectorWorker:
 
         p_cp_group = get_cp_group(self.tp_size, self.total_num_kv_heads, self.dcp_size)
         d_cp_group = get_cp_group(remote_tp_size, self.total_num_kv_heads, remote_dcp_size)
-        logger.debug(f"Compute cp group for P&D {req_id=} {p_cp_group=} {d_cp_group=}")
+        logger.debug("Compute cp group for P&D req_id=%r p_cp_group=%r d_cp_group=%r", req_id, p_cp_group, d_cp_group)
 
         cp_ratio = len(p_cp_group) // len(d_cp_group)
         if cp_ratio == 0:
@@ -1339,9 +1348,11 @@ class MooncakeLayerwiseConnectorWorker:
             return {}
 
         logger.debug(
-            f"MooncakeLayerwiseConnector _get_kv_split_metadata {req_id=} "
-            f"P-side selected head_group cp group: {selected_p_cp_group}, "
-            f"D-side selected head_group cp group: {selected_d_cp_group}"
+            "MooncakeLayerwiseConnector _get_kv_split_metadata req_id=%r "
+            "P-side selected head_group cp group: %s, D-side selected head_group cp group: %s",
+            req_id,
+            selected_p_cp_group,
+            selected_d_cp_group,
         )
 
         context_parallel_parameters_check(
@@ -1647,11 +1658,14 @@ class MooncakeLayerwiseConnectorWorker:
                     req_meta_update = self.update_decoder_info(req_id, req_meta)
                 except Exception as e:
                     logger.warning(
-                        f"MooncakeLayerwiseConnector transfer fail for req_id {req_id} in layer_idx "
-                        f"{self.current_layer}, update_decoder_info with error: {e}"
+                        "MooncakeLayerwiseConnector transfer fail for req_id %s in layer_idx %s, "
+                        "update_decoder_info with error: %s",
+                        req_id,
+                        self.current_layer,
+                        e,
                     )
                     continue
-                logger.debug(f"Add request {req_id} to kv send layer thread. {req_meta_update=}")
+                logger.debug("Add request %s to kv send layer thread. req_meta_update=%r", req_id, req_meta_update)
                 layer_send_task.send_request[req_id] = req_meta_update
 
             self.kv_send_layer_thread.send_queue.put(layer_send_task)
@@ -1701,9 +1715,11 @@ class MooncakeLayerwiseConnectorWorker:
                 agent_meta: MooncakeAgentMetadata = self.decoder.decode(metadata_bytes)
             except Exception as e:
                 logger.error(
-                    f"Query to port and kv base addr for request {req_id}"
-                    f"from {req_meta.remote_host}:{req_meta.remote_port}"
-                    f"fail with error: {e}"
+                    "Query to port and kv base addr for request %sfrom %s:%sfail with error: %s",
+                    req_id,
+                    req_meta.remote_host,
+                    req_meta.remote_port,
+                    e,
                 )
                 raise e
             assert req_meta.remote_engine_id != self.engine_id, (
@@ -1712,9 +1728,13 @@ class MooncakeLayerwiseConnectorWorker:
             self.remote_layer_metadata[req_meta.remote_engine_id][req_meta.remote_port] = agent_meta.layer_metadata
             self.remote_te_port[req_meta.remote_engine_id][req_meta.remote_port] = agent_meta.te_rpc_port
             logger.debug(
-                f"Query to port and kv base addr for request {req_id}"
-                f"from {req_meta.remote_host}:{req_meta.remote_port}"
-                f"success {agent_meta.layer_metadata=} {agent_meta.te_rpc_port=}"
+                "Query to port and kv base addr for request %s from %s:%s success "
+                "agent_meta.layer_metadata=%r agent_meta.te_rpc_port=%r",
+                req_id,
+                req_meta.remote_host,
+                req_meta.remote_port,
+                agent_meta.layer_metadata,
+                agent_meta.te_rpc_port,
             )
             if self.pd_head_ratio > 1:
                 # for tp inequal, pre-create link to prevent alltoall out of memory
@@ -1727,7 +1747,7 @@ class MooncakeLayerwiseConnectorWorker:
                     [128],
                 )
                 if ret < 0:
-                    logger.error(f"Mooncake transfer failed to create link to device {session_id}")
+                    logger.error("Mooncake transfer failed to create link to device %s", session_id)
         req_meta.remote_te_rpc_port = self.remote_te_port[req_meta.remote_engine_id][req_meta.remote_port]
         req_meta.remote_layer_metadata = self.remote_layer_metadata[req_meta.remote_engine_id][req_meta.remote_port]
         return req_meta
@@ -1778,8 +1798,11 @@ class MooncakeLayerwiseConnectorWorker:
                         raise RuntimeError(f"Failed to receive ACK after {max_retries} attempts: {e}") from e
         except Exception as e:
             logger.error(
-                f"Sending done sending signal for request {external_req_id} to "
-                f"{req_meta.remote_host}:{req_meta.remote_port} fail with error: {e}"
+                "Sending done sending signal for request %s to %s:%s fail with error: %s",
+                external_req_id,
+                req_meta.remote_host,
+                req_meta.remote_port,
+                e,
             )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -1861,10 +1884,10 @@ def ensure_zmq_send(
         except zmq.ZMQError as e:  # type: ignore
             retries_left -= 1
             if retries_left > 0:
-                logger.warning(f"Send failed: {e}, retrying... ({retries_left} attempts left)")
+                logger.warning("Send failed: %s, retrying... (%s attempts left)", e, retries_left)
                 time.sleep(0.1)
             else:
-                logger.error(f"Send failed after all retries: {e}")
+                logger.error("Send failed after all retries: %s", e)
                 raise RuntimeError(f"Failed to send data to {path} after {max_retries} retries: {e}")
 
 
@@ -1886,10 +1909,10 @@ def ensure_zmq_recv(
         except zmq.ZMQError as e:  # type: ignore
             retries_left -= 1
             if retries_left > 0:
-                logger.warning(f"Receive failed: {e}, retrying... ({retries_left} attempts left)")
+                logger.warning("Receive failed: %s, retrying... (%s attempts left)", e, retries_left)
                 time.sleep(0.1)
             else:
-                logger.error(f"Receive failed after all retries: {e}")
+                logger.error("Receive failed after all retries: %s", e)
                 raise RuntimeError(f"Failed to receive data from {path} after {max_retries} retries: {e}")
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -64,15 +64,15 @@ class MemcacheBackend(Backend):
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
             for value in res:
                 if value != 0:
-                    logger.error(f"Failed to get key {key},res:{res}")
+                    logger.error("Failed to get key %s,res:%s", key, res)
         except Exception as e:
-            logger.error(f"Failed to get key {key}. {e}")
+            logger.error("Failed to get key %s. %s", key, e)
 
     def put(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         try:
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
             for value in res:
                 if value != 0:
-                    logger.error(f"Failed to get key {key},res:{res}")
+                    logger.error("Failed to get key %s,res:%s", key, res)
         except Exception as e:
-            logger.error(f"Failed to put key {key},error:{e}")
+            logger.error("Failed to put key %s,error:%s", key, e)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -85,18 +85,18 @@ class MooncakeBackend(Backend):
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
             for value in res:
                 if value < 0:
-                    logger.error(f"Failed to put key {keys},res:{res}")
+                    logger.error("Failed to put key %s,res:%s", keys, res)
         except Exception as e:
-            logger.error(f"Failed to put key {keys},error:{e}")
+            logger.error("Failed to put key %s,error:%s", keys, e)
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
             for value in res:
                 if value < 0:
-                    logger.error(f"Failed to get key {keys}, res:{res}")
+                    logger.error("Failed to get key %s, res:%s", keys, res)
         except Exception as e:
-            logger.error(f"Failed to get key {keys}, error:{e}")
+            logger.error("Failed to get key %s, error:%s", keys, e)
 
 
 @dataclass

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -368,7 +368,7 @@ class ReqMeta:
         else:
             # Do not load if not in `can_load` state
             load_spec = None
-        logger.debug(f"request:{tracker.req_id}, meta save spec:{not skip_save}, meta load spec:{load_spec}")
+        logger.debug("request:%s, meta save spec:%s, meta load spec:%s", tracker.req_id, not skip_save, load_spec)
         return ReqMeta(
             req_id=tracker.req_id,
             token_len_chunk=num_tokens_to_save,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1,3 +1,4 @@
+import logging
 import queue
 import threading
 from collections import defaultdict
@@ -80,7 +81,7 @@ class KVTransferThread(threading.Thread):
                     continue
                 self._handle_request(request_data)
             except Exception as e:
-                logger.error(f"Error in KVCacheTransferThread: {e}")
+                logger.error("Error in KVCacheTransferThread: %s", e)
 
     def _handle_request(self, req_meta: Any):
         pass
@@ -100,7 +101,7 @@ class KVTransferThread(threading.Thread):
                 exists_list[index] = value == 1
             return exists_list
         except Exception as e:
-            logger.error(f"Remote connection failed in contains: {e}")
+            logger.error("Remote connection failed in contains: %s", e)
             return [False] * len(keys)
 
     def update_kv_event(self, event: list[BlockStored]):
@@ -190,13 +191,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
         keys = [keys[index] for index in missing_indices]
         block_hashes = [block_hashes[index] for index in missing_indices]
 
-        logger.debug(
-            "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s",
-            len(keys),
-            token_len // self.block_size,
-            len(missing_indices),
-            req_id,
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s",
+                len(keys),
+                token_len // self.block_size,
+                len(missing_indices),
+                req_id,
+            )
 
         if keys:
             """
@@ -229,7 +231,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
                     stored_events.append(stored_event)
                     prev_key = new_block_hashes[index]
-                    logger.debug(f"Added kv cache event '{stored_event}' to kv cache events queue")
+                    logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
             if self.kv_role == "kv_consumer":
                 keys, addrs, sizes = self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import vllm.envs as envs
@@ -336,7 +337,8 @@ class KVPoolScheduler:
             return False, None
         delay_free_blocks = len(block_ids) > 0
         if delay_free_blocks:
-            logger.debug("Delaying free of %d blocks for request %s", len(block_ids), request.request_id)
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Delaying free of %d blocks for request %s", len(block_ids), request.request_id)
         return delay_free_blocks, None
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import math
 import threading
 from collections.abc import Generator
@@ -303,7 +304,7 @@ class KVPoolWorker:
             if self.current_layer == self.num_layers - 1:
                 assert ret_token_mask is not None
                 num_retrieved_tokens = ret_token_mask.sum().item()
-                logger.debug(f"Retrieved {num_retrieved_tokens} tokens")
+                logger.debug("Retrieved %s tokens", num_retrieved_tokens)
 
     def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
         if self.current_layer == 0:
@@ -418,7 +419,7 @@ class KVPoolWorker:
                 yield None
 
         retrieved_tokens = torch.sum(ret_mask)
-        logger.debug(f"Retrieved {retrieved_tokens} out of {num_required_tokens} out of total {token_len} tokens")
+        logger.debug("Retrieved %s out of %s out of total %s tokens", retrieved_tokens, num_required_tokens, token_len)
 
         yield ret_mask
 
@@ -494,12 +495,13 @@ class KVPoolWorker:
             else set()
         )
 
-        logger.debug(
-            "Number of completed KV cache send requests: %d, receive requests: %d, tp_rank:%d",
-            len(done_sending),
-            len(done_recving),
-            self.tp_rank,
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Number of completed KV cache send requests: %d, receive requests: %d, tp_rank:%d",
+                len(done_sending),
+                len(done_recving),
+                self.tp_rank,
+            )
         return done_sending, done_recving
 
     def get_and_clear_finished_requests(self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
@@ -570,7 +572,7 @@ class KVPoolWorker:
                     return starts[index]
             # all tokens where found, return the maximal end
         except Exception as e:
-            logger.error(f"Remote connection failed in contains: {e}")
+            logger.error("Remote connection failed in contains: %s", e)
             return 0
         return end
 
@@ -628,7 +630,7 @@ class KVPoolWorker:
                 return starts[index]
         # all tokens where found, return the maximal end
         except Exception as e:
-            logger.error(f"Remote connection failed in contains: {e}")
+            logger.error("Remote connection failed in contains: %s", e)
             return 0
         return end
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
@@ -151,11 +151,11 @@ class CPUKVCacheManager:
         return req_to_new_blocks
 
     def record_request_cache_and_free_slots(self, request: Request):
-        logger.debug(f"record_request_cache_and_free_slots for request {request.request_id} in cpu_kv_cache_manager")
+        logger.debug("record_request_cache_and_free_slots for request %s in cpu_kv_cache_manager", request.request_id)
         self.req_to_free[request.request_id] = request
 
     def cache_and_free_slots(self, request_id: str):
-        logger.debug(f"Cache and free slots for request {request_id} in cpu_kv_cache_manager")
+        logger.debug("Cache and free slots for request %s in cpu_kv_cache_manager", request_id)
         if request_id not in self.req_to_free:
             logger.Error(f"request {request_id} not in req_to_free, maybe bug!")
             return
@@ -166,7 +166,7 @@ class CPUKVCacheManager:
                 self.req_to_num_tokens[request_id],
             )
         self._free_slots(request_id)
-        logger.debug(f"delete request {request_id} in cpu_kv_cache_manager req_to_free")
+        logger.debug("delete request %s in cpu_kv_cache_manager req_to_free", request_id)
         del self.req_to_free[request_id]
 
     def _free_slots(self, request_id: str):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_offload_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_offload_connector.py
@@ -152,7 +152,7 @@ class CPUOffloadingConnectorScheduler:
             self.swap_in_threshold = vllm_config.kv_transfer_config.get_from_extra_config("swap_in_threshold", 0)
         else:
             self.swap_in_threshold = 0
-        logger.info(f"swap_in_threshold: {self.swap_in_threshold}")
+        logger.info("swap_in_threshold: %s", self.swap_in_threshold)
 
     def get_num_new_matched_tokens(self, ori_request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         request = copy.deepcopy(ori_request)
@@ -271,7 +271,7 @@ class CPUOffloadingConnectorWorker:
                 if self.zmq_rpc_client.call("ready"):
                     break
             except Exception as e:
-                logger.info(f"wait for metadata server to start, error: {e}")
+                logger.info("wait for metadata server to start, error: %s", e)
                 time.sleep(1)
 
     def bind_connector_metadata(self, connector_metadata: CPUOffloadingConnectorMetadata) -> None:
@@ -367,7 +367,7 @@ class CPUOffloadingConnectorWorker:
 
     def _sending_finished(self, all_done_sending):
         for req_id in all_done_sending:
-            logger.debug(f"call cache_and_free_slots for req_id: {req_id}")
+            logger.debug("call cache_and_free_slots for req_id: %s", req_id)
             self.zmq_rpc_client.call("cache_and_free_slots", req_id)
 
     def _save_listener(self):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/metadata.py
@@ -46,7 +46,7 @@ class MetadataServer:
         def __init__(self, identity=None):
             if identity is None:
                 identity = f"worker-{os.getpid()}-{id(self)}"
-            logger.info(f"metadata client for worker {identity} started")
+            logger.info("metadata client for worker %s started", identity)
             self.ctx = zmq.Context()  # type: ignore
             self.socket = make_zmq_socket(
                 self.ctx,
@@ -65,7 +65,7 @@ class MetadataServer:
             response = pickle.loads(self.socket.recv())
             result, error = response
             if error:
-                logger.exception(f"call metadata sever error: {error}")
+                logger.exception("call metadata sever error: %s", error)
                 raise error
             if func_name == "init_cpu_kv_caches":
                 (memory_dict, layer_size, layer_dtype, mla_config) = result
@@ -96,7 +96,7 @@ class MetadataServer:
             "cpu_swap_space_gb", MetadataServer.DEFAULT_CPU_SWAP_SPACE_GB
         )
         self.available_memory = available_memory_gb * 1024 * 1024 * 1024
-        logger.info(f"cpu swap space: {self.available_memory} bytes")
+        logger.info("cpu swap space: %s bytes", self.available_memory)
         self.ctx = zmq.Context()  # type: ignore
         self.socket = make_zmq_socket(
             self.ctx,
@@ -133,7 +133,7 @@ class MetadataServer:
         kv_cache_specs: dict[str, AttentionSpec],
         mla_config: MLAConfig,
     ) -> tuple[dict[str, SharedMemory], tuple[int, ...], torch.dtype, MLAConfig]:
-        logger.info(f"receive pp rank: {pp_rank}, tp rank: {tp_rank}")
+        logger.info("receive pp rank: %s, tp rank: %s", pp_rank, tp_rank)
         # follow the assumption that each layer has the same spec
         layer = next(iter(kv_cache_specs.values()))
         assert all([layer.page_size_bytes == any.page_size_bytes for any in kv_cache_specs.values()])
@@ -177,7 +177,7 @@ class MetadataServer:
         if hasattr(self, "cpu_block_manager"):
             return
         # do shared_memory() at least once
-        logger.info(f"assign cpu num blocks: {self.num_cpu_blocks}")
+        logger.info("assign cpu num blocks: %s", self.num_cpu_blocks)
         assert self.num_cpu_blocks >= 0
         self.cpu_block_manager = CPUKVCacheManager(self.layer, self.num_cpu_blocks)
         self.functions.update(
@@ -203,7 +203,7 @@ class MetadataServer:
                     result = self.functions[func_name](*args, **kwargs)
                     response = (result, None)  # type: ignore
                 except Exception as e:
-                    logger.exception(f"metadata execute error: {e}")
+                    logger.exception("metadata execute error: %s", e)
                     response = (None, e)  # type: ignore
             else:
                 response = (None, NameError(f"Function {func_name} not found"))
@@ -250,7 +250,7 @@ class MetadataServerProc:
             logger.info("Metadata server exiting.")
             raise
         except Exception as e:
-            logger.exception(f"Metadata server error: {e}.")
+            logger.exception("Metadata server error: %s.", e)
             raise e
         finally:
             if metadata_server is not None:

--- a/vllm_ascend/distributed/kv_transfer/utils/utils.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/utils.py
@@ -244,13 +244,17 @@ def get_local_remote_block_port_mappings(
             if head in head_to_d_groups:
                 target_d_ranks.update(head_to_d_groups[head])
             else:
-                logger.info(f"Warning: Head {head} exists in P but not in D mapping.")
+                logger.info("Warning: Head %s exists in P but not in D mapping.", head)
         pd_head_mapping[p_rank] = sorted(list(target_d_ranks))
     logger.debug(
-        f"MooncakeLayerwiseConnector _get_kv_split_metadata {req_id=} "
-        f"P-side logic_block to rank mapping: {p_rank_block_mapping}, "
-        f"D-side logic_block to rank mapping: {d_block_rank_mapping}, "
-        f"P&D head_group_rank mapping: {pd_head_mapping}"
+        "MooncakeLayerwiseConnector _get_kv_split_metadata req_id=%r "
+        "P-side logic_block to rank mapping: %s, "
+        "D-side logic_block to rank mapping: %s, "
+        "P&D head_group_rank mapping: %s",
+        req_id,
+        p_rank_block_mapping,
+        d_block_rank_mapping,
+        pd_head_mapping,
     )
     return p_rank_block_mapping, d_block_rank_mapping, pd_head_mapping, d_trans_count_mapping
 
@@ -294,5 +298,5 @@ def get_transfer_mappings(
             transfer_mappings[(remote_host, remote_port)]["remote_block_ids"].append(d_block_id)
     for (host, port), block_dict in transfer_mappings.items():
         block_dict["trans_count"] = d_trans_count_mapping[(host, port)]
-    logger.debug(f"MooncakeLayerwiseConnector Request {req_id} transfer tasks: {transfer_mappings}")
+    logger.debug("MooncakeLayerwiseConnector Request %s transfer tasks: %s", req_id, transfer_mappings)
     return transfer_mappings

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -133,7 +133,7 @@ class VllmEplbAdaptor:
             self.expert_param_per_layer[layer_id][local_expert_to_replace], self.buffer_tensor_list[buffer_tensor_id]
         ):
             expert_tensor.copy_(buffer_tensor)
-            logger.debug(f"Expert tensor shape is :{expert_tensor.shape}")
+            logger.debug("Expert tensor shape is :%s", expert_tensor.shape)
 
     def do_update_log2phy_map(self, layer_id, updated_log2phy_map):
         if self.log2phy_map_per_layer[layer_id] is not None:

--- a/vllm_ascend/eplb/core/eplb_worker.py
+++ b/vllm_ascend/eplb/core/eplb_worker.py
@@ -70,9 +70,11 @@ class EplbWorker:
             current_mean, current_max = self._compute_imbalance(old_placement, hotness)
             update_mean, update_max = self._compute_imbalance(new_placement, hotness)
             logger.info(
-                "[Expert Hotness] Current: mean={:.3f}, max={:.3f}, Updated: mean={:.3f}, max={:.3f}".format(
-                    current_mean, current_max, update_mean, update_max
-                )
+                "[Expert Hotness] Current: mean=%.3f, max=%.3f, Updated: mean=%.3f, max=%.3f",
+                current_mean,
+                current_max,
+                update_mean,
+                update_max,
             )
 
         if not torch.is_tensor(new_placement):
@@ -96,7 +98,7 @@ class EplbWorker:
         for layer_id in range(num_layers):
             # check if any logical expert is not placed on any rank
             if torch.unique(new_placement[layer_id]).numel() < torch.unique(old_placement[layer_id]).numel():
-                logger.error(f"There exists expert not placed on any rank in layer {layer_id}")
+                logger.error("There exists expert not placed on any rank in layer %s", layer_id)
                 new_placement[layer_id] = old_placement[layer_id]
                 continue
 
@@ -107,8 +109,10 @@ class EplbWorker:
                 # check if same logical experts are placed on the same NPU
                 if new_placement_check.numel() != torch.unique(new_placement_check).numel():
                     logger.error(
-                        "Replicated experts are placed on the same NPU; expert placement on "
-                        f"layer {layer_id}, rank {rank_id} is invalid"
+                        "Replicated experts are placed on the same NPU; "
+                        "expert placement on layer %s, rank %s is invalid",
+                        layer_id,
+                        rank_id,
                     )
                     new_placement[layer_id] = old_placement[layer_id]
                     break
@@ -117,8 +121,9 @@ class EplbWorker:
                 expert_not_move = torch.isin(new_placement_check, old_placement_check)
                 if not torch.equal(new_placement_check[expert_not_move], old_placement_check[expert_not_move]):
                     logger.error(
-                        "There exists expert movement inside NPU; expert placement on "
-                        f"layer {layer_id}, rank {rank_id} is invalid"
+                        "There exists expert movement inside NPU; expert placement on layer %s, rank %s is invalid",
+                        layer_id,
+                        rank_id,
                     )
                     new_placement[layer_id] = old_placement[layer_id]
                     break
@@ -346,7 +351,8 @@ class EplbProcess:
 
             except Exception as e:
                 logger.warning(
-                    f"[EPLB subprocess exiting due to error: {e}]",
+                    "[EPLB subprocess exiting due to error: %s]",
+                    e,
                     exc_info=True,
                 )
                 break

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -70,7 +70,7 @@ class EplbUpdator:
 
         self.process = process
 
-        logger.info(f"[ModelRunner] Launched EPLB process (pid={self.process.pid})")
+        logger.info("[ModelRunner] Launched EPLB process (pid=%s)", self.process.pid)
 
     def update_iteration(self):
         self.cur_iterations += 1
@@ -138,7 +138,7 @@ class EplbUpdator:
             moe_load = moe_load.permute(2, 0, 1, 3)
 
         self.shared_dict["moe_load"] = moe_load
-        logger.debug(f"[ModelRunner] Updated shared_dict['moe_load'] shape={moe_load.shape}")
+        logger.debug("[ModelRunner] Updated shared_dict['moe_load'] shape=%s", moe_load.shape)
 
         return moe_load
 

--- a/vllm_ascend/model_loader/netloader/executor/elastic_load.py
+++ b/vllm_ascend/model_loader/netloader/executor/elastic_load.py
@@ -55,7 +55,9 @@ class P2PLoad:
         - The model if loading is successful, otherwise None.
         """
         model_device = next(model.parameters()).device
-        logger.info(f"Start init_process_group, name: {self.world_name}, addr: {self.source_ip}:{self.source_port}")
+        logger.info(
+            "Start init_process_group, name: %s, addr: %s:%s", self.world_name, self.source_ip, self.source_port
+        )
         receiver_pg = None
         loaded_model = None
         try:
@@ -67,11 +69,11 @@ class P2PLoad:
                 group_name="netloader",
             )
             logger.info(
-                f"Finish init_process_group, name: {self.world_name}, addr: {self.source_ip}:{self.source_port}"
+                "Finish init_process_group, name: %s, addr: %s:%s", self.world_name, self.source_ip, self.source_port
             )
 
-            logger.info(f"Start recv, name: {self.world_name}, addr: {self.source_ip}:{self.source_port}")
-            logger.info(f"Model device: {model_device}")
+            logger.info("Start recv, name: %s, addr: %s:%s", self.world_name, self.source_ip, self.source_port)
+            logger.info("Model device: %s", model_device)
 
             trans_stream = torch_npu.npu.Stream()
             with torch_npu.npu.stream(trans_stream):
@@ -83,10 +85,10 @@ class P2PLoad:
 
             torch_npu.npu.synchronize(trans_stream)
 
-            logger.info(f"Finish recv, name: {self.world_name}, addr: {self.source_ip}:{self.source_port}")
+            logger.info("Finish recv, name: %s, addr: %s:%s", self.world_name, self.source_ip, self.source_port)
             loaded_model = model
         except Exception as e:
-            logger.error("Failed to recv model: {}".format(e))
+            logger.error("Failed to recv model: %s", e)
         finally:
             if receiver_pg:
                 destroy_stateless_process_group(receiver_pg)
@@ -121,7 +123,7 @@ class P2PSend:
         """
         model_device = next(model.parameters()).device
         torch.npu.set_device(model_device)
-        logger.info(f"Start init_process_group, name: {self.comm_name}, addr: {self.listen_ip}:{self.listen_port}")
+        logger.info("Start init_process_group, name: %s, addr: %s:%s", self.comm_name, self.listen_ip, self.listen_port)
         sender_pg = None
         try:
             sender_pg = stateless_init_process_group(
@@ -131,9 +133,11 @@ class P2PSend:
                 world_size=2,
                 group_name="netloader",
             )
-            logger.info(f"Finish init_process_group, name: {self.comm_name}, addr: {self.listen_ip}:{self.listen_port}")
-            logger.info(f"Start send, name: {self.comm_name}, addr: {self.listen_ip}:{self.listen_port}")
-            logger.info(f"Model device: {model_device}")
+            logger.info(
+                "Finish init_process_group, name: %s, addr: %s:%s", self.comm_name, self.listen_ip, self.listen_port
+            )
+            logger.info("Start send, name: %s, addr: %s:%s", self.comm_name, self.listen_ip, self.listen_port)
+            logger.info("Model device: %s", model_device)
 
             trans_stream = torch_npu.npu.Stream()
             with torch_npu.npu.stream(trans_stream):
@@ -146,7 +150,7 @@ class P2PSend:
                         sender_pg.send([param.contiguous()], 0, 0).wait()
                 torch.distributed.barrier(group=sender_pg, device_ids=[model_device.index])
             torch_npu.npu.synchronize(trans_stream)
-            logger.info(f"Finish send, name: {self.comm_name}, addr: {self.listen_ip}:{self.listen_port}")
+            logger.info("Finish send, name: %s, addr: %s:%s", self.comm_name, self.listen_ip, self.listen_port)
         finally:
             if sender_pg:
                 destroy_stateless_process_group(sender_pg)

--- a/vllm_ascend/model_loader/netloader/interaction/elastic.py
+++ b/vllm_ascend/model_loader/netloader/interaction/elastic.py
@@ -59,7 +59,7 @@ class ElasticClient:
                 ip, port_str = source.split(":")
                 port = int(port_str)
             except Exception as e:
-                logger.info(f"IP format error: {source}, detail: {e}")
+                logger.info("IP format error: %s, detail: %s", source, e)
                 continue
 
             self.server_addr = ip
@@ -67,16 +67,16 @@ class ElasticClient:
 
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                logger.info(f"Start connection to server: {self.server_addr}:{self.server_port}")
+                logger.info("Start connection to server: %s:%s", self.server_addr, self.server_port)
                 sock.connect((self.server_addr, self.server_port))
-                logger.info(f"Finish connection to server: {self.server_addr}:{self.server_port}")
+                logger.info("Finish connection to server: %s:%s", self.server_addr, self.server_port)
                 sock.settimeout(60)
 
                 self.s = sock
                 self.ack = self.register(device_id, model_path, tp, pp)
                 break
             except Exception as e:
-                logger.error(f"Connect to {source} fails, detail: {e}")
+                logger.error("Connect to %s fails, detail: %s", source, e)
                 if sock is not None:
                     with suppress(Exception):
                         sock.close()
@@ -93,7 +93,7 @@ class ElasticClient:
             try:
                 self.s.close()
             except Exception as e:
-                logger.error(f"Error closing socket: {e}")
+                logger.error("Error closing socket: %s", e)
             finally:
                 self.s = None
 
@@ -176,7 +176,7 @@ class ElasticClient:
         except Exception as e:
             raise RuntimeError(f"Receive data {ack_str} cannot be converted to JSON format, detail: {e}")
 
-        logger.info(f"Receive ack: {ack}")
+        logger.info("Receive ack: %s", ack)
 
         if (
             "label" in ack
@@ -247,7 +247,7 @@ class ElasticServer:
                         try:
                             self.original_int8[name] = param.data.clone().detach()
                         except RuntimeError as e:
-                            logger.error(f"Failed to cache int8 tensor {name} to HBM, change to DRAM, due to {e}")
+                            logger.error("Failed to cache int8 tensor %s to HBM, change to DRAM, due to %s", name, e)
                             self.original_int8[name] = param.data.cpu()
 
                 elif int8_cache == "dram":
@@ -259,13 +259,19 @@ class ElasticServer:
                     pass
                 else:
                     logger.warning(
-                        f"int8_cache should be selected in [HBM, DRAM], but got {int8_cache}, change to no cache"
+                        "int8_cache should be selected in [HBM, DRAM], but got %s, change to no cache", int8_cache
                     )
 
         logger.info(
-            f"Server {self.addr}:{self.port} starts, device id: {self.device_id}, "
-            f"model path: {self.model_path}, tp: {self.tp}, pp: {self.pp}, "
-            f"int8 params {list(self.original_int8)} are saved to {int8_cache}"
+            "Server %s:%s starts, device id: %s, model path: %s, tp: %s, pp: %s, int8 params %s are saved to %s",
+            self.addr,
+            self.port,
+            self.device_id,
+            self.model_path,
+            self.tp,
+            self.pp,
+            list(self.original_int8),
+            int8_cache,
         )
 
     def __del__(self):
@@ -290,7 +296,7 @@ class ElasticServer:
         """
         while True:
             conn, addr = self.s.accept()
-            logger.info("Accept new connection from {}:{}...".format(*addr))
+            logger.info("Accept new connection from %s:%s...", *addr)
             self.register_handler(conn, addr)
 
     def register_handler(self, conn, addr, buffer_size=1024):
@@ -308,7 +314,7 @@ class ElasticServer:
         try:
             data = json.loads(data_str)
         except Exception:
-            logger.error(f"Failed to load {data_str} as JSON string")
+            logger.error("Failed to load %s as JSON string", data_str)
             conn.close()
             return
 
@@ -360,20 +366,20 @@ class ElasticServer:
                     "content": msg,
                 }
         else:
-            logger.warning(f"Received data does not contain required fields: {data}")
+            logger.warning("Received data does not contain required fields: %s", data)
             ack = {"label": "JOIN_NACK", "content": f"Received data does not contain required fields: {data}"}
 
         try:
             ack_str = json.dumps(ack).encode("utf-8")
         except Exception as e:
-            logger.error(f"Failed to convert {ack} to JSON format, details: {e}")
+            logger.error("Failed to convert %s to JSON format, details: %s", ack, e)
             conn.close()
             return
 
         try:
             conn.send(ack_str)
         except Exception as e:
-            logger.error(f"Failed to send {ack} to {addr}, details: {e}")
+            logger.error("Failed to send %s to %s, details: %s", ack, addr, e)
             conn.close()
             return
 
@@ -382,5 +388,5 @@ class ElasticServer:
                 p2psend = P2PSend(self.addr, data["content"]["port"], ack["content"]["name"])
                 p2psend.send(self.model, self.original_int8)
             except Exception as e:
-                logger.error(f"P2PSend Failed to send model to {self.addr}, details: {e}")
+                logger.error("P2PSend Failed to send model to %s, details: %s", self.addr, e)
         conn.close()

--- a/vllm_ascend/model_loader/netloader/load.py
+++ b/vllm_ascend/model_loader/netloader/load.py
@@ -68,8 +68,8 @@ def elastic_load(
             if model_loaded is None:
                 logger.error("Failed to load model")
                 return None
-            logger.info("Finish elastic load (duration: {}s)".format(time.perf_counter() - t0))
+            logger.info("Finish elastic load (duration: %ss)", time.perf_counter() - t0)
             return model_loaded
     except Exception as e:
-        logger.info(f"elastic_load error: {e}")
+        logger.info("elastic_load error: %s", e)
         return None

--- a/vllm_ascend/model_loader/netloader/netloader.py
+++ b/vllm_ascend/model_loader/netloader/netloader.py
@@ -62,7 +62,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
         extra = load_config.model_loader_extra_config
         if extra and "CONFIG_FILE" in extra:
             try:
-                logger.info(f"Reading configs in file {load_config.model_loader_extra_config['CONFIG_FILE']} ...")
+                logger.info("Reading configs in file %s ...", load_config.model_loader_extra_config["CONFIG_FILE"])
                 with open(extra["CONFIG_FILE"]) as f:
                     config = json.load(f)
             except FileNotFoundError:
@@ -70,7 +70,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
             except json.JSONDecodeError:
                 logger.error("CONFIG_FILE is not a valid JSON file")
             except Exception as e:
-                logger.error(f"Unexpected error while reading CONFIG_FILE: {e}")
+                logger.error("Unexpected error while reading CONFIG_FILE: %s", e)
 
         if config is None and extra:
             logger.info("Reading configs in model_loader_extra_config ...")
@@ -142,7 +142,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
 
         if self.model_path is None:
             self.model_path = model_config.model
-            logger.info(f"model_path is set to {self.model_path}")
+            logger.info("model_path is set to %s", self.model_path)
 
         device_id = torch.distributed.get_rank()
 
@@ -179,7 +179,7 @@ class ModelNetLoaderElastic(BaseModelLoader):
                     pp=parallel_config.pipeline_parallel_size,
                 )
                 end_elastic_load = time.perf_counter()
-                logger.info(f"Elastic load time: {end_elastic_load - start_elastic_load}, rank: {device_id}")
+                logger.info("Elastic load time: %s, rank: %s", end_elastic_load - start_elastic_load, device_id)
                 need_process_weights_after_loading = True
 
                 if model is None:
@@ -219,24 +219,29 @@ class ModelNetLoaderElastic(BaseModelLoader):
                     self.listen_port += device_id
 
                 logger.info(
-                    f"Start elastic Netloader server, rank: {device_id}, listen port: {driver_ip}:{self.listen_port}"
+                    "Start elastic Netloader server, rank: %s, listen port: %s:%s",
+                    device_id,
+                    driver_ip,
+                    self.listen_port,
                 )
 
                 if self.output_prefix is not None:
                     try:
                         with open(self.output_prefix + str(device_id) + ".txt", "w") as file:
                             file.write(f"{driver_ip}:{self.listen_port}")
-                        logger.info(f"Successfully wrote server address to file: {self.output_prefix + str(device_id)}")
+                        logger.info(
+                            "Successfully wrote server address to file: %s", self.output_prefix + str(device_id)
+                        )
                     except FileNotFoundError:
-                        logger.error(f"File path {self.output_prefix + str(device_id)} does not exist.")
+                        logger.error("File path %s does not exist.", self.output_prefix + str(device_id))
                     except PermissionError:
-                        logger.error(f"No permission to write to file {self.output_prefix + str(device_id)}.")
+                        logger.error("No permission to write to file %s.", self.output_prefix + str(device_id))
                     except OSError as e:
                         logger.error(
-                            f"I/O error occurred while writing to file {self.output_prefix + str(device_id)}: {e}"
+                            "I/O error occurred while writing to file %s: %s", self.output_prefix + str(device_id), e
                         )
                     except Exception as e:
-                        logger.error(f"Unknown error: {e}")
+                        logger.error("Unknown error: %s", e)
 
                 try:
                     assert isinstance(self.listen_port, int), f"listen port should be int but get {self.listen_port}"
@@ -254,12 +259,12 @@ class ModelNetLoaderElastic(BaseModelLoader):
                     )
                     elastic_server.start()
                 except Exception as e:
-                    logger.error(f"Failed to start Netloader server for rank: {device_id}, details: {e}")
+                    logger.error("Failed to start Netloader server for rank: %s, details: %s", device_id, e)
         else:
             logger.info("Skip to start Netloader server")
 
         end_elastic_server = time.perf_counter()
-        logger.info(f"Elastic server start time: {end_elastic_server - start_elastic_server}, rank: {device_id}")
+        logger.info("Elastic server start time: %s, rank: %s", end_elastic_server - start_elastic_server, device_id)
 
         if need_process_weights_after_loading:
             process_weights_after_loading(model, model_config, torch.device(device_config.device))

--- a/vllm_ascend/model_loader/netloader/utils.py
+++ b/vllm_ascend/model_loader/netloader/utils.py
@@ -47,17 +47,17 @@ def is_valid_path_prefix(path_prefix):
         return False
 
     if re.search(r'[<>:"|?*]', path_prefix):
-        logger.warning(f"The path prefix {path_prefix} contains illegal characters.")
+        logger.warning("The path prefix %s contains illegal characters.", path_prefix)
         return False
 
     if path_prefix.startswith("/") or path_prefix.startswith("\\"):
         if not os.path.exists(os.path.dirname(path_prefix)):
-            logger.warning(f"The directory for the path prefix {os.path.dirname(path_prefix)} does not exist.")
+            logger.warning("The directory for the path prefix %s does not exist.", os.path.dirname(path_prefix))
             return False
     else:
         if not os.path.exists(os.path.dirname(os.path.abspath(path_prefix))):
             logger.warning(
-                f"The directory for the path prefix {os.path.dirname(os.path.abspath(path_prefix))} does not exist."
+                "The directory for the path prefix %s does not exist.", os.path.dirname(os.path.abspath(path_prefix))
             )
             return False
     return True

--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -156,7 +156,7 @@ class RForkModelLoader(BaseModelLoader):
 
                 return model.eval()
             except Exception as e:
-                logger.warning(f"RFork transfer failed: {e}, clean up and fall back to default loader")
+                logger.warning("RFork transfer failed: %s, clean up and fall back to default loader", e)
 
                 rfork_worker.post_transfer()
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -639,7 +639,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         if not torch.allclose(integrated_out, split_out):
             diff = (integrated_out - split_out).abs()
             logger.error("SharedFusedMoE shared experts split computation does not match the integrated computation.")
-            logger.error(f"Max absolute difference: {diff.max().item()}")
+            logger.error("Max absolute difference: %s", diff.max().item())
             logger.error(
                 "Integrated output - sum: %s, norm: %s", integrated_out.sum().item(), integrated_out.norm().item()
             )

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -64,8 +64,8 @@ def get_rotataion_matrix(rotation_path):
         return Q
     except Exception as e:
         logger.error(
-            f"Failed to load rotation weight from '{rotation_path}'. "
-            "If you want to use quarot model with eagle3, take a check."
+            "Failed to load rotation weight from '%s'. If you want to use quarot model with eagle3, take a check.",
+            rotation_path,
         )
         raise e
 

--- a/vllm_ascend/patch/worker/patch_weight_utils.py
+++ b/vllm_ascend/patch/worker/patch_weight_utils.py
@@ -29,7 +29,7 @@ class ImportPatchDecorator:
                 try:
                     patch_func(module)
                 except Exception as e:
-                    logger.error(f"Patch application failed {module_name}: {e}")
+                    logger.error("Patch application failed %s: %s", module_name, e)
 
 
 @ImportPatchDecorator.register("vllm.model_executor.models.deepseek_v2")
@@ -83,7 +83,7 @@ def patched_import(name, globals=None, locals=None, fromlist=(), level=0):
         try:
             ImportPatchDecorator._patches[name](module)
         except Exception as e:
-            logger.error(f"Patch application failed during import {name}: {e}")
+            logger.error("Patch application failed during import %s: %s", name, e)
 
     return module
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -202,7 +202,7 @@ class NPUPlatform(Platform):
             from vllm_ascend.compilation.passes.sequence_parallelism import get_sp_min_token_num
 
             pass_config.sp_min_token_num = get_sp_min_token_num(vllm_config)
-            logger.info(f"set sp_min_token_num to {pass_config.sp_min_token_num}")
+            logger.info("set sp_min_token_num to %s", pass_config.sp_min_token_num)
 
         default_max_cg_capture_size = cls._get_default_max_cudagraph_capture_size(vllm_config)
         if default_max_cg_capture_size is not None:

--- a/vllm_ascend/profiling_config.py
+++ b/vllm_ascend/profiling_config.py
@@ -192,7 +192,7 @@ def generate_service_profiling_config() -> Path | None:
     try:
         config_dir.mkdir(parents=True, exist_ok=True)
     except (OSError, PermissionError) as e:
-        logger.error(f"Failed to create configuration directory {config_dir}: {e}", exc_info=True)
+        logger.exception("Failed to create configuration directory %s: %s", config_dir, e)
         return None
 
     # Write the configuration file atomically using a temporary file
@@ -210,7 +210,7 @@ def generate_service_profiling_config() -> Path | None:
         tmp_path.replace(config_file)
         return config_file
     except (OSError, PermissionError) as e:
-        logger.error(f"Failed to write configuration file {config_file}: {e}", exc_info=True)
+        logger.exception("Failed to write configuration file %s: %s", config_file, e)
         return None
     finally:
         # Clean up the temporary file if it wasn't successfully replaced

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -70,7 +70,7 @@ def get_model_file(
             )
             return Path(downloaded_path)
     except Exception as e:
-        logger.debug(f"Could not download {filename} from {model}: {e}")
+        logger.debug("Could not download %s from %s: %s", filename, model, e)
         return None
 
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1124,7 +1124,7 @@ def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
     if not flashcomm2_enable():
         return 0
 
-    logger.info(f"Enable FLASHCOMM2 with flashcomm2_oproj_tensor_parallel_size = {flashcomm2_oproj_tp_size}")
+    logger.info("Enable FLASHCOMM2 with flashcomm2_oproj_tensor_parallel_size = %s", flashcomm2_oproj_tp_size)
 
     layer_sharding = ascend_config.layer_sharding or []
     if layer_sharding:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -19,6 +19,7 @@
 
 import copy
 import gc
+import logging
 from types import NoneType
 
 import torch
@@ -545,7 +546,7 @@ class NPUWorker(WorkerBase):
             try:
                 bind_cpus(self.local_rank)
             except Exception as e:
-                logger.warning(f"Bind cpus failed in rank{self.local_rank}: {e} Skip binding cpu.")
+                logger.warning("Bind cpus failed in rank%s: %s Skip binding cpu.", self.local_rank, e)
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)
@@ -613,12 +614,13 @@ class NPUWorker(WorkerBase):
 
         # Log for debugging in PP mode
         if not is_first_pp_rank:
-            logger.debug(
-                "[ProfilingChunk] PP rank %d: profiled %d tokens, latency=%.2f ms (not used)",
-                get_pp_group().rank_in_group,
-                num_tokens,
-                latency_ms,
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[ProfilingChunk] PP rank %d: profiled %d tokens, latency=%.2f ms (not used)",
+                    get_pp_group().rank_in_group,
+                    num_tokens,
+                    latency_ms,
+                )
 
         return latency_ms
 
@@ -792,13 +794,13 @@ class NPUWorker(WorkerBase):
                 parse_text_output(result.stdout)
                 logger.info("check_health success!")
             else:
-                logger.info(f"query NPU card {self.local_rank} fail: {result.stderr}")
+                logger.info("query NPU card %s fail: %s", self.local_rank, result.stderr)
         except subprocess.TimeoutExpired:
-            logger.info(f"query NPU card  {self.local_rank} timeout.")
+            logger.info("query NPU card  %s timeout.", self.local_rank)
         except FileNotFoundError:
             logger.info("npu-smi tool not found.")
         except Exception as e:
-            logger.info(f"query NPU card {self.local_rank} fail: {e}")
+            logger.info("query NPU card %s fail: %s", self.local_rank, e)
         return
 
 

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -491,7 +491,7 @@ class XliteWrapper:
 
         rt_pool_size = self.xlite_model.get_tensor_pool_size()
         if rank == 0:
-            logger.info(f"xlite runtime pool size: {rt_pool_size} MB")
+            logger.info("xlite runtime pool size: %s MB", rt_pool_size)
         if self.xlite_rt.init_tensor_pool(rt_pool_size) != 0:
             raise ValueError(f"xlite wrapper init failed! runtime pool size: {rt_pool_size} MB")
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR replaces eager log message formatting with lazy logging formatting across the repository.

- Converts `logger.*(f"...")` and `logging.*(f"...")` calls to lazy `%`-style logging arguments.
- Replaces deprecated `logger.warn(...)` usage with `logger.warning(...)`.
- Adds `logger.isEnabledFor(logging.DEBUG)` guards for debug logs whose arguments include function or method calls.
- Enables Ruff `G004` enforcement by removing it from `ignore` and registering `vllm.logger.logger` as a logger object.

This avoids unnecessary string formatting and expensive argument evaluation when the corresponding log level is disabled.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
