### PR TITLE
[BugFix][Platform] Backport MiniMax reasoning usage accounting

### DIFF
--- a/tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
+++ b/tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from vllm.reasoning.minimax_m2_reasoning_parser import (
+    MiniMaxM2AppendThinkReasoningParser,
+    MiniMaxM2ReasoningParser,
+)
+
+from vllm_ascend.patch.platform import (
+    patch_minimax_usage_accounting as minimax_usage_patch,
+)
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {
+            "<think>": 1,
+            "</think>": 2,
+        }
+
+
+@pytest.mark.parametrize(
+    ("parser_cls", "token_ids", "expected_reasoning_tokens"),
+    [
+        pytest.param(
+            MiniMaxM2ReasoningParser,
+            [10, 11, 2, 20],
+            2,
+            id="minimax-reasoning-before-end-token",
+        ),
+        pytest.param(
+            MiniMaxM2AppendThinkReasoningParser,
+            [10, 11, 2, 20],
+            2,
+            id="append-think-reasoning-before-end-token",
+        ),
+        pytest.param(
+            MiniMaxM2ReasoningParser,
+            [10, 11, 20],
+            3,
+            id="minimax-no-end-token-means-all-output-is-reasoning",
+        ),
+        pytest.param(
+            MiniMaxM2AppendThinkReasoningParser,
+            [10, 11, 20],
+            3,
+            id="append-think-no-end-token-means-all-output-is-reasoning",
+        ),
+        pytest.param(
+            MiniMaxM2ReasoningParser,
+            [2, 20],
+            0,
+            id="minimax-end-token-first-means-no-reasoning-tokens",
+        ),
+        pytest.param(
+            MiniMaxM2AppendThinkReasoningParser,
+            [2, 20],
+            0,
+            id="append-think-end-token-first-means-no-reasoning-tokens",
+        ),
+    ],
+)
+def test_count_reasoning_tokens(
+    parser_cls,
+    token_ids,
+    expected_reasoning_tokens,
+):
+    parser = parser_cls(FakeTokenizer())
+
+    assert parser.count_reasoning_tokens(token_ids) == expected_reasoning_tokens
+
+
+def test_update_usage_tracking_state_tracks_prompt_and_completion_tokens():
+    state = minimax_usage_patch._create_usage_tracking_state(
+        num_choices=2,
+        reasoning_parser=None,
+    )
+
+    res = SimpleNamespace(
+        prompt_token_ids=[1, 2],
+        encoder_prompt_token_ids=[3],
+        num_cached_tokens=4,
+        outputs=[
+            SimpleNamespace(index=0, token_ids=(10, 11)),
+            SimpleNamespace(index=1, token_ids=[20]),
+        ],
+    )
+
+    minimax_usage_patch._update_usage_tracking_state(state, res)
+
+    assert state.num_prompt_tokens == 3
+    assert state.num_cached_tokens == 4
+    assert state.completion_tokens == [2, 1]
+    assert state.raw_output_token_ids == [[10, 11], [20]]
+
+
+def test_make_usage_info_injects_reasoning_token_details():
+    fake_serving = SimpleNamespace(enable_prompt_tokens_details=True)
+    usage = minimax_usage_patch._make_usage_info(
+        fake_serving,
+        prompt_tokens=3,
+        completion_tokens=4,
+        num_cached_tokens=1,
+        reasoning_tokens=2,
+    )
+
+    payload = usage.model_dump(exclude_none=True)
+
+    assert payload["completion_tokens_details"]["reasoning_tokens"] == 2
+    assert payload["prompt_tokens_details"]["cached_tokens"] == 1
+
+
+def test_make_full_response_usage_sums_reasoning_tokens():
+    class FakeServing:
+        enable_prompt_tokens_details = False
+
+        def _make_usage_info(self, **kwargs):
+            return minimax_usage_patch._make_usage_info(self, **kwargs)
+
+    class FakeReasoningParser:
+        def count_reasoning_tokens(self, token_ids):
+            return 2 if 2 in token_ids else 0
+
+    state = minimax_usage_patch._create_usage_tracking_state(
+        num_choices=2,
+        reasoning_parser=FakeReasoningParser(),
+    )
+    state.num_prompt_tokens = 3
+    state.num_cached_tokens = 1
+    state.final_res = SimpleNamespace(num_cached_tokens=1)
+    state.completion_tokens = [4, 2]
+    state.raw_output_token_ids = [[10, 11, 2, 20], [30, 31]]
+
+    usage = minimax_usage_patch._make_full_response_usage(FakeServing(), state)
+
+    assert usage.prompt_tokens == 3
+    assert usage.completion_tokens == 6
+    assert usage.total_tokens == 9
+    assert usage.completion_tokens_details.reasoning_tokens == 2
+    assert usage.prompt_tokens_details is None
+
+
+def test_stream_usage_details_are_injected_without_replacing_source():
+    class FakeReasoningParser:
+        def count_reasoning_tokens(self, token_ids):
+            return token_ids.index(2) if 2 in token_ids else len(token_ids)
+
+    state = minimax_usage_patch._create_usage_tracking_state(
+        num_choices=1,
+        reasoning_parser=FakeReasoningParser(),
+    )
+    state.raw_output_token_ids = [[10, 11, 2, 20]]
+
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": None}],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 7,
+        },
+    }
+
+    data = minimax_usage_patch._inject_stream_usage_details(
+        f"data: {json.dumps(chunk)}\n\n",
+        state,
+    )
+    payload = json.loads(data.removeprefix("data: ").removesuffix("\n\n"))
+
+    assert payload["usage"]["completion_tokens_details"] == {
+        "reasoning_tokens": 2,
+    }
+    assert not hasattr(minimax_usage_patch, "_extract_class_method_source")
+    assert not hasattr(minimax_usage_patch, "_patch_chat_completion_stream_generator")

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -155,7 +155,25 @@
 #       Drop the alias once upstream registry includes it or the checkpoint
 #       standardizes architecture strings.
 #
