### PR TITLE
[BugFix][Doc] Avoid A2 CPU binding overlap from hidden NPUs and doc updates

### DIFF
--- a/docs/source/developer_guide/Design_Documents/cpu_binding.md
+++ b/docs/source/developer_guide/Design_Documents/cpu_binding.md
@@ -2,227 +2,234 @@
 
 ## Overview
 
-CPU binding pins vLLM Ascend worker processes and key threads to specific CPU cores to reduce CPU–NPU cross‑NUMA traffic and stabilize latency under multi‑process workloads. It is designed for ARM servers running Ascend NPUs and is executed after worker warmup completes when enabled.
+CPU binding is an **Ascend-native host-side optimization** for vLLM workers on
+ARM servers. **Starting from vllm-ascend v0.18.0rc1, it is enabled by default
+through `enable_cpu_binding=True`.**
 
-## Background
+The feature does not change model execution logic or numerical results. It only
+controls CPU placement for the worker process, key runtime threads, memory
+pages, and NPU IRQs when the host environment allows it. By keeping the main
+worker, ACL, and release threads on dedicated CPU ranges, it **helps reduce
+context-switch overhead from scheduler preemption on busy hosts.**
 
-On multi‑socket ARM systems, the OS scheduler may place vLLM threads on CPUs far from the local NPU, causing NUMA cross‑traffic and jitter. CPU binding enforces a deterministic CPU placement strategy and optionally binds NPU IRQs to the same CPU pool. This is distinct from other performance features (e.g., graph mode or dynamic batch) because it is purely a host‑side affinity policy and does not change model execution logic.
+## Why CPU Binding?
 
-## Design & How it works
+On multi-socket ARM systems, the Linux scheduler may place worker threads on
+CPUs far from the NPU that the worker drives. This can increase cross-NUMA
+traffic, increase thread preemption, and introduce latency jitter. The Ascend
+backend therefore owns a CPU allocation policy to **reduce cross-NUMA traffic,
+reduce thread preemption, and improve latency stability** instead of relying on
+upstream GPU NUMA binding flags.
 
-### Key concepts
+This is also why upstream NUMA flags are adapted on Ascend:
 
-- **Allowed CPU list**: The cpuset from /proc/self/status (Cpus_allowed_list). All allocations are constrained to this list.
-- **Running NPU list**: Logical NPU IDs extracted from npu‑smi process listing, optionally filtered by ASCEND_RT_VISIBLE_DEVICES.
-- **CPU pool per NPU**: The CPU list assigned to each logical NPU ID based on the binding mode.
-- **Binding modes & Device behavior**:
+- `--numa-bind` is converted to `additional_config={"enable_cpu_binding": true}`.
+- `--numa-bind-nodes` and `--numa-bind-cpus` are ignored because Ascend computes CPU pools from NPU topology or global logical NPU IDs.
 
-  | Device type | Default mode | Description |
-  | ----------- | ------------ | ------------ |
-  | A3 (No Affinity) | `global_slice` | Splits the allowed CPU list evenly based on the **total number of global logical NPUs**, ensuring each NPU is assigned a contiguous segment of CPU cores. This prevents CPU core overlap across multiple process groups. |
-  | A2 / Atlas 300 inference products / Others | `topo_affinity` | Allocates CPUs based on NPU topology affinity (`npu‑smi info -t topo`). If multiple NPUs are assigned to a single NUMA node (which may cause bandwidth contention), the CPU allocation extends to adjacent NUMA nodes. |
+## How It Works?
 
-    - **Default**: enabled (enable_cpu_binding = true).
-    - **Fallback**: If NPU topo affinity is unavailable, global_slice is used.
-    - **Failure handling**: Any exception in binding is logged as a warning and **binding is skipped for that rank**.
+The allocator derives its plan from runtime host state:
 
-### Execution flow (simplified)
+| Input | Source | Purpose |
+| --- | --- | --- |
+| Allowed CPUs | `/proc/self/status` `Cpus_allowed_list` | The only CPUs eligible for binding. Container cpusets are respected. |
+| Logical NPU map | `npu-smi info -m` | Maps card/chip IDs to global logical NPU IDs and gives `total_logic_npus`. |
+| Running NPUs | `npu-smi info` process table, filtered by `ASCEND_RT_VISIBLE_DEVICES` | Identifies the logical NPUs used by this worker process. |
+| Topology affinity | `npu-smi info -t topo` | Provides NPU-to-CPU affinity for `topo_affinity` mode. |
+| CPU NUMA map | `lscpu -e=CPU,NODE` | Used to extend single-NUMA affinity pools to the next NUMA node. |
 
-1. **Feature entry**: `compile_or_warm_up_model()` calls `bind_cpus(local_rank)` after warmup, graph capture, and ATB warmup when `enable_cpu_binding` is true.
-2. **CPU architecture gate**: If the CPU is not ARM, binding is skipped with a log.
-3. **Collect device info**:
-   - Map logical NPU IDs from `npu‑smi info -m`.
-   - Detect running NPU IDs from npu‑smi info process table.
-   - Read cpuset from /proc/self/status.
-   - Read topo affinity from `npu‑smi info -t topo`.
-4. **Build CPU pools**:
-   - Use **global_slice** for A3 devices; **topo_affinity** for A2 and Atlas 300 inference products.
-   - If topo affinity is missing, fall back to global_slice.
-   - Ensure each NPU has at least 5 CPUs.
-5. **Allocate per‑role CPUs**:
-   - Reserve the first two CPUs for IRQ binding.
-   - `main`: pool[2:-2]
-   - `acl`: pool[-2]
-   - `release`: pool[-1]
-6. **Bind threads**:
-   - Main process is pinned to `main` CPUs.
-   - ACL threads (named with acl_thread) are pinned to `acl` CPU.
-   - Release threads (named with release_thread) are pinned to `release` CPU.
-7. **Bind NPU IRQs (optional)**:
-   - If /proc/irq is writable, bind SQ/CQ IRQs to the first two CPUs in the pool.
-   - irqbalance may be stopped to prevent overrides.
-8. **Memory binding (optional)**:
-   - If migratepages is available, memory for ACL threads is migrated to the NPU’s NUMA node.
+### Strategy Selection
 
