### PR TITLE
[BugFix] [P/D] release proxy resources on stream cancellation

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -536,9 +536,9 @@ async def _handle_completions(api: str, request: Request):
                     e,
                     request_id,
                 )
-
-            # After streaming done, release tokens
-            proxy_state.release_decoder(decoder_idx, decoder_score)
+            finally:
+                # After streaming done, release tokens
+                proxy_state.release_decoder(decoder_idx, decoder_score)
 
         if stream_flag:
             return StreamingResponse(generate_stream(), media_type="text/event-stream")
@@ -602,11 +602,10 @@ async def metaserver(request: Request):
             max_retries=global_args.max_retries,
             base_delay=global_args.retry_delay,
         )
-        proxy_state.release_prefiller(prefiller_idx, prefiller_score)
-        proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 
     except Exception as e:
         logger.error("Post metaserver failed with: %s", e)
+    finally:
         proxy_state.release_prefiller(prefiller_idx, prefiller_score)
         proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -734,6 +734,13 @@ async def _handle_completions(api: str, request: Request):
             retry_count = 0
             retry = True
             completion_tokens = 0
+
+            def release_prefiller_kv_once():
+                nonlocal released_kv
+                if not released_kv:
+                    proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
+                    released_kv = True
+
             # Only one await per chunk, minimal logic in loop
             try:
                 while retry:
@@ -747,8 +754,7 @@ async def _handle_completions(api: str, request: Request):
                         base_delay=global_args.retry_delay,
                     ):
                         if not released_kv and chunk:
-                            proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
-                            released_kv = True
+                            release_prefiller_kv_once()
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
@@ -802,6 +808,8 @@ async def _handle_completions(api: str, request: Request):
                                 choice["text"] = generated_token
                             chunk = json.dumps(chunk_json).encode("utf-8")
                         yield chunk
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 logger.error(
                     "Error during streaming from decoder %s: %s the aborted request %s "
@@ -811,10 +819,12 @@ async def _handle_completions(api: str, request: Request):
                     instance_info.request_id,
                 )
                 proxy_state.abort_prefiller_request(instance_info.prefiller_idx, instance_info.request_id)
-                proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
-
-            # After streaming done, release tokens
-            proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
+                release_prefiller_kv_once()
+            finally:
+                # After streaming is done or cancelled, release tokens.
+                release_prefiller_kv_once()
+                proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
+                proxy_state.request_num -= 1
 
         # Determine the correct media type based on stream flag
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
@@ -826,9 +836,8 @@ async def _handle_completions(api: str, request: Request):
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print(e)
         print("".join(traceback.format_exception(*exc_info)))
-        raise
-    finally:
         proxy_state.request_num -= 1
+        raise
 
 
 async def _handle_adjust_instances(adjust_mode: str, request: Request):


### PR DESCRIPTION

### What this PR does / why we need it?
Solve the problem of unbalanced proxy load in the PD separation scenario. When a user cancels a request, an asyncio.CancelledError exception is thrown, which does not belong to Exception, causing the load score of the D node not to be released.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
by nightly

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
