### PR TITLE
[Doc] Align PR title prefix guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,14 +321,14 @@ update code
 
 PR titles should follow the format: `[Type][Module] Description`
 
-- **Type**: The type of change (e.g., `CI`, `Doc`, `Bugfix`, `Feat`, `Platform`, `Refactor`)
+- **Type**: The type of change (e.g., `CI`, `Doc`, `BugFix`, `Feat`, `Platform`, `Refactor`)
 - **Module**: The affected module (optional, e.g., `Misc`, `Model`, `Worker`)
 - **Description**: Brief description of the change
 
 **Examples:**
 
 - `[Doc][Misc] Update contribution guidelines`
-- `[Bugfix] Fix CPU binding logic`
+- `[BugFix] Fix CPU binding logic`
 - `[CI] Update image build workflow`
 
 ### Pull Request Template

--- a/docs/source/developer_guide/contribution/index.md
+++ b/docs/source/developer_guide/contribution/index.md
@@ -89,7 +89,7 @@ Only specific types of PRs will be reviewed. The PR title is prefixed appropriat
 - `[Worker]` for new features or optimization in worker.
 - `[Core]` for new features or optimization  in the core vllm-ascend logic (such as platform, attention, communicators, model runner)
 - `[Kernel]` for changes affecting compute kernels and ops.
-- `[Bugfix]` for bug fixes.
+- `[BugFix]` for bug fixes.
 - `[Doc]` for documentation fixes and improvements.
 - `[Test]` for tests (such as unit tests).
 - `[CI]` for build or continuous integration improvements.

--- a/docs/source/locale/zh_CN/LC_MESSAGES/developer_guide/contribution/index.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/developer_guide/contribution/index.po
@@ -142,8 +142,8 @@ msgid "`[Kernel]` for changes affecting compute kernels and ops."
 msgstr "`[Kernel]`：影响计算内核和算子的更改。"
 
 #: ../../source/developer_guide/contribution/index.md:92
-msgid "`[Bugfix]` for bug fixes."
-msgstr "`[Bugfix]`：错误修复。"
+msgid "`[BugFix]` for bug fixes."
+msgstr "`[BugFix]`：错误修复。"
 
 #: ../../source/developer_guide/contribution/index.md:93
 msgid "`[Doc]` for documentation fixes and improvements."


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aligns the documented bug-fix PR title prefix with the current CI validator. The docs now use the CI-recognized `[BugFix]` casing instead of `[Bugfix]`.

Fixes #8840.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

- `git diff --check`
- `pre-commit run markdownlint --hook-stage manual --files AGENTS.md docs/source/developer_guide/contribution/index.md`
- `pre-commit run typos --files AGENTS.md docs/source/developer_guide/contribution/index.md docs/source/locale/zh_CN/LC_MESSAGES/developer_guide/contribution/index.po`

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