-## Allocation plan examples
+The binding strategy is selected by Ascend device type:
 
-The allocation plan is derived directly from the CPU pool per NPU and then split into roles:
+| Device type | Strategy | Reason |
+| --- | --- | --- |
+| A3 | `global_slice` | A3 uses HCCS card-to-card interconnect. Each NPU is nearly equidistant from all NUMA nodes, so there is no strong NPU-to-NUMA affinity signal. Global logical NPU ID based slicing gives deterministic, non-overlapping CPU pools and CPU/NUMA isolation between workers. |
+| A2, Atlas 300 inference products, and other non-A3 device types | `topo_affinity` | A2 and Atlas 300 inference products provide NPU-to-CPU affinity information through `npu-smi info -t topo`. Non-A3 device types use this topology signal when available. |
 
-- IRQ CPUs: pool[0], pool[1]
-- `main`: pool[2:-2]
-- `acl`: pool[-2]
-- `release`: pool[-1]
+If `topo_affinity` is selected but topo affinity is unavailable, the allocator falls back to `global_slice`.
 
-Below are concrete examples that reflect the actual code paths.
+### CPU Pool Construction
 
-### Example 1: A3 inference server with 640 CPUs and 16 NPUs
+#### global_slice
 
-- allowed_cpus = [0..639] (640 CPUs)
-- NUMA nodes = 0..7 (8 NUMA nodes, symmetric layout)
-- total_npus = 16
-- running_npu_list = [0..15]
-- base = 640 // 16 = 40, extra = 0
-- Each NPU gets a 40‑CPU pool.
+`global_slice` is designed for A3. Because A3's **HCCS interconnect makes the
+distance from each NPU to each NUMA node nearly the same**, topology affinity is
+not a useful placement signal. The allocator therefore partitions the sorted
+`allowed_cpus` list by global logical NPU ID.
 
-|NPU ID|Assigned CPU Cores (global_slice)|Role Division (IRQ/Main/ACL/Release)|
-|---|---|---|
-|0|0-39|`IRQ`: 0-1, `Main`: 2-37, `ACL`: 38, `Release`: 39|
-|1|40-79|`IRQ`: 40-41, `Main`: 42-77, `ACL`: 78, `Release`: 79|
-|...|...|...|
-|15|600-639|`IRQ`: 600-601, `Main`: 602-637, `ACL`: 638, `Release`: 639|
+1. Determine `total_npus` in this order:
+   - `total_logic_npus` from `npu-smi info -m`
+   - number of topo affinity entries
+   - number of running NPUs
+2. Compute:
+   - `base = len(allowed_cpus) // total_npus`
+   - `extra = len(allowed_cpus) % total_npus`
+3. Each logical NPU gets a deterministic slice:
+   - NPU IDs `< extra` receive `base + 1` CPUs.
+   - Remaining NPU IDs receive `base` CPUs.
+4. Only running NPUs are materialized into `npu_cpu_pool`.
 
-This layout remains deterministic even when multiple processes share the same cpuset, because slicing is based on the global logical NPU ID.
+This is the key property: two independent worker processes with the same cpuset
+but different visible NPU IDs still get **non-overlapping CPU pools** because
+both processes slice against the same global NPU ID space. With a NUMA-aligned
+cpuset, this also provides **CPU/NUMA isolation between workers**, so one worker
+does not share the same CPU or NUMA slice with another worker.
 
-### Example 2: A3 global_slice, even split
+`global_slice` requires `base >= 5`, because every NPU pool reserves:
 
-**Inputs**:
+- 2 CPUs for SQ/CQ IRQ binding
+- at least 1 CPU for the main worker
+- 1 CPU for ACL thread
+- 1 CPU for release thread
 
-- allowed_cpus = [0..23] (24 CPUs)
-- NUMA nodes = 0..1 (2 NUMA nodes, symmetric layout; NUMA0 = 0..11, NUMA1 = 12..23)
-- total_npus = 4 (from npu-smi info -m)
-- running_npu_list = [0, 1, 2, 3]
+#### topo_affinity
 
-**Global slice**:
+`topo_affinity` is designed for A2, Atlas 300 inference products, and
+other non-A3 device types. A2 and Atlas 300 inference products expose
+**meaningful NPU-to-CPU affinity information**, so the allocator starts from NPU
+topology affinity when it is available and then avoids overlap for shared
+affinity groups.
 
-- base = 24 // 4 = 6, extra = 0
-- Each NPU gets a 6‑CPU pool.
+1. Build candidate NPUs from all logical NPUs:
+   - always include running NPUs
+   - include non-running NPUs only when their affinity overlaps this process's allowed cpuset
+2. For each candidate NPU, intersect topo affinity with `allowed_cpus`.
+3. If the intersection is empty for a candidate, binding fails for this rank.
+4. If the affinity CPUs are all on one NUMA node, extend the pool with CPUs from the next NUMA node, constrained by `allowed_cpus`.
+5. Group NPUs with identical extended pools and split each shared pool evenly across that group.
+6. Keep only running NPUs in the final `npu_cpu_pool`.
 
