### PR TITLE
[BugFix][Patch] Backport forced tool choice none-content handling

### DIFF
--- a/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
+++ b/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.serving import OpenAIServing
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.parser.abstract_parser import DelegatingParser
+
+from vllm_ascend.patch.platform import patch_tool_choice_none_content  # noqa: F401
+
+
+class _DummyDelegatingParser(DelegatingParser):
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        return False
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        return input_ids
+
+    def extract_reasoning(self, model_output: str, request):
+        return None, model_output
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: list[int],
+        current_token_ids: list[int],
+        delta_token_ids: list[int],
+    ):
+        return None
+
+    def extract_tool_calls(self, model_output: str, request):
+        return None
+
+
+def test_parse_tool_calls_from_content_allows_named_tool_choice_with_none_content():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        }
+    )
+
+    tool_calls, content = OpenAIServing._parse_tool_calls_from_content(
+        request=request,
+        tokenizer=None,
+        enable_auto_tools=True,
+        tool_parser_cls=None,
+        content=None,
+    )
+
+    assert content is None
+    assert tool_calls == []
+    assert not request.tool_choice
+
+    tool_calls, content = OpenAIServing._parse_tool_calls_from_content(
+        request=request,
+        tokenizer=None,
+        enable_auto_tools=True,
+        tool_parser_cls=None,
+        content='{"city": "Beijing"}',
+    )
+
+    assert content is None
+    assert request.tool_choice
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    assert tool_calls[0].arguments == '{"city": "Beijing"}'
+
+
+def test_responses_parser_allows_named_tool_choice_with_none_content():
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "test-model",
+            "input": "test",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            "tool_choice": {"type": "function", "name": "get_weather"},
+        }
+    )
+    parser = _DummyDelegatingParser(tokenizer=None)
+
+    tool_calls, content = parser._parse_tool_calls(
+        request=request,
+        content=None,
+        enable_auto_tools=False,
+    )
+
+    assert content is None
+    assert tool_calls == []

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -205,6 +205,26 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
+# ** 10. File: platform/patch_tool_choice_none_content.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.engine.serving.OpenAIServing._parse_tool_calls_from_content`
+#      `vllm.parser.abstract_parser.DelegatingParser._parse_tool_calls`
+#    Why:
+#       Forced tool choice can receive `content=None` when reasoning extraction
+#       consumes the whole generated text, for example when generation stops at
+#       `max_tokens`. Upstream vLLM 0.19.1 asserts in that case.
+#    How：
+#       Return an empty tool-call list for forced tool choice with `content=None`
+#       and mark the current named chat tool-choice result so the downstream
+#       chat response path does not assert. Preserve normal forced tool-call
+#       behavior when content is present.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/40148
+#       https://github.com/vllm-project/vllm-ascend/pull/8400
+#    Future Plan:
+#       Remove this patch once the vLLM fix is included in the supported vLLM
+#       version.
+#
 # * Worker Patch:
 # ===============
 #

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -28,6 +28,7 @@ else:
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_sched_yield  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
+import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# OpenAI forced tool choice: tolerate None content after reasoning extraction.
+#
+
+from __future__ import annotations
+
+from openai.types.responses import ToolChoiceFunction
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+)
+from vllm.entrypoints.openai.engine.serving import OpenAIServing
+from vllm.parser.abstract_parser import DelegatingParser
+
+_NO_FORCED_TOOL_CALL = "_vllm_ascend_no_forced_tool_call"
+
+
+def _is_forced_tool_choice(request) -> bool:
+    tool_choice = getattr(request, "tool_choice", None)
+    return isinstance(
+        tool_choice,
+        (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
+    )
+
+
+def _set_no_forced_tool_call(request, value: bool) -> None:
+    tool_choice = getattr(request, "tool_choice", None)
+    if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
+        setattr(tool_choice, _NO_FORCED_TOOL_CALL, value)
+
+
+def _patch_named_tool_choice_bool() -> None:
+    if getattr(ChatCompletionNamedToolChoiceParam, "_vllm_ascend_bool_patched", False):
+        return
+
+    original_bool = getattr(ChatCompletionNamedToolChoiceParam, "__bool__", None)
+
+    def _patched_named_tool_choice_bool(self) -> bool:
+        if getattr(self, _NO_FORCED_TOOL_CALL, False):
+            return False
+        if original_bool is not None:
+            return original_bool(self)
+        return True
+
+    ChatCompletionNamedToolChoiceParam.__bool__ = _patched_named_tool_choice_bool
+    ChatCompletionNamedToolChoiceParam._vllm_ascend_bool_patched = True
+
+
+_patch_named_tool_choice_bool()
+
+
+_original_parse_tool_calls_from_content = OpenAIServing._parse_tool_calls_from_content
+
+
+def _patched_parse_tool_calls_from_content(
+    request,
+    tokenizer,
+    enable_auto_tools: bool,
+    tool_parser_cls,
+    content: str | None = None,
+):
+    if content is None and _is_forced_tool_choice(request):
+        _set_no_forced_tool_call(request, True)
+        return [], None
+
+    _set_no_forced_tool_call(request, False)
+    return _original_parse_tool_calls_from_content(
+        request=request,
+        tokenizer=tokenizer,
+        enable_auto_tools=enable_auto_tools,
+        tool_parser_cls=tool_parser_cls,
+        content=content,
+    )
+
+
+OpenAIServing._parse_tool_calls_from_content = staticmethod(_patched_parse_tool_calls_from_content)
+
+_original_delegating_parse_tool_calls = DelegatingParser._parse_tool_calls
+
+
+def _patched_delegating_parse_tool_calls(
+    self,
+    request,
+    content: str | None,
+    enable_auto_tools: bool,
+):
+    if content is None and _is_forced_tool_choice(request):
+        return [], None
+
+    return _original_delegating_parse_tool_calls(
+        self,
+        request,
+        content,
+        enable_auto_tools,
+    )
+
+
+DelegatingParser._parse_tool_calls = _patched_delegating_parse_tool_calls


### PR DESCRIPTION
### What this PR does / why we need it?
Backports the forced tool-choice `content=None` handling from vLLM Ascend PR https://github.com/vllm-project/vllm-ascend/pull/8400 for the vLLM 0.19.1 patch layer.

Related issue and PR:
- vLLM issue: https://github.com/vllm-project/vllm/issues/40147
- vLLM PR: https://github.com/vllm-project/vllm/pull/40148
- vLLM Ascend PR: https://github.com/vllm-project/vllm-ascend/pull/8400

Per the latest PR #40148 discussion, this patch does not synthesize an empty function call or empty `{}` arguments. When forced tool choice sees `content=None`, it returns an empty tool-call list and preserves normal forced tool-call behavior when content is present.

### Does this PR introduce _any_ user-facing change?
Yes. Forced tool-choice requests no longer assert when reasoning extraction leaves `content=None`; they return no tool calls for that empty-content result instead.

### How was this patch tested?
- `ruff format --check vllm_ascend/patch/platform/patch_tool_choice_none_content.py tests/ut/patch/platform/test_patch_tool_choice_none_content.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py`
- `ruff check vllm_ascend/patch/platform/patch_tool_choice_none_content.py tests/ut/patch/platform/test_patch_tool_choice_none_content.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py`
- `python -m py_compile vllm_ascend/patch/platform/patch_tool_choice_none_content.py tests/ut/patch/platform/test_patch_tool_choice_none_content.py`
- `PYTHONPATH=../vllm:. pytest -q --confcutdir=tests/ut/patch/platform tests/ut/patch/platform/test_patch_tool_choice_none_content.py`

Also ran `bash format.sh ci`; it passed the available hooks but could not complete `shellcheck` because `shellcheck` is not installed in this environment.

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
