### PR TITLE
[CI][Bugfix] Retry failed links in Sphinx linkcheck

### DIFF
--- a/.github/workflows/schedule_doc_linkcheck.yaml
+++ b/.github/workflows/schedule_doc_linkcheck.yaml
@@ -52,7 +52,34 @@ jobs:
       - name: Run full Sphinx linkcheck
         if: ${{ github.event_name != 'pull_request' }}
         run: |
+          set +e
           make -C docs linkcheck SPHINXOPTS="-W --keep-going"
+          LINKCHECK_EXIT_CODE=$?
+          set -e
+
+          if [[ "${LINKCHECK_EXIT_CODE}" == "0" ]]; then
+            exit 0
+          fi
+
+          # Retry all failed links reported by Sphinx linkcheck.
+          retry_failed=0
+          retried=0
+          while IFS= read -r url; do
+            retried=1
+            echo "Retrying failed link: ${url}"
+            curl_args=(-fsSL --retry 3 --retry-delay 3 --retry-all-errors -o /dev/null)
+            if curl "${curl_args[@]}" "${url}"; then
+              echo "Retry succeeded: ${url}"
+            else
+              echo "Retry failed: ${url}"
+              retry_failed=1
+            fi
+          done < <(python -c 'import json, pathlib; p = pathlib.Path("docs/_build/linkcheck/output.json"); print("\n".join(sorted({json.loads(line).get("uri", "").split("#", 1)[0] for line in p.read_text(encoding="utf-8").splitlines() if json.loads(line).get("status") in {"broken", "timeout"} and json.loads(line).get("uri")})) if p.exists() else "")')
+
+          if [[ "${retried}" == "0" ]]; then
+            exit "${LINKCHECK_EXIT_CODE}"
+          fi
+          exit "${retry_failed}"
 
       - name: Run Sphinx linkcheck for changed docs
         if: ${{ github.event_name == 'pull_request' && steps.changed-docs.outputs.any_changed == 'true' }}
@@ -61,11 +88,40 @@ jobs:
         run: |
           set -euo pipefail
 
+          # shellcheck disable=SC2153
+          read -r -a changed_docs <<< "${CHANGED_DOCS}"
           echo "Changed docs files:"
-          printf '  %s\n' ${CHANGED_DOCS}
+          printf '  %s\n' "${changed_docs[@]}"
 
+          set +e
           sphinx-build -b linkcheck -W --keep-going \
-            docs/source docs/_build/linkcheck ${CHANGED_DOCS}
+            docs/source docs/_build/linkcheck "${changed_docs[@]}"
+          LINKCHECK_EXIT_CODE=$?
+          set -e
+
+          if [[ "${LINKCHECK_EXIT_CODE}" == "0" ]]; then
+            exit 0
+          fi
+
+          # Retry all failed links reported by Sphinx linkcheck.
+          retry_failed=0
+          retried=0
+          while IFS= read -r url; do
+            retried=1
+            echo "Retrying failed link: ${url}"
+            curl_args=(-fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /dev/null)
+            if curl "${curl_args[@]}" "${url}"; then
+              echo "Retry succeeded: ${url}"
+            else
+              echo "Retry failed: ${url}"
+              retry_failed=1
+            fi
+          done < <(python -c 'import json, pathlib; p = pathlib.Path("docs/_build/linkcheck/output.json"); print("\n".join(sorted({json.loads(line).get("uri", "").split("#", 1)[0] for line in p.read_text(encoding="utf-8").splitlines() if json.loads(line).get("status") in {"broken", "timeout"} and json.loads(line).get("uri")})) if p.exists() else "")')
+
+          if [[ "${retried}" == "0" ]]; then
+            exit "${LINKCHECK_EXIT_CODE}"
+          fi
+          exit "${retry_failed}"
 
       - name: Upload linkcheck reports
         if: ${{ always() && github.event_name != 'pull_request' }}

--- a/.github/workflows/schedule_doc_linkcheck.yaml
+++ b/.github/workflows/schedule_doc_linkcheck.yaml
@@ -49,6 +49,41 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r docs/requirements-docs.txt
 