-|NPU ID|Assigned CPU Cores (global_slice)|Role Division (IRQ/Main/ACL/Release)|
-|---|---|---|
-|0|0-5|`IRQ`: 0-1, `Main`: 2-3, `ACL`: 4, `Release`: 5|
-|1|6-11|`IRQ`: 6-7, `Main`: 8-9, `ACL`: 10, `Release`: 11|
-|2|12-17|`IRQ`: 12-13, `Main`: 14-15, `ACL`: 16, `Release`: 17|
-|3|18-23|`IRQ`: 18-19, `Main`: 20-21, `ACL`: 22, `Release`: 23|
+The non-running candidate step is intentional. It prevents two independent
+single-card workers from selecting the same CPU range when their visible NPUs
+share the same topology affinity.
 
-### Example 3: A3 global_slice, remainder distribution
+### Role Split
 
-**Inputs**:
+After a CPU pool is built, the allocator splits it by role:
 
-- allowed_cpus = [0..16] (17 CPUs)
-- NUMA nodes = 0..1 (2 NUMA nodes, symmetric layout; NUMA0 = 0..7, NUMA1 = 8..16)
-- total_npus = 3
-- running_npu_list = [0, 1, 2]
+| Role | CPUs |
+| --- | --- |
+| SQ/CQ IRQ | `pool[0]`, `pool[1]` |
+| Main worker process and subthreads | `pool[2:-2]` |
+| ACL thread | `pool[-2]` |
+| Release thread | `pool[-1]` |
 
-**Global slice**:
+If a final pool has fewer than 5 CPUs, binding fails for this rank and the worker logs a warning from the caller.
 
-- base = 17 // 3 = 5, extra = 2
-- NPU0 pool size = 6 (base+1)
-- NPU1 pool size = 6 (base+1)
-- NPU2 pool size = 5 (base)
+## Conditional Host Tuning
 
-|NPU ID|Assigned CPU Cores (global_slice)|Role Division (IRQ/Main/ACL/Release)|
-|---|---|---|
-|0|0-5|`IRQ`: 0-1, `Main`: 2-3, `ACL`: 4, `Release`: 5|
-|1|6-11|`IRQ`: 6-7, `Main`: 8-9, `ACL`: 10, `Release`: 11|
-|2|12-16|`IRQ`: 12-13, `Main`: 14, `ACL`: 15, `Release`: 16|
+After CPU affinity is applied, CPU binding can also apply two host-side tuning
+steps when the environment supports them:
 
-Note: When a pool size is exactly 5, `main` has a single CPU (pool[2]). If any pool is <5, binding raises an error.
+- Memory migration uses `migratepages` to move the worker process's existing
+  pages to the selected NUMA node. This keeps the worker closer to the memory it
+  reads and reduces remote-NUMA memory read latency.
+- IRQ binding places NPU IRQ handling on the CPUs reserved for the corresponding
+  NPU when `/proc/irq` is writable and IRQ files can be resolved.
 
-**NUMA analysis**:
+These are conditional parts of CPU binding, not separate feature switches. If a
+host prerequisite is missing, that step is skipped while CPU thread binding
+still proceeds. Missing `migratepages` can still leave pages on remote NUMA
+nodes, so **latency or throughput may regress compared with a full CPU binding
+setup.**
 
-- With the symmetric NUMA layout above (NUMA0 = 0..7, NUMA1 = 8..16), NPU0 stays within NUMA0, NPU2 stays within NUMA1, but NPU1 spans both NUMA0 (6,7) and NUMA1 (8..11). This is a direct consequence of global slicing over the ordered cpuset; the remainder distribution does not enforce NUMA boundaries.
-- If the cpuset numbering is interleaved across NUMA nodes (non‑symmetric layout), cross‑NUMA pools can happen even earlier. This is why symmetric NUMA layout is recommended for best locality.
+## Examples
 
-### Known limitations and future improvements
+### A3 inference server with 640 CPUs and 16 NPUs
 
-With the current `global_slice` strategy, some CPU/NPU layouts cannot avoid cross‑NUMA pools. A future enhancement should incorporate NUMA node boundaries into the slicing logic so that pools remain within a single NUMA node whenever possible.
+Inputs:
 
-### Example 4: global_slice with visible subset of NPUs
+- `allowed_cpus = [0..639]`
+- `total_logic_npus = 16`
+- `running_npu_list = [0..15]`
 
-**Inputs**:
+Computation:
 
-- total_npus = 8 (from npu-smi info -m)
-- running_npu_list = [2, 3] (filtered by ASCEND_RT_VISIBLE_DEVICES)
-- allowed_cpus = [0..39] (40 CPUs)
-- NUMA nodes = 0..3 (4 NUMA nodes, symmetric layout; 0..9, 10..19, 20..29, 30..39)
+- `base = 640 // 16 = 40`
+- `extra = 0`
+- Worker `i` driving logical NPU `i` receives CPU slice
+  `[i * 40 .. i * 40 + 39]`.
 
-**Global slice**:
+Global slice view:
 
-- base = 40 // 8 = 5, extra = 0
-- Only the visible logical NPUs get pools, but slicing uses the global NPU ID so different processes do not overlap.
+```text
+CPU range: 0                                                             639
+           |-- worker0/NPU0 --|-- worker1/NPU1 --| ... |-- worker15/NPU15 --|
+           |      0-39        |      40-79       | ... |      600-639       |
+```
 
-|NPU ID|Assigned CPU Cores (global_slice)|Role Division (IRQ/Main/ACL/Release)|
-|---|---|---|
-|2|10-14|`IRQ`: 10-11, `Main`: 12, `ACL`: 13, `Release`: 14|
-|3|15-19|`IRQ`: 15-16, `Main`: 17, `ACL`: 18, `Release`: 19|
+Role split inside each worker slice:
 
