### PR TITLE
[BugFix][SP] Preserve graph stringification in MoE sequence parallel pass

### DIFF
--- a/vllm_ascend/compilation/passes/sequence_parallelism_moe.py
+++ b/vllm_ascend/compilation/passes/sequence_parallelism_moe.py
@@ -186,9 +186,9 @@ class SequenceParallelismMoePass(VllmInductorPass):
 
     def __call__(self, graph: torch.fx.Graph):
         self.begin()
-        logger.debug("before apply replacement %s", graph)
+        logger.debug("before apply replacement %s", str(graph))
         self.matched_count = self.patterns.apply(graph)
-        logger.debug("after apply replacement %s", graph)
+        logger.debug("after apply replacement %s", str(graph))
         logger.debug("SequenceParallelismMoePass replaced %s patterns", self.matched_count)
         pattern_idx = 0
         for pattern_entry in self.patterns.patterns.values():


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates `SequenceParallelismMoePass` debug logging to explicitly stringify the FX graph:

```python
logger.debug("before apply replacement %s", str(graph))
logger.debug("after apply replacement %s", str(graph))
```

A previous lazy logging change avoided evaluating str(graph) when debug logging was disabled. In this pass, the previous eager graph stringification behavior was observable and affected the SP MoE compile flow in the 2-card e2e test.

This keeps the logging format compliant while preserving the previous graph stringification behavior for this pass.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
