### PR TITLE
[BugFix] [P/D] cancel layerwise metaserver request

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -311,12 +311,16 @@ async def listen_for_disconnect(request: Request) -> None:
 def with_cancellation(handler_func):
     @functools.wraps(handler_func)
     async def wrapper(*args, **kwargs):
-        request = kwargs["request"]
+        request = kwargs.get("request")
+        if request is None:
+            request = next(arg for arg in args if isinstance(arg, Request))
         handler_task = asyncio.create_task(handler_func(*args, **kwargs))
         cancellation_task = asyncio.create_task(listen_for_disconnect(request))
         done, pending = await asyncio.wait([handler_task, cancellation_task], return_when=asyncio.FIRST_COMPLETED)
         for task in pending:
             task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         if handler_task in done:
             return handler_task.result()
         return None
@@ -532,9 +536,9 @@ async def _handle_completions(api: str, request: Request):
                     f"the aborted request {request_id} will be routing to the target "
                     "prefiller when new request is ready to dispatch to it"
                 )
-
-            # After streaming done, release tokens
-            proxy_state.release_decoder(decoder_idx, decoder_score)
+            finally:
+                # After streaming done or is cancelled, release tokens.
+                proxy_state.release_decoder(decoder_idx, decoder_score)
 
         if stream_flag:
             return StreamingResponse(generate_stream(), media_type="text/event-stream")
@@ -572,7 +576,10 @@ async def healthcheck():
 
 
 @app.post("/v1/metaserver")
+@with_cancellation
 async def metaserver(request: Request):
+    prefiller_idx = None
+    prefiller_score = None
     try:
         kv_transfer_params = await request.json()
 
@@ -598,13 +605,13 @@ async def metaserver(request: Request):
             max_retries=global_args.max_retries,
             base_delay=global_args.retry_delay,
         )
-        proxy_state.release_prefiller(prefiller_idx, prefiller_score)
-        proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 
     except Exception as e:
         logger.error(f"Post metaserver failed with: {str(e)}")
-        proxy_state.release_prefiller(prefiller_idx, prefiller_score)
-        proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
+    finally:
+        if prefiller_idx is not None and prefiller_score is not None:
+            proxy_state.release_prefiller(prefiller_idx, prefiller_score)
+            proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 
 
 if __name__ == "__main__":

--- a/tests/ut/kv_connector/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_layerwise_connector.py
@@ -417,6 +417,21 @@ class MockRequest:
         self.all_token_ids = list(self.prompt_token_ids)
 
 
+class MockMetaserverClient:
+    def __init__(self, post_side_effect=None):
+        self.closed = False
+        self.post_calls = []
+        self.post_side_effect = post_side_effect
+
+    def post(self, url, json):
+        self.post_calls.append((url, json))
+        if self.post_side_effect is not None:
+            raise self.post_side_effect()
+
+    def close(self):
+        self.closed = True
+
+
 class TestMooncakeLayerwiseConnectorMetadata(unittest.TestCase):
     def test_add_new_req(self):
         meta = MooncakeLayerwiseConnectorMetadata()
@@ -642,6 +657,58 @@ class TestMooncakeLayerwiseConnectorScheduler_More(unittest.TestCase):
         ok, params = self.scheduler.request_finished(MockRequest("req_fin"), [1, 2])
         self.assertFalse(ok)
         self.assertIsNone(params)
+
+
+class TestMooncakeLayerwiseMetaserverCancel(unittest.TestCase):
+    def setUp(self):
+        self.scheduler = object.__new__(MooncakeLayerwiseConnectorScheduler)
+        self.scheduler.metaserver_client_lock = threading.Lock()
+        self.scheduler.metaserver_clients = {}
+        self.scheduler.metaserver_request_ids = set()
+        self.scheduler.aborted_metaserver_requests = set()
+
+    def test_request_finished_closes_active_metaserver_client(self):
+        client = MockMetaserverClient()
+        self.scheduler.metaserver_request_ids.add("req-1")
+        self.scheduler.metaserver_clients["req-1"] = client
+
+        delay_free, params = self.scheduler.request_finished(MockRequest("req-1"), [])
+
+        self.assertFalse(delay_free)
+        self.assertIsNone(params)
+        self.assertTrue(client.closed)
+        self.assertNotIn("req-1", self.scheduler.metaserver_clients)
+        self.assertIn("req-1", self.scheduler.aborted_metaserver_requests)
+
+    def test_access_metaserver_skips_request_cancelled_before_worker_starts(self):
+        client = MockMetaserverClient()
+        self.scheduler.metaserver_request_ids.add("req-2")
+        self.scheduler.aborted_metaserver_requests.add("req-2")
+
+        with patch.object(self.scheduler, "_new_metaserver_client", return_value=client):
+            self.scheduler._access_metaserver("http://proxy/v1/metaserver", {"request_id": "req-2"}, "req-2")
+
+        self.assertTrue(client.closed)
+        self.assertEqual(client.post_calls, [])
+        self.assertNotIn("req-2", self.scheduler.metaserver_request_ids)
+        self.assertNotIn("req-2", self.scheduler.aborted_metaserver_requests)
+
+    def test_access_metaserver_stops_retrying_after_request_is_cancelled(self):
+        def cancel_before_error():
+            self.scheduler._abort_metaserver_request("req-3")
+            return RuntimeError("connection closed")
+
+        client = MockMetaserverClient(post_side_effect=cancel_before_error)
+        self.scheduler.metaserver_request_ids.add("req-3")
+
+        with patch.object(self.scheduler, "_new_metaserver_client", return_value=client):
+            self.scheduler._access_metaserver("http://proxy/v1/metaserver", {"request_id": "req-3"}, "req-3")
+
+        self.assertTrue(client.closed)
+        self.assertEqual(len(client.post_calls), 1)
+        self.assertNotIn("req-3", self.scheduler.metaserver_clients)
+        self.assertNotIn("req-3", self.scheduler.metaserver_request_ids)
+        self.assertNotIn("req-3", self.scheduler.aborted_metaserver_requests)
 
 
 class TestHelperFunctions(unittest.TestCase):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -759,12 +759,10 @@ class MooncakeLayerwiseConnectorScheduler:
         self.cert_path = (ssl_certfile, ssl_keyfile, ssl_keyfile_password)
         self.ssl_enable = tls_config.get("ssl_enable", False)
         self.ca_path = ssl_ca_certs