-### Example 5: A2/Atlas 300 inference products topo_affinity with NUMA extension
+```text
+40-CPU worker slice
+| IRQ CPUs | main worker process and subthreads | ACL thread | release thread |
+|  c0-c1   |              c2-c37                |    c38     |      c39       |
+```
 
-**Inputs**:
+Concrete examples:
 
-- npu_affinity = {0: [0..7], 1: [0..7]} (from `npu-smi info -t topo`)
-- allowed_cpus = [0..15] (16 CPUs)
-- NUMA nodes = 0..1 (2 NUMA nodes; NUMA0 = 0..7, NUMA1 = 8..15)
+| Worker | Logical NPU | CPU pool | IRQ CPUs | Main CPUs | ACL CPU | Release CPU |
+| --- | --- | --- | --- | --- | --- | --- |
+| 0 | 0 | 0-39 | 0-1 | 2-37 | 38 | 39 |
+| 1 | 1 | 40-79 | 40-41 | 42-77 | 78 | 79 |
+| ... | ... | ... | ... | ... | ... | ... |
+| 15 | 15 | 600-639 | 600-601 | 602-637 | 638 | 639 |
 
-**NUMA extension**:
+This layout remains deterministic even when different worker processes share
+the same cpuset, because slicing is based on the global logical NPU ID.
 
-- Both NPUs are on NUMA0, so each pool extends to the nearest NUMA node to reduce contention.
-- NPU0 extends to NUMA1 -> [0..15]
-- NPU1 extends to NUMA1 -> [0..15]
+### A2 topo_affinity with hidden same-affinity NPUs
 
-Because both pools are identical, the allocator applies average distribution across NPUs to avoid overlap. With a pool [0..15] and 2 NPUs, the final pools become:
+Inputs from an A2 topology:
 
-|NPU ID|Assigned CPU Cores (topo_affinity)|Role Division (IRQ/Main/ACL/Release)|
-|---|---|---|
-|0|0-7|`IRQ`: 0-1, `Main`: 2-5, `ACL`: 6, `Release`: 7|
-|1|8-15|`IRQ`: 8-9, `Main`: 10-13, `ACL`: 14, `Release`: 15|
+- NPU0 affinity: 144-167
+- NPU2 affinity: 144-167
+- Process A sees only NPU0
+- Process B sees only NPU2
+- Both processes have `allowed_cpus = [144..191]`
 
-### Example 6: Minimum CPUs per NPU
+The allocator includes the hidden same-affinity NPU as a candidate in each
+process, splits the shared extended pool, and then keeps only the visible NPU in
+the final pool.
 
-**Inputs**:
+Final pools:
 
-- total_npus = 2
-- allowed_cpus = [0..7] (8 CPUs)
-- NUMA nodes = 0..1 (2 NUMA nodes, symmetric layout; NUMA0 = 0..3, NUMA1 = 4..7)
+| Process | Visible NPU | Final CPU pool |
+| --- | --- | --- |
+| A | 0 | 144-167 |
+| B | 2 | 168-191 |
 
-**Result**:
+This avoids overlapping CPU pools even when the two workers are launched as independent single-card services.
 
-- base = 4, which is < 5, so binding fails with: "Insufficient CPUs for binding with IRQ/ACL/REL reservations..."
+## Logs
 
-|NPU ID|Assigned CPU Cores|Role Division (IRQ/Main/ACL/Release)|
-|---|---|---|
-|0|N/A|Binding error (insufficient CPUs per NPU)|
-|1|N/A|Binding error (insufficient CPUs per NPU)|
+The allocator logs the selected mode and allocation plan:
 
-To resolve, either reduce total_npus or enlarge the cpuset so that each NPU has at least 5 CPUs.
+```text
+[cpu_bind_mode] mode=topo_affinity rank=0 visible_npus=[0]
+The CPU allocation plan is as follows:
+NPU0: main=[...] acl=[...] release=[...]
+```
 
-### Logging and verification
+## Limitations
 
-- Logs show the selected binding mode and the allocation plan, for example:
-    - `[cpu_bind_mode] mode=global_slice rank=0 visible_npus=[...]`
-    - `The CPU allocation plan is as follows: ...`
-- You can verify affinity via taskset or `/proc/<pid>/status` after startup.
-
-## Limitations & Notes
-
-- **ARM‑only**: Binding is skipped on non‑ARM CPUs.
-- **Minimum CPU requirement**: Each logical NPU requires at least 5 CPUs. If the cpuset is smaller, binding fails with an error.
-- **NUMA symmetry assumption**: For best locality, the current strategies assume the cpuset is evenly distributed across NUMA nodes and CPU numbering aligns with NUMA layout; otherwise NUMA locality may be suboptimal.
-    - Example (symmetric layout): 2 NUMA nodes, 64 CPUs total. NUMA0 = CPUs 0–31, NUMA1 = CPUs 32–63, and the cpuset is 0–63. With 4 logical NPUs, global slicing yields 16 CPUs per NPU (0–15, 16–31, 32–47, 48–63), so each NPU’s pool stays within a single NUMA node.
-- **Runtime dependencies**:
-    - Requires npu‑smi and lscpu commands.
-    - IRQ binding requires write access to /proc/irq.
-    - Memory binding requires migratepages; otherwise it is skipped.
-- **IRQ side effects**: irqbalance may be stopped to avoid overriding bindings.
-- **Per‑process behavior**: Only the current rank’s NPU is used for IRQ binding to avoid cross‑process overwrite.
-
-### Debug logging
-
-Use the standard vLLM logging configuration to enable debug logs. The binding process emits debug messages (e.g., `[cpu_global_slice] ...`) when debug level is enabled.
+- CPU binding runs only on ARM. It is skipped on x86_64.
+- Each final NPU pool must have at least 5 CPUs.
+- `global_slice` is deterministic and provides CPU/NUMA isolation when the
+  cpuset is NUMA-aligned, but it cannot guarantee NUMA-local pools when CPU
+  numbering or cpuset layout crosses NUMA boundaries.
+- `topo_affinity` depends on usable output from `npu-smi info -t topo`.
+- IRQ binding requires writable `/proc/irq` and resolvable PCI/IRQ information.
+- Memory migration requires `migratepages`; otherwise only memory migration is
+  skipped. CPU affinity still applies, but performance may degrade because
+  existing pages are not moved to the target NUMA node and may be read through
+  higher-latency remote NUMA access.
+- If an exception escapes the binding flow, `NPUWorker` logs a warning and skips CPU binding for that rank.
 
 ## References
 
