### PR TITLE
[CI][BugFix] Align vllm-ascend with upstream vLLM UT expectation

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -108,3 +108,20 @@ class TestAscendConfig(TestBase):
         clear_ascend_config()
         with self.assertRaises(RuntimeError):
             get_ascend_config()
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
+    def test_init_ascend_config_recreates_for_new_vllm_config(self, mock_fix_incompatible_config):
+        first_vllm_config = VllmConfig()
+        first_vllm_config.additional_config = {
+            "ascend_compilation_config": {
+                "enable_npugraph_ex": False,
+            }
+        }
+        first_ascend_config = init_ascend_config(first_vllm_config)
+        self.assertFalse(first_ascend_config.ascend_compilation_config.enable_npugraph_ex)
+
+        second_vllm_config = VllmConfig()
+        second_ascend_config = init_ascend_config(second_vllm_config)
+        self.assertIsNot(first_ascend_config, second_ascend_config)
+        self.assertTrue(second_ascend_config.ascend_compilation_config.enable_npugraph_ex)

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -23,6 +23,8 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config = MagicMock()
         mock_vllm_config.compilation_config = MagicMock()
         mock_vllm_config.model_config = MagicMock()
+        mock_vllm_config.device_config = MagicMock()
+        mock_vllm_config.device_config.device_type = "npu"
         mock_vllm_config.parallel_config = MagicMock()
         mock_vllm_config.cache_config = MagicMock()
         mock_vllm_config.scheduler_config = MagicMock()
@@ -213,6 +215,21 @@ class TestNPUPlatform(TestBase):
         mock_get_device_name.return_value = device_name
         self.assertEqual(self.platform.get_device_name(device_id), device_name)
         mock_get_device_name.assert_called_once_with(0)
+
+    @patch("torch.npu.get_device_properties")
+    @patch("vllm_ascend.platform.subprocess.check_output")
+    def test_get_device_total_memory_prefers_npu_smi(self, mock_check_output, mock_get_device_properties):
+        mock_check_output.return_value = (
+            "        DDR Capacity(MB)               : 0\n        HBM Capacity(MB)               : 32768\n"
+        )
+
+        self.assertEqual(self.platform.get_device_total_memory(0), 32768 * 1024 * 1024)
+        mock_check_output.assert_called_once_with(
+            ["npu-smi", "info", "-t", "memory", "-i", "0", "-c", "0"],
+            stderr=-3,
+            text=True,
+        )
+        mock_get_device_properties.assert_not_called()
 
     @patch("torch.npu.get_device_properties")
     def test_get_device_uuid(self, mock_get_device_properties):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -30,6 +30,7 @@ class AscendConfig:
 
     def __init__(self, vllm_config: "VllmConfig"):
         self.vllm_config = vllm_config
+        model_config = vllm_config.model_config
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
 
         xlite_graph_config = additional_config.get("xlite_graph_config", {})
@@ -112,14 +113,14 @@ class AscendConfig:
         self.pd_tp_ratio = 1
         self.pd_head_ratio = 1
         self.num_head_replica = 1
-        if vllm_config.kv_transfer_config is not None and not vllm_config.model_config.is_deepseek_mla:
+        if vllm_config.kv_transfer_config is not None and model_config is not None and not model_config.is_deepseek_mla:
             prefill_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {"tp_size": 1})["tp_size"]
             decode_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("decode", {"tp_size": 1})["tp_size"]
             assert prefill_tp_size % decode_tp_size == 0, "Prefill TP size must be divisible by Decode TP size."
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
                 # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
-                num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
+                num_kv_head = model_config.get_total_num_kv_heads()
                 if not num_kv_head or num_kv_head < 1:
                     raise ValueError(
                         "Could not determine a positive total KV head count for PD "
@@ -152,13 +153,17 @@ class AscendConfig:
             bool(additional_config.get("enable_async_exponential", False)) and not envs.VLLM_BATCH_INVARIANT
         )
 
-        use_sparse = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
-            vllm_config.model_config.hf_text_config, "index_topk"
+        use_sparse = (
+            model_config is not None
+            and hasattr(model_config, "hf_text_config")
+            and hasattr(model_config.hf_text_config, "index_topk")
         )
 
         self.enable_kv_nz = additional_config.get("enable_kv_nz", False)
         if self.enable_kv_nz:
