### PR TITLE
[feature] replace scatter and gather with custom op

### DIFF
--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -730,15 +730,14 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         key = torch.empty(total_toks, num_heads, head_size, dtype=query.dtype, device=query.device)
         value = torch.empty(total_toks, num_heads, head_size, dtype=query.dtype, device=query.device)
         if total_toks > 0:
-            torch_npu.atb.npu_paged_cache_load(
+            torch.ops._C_ascend.npu_gather_pa_kv_cache_vllm(
                 cache_key,
                 cache_value,
                 attn_metadata.prefill.block_tables,
                 local_chunked_kv_lens_rank,
-                # slot offsets of current chunk in current iteration
-                seq_starts=attn_metadata.prefill.chunked_context.starts,
-                key=key,
-                value=value,
+                key,
+                value,
+                attn_metadata.prefill.chunked_context.starts,
             )
         return key, value
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -29,8 +29,8 @@ from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
-        torch_npu._npu_reshape_and_cache(
-            key=key, value=value, key_cache=key_cache, value_cache=value_cache, slot_indices=slot_mapping
+        torch.ops._C_ascend.npu_scatter_pa_kv_cache_vllm(
+            key, value, key_cache, value_cache, slot_mapping
         )
 
     @staticmethod

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -681,8 +681,8 @@ class KVCacheRecvingThread(threading.Thread):
         v_buffer = _transpose_kv_cache_between_head(v_buffer)
 
         # Reshape and cache the processed buffers
-        torch_npu._npu_reshape_and_cache(
-            key=k_buffer, value=v_buffer, key_cache=k_cache_layer, value_cache=v_cache_layer, slot_indices=slot_mapping
+        torch.ops._C_ascend.npu_scatter_pa_kv_cache_vllm(
+            k_buffer, v_buffer, k_cache_layer, v_cache_layer, slot_mapping
         )
 
     def _nz_kv_cache(self, k_cache_layer, v_cache_layer, k_buffer, v_buffer, slot_mapping):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -1586,14 +1586,14 @@ class MooncakeLayerwiseConnectorWorker:
                     )
 
                     # Load cache data into buffers
-                    torch_npu.atb.npu_paged_cache_load(
+                    torch.ops._C_ascend.npu_gather_pa_kv_cache_vllm(
                         kv_layer[0],
                         kv_layer[1],
                         send_task.group_block_table[layer_group_idx],
                         send_task.group_block_len_tensor[layer_group_idx],
-                        seq_starts=send_task.group_seq_start_tensor[layer_group_idx],
-                        key=keys,
-                        value=values,
+                        keys,
+                        values,
+                        send_task.group_seq_start_tensor[layer_group_idx],
                     )
                     if self.pd_head_ratio != 1:
                         # sort kv caches for each block


### PR DESCRIPTION
### What this PR does / why we need it?

Replace npu_paged_cache_load and _npu_reshape_and_cache with custom op (PR 8369) to support non-continuous gather and scatter for KV cache

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