-- CPU binding implementation: vllm_ascend/cpu_binding.py (`DeviceInfo`, `CpuAlloc`, `bind_cpus`)
-- Worker integration: vllm_ascend/worker/worker.py (`NPUWorker.compile_or_warm_up_model`)
-- Additional config option: docs/source/user_guide/configuration/additional_config.md (`enable_cpu_binding`)
-- Tests: tests/ut/device_allocator/test_cpu_binding.py
+- Implementation: `vllm_ascend/cpu_binding.py`
+- Worker integration: `vllm_ascend/worker/worker.py`
+- Config: `vllm_ascend/ascend_config.py` and `docs/source/user_guide/configuration/additional_config.md`
+- Tests: `tests/ut/device_allocator/test_cpu_binding.py`

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -38,7 +38,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
 | `multistream_overlap_gate`          | bool | `False` | Whether to enable multi-stream overlap gate. This option only takes effect on MoE models with shared experts.  |
 | `recompute_scheduler_enable`        | bool | `False` | Whether to enable the recompute scheduler. **Only valid in PD-disaggregated mode** (`kv_role` is `kv_producer` or `kv_consumer`). **Do not enable in PD-mixed mode** (no `kv_transfer_config`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
-| `enable_cpu_binding`                | bool | `True`  | Whether to enable CPU binding. Only takes effect on ARM CPUs; A3 uses the global-slicing CPU allocation strategy and other device types use the topo-affinity CPU allocation strategy. |
+| `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
 | `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic batch feature                            |
 | `enable_npugraph_ex`                | bool | `False` | Whether to enable npugraph_ex graph mode.                                                                 |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |

--- a/docs/source/user_guide/feature_guide/cpu_binding.md
+++ b/docs/source/user_guide/feature_guide/cpu_binding.md
@@ -1,135 +1,122 @@
 # CPU Binding
 
-## Overview
+**Starting from vllm-ascend v0.18.0rc1, CPU binding is enabled by default on
+ARM-based Ascend servers.**
 
-CPU Binding is a performance optimization feature for vLLM, specifically designed for servers equipped with **ARM architecture and Ascend NPUs**. It pins vLLM processes and threads to specific CPU cores to reduce CPU–NPU cross‑NUMA communication overhead and stabilize inference latency. This feature only adjusts host-side CPU affinity policies and **does not alter model execution logic or impact inference results**.
+**You usually do not need to configure it manually.** Set `enable_cpu_binding`
+only when you want to disable it or make the default explicit.
+
+## Benefits of CPU Binding
+
+CPU Binding improves **host-side scheduling** for multi-socket ARM servers with
+Ascend NPUs. It is designed to solve three common host-side inference performance issues:
+
+- **Lower cross-NUMA traffic.** Worker processes stay closer to the CPU and
+  memory resources selected for their active NPU, reducing remote NUMA access.
+- **Lower context-switch overhead from thread preemption.** Key runtime threads
+  run on stable CPU ranges, reducing scheduler movement and CPU contention on
+  busy hosts.
+- **Better latency stability and multi-worker isolation.** Independent workers
+  avoid sharing the same CPU/NUMA resources, which helps reduce tail-latency
+  jitter and makes throughput more predictable during multi-NPU serving.
+
+This feature is a host-side performance optimization. **It does not change model
+execution logic or numerical outputs.** When memory migration support is
+unavailable, CPU affinity still works, but memory locality may be worse and
+latency or throughput may degrade.
 
 ## Usage
 
-### Online serving example with CPU binding enabled (by default)
+### Online Serving
+
+Default behavior:
 
 ```bash
-vllm serve Qwen/Qwen2.5-7B-Instruct \
-  --additional-config '{"enable_cpu_binding": true}'
+vllm serve Qwen/Qwen2.5-7B-Instruct
 ```
 
-### Online serving example with CPU binding disabled
+Disable CPU binding:
 
 ```bash
 vllm serve Qwen/Qwen2.5-7B-Instruct \
   --additional-config '{"enable_cpu_binding": false}'
 ```
 
-### Offline inference example with CPU binding enabled
+### Offline Inference
+
+Default behavior:
+
+```python
+from vllm import LLM
+
+llm = LLM(model="Qwen/Qwen2.5-7B-Instruct")
+```
+
+Disable CPU binding:
 
 ```python
 from vllm import LLM
 
 llm = LLM(
     model="Qwen/Qwen2.5-7B-Instruct",
-    additional_config={"enable_cpu_binding": True},
+    additional_config={"enable_cpu_binding": False},
 )
 ```
 
-### Offline inference example with CPU binding disabled
+## Requirements
 
-```python
-from vllm import LLM
+Official vllm-ascend images have already included `util-linux` and `procps` /
+`procps-ng` in v0.18.0rc1 and earlier releases. **Starting from v0.18.0rc1, the
+official images also include `numactl`.**
 
-llm = LLM(
-  model="Qwen/Qwen2.5-7B-Instruct",
-  additional_config={"enable_cpu_binding": False},
-)
-```
-
-## Dependencies
-
-### Installation
-
-#### Ubuntu/Debian
+If you are not using the official image, install the host tools manually:
 
 ```bash
-sudo apt-get update
+# Ubuntu/Debian
 sudo apt-get install -y util-linux numactl procps
-```
 
-#### RHEL/CentOS/Alma/Rocky
-
-```bash
+# RHEL/CentOS/Alma/Rocky
 sudo yum install -y util-linux numactl procps-ng
-```
 
-#### openEuler
-
-```bash
+# openEuler
 sudo dnf install -y util-linux numactl procps-ng
 ```
 
-### IRQ binding's additional considerations
+**Without `numactl` / `migratepages`, vLLM Ascend skips only memory migration.**
+The worker process and runtime threads are still pinned, but pages already
+placed on remote NUMA nodes are not migrated, which **can reduce locality and
+degrade latency or throughput.**
 
-For best results, if you run inside a Docker container where `systemctl` is likely unavailable, stop the `irqbalance` service on the host manually before starting vLLM. Also make sure the container has the necessary permissions to write to `/proc/irq/*/smp_affinity` for IRQ binding:
+For optimal locality, use a cpuset that is evenly distributed across NUMA
+nodes. Unbalanced cpusets may reduce the locality benefit of CPU binding.
 
-- **Stop `irqbalance` service**:
+For IRQ binding, the process also needs permission to read `/proc/interrupts`
+and write `/proc/irq/*/smp_affinity`. If `irqbalance` is running and the process
+can use `systemctl`, vLLM Ascend stops it before applying IRQ affinity. In
+containers where `systemctl` is unavailable, stop `irqbalance` on the host when
+IRQ affinity matters.
 
-    For example, on Ubuntu and other systemd-based Linux distributions, you can stop irqbalance with:
+On the host, stop `irqbalance` before starting vLLM when you need stable IRQ
+affinity:
 
-    ```bash
-    sudo systemctl stop irqbalance
-    ```
+```bash
+sudo systemctl stop irqbalance
+```
 
-    After you finish the vLLM process, you can restore irqbalance on the host:
+After the vLLM service exits, restart it if the host should return to the
+default IRQ balancing policy:
 
-    ```bash
-    sudo systemctl start irqbalance
-    ```
+```bash
+sudo systemctl start irqbalance
+```
 
-    Note: On systems that do not use systemd, use the corresponding service-management command provided by the distribution.
+## Troubleshooting
 
-- **Permissions**:
-    - Read access to `/proc/self/status` and `/proc/interrupts`
-    - Write access to `/proc/irq/*/smp_affinity` for IRQ binding
-
-## Common Issues & Troubleshooting
-
-|Error/Warning Message|Core Cause|Solution|
-|---|---|---|
-|Can not get running npu info.|The npu-smi process table is empty, or the `ASCEND_RT_VISIBLE_DEVICES` environment variable filters out all NPUs.|1. Ensure the process is running on visible NPUs; 2. Verify that the `ASCEND_RT_VISIBLE_DEVICES` value matches the actual logical NPU IDs.|
-|Insufficient CPUs for binding...|The number of CPU cores allocated to each NPU is less than the minimum requirement of 5.|1. Expand the allowed CPU list; 2. Reduce the number of visible NPUs.|
-|NPU topo affinity not found...|npu-smi is unable to retrieve NPU topology affinity information.|Verify the integrity of the npu-smi installation and ensure the user has sufficient execution permissions.|
-|Bind cpus failed in rankX...|The CPU binding process failed (e.g., taskset is unavailable, or the user lacks write permissions for /proc/irq).|1. Confirm that required tools (taskset, lscpu, npu-smi) are installed and available; 2. Verify the Cpus_allowed_list in `/proc/self/status` is valid.|
-
-## Key Limitations
-
-- ARM architecture only: Binding is automatically skipped on x86_64 systems.
-
-- Symmetric NUMA layout required for optimal performance: CPU numbering should be aligned with NUMA nodes. Non-symmetric layouts may result in cross-NUMA CPU pools, reducing locality.
-
-- IRQ binding requires write permissions for /proc/irq. Memory binding depends on the `migratepages` tool; if unavailable, memory migration is skipped.
-
-## FAQ
-
-**Q1: Does CPU binding work on x86_64?**
-
-No. The binding is skipped on non‑ARM CPUs.
-
-**Q2: Why are only the current rank’s IRQs bound?**
-
-To avoid multiple processes overwriting IRQ affinity settings for the same device.
-
-**Q3: What if my cpuset already limits CPUs?**
-
-The binder uses Cpus_allowed_list from /proc/self/status as the only eligible CPU set. Ensure this list is large enough.
-
-**Q4: Does CPU binding change model outputs?**
-
-No. It only affects host‑side affinity and should not change numerical results.
-
----
-
-## Summary
-
-1. **Core Objective**: Reduce cross‑NUMA communication by pinning vLLM processes and threads to specific CPU cores, thereby stabilizing inference latency in Ascend NPU deployments (only applicable to ARM architectures).
-
-2. **Usage**: Enable or disable with `enable_cpu_binding` via `additional_config` in both online and offline workflows.
-
-3. **Key Limitations**: ARM‑only; relies on symmetric NUMA layouts; binding fails if the CPU pool has fewer than 5 cores; binding errors trigger a warning log but do not terminate the process.
+| Message | Meaning | Action |
+| --- | --- | --- |
+| `CPU binding skipped: non-ARM CPU detected.` | CPU binding only runs on ARM. | No action needed on x86_64. |
+| `Can not get running npu info.` | No running NPU was found, or `ASCEND_RT_VISIBLE_DEVICES` filtered all NPUs. | Check visible NPU IDs and `npu-smi info`. |
+| `Insufficient CPUs for binding...` | Fewer than 5 CPUs are available per logical NPU. | Expand the cpuset or reduce visible NPUs. |
+| `NPU topo affinity not found...` | Topology affinity is unavailable. | vLLM Ascend falls back to `global_slice`; check `npu-smi info -t topo` only if topology affinity is expected on this device. |
+| `The 'migratepages' command is not available...` | Memory migration is skipped, while CPU thread binding still proceeds. | Install `numactl` if NUMA locality or performance is affected. |
+| `Bind cpus failed in rank...` | A binding step failed and CPU binding was skipped for that rank. | Check `taskset`, `lscpu`, `npu-smi`, cpuset size, and `/proc/irq` permissions. |

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -293,6 +293,38 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.build_global_slice_cpu_pool()
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], list(range(10, 20)))
 
