### PR TITLE
[ascend950][BugFix] set cache_mode of npu_scatter_pa_kv_cache to 'Norm' with ND KVCache

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -316,6 +316,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             key_cache=key_cache,
             value_cache=value_cache,
             slot_mapping=slot_mapping.contiguous(),
+            cache_mode="Norm",
         )
 
     @staticmethod


### PR DESCRIPTION

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