-        if self.ssl_enable:
-            self.metaserver_client = httpx.Client(
-                limits=httpx.Limits(max_connections=100000), timeout=None, cert=self.cert_path, verify=self.ca_path
-            )
-        else:
-            self.metaserver_client = httpx.Client(limits=httpx.Limits(max_connections=100000), timeout=None)
+        self.metaserver_clients: dict[str, httpx.Client] = {}
+        self.metaserver_client_lock = threading.Lock()
+        self.metaserver_request_ids: set[str] = set()
+        self.aborted_metaserver_requests: set[str] = set()
 
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         """
@@ -844,8 +842,13 @@ class MooncakeLayerwiseConnectorScheduler:
                 remote_cached_tokens=remote_cached_tokens,
             )
             if not do_virtual:
+                with self.metaserver_client_lock:
+                    self.metaserver_request_ids.add(request.request_id)
                 future = self.executor.submit(
-                    self._access_metaserver, url=params.get("metaserver", None), message=kv_transfer_params
+                    self._access_metaserver,
+                    url=params.get("metaserver", None),
+                    message=kv_transfer_params,
+                    request_id=request.request_id,
                 )
 
                 def handle_exception(future):
@@ -953,18 +956,55 @@ class MooncakeLayerwiseConnectorScheduler:
                         self._reqs_need_send_layerwise.pop(req_id)
         return meta
 
-    def _access_metaserver(self, url, message):
+    def _new_metaserver_client(self):
+        if self.ssl_enable:
+            return httpx.Client(
+                limits=httpx.Limits(max_connections=100000), timeout=None, cert=self.cert_path, verify=self.ca_path
+            )
+        return httpx.Client(limits=httpx.Limits(max_connections=100000), timeout=None)
+
+    def _abort_metaserver_request(self, request_id: str):
+        with self.metaserver_client_lock:
+            if request_id not in self.metaserver_request_ids and request_id not in self.metaserver_clients:
+                return
+            self.aborted_metaserver_requests.add(request_id)
+            client = self.metaserver_clients.pop(request_id, None)
+        if client is not None:
+            logger.info("Closing metaserver connection for request %s", request_id)
+            client.close()
+
+    def _access_metaserver(self, url, message, request_id: str):
         success = False
         retry = 0
-        while retry < 3 and success is False:
-            retry += 1
-            try:
-                self.metaserver_client.post(url, json=message)
-                success = True
-            except Exception as e:
-                logger.error(f"Failed to connect to metaserver: {url}, retry {retry} time.")
-                if retry == 3:
-                    raise e
+        client = self._new_metaserver_client()
+        with self.metaserver_client_lock:
+            if request_id in self.aborted_metaserver_requests:
+                client.close()
+                self.metaserver_request_ids.discard(request_id)
+                self.aborted_metaserver_requests.discard(request_id)
+                return
+            self.metaserver_clients[request_id] = client
+        try:
+            while retry < 3 and success is False:
+                retry += 1
+                try:
+                    client.post(url, json=message)
+                    success = True
+                except Exception as e:
+                    with self.metaserver_client_lock:
+                        is_aborted = request_id in self.aborted_metaserver_requests
+                    if is_aborted:
+                        logger.info("Metaserver request %s is aborted.", request_id)
+                        return
+                    logger.error(f"Failed to connect to metaserver: {url}, retry {retry} time.")
+                    if retry == 3:
+                        raise e
+        finally:
+            with self.metaserver_client_lock:
+                self.metaserver_clients.pop(request_id, None)
+                self.metaserver_request_ids.discard(request_id)
+                self.aborted_metaserver_requests.discard(request_id)
+            client.close()
 
     def request_finished(
         self,
@@ -975,6 +1015,7 @@ class MooncakeLayerwiseConnectorScheduler:
         Once a request is finished, determine whether request blocks
         should be freed now or will be sent asynchronously and freed later.
         """
+        self._abort_metaserver_request(request.request_id)
         # layer_wise push, not need delay_free_blocks
         return False, None
 
@@ -987,6 +1028,7 @@ class MooncakeLayerwiseConnectorScheduler:
         Once a request is finished, determine whether request blocks
         should be freed now or will be sent asynchronously and freed later.
         """
+        self._abort_metaserver_request(request.request_id)
         # layer_wise push, not need delay_free_blocks
         return False, None
 


### PR DESCRIPTION
### What this PR does / why we need it?
Close the decoder-to-metaserver request when a layerwise decode request finishes or is aborted. This lets the proxy cancel both the decoder stream and the metaserver path, so the prefiller request is also disconnected.

Add unit coverage for active and pre-start metaserver cancellation cleanup.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
by nightly

- vLLM version: v0.19.0
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