+    def test_build_global_slice_cpu_pool_splits_same_cpuset_across_processes(self):
+        def build_single_card_process(visible_npu):
+            cpu_alloc = make_cpu_alloc()
+            cpu_alloc.device_info.running_npu_list = [visible_npu]
+            cpu_alloc.device_info.allowed_cpus = list(range(20))
+            cpu_alloc.device_info.total_logic_npus = 4
+            cpu_alloc.device_info.npu_affinity = {}
+
+            cpu_alloc.build_global_slice_cpu_pool()
+            cpu_alloc.allocate()
+            return cpu_alloc
+
+        npu0_process = build_single_card_process(0)
+        npu3_process = build_single_card_process(3)
+
+        self.assertEqual(npu0_process.npu_cpu_pool, {0: [0, 1, 2, 3, 4]})
+        self.assertEqual(npu3_process.npu_cpu_pool, {3: [15, 16, 17, 18, 19]})
+        self.assertFalse(set(npu0_process.npu_cpu_pool[0]) & set(npu3_process.npu_cpu_pool[3]))
+        self.assertFalse(set(npu0_process.assign_main[0]) & set(npu3_process.assign_main[3]))
+
+    def test_build_global_slice_cpu_pool_distributes_remainder_by_npu_id(self):
+        self.cpu_alloc.device_info.running_npu_list = [0, 1, 2]
+        self.cpu_alloc.device_info.allowed_cpus = list(range(17))
+        self.cpu_alloc.device_info.total_logic_npus = 3
+        self.cpu_alloc.device_info.npu_affinity = {}
+
+        self.cpu_alloc.build_global_slice_cpu_pool()
+
+        self.assertEqual(self.cpu_alloc.npu_cpu_pool[0], [0, 1, 2, 3, 4, 5])
+        self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], [6, 7, 8, 9, 10, 11])
+        self.assertEqual(self.cpu_alloc.npu_cpu_pool[2], [12, 13, 14, 15, 16])
+
     def test_build_global_slice_cpu_pool_fallback_to_affinity_len(self):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(12))