-            if not vllm_config.model_config.is_deepseek_mla or use_sparse:
+            if model_config is None:
+                raise RuntimeError("enable_kv_nz requires a valid model_config.")
+            if not model_config.is_deepseek_mla or use_sparse:
                 raise RuntimeError("enable_kv_nz is only supported for mla currently.")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise NotImplementedError(
@@ -181,8 +186,8 @@ class AscendConfig:
         )
         self._sparse_c8_layer_filter_enabled = self._has_sparse_c8_layer_config(quant_config)
         self.enable_sp_by_pass = (
-            vllm_config.model_config is not None
-            and not vllm_config.model_config.enforce_eager
+            model_config is not None
+            and not model_config.enforce_eager
             and vllm_config.compilation_config.pass_config.enable_sp
         )
 
@@ -293,6 +298,7 @@ class FinegrainedTPConfig:
     """
 
     def __init__(self, finegrained_tp_config: dict, vllm_config):
+        model_config = vllm_config.model_config
         self.oproj_tensor_parallel_size = finegrained_tp_config.get("oproj_tensor_parallel_size", 0)
         self.lmhead_tensor_parallel_size = finegrained_tp_config.get("lmhead_tensor_parallel_size", 0)
         self.embedding_tensor_parallel_size = finegrained_tp_config.get("embedding_tensor_parallel_size", 0)
@@ -303,7 +309,7 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config.enforce_eager is True:
+            if model_config.enforce_eager is True:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
@@ -556,7 +562,12 @@ def init_ascend_config(vllm_config):
     additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
     refresh = additional_config.get("refresh", False) if additional_config else False
     global _ASCEND_CONFIG
-    if _ASCEND_CONFIG is not None and not refresh and _is_ascend_config_initialized(_ASCEND_CONFIG):
+    if (
+        _ASCEND_CONFIG is not None
+        and not refresh
+        and _is_ascend_config_initialized(_ASCEND_CONFIG)
+        and getattr(_ASCEND_CONFIG, "vllm_config", None) is vllm_config
+    ):
         return _ASCEND_CONFIG
     new_config = AscendConfig(vllm_config)
     if _is_ascend_config_initialized(new_config):

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -74,7 +74,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         w_t_all: torch.Tensor,
         scale: float,
     ):
-        self.bgmv_shrink(x, w_t_all, y, self.token_lora_indices, scale)
+        self.bgmv_shrink(x, w_t_all, y, self._narrow_active_indices(self._token_lora_indices, x), scale)
 
     def _expand_prefill(
         self,
@@ -101,7 +101,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         w_t_all: torch.Tensor,
         add_inputs: bool,
     ):
-        self.bgmv_expand(x, w_t_all, y, self.token_lora_indices, add_inputs)
+        self.bgmv_expand(x, w_t_all, y, self._narrow_active_indices(self._token_lora_indices, x), add_inputs)
 
     def _expand_slice_prefill(
         self,
@@ -134,7 +134,26 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         y_slice_size: int,
         add_inputs: bool,
     ):
-        self.bgmv_expand_slice(x, w_t_all, y, self.token_lora_indices, y_offset, y_slice_size, add_inputs)
+        self.bgmv_expand_slice(
+            x,
+            w_t_all,
+            y,
+            self._narrow_active_indices(self._token_lora_indices, x),
+            y_offset,
+            y_slice_size,
+            add_inputs,
+        )
+
+    def _narrow_active_indices(self, indices: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        """Align a preallocated LoRA index buffer with the active token window.
+
+        `PunicaWrapperBase` stores index tensors in max-sized reusable buffers,
+        while the runtime `x` passed into BGMV ops may be a smaller live slice.
+        Narrowing here keeps the first dimension of `indices` consistent with
+        the current `x`/`y` tensors and avoids shape mismatches in dynamic
+        decode / logits paths.
+        """
+        return torch.narrow(indices, 0, 0, x.size(0))
 
     def _apply_expand(
         self,
@@ -344,7 +363,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         if buffer is None:
             buffer = torch.zeros((x.size(0), r), dtype=torch.float32, device=x.device)
 
-        indices = self.sampler_indices
+        indices = self._narrow_active_indices(self._sampler_indices, x)
 
         self.bgmv_shrink(x, lora_a_stacked, buffer, indices, scale)
         self.bgmv_expand(buffer, lora_b_stacked, y, indices, add_inputs=True)

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -5,6 +5,7 @@ from vllm.config import LoRAConfig
 from vllm.lora.layers import (
     ColumnParallelLinearWithLoRA,
     ColumnParallelLinearWithShardedLoRA,
+    MergedColumnParallelLinearVariableSliceWithLoRA,
     MergedColumnParallelLinearWithLoRA,
     MergedColumnParallelLinearWithShardedLoRA,
     MergedQKVParallelLinearWithLoRA,
@@ -38,7 +39,13 @@ class AscendColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is AscendColumnParallelLinear
+        if type(source_layer) is AscendColumnParallelLinear:
+            return True
+        if type(source_layer) is AscendMergedColumnParallelLinear:
+            if len(packed_modules_list) != 1:
+                return False
+            return not (hasattr(source_layer, "output_sizes") and len(source_layer.output_sizes) >= 3)
+        return False
 
 
 class AscendMergedColumnParallelLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
@@ -51,7 +58,29 @@ class AscendMergedColumnParallelLinearWithLoRA(MergedColumnParallelLinearWithLoR
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is AscendMergedColumnParallelLinear
+        return type(source_layer) is AscendMergedColumnParallelLinear and len(packed_modules_list) == 2
+
+
+class AscendMergedColumnParallelLinearVariableSliceWithLoRA(MergedColumnParallelLinearVariableSliceWithLoRA):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        if type(source_layer) is not AscendMergedColumnParallelLinear:
+            return False
+
+        if len(packed_modules_list) >= 3:
+            return True
+
+        if len(packed_modules_list) == 2:
+            return False
+
+        return hasattr(source_layer, "output_sizes") and len(source_layer.output_sizes) >= 3
 
 
 class AscendRowParallelLinearWithLoRA(RowParallelLinearWithLoRA):
@@ -187,6 +216,7 @@ class AscendRowParallelLinearWithShardedLoRA(RowParallelLinearWithShardedLoRA):
 def refresh_all_lora_classes():
     vllm.lora.utils._all_lora_classes.add(AscendColumnParallelLinearWithLoRA)
     vllm.lora.utils._all_lora_classes.add(AscendMergedColumnParallelLinearWithLoRA)
+    vllm.lora.utils._all_lora_classes.add(AscendMergedColumnParallelLinearVariableSliceWithLoRA)
     vllm.lora.utils._all_lora_classes.add(AscendRowParallelLinearWithLoRA)
     vllm.lora.utils._all_lora_classes.add(AscendVocabParallelEmbeddingWithLoRA)
     vllm.lora.utils._all_lora_classes.add(AscendQKVParallelLinearWithLoRA)

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -397,9 +397,6 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
 
         self.gather_output = gather_output
 
-        if output_sizes is None:
-            output_sizes = [output_size]
-
         assert self.quant_method is not None
         self.quant_method.create_weights(
             layer=self,

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import os
+import subprocess
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -59,6 +60,34 @@ else:
     FlexibleArgumentParser = None
 
 _CUSTOM_OP_REGISTERED = False
+
+
+def _get_npu_smi_field(lines: list[str], key: str) -> str | None:
+    for line in lines:
+        normalized = " ".join(line.split())
+        if normalized.startswith(f"{key} :"):
+            return normalized.split(":", 1)[1].strip()
+    return None
+
+
+def _get_npu_smi_hbm_capacity_mb(device_id: int) -> int | None:
+    try:
+        output = subprocess.check_output(
+            ["npu-smi", "info", "-t", "memory", "-i", str(device_id), "-c", "0"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    value = _get_npu_smi_field(output.splitlines(), "HBM Capacity(MB)")
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def config_deprecated_logging():
@@ -129,6 +158,22 @@ class NPUPlatform(Platform):
         To use graph fusion operations, we defined our own backend compiler.
         """
         return "vllm_ascend.compilation.compiler_interface.AscendCompiler"