+      - name: Prepare linkcheck retry helper
+        if: ${{ github.event_name != 'pull_request' || steps.changed-docs.outputs.any_changed == 'true' }}
+        run: |
+          cat > /tmp/retry-linkcheck-failed-links.sh <<'BASH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          linkcheck_exit_code="${1:?missing linkcheck exit code}"
+          output_json="${2:?missing linkcheck output json}"
+
+          if [[ "${linkcheck_exit_code}" == "0" ]]; then
+            exit 0
+          fi
+
+          retry_failed=0
+          retried=0
+          while IFS= read -r url; do
+            retried=1
+            echo "Retrying failed link: ${url}"
+            curl_args=(-fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /dev/null)
+            if curl "${curl_args[@]}" "${url}"; then
+              echo "Retry succeeded: ${url}"
+            else
+              echo "Retry failed: ${url}"
+              retry_failed=1
+            fi
+          done < <(python -c 'import json, pathlib, sys; p = pathlib.Path(sys.argv[1]); print("\n".join(sorted({json.loads(line).get("uri", "").split("#", 1)[0] for line in p.read_text(encoding="utf-8").splitlines() if json.loads(line).get("status") in {"broken", "timeout"} and json.loads(line).get("uri")})) if p.exists() else "")' "${output_json}")
+
+          if [[ "${retried}" == "0" ]]; then
+            exit "${linkcheck_exit_code}"
+          fi
+          exit "${retry_failed}"
+          BASH
+          chmod +x /tmp/retry-linkcheck-failed-links.sh
+
       - name: Run full Sphinx linkcheck
         if: ${{ github.event_name != 'pull_request' }}
         run: |
@@ -57,29 +92,8 @@ jobs:
           LINKCHECK_EXIT_CODE=$?
           set -e
 
-          if [[ "${LINKCHECK_EXIT_CODE}" == "0" ]]; then
-            exit 0
-          fi
-
-          # Retry all failed links reported by Sphinx linkcheck.
-          retry_failed=0
-          retried=0
-          while IFS= read -r url; do
-            retried=1
-            echo "Retrying failed link: ${url}"
-            curl_args=(-fsSL --retry 3 --retry-delay 3 --retry-all-errors -o /dev/null)
-            if curl "${curl_args[@]}" "${url}"; then
-              echo "Retry succeeded: ${url}"
-            else
-              echo "Retry failed: ${url}"
-              retry_failed=1
-            fi
-          done < <(python -c 'import json, pathlib; p = pathlib.Path("docs/_build/linkcheck/output.json"); print("\n".join(sorted({json.loads(line).get("uri", "").split("#", 1)[0] for line in p.read_text(encoding="utf-8").splitlines() if json.loads(line).get("status") in {"broken", "timeout"} and json.loads(line).get("uri")})) if p.exists() else "")')
-
-          if [[ "${retried}" == "0" ]]; then
-            exit "${LINKCHECK_EXIT_CODE}"
-          fi
-          exit "${retry_failed}"
+          /tmp/retry-linkcheck-failed-links.sh \
+            "${LINKCHECK_EXIT_CODE}" docs/_build/linkcheck/output.json
 
       - name: Run Sphinx linkcheck for changed docs
         if: ${{ github.event_name == 'pull_request' && steps.changed-docs.outputs.any_changed == 'true' }}
@@ -99,29 +113,8 @@ jobs:
           LINKCHECK_EXIT_CODE=$?
           set -e
 
