### PR TITLE
[Performance][310P] Optimize M-RoPE with cache and NPU forward integration

### DIFF
--- a/tests/ut/_310p/ops/test_rotary_embedding_310.py
+++ b/tests/ut/_310p/ops/test_rotary_embedding_310.py
@@ -1,0 +1,75 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import torch
+
+from vllm_ascend._310p.ops import rotary_embedding as rotary_310
+from vllm_ascend._310p.ops.rotary_embedding import (
+    AscendMRotaryEmbedding310,
+    set_mrope_apply_rotary_slices,
+)
+
+
+def _reset_mrope_globals():
+    rotary_310._mrope_cos_slice = None
+    rotary_310._mrope_sin_slice = None
+
+
+def _build_mrope_embedding() -> AscendMRotaryEmbedding310:
+    emb = AscendMRotaryEmbedding310.__new__(AscendMRotaryEmbedding310)
+    emb.mrope_section = [2, 2, 2]
+    emb.mrope_interleaved = False
+    emb.cos_sin_cache = torch.randn(64, 12, dtype=torch.float32)
+    return emb
+
+
+def test_set_mrope_apply_rotary_slices_populates_globals():
+    _reset_mrope_globals()
+    emb = _build_mrope_embedding()
+    positions = torch.randint(0, emb.cos_sin_cache.shape[0], (3, 4), dtype=torch.long)
+    set_mrope_apply_rotary_slices(
+        emb.cos_sin_cache,
+        positions,
+        mrope_section=emb.mrope_section,
+        mrope_interleaved=emb.mrope_interleaved,
+    )
+
+    assert rotary_310._mrope_cos_slice is not None
+    assert rotary_310._mrope_sin_slice is not None
+    assert rotary_310._mrope_cos_slice.shape[1] == positions.shape[-1]
+
+
+def test_set_mrope_apply_rotary_slices_reuses_buffer_address():
+    _reset_mrope_globals()
+    emb = _build_mrope_embedding()
+    positions = torch.randint(0, emb.cos_sin_cache.shape[0], (3, 4), dtype=torch.long)
+
+    set_mrope_apply_rotary_slices(
+        emb.cos_sin_cache,
+        positions,
+        mrope_section=emb.mrope_section,
+        mrope_interleaved=emb.mrope_interleaved,
+    )
+    first_ptr = rotary_310._mrope_cos_slice.data_ptr()
+
+    set_mrope_apply_rotary_slices(
+        emb.cos_sin_cache,
+        positions,
+        mrope_section=emb.mrope_section,
+        mrope_interleaved=emb.mrope_interleaved,
+    )
+    second_ptr = rotary_310._mrope_cos_slice.data_ptr()
+
+    assert first_ptr == second_ptr

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -38,6 +38,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.sample.rejection_sampler import RejectionSampler
 
 from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
+from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
@@ -204,6 +205,27 @@ class NPUModelRunner310(NPUModelRunner):
                 num_active_loras=num_active_loras,
                 profile_seq_lens=profile_seq_lens,
             )
