### PR TITLE
[Feature] Support pooling models on 310P platform

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -1033,7 +1033,7 @@ jobs:
           pytest -sv --durations=0 tests/e2e/310p/singlecard/test_dense_model_singlecard.py \
           tests/e2e/310p/singlecard/test_vl_model_singlecard.py \
           tests/e2e/310p/singlecard/pooling/test_classification.py \
-          tests/e2e/310p/singlecard/pooling/test_pooling.py \
+          tests/e2e/310p/singlecard/pooling/test_embedding.py \
           tests/e2e/310p/singlecard/pooling/test_scoring.py \
           2>&1 | tee /tmp/e2e-310p-singlecard.log
           exit ${PIPESTATUS[0]}

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -1032,6 +1032,9 @@ jobs:
           set -o pipefail
           pytest -sv --durations=0 tests/e2e/310p/singlecard/test_dense_model_singlecard.py \
           tests/e2e/310p/singlecard/test_vl_model_singlecard.py \
+          tests/e2e/310p/singlecard/pooling/test_classification.py \
+          tests/e2e/310p/singlecard/pooling/test_pooling.py \
+          tests/e2e/310p/singlecard/pooling/test_scoring.py \
           2>&1 | tee /tmp/e2e-310p-singlecard.log
           exit ${PIPESTATUS[0]}
 

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -16,16 +16,14 @@ def test_qwen_pooling_classify_correctness() -> None:
         "The future of AI is what",
     ]
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            max_model_len=1024,
-            enforce_eager=True,
+        model_name,
+        runner="pooling",
+        max_model_len=1024,
+        enforce_eager=True,
     ) as vllm_runner:
         vllm_outputs = vllm_runner.classify(prompts)
 
-    with HfRunner(model_name,
-                  dtype="float16",
-                  auto_cls=AutoModelForSequenceClassification) as hf_runner:
+    with HfRunner(model_name,dtype="float16",auto_cls=AutoModelForSequenceClassification) as hf_runner:
         hf_outputs = hf_runner.classify(prompts)
 
     for hf_output, vllm_output in zip(hf_outputs, vllm_outputs):

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -23,7 +23,7 @@ def test_qwen_pooling_classify_correctness() -> None:
     ) as vllm_runner:
         vllm_outputs = vllm_runner.classify(prompts)
 
-    with HfRunner(model_name,dtype="float16",auto_cls=AutoModelForSequenceClassification) as hf_runner:
+    with HfRunner(model_name, dtype="float16", auto_cls=AutoModelForSequenceClassification) as hf_runner:
         hf_outputs = hf_runner.classify(prompts)
 
     for hf_output, vllm_output in zip(hf_outputs, vllm_outputs):

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -6,7 +6,6 @@ from tests.e2e.conftest import HfRunner, VllmRunner
 
 
 def test_qwen_pooling_classify_correctness() -> None:
-
     model_name = snapshot_download("Howeee/Qwen2.5-1.5B-apeach")
 
     prompts = [

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -1,0 +1,34 @@
+import torch
+from modelscope import snapshot_download  # type: ignore[import-untyped]
+from transformers import AutoModelForSequenceClassification
+
+from tests.e2e.conftest import HfRunner, VllmRunner
+
+
+def test_qwen_pooling_classify_correctness() -> None:
+
+    model_name = snapshot_download("Howeee/Qwen2.5-1.5B-apeach")
+
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is what",
+    ]
+    with VllmRunner(
+            model_name,
+            runner="pooling",
+            max_model_len=1024,
+            enforce_eager=True,
+    ) as vllm_runner:
+        vllm_outputs = vllm_runner.classify(prompts)
+
+    with HfRunner(model_name,
+                  dtype="float16",
+                  auto_cls=AutoModelForSequenceClassification) as hf_runner:
+        hf_outputs = hf_runner.classify(prompts)
+
+    for hf_output, vllm_output in zip(hf_outputs, vllm_outputs):
+        hf_output = torch.tensor(hf_output)
+        vllm_output = torch.tensor(vllm_output)
+        assert torch.allclose(hf_output, vllm_output, 1e-2)

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -25,9 +25,11 @@ def test_qwen_pooling_classify_correctness() -> None:
     ) as vllm_runner:
         vllm_outputs = vllm_runner.classify(prompts)
 
-
     with HfRunner(
-        model_name, dtype="float16", model_kwargs={"attn_implementation": "eager"}, auto_cls=AutoModelForSequenceClassification
+        model_name,
+        dtype="float16",
+        model_kwargs={"attn_implementation": "eager"},
+        auto_cls=AutoModelForSequenceClassification,
     ) as hf_runner:
         hf_outputs = hf_runner.classify(prompts)
 

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -19,6 +19,7 @@ def test_qwen_pooling_classify_correctness() -> None:
         runner="pooling",
         max_model_len=1024,
         enforce_eager=True,
+        dtype="float16",
         gpu_memory_utilization=0.6,
     ) as vllm_runner:
         vllm_outputs = vllm_runner.classify(prompts)

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -19,6 +19,7 @@ def test_qwen_pooling_classify_correctness() -> None:
         runner="pooling",
         max_model_len=1024,
         enforce_eager=True,
+        gpu_memory_utilization=0.6,
     ) as vllm_runner:
         vllm_outputs = vllm_runner.classify(prompts)
 

--- a/tests/e2e/310p/singlecard/pooling/test_classification.py
+++ b/tests/e2e/310p/singlecard/pooling/test_classification.py
@@ -14,6 +14,7 @@ def test_qwen_pooling_classify_correctness() -> None:
         "The capital of France is",
         "The future of AI is what",
     ]
+
     with VllmRunner(
         model_name,
         runner="pooling",
@@ -24,7 +25,10 @@ def test_qwen_pooling_classify_correctness() -> None:
     ) as vllm_runner:
         vllm_outputs = vllm_runner.classify(prompts)
 
-    with HfRunner(model_name, dtype="float16", auto_cls=AutoModelForSequenceClassification) as hf_runner:
+
+    with HfRunner(
+        model_name, dtype="float16", model_kwargs={"attn_implementation": "eager"}, auto_cls=AutoModelForSequenceClassification
+    ) as hf_runner:
         hf_outputs = hf_runner.classify(prompts)
 
     for hf_output, vllm_output in zip(hf_outputs, vllm_outputs):

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -42,9 +42,9 @@ def test_embed_models_correctness(model: str):
         vllm_outputs = vllm_runner.embed(queries)
 
     with HfRunner(
-            model_name,
-            dtype="float16",
-            is_sentence_transformer=True,
+        model_name,
+        dtype="float16",
+        is_sentence_transformer=True,
     ) as hf_runner:
         hf_outputs = hf_runner.encode(queries)
 

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -24,20 +24,20 @@ from tests.e2e.utils import check_embeddings_close
 
 MODELS = [
     "Qwen/Qwen3-Embedding-0.6B",  # lasttoken
-    "intfloat/multilingual-e5-small"  # mean_tokens
+    "intfloat/multilingual-e5-small",  # mean_tokens
 ]
 
 
 @pytest.mark.parametrize("model", MODELS)
 def test_embed_models_correctness(model: str):
