### PR TITLE
[BugFix] fix _seq_lens_cpu in spec decode

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -1245,9 +1245,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 arange=self.arange,
                 new_slot_mapping=new_slot_mapping,
             )
-            # FIXME(klyzhenko-vadim): seq_lens_cpu is deprecated in vllm.
-            # Updating using .replace() does not work for seq_lens_cpu!
-            new_cad._seq_lens_cpu = new_cad.seq_lens.to("cpu")
 
             return total_num_output_tokens, token_indices_to_sample, new_cad, None
 


### PR DESCRIPTION
### What this PR does / why we need it?
refer to: https://github.com/vllm-project/vllm-ascend/pull/8461 , PR # 8461 has already fixed the value of _seq_lens_cpu through asynchronous non blocking methods, but currently there are still redundant operations in the proposer, which are redundant and result in performance loss.

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
