### PR TITLE
[CI][BugFix] Remove e2e tracker guard on smart e2e

### DIFF
--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -87,7 +87,6 @@ jobs:
               - 'CMakeLists.txt'
 
       - name: Determine smart UT test scope
-        if: ${{ steps.filter.outputs.e2e_tracker == 'true' }}
         id: scope
         run: |
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -77,6 +77,8 @@ jobs:
               - 'requirements-dev.txt'
               - 'requirements-lint.txt'
               - 'packages.txt'
+            ut_tracker:
+              - 'tests/ut/**'
             _310_tracker:
               - 'vllm_ascend/_310p/**'
               - 'tests/e2e/310p/**'
@@ -87,6 +89,7 @@ jobs:
               - 'CMakeLists.txt'
 
       - name: Determine smart UT test scope
+        if: ${{ steps.filter.outputs.ut_tracker == 'true' || steps.filter.outputs.e2e_tracker == 'true' }}
         id: scope
         run: |
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend

--- a/.github/workflows/scripts/ut_config.yaml
+++ b/.github/workflows/scripts/ut_config.yaml
@@ -128,7 +128,7 @@
     - tests/ut/batch_invariant
 
 - name: dummy
-  optional: false
+  optional: true
   source_file_dependencies:
     - tests/ut/dummy
   tests:


### PR DESCRIPTION
### What this PR does / why we need it?
This patch fixed an edge case where Smart e2e wasn't triggered as expected when only tests were added to the `tests/ut` directory. Ideally, Smart E2E shouldn't use E2E triggering conditions as its entry point. Furthermore, the specific routing logic should be left to Smart E2E to determine itself.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