-    queries = ['What is the capital of China?', 'Explain gravity']
+    queries = ["What is the capital of China?", "Explain gravity"]
 
     model_name = snapshot_download(model)
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            max_model_len=1024,
-            enforce_eager=True,
+        model_name,
+        runner="pooling",
+        max_model_len=1024,
+        enforce_eager=True,
     ) as vllm_runner:
         vllm_outputs = vllm_runner.embed(queries)
 
@@ -58,27 +58,27 @@ def test_embed_models_correctness(model: str):
 
 
 def test_bge_m3_correctness():
-    queries = ['What is the capital of China?', 'Explain gravity']
+    queries = ["What is the capital of China?", "Explain gravity"]
 
     model_name = snapshot_download("BAAI/bge-m3")
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            cudagraph_capture_sizes=[4],
+        model_name,
+        runner="pooling",
+        cudagraph_capture_sizes=[4],
     ) as vllm_aclgraph_runner:
         vllm_aclgraph_outputs = vllm_aclgraph_runner.embed(queries)
 
     with VllmRunner(
-            model_name,
-            runner="pooling",
-            enforce_eager=True,
+        model_name,
+        runner="pooling",
+        enforce_eager=True,
     ) as vllm_runner:
         vllm_eager_outputs = vllm_runner.embed(queries)
 
     with HfRunner(
-            model_name,
-            dtype="float32",
-            is_sentence_transformer=True,
+        model_name,
+        dtype="float32",
+        is_sentence_transformer=True,
     ) as hf_runner:
         hf_outputs = hf_runner.encode(queries)
 

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+# Adapted from vllm/tests/basic_correctness/test_basic_correctness.py
+#
+import pytest
+from modelscope import snapshot_download  # type: ignore[import-untyped]
+
+from tests.e2e.conftest import HfRunner, VllmRunner
+from tests.e2e.utils import check_embeddings_close
+
+MODELS = [
+    "Qwen/Qwen3-Embedding-0.6B",  # lasttoken
+    "intfloat/multilingual-e5-small"  # mean_tokens
+]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_embed_models_correctness(model: str):
+    queries = ['What is the capital of China?', 'Explain gravity']
+
+    model_name = snapshot_download(model)
+    with VllmRunner(
+            model_name,
+            runner="pooling",
+            max_model_len=1024,
+            enforce_eager=True,
+    ) as vllm_runner:
+        vllm_outputs = vllm_runner.embed(queries)
+
+    with HfRunner(
+            model_name,
+            dtype="float16",
+            is_sentence_transformer=True,
+    ) as hf_runner:
+        hf_outputs = hf_runner.encode(queries)
+
+    check_embeddings_close(
+        embeddings_0_lst=hf_outputs,
+        embeddings_1_lst=vllm_outputs,
+        name_0="hf",
+        name_1="vllm",
+        tol=1e-2,
+    )
+
+
+def test_bge_m3_correctness():
+    queries = ['What is the capital of China?', 'Explain gravity']
+
+    model_name = snapshot_download("BAAI/bge-m3")
+    with VllmRunner(
+            model_name,
+            runner="pooling",
+            cudagraph_capture_sizes=[4],
+    ) as vllm_aclgraph_runner:
+        vllm_aclgraph_outputs = vllm_aclgraph_runner.embed(queries)
+
+    with VllmRunner(
+            model_name,
+            runner="pooling",
+            enforce_eager=True,
+    ) as vllm_runner:
+        vllm_eager_outputs = vllm_runner.embed(queries)
+
+    with HfRunner(
+            model_name,
+            dtype="float32",
+            is_sentence_transformer=True,
+    ) as hf_runner:
+        hf_outputs = hf_runner.encode(queries)
+
+    check_embeddings_close(
+        embeddings_0_lst=hf_outputs,
+        embeddings_1_lst=vllm_eager_outputs,
+        name_0="hf",
+        name_1="vllm",
+        tol=1e-2,
+    )
+    check_embeddings_close(
+        embeddings_0_lst=vllm_eager_outputs,
+        embeddings_1_lst=vllm_aclgraph_outputs,
+        name_0="eager",
+        name_1="aclgraph",
+        tol=1e-2,
+    )

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -38,6 +38,7 @@ def test_embed_models_correctness(model: str):
         runner="pooling",
         max_model_len=512,
         enforce_eager=True,
+        dtype="float16",
         gpu_memory_utilization=0.6,
     ) as vllm_runner:
         vllm_outputs = vllm_runner.embed(queries)
@@ -66,8 +67,10 @@ def test_bge_m3_correctness():
         model_name,
         runner="pooling",
         max_model_len=512,
+        dtype="float16",
         gpu_memory_utilization=0.6,
         cudagraph_capture_sizes=[4],
+        additional_config={"ascend_compilation_config": {"fuse_norm_quant": False}},
     ) as vllm_aclgraph_runner:
         vllm_aclgraph_outputs = vllm_aclgraph_runner.embed(queries)
 
@@ -75,6 +78,7 @@ def test_bge_m3_correctness():
         model_name,
         runner="pooling",
         max_model_len=512,
+        dtype="float16",
         gpu_memory_utilization=0.6,
         enforce_eager=True,
     ) as vllm_runner:

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -17,6 +17,7 @@
 # Adapted from vllm/tests/basic_correctness/test_basic_correctness.py
 #
 import pytest
+import huggingface_hub
 from modelscope import snapshot_download  # type: ignore[import-untyped]
 
 from tests.e2e.conftest import HfRunner, VllmRunner
@@ -24,7 +25,7 @@ from tests.e2e.utils import check_embeddings_close
 
 MODELS = [
     "Qwen/Qwen3-Embedding-0.6B",  # lasttoken
-    "BAAI/bge-large-zh-v1.5",  # mean_tokens
+    "intfloat/multilingual-e5-small",  # mean_tokens
 ]
 
 
@@ -66,10 +67,9 @@ def test_bge_m3_correctness():
     with VllmRunner(
         model_name,
         runner="pooling",
-        max_model_len=512,
+        max_model_len=1024,
         dtype="float16",
-        gpu_memory_utilization=0.6,
-        cudagraph_capture_sizes=[4],
+        cudagraph_capture_sizes=[512, 1024],
         additional_config={"ascend_compilation_config": {"fuse_norm_quant": False}},
     ) as vllm_aclgraph_runner:
         vllm_aclgraph_outputs = vllm_aclgraph_runner.embed(queries)
@@ -77,12 +77,26 @@ def test_bge_m3_correctness():
     with VllmRunner(
         model_name,
         runner="pooling",
-        max_model_len=512,
+        max_model_len=1024,
         dtype="float16",
-        gpu_memory_utilization=0.6,
         enforce_eager=True,
     ) as vllm_runner:
         vllm_eager_outputs = vllm_runner.embed(queries)
