### PR TITLE
[Doc][Misc] Enable MathJax rendering for Markdown formulas

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,7 @@ release = ""
 extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
     "sphinx_copybutton",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -61,7 +62,7 @@ extensions = [
     "sphinx_substitution_extensions",
 ]
 
-myst_enable_extensions = ["colon_fence", "substitution"]
+myst_enable_extensions = ["colon_fence", "dollarmath", "substitution"]
 
 # Change this when cut down release
 myst_substitutions = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ extensions = [
     "sphinx_substitution_extensions",
 ]
 
-myst_enable_extensions = ["colon_fence", "dollarmath", "substitution"]
+myst_enable_extensions = ["colon_fence", "amsmath", "dollarmath", "substitution"]
 
 # Change this when cut down release
 myst_substitutions = {


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enables math formula rendering in Markdown docs by:

- Adding `sphinx.ext.mathjax` to the Sphinx extensions
- Enabling MyST `dollarmath` and `amsmath` support for `$...$` and `$$...$$` syntax

Without this, formulas in docs such as `dynamic_chunked_pipeline_parallel.md` were rendered as raw text instead of mathematical notation.

issue:
<img width="512" height="264" alt="image" src="https://github.com/user-attachments/assets/ad769a31-5bd1-4a94-8b1b-cd40c8a5768f" />

fixed:
<img width="678" height="282" alt="image" src="https://github.com/user-attachments/assets/304d231f-fb53-4f80-bfba-da9e5cd44432" />

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/6f786f2c506cb07f4566771fdc62e640e2c4a176