@@ -494,8 +526,11 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
         cpu_alloc.device_info.running_npu_list = [0]
-        cpu_alloc.device_info.allowed_cpus = [192, 193, 194, 195, 196]
-        cpu_alloc.device_info.npu_affinity = {0: [192, 193, 194, 195, 196], 1: [196]}
+        cpu_alloc.device_info.allowed_cpus = list(range(192, 202))
+        cpu_alloc.device_info.npu_affinity = {
+            0: list(range(192, 202)),
+            1: list(range(192, 202)),
+        }
 
         with (
             patch.object(cpu_alloc, "build_cpu_node_map"),
@@ -506,6 +541,42 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193, 194, 195, 196]})
         self.assertEqual(cpu_alloc.assign_main, {0: [194]})
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_splits_hidden_same_affinity_npus_across_processes(self, _mock_get_device_type):
+        def build_single_card_process(visible_npu):
+            cpu_alloc = make_cpu_alloc()
+            cpu_alloc.device_info.all_logic_npus = list(range(8))
+            cpu_alloc.device_info.running_npu_list = [visible_npu]
+            cpu_alloc.device_info.allowed_cpus = list(range(144, 192))
+            cpu_alloc.device_info.npu_affinity = {
+                0: list(range(144, 168)),
+                1: list(range(0, 24)),
+                2: list(range(144, 168)),
+                3: list(range(0, 24)),
+                4: list(range(96, 120)),
+                5: list(range(48, 72)),
+                6: list(range(96, 120)),
+                7: list(range(48, 72)),
+            }
+
+            with (
+                patch.object(cpu_alloc, "build_cpu_node_map"),
+                patch.object(cpu_alloc, "extend_numa", return_value=list(range(144, 192))),
+            ):
+                cpu_alloc.build_cpu_pools()
+                cpu_alloc.allocate()
+            return cpu_alloc
+
+        npu0_process = build_single_card_process(0)
+        npu2_process = build_single_card_process(2)
+
+        self.assertEqual(npu0_process.npu_cpu_pool, {0: list(range(144, 168))})
+        self.assertEqual(npu2_process.npu_cpu_pool, {2: list(range(168, 192))})
+        self.assertFalse(set(npu0_process.npu_cpu_pool[0]) & set(npu2_process.npu_cpu_pool[2]))
+        self.assertFalse(set(npu0_process.assign_main[0]) & set(npu2_process.assign_main[2]))
+        self.assertFalse(set(npu0_process.assign_acl[0]) & set(npu2_process.assign_acl[2]))
+        self.assertFalse(set(npu0_process.assign_rel[0]) & set(npu2_process.assign_rel[2]))
 
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info):

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -29,6 +29,7 @@ def make_cpu_alloc(rank_id=0):
     cpu_alloc.rank_id = rank_id
     cpu_alloc.device_info = SimpleNamespace(
         running_npu_list=[0],
+        all_logic_npus=[0],
         allowed_cpus=[],
         npu_affinity={},
         total_logic_npus=0,
@@ -459,6 +460,7 @@ class TestCpuBindingSupplemental(unittest.TestCase):
     @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
     def test_build_cpu_pools_topo_mode_builds_and_splits_duplicate_groups(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.all_logic_npus = [0, 1, 2]
         cpu_alloc.device_info.running_npu_list = [0, 1, 2]
         cpu_alloc.device_info.allowed_cpus = [0, 1, 2, 3]
         cpu_alloc.device_info.npu_affinity = {0: [0, 1], 1: [2, 3], 2: [2, 3]}
@@ -470,6 +472,40 @@ class TestCpuBindingSupplemental(unittest.TestCase):
             cpu_alloc.build_cpu_pools()
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [0, 1], 1: [2], 2: [3]})
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_skips_non_running_npu_without_cpuset_overlap(self, _mock_get_device_type):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.all_logic_npus = [0, 1]
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.device_info.allowed_cpus = [192, 193]
+        cpu_alloc.device_info.npu_affinity = {0: [192, 193], 1: [128, 129]}
+
+        with (
+            patch.object(cpu_alloc, "build_cpu_node_map"),
+            patch.object(cpu_alloc, "extend_numa", side_effect=lambda cpus: cpus),
+        ):
+            cpu_alloc.build_cpu_pools()
+
+        self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193]})
+
+    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_build_cpu_pools_topo_mode_excludes_non_running_npu_from_final_pool(self, _mock_get_device_type):
+        cpu_alloc = make_cpu_alloc()
+        cpu_alloc.device_info.all_logic_npus = [0, 1]
+        cpu_alloc.device_info.running_npu_list = [0]
+        cpu_alloc.device_info.allowed_cpus = [192, 193, 194, 195, 196]
+        cpu_alloc.device_info.npu_affinity = {0: [192, 193, 194, 195, 196], 1: [196]}
+
+        with (
+            patch.object(cpu_alloc, "build_cpu_node_map"),
+            patch.object(cpu_alloc, "extend_numa", side_effect=lambda cpus: cpus),
+        ):
+            cpu_alloc.build_cpu_pools()
+            cpu_alloc.allocate()
+
+        self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193, 194, 195, 196]})
+        self.assertEqual(cpu_alloc.assign_main, {0: [194]})
 
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info):

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -338,7 +338,17 @@ class CpuAlloc:
             self.build_global_slice_cpu_pool()
             return
 