+
+    with HfRunner(
+        model_name,
+        dtype="float16",
+        is_sentence_transformer=True,
+    ) as hf_runner:
+        hf_outputs = hf_runner.encode(queries)
+
+    check_embeddings_close(
+        embeddings_0_lst=hf_outputs,
+        embeddings_1_lst=vllm_eager_outputs,
+        name_0="hf",
+        name_1="vllm",
+        tol=1e-2,
+    )
 
     check_embeddings_close(
         embeddings_0_lst=vllm_eager_outputs,
@@ -91,3 +105,4 @@ def test_bge_m3_correctness():
         name_1="aclgraph",
         tol=1e-2,
     )
+

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -17,7 +17,6 @@
 # Adapted from vllm/tests/basic_correctness/test_basic_correctness.py
 #
 import pytest
-import huggingface_hub
 from modelscope import snapshot_download  # type: ignore[import-untyped]
 
 from tests.e2e.conftest import HfRunner, VllmRunner
@@ -105,4 +104,3 @@ def test_bge_m3_correctness():
         name_1="aclgraph",
         tol=1e-2,
     )
-

--- a/tests/e2e/310p/singlecard/pooling/test_embedding.py
+++ b/tests/e2e/310p/singlecard/pooling/test_embedding.py
@@ -24,7 +24,7 @@ from tests.e2e.utils import check_embeddings_close
 
 MODELS = [
     "Qwen/Qwen3-Embedding-0.6B",  # lasttoken
-    "intfloat/multilingual-e5-small",  # mean_tokens
+    "BAAI/bge-large-zh-v1.5",  # mean_tokens
 ]
 
 
@@ -36,8 +36,9 @@ def test_embed_models_correctness(model: str):
     with VllmRunner(
         model_name,
         runner="pooling",
-        max_model_len=1024,
+        max_model_len=512,
         enforce_eager=True,
+        gpu_memory_utilization=0.6,
     ) as vllm_runner:
         vllm_outputs = vllm_runner.embed(queries)
 
@@ -64,6 +65,8 @@ def test_bge_m3_correctness():
     with VllmRunner(
         model_name,
         runner="pooling",
+        max_model_len=512,
+        gpu_memory_utilization=0.6,
         cudagraph_capture_sizes=[4],
     ) as vllm_aclgraph_runner:
         vllm_aclgraph_outputs = vllm_aclgraph_runner.embed(queries)
@@ -71,24 +74,12 @@ def test_bge_m3_correctness():
     with VllmRunner(
         model_name,
         runner="pooling",
+        max_model_len=512,
+        gpu_memory_utilization=0.6,
         enforce_eager=True,
     ) as vllm_runner:
         vllm_eager_outputs = vllm_runner.embed(queries)
 
