### PR TITLE
[Test]Add quantization npu test case

### DIFF
--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -16,6 +16,7 @@
 # This file is a part of the vllm-ascend project.
 #
 import functools
+import inspect
 import subprocess
 import sys
 from enum import Enum
@@ -68,13 +69,23 @@ class RunnerDeviceType(str, Enum):
 def npu_test(num_npus: int = 1, npu_type: str | RunnerDeviceType = RunnerDeviceType.A2):
     """Decorator that marks a test with NPU resource requirements.
 
-    Serves two purposes:
-      1. **CI routing** — the AST parser in determine_smart_e2e_scope.py reads
-         the decorator keyword arguments (num_npus, npu_type) to group tests
-         by runner type. The parameter names and decorator name must stay in
-         sync with the parser.
-      2. **Runtime gating** — at test time the decorator skips the test when
-         the current environment lacks the required NPU hardware.
+    Can be applied to either a single test function/method or a test class.
+
+    Serves two purposes, depending on the target:
+
+      - **Function/method**: declarative metadata for the AST parser AND
+        runtime gating. If the runner does not satisfy the declared
+        requirements, the wrapper raises ``RuntimeError`` (fails loudly,
+        not ``pytest.skip``) — a mismatch means routing or the runner
+        environment is broken.
+      - **Class**: declarative metadata only. The class is returned
+        unchanged so pytest's standard class-based collection still works.
+        CI routing (driven by the AST parser) is the single source of
+        truth — runtime gating per method would be redundant.
+
+    The AST parser in ``determine_smart_e2e_scope.py`` reads the decorator
+    keyword arguments (num_npus, npu_type) to group tests by runner type.
+    The parameter names and decorator name must stay in sync with the parser.
 
     Args:
         num_npus: Number of NPU devices required (default 1).
@@ -83,7 +94,7 @@ def npu_test(num_npus: int = 1, npu_type: str | RunnerDeviceType = RunnerDeviceT
     if not isinstance(npu_type, RunnerDeviceType):
         npu_type = RunnerDeviceType(npu_type)
 
-    def decorator(func):
+    def _wrap_callable(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if npu_type == RunnerDeviceType.CPU:
@@ -107,5 +118,13 @@ def npu_test(num_npus: int = 1, npu_type: str | RunnerDeviceType = RunnerDeviceT
             return func(*args, **kwargs)
 
         return wrapper
+
+    def decorator(obj):
+        # Class decoration is purely declarative — the AST parser handles
+        # routing, and CI routing is the single source of truth. Returning
+        # the class unchanged keeps pytest's class-based collection working.
+        if inspect.isclass(obj):
+            return obj
+        return _wrap_callable(obj)
 
     return decorator

--- a/tests/ut/quantization/conftest_quantization.py
+++ b/tests/ut/quantization/conftest_quantization.py
@@ -188,3 +188,32 @@ def create_mxfp_moe_layer(
         requires_grad=False,
     )
     return layer
+
+
+def create_linear_layer(
+    quant_method,
+    input_size=128,
+    output_size=256,
+    params_dtype=torch.bfloat16,
+):
+    layer = nn.Module()
+    weight_dict = quant_method.get_weight(input_size, output_size, params_dtype)
+    for weight_name, weight_param in weight_dict.items():
+        param = torch.nn.Parameter(weight_param.npu(), requires_grad=False)
+        layer.register_parameter(weight_name, param)
+
+    pertensor_dict = quant_method.get_pertensor_param(params_dtype)
+    for pertensor_name, pertensor_param in pertensor_dict.items():
+        param = torch.nn.Parameter(pertensor_param.npu(), requires_grad=False)
+        layer.register_parameter(pertensor_name, param)
+
+    perchannel_dict = quant_method.get_perchannel_param(output_size, params_dtype)
+    for perchannel_name, perchannel_param in perchannel_dict.items():
+        param = torch.nn.Parameter(perchannel_param.npu(), requires_grad=False)
+        layer.register_parameter(perchannel_name, param)
+
+    pergroup_dict = quant_method.get_pergroup_param(input_size, output_size, params_dtype, layer_type="row")
+    for pergroup_name, pergroup_param in pergroup_dict.items():
+        param = torch.nn.Parameter(pergroup_param.npu(), requires_grad=False)
+        layer.register_parameter(pergroup_name, param)
+    return layer

--- a/tests/ut/quantization/methods/test_w4a4_flatquant.py
+++ b/tests/ut/quantization/methods/test_w4a4_flatquant.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch.nn as nn
 
+from tests.ut.conftest import npu_test
+from tests.ut.quantization.conftest_quantization import create_linear_layer
 from vllm_ascend.quantization.methods.w4a4_flatquant import (
     KRONECKER_QUANT_MAX_BATCH_SIZE,
     AscendW4A4FlatQuantDynamicLinearMethod,
@@ -214,6 +216,22 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         self.assertTrue(layer.aclnn_clip_ratio - 0.9 < 0.01)
         self.assertEqual(layer.left_trans.shape, (24, 24))
         self.assertTrue(layer.left_trans.is_contiguous())
+
+    @npu_test(num_npus=1, npu_type="a3")
+    def test_apply_with_npu(self):
+        """Tests the apply method with NPU."""
+        batch_size = 16
+        input_size = self.input_size
+        output_size = self.output_size
+        params_dtype = torch.bfloat16
+        layer = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        self.method.process_weights_after_loading(layer)
+
+        x = torch.randn(batch_size, input_size, dtype=params_dtype).npu()
+        output = self.method.apply(layer, x)
+
+        self.assertEqual(output.shape, (batch_size, output_size))
+        self.assertEqual(output.dtype, params_dtype)
 
 
 if __name__ == "__main__":

--- a/tests/ut/quantization/methods/test_w4a4_flatquant.py
+++ b/tests/ut/quantization/methods/test_w4a4_flatquant.py
@@ -217,21 +217,32 @@ class TestW4A4FlatQuantDynamic(unittest.TestCase):
         self.assertEqual(layer.left_trans.shape, (24, 24))
         self.assertTrue(layer.left_trans.is_contiguous())
 
-    @npu_test(num_npus=1, npu_type="a3")
+
+@npu_test(num_npus=1, npu_type="a2")
+class TestW4A4FlatQuantDynamicWithNpu(unittest.TestCase):
+    """
+    Unit test suite for AscendW4A4FlatQuantDynamicLinearMethod and its helper functions.
+    """
+
+    def setUp(self):
+        """Set up the test environment before each test."""
+        self.method = AscendW4A4FlatQuantDynamicLinearMethod()
+        self.output_size = 64
+        self.input_size = 768  # 768 = 24 * 32, divisible by 8
+        self.params_dtype = torch.bfloat16
+
     def test_apply_with_npu(self):
         """Tests the apply method with NPU."""
         batch_size = 16
-        input_size = self.input_size
-        output_size = self.output_size
-        params_dtype = torch.bfloat16
-        layer = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        layer = create_linear_layer(self.method, self.input_size, self.output_size, self.params_dtype)
+        layer.clip_ratio = nn.Parameter(torch.tensor([0.95], dtype=torch.float32).npu(), requires_grad=False)
         self.method.process_weights_after_loading(layer)
 
-        x = torch.randn(batch_size, input_size, dtype=params_dtype).npu()
+        x = torch.randn(batch_size, self.input_size, dtype=self.params_dtype).npu()
         output = self.method.apply(layer, x)
 
-        self.assertEqual(output.shape, (batch_size, output_size))
-        self.assertEqual(output.dtype, params_dtype)
+        self.assertEqual(output.shape, (batch_size, self.output_size))
+        self.assertEqual(output.dtype, self.params_dtype)
 
 
 if __name__ == "__main__":

--- a/tests/ut/quantization/methods/test_w4a4_laos_dynamic.py
+++ b/tests/ut/quantization/methods/test_w4a4_laos_dynamic.py
@@ -4,6 +4,8 @@ import torch
 import torch.nn as nn
 
 from tests.ut.base import TestBase
+from tests.ut.conftest import npu_test
+from tests.ut.quantization.conftest_quantization import create_linear_layer
 from vllm_ascend.quantization.methods.w4a4_laos_dynamic import AscendW4A4LaosDynamicLinearMethod
 
 
@@ -58,3 +60,16 @@ class TestAscendW4A4LaosDynamicLinearMethod(TestBase):
             mock_convert.assert_called()
             self.assertEqual(layer.weight_scale.data.dtype, torch.float32)
             self.assertEqual(layer.weight.shape, (input_size // 8, output_size))
+
+    @npu_test(num_npus=1, npu_type="a3")
+    def test_apply_with_npu(self):
+        token_num = 32
+        input_size, output_size = 128, 256
+        params_dtype = torch.bfloat16
+        layer = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        self.method.process_weights_after_loading(layer)
+
+        x = torch.randn(token_num, input_size, dtype=params_dtype).npu()
+        bias = torch.randn(output_size, dtype=params_dtype).npu()
+        output = self.method.apply(layer, x, bias)
+        self.assertEqual(output.shape, (token_num, output_size))

--- a/tests/ut/quantization/methods/test_w4a4_laos_dynamic.py
+++ b/tests/ut/quantization/methods/test_w4a4_laos_dynamic.py
@@ -61,7 +61,12 @@ class TestAscendW4A4LaosDynamicLinearMethod(TestBase):
             self.assertEqual(layer.weight_scale.data.dtype, torch.float32)
             self.assertEqual(layer.weight.shape, (input_size // 8, output_size))
 
-    @npu_test(num_npus=1, npu_type="a3")
+
+@npu_test(num_npus=1, npu_type="a2")
+class TestAscendW4A4LaosDynamicLinearMethodWithNpu(TestBase):
+    def setUp(self):
+        self.method = AscendW4A4LaosDynamicLinearMethod()
+
     def test_apply_with_npu(self):
         token_num = 32
         input_size, output_size = 128, 256

--- a/tests/ut/quantization/methods/test_w4a8.py
+++ b/tests/ut/quantization/methods/test_w4a8.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 import torch
 
 from tests.ut.base import TestBase
+from tests.ut.conftest import npu_test
 from tests.ut.quantization.conftest_quantization import identity
 from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
 from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD
@@ -101,6 +102,21 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         x = torch.randn(32, 256)
         self.method.apply(layer, x)
         mock_matmul.assert_called_once()
+
+    @npu_test(num_npus=1, npu_type="a3")
+    def test_apply_with_npu(self):
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(
+            torch.randint(-128, 127, (128, 32), dtype=torch.int32).npu(), requires_grad=False
+        )
+        layer.weight_scale_second = torch.nn.Parameter(
+            torch.randn(2, 256, dtype=torch.bfloat16).npu(), requires_grad=False
+        )
+
+        x = torch.randn(32, 128, dtype=torch.bfloat16).npu()
+        self.method.group_size = 64
+        output = self.method.apply(layer, x)
+        self.assertEqual(output.shape, (32, 256))
 
 
 class TestAscendW4A8DynamicFusedMoEMethod(TestBase):

--- a/tests/ut/quantization/methods/test_w4a8.py
+++ b/tests/ut/quantization/methods/test_w4a8.py
@@ -103,7 +103,18 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         self.method.apply(layer, x)
         mock_matmul.assert_called_once()
 
-    @npu_test(num_npus=1, npu_type="a3")
+
+@npu_test(num_npus=1, npu_type="a2")
+class TestAscendW4A8DynamicLinearMethodWithNpu(TestBase):
+    @patch("vllm.distributed.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    def setUp(self, mock_get_current_vllm_config, mock_get_tp_world_size):
+        mock_get_tp_world_size.return_value = 1
+        mock_vllm_config = Mock()
+        mock_vllm_config.quant_config = Mock(quant_description={"group_size": 64})
+        mock_get_current_vllm_config.return_value = mock_vllm_config
+        self.method = AscendW4A8DynamicLinearMethod()
+
     def test_apply_with_npu(self):
         layer = torch.nn.Module()
         layer.weight = torch.nn.Parameter(
@@ -114,7 +125,6 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         )
 
         x = torch.randn(32, 128, dtype=torch.bfloat16).npu()
-        self.method.group_size = 64
         output = self.method.apply(layer, x)
         self.assertEqual(output.shape, (32, 256))
 

--- a/tests/ut/quantization/methods/test_w8a16.py
+++ b/tests/ut/quantization/methods/test_w8a16.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from tests.ut.base import TestBase
-from tests.ut.quantization.conftest_quantization import identity
+from tests.ut.conftest import npu_test
+from tests.ut.quantization.conftest_quantization import create_linear_layer, identity
 from vllm_ascend.quantization.methods.w8a16 import AscendW8A16LinearMethod
 
 
@@ -65,3 +66,16 @@ class TestAscendW8A16LinearMethod(TestBase):
         self.assertEqual(layer.weight_scale.data.shape, (128,))
         self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()
+
+    @npu_test(num_npus=1, npu_type="a3")
+    def test_apply_with_npu(self):
+        input_size, output_size = 128, 256
+        params_dtype = torch.bfloat16
+        layer = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        self.method.process_weights_after_loading(layer)
+
+        x = torch.randn(32, input_size, dtype=params_dtype).npu()
+        bias = torch.randn(output_size, dtype=torch.float32).npu()
+
+        output = self.method.apply(layer, x, bias)
+        self.assertEqual(output.shape, (32, output_size))

--- a/tests/ut/quantization/methods/test_w8a16.py
+++ b/tests/ut/quantization/methods/test_w8a16.py
@@ -67,7 +67,12 @@ class TestAscendW8A16LinearMethod(TestBase):
         self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()
 
-    @npu_test(num_npus=1, npu_type="a3")
+
+@npu_test(num_npus=1, npu_type="a2")
+class TestAscendW8A16LinearMethodWithNpu(TestBase):
+    def setUp(self):
+        self.method = AscendW8A16LinearMethod()
+
     def test_apply_with_npu(self):
         input_size, output_size = 128, 256
         params_dtype = torch.bfloat16

--- a/tests/ut/quantization/methods/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8_dynamic.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, Mock, patch
 import torch
 
 from tests.ut.base import TestBase
+from tests.ut.conftest import npu_test
 from tests.ut.quantization.conftest_quantization import (
+    create_linear_layer,
     create_mock_ascend_config,
     create_mock_vllm_config,
     create_moe_layer,
@@ -63,6 +65,20 @@ class TestAscendW8A8DynamicLinearMethod(TestBase):
         self.assertEqual(layer.weight_scale.data.shape, (256,))
         self.assertEqual(layer.weight_offset.data.shape, (256,))
         self.assertEqual(layer.weight.data.shape, (256, 128))
+
+    @npu_test(num_npus=1, npu_type="a3")
+    def test_apply_with_npu(self):
+        input_size, output_size = 128, 256
+        params_dtype = torch.bfloat16
+        layer = torch.nn.Module()
+        layer.weight = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        self.method.process_weights_after_loading(layer)
+
+        x = torch.randn(32, input_size, dtype=params_dtype).npu()
+        bias = torch.randn(output_size, dtype=torch.float32).npu()
+
+        output = self.method.apply(layer, x, bias)
+        self.assertEqual(output.shape, (32, output_size))
 
 
 class TestAscendW8A8FusedMoEMethod(TestBase):

--- a/tests/ut/quantization/methods/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8_dynamic.py
@@ -66,7 +66,12 @@ class TestAscendW8A8DynamicLinearMethod(TestBase):
         self.assertEqual(layer.weight_offset.data.shape, (256,))
         self.assertEqual(layer.weight.data.shape, (256, 128))
 
-    @npu_test(num_npus=1, npu_type="a3")
+
+@npu_test(num_npus=1, npu_type="a2")
+class TestAscendW8A8DynamicLinearMethodWithNpu(TestBase):
+    def setUp(self):
+        self.method = AscendW8A8DynamicLinearMethod()
+
     def test_apply_with_npu(self):
         input_size, output_size = 128, 256
         params_dtype = torch.bfloat16

--- a/tests/ut/quantization/methods/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8_dynamic.py
@@ -70,8 +70,7 @@ class TestAscendW8A8DynamicLinearMethod(TestBase):
     def test_apply_with_npu(self):
         input_size, output_size = 128, 256
         params_dtype = torch.bfloat16
-        layer = torch.nn.Module()
-        layer.weight = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        layer = create_linear_layer(self.method, input_size, output_size, params_dtype)
         self.method.process_weights_after_loading(layer)
 
         x = torch.randn(32, input_size, dtype=params_dtype).npu()

--- a/tests/ut/quantization/methods/test_w8a8_static.py
+++ b/tests/ut/quantization/methods/test_w8a8_static.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from tests.ut.base import TestBase
-from tests.ut.quantization.conftest_quantization import identity
+from tests.ut.conftest import npu_test
+from tests.ut.quantization.conftest_quantization import create_linear_layer, identity
 from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD
 
@@ -148,3 +149,20 @@ class TestAscendW8A8LinearMethod(TestBase):
         self.assertEqual(layer.weight_offset.data.shape, (128,))
         mock_npu_format_cast.assert_called_once()
         self.assertFalse(isinstance(layer.deq_scale, MagicMock))
+
+    @patch("vllm_ascend.quantization.methods.w8a8_static.get_weight_prefetch_method")
+    @npu_test(num_npus=1, npu_type="a3")
+    def test_apply_with_npu(self, mock_get_weight_prefetch_method):
+        mock_get_weight_prefetch_method.return_value = MagicMock()
+
+        input_size, output_size = 128, 256
+        params_dtype = torch.bfloat16
+        layer = create_linear_layer(self.method, input_size, output_size, params_dtype)
+        layer.params_dtype = params_dtype
+        self.method.process_weights_after_loading(layer)
+
+        x = torch.randn(32, input_size, dtype=params_dtype).npu()
+        bias = torch.randn(output_size, dtype=torch.float32).npu()
+
+        output = self.method.apply(layer, x, bias)
+        self.assertEqual(output.shape, (32, output_size))

--- a/tests/ut/quantization/methods/test_w8a8_static.py
+++ b/tests/ut/quantization/methods/test_w8a8_static.py
@@ -150,8 +150,12 @@ class TestAscendW8A8LinearMethod(TestBase):
         mock_npu_format_cast.assert_called_once()
         self.assertFalse(isinstance(layer.deq_scale, MagicMock))
 
+@npu_test(num_npus=1, npu_type="a2")
+class TestAscendW8A8LinearMethodWithNpu(TestBase):
+    def setUp(self):
+        self.method = AscendW8A8LinearMethod()
+
     @patch("vllm_ascend.quantization.methods.w8a8_static.get_weight_prefetch_method")
-    @npu_test(num_npus=1, npu_type="a3")
     def test_apply_with_npu(self, mock_get_weight_prefetch_method):
         mock_get_weight_prefetch_method.return_value = MagicMock()
 

--- a/tests/ut/quantization/methods/test_w8a8_static.py
+++ b/tests/ut/quantization/methods/test_w8a8_static.py
@@ -150,6 +150,7 @@ class TestAscendW8A8LinearMethod(TestBase):
         mock_npu_format_cast.assert_called_once()
         self.assertFalse(isinstance(layer.deq_scale, MagicMock))
 
+
 @npu_test(num_npus=1, npu_type="a2")
 class TestAscendW8A8LinearMethodWithNpu(TestBase):
     def setUp(self):


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds NPU-based unit tests for various quantization methods (W4A4 FlatQuant, W4A4 Laos, W4A8, W8A16, W8A8 Dynamic/Static) to ensure their methods work correctly on Ascend hardware. It also introduces a `create_linear_layer` helper in `conftest_quantization.py` to simplify layer creation for these tests.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
pytest -sv tests/ut/quantization
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