+
+    @staticmethod
+    def _sync_additional_config(vllm_config: VllmConfig, ascend_config) -> None:
+        ascend_compilation_config = getattr(ascend_config, "ascend_compilation_config", None)
+        if ascend_compilation_config:
+            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
+                vars(ascend_compilation_config)
+                if not isinstance(ascend_compilation_config, dict)
+                else ascend_compilation_config
+            )
+
+        ascend_fusion_config = getattr(ascend_config, "ascend_fusion_config", None)
+        if ascend_fusion_config:
+            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
+                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
+            )
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:
@@ -220,6 +265,20 @@ class NPUPlatform(Platform):
         return device_props.uuid
 
     @classmethod
+    def get_device_total_memory(cls, device_id: int = 0) -> int:
+        """
+        Return total memory of the device in bytes.
+        """
+        hbm_capacity_mb = _get_npu_smi_hbm_capacity_mb(device_id)
+        if hbm_capacity_mb is not None:
+            return hbm_capacity_mb * 1024 * 1024
+
+        device_props = torch.npu.get_device_properties(device_id)
+        total_memory = getattr(device_props, "total_memory", None)
+        if total_memory is not None:
+            return int(total_memory)
+        raise RuntimeError(f"Unable to determine total memory for device {device_id}.")
+
     def num_compute_units(cls, device_id: int = 0) -> int:
         """Return the number of Cube Cores on the NPU device.
         This is the NPU equivalent of CUDA's ``multi_processor_count``
@@ -273,8 +332,19 @@ class NPUPlatform(Platform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         from vllm_ascend.quantization.utils import maybe_auto_detect_quantization
 
-        if vllm_config.model_config is not None:
-            maybe_auto_detect_quantization(vllm_config)
+        device_config = getattr(vllm_config, "device_config", None)
+        if device_config is not None and getattr(device_config, "device_type", cls.device_type) != cls.device_type:
+            logger.debug(
+                "Skipping Ascend-specific config updates for device type %s.",
+                device_config.device_type,
+            )
+            return
+
+        if vllm_config.model_config is None:
+            logger.warning("Model config is missing. Skipping Ascend-specific config updates.")
+            return
+
+        maybe_auto_detect_quantization(vllm_config)
 
         cls._validate_layer_sharding_config(vllm_config)
 
@@ -294,30 +364,13 @@ class NPUPlatform(Platform):
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config
-        ascend_compilation_config = ascend_config.ascend_compilation_config
-        if ascend_compilation_config:
-            vllm_config.additional_config.setdefault("ascend_compilation_config", {}).update(
-                vars(ascend_compilation_config)
-                if not isinstance(ascend_compilation_config, dict)
-                else ascend_compilation_config
-            )
 
         ascend_config.update_compile_ranges_split_points()
 
         if model_config and hasattr(model_config.hf_text_config, "index_topk"):
             vllm_config.cache_config.cache_dtype = str(model_config.dtype).replace("torch.", "")
 
-        ascend_fusion_config = ascend_config.ascend_fusion_config
-        if ascend_fusion_config:
-            vllm_config.additional_config.setdefault("ascend_fusion_config", {}).update(
-                vars(ascend_fusion_config) if not isinstance(ascend_fusion_config, dict) else ascend_fusion_config
-            )
-
-        if model_config is None:
-            logger.warning("Model config is missing. This may indicate that we are running a test case")
-            enforce_eager = False
-        else:
-            enforce_eager = getattr(model_config, "enforce_eager", False)
+        enforce_eager = getattr(model_config, "enforce_eager", False)
 
         from vllm.config.compilation import CUDAGraphMode
 
@@ -451,6 +504,8 @@ class NPUPlatform(Platform):
                 "for example, check the plog files (default: $HOME/ascend/log/debug) "
                 "for more information about runtime errors."
             )
+
+        cls._sync_additional_config(vllm_config, ascend_config)
 
         if parallel_config and parallel_config.worker_cls == "auto":
             # TODO: this is a tricky way to disable `use_sequence_parallel_moe` in vllm.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3782,7 +3782,7 @@ def _torch_cuda_wrapper():
         torch.cuda.synchronize = torch.npu.synchronize
         torch.cuda.mem_get_info = torch.npu.mem_get_info
         yield
-    except Exception as e:
+    except Exception:
         torch.cuda.Event = _EventPlaceholder
         torch.cuda.Stream = _StreamPlaceholder
         torch.cuda.default_stream = _StreamPlaceholder
@@ -3790,7 +3790,8 @@ def _torch_cuda_wrapper():
         torch.cuda.stream = _StreamPlaceholder
         torch.cuda.synchronize = _StreamPlaceholder
         torch.cuda.mem_get_info = _StreamPlaceholder
-        raise RuntimeError(f"NPUModelRunner init failed, error is {e}")
+        logger.exception("NPUModelRunner init failed inside _torch_cuda_wrapper")
+        raise
     finally:
         # if anything goes wrong, just patch it with a placeholder
         torch.cuda.Event = _EventPlaceholder


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aligns `vllm-ascend` with upstream `vLLM` unit-test behavior by fixing several Ascend-specific adaptation issues that were polluting generic upstream code paths or diverging from upstream semantics.

Main changes in this PR:
- Restore the Ascend plugin activation boundary so Ascend-specific config mutation does not run on non-NPU paths or config-only flows where `model_config` is not available.
- Harden model-dependent Ascend config branches by adding explicit `model_config` guards for paths such as MLA checks, sparse config checks, and `enable_kv_nz`.
- Implement device total-memory probing with an `npu-smi`-first path to avoid unnecessary early runtime side effects from `torch.npu` device probing.
- Restore upstream-equivalent LoRA wrapper routing for merged / packed linear layers instead of collapsing them into a single coarse Ascend path.
- Fix decode-time LoRA index handling by narrowing token indices to the active decode window before invoking BGMV kernels.
- Preserve upstream exception semantics in model runner initialization by re-raising the original exception instead of rewriting it as a generic `RuntimeError`.
- Fix same-process config pollution by narrowing `AscendConfig` singleton reuse to the same `VllmConfig` object and delaying synchronization of finalized Ascend compilation/fusion settings back into `additional_config`.

Why these changes are needed:
- Several upstream UT failures were caused by the Ascend plugin affecting CPU-only, config-only, or other generic upstream code paths that should have remained backend-agnostic.
- Some Ascend-side implementations had drifted from upstream behavior contracts, especially around config isolation, LoRA wrapper selection, decode metadata handling, and exception transparency.
- The goal of this PR is to preserve upstream behavior and logic at the adaptation boundary rather than redefine them inside the plugin.

### Does this PR introduce any user-facing change?

No intended API or interface change.

This PR is a bug-fix and behavior-alignment patch so that `vllm-ascend` preserves upstream semantics more faithfully in config generation, LoRA execution, platform capability probing, and error propagation.

### How was this patch tested?

Tested on `quay.io/ascend/vllm-ascend:v0.17.0rc1` image.

This patch was validated through targeted upstream test re-runs using isolated single-test execution on idle NPUs.

Confirmed recoveries:
- `tests/v1/kv_connector/unit/test_cache_pollution_prevention.py` (`1 passed`)
- `tests/v1/kv_connector/unit/test_error_propagation.py` (`2 passed`)
- `tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py` (`3 passed`)
- `tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py` (`11 passed`)
- `tests/v1/kv_connector/unit/test_decode_bench_connector.py` (`8 passed`)
- `tests/v1/kv_connector/unit/test_offloading_connector.py` (`10 passed`)
- `tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py` (`4 passed`)
- `tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py` (`6 passed`)
- `tests/v1/kv_connector/unit/test_config.py` (`6 passed`)
- `tests/v1/engine/test_engine_args.py` (`2 passed, 1 skipped`)
- `tests/config/test_config_generation.py::test_cuda_empty_vs_unset_configs` (`1 passed`)
- `tests/config/test_config_generation.py` (`3 passed`)
- `tests/v1/logits_processors/test_custom_offline.py::test_rejects_custom_logitsprocs[...]` (6 rejection subcases re-run independently and recovered)
- `tests/lora/test_add_lora.py` (`1 passed`)
- `tests/lora/test_qwenvl.py` (`6 passed`)
- `tests/lora/test_chatglm3_tp.py` (`1 passed`)
- `tests/model_executor/test_enabled_custom_ops.py` (`21 passed`)
- `tests/entrypoints/openai/test_return_tokens_as_ids.py` (`5 passed`)

Test conditions used in this analysis:
- single test case
- single idle NPU
- isolated process