-# ** 8. File: platform/patch_kv_cache_interface.py**
+# ** 8. File: platform/patch_minimax_usage_accounting.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#      `vllm.reasoning.minimax_m2_reasoning_parser`
+#    Why:
+#       MiniMax-M2 reasoning usage accounting needs to report
+#       `completion_tokens_details.reasoning_tokens` for both streaming and
+#       non-streaming chat completions.
+#    How：
+#       Monkey-patch MiniMax reasoning token counters, extend `UsageInfo`, and
+#       update chat usage construction to count reasoning tokens from raw output
+#       token ids.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/37955
+#    Future Plan:
+#       Remove this patch once the runtime vLLM version contains the upstream
+#       MiniMax usage-accounting fix.
+#
+# ** 9. File: platform/patch_kv_cache_interface.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.kv_cache_interface.MLAAttentionSpec`
 #    Why:
@@ -177,7 +195,7 @@
 #    Future Plan:
 #       Remove this patch after the upcoming KV cache spec refactor.
 #
-# ** 9. File: platform/patch_profiling_chunk.py**
+# ** 10. File: platform/patch_profiling_chunk.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCore.__init__`
 #   2. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -26,6 +26,7 @@ if not is_310p():
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
+import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 

--- a/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
@@ -1,0 +1,373 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# OpenAI chat usage accounting: backport MiniMax reasoning token accounting.
+#
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion import protocol as chat_protocol
+from vllm.entrypoints.openai.chat_completion import serving as chat_serving
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine import protocol as engine_protocol
+from vllm.reasoning import minimax_m2_reasoning_parser as minimax_parser
+
+
+class CompletionTokenUsageInfo(engine_protocol.OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+    audio_tokens: int | None = None
+    accepted_prediction_tokens: int | None = None
+    rejected_prediction_tokens: int | None = None
+
+
+class UsageInfo(engine_protocol.UsageInfo):
+    completion_tokens_details: CompletionTokenUsageInfo | None = None
+
+
+CompletionTokenUsageInfo.__module__ = engine_protocol.__name__
+UsageInfo.__module__ = engine_protocol.__name__
+
+engine_protocol.CompletionTokenUsageInfo = CompletionTokenUsageInfo
+engine_protocol.UsageInfo = UsageInfo
+chat_protocol.UsageInfo = UsageInfo
+chat_serving.CompletionTokenUsageInfo = CompletionTokenUsageInfo
+chat_serving.UsageInfo = UsageInfo
+
+
+def _rebuild_model_field(model_cls, field_name: str, annotation) -> None:
+    model_cls.__annotations__[field_name] = annotation
+    model_cls.model_fields[field_name].annotation = annotation
+    model_cls.model_rebuild(force=True)
+
+
+_rebuild_model_field(chat_protocol.ChatCompletionResponse, "usage", UsageInfo)
+_rebuild_model_field(chat_protocol.ChatCompletionStreamResponse, "usage", UsageInfo | None)
+_rebuild_model_field(engine_protocol.RequestResponseMetadata, "final_usage_info", UsageInfo | None)
+
+
+def _count_minimax_reasoning_tokens(
+    token_ids: Sequence[int],
+    end_token_id: int | None,
+) -> int:
+    if end_token_id is None:
+        return 0
+
+    for idx, token_id in enumerate(token_ids):
+        if token_id == end_token_id:
+            return idx
+    return len(token_ids)
+
+
+def _patched_count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+    return _count_minimax_reasoning_tokens(token_ids, self.end_token_id)
+
+
+minimax_parser.MiniMaxM2ReasoningParser.count_reasoning_tokens = _patched_count_reasoning_tokens
+minimax_parser.MiniMaxM2AppendThinkReasoningParser.count_reasoning_tokens = _patched_count_reasoning_tokens
+
+
+def _count_reasoning_tokens_for_usage(
+    token_ids: Sequence[int],
+    reasoning_parser,
+) -> int | None:
+    if reasoning_parser is None:
+        return None
+    return reasoning_parser.count_reasoning_tokens(token_ids)
+
+
+def _clamp_reasoning_tokens(
+    reasoning_tokens: int | None,
+    completion_tokens: int,
+) -> int | None:
+    if reasoning_tokens is None:
+        return None
+    return max(0, min(reasoning_tokens, completion_tokens))
+
+
+def _make_usage_info(
+    self,
+    *,
+    prompt_tokens: int,
+    completion_tokens: int,
+    num_cached_tokens: int | None = None,
+    reasoning_tokens: int | None = None,
+) -> UsageInfo:
+    usage = UsageInfo(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    reasoning_tokens = _clamp_reasoning_tokens(reasoning_tokens, completion_tokens)
+    if reasoning_tokens is not None:
+        usage.completion_tokens_details = CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+    if self.enable_prompt_tokens_details and num_cached_tokens:
+        usage.prompt_tokens_details = chat_serving.PromptTokenUsageInfo(cached_tokens=num_cached_tokens)
+    return usage
+
+
+OpenAIServingChat._count_reasoning_tokens_for_usage = staticmethod(_count_reasoning_tokens_for_usage)
+OpenAIServingChat._make_usage_info = _make_usage_info
+
+
+@dataclass
+class _UsageTrackingState:
+    completion_tokens: list[int]
+    raw_output_token_ids: list[list[int]]
+    reasoning_parser: Any
+    num_prompt_tokens: int = 0
+    num_cached_tokens: int | None = None
+    final_res: Any = None
+
+
+def _create_usage_tracking_state(
+    num_choices: int,
+    reasoning_parser,
+) -> _UsageTrackingState:
+    return _UsageTrackingState(
+        completion_tokens=[0] * num_choices,
+        raw_output_token_ids=[[] for _ in range(num_choices)],
+        reasoning_parser=reasoning_parser,
+    )
+
+
+def _update_usage_tracking_state(
+    state: _UsageTrackingState,
+    res,
+) -> None:
+    if res.prompt_token_ids is not None:
+        num_prompt_tokens = len(res.prompt_token_ids)
+        if res.encoder_prompt_token_ids is not None:
+            num_prompt_tokens += len(res.encoder_prompt_token_ids)
+        state.num_prompt_tokens = num_prompt_tokens
+
+    if state.num_cached_tokens is None:
+        state.num_cached_tokens = res.num_cached_tokens
+
+    state.final_res = res
+
+    for output in res.outputs:
+        if 0 <= output.index < len(state.completion_tokens):
+            token_ids = chat_serving.as_list(output.token_ids)
+            state.completion_tokens[output.index] += len(token_ids)
+            state.raw_output_token_ids[output.index].extend(token_ids)
+
+
+async def _tracked_result_generator(
+    result_generator: AsyncIterator,
+    state: _UsageTrackingState,
+):
+    async for res in result_generator:
+        _update_usage_tracking_state(state, res)
+        yield res
+
+
+def _sum_reasoning_tokens_for_usage(
+    raw_output_token_ids: list[list[int]],
+    reasoning_parser,
+) -> int | None:
+    if reasoning_parser is None:
+        return None
+    return sum(
+        _count_reasoning_tokens_for_usage(token_ids, reasoning_parser) or 0 for token_ids in raw_output_token_ids
+    )
+
+
+def _reasoning_tokens_for_choice(
+    state: _UsageTrackingState,
+    choice_index: int,
+) -> int | None:
+    if state.reasoning_parser is None:
+        return None
+    if not 0 <= choice_index < len(state.raw_output_token_ids):
+        return None
+    return _count_reasoning_tokens_for_usage(
+        state.raw_output_token_ids[choice_index],
+        state.reasoning_parser,
+    )
+
+
+def _make_full_response_usage(
+    self,
+    state: _UsageTrackingState,
+) -> UsageInfo | None:
+    if state.final_res is None:
+        return None
+
+    return self._make_usage_info(
+        prompt_tokens=state.num_prompt_tokens,
+        completion_tokens=sum(state.completion_tokens),
+        num_cached_tokens=state.num_cached_tokens,
+        reasoning_tokens=_sum_reasoning_tokens_for_usage(
+            state.raw_output_token_ids,
+            state.reasoning_parser,
+        ),
+    )
+
+
+def _usage_reasoning_tokens_for_stream_chunk(
+    state: _UsageTrackingState,
+    chunk: dict[str, Any],
+    completion_tokens: int,
+) -> int | None:
+    if state.reasoning_parser is None:
+        return None
+
+    choices = chunk.get("choices") or []
+    if choices:
+        choice_index = choices[0].get("index", 0)
+        reasoning_tokens = _reasoning_tokens_for_choice(state, choice_index)
+    else:
+        reasoning_tokens = _sum_reasoning_tokens_for_usage(
+            state.raw_output_token_ids,
+            state.reasoning_parser,
+        )
+    return _clamp_reasoning_tokens(reasoning_tokens, completion_tokens)
+
+
+def _inject_stream_usage_details(
+    data: str,
+    state: _UsageTrackingState,
+) -> str:
+    prefix = "data: "
+    suffix = "\n\n"
+    if not data.startswith(prefix):
+        return data
+
+    payload = data[len(prefix) :]
+    if payload.endswith(suffix):
+        payload = payload[: -len(suffix)]
+    if payload == "[DONE]":
+        return data
+
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        return data
+
+    usage = chunk.get("usage")
+    if not isinstance(usage, dict):
+        return data
+
+    completion_tokens = usage.get("completion_tokens") or 0
+    reasoning_tokens = _usage_reasoning_tokens_for_stream_chunk(
+        state,
+        chunk,
+        completion_tokens,
+    )
+    if reasoning_tokens is None:
+        return data
+
+    usage["completion_tokens_details"] = {
+        "reasoning_tokens": reasoning_tokens,
+    }
+    return f"{prefix}{json.dumps(chunk, ensure_ascii=False)}{suffix}"
+
+
+if not hasattr(OpenAIServingChat, "_ascend_original_chat_completion_stream_generator"):
+    OpenAIServingChat._ascend_original_chat_completion_stream_generator = (
+        OpenAIServingChat.chat_completion_stream_generator
+    )
+
+if not hasattr(OpenAIServingChat, "_ascend_original_chat_completion_full_generator"):
+    OpenAIServingChat._ascend_original_chat_completion_full_generator = OpenAIServingChat.chat_completion_full_generator
+
+
+async def _wrapped_chat_completion_stream_generator(
+    self,
+    request: chat_protocol.ChatCompletionRequest,
+    result_generator: AsyncIterator,
+    request_id: str,
+    model_name: str,
+    conversation,
+    tokenizer,
+    request_metadata: engine_protocol.RequestResponseMetadata,
+    reasoning_parser=None,
+):
+    num_choices = 1 if request.n is None else request.n
+    state = _create_usage_tracking_state(num_choices, reasoning_parser)
+
+    original_stream_generator = self._ascend_original_chat_completion_stream_generator
+    async for data in original_stream_generator(
+        request,
+        _tracked_result_generator(result_generator, state),
+        request_id,
+        model_name,
+        conversation,
+        tokenizer,
+        request_metadata,
+        reasoning_parser,
+    ):
+        yield _inject_stream_usage_details(data, state)
+
+    usage = _make_full_response_usage(self, state)
+    if usage is not None:
+        request_metadata.final_usage_info = usage
+
+
+async def _wrapped_chat_completion_full_generator(
+    self,
+    request: chat_protocol.ChatCompletionRequest,
+    result_generator: AsyncIterator,
+    request_id: str,
+    model_name: str,
+    conversation,
+    tokenizer,
+    request_metadata: engine_protocol.RequestResponseMetadata,
+    reasoning_parser=None,
+):
+    num_choices = 1 if request.n is None else request.n
+    state = _create_usage_tracking_state(num_choices, reasoning_parser)
+
+    original_full_generator = self._ascend_original_chat_completion_full_generator
+    response = await original_full_generator(
+        request,
+        _tracked_result_generator(result_generator, state),
+        request_id,
+        model_name,
+        conversation,
+        tokenizer,
+        request_metadata,
+        reasoning_parser,
+    )
+
+    if not isinstance(response, chat_protocol.ChatCompletionResponse):
+        return response
+
+    usage = _make_full_response_usage(self, state)
+    if usage is None:
+        return response
+
+    response.usage = usage
+    request_metadata.final_usage_info = usage
+    return response
+
+
+_wrapped_chat_completion_stream_generator.__module__ = OpenAIServingChat.__module__
+_wrapped_chat_completion_stream_generator.__qualname__ = (
+    f"{OpenAIServingChat.__qualname__}.chat_completion_stream_generator"
+)
+_wrapped_chat_completion_full_generator.__module__ = OpenAIServingChat.__module__
+_wrapped_chat_completion_full_generator.__qualname__ = (
+    f"{OpenAIServingChat.__qualname__}.chat_completion_full_generator"
+)
+
+OpenAIServingChat.chat_completion_stream_generator = _wrapped_chat_completion_stream_generator
+OpenAIServingChat.chat_completion_full_generator = _wrapped_chat_completion_full_generator


### PR DESCRIPTION
## What this PR does / why we need it?

Backports the MiniMax-M2 reasoning usage accounting fix into the vLLM Ascend platform patch layer for the vLLM 0.19.1 runtime.

The patch:
- adds completion_tokens_details.reasoning_tokens to UsageInfo
- fixes MiniMax-M2 reasoning token counting before the first </think> token
- wraps chat streaming/non-streaming generators to track raw output token ids and inject reasoning usage details
- avoids source-code extraction/replacement of OpenAIServingChat methods

References:
- vLLM upstream PR: https://github.com/vllm-project/vllm/pull/37955
- vLLM upstream issue: https://github.com/vllm-project/vllm/issues/37988
- vLLM Ascend PR: https://github.com/vllm-project/vllm-ascend/pull/7700
- vLLM Ascend PR: https://github.com/vllm-project/vllm-ascend/pull/7835

## Does this PR introduce _any_ user-facing change?

Yes. MiniMax-M2 OpenAI-compatible chat responses can now include accurate completion_tokens_details.reasoning_tokens usage accounting.

## How was this patch tested?

- PYTHONPATH=../vllm:. pytest -q --confcutdir=tests/ut/patch/platform tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
  - 10 passed
- ruff check vllm_ascend/patch/platform/patch_minimax_usage_accounting.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py vllm_ascend/patch/platform/__init__.py
  - passed
- python -m py_compile vllm_ascend/patch/platform/patch_minimax_usage_accounting.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
  - passed

Note: running the test without --confcutdir currently loads the repo-wide UT conftest, which imports worker patches and fails before test collection because ../vllm v0.19.1 does not contain vllm.model_executor.models.qwen3_dflash.
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8