+
+    def _model_forward(
+        self,
+        num_tokens_padded: int,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors=None,
+        inputs_embeds: torch.Tensor | None = None,
+        **model_kwargs,
+    ):
+        if self.uses_mrope:
+            assert positions is not None
+            prepare_mrope_cos_sin_slices_from_runner(self, positions)
+        return super()._model_forward(
+            num_tokens_padded,
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            **model_kwargs,
+        )
 
     def _check_and_update_cudagraph_mode(
         self,

--- a/vllm_ascend/_310p/ops/rotary_embedding.py
+++ b/vllm_ascend/_310p/ops/rotary_embedding.py
@@ -15,11 +15,107 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from __future__ import annotations
+
+from typing import Any
 
 import torch
 import torch_npu
+from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
 
 from vllm_ascend.ops.rotary_embedding import AscendRotaryEmbedding, get_cos_and_sin_slice
+
+# Filled once per model forward in NPUModelRunner310._model_forward; read by every MRoPE layer.
+_mrope_cos_slice: torch.Tensor | None = None
+_mrope_sin_slice: torch.Tensor | None = None
+
+
+def _apply_rotary_mrope_torch(
+    q_rot: torch.Tensor,
+    k_rot: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch path aligned with vLLM MRotaryEmbedding.forward_native -> ApplyRotaryEmb."""
+    half = cos.shape[-1] // 2
+    cos_h = cos[0, :, 0, :half].contiguous()
+    sin_h = sin[0, :, 0, :half].contiguous()
+    q_out = ApplyRotaryEmb.forward_static(q_rot[0], cos_h, sin_h, is_neox_style)
+    k_out = ApplyRotaryEmb.forward_static(k_rot[0], cos_h, sin_h, is_neox_style)
+    return q_out.unsqueeze(0), k_out.unsqueeze(0)
+
+
+def merge_mrope_cos_sin_for_apply(
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    mrope_section: list[int],
+    mrope_interleaved: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if mrope_interleaved:
+        return (
+            apply_interleaved_rope(cos, mrope_section),
+            apply_interleaved_rope(sin, mrope_section),
+        )
+    return (
+        torch.cat([m[i] for i, m in enumerate(cos.split(mrope_section, dim=-1))], dim=-1),
+        torch.cat([m[i] for i, m in enumerate(sin.split(mrope_section, dim=-1))], dim=-1),
+    )
+
+
+def set_mrope_apply_rotary_slices(
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    mrope_section: list[int] | None = None,
+    mrope_interleaved: bool = False,
+    capacity_tokens: int = 0,
+) -> None:
+    """Build cos/sin views for `npu_apply_rotary_pos_emb` from positions; must run once per forward before layers."""
+    global _mrope_cos_slice
+    global _mrope_sin_slice
+
+    assert positions.ndim in (1, 2), "M-RoPE positions must be [num_tokens] or [3, num_tokens]."
+    cos_sin = cos_sin_cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if positions.ndim == 2:
+        assert positions.shape[0] == 3, "MRoPE expects positions [3, num_tokens] (T/H/W)."
+        assert mrope_section is not None
+        cos, sin = merge_mrope_cos_sin_for_apply(
+            cos,
+            sin,
+            list(mrope_section),
+            mrope_interleaved,
+        )
+    # `npu_apply_rotary_pos_emb` follows ApplyRotaryPosEmbV2 semantics:
+    # q_embed = q * cos + rotate(q) * sin, where cos/sin have full rotary dim.
+    # MRoPE merge above gives half-dim cos/sin, so expand to full dim here.
+    cos = torch.cat((cos, cos), dim=-1)
+    sin = torch.cat((sin, sin), dim=-1)
+    num_tokens = positions.shape[-1]
+    cos_view = cos.contiguous().view(1, num_tokens, 1, -1)
+    sin_view = sin.contiguous().view(1, num_tokens, 1, -1)
+
+    # Keep stable storage across forwards for graph replay.
+    if _mrope_cos_slice is None or _mrope_sin_slice is None:
+        capacity = capacity_tokens if capacity_tokens is not None else num_tokens
+        if capacity < num_tokens:
+            capacity = num_tokens
+        _mrope_cos_slice = torch.empty(
+            (1, capacity, 1, cos_view.shape[-1]),
+            dtype=cos_view.dtype,
+            device=cos_view.device,
+        )
+        _mrope_sin_slice = torch.empty(
+            (1, capacity, 1, sin_view.shape[-1]),
+            dtype=sin_view.dtype,
+            device=sin_view.device,
+        )
+
+    _mrope_cos_slice[:, :num_tokens].copy_(cos_view)
+    _mrope_sin_slice[:, :num_tokens].copy_(sin_view)
 
 
 def _rope_forward_oot(
@@ -82,6 +178,73 @@ def _rope_forward_oot(
             is_neox_style,
         )
     return query.view(query_shape), key.view(key_shape)
+
+
+class AscendMRotaryEmbedding310(MRotaryEmbedding):
+    def forward_oot(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ):
+        query_shape, key_shape = query.shape, key.shape
+
+        # MRoPE T/H/W layout is handled in `merge_mrope_cos_sin_for_apply` (mrope_interleaved).
+        # Here `rotary_mode` matches vLLM ApplyRotaryEmb: half = neox chunk, interleave = GPT-J pairs.
+        rotary_mode = "half" if self.is_neox_style else "interleave"
+        num_tokens = query.shape[0]
+        if _mrope_cos_slice is None or _mrope_sin_slice is None:
+            raise RuntimeError(
+                "MRoPE cos/sin slices are not initialized. Call set_mrope_apply_rotary_slices before forward."
+            )
+        cos, sin = _mrope_cos_slice[:, :num_tokens], _mrope_sin_slice[:, :num_tokens]
+
+        is_partial_rope = self.rotary_dim < self.head_size
+        if is_partial_rope:
+            query = query.view(num_tokens, -1, self.head_size)
+            key = key.view(num_tokens, -1, self.head_size)
+            q_pass = query[..., self.rotary_dim :]
+            k_pass = key[..., self.rotary_dim :]
+            q_rot = query[..., : self.rotary_dim].contiguous().view(1, num_tokens, -1, self.rotary_dim)
+            k_rot = key[..., : self.rotary_dim].contiguous().view(1, num_tokens, -1, self.rotary_dim)
+        else:
+            q_rot = query.contiguous().view(1, num_tokens, -1, self.head_size)
+            k_rot = key.contiguous().view(1, num_tokens, -1, self.head_size)
+
+        # `npu_apply_rotary_pos_emb` only supports rotary_dim 64 or 128.
+        use_npu_apply = self.rotary_dim in (64, 128)
+
+        if use_npu_apply:
+            q_rot, k_rot = torch_npu.npu_apply_rotary_pos_emb(q_rot, k_rot, cos, sin, rotary_mode=rotary_mode)
+        else:
+            q_rot, k_rot = _apply_rotary_mrope_torch(q_rot, k_rot, cos, sin, self.is_neox_style)
+
+        if is_partial_rope:
+            q_rot = q_rot.view(num_tokens, -1, self.rotary_dim)
+            k_rot = k_rot.view(num_tokens, -1, self.rotary_dim)
+            query = torch.cat((q_rot, q_pass), dim=-1).reshape(query_shape)
+            key = torch.cat((k_rot, k_pass), dim=-1).reshape(key_shape)
+        else:
+            query = q_rot.view(query_shape)
+            key = k_rot.view(key_shape)
+
+        return query, key
+
+
+def prepare_mrope_cos_sin_slices_from_runner(runner: Any, positions: torch.Tensor) -> None:
+    """Resolve MRoPE embedding from the runner and populate `_mrope_cos_slice` / `_mrope_sin_slice`."""
+    emb = getattr(runner, "_mrope_embedding", None)
+    if emb is None:
+        emb = next(module for module in runner.model.modules() if isinstance(module, AscendMRotaryEmbedding310))
+        runner._mrope_embedding = emb
+    assert isinstance(emb, AscendMRotaryEmbedding310)
+    set_mrope_apply_rotary_slices(
+        emb.cos_sin_cache,
+        positions,
+        mrope_section=emb.mrope_section,
+        mrope_interleaved=emb.mrope_interleaved,
+        capacity_tokens=runner.max_num_tokens,
+    )
 
 
 class AscendRotaryEmbedding310(AscendRotaryEmbedding):

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -38,6 +38,7 @@ if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_gdn_attn  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
+    import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa
@@ -52,6 +53,5 @@ import vllm_ascend.patch.worker.patch_v2.patch_input_batch  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_model_state  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_block_table  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa
-import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_attn_utils  # noqa
 import vllm_ascend.patch.worker.patch_bailing_moe_linear  # noqa

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -692,7 +692,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
             AscendRMSNormGated310,
         )
         from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
-        from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
+        from vllm_ascend._310p.ops.rotary_embedding import AscendMRotaryEmbedding310, AscendRotaryEmbedding310
         from vllm_ascend._310p.ops.vocab_parallel_embedding import (
             AscendParallelLMHead310,
             AscendVocabParallelEmbedding310,
@@ -711,10 +711,9 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
                 "MMEncoderAttention": AscendMMEncoderAttention310,
                 "Conv3dLayer": AscendConv3dLayer310,
                 "GatedDeltaNetAttention": AscendGatedDeltaNetAttention310,
+                "MRotaryEmbedding": AscendMRotaryEmbedding310,
             }
         )
-
-        REGISTERED_ASCEND_OPS.pop("MRotaryEmbedding", None)
 
     for name, op_cls in REGISTERED_ASCEND_OPS.items():
         CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)


### PR DESCRIPTION
### What this PR does / why we need it?

- Adds an **M-RoPE cache path on 310P**: precomputes cos/sin slices once per forward (`set_mrope_apply_rotary_slices`) with stable buffers for graph replay.
- **`AscendMRotaryEmbedding310`**: uses `npu_apply_rotary_pos_emb` when `rotary_dim` is 64/128, otherwise aligns with vLLM via a PyTorch fallback.
- **`NPUModelRunner310._model_forward`**: calls `prepare_mrope_cos_sin_slices_from_runner` when `uses_mrope`.
- Registers **`MRotaryEmbedding` → `AscendMRotaryEmbedding310`** in `register_ascend_customop`.
- Adds **unit tests** for MRoPE slice setup; minor worker patch import order tweak.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
- `tests/ut/_310p/ops/test_rotary_embedding_310.py`
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