-        for npu in self.device_info.running_npu_list:
+        allowed_cpu_set = set(self.device_info.allowed_cpus)
+        # Consider all logical NPUs to avoid CPU distribution overlap across worker processes.
+        candidate_npus = [
+            npu
+            for npu in self.device_info.all_logic_npus
+            # Always keep visible NPUs for strict conflict checks; include
+            # non-visible NPUs only when they overlap this process's cpuset.
+            if npu in self.device_info.running_npu_list
+            or any(cpu in allowed_cpu_set for cpu in self.device_info.npu_affinity.get(npu, []))
+        ]
+        for npu in candidate_npus:
             base_cpu_list = [
                 cpu for cpu in self.device_info.npu_affinity.get(npu, []) if cpu in self.device_info.allowed_cpus
             ]
@@ -357,7 +367,8 @@ class CpuAlloc:
                 final[npu_list[0]] = self.npu_cpu_pool[npu_list[0]]
             else:
                 final.update(self.average_distribute({key: npu_list}))
-        self.npu_cpu_pool = final
+        # Keep only visible NPUs in the final binding pool. Non-visible NPUs are used only to avoid overlap.
+        self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
 
     def allocate(self) -> None:
         for npu, pool in self.npu_cpu_pool.items():


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes A2 CPU binding pool construction when a worker process only sees part of the logical NPU topology but its cpuset overlaps CPUs affiliated with non-visible NPUs. Also update CPU binding community docs following v0.18.0 version's release.

- CPU Binding Logic Improvement: Updated the CPU binding planner to consider all logical NPUs, including non-visible ones, when calculating CPU distribution to prevent potential overlaps in partial-visibility A2 worker environments.
- Binding Pool Filtering: Ensured that the final CPU binding pool is strictly limited to visible/running NPUs, while using non-visible NPUs only as a reference to avoid conflicting assignments.
- Test Coverage: Added new unit tests to verify that non-running NPUs are correctly skipped during pool construction while still respecting cpuset overlaps.

This PR is built over https://github.com/vllm-project/vllm-ascend/pull/8645 while fixing some critical logic defects.
Fixes issue #8600.
Co-authored with @Rozwel-dx.

Related RFC:
#6966

### Does this PR introduce _any_ user-facing change?

No public API change.

For Ascend A2 deployments that use CPU binding with partial NPU visibility, CPU assignment can change to avoid overlap with CPUs associated with non-visible logical NPUs. The final assignment remains limited to the visible/running NPUs for the worker.

### How was this patch tested?
E2E test on A2