-    with HfRunner(
-        model_name,
-        dtype="float32",
-        is_sentence_transformer=True,
-    ) as hf_runner:
-        hf_outputs = hf_runner.encode(queries)
-
-    check_embeddings_close(
-        embeddings_0_lst=hf_outputs,
-        embeddings_1_lst=vllm_eager_outputs,
-        name_0="hf",
-        name_1="vllm",
-        tol=1e-2,
-    )
     check_embeddings_close(
         embeddings_0_lst=vllm_eager_outputs,
         embeddings_1_lst=vllm_aclgraph_outputs,

--- a/tests/e2e/310p/singlecard/pooling/test_scoring.py
+++ b/tests/e2e/310p/singlecard/pooling/test_scoring.py
@@ -39,11 +39,7 @@ def test_cross_encoder_score_1_to_1(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict([text_pair]).tolist()
 
-    with VllmRunner(model_name,
-                    runner="pooling",
-                    dtype=DTYPE,
-                    max_model_len=1024,
-                    enforce_eager=True) as vllm_model:
+    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
         vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
 
     assert len(vllm_outputs) == 1
@@ -100,9 +96,11 @@ def test_embedding_score_1_to_1(emb_model_name):
 
     with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
         hf_embeddings = hf_model.encode(text_pair)
-        hf_outputs = [F.cosine_similarity(*map(torch.tensor, hf_embeddings), dim=0)]
+        hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
-    with VllmRunner(emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
+    with VllmRunner(
+           emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
+    ) as vllm_model:
         vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
 
     assert len(vllm_outputs) == 1
@@ -119,9 +117,11 @@ def test_embedding_score_1_to_N(emb_model_name):
 
     with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
         hf_embeddings = [hf_model.encode(text_pair) for text_pair in text_pairs]
-        hf_outputs = [ F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
+        hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
-    with VllmRunner(emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
+    with VllmRunner(
+           emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
+    ) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
 
     assert len(vllm_outputs) == 2
@@ -141,11 +141,9 @@ def test_embedding_score_N_to_N(emb_model_name):
         hf_embeddings = [hf_model.encode(text_pair) for text_pair in text_pairs]
         hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
-    with VllmRunner(emb_model_name,
-                    runner="pooling",
-                    dtype=DTYPE,
-                    max_model_len=1024,
-                    enforce_eager=True) as vllm_model:
+    with VllmRunner(
+           emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
+    ) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
 
     assert len(vllm_outputs) == 2

--- a/tests/e2e/310p/singlecard/pooling/test_scoring.py
+++ b/tests/e2e/310p/singlecard/pooling/test_scoring.py
@@ -33,6 +33,7 @@ DTYPE = "float16"
 def model_name(request):
     yield snapshot_download(request.param)
 
+
 def test_cross_encoder_score_1_to_1(model_name):
     text_pair = [TEXTS_1[0], TEXTS_2[0]]
 
@@ -99,7 +100,7 @@ def test_embedding_score_1_to_1(emb_model_name):
         hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
     with VllmRunner(
-           emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
+        emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
     ) as vllm_model:
         vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
 
@@ -120,7 +121,7 @@ def test_embedding_score_1_to_N(emb_model_name):
         hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
     with VllmRunner(
-           emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
+        emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
     ) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
 
@@ -142,7 +143,7 @@ def test_embedding_score_N_to_N(emb_model_name):
         hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
     with VllmRunner(
-           emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
+        emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
     ) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
 

--- a/tests/e2e/310p/singlecard/pooling/test_scoring.py
+++ b/tests/e2e/310p/singlecard/pooling/test_scoring.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+import torch.nn.functional as F
+from modelscope import snapshot_download  # type: ignore[import-untyped]
+
+from tests.e2e.conftest import HfRunner, VllmRunner
+
+CROSS_ENCODER_MODELS = [
+    "dengcao/ms-marco-MiniLM-L6-v2",  # Bert
+    "BAAI/bge-reranker-v2-m3",  # Roberta
+]
+
+EMBEDDING_MODELS = [
+    "sentence-transformers/all-MiniLM-L12-v2",
+]
+
+TEXTS_1 = [
+    "What is the capital of France?",
+    "What is the capital of Germany?",
+]
+
+TEXTS_2 = [
+    "The capital of France is Paris.",
+    "The capital of Germany is Berlin.",
+]
+
+DTYPE = "float16"
+
+
+@pytest.fixture(scope="module", params=CROSS_ENCODER_MODELS)
+def model_name(request):
+    yield snapshot_download(request.param)
+
+def test_cross_encoder_score_1_to_1(model_name):
+    text_pair = [TEXTS_1[0], TEXTS_2[0]]
+
+    with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
+        hf_outputs = hf_model.predict([text_pair]).tolist()
+
+    with VllmRunner(model_name,
+                    runner="pooling",
+                    dtype=DTYPE,
+                    max_model_len=1024,
+                    enforce_eager=True) as vllm_model:
+        vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
+
+    assert len(vllm_outputs) == 1
+    assert len(hf_outputs) == 1
+
+    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
+
+
+def test_cross_encoder_score_1_to_N(model_name):
+    text_pairs = [
+        [TEXTS_1[0], TEXTS_2[0]],
+        [TEXTS_1[0], TEXTS_2[1]],
+    ]
+
+    with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
+        hf_outputs = hf_model.predict(text_pairs).tolist()
+
+    with VllmRunner(model_name,
+                    runner="pooling",
+                    dtype=DTYPE,
+                    max_model_len=1024,
+                    enforce_eager=True) as vllm_model:
+        vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
+
+    assert len(vllm_outputs) == 2
+    assert len(hf_outputs) == 2
+
+    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
+    assert hf_outputs[1] == pytest.approx(vllm_outputs[1], rel=0.01)
+
+
+def test_cross_encoder_score_N_to_N(model_name):
+    text_pairs = [
+        [TEXTS_1[0], TEXTS_2[0]],
+        [TEXTS_1[1], TEXTS_2[1]],
+    ]
+
+    with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
+        hf_outputs = hf_model.predict(text_pairs).tolist()
+
+    with VllmRunner(model_name,
+                    runner="pooling",
+                    dtype=DTYPE,
+                    max_model_len=1024,
+                    enforce_eager=True) as vllm_model:
+        vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
+
+    assert len(vllm_outputs) == 2
+    assert len(hf_outputs) == 2
+
+    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
+    assert hf_outputs[1] == pytest.approx(vllm_outputs[1], rel=0.01)
+
+
+@pytest.fixture(scope="module", params=EMBEDDING_MODELS)
+def emb_model_name(request):
+    yield snapshot_download(request.param)
+
+
+def test_embedding_score_1_to_1(emb_model_name):
+    text_pair = [TEXTS_1[0], TEXTS_2[0]]
+
+    with HfRunner(emb_model_name, dtype=DTYPE,
+                  is_sentence_transformer=True) as hf_model:
+        hf_embeddings = hf_model.encode(text_pair)
+        hf_outputs = [
+            F.cosine_similarity(*map(torch.tensor, hf_embeddings), dim=0)
+        ]
+
+    with VllmRunner(emb_model_name,
+                    runner="pooling",
+                    dtype=DTYPE,
+                    max_model_len=1024,
+                    enforce_eager=True) as vllm_model:
+        vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
+
+    assert len(vllm_outputs) == 1
+    assert len(hf_outputs) == 1
+
+    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
+
+
+def test_embedding_score_1_to_N(emb_model_name):
+    text_pairs = [
+        [TEXTS_1[0], TEXTS_2[0]],
+        [TEXTS_1[0], TEXTS_2[1]],
+    ]
+
+    with HfRunner(emb_model_name, dtype=DTYPE,
+                  is_sentence_transformer=True) as hf_model:
+        hf_embeddings = [
+            hf_model.encode(text_pair) for text_pair in text_pairs
+        ]
+        hf_outputs = [
+            F.cosine_similarity(*map(torch.tensor, pair), dim=0)
+            for pair in hf_embeddings
+        ]
+
+    with VllmRunner(emb_model_name,
+                    runner="pooling",
+                    dtype=DTYPE,
+                    max_model_len=1024,
+                    enforce_eager=True) as vllm_model:
+        vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
+
+    assert len(vllm_outputs) == 2
+    assert len(hf_outputs) == 2
+
+    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
+    assert hf_outputs[1] == pytest.approx(vllm_outputs[1], rel=0.01)
+
+
+def test_embedding_score_N_to_N(emb_model_name):
+    text_pairs = [
+        [TEXTS_1[0], TEXTS_2[0]],
+        [TEXTS_1[1], TEXTS_2[1]],
+    ]
+
+    with HfRunner(emb_model_name, dtype=DTYPE,
+                  is_sentence_transformer=True) as hf_model:
+        hf_embeddings = [
+            hf_model.encode(text_pair) for text_pair in text_pairs
+        ]
+        hf_outputs = [
+            F.cosine_similarity(*map(torch.tensor, pair), dim=0)
+            for pair in hf_embeddings
+        ]
+
+    with VllmRunner(emb_model_name,
+                    runner="pooling",
+                    dtype=DTYPE,
+                    max_model_len=1024,
+                    enforce_eager=True) as vllm_model:
+        vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
+
+    assert len(vllm_outputs) == 2
+    assert len(hf_outputs) == 2
+
+    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
+    assert hf_outputs[1] == pytest.approx(vllm_outputs[1], rel=0.01)

--- a/tests/e2e/310p/singlecard/pooling/test_scoring.py
+++ b/tests/e2e/310p/singlecard/pooling/test_scoring.py
@@ -61,11 +61,7 @@ def test_cross_encoder_score_1_to_N(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict(text_pairs).tolist()
 
-    with VllmRunner(model_name,
-                    runner="pooling",
-                    dtype=DTYPE,
-                    max_model_len=1024,
-                    enforce_eager=True) as vllm_model:
+    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
 
     assert len(vllm_outputs) == 2
@@ -84,11 +80,7 @@ def test_cross_encoder_score_N_to_N(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict(text_pairs).tolist()
 
-    with VllmRunner(model_name,
-                    runner="pooling",
-                    dtype=DTYPE,
-                    max_model_len=1024,
-                    enforce_eager=True) as vllm_model:
+    with VllmRunner(model_name, unner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
 
     assert len(vllm_outputs) == 2
@@ -106,18 +98,11 @@ def emb_model_name(request):
 def test_embedding_score_1_to_1(emb_model_name):
     text_pair = [TEXTS_1[0], TEXTS_2[0]]
 
-    with HfRunner(emb_model_name, dtype=DTYPE,
-                  is_sentence_transformer=True) as hf_model:
+    with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
         hf_embeddings = hf_model.encode(text_pair)
-        hf_outputs = [
-            F.cosine_similarity(*map(torch.tensor, hf_embeddings), dim=0)
-        ]
+        hf_outputs = [F.cosine_similarity(*map(torch.tensor, hf_embeddings), dim=0)]
 
-    with VllmRunner(emb_model_name,
-                    runner="pooling",
-                    dtype=DTYPE,
-                    max_model_len=1024,
-                    enforce_eager=True) as vllm_model:
+    with VllmRunner(emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
         vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
 
     assert len(vllm_outputs) == 1
@@ -132,21 +117,11 @@ def test_embedding_score_1_to_N(emb_model_name):
         [TEXTS_1[0], TEXTS_2[1]],
     ]
 
-    with HfRunner(emb_model_name, dtype=DTYPE,
-                  is_sentence_transformer=True) as hf_model:
-        hf_embeddings = [
-            hf_model.encode(text_pair) for text_pair in text_pairs
-        ]
-        hf_outputs = [
-            F.cosine_similarity(*map(torch.tensor, pair), dim=0)
-            for pair in hf_embeddings
-        ]
+    with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
+        hf_embeddings = [hf_model.encode(text_pair) for text_pair in text_pairs]
+        hf_outputs = [ F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
-    with VllmRunner(emb_model_name,
-                    runner="pooling",
-                    dtype=DTYPE,
-                    max_model_len=1024,
-                    enforce_eager=True) as vllm_model:
+    with VllmRunner(emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
 
     assert len(vllm_outputs) == 2
@@ -162,15 +137,9 @@ def test_embedding_score_N_to_N(emb_model_name):
         [TEXTS_1[1], TEXTS_2[1]],
     ]
 
-    with HfRunner(emb_model_name, dtype=DTYPE,
-                  is_sentence_transformer=True) as hf_model:
-        hf_embeddings = [
-            hf_model.encode(text_pair) for text_pair in text_pairs
-        ]
-        hf_outputs = [
-            F.cosine_similarity(*map(torch.tensor, pair), dim=0)
-            for pair in hf_embeddings
-        ]
+    with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
+        hf_embeddings = [hf_model.encode(text_pair) for text_pair in text_pairs]
+        hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
 
     with VllmRunner(emb_model_name,
                     runner="pooling",

--- a/tests/e2e/310p/singlecard/pooling/test_scoring.py
+++ b/tests/e2e/310p/singlecard/pooling/test_scoring.py
@@ -8,13 +8,9 @@ from modelscope import snapshot_download  # type: ignore[import-untyped]
 from tests.e2e.conftest import HfRunner, VllmRunner
 
 CROSS_ENCODER_MODELS = [
-    "dengcao/ms-marco-MiniLM-L6-v2",  # Bert
     "BAAI/bge-reranker-v2-m3",  # Roberta
 ]
 
-EMBEDDING_MODELS = [
-    "sentence-transformers/all-MiniLM-L12-v2",
-]
 
 TEXTS_1 = [
     "What is the capital of France?",
@@ -40,7 +36,7 @@ def test_cross_encoder_score_1_to_1(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict([text_pair]).tolist()
 
-    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
+    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6) as vllm_model:
         vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
 
     assert len(vllm_outputs) == 1
@@ -58,7 +54,7 @@ def test_cross_encoder_score_1_to_N(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict(text_pairs).tolist()
 
-    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
+    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
 
     assert len(vllm_outputs) == 2
@@ -77,74 +73,7 @@ def test_cross_encoder_score_N_to_N(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict(text_pairs).tolist()
 
-    with VllmRunner(model_name, unner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True) as vllm_model:
-        vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
-
-    assert len(vllm_outputs) == 2
-    assert len(hf_outputs) == 2
-
-    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
-    assert hf_outputs[1] == pytest.approx(vllm_outputs[1], rel=0.01)
-
-
-@pytest.fixture(scope="module", params=EMBEDDING_MODELS)
-def emb_model_name(request):
-    yield snapshot_download(request.param)
-
-
-def test_embedding_score_1_to_1(emb_model_name):
-    text_pair = [TEXTS_1[0], TEXTS_2[0]]
-
-    with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
-        hf_embeddings = hf_model.encode(text_pair)
-        hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
-
-    with VllmRunner(
-        emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
-    ) as vllm_model:
-        vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
-
-    assert len(vllm_outputs) == 1
-    assert len(hf_outputs) == 1
-
-    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
-
-
-def test_embedding_score_1_to_N(emb_model_name):
-    text_pairs = [
-        [TEXTS_1[0], TEXTS_2[0]],
-        [TEXTS_1[0], TEXTS_2[1]],
-    ]
-
-    with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
-        hf_embeddings = [hf_model.encode(text_pair) for text_pair in text_pairs]
-        hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
-
-    with VllmRunner(
-        emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
-    ) as vllm_model:
-        vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
-
-    assert len(vllm_outputs) == 2
-    assert len(hf_outputs) == 2
-
-    assert hf_outputs[0] == pytest.approx(vllm_outputs[0], rel=0.01)
-    assert hf_outputs[1] == pytest.approx(vllm_outputs[1], rel=0.01)
-
-
-def test_embedding_score_N_to_N(emb_model_name):
-    text_pairs = [
-        [TEXTS_1[0], TEXTS_2[0]],
-        [TEXTS_1[1], TEXTS_2[1]],
-    ]
-
-    with HfRunner(emb_model_name, dtype=DTYPE, is_sentence_transformer=True) as hf_model:
-        hf_embeddings = [hf_model.encode(text_pair) for text_pair in text_pairs]
-        hf_outputs = [F.cosine_similarity(*map(torch.tensor, pair), dim=0) for pair in hf_embeddings]
-
-    with VllmRunner(
-        emb_model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True
-    ) as vllm_model:
+    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
 
     assert len(vllm_outputs) == 2

--- a/tests/e2e/310p/singlecard/pooling/test_scoring.py
+++ b/tests/e2e/310p/singlecard/pooling/test_scoring.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pytest
-import torch
-import torch.nn.functional as F
 from modelscope import snapshot_download  # type: ignore[import-untyped]
 
 from tests.e2e.conftest import HfRunner, VllmRunner
@@ -36,7 +34,9 @@ def test_cross_encoder_score_1_to_1(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict([text_pair]).tolist()
 
-    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6) as vllm_model:
+    with VllmRunner(
+        model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6
+    ) as vllm_model:
         vllm_outputs = vllm_model.score(text_pair[0], text_pair[1])
 
     assert len(vllm_outputs) == 1
@@ -54,7 +54,9 @@ def test_cross_encoder_score_1_to_N(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict(text_pairs).tolist()
 
-    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6) as vllm_model:
+    with VllmRunner(
+        model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6
+    ) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1[0], TEXTS_2)
 
     assert len(vllm_outputs) == 2
@@ -73,7 +75,9 @@ def test_cross_encoder_score_N_to_N(model_name):
     with HfRunner(model_name, dtype=DTYPE, is_cross_encoder=True) as hf_model:
         hf_outputs = hf_model.predict(text_pairs).tolist()
 
-    with VllmRunner(model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6) as vllm_model:
+    with VllmRunner(
+        model_name, runner="pooling", dtype=DTYPE, max_model_len=1024, enforce_eager=True, gpu_memory_utilization=0.6
+    ) as vllm_model:
         vllm_outputs = vllm_model.score(TEXTS_1, TEXTS_2)
 
     assert len(vllm_outputs) == 2

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1450,7 +1450,11 @@ DataParallelVllmRunner = DPVllmRunner
 
 class HfRunner:
     def get_default_device(self):
-        return "cpu" if current_platform.is_cpu() else current_platform.device_type
+        if current_platform.is_cpu():
+            return "cpu"
+        else:
+            torch.npu.set_compile_mode(jit_compile=False)
+            return current_platform.device_type
 
     def wrap_device(self, x: _T, device: str | None = None) -> _T:
         if x is None or isinstance(x, (bool,)):

--- a/tests/ut/_310p/attention/test_attention_mask_310.py
+++ b/tests/ut/_310p/attention/test_attention_mask_310.py
@@ -26,17 +26,11 @@ class TestAttentionMaskBuilder310(TestBase):
         self.max_seqlen = 4096
         self.attention_mask_builder = AttentionMaskBuilder310(torch.device("cpu"), self.max_seqlen)
 
-    def test_get_attention_mask_310_for_pooling_model(self):
-        model_config = MagicMock()
-        model_config.runner_type = "pooling"
-        with self.assertRaises(NotImplementedError):
-            self.attention_mask_builder.get_attention_mask(model_config)
-
     @patch("torch_npu.npu_format_cast")
     def test_get_attention_mask_310(self, mock_format_cast):
         mock_format_cast.side_effect = lambda x, y: x
         model_config = MagicMock()
-        attn_mask = self.attention_mask_builder.get_attention_mask(model_config)
+        attn_mask = self.attention_mask_builder.get_attention_mask(causal=True, model_config=model_config)
         self.assertEqual(attn_mask.shape, (1, self.max_seqlen // 16, self.max_seqlen, 16))
         self.assertEqual(attn_mask[0][-1][0][-1], torch.tensor(float("-inf"), dtype=torch.float16))
 

--- a/tests/ut/attention/test_attention_cp_precision.py
+++ b/tests/ut/attention/test_attention_cp_precision.py
@@ -339,7 +339,7 @@ def build_cp_attn_metadata(
     query_start_loc = query_start_loc_cpu.to(device, non_blocking=True)
 
     attn_mask_builder = AttentionMaskBuilder(device)
-    attn_mask = attn_mask_builder.get_attention_mask(vllm_config.model_config)
+    attn_mask = attn_mask_builder.get_attention_mask(common_attn_metadata.causal, vllm_config.model_config)
 
     prefill_metadata = None
     if num_prefills > 0:

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -88,7 +88,32 @@ class AttentionMaskBuilder310:
         splitfuse_mask_nz = torch_npu.npu_format_cast(nd_to_nz_spec(splitfuse_mask).contiguous(), ACL_FORMAT_FRACTAL_NZ)
         return splitfuse_mask_nz
 
-    def get_attention_mask(self, model_config) -> torch.Tensor:
+    def get_swa_mask(self, dtype: torch.dtype, sliding_window):
+        """
+        Generates or retrieves a cached Sliding Window Attention (SWA) mask.
+
+        This mask allows attention only within a specific local window (diagonal band),
+        masking out tokens that are too far in the past or in the future.
+
+        Args:
+            dtype (torch.dtype): Data type of the mask.
+            sliding_window (int): The size of the sliding window.
+
+        Returns:
+            torch.Tensor: The SWA mask cast to ACL_FORMAT_FRACTAL_NZ.
+        """
+        assert dtype == torch.float16
+        if sliding_window is not None and self.swa_mask is None:
+            mask = torch.ones(self.max_seqlen, self.max_seqlen, dtype=torch.bool)
+            triu_mask = torch.triu(mask, diagonal=1).to(self.device)
+            tril_mask = torch.tril(mask, -sliding_window).to(self.device)
+            mask = triu_mask + tril_mask
+            swa_mask = torch.zeros((self.max_seqlen, self.max_seqlen), dtype=dtype, device=self.device)
+            swa_mask.masked_fill_(mask, float("-inf"))
+            self.swa_mask = torch_npu.npu_format_cast(nd_to_nz_2d(swa_mask), ACL_FORMAT_FRACTAL_NZ)
+        return self.swa_mask
+
+    def get_attention_mask(self, causal:bool, model_config) -> torch.Tensor:
         """
         Retrieves the appropriate attention mask based on the model configuration.
 
@@ -96,6 +121,7 @@ class AttentionMaskBuilder310:
         on 310P hardware.
 
         Args:
+            causal (bool): Whether to generate a causal mask.
             model_config: Configuration object containing runner details.
 
         Returns:
@@ -105,8 +131,20 @@ class AttentionMaskBuilder310:
             NotImplementedError: If the runner_type is 'pooling'.
         """
         if getattr(model_config, "runner_type", None) == "pooling":
-            # TODO: pooling model will be supported soon.
-            raise NotImplementedError("310P does not support runner_type='pooling'")
+            if causal:
+                return self._get_causal_mask(self.max_seqlen)
+            else:
+                if self.attn_mask_cache is not None:
+                    return self.attn_mask_cache
+
+                max_seq_len = self.max_seqlen
+                attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len),
+                                                 dtype=model_config.dtype, device=self.device)
+                attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
+                self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
+
+                return self.attn_mask_cache
+
         return self._get_causal_mask(self.max_seqlen)
 
     def _get_causal_mask(self, max_seq_len: int) -> torch.Tensor:

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -149,6 +149,6 @@ class AttentionMaskBuilder310:
 
         attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len), dtype=torch.bool, device=self.device)
         attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
-        self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
+        self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), ACL_FORMAT_FRACTAL_NZ)
 
         return self.attn_mask_cache

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -138,8 +138,9 @@ class AttentionMaskBuilder310:
                     return self.attn_mask_cache
 
                 max_seq_len = self.max_seqlen
-                attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len),
-                                                 dtype=model_config.dtype, device=self.device)
+                attention_mask_npu = torch.zeros(
+                    size=(max_seq_len, max_seq_len), dtype=model_config.dtype, device=self.device
+                )
                 attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
                 self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
 

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -109,17 +109,7 @@ class AttentionMaskBuilder310:
             if causal:
                 return self._get_causal_mask(self.max_seqlen)
             else:
-                if self.attn_mask_cache is not None:
-                    return self.attn_mask_cache
-
-                max_seq_len = self.max_seqlen
-                attention_mask_npu = torch.zeros(
-                    size=(max_seq_len, max_seq_len), dtype=model_config.dtype, device=self.device
-                )
-                attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
-                self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
-
-                return self.attn_mask_cache
+                return self._get_non_causal_mask(self.max_seqlen)
 
         return self._get_causal_mask(self.max_seqlen)
 
@@ -139,4 +129,28 @@ class AttentionMaskBuilder310:
         if self.attn_mask_cache is None:
             attn_mask = self.gen_causal_additive_mask(max_seq_len, self.device)
             self.attn_mask_cache = torch_npu.npu_format_cast(nd_to_nz_2d(attn_mask), ACL_FORMAT_FRACTAL_NZ)
+        return self.attn_mask_cache
+
+    def _get_non_causal_mask(self, max_seq_len: int) -> torch.Tensor:
+        """
+        Internal method to get or update the cached non-causal attention mask.
+
+        If the cache is empty or the requested length exceeds the cached length,
+        a new mask is generated and converted to the NPU fractal format.
+
+        Args:
+            max_seq_len (int): The required sequence length.
+
+        Returns:
+            torch.Tensor: The cached causal mask in ACL_FORMAT_FRACTAL_NZ.
+        """
+        if self.attn_mask_cache is not None:
+            return self.attn_mask_cache
+
+        attention_mask_npu = torch.zeros(
+            size=(max_seq_len, max_seq_len), dtype=torch.bool, device=self.device
+        )
+        attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
+        self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
+
         return self.attn_mask_cache

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -88,31 +88,6 @@ class AttentionMaskBuilder310:
         splitfuse_mask_nz = torch_npu.npu_format_cast(nd_to_nz_spec(splitfuse_mask).contiguous(), ACL_FORMAT_FRACTAL_NZ)
         return splitfuse_mask_nz
 
-    def get_swa_mask(self, dtype: torch.dtype, sliding_window):
-        """
-        Generates or retrieves a cached Sliding Window Attention (SWA) mask.
-
-        This mask allows attention only within a specific local window (diagonal band),
-        masking out tokens that are too far in the past or in the future.
-
-        Args:
-            dtype (torch.dtype): Data type of the mask.
-            sliding_window (int): The size of the sliding window.
-
-        Returns:
-            torch.Tensor: The SWA mask cast to ACL_FORMAT_FRACTAL_NZ.
-        """
-        assert dtype == torch.float16
-        if sliding_window is not None and self.swa_mask is None:
-            mask = torch.ones(self.max_seqlen, self.max_seqlen, dtype=torch.bool)
-            triu_mask = torch.triu(mask, diagonal=1).to(self.device)
-            tril_mask = torch.tril(mask, -sliding_window).to(self.device)
-            mask = triu_mask + tril_mask
-            swa_mask = torch.zeros((self.max_seqlen, self.max_seqlen), dtype=dtype, device=self.device)
-            swa_mask.masked_fill_(mask, float("-inf"))
-            self.swa_mask = torch_npu.npu_format_cast(nd_to_nz_2d(swa_mask), ACL_FORMAT_FRACTAL_NZ)
-        return self.swa_mask
-
     def get_attention_mask(self, causal: bool, model_config) -> torch.Tensor:
         """
         Retrieves the appropriate attention mask based on the model configuration.

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -148,7 +148,6 @@ class AttentionMaskBuilder310:
             return self.attn_mask_cache
 
         attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len), dtype=torch.bool, device=self.device)
-        
         attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
         self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
 

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -113,7 +113,7 @@ class AttentionMaskBuilder310:
             self.swa_mask = torch_npu.npu_format_cast(nd_to_nz_2d(swa_mask), ACL_FORMAT_FRACTAL_NZ)
         return self.swa_mask
 
-    def get_attention_mask(self, causal:bool, model_config) -> torch.Tensor:
+    def get_attention_mask(self, causal: bool, model_config) -> torch.Tensor:
         """
         Retrieves the appropriate attention mask based on the model configuration.
 

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -147,9 +147,8 @@ class AttentionMaskBuilder310:
         if self.attn_mask_cache is not None:
             return self.attn_mask_cache
 
-        attention_mask_npu = torch.zeros(
-            size=(max_seq_len, max_seq_len), dtype=torch.bool, device=self.device
-        )
+        attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len), dtype=torch.bool, device=self.device)
+        
         attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
         self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
 

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -109,7 +109,7 @@ class AttentionMaskBuilder310:
             if causal:
                 return self._get_causal_mask(self.max_seqlen)
             else:
-                return self._get_non_causal_mask(self.max_seqlen)
+                return self._get_non_causal_mask(self.max_seqlen, model_config.dtype)
 
         return self._get_causal_mask(self.max_seqlen)
 
@@ -131,7 +131,7 @@ class AttentionMaskBuilder310:
             self.attn_mask_cache = torch_npu.npu_format_cast(nd_to_nz_2d(attn_mask), ACL_FORMAT_FRACTAL_NZ)
         return self.attn_mask_cache
 
-    def _get_non_causal_mask(self, max_seq_len: int) -> torch.Tensor:
+    def _get_non_causal_mask(self, max_seq_len: int, dtype: torch.dtype) -> torch.Tensor:
         """
         Internal method to get or update the cached non-causal attention mask.
 
@@ -147,8 +147,10 @@ class AttentionMaskBuilder310:
         if self.attn_mask_cache is not None:
             return self.attn_mask_cache
 
-        attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len), dtype=torch.bool, device=self.device)
+        attention_mask_npu = torch.zeros(
+            size=(max_seq_len, max_seq_len), dtype=dtype, device=self.device
+        )
         attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
-        self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), ACL_FORMAT_FRACTAL_NZ)
+        self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
 
         return self.attn_mask_cache

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -35,7 +35,8 @@ class AttentionMaskBuilder310:
             max_seqlen (int): Maximum length of a sequence (including prompt and generated text).
         """
         AttentionMaskBuilder310.max_seqlen = max_seqlen
-        self.attn_mask_cache = None
+        self.causal_attn_mask_cache = None
+        self.non_causal_attn_mask_cache = None
         self.device = device
 
     @staticmethod
@@ -126,10 +127,10 @@ class AttentionMaskBuilder310:
         Returns:
             torch.Tensor: The cached causal mask in ACL_FORMAT_FRACTAL_NZ.
         """
-        if self.attn_mask_cache is None:
+        if self.causal_attn_mask_cache is None:
             attn_mask = self.gen_causal_additive_mask(max_seq_len, self.device)
-            self.attn_mask_cache = torch_npu.npu_format_cast(nd_to_nz_2d(attn_mask), ACL_FORMAT_FRACTAL_NZ)
-        return self.attn_mask_cache
+            self.causal_attn_mask_cache = torch_npu.npu_format_cast(nd_to_nz_2d(attn_mask), ACL_FORMAT_FRACTAL_NZ)
+        return self.causal_attn_mask_cache
 
     def _get_non_causal_mask(self, max_seq_len: int, dtype: torch.dtype) -> torch.Tensor:
         """
@@ -144,13 +145,13 @@ class AttentionMaskBuilder310:
         Returns:
             torch.Tensor: The cached causal mask in ACL_FORMAT_FRACTAL_NZ.
         """
-        if self.attn_mask_cache is not None:
-            return self.attn_mask_cache
+        if self.non_causal_attn_mask_cache is not None:
+            return self.non_causal_attn_mask_cache
 
-        attention_mask_npu = torch.zeros(
-            size=(max_seq_len, max_seq_len), dtype=dtype, device=self.device
-        )
+        attention_mask_npu = torch.zeros(size=(max_seq_len, max_seq_len), dtype=dtype, device=self.device)
         attention_mask_npu = nd_to_nz_2d(attention_mask_npu)
-        self.attn_mask_cache = torch_npu.npu_format_cast(attention_mask_npu.contiguous(), 29)
+        self.non_causal_attn_mask_cache = torch_npu.npu_format_cast(
+            attention_mask_npu.contiguous(), ACL_FORMAT_FRACTAL_NZ
+        )
 
-        return self.attn_mask_cache
+        return self.non_causal_attn_mask_cache

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 
+import torch
 import torch_npu
 from vllm.v1.attention.backends.registry import (  # type: ignore
     AttentionBackendEnum,
@@ -94,6 +95,25 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
     Implementation of attention operations (Prefill, Decode, Chunked Prefill)
     optimized for the Ascend 310P architecture.
     """
+
+    def _forward_encoder_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        torch_npu._npu_flash_attention(query=query,
+                                       key=key,
+                                       value=value,
+                                       mask=attn_metadata.attn_mask,
+                                       seq_len=attn_metadata.seq_lens,
+                                       scale_value=self.scale,
+                                       num_heads=self.num_heads,
+                                       num_kv_heads=self.num_kv_heads,
+                                       out=output)
+        return output
 
     def forward_paged_attention(
         self,

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -104,15 +104,17 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
     ) -> torch.Tensor:
-        torch_npu._npu_flash_attention(query=query,
-                                       key=key,
-                                       value=value,
-                                       mask=attn_metadata.attn_mask,
-                                       seq_len=attn_metadata.seq_lens,
-                                       scale_value=self.scale,
-                                       num_heads=self.num_heads,
-                                       num_kv_heads=self.num_kv_heads,
-                                       out=output)
+        torch_npu._npu_flash_attention(
+            query=query,
+            key=key,
+            value=value,
+            mask=attn_metadata.attn_mask,
+            seq_len=attn_metadata.seq_lens,
+            scale_value=self.scale,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            out=output,
+        )
         return output
 
     def forward_paged_attention(

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -72,7 +72,16 @@ class AttentionMaskBuilder:
             self.pcp_mla_mask = torch.triu(torch.ones(512, 512, device=self.device, dtype=dtype), 1)
         return self.pcp_mla_mask
 
-    def get_attention_mask(self, model_config: ModelConfig):
+    def get_swa_mask(self, dtype: torch.dtype, sliding_window):
+        if self.swa_mask is None or self.swa_mask.dtype != dtype:
+            if sliding_window is not None:
+                mask = torch.ones(2048, 2048, dtype=torch.bool)
+                triu_mask = torch.triu(mask, diagonal=1).to(self.device)
+                tril_mask = torch.tril(mask, -sliding_window).to(self.device)
+                self.swa_mask = triu_mask + tril_mask
+        return self.swa_mask
+
+    def get_attention_mask(self, causal: bool, model_config: ModelConfig):
         if model_config.runner_type == "pooling":
             return self.get_attn_mask(2048, torch.bool)
 

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -72,7 +72,7 @@ class AttentionMaskBuilder:
             self.pcp_mla_mask = torch.triu(torch.ones(512, 512, device=self.device, dtype=dtype), 1)
         return self.pcp_mla_mask
 
-    def get_attention_mask(self, model_config: ModelConfig):
+    def get_attention_mask(self, causal: bool, model_config: ModelConfig):
         if model_config.runner_type == "pooling":
             return self.get_attn_mask(2048, torch.bool)
 

--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -72,16 +72,7 @@ class AttentionMaskBuilder:
             self.pcp_mla_mask = torch.triu(torch.ones(512, 512, device=self.device, dtype=dtype), 1)
         return self.pcp_mla_mask
 
-    def get_swa_mask(self, dtype: torch.dtype, sliding_window):
-        if self.swa_mask is None or self.swa_mask.dtype != dtype:
-            if sliding_window is not None:
-                mask = torch.ones(2048, 2048, dtype=torch.bool)
-                triu_mask = torch.triu(mask, diagonal=1).to(self.device)
-                tril_mask = torch.tril(mask, -sliding_window).to(self.device)
-                self.swa_mask = triu_mask + tril_mask
-        return self.swa_mask
-
-    def get_attention_mask(self, causal: bool, model_config: ModelConfig):
+    def get_attention_mask(self, model_config: ModelConfig):
         if model_config.runner_type == "pooling":
             return self.get_attn_mask(2048, torch.bool)
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -305,7 +305,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
 
         attn_state = common_attn_metadata.attn_state
 
-        # Get attn_mask and swa_mask from singleton AttentionMaskBuilder
+        # Get attn_mask from singleton AttentionMaskBuilder
         attn_mask = self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config)
 
         # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -305,8 +305,8 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
 
         attn_state = common_attn_metadata.attn_state
 
-        # Get attn_mask from singleton AttentionMaskBuilder
-        attn_mask = self.attn_mask_builder.get_attention_mask(self.model_config)
+        # Get attn_mask and swa_mask from singleton AttentionMaskBuilder
+        attn_mask = self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config)
 
         # TODO: Yet another unnecessary H2D while we already have a query_start_loc on device
         query_start_loc = query_start_loc_cpu.pin_memory().to(self.device, non_blocking=True)

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -138,7 +138,7 @@ class AscendAttentionCPMetadataBuilder(AscendAttentionMetadataBuilder):
             num_actual_tokens_pcp_padded = num_actual_tokens
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_actual_tokens_pcp_padded]
-        attn_mask = self.attn_mask_builder.get_attention_mask(self.model_config)
+        attn_mask = self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config)
         attn_state = common_attn_metadata.attn_state
         num_computed_tokens_cpu = seq_lens - query_lens
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -338,7 +338,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             seq_lens_cpu=seq_lens_cpu,
             slot_mapping=slot_mapping,
             head_dim=self.model_config.get_head_size(),
-            attn_mask=self.attn_mask_builder.get_attention_mask(self.model_config),
+            attn_mask=self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config),
             attn_state=common_attn_metadata.attn_state,
             block_table=block_table,
             sin=sin[:num_input_tokens],


### PR DESCRIPTION
### What this PR does / why we need it?
this PR adds support for pooling models (e.g., embedding, classification, scoring) on the Ascend 310P platform. It implements the necessary attention mask generation and flash attention forward pass for non-causal attention used by these models

### Does this PR introduce _any_ user-facing change?
Yes, pooling models are now supported on 310P.

### How was this patch tested?
Added E2E tests for classification, embedding, and scoring models on 310P.

resolve thess issues: [6471](https://github.com/vllm-project/vllm-ascend/issues/6471) [7363](https://github.com/vllm-project/vllm-ascend/pull/7363) [6199](https://github.com/vllm-project/vllm-ascend/issues/6199)

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