-          if [[ "${LINKCHECK_EXIT_CODE}" == "0" ]]; then
-            exit 0
-          fi
-
-          # Retry all failed links reported by Sphinx linkcheck.
-          retry_failed=0
-          retried=0
-          while IFS= read -r url; do
-            retried=1
-            echo "Retrying failed link: ${url}"
-            curl_args=(-fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /dev/null)
-            if curl "${curl_args[@]}" "${url}"; then
-              echo "Retry succeeded: ${url}"
-            else
-              echo "Retry failed: ${url}"
-              retry_failed=1
-            fi
-          done < <(python -c 'import json, pathlib; p = pathlib.Path("docs/_build/linkcheck/output.json"); print("\n".join(sorted({json.loads(line).get("uri", "").split("#", 1)[0] for line in p.read_text(encoding="utf-8").splitlines() if json.loads(line).get("status") in {"broken", "timeout"} and json.loads(line).get("uri")})) if p.exists() else "")')
-
-          if [[ "${retried}" == "0" ]]; then
-            exit "${LINKCHECK_EXIT_CODE}"
-          fi
-          exit "${retry_failed}"
+          /tmp/retry-linkcheck-failed-links.sh \
+            "${LINKCHECK_EXIT_CODE}" docs/_build/linkcheck/output.json
 
       - name: Upload linkcheck reports
         if: ${{ always() && github.event_name != 'pull_request' }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,9 +147,9 @@ html_extra_path = ["llms.txt"]
 # Check external links without validating remote anchors. Many third-party
 # sites render anchors dynamically, which makes anchor checks flaky in CI.
 linkcheck_anchors = False
-linkcheck_retries = 1
-linkcheck_timeout = 3
-linkcheck_workers = 20
+linkcheck_retries = 3
+linkcheck_timeout = 15
+linkcheck_workers = 10
 
 # Example service endpoints in docs are intentionally not reachable from CI.
 linkcheck_ignore = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,9 +147,9 @@ html_extra_path = ["llms.txt"]
 # Check external links without validating remote anchors. Many third-party
 # sites render anchors dynamically, which makes anchor checks flaky in CI.
 linkcheck_anchors = False
-linkcheck_retries = 3
-linkcheck_timeout = 15
-linkcheck_workers = 10
+linkcheck_retries = 1
+linkcheck_timeout = 3
+linkcheck_workers = 20
 
 # Example service endpoints in docs are intentionally not reachable from CI.
 linkcheck_ignore = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,7 +147,7 @@ html_extra_path = ["llms.txt"]
 # Check external links without validating remote anchors. Many third-party
 # sites render anchors dynamically, which makes anchor checks flaky in CI.
 linkcheck_anchors = False
-linkcheck_retries = 2
+linkcheck_retries = 3
 linkcheck_timeout = 15
 linkcheck_workers = 10
 

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+test
+
 ## v0.18.0rc1 - 2026.04.01
 
 This is the first release candidate of v0.18.0 for vLLM Ascend. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,7 +1,5 @@
 # Release Notes
 
-test
-
 ## v0.18.0rc1 - 2026.04.01
 
 This is the first release candidate of v0.18.0 for vLLM Ascend. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/latest) to get started.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves the stability of the docs linkcheck workflow.

Changes include:

- Increase `linkcheck_retries` to `3`.
- When Sphinx linkcheck still fails, collect all `broken` / `timeout` links from `docs/_build/linkcheck/output.json`.
- Retry only those failed links with `curl --retry`.
- Print retry success or failure for each failed URL.
- Keep CI failed if any retried link still fails.

`linkcheck_retries = 3` helps with short transient failures inside Sphinx, but it is not enough by itself. Sphinx retries happen during the same linkcheck run, and a temporary GitHub/proxy/network issue may still last long enough for all internal retries to fail. Increasing `linkcheck_retries` too much also slows down checks for every link.

The extra retry step only runs after linkcheck fails and only retries the links that actually failed. This reduces CI flakes caused by transient network errors while preserving real broken-link failures.

**Example:**

First link check:
```bash
(user_guide/release_notes: line  917) timeout   https://github.com/vllm-project/vllm-ascend/pull/2312 - HTTPSConnectionPool(host='github.com', port=443): Read timed out. (read timeout=5)
```

Second link check:
```bash
build finished with problems.
Retrying failed link: https://github.com/vllm-project/vllm-ascend/pull/2312
Retry succeeded: https://github.com/vllm-project/vllm-ascend/pull/2312
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

test actions:
https://github.com/vllm-project/vllm-ascend/actions/runs/25155660925/job/73736769235?pr=8839

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
