### PR TITLE
[Feature] [P/D] support hybrid attention for mooncake connector

### DIFF
--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -494,9 +494,7 @@ class TestMetadataHandling(unittest.TestCase):
 
             mock_get_socket.assert_called_once_with("host1", 5555)
             mock_return_socket.assert_called_once_with(mock_socket, "host1", 5555)
-            mock_send.assert_called_once_with(
-                mock_socket, self.thread.encoder.encode((GET_META_MSG, "")), "host1:5555"
-            )
+            mock_send.assert_called_once_with(mock_socket, self.thread.encoder.encode((GET_META_MSG, "")), "host1:5555")
             mock_recv.assert_called_once_with(mock_socket, self.thread.remote_poller, "host1:5555")
             self.assertEqual(self.thread.kv_caches_base_addr["remote_engine"][5555], [[0x3000], [0x4000]])
 

--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -244,6 +244,33 @@ class TestKVCacheSendingThread(unittest.TestCase):
         sock.close()
         context.term()
 
+    def test_reformat_kv_cache_hybrid_linear_uses_cache_block_size(self):
+        block_size = 4
+        num_blocks = 2
+        tp_num_need_pulls = 2
+        feature_size = 3
+
+        transferred = torch.arange(
+            num_blocks * tp_num_need_pulls * block_size * feature_size,
+            dtype=torch.float32,
+        ).reshape(num_blocks, tp_num_need_pulls, block_size, feature_size)
+        cache = transferred.reshape(num_blocks, block_size, tp_num_need_pulls * feature_size).clone()
+        expected = transferred.transpose(1, 2).contiguous().reshape_as(cache)
+
+        thread = KVCacheSendingThread.__new__(KVCacheSendingThread)
+        thread.kv_caches = {"layer.0": (cache, cache.clone())}
+        group_kv_caches = {"layer.0": (cache.clone(), cache.clone())}
+
+        thread.reformat_kv_cache_hybrid_linear_torch(
+            [[0, 1]],
+            tp_num_need_pulls,
+            group_kv_caches,
+        )
+
+        reformatted_k_cache, reformatted_v_cache = group_kv_caches["layer.0"]
+        torch.testing.assert_close(reformatted_k_cache, expected)
+        torch.testing.assert_close(reformatted_v_cache, expected)
+
 
 class TestKVCacheRecvingThreadBasic(unittest.TestCase):
     def setUp(self):
@@ -293,6 +320,7 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
         queued = self.thread.request_queue.get_nowait()
         self.assertEqual(queued["request_id"], "req1")
         self.assertEqual(queued["remote_host"], "localhost")
+        self.assertEqual(queued["num_computed_tokens"], 0)
 
     def test_mark_and_is_failed(self):
         self.thread._mark_failed_recv_request("req1", [10, 20])
@@ -442,6 +470,44 @@ class TestCoreFunctionality(unittest.TestCase):
         self.assertIsInstance(call_args[3], list)
         self.assertEqual(len(call_args[1]), len(call_args[2]))
         self.assertEqual(len(call_args[1]), len(call_args[3]))
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_prefix_cache_uses_computed_token_offset(self, mock_get_meta):
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[1, 2]]
+        req["remote_block_ids"] = [[3, 4]]
+        req["num_computed_tokens"] = 8
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+            self.thread.block_size_scale = [[2]]
+            self.thread.remote_block_size_scale["remote_engine"] = {6666: [[2]]}
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x1000 + 2 * 1024])
+        self.assertEqual(call_args[2], [0x3000 + 7 * 1024])
+        self.assertEqual(call_args[3], [3 * 1024])
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_prefix_cache_trims_remote_kernel_blocks(self, mock_get_meta):
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[1, 2]]
+        req["remote_block_ids"] = [[3, 4]]
+        req["num_computed_tokens"] = 0
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+            self.thread.block_size_scale = [[1]]
+            self.thread.remote_block_size_scale["remote_engine"] = {6666: [[2]]}
+            self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x1000 + 1024])
+        self.assertEqual(call_args[2], [0x3000 + 6 * 1024])
+        self.assertEqual(call_args[3], [2 * 1024])
         mock_get_meta.assert_not_called()
 
     def test_transfer_kv_cache_failure(self):
@@ -751,6 +817,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
         tokens, async_flag = self.scheduler.get_num_new_matched_tokens(request, 0)
         self.assertEqual(tokens, 4)
         self.assertTrue(async_flag)
+        self.assertEqual(request.kv_transfer_params["num_computed_tokens"], 0)
 
     def test_build_connector_meta(self):
         request = MockRequest("req1")
@@ -765,6 +832,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
             "remote_port": 5000,
             "remote_pcp_size": 1,
             "remote_dcp_size": 1,
+            "num_computed_tokens": 16,
         }
 
         meta = self.scheduler.build_connector_meta(MagicMock())
@@ -772,6 +840,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
         self.assertEqual(len(meta.requests), 1)
         self.assertEqual(meta.requests["req1"].local_block_ids, [4, 5, 6])
         self.assertEqual(meta.requests["req1"].remote_block_ids, [1, 2, 3])
+        self.assertEqual(meta.requests["req1"].num_computed_tokens, 16)
         self.assertEqual(len(self.scheduler._reqs_need_recv), 0)
 
 

--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -257,7 +257,7 @@ class TestKVCacheSendingThread(unittest.TestCase):
         cache = transferred.reshape(num_blocks, block_size, tp_num_need_pulls * feature_size).clone()
         expected = transferred.transpose(1, 2).contiguous().reshape_as(cache)
 
-        thread = KVCacheSendingThread.__new__(KVCacheSendingThread)
+        thread = KVCacheRecvingThread.__new__(KVCacheRecvingThread)
         thread.kv_caches = {"layer.0": (cache, cache.clone())}
         group_kv_caches = {"layer.0": (cache.clone(), cache.clone())}
 

--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -7,7 +7,7 @@ import time
 import types
 import unittest
 from collections import OrderedDict, defaultdict, deque
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import msgspec
@@ -60,8 +60,8 @@ GET_META_MSG = b"get_meta_msg"
 DONE_RECVING_MSG = b"done_recving_msg"
 
 
-def make_agent_metadata(**overrides):
-    metadata = {
+def make_agent_metadata(**overrides: Any) -> MooncakeAgentMetadata:
+    metadata: dict[str, Any] = {
         "engine_id": "engine1",
         "te_rpc_port": 9090,
         "kv_group2layeridx": {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])},
@@ -121,7 +121,7 @@ class TestGetAndClearFinishedSingleRequests(unittest.TestCase):
 class TestKVCacheSendingThreadInit(unittest.TestCase):
     def setUp(self):
         kv_caches: dict[str, Any] = {}
-        self.common_args = {
+        self.common_args: dict[str, Any] = {
             "tp_rank": 1,
             "prefill_tp_size": 4,
             "local_engine_id": "engine_1",
@@ -164,7 +164,7 @@ class TestKVCacheSendingThreadInit(unittest.TestCase):
 class TestGetAndClearFinishedRequests(unittest.TestCase):
     def setUp(self):
         kv_caches: dict[str, Any] = {}
-        self.common_args = {
+        self.common_args: dict[str, Any] = {
             "tp_rank": 1,
             "prefill_tp_size": 4,
             "local_engine_id": "engine_1",
@@ -268,7 +268,7 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
         )
 
     def test_add_request(self):
-        test_req = {
+        test_req: dict[str, Any] = {
             "request_id": "req1",
             "local_block_ids": [1, 2],
             "remote_block_ids": [3, 4],
@@ -424,7 +424,7 @@ class TestCoreFunctionality(unittest.TestCase):
 
         mock_transfer.assert_called_once_with(self.test_req)
         mock_send.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
-        self.thread.task_tracker.update_done_task_count.assert_called_once_with("req1")
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
         self.mock_queue.task_done.assert_called_once()
 
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
@@ -1264,7 +1264,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                 self.vllm_config.model_config.is_deepseek_mla = is_deepseek_mla
                 worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
                 worker.tp_num_need_pulls = tp_num_need_pulls
-                worker.use_sparse = 0
+                worker.use_sparse = False
                 return worker._get_remote_ranks_for_req("test", remote_ptp_size)
 
         self.assertIn(
@@ -1362,7 +1362,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             meta.remote_multi_nodes_meta_mapping = {}
 
             remote_handshake_port_list, local_block_ids_list, remote_block_ids_list = worker._get_kv_split_metadata(
-                "0", meta
+                "0", cast(ReqMeta, meta)
             )
 
             return (
@@ -1539,7 +1539,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.assertEqual(finish_count_by_group, expected_finishes)
 
     def test_pd_disaggregated_split_cross_covers_prefix_tp_cp_pp(self):
-        cases = [
+        cases: list[dict[str, Any]] = [
             {
                 "name": "gqa_tp_unequal_remote_cp_pp_unequal",
                 "use_mla": False,
@@ -1664,7 +1664,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                     remote_multi_nodes_meta_mapping={},
                 )
 
-                ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_hybrid", meta)
+                ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_hybrid", cast(ReqMeta, meta))
                 group_pulls = worker._get_group_pulls_metadata("req_hybrid", ports, 4, 31000)
 
                 self.assertEqual(local_ids, [meta.local_block_ids])

--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import msgspec
+import torch
 import zmq
 from vllm.utils.network_utils import make_zmq_path
 
@@ -37,6 +38,7 @@ patch(
 patch("vllm.distributed.parallel_state._DCP", _mock_dcp_group).start()
 
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (  # noqa: E402
+    GroupPull,
     KVCacheRecvingThread,
     KVCacheSendingThread,
     KVCacheTaskTracker,
@@ -56,6 +58,21 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (  # n
 
 GET_META_MSG = b"get_meta_msg"
 DONE_RECVING_MSG = b"done_recving_msg"
+
+
+def make_agent_metadata(**overrides):
+    metadata = {
+        "engine_id": "engine1",
+        "te_rpc_port": 9090,
+        "kv_group2layeridx": {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])},
+        "block_size": 16,
+        "kv_caches_base_addr": [[12345678]],
+        "block_size_scale": [[1]],
+        "num_blocks": 2,
+        "block_lens": [[1024]],
+    }
+    metadata.update(overrides)
+    return MooncakeAgentMetadata(**metadata)
 
 
 class TestKVCacheTaskTrackerInit(unittest.TestCase):
@@ -173,10 +190,9 @@ class TestGetAndClearFinishedRequests(unittest.TestCase):
 class TestKVCacheSendingThread(unittest.TestCase):
     def test_run_handles_get_meta_and_done_recv_msgs(self):
         ready_event = threading.Event()
-        metadata = MooncakeAgentMetadata(
+        metadata = make_agent_metadata(
             engine_id="engine1",
-            te_rpc_port=9090,
-            kv_caches_base_addr=[12345678],
+            kv_caches_base_addr=[[12345678]],
             num_blocks=2,
         )
         vllm_config = MockVllmConfig()
@@ -214,10 +230,11 @@ class TestKVCacheSendingThread(unittest.TestCase):
         self.assertEqual(frames[0], b"")
         meta = decoder.decode(frames[1])
         self.assertEqual(meta.engine_id, "engine1")
-        self.assertEqual(meta.kv_caches_base_addr, [12345678])
+        self.assertEqual(meta.kv_caches_base_addr, [[12345678]])
         self.assertEqual(meta.num_blocks, 2)
 
         req_id = "request_42"
+        thread.task_tracker.add_req_to_process(req_id)
         sock.send_multipart([b"", encoder.encode((DONE_RECVING_MSG, req_id, 0))])
         frames = sock.recv_multipart()
         self.assertEqual(frames[0], b"")
@@ -242,8 +259,8 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
             local_engine_id="local_engine",
             local_handshake_port=5555,
             side_channel_port=30000,
-            local_kv_caches_base_addr=[0x1000, 0x2000],
-            block_len=[1024, 2048],
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -264,13 +281,13 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
         }
         self.thread.add_request(
             request_id=test_req["request_id"],
+            remote_request_id=test_req["request_id"],
             local_block_ids=test_req["local_block_ids"],
             remote_block_ids=test_req["remote_block_ids"],
+            group_pulls=[GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1)],
             remote_engine_id=test_req["remote_engine_id"],
             remote_host=test_req["remote_host"],
             remote_handshake_port=test_req["remote_handshake_port"],
-            offset=test_req["offset"],
-            tp_num_need_pulls=test_req["tp_num_need_pulls"],
             all_task_done=test_req["all_task_done"],
         )
         queued = self.thread.request_queue.get_nowait()
@@ -315,8 +332,8 @@ class TestSocketManagement(unittest.TestCase):
             local_engine_id="local_engine",
             local_handshake_port=5555,
             side_channel_port=30000,
-            local_kv_caches_base_addr=[0x1000, 0x2000],
-            block_len=[1024, 2048],
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -371,8 +388,8 @@ class TestCoreFunctionality(unittest.TestCase):
             local_engine_id="local_engine",
             local_handshake_port=5555,
             side_channel_port=30000,
-            local_kv_caches_base_addr=[0x1000, 0x2000],
-            block_len=[1024, 2048],
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -381,22 +398,23 @@ class TestCoreFunctionality(unittest.TestCase):
         self.thread.request_queue = self.mock_queue
         self.test_req = {
             "request_id": "req1",
-            "local_block_ids": [1, 2],
-            "remote_block_ids": [3, 4],
+            "remote_request_id": "req1",
+            "local_block_ids": [[1, 2]],
+            "remote_block_ids": [[3, 4]],
+            "group_pulls": [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)],
             "remote_engine_id": "remote_engine",
             "remote_host": "localhost",
             "remote_handshake_port": 6666,
-            "remote_transfer_port": 7777,
-            "offset": 0,
-            "tp_num_need_pulls": 2,
             "remote_port_send_num": {6666: 1},
-            "all_task_done": False,
+            "all_task_done": True,
         }
+        self.thread.kv_group2layeridx = {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])}
+        self.thread.block_size_scale = [[1]]
         self.thread.task_tracker = MagicMock()
         self.engine.batch_transfer_sync_read.return_value = 0
         self.thread.remote_te_port = {"remote_engine": {6666: 7777}}
 
-    @patch.object(KVCacheRecvingThread, "_transfer_kv_cache")
+    @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
     @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
     def test_handle_request(self, mock_send, mock_transfer):
         mock_transfer.return_value = None
@@ -406,8 +424,6 @@ class TestCoreFunctionality(unittest.TestCase):
 
         mock_transfer.assert_called_once_with(self.test_req)
         mock_send.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
-        if not self.thread.task_tracker.update_done_task_count.called:
-            self.thread.task_tracker.update_done_task_count("req1")
         self.thread.task_tracker.update_done_task_count.assert_called_once_with("req1")
         self.mock_queue.task_done.assert_called_once()
 
@@ -415,8 +431,9 @@ class TestCoreFunctionality(unittest.TestCase):
     def test_transfer_kv_cache(self, mock_get_meta):
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
             mock_config.return_value.enable_kv_nz = False
-            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [0x3000, 0x4000]}
-            self.thread._transfer_kv_cache(self.test_req)
+            self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+            self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1]]}
+            self.thread._transfer_kv_cache_all_groups(self.test_req)
         self.engine.batch_transfer_sync_read.assert_called_once()
         call_args, call_kwargs = self.engine.batch_transfer_sync_read.call_args
         self.assertEqual(call_args[0], "localhost:7777")
@@ -429,10 +446,11 @@ class TestCoreFunctionality(unittest.TestCase):
 
     def test_transfer_kv_cache_failure(self):
         self.engine.batch_transfer_sync_read.return_value = -1
-        self.thread.kv_caches_base_addr["remote_engine"] = {6666: [0x3000, 0x4000]}
+        self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+        self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1]]}
 
         with self.assertRaises(RuntimeError):
-            self.thread._transfer_kv_cache(self.test_req)
+            self.thread._transfer_kv_cache_all_groups(self.test_req)
 
 
 class TestMetadataHandling(unittest.TestCase):
@@ -449,15 +467,15 @@ class TestMetadataHandling(unittest.TestCase):
             local_engine_id="local_engine",
             local_handshake_port=5555,
             side_channel_port=30000,
-            local_kv_caches_base_addr=[0x1000, 0x2000],
-            block_len=[1024, 2048],
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
             prefill_pp_layer_partition=None,
         )
-        self.test_metadata = MooncakeAgentMetadata(
-            engine_id="remote_engine", te_rpc_port=9090, kv_caches_base_addr=[0x3000, 0x4000], num_blocks=2
+        self.test_metadata = make_agent_metadata(
+            engine_id="remote_engine", te_rpc_port=9090, kv_caches_base_addr=[[0x3000], [0x4000]], num_blocks=2
         )
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.ensure_zmq_send")
@@ -476,9 +494,11 @@ class TestMetadataHandling(unittest.TestCase):
 
             mock_get_socket.assert_called_once_with("host1", 5555)
             mock_return_socket.assert_called_once_with(mock_socket, "host1", 5555)
-            mock_send.assert_called_once_with(mock_socket, self.thread.encoder.encode((GET_META_MSG, "")))
-            mock_recv.assert_called_once_with(mock_socket, self.thread.remote_poller)
-            self.assertEqual(self.thread.kv_caches_base_addr["remote_engine"][5555], [0x3000, 0x4000])
+            mock_send.assert_called_once_with(
+                mock_socket, self.thread.encoder.encode((GET_META_MSG, "")), "host1:5555"
+            )
+            mock_recv.assert_called_once_with(mock_socket, self.thread.remote_poller, "host1:5555")
+            self.assertEqual(self.thread.kv_caches_base_addr["remote_engine"][5555], [[0x3000], [0x4000]])
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.ensure_zmq_send")
     @patch(
@@ -514,8 +534,8 @@ class TestMainThreadLoop(unittest.TestCase):
             local_engine_id="local_engine",
             local_handshake_port=5555,
             side_channel_port=30000,
-            local_kv_caches_base_addr=[0x1000, 0x2000],
-            block_len=[1024, 2048],
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
             ready_event=self.ready_event,
             vllm_config=self.vllm_config,
             kv_caches=self.kv_caches,
@@ -556,17 +576,32 @@ class MockVllmConfig:
         self.parallel_config = MagicMock()
         self.cache_config = MagicMock()
         self.kv_transfer_config = MagicMock()
-        self.speculative_config = MagicMock()
-        self.model_config.use_mla = True
+        self.scheduler_config = MagicMock(disable_hybrid_kv_cache_manager=True)
+        self.speculative_config = None
+        self.model_config.use_mla = False
+        self.model_config.is_deepseek_mla = False
+        self.model_config.hf_text_config = types.SimpleNamespace(
+            num_key_value_heads=8,
+            num_hidden_layers=32,
+            head_dim=16,
+            kv_lora_rank=16,
+            qk_rope_head_dim=8,
+            model_type="qwen2",
+        )
+        self.model_config.get_num_layers = MagicMock(return_value=32)
         self.parallel_config.tensor_parallel_size = 2
         self.parallel_config.data_parallel_rank = 0
+        self.parallel_config.data_parallel_size = 1
         self.parallel_config.data_parallel_size_local = 1
         self.parallel_config.pipeline_parallel_size = 1
         self.parallel_config.data_parallel_rank_local = 0
+        self.parallel_config.prefill_context_parallel_size = 1
+        self.parallel_config.decode_context_parallel_size = 1
         self.model_config.get_num_layers_by_block_type = MagicMock(return_value=32)
         self.cache_config.block_size = 16
         self.kv_transfer_config.kv_port = 5000
         self.kv_transfer_config.kv_role = "kv_producer"
+        self.kv_transfer_config.engine_id = "test_engine"
         self.kv_transfer_config.get_from_extra_config = MagicMock()
         self.kv_transfer_config.get_from_extra_config.side_effect = lambda k, d: {
             "prefill": {"tp_size": 2, "dp_size": 1, "pp_size": 1},
@@ -584,6 +619,18 @@ class MockRequest:
         self.output_token_ids = [101, 102]
 
 
+class MockKVCacheGroup:
+    def __init__(self, layer_names=None, kv_cache_spec=None):
+        self.layer_names = layer_names or ["model.layers.0.self_attn"]
+        self.kv_cache_spec = kv_cache_spec or MagicMock()
+
+
+class MockKVCacheConfig:
+    def __init__(self, kv_cache_groups=None, num_blocks=10):
+        self.kv_cache_groups = kv_cache_groups or [MockKVCacheGroup()]
+        self.num_blocks = num_blocks
+
+
 class TestKVCacheTaskTracker(unittest.TestCase):
     def setUp(self):
         self.tracker = KVCacheTaskTracker()
@@ -591,46 +638,40 @@ class TestKVCacheTaskTracker(unittest.TestCase):
     def test_update_done_task_count(self):
         self.assertEqual(len(self.tracker.finished_requests), 0)
         self.assertEqual(len(self.tracker.delayed_free_requests), 0)
-        self.assertEqual(len(self.tracker.record_finished_requests), 0)
+        self.assertEqual(len(self.tracker.reqs_to_process), 0)
 
         current_time = time.time()
+        self.tracker.add_req_to_process("req_1")
         self.tracker.add_delayed_request("req_1", current_time)
         result = self.tracker.delayed_free_requests
-        result_record = self.tracker.record_finished_requests
         self.assertEqual(len(result), 1)
         self.assertEqual(result["req_1"], current_time)
-        self.assertEqual(len(result_record), 0)
 
         self.tracker.update_done_task_count("req_1")
         result_finished = self.tracker.finished_requests
         result_delayed = self.tracker.delayed_free_requests
-        result_record = self.tracker.record_finished_requests
         self.assertEqual(result_finished, {"req_1"})
         self.assertEqual(len(result_delayed), 0)
-        self.assertEqual(len(result_record), 0)
+        self.assertEqual(len(self.tracker.reqs_to_process), 0)
 
         self.tracker.update_done_task_count("req_2")
         result_finished = self.tracker.finished_requests
         result_delayed = self.tracker.delayed_free_requests
-        result_record = self.tracker.record_finished_requests
-        self.assertEqual(result_finished, {"req_1", "req_2"})
+        self.assertEqual(result_finished, {"req_1"})
         self.assertEqual(len(result_delayed), 0)
-        self.assertEqual(len(result_record), 1)
-        self.assertEqual(result_record, {"req_2"})
+        self.assertEqual(len(self.tracker.reqs_to_process), 0)
 
     def test_updtate_add_delayed_request(self) -> None:
         self.tracker.update_done_task_count("req2")
-        result_start_record = self.tracker.record_finished_requests
-        self.assertEqual(len(result_start_record), 1)
         self.tracker.add_delayed_request("req2", time.time())
         result_delayed = self.tracker.delayed_free_requests
-        result_end_record = self.tracker.record_finished_requests
         self.assertEqual(len(result_delayed), 0)
-        self.assertEqual(len(result_end_record), 0)
 
     def test_retrieve_expired_requests(self):
         current_time = time.time()
-        self.tracker.add_delayed_request("req_1", current_time - 600)
+        self.tracker.add_req_to_process("req_1")
+        self.tracker.add_req_to_process("req_2")
+        self.tracker.add_delayed_request("req_1", current_time - 100000)
         self.tracker.add_delayed_request("req_2", current_time)
         result = self.tracker._retrieve_expired_requests()
         self.assertEqual(
@@ -644,6 +685,7 @@ class TestKVCacheTaskTracker(unittest.TestCase):
         self.assertIn("req_2", result_delay)
 
     def test_duplicate_task_update(self):
+        self.tracker.add_req_to_process("req1")
         self.tracker.update_done_task_count("req1")
         self.tracker.update_done_task_count("req1")
         self.tracker.update_done_task_count("req1")
@@ -665,6 +707,7 @@ class TestMooncakeConnectorMetadata(unittest.TestCase):
             kv_transfer_params={
                 "remote_block_ids": [4, 5, 6],
                 "remote_engine_id": "remote_engine",
+                "remote_request_id": "remote_req1",
                 "remote_host": "localhost",
                 "remote_port": 5000,
                 "remote_pcp_size": 1,
@@ -698,7 +741,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
         self.p2.start()
         self.addCleanup(self.p1.stop)
         self.addCleanup(self.p2.stop)
-        self.scheduler = MooncakeConnectorScheduler(config, "test_engine")
+        self.scheduler = MooncakeConnectorScheduler(config, "test_engine", MockKVCacheConfig())
 
     def test_get_num_new_matched_tokens(self):
         request = MockRequest("req1")
@@ -719,6 +762,7 @@ class TestMooncakeConnectorSchedulerMatchedTokens(unittest.TestCase):
         request.kv_transfer_params = {
             "remote_block_ids": [1, 2, 3],
             "remote_engine_id": "remote",
+            "remote_request_id": "remote_req1",
             "remote_host": "localhost",
             "remote_port": 5000,
             "remote_pcp_size": 1,
@@ -772,7 +816,7 @@ class TestMooncakeConnectorForScheduler(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         self.assertIsNotNone(connector.connector_scheduler)
         self.assertIsNone(connector.connector_worker)
 
@@ -786,7 +830,7 @@ class TestMooncakeConnectorForScheduler(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         request = MockRequest("req1")
         connector.get_num_new_matched_tokens(request, 0)
         mock_method.assert_called_once_with(request, 0)
@@ -795,6 +839,9 @@ class TestMooncakeConnectorForScheduler(unittest.TestCase):
 class MockKVCacheBlocks:
     def get_unhashed_block_ids(self):
         return [4, 5, 6]
+
+    def get_unhashed_block_ids_all_groups(self):
+        return ([4, 5, 6],)
 
 
 class MockSchedulerOutput:
@@ -818,7 +865,7 @@ class TestMooncakeConnector(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         self.assertIsNotNone(connector.connector_scheduler)
         self.assertIsNone(connector.connector_worker)
 
@@ -831,7 +878,7 @@ class TestMooncakeConnector(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         request = MockRequest("req1")
         connector.get_num_new_matched_tokens(request, 0)
         mock_method.assert_called_once_with(request, 0)
@@ -845,7 +892,7 @@ class TestMooncakeConnector(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         request = MockRequest("req1")
         blocks = MockKVCacheBlocks()
         connector.update_state_after_alloc(request, blocks, 3)
@@ -860,7 +907,7 @@ class TestMooncakeConnector(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         scheduler_output = MockSchedulerOutput()
         connector.build_connector_meta(scheduler_output)
         mock_method.assert_called_once_with(scheduler_output)
@@ -874,10 +921,10 @@ class TestMooncakeConnector(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER)
+            connector = MooncakeConnector(self.config, KVConnectorRole.SCHEDULER, MockKVCacheConfig())
         request = MockRequest("req1")
         connector.request_finished(request, [1, 2, 3])
-        mock_method.assert_called_once_with(request, [1, 2, 3])
+        mock_method.assert_called_once_with(request, ([1, 2, 3],))
 
 
 class TestMooncakeConnectorScheduler(unittest.TestCase):
@@ -890,7 +937,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
                 return_value=MagicMock(),
             ),
         ):
-            self.scheduler = MooncakeConnectorScheduler(self.config, "test_engine")
+            self.scheduler = MooncakeConnectorScheduler(self.config, "test_engine", MockKVCacheConfig())
 
     def test_get_num_new_matched_tokens_no_remote_prefill(self):
         request = MockRequest("req1")
@@ -917,6 +964,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
                 "do_remote_prefill": True,
                 "remote_block_ids": [1, 2, 3],
                 "remote_engine_id": "remote",
+                "remote_request_id": "remote_req1",
                 "remote_host": "localhost",
                 "remote_port": 5000,
             },
@@ -925,7 +973,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.scheduler.update_state_after_alloc(request, blocks, 3)
         self.assertEqual(len(self.scheduler._reqs_need_recv), 1)
         self.assertEqual(self.scheduler._reqs_need_recv["req1"][0], request)
-        self.assertEqual(self.scheduler._reqs_need_recv["req1"][1], [4, 5, 6])
+        self.assertEqual(self.scheduler._reqs_need_recv["req1"][1], ([4, 5, 6],))
 
     def test_request_finished_no_remote_decode(self):
         request = MockRequest("req1")
@@ -969,7 +1017,7 @@ class TestUtils(unittest.TestCase):
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.logger")
     def test_ensure_zmq_send_success(self, mock_logger):
         mock_socket = MagicMock()
-        ensure_zmq_send(mock_socket, b"hello")
+        ensure_zmq_send(mock_socket, b"hello", "tcp://localhost:1234")
         mock_socket.send.assert_called_once_with(b"hello")
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.logger")
@@ -979,7 +1027,7 @@ class TestUtils(unittest.TestCase):
             "send failed"
         )
         with self.assertRaises(RuntimeError):
-            ensure_zmq_send(mock_socket, b"hello", max_retries=2)
+            ensure_zmq_send(mock_socket, b"hello", "tcp://localhost:1234", max_retries=2)
         self.assertEqual(mock_socket.send.call_count, 2)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.logger")
@@ -990,7 +1038,7 @@ class TestUtils(unittest.TestCase):
         mock_poller.poll.return_value = [
             (mock_socket, zmq.POLLIN)  # type: ignore
         ]
-        data = ensure_zmq_recv(mock_socket, mock_poller)
+        data = ensure_zmq_recv(mock_socket, mock_poller, "tcp://localhost:1234")
         self.assertEqual(data, b"response")
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.logger")
@@ -999,7 +1047,7 @@ class TestUtils(unittest.TestCase):
         mock_poller = MagicMock()
         mock_poller.poll.return_value = []
         with self.assertRaises(RuntimeError):
-            ensure_zmq_recv(mock_socket, mock_poller, timeout=0.01, max_retries=2)
+            ensure_zmq_recv(mock_socket, mock_poller, "tcp://localhost:1234", timeout=0.01, max_retries=2)
 
 
 class MockMooncakeAgentMetadata:
@@ -1078,6 +1126,13 @@ def mock_string_to_int64_hash(s):
     return hash(s)
 
 
+def make_cpu_kv_cache(kv_heads: int = 8, head_dim: int = 16):
+    return (
+        torch.empty((10, 16, kv_heads, head_dim), device="cpu"),
+        torch.empty((10, 16, kv_heads, head_dim), device="cpu"),
+    )
+
+
 class TestMooncakeConnectorWorker(unittest.TestCase):
     def setUp(self):
         self.mock_transfer_engine = MagicMock()
@@ -1086,10 +1141,6 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.mock_transfer_engine.register_memory.return_value = 0
 
         self.patches = [
-            patch("torch.Tensor.size", return_value=(10, 16, 8, 16)),
-            patch("torch.Tensor.element_size", return_value=4),
-            patch("torch.Tensor.data_ptr", return_value=0x1000),
-            patch("math.prod", return_value=128),
             patch(
                 "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_tensor_model_parallel_rank",
                 mock_get_tensor_model_parallel_rank,
@@ -1098,6 +1149,18 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             patch(
                 "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_pp_group",
                 return_value=_mock_pp_group,
+            ),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_pcp_group",
+                return_value=_mock_pcp_group,
+            ),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_decode_context_model_parallel_world_size",
+                return_value=1,
+            ),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_decode_context_model_parallel_rank",
+                return_value=0,
             ),
             patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ip", mock_get_ip),
             patch(
@@ -1120,6 +1183,19 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                 "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config",
                 return_value=MagicMock(),
             ),
+            patch.object(
+                MooncakeConnectorWorker,
+                "_build_kv_group2layeridx",
+                return_value={
+                    0: (
+                        {
+                            "kv_cache_spec_type": "FullAttentionSpec",
+                            "layer_names": ["model.layers.0.self_attn"],
+                        },
+                        [0],
+                    )
+                },
+            ),
         ]
 
         for p in self.patches:
@@ -1127,14 +1203,14 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
         self.vllm_config = MockVllmConfig()
         self.engine_id = "test_engine"
-        self.kv_caches = {"layer1": (MagicMock(), MagicMock())}
+        self.kv_caches = {"model.layers.0.self_attn": make_cpu_kv_cache()}
 
     def tearDown(self):
         for p in self.patches:
             p.stop()  # type: ignore
 
     def test_register_kv_caches_producer(self):
-        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         worker.register_kv_caches(self.kv_caches)
         self.assertEqual(len(worker.kv_caches), 1)
         self.assertIsNotNone(worker.kv_send_thread)
@@ -1142,26 +1218,23 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
     def test_register_kv_caches_consumer(self):
         self.vllm_config.kv_transfer_config.kv_role = "kv_consumer"
-        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         worker.register_kv_caches(self.kv_caches)
         self.assertIsNone(worker.kv_send_thread)
         self.assertIsNotNone(worker.kv_recv_thread)
 
     def test_register_kv_caches_mla_case(self):
-        mla_cache1 = MagicMock()
-        mla_cache1.size.return_value = (10, 16, 1, 16)
-        mla_cache2 = MagicMock()
-        mla_cache2.size.return_value = (10, 16, 1, 8)
-        mla_caches = {"layer1": (mla_cache1, mla_cache2)}
+        self.vllm_config.model_config.is_deepseek_mla = True
+        mla_caches = {"model.layers.0.self_attn": make_cpu_kv_cache(kv_heads=1)}
 
-        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         worker.register_kv_caches(mla_caches)
         self.assertTrue(worker.use_mla)
-        self.assertEqual(len(worker.block_len), 2)
+        self.assertEqual(len(worker.block_len_per_addr[0]), 2)
 
     def test_device_id_selection_with_physical_devices(self):
         # Test with physical devices set
-        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         # Default tp_rank is 0, so device_id should be 10
         self.assertIsNotNone(worker.engine)
 
@@ -1191,7 +1264,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             ):
                 self.vllm_config.model_config.hf_text_config.num_key_value_heads = num_kv_heads
                 self.vllm_config.model_config.is_deepseek_mla = is_deepseek_mla
-                worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+                worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
                 worker.tp_num_need_pulls = tp_num_need_pulls
                 worker.use_sparse = 0
                 return worker._get_remote_ranks_for_req("test", remote_ptp_size)
@@ -1262,7 +1335,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             remote_engine_id,
             remote_ptp_size=None,
         ):
-            worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+            worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
 
             worker.use_mla = use_mla
             worker.pcp_size = pcp_size
@@ -1274,6 +1347,7 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             worker.local_remote_block_port_mapping = {}
             worker.block_size = 16
             worker.num_key_value_heads = 1
+            worker.use_sparse = False
 
             meta = types.SimpleNamespace()
 
@@ -1281,17 +1355,23 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             meta.remote_dcp_size = remote_dcp_size
             meta.remote_ptp_size = remote_ptp_size
             meta.remote_port = remote_port
-            meta.remote_block_ids = remote_block_ids
-            meta.local_block_ids = local_block_ids
+            meta.remote_block_ids = (remote_block_ids,)
+            meta.local_block_ids = (local_block_ids,)
             meta.num_external_tokens = pcp_size * dcp_size * len(local_block_ids) * worker.block_size
             meta.num_prompt_blocks = pcp_size * dcp_size * len(local_block_ids)
             meta.remote_engine_id = remote_engine_id
+            meta.remote_host = "localhost"
+            meta.remote_multi_nodes_meta_mapping = {}
 
             remote_handshake_port_list, local_block_ids_list, remote_block_ids_list = worker._get_kv_split_metadata(
                 "0", meta
             )
 
-            return remote_handshake_port_list, local_block_ids_list, remote_block_ids_list
+            return (
+                remote_handshake_port_list,
+                [block_ids[0] for block_ids in local_block_ids_list],
+                [block_ids[0] for block_ids in remote_block_ids_list],
+            )
 
         self.assertEqual(
             get_kv_split_metadata(True, 1, 1, 8, 1, 0, 8, 1, 8, 30000, [1], [1], 0),
@@ -1367,10 +1447,243 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
             get_kv_split_metadata(False, 1, 1, 8, 1, 0, 16, 2, 8, 30000, [1], [1], 0),
         )
 
+    def _build_worker_for_pd_case(self, case, tp_rank, pcp_rank=0, dcp_rank=0):
+        with patch.object(
+            self.vllm_config.kv_transfer_config,
+            "get_from_extra_config",
+            side_effect=lambda k, d=None, case=case: {
+                "prefill": {
+                    "tp_size": case["prefill_tp_size"],
+                    "dp_size": 1,
+                    "pp_size": case["prefill_pp_size"],
+                },
+                "decode": {"tp_size": case["decode_tp_size"], "dp_size": 1, "pp_size": 1},
+            }.get(k, d),
+        ):
+            self.vllm_config.model_config.is_deepseek_mla = case["use_mla"]
+            self.vllm_config.model_config.hf_text_config.num_key_value_heads = case["num_key_value_heads"]
+            worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
+
+        worker.use_mla = case["use_mla"]
+        worker.use_sparse = False
+        worker.num_key_value_heads = case["num_key_value_heads"]
+        worker.tp_size = case["decode_tp_size"]
+        worker.tp_rank = tp_rank
+        worker.pcp_size = case["pcp_size"]
+        worker.dcp_size = case["dcp_size"]
+        worker.pcp_rank = pcp_rank
+        worker.dcp_rank = dcp_rank
+        worker.pp_rank = 0
+        worker._prefill_tp_size = case["prefill_tp_size"]
+        worker._prefill_pp_size = case["prefill_pp_size"]
+        worker._decode_tp_size = case["decode_tp_size"]
+        worker.local_remote_block_port_mapping = {}
+        worker.remote_port_send_num = {}
+        worker.side_channel_port = 5000
+        worker.handshake_port = worker.side_channel_port + (worker.pp_rank + pcp_rank) * worker.tp_size + tp_rank
+        worker.kv_group2layeridx = {
+            0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0]),
+            1: ({"kv_cache_spec_type": "FullAttentionSpec"}, [1]),
+        }
+        return worker
+
+    def _assert_group_pull_finish_flags(self, ports, group_pulls, expected_group_ids):
+        self.assertEqual(len(group_pulls), len(ports))
+        finish_count_by_group = {group_id: 0 for group_id in expected_group_ids}
+
+        for pcp_dcp_rank, (remote_ports, port_group_pulls) in enumerate(zip(ports, group_pulls)):
+            self.assertEqual(len(port_group_pulls), len(remote_ports))
+            for remote_port_idx, pulls in enumerate(port_group_pulls):
+                self.assertEqual({pull.group_id for pull in pulls}, expected_group_ids)
+                for pull in pulls:
+                    self.assertEqual(
+                        pull.is_group_transfer_end,
+                        pull.remote_tp_offset == pull.num_group_pulls - 1,
+                        f"port={remote_ports[remote_port_idx]}, group={pull.group_id}, "
+                        f"offset={pull.remote_tp_offset}, num_pulls={pull.num_group_pulls}",
+                    )
+                    if pull.is_group_transfer_end:
+                        finish_count_by_group[pull.group_id] += 1
+
+                if len(remote_ports) == 1:
+                    expected_offset = pcp_dcp_rank % pulls[0].num_group_pulls
+                else:
+                    expected_offset = remote_port_idx % pulls[0].num_group_pulls
+                self.assertTrue(all(pull.remote_tp_offset == expected_offset for pull in pulls))
+
+        self.assertTrue(
+            all(count > 0 for count in finish_count_by_group.values()),
+            f"Each group should have at least one pull-finish marker: {finish_count_by_group}",
+        )
+
+    def _assert_hybrid_group_pull_finish_flags(self, ports, group_pulls, expected_group_ids, expected_finishes):
+        self.assertEqual(len(group_pulls), len(ports))
+        finish_count_by_group = {group_id: 0 for group_id in expected_group_ids}
+        seen_group_ids = set()
+
+        for remote_ports, port_group_pulls in zip(ports, group_pulls):
+            self.assertEqual(len(port_group_pulls), len(remote_ports))
+            for remote_port, pulls in zip(remote_ports, port_group_pulls):
+                self.assertTrue(pulls, f"remote port {remote_port} should pull at least one group")
+                for pull in pulls:
+                    self.assertIn(pull.group_id, expected_group_ids)
+                    seen_group_ids.add(pull.group_id)
+                    self.assertEqual(
+                        pull.is_group_transfer_end,
+                        pull.remote_tp_offset == pull.num_group_pulls - 1,
+                        f"port={remote_port}, group={pull.group_id}, offset={pull.remote_tp_offset}, "
+                        f"num_pulls={pull.num_group_pulls}",
+                    )
+                    if pull.is_group_transfer_end:
+                        finish_count_by_group[pull.group_id] += 1
+
+        self.assertEqual(seen_group_ids, expected_group_ids)
+        self.assertEqual(finish_count_by_group, expected_finishes)
+
+    def test_pd_disaggregated_split_cross_covers_prefix_tp_cp_pp(self):
+        cases = [
+            {
+                "name": "gqa_tp_unequal_remote_cp_pp_unequal",
+                "use_mla": False,
+                "num_key_value_heads": 2,
+                "prefill_tp_size": 8,
+                "decode_tp_size": 4,
+                "prefill_pp_size": 2,
+                "remote_pcp_size": 2,
+                "remote_dcp_size": 2,
+                "pcp_size": 1,
+                "dcp_size": 2,
+                "remote_block_ids": [10, 11],
+                "local_block_ids": [20, 21],
+                "num_prompt_blocks": 6,
+                "num_external_blocks": 4,
+            },
+            {
+                "name": "mla_tp_unequal_decode_cp_unequal",
+                "use_mla": True,
+                "num_key_value_heads": 1,
+                "prefill_tp_size": 8,
+                "decode_tp_size": 4,
+                "prefill_pp_size": 1,
+                "remote_pcp_size": 1,
+                "remote_dcp_size": 4,
+                "pcp_size": 1,
+                "dcp_size": 2,
+                "remote_block_ids": [30, 31, 32],
+                "local_block_ids": [40, 41],
+                "num_prompt_blocks": 5,
+                "num_external_blocks": 4,
+            },
+        ]
+
+        for case in cases:
+            for tp_rank in range(case["decode_tp_size"]):
+                for pcp_rank in range(case["pcp_size"]):
+                    for dcp_rank in range(case["dcp_size"]):
+                        with self.subTest(
+                            case=case["name"],
+                            tp_rank=tp_rank,
+                            pcp_rank=pcp_rank,
+                            dcp_rank=dcp_rank,
+                        ):
+                            worker = self._build_worker_for_pd_case(case, tp_rank, pcp_rank, dcp_rank)
+                            meta = types.SimpleNamespace(
+                                remote_pcp_size=case["remote_pcp_size"],
+                                remote_dcp_size=case["remote_dcp_size"],
+                                remote_ptp_size=case["prefill_tp_size"],
+                                remote_port=30000,
+                                remote_block_ids=(case["remote_block_ids"],),
+                                local_block_ids=(case["local_block_ids"],),
+                                num_external_tokens=case["num_external_blocks"] * worker.block_size,
+                                num_prompt_blocks=case["num_prompt_blocks"],
+                                remote_engine_id=f"remote_{case['name']}_{tp_rank}_{pcp_rank}_{dcp_rank}",
+                                remote_host="localhost",
+                                remote_multi_nodes_meta_mapping={},
+                            )
+
+                            ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_pd", meta)
+                            group_pulls = worker._get_group_pulls_metadata(
+                                "req_pd", ports, case["prefill_tp_size"], 30000
+                            )
+
+                            self.assertEqual(len(ports), len(local_ids))
+                            self.assertEqual(len(local_ids), len(remote_ids))
+                            self.assertEqual(
+                                sum(len(ids[0]) for ids in local_ids),
+                                case["num_external_blocks"] // (case["pcp_size"] * case["dcp_size"]),
+                            )
+                            self._assert_group_pull_finish_flags(ports, group_pulls, {0, 1})
+
+    def test_pd_disaggregated_hybrid_prefix_tp_and_pp_unequal(self):
+        for tp_rank in range(2):
+            with self.subTest(tp_rank=tp_rank):
+                with patch.object(
+                    self.vllm_config.kv_transfer_config,
+                    "get_from_extra_config",
+                    side_effect=lambda k, d=None: {
+                        "prefill": {"tp_size": 4, "dp_size": 1, "pp_size": 2},
+                        "decode": {"tp_size": 2, "dp_size": 1, "pp_size": 1},
+                    }.get(k, d),
+                ):
+                    self.vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+                    self.vllm_config.model_config.is_deepseek_mla = False
+                    self.vllm_config.model_config.hf_text_config.num_key_value_heads = 8
+                    worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
+
+                worker._is_hma_required = True
+                worker.use_mla = False
+                worker.use_sparse = False
+                worker.num_key_value_heads = 8
+                worker.tp_size = 2
+                worker.tp_rank = tp_rank
+                worker.pcp_size = 1
+                worker.dcp_size = 1
+                worker._decode_tp_size = 2
+                worker._prefill_tp_size = 4
+                worker._prefill_pp_size = 2
+                worker.kv_group2layeridx = {
+                    0: (
+                        {
+                            "kv_cache_spec_type": "FullAttentionSpec",
+                            "kv_cache_spec": {"num_kv_heads": 8},
+                        },
+                        [0, 1],
+                    ),
+                    1: ({"kv_cache_spec_type": "MambaSpec"}, [2]),
+                }
+
+                meta = types.SimpleNamespace(
+                    remote_pcp_size=1,
+                    remote_dcp_size=1,
+                    remote_ptp_size=4,
+                    remote_port=31000,
+                    remote_block_ids=([50, 51, 52], [60, 61, 62]),
+                    local_block_ids=([70, 71], [80, 81, 82]),
+                    num_external_tokens=3 * worker.block_size,
+                    num_prompt_blocks=4,
+                    remote_engine_id=f"remote_hybrid_{tp_rank}",
+                    remote_host="localhost",
+                    remote_multi_nodes_meta_mapping={},
+                )
+
+                ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_hybrid", meta)
+                group_pulls = worker._get_group_pulls_metadata("req_hybrid", ports, 4, 31000)
+
+                self.assertEqual(local_ids, [meta.local_block_ids])
+                self.assertEqual(remote_ids, [meta.remote_block_ids])
+                self.assertGreater(len(ports[0]), 1)
+                self._assert_hybrid_group_pull_finish_flags(
+                    ports,
+                    group_pulls,
+                    expected_group_ids={0, 1},
+                    expected_finishes={0: worker._prefill_pp_size, 1: worker._prefill_pp_size},
+                )
+
     def test_get_tp_num_need_pulls(self):
-        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id)
+        worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         worker.num_key_value_heads = 8
 
+        worker.vllm_config.model_config.is_deepseek_mla = True
         tp_num_need_pulls = worker._get_tp_num_need_pulls(prefill_tp_size=4)
         self.assertEqual(tp_num_need_pulls, 1)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -681,8 +681,8 @@ class KVCacheRecvingThread(threading.Thread):
                             src_list[start_meta_idx:], dst_list[start_meta_idx:], length_list[start_meta_idx:]
                         ):
                             logger.debug(
-                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s layer_idx=%s "
-                                "local_block_id=%s remote_block_id=%s tp_num_need_pulls=%s remote_tp_offset=%s",
+                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s layer_idx=%s local_block_id=%s "
+                                "remote_block_id=%s tp_num_need_pulls=%s remote_tp_offset=%s session_id=%s",
                                 remote_request_id,
                                 group_idx,
                                 layer_idx,
@@ -690,6 +690,7 @@ class KVCacheRecvingThread(threading.Thread):
                                 grouped_remote_block_ids[0][0],
                                 tp_num_need_pulls,
                                 inner_offset,
+                                session_id
                             )
                 continue
 
@@ -707,8 +708,8 @@ class KVCacheRecvingThread(threading.Thread):
                         dst_list.append(dst)
                         length_list.append(length)
                     logger.debug(
-                        "Mooncake kv transfer meta: request_id=%s group_idx=%s layer_idx=%s "
-                        "local_block_ids=%s remote_block_ids=%s tp_num_need_pulls=%s remote_tp_offset=%s",
+                        "Mooncake kv transfer meta: request_id=%s group_idx=%s layer_idx=%s local_block_ids=%s "
+                        "remote_block_ids=%s tp_num_need_pulls=%s remote_tp_offset=%s session_id=%s",
                         remote_request_id,
                         group_idx,
                         layer_idx,
@@ -716,6 +717,7 @@ class KVCacheRecvingThread(threading.Thread):
                         grouped_remote_block_ids,
                         tp_num_need_pulls,
                         inner_offset,
+                        session_id
                     )
         if not src_list:
             return
@@ -1661,9 +1663,9 @@ class MooncakeConnectorWorker:
         ptrs: list[int] = []
         lengths: list[int] = []
 
+        conv_padding = 0
         for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
             shared_addrs: list[int] = []
-            conv_padding = 0
             has_mtp = False
             for layer_name in kv_cache_tensor.shared_by:
                 has_mtp = has_mtp or "mtp" in layer_name
@@ -1677,6 +1679,7 @@ class MooncakeConnectorWorker:
             base_addr = min(shared_addrs)
             if has_mtp:
                 base_addr -= conv_padding
+            assert base_addr % (2*1024*1024) == 0, f"Tensor start addr {base_addr} is not align with 2M."
             ptrs.append(base_addr)
             lengths.append(kv_cache_tensor.size)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -393,7 +393,13 @@ class KVCacheRecvingThread(threading.Thread):
         self.use_mla = self.model_config.is_deepseek_mla
         self.is_hma_required = is_hma_required
         self.block_size = self.vllm_config.cache_config.block_size
-        self.num_layers = self.model_config.hf_text_config.num_hidden_layers
+        try:
+            hf_text_config = self.model_config.hf_text_config
+            if hf_text_config is None:
+                raise AttributeError
+        except AttributeError:
+            hf_text_config = self.model_config.hf_config
+        self.num_layers = hf_text_config.num_hidden_layers
         if block_size_scale is None:
             block_size_scale = []
         self.block_size_scale = block_size_scale
@@ -403,17 +409,17 @@ class KVCacheRecvingThread(threading.Thread):
         }
         if not is_vl_model(vllm_config):
             if self.use_mla:
-                self.k_head_dim = self.model_config.hf_text_config.kv_lora_rank
-                self.v_head_dim = self.model_config.hf_text_config.qk_rope_head_dim
+                self.k_head_dim = hf_text_config.kv_lora_rank
+                self.v_head_dim = hf_text_config.qk_rope_head_dim
                 self.num_kv_heads = 1
             else:
-                self.k_head_dim = self.model_config.hf_text_config.head_dim
-                self.v_head_dim = self.model_config.hf_text_config.head_dim
-                self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
+                self.k_head_dim = hf_text_config.head_dim
+                self.v_head_dim = hf_text_config.head_dim
+                self.num_kv_heads = max(hf_text_config.num_key_value_heads // self.tp_size, 1)
         else:
-            self.k_head_dim = self.model_config.hf_text_config.head_dim
-            self.v_head_dim = self.model_config.hf_text_config.head_dim
-            self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
+            self.k_head_dim = hf_text_config.head_dim
+            self.v_head_dim = hf_text_config.head_dim
+            self.num_kv_heads = max(hf_text_config.num_key_value_heads // self.tp_size, 1)
         self.proc_not_transfer_request: dict[str, bool] = {}
         self.failed_recv_requests: set[str] = set()
         self.invalid_block_ids: set[int] = set()

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -93,6 +93,7 @@ class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
 class ReqMeta:
     local_block_ids: BlockIds
     num_external_tokens: int
+    num_computed_tokens: int
     remote_block_ids: BlockIds
     remote_host: str
     remote_port: int
@@ -451,6 +452,7 @@ class KVCacheRecvingThread(threading.Thread):
         remote_host: str,
         remote_handshake_port: int,
         remote_port_send_num: dict[int, RemotePortInfo] | None = None,
+        num_computed_tokens: int = 0,
         all_task_done: bool = False,
     ):
         """Add a new request to the queue for processing."""
@@ -465,6 +467,7 @@ class KVCacheRecvingThread(threading.Thread):
             "remote_request_id": remote_request_id,
             "remote_host": remote_host,
             "remote_handshake_port": remote_handshake_port,
+            "num_computed_tokens": num_computed_tokens,
             "remote_port_send_num": remote_port_send_num,
             "all_task_done": all_task_done,
         }
@@ -627,9 +630,14 @@ class KVCacheRecvingThread(threading.Thread):
                 remote_scale = remote_block_size_scale[layer_indices[0]][0]
                 kernel_local_block_ids = expand_block_ids(local_group_block_ids, local_scale)
                 kernel_remote_block_ids = expand_block_ids(remote_group_block_ids, remote_scale)
-                # For FullAttentionSpec Prefix cache
-                if len(local_group_block_ids) < len(remote_group_block_ids):
-                    kernel_remote_block_ids = kernel_remote_block_ids[-len(kernel_local_block_ids) :]
+                # For FullAttentionSpec prefix cache with hybrid kernel blocks.
+                num_computed_tokens = req_meta.get("num_computed_tokens", 0)
+                remote_kernel_block_size = self.block_size // remote_scale
+                remote_start_idx = num_computed_tokens // remote_kernel_block_size
+                kernel_remote_block_ids = kernel_remote_block_ids[remote_start_idx:]
+                num_kernel_blocks = min(len(kernel_remote_block_ids), len(kernel_local_block_ids))
+                kernel_remote_block_ids = kernel_remote_block_ids[:num_kernel_blocks]
+                kernel_local_block_ids = kernel_local_block_ids[:num_kernel_blocks]
 
                 if tp_num_need_pulls == 1:
                     grouped_remote_block_ids, grouped_local_block_ids = group_concurrent_contiguous(
@@ -645,9 +653,9 @@ class KVCacheRecvingThread(threading.Thread):
                     )
                 )
             else:
-                # For MambaSpec Prefix cache on D node
-                if len(local_group_block_ids) < len(remote_group_block_ids):
-                    raise RuntimeError("Mooncake connector does not support prefix cache with Mamba now.")
+                # For MambaSpec num block should equal on P node and D node
+                if len(local_group_block_ids) != len(remote_group_block_ids):
+                    raise RuntimeError("For MambaSpec num block should equal on P node and D node.")
                 transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
                 grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
@@ -809,8 +817,9 @@ class KVCacheRecvingThread(threading.Thread):
             # [block, split, token, head_per_split, dim]. Restore it to
             # [block, token, split, head_per_split, dim] in the selected blocks.
             selected = cache.index_select(0, block_ids_tensor)
+            block_size = cache.shape[1]
             transposed = (
-                selected.reshape(num_blocks, tp_num_need_pulls, 128, -1)  # TODO
+                selected.reshape(num_blocks, tp_num_need_pulls, block_size, -1)
                 .transpose(1, 2)
                 .contiguous()
                 .reshape_as(selected)
@@ -1152,6 +1161,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         self.requests[request_id] = ReqMeta(
             local_block_ids=local_block_ids,
             num_external_tokens=num_external_tokens,
+            num_computed_tokens=kv_transfer_params.get("num_computed_tokens", 0),
             remote_block_ids=kv_transfer_params["remote_block_ids"],
             remote_engine_id=kv_transfer_params["remote_engine_id"],
             remote_request_id=kv_transfer_params["remote_request_id"],
@@ -1344,6 +1354,7 @@ class MooncakeConnectorScheduler:
         if params is not None and params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
             assert num_computed_tokens % self.block_size == 0
+            params["num_computed_tokens"] = num_computed_tokens
             # Note: We use the full token count as transmit data here.
             count = max(len(request.prompt_token_ids) - num_computed_tokens, 0)
             return count, count > 0
@@ -2273,6 +2284,7 @@ class MooncakeConnectorWorker:
                         remote_host=remote_host,
                         remote_handshake_port=remote_handshake_port,
                         remote_port_send_num=remote_port_send_num,
+                        num_computed_tokens=meta.num_computed_tokens,
                         all_task_done=(
                             pcp_dcp_rank == len(remote_handshake_port_list) - 1
                             and remote_tp_offset == len(remote_ports) - 1

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -383,7 +383,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.remote_poller = zmq.Poller()  # type: ignore
         self.timeout = 1.0  # seconds
 
-        self.vllm_config = vllm_config
+        assert vllm_config is not None
+        self.vllm_config: VllmConfig = vllm_config
         self.model_config = self.vllm_config.model_config
         self.num_speculative_tokens = (
             self.vllm_config.speculative_config.num_speculative_tokens
@@ -407,7 +408,7 @@ class KVCacheRecvingThread(threading.Thread):
             rank: get_prefill_pp_indices(self.num_layers, rank, self._prefill_pp_size, prefill_pp_layer_partition)
             for rank in range(self._prefill_pp_size)
         }
-        if not is_vl_model(vllm_config):
+        if not is_vl_model(self.vllm_config):
             if self.use_mla:
                 self.k_head_dim = hf_text_config.kv_lora_rank
                 self.v_head_dim = hf_text_config.qk_rope_head_dim
@@ -593,7 +594,9 @@ class KVCacheRecvingThread(threading.Thread):
         session_id = f"{remote_host}:{remote_transfer_port}"
 
         req_start_time = time.perf_counter()
-        src_list, dst_list, length_list = [], [], []
+        src_list: list[int] = []
+        dst_list: list[int] = []
+        length_list: list[int] = []
         attention_group_reformat_block_ids: list[tuple[tuple[int, list[list[int]], int, list[int]], bool]] = []
 
         def expand_block_ids(block_ids, scale):
@@ -1505,6 +1508,8 @@ class MooncakeConnectorWorker:
 
         # kv cache config
         self.kv_cache_config = kv_cache_config
+        self.num_blocks: int = kv_cache_config.num_blocks
+        self.kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] = {}
         self._is_hma_required = not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager and any(
             not isinstance(g.kv_cache_spec, FullAttentionSpec) for g in kv_cache_config.kv_cache_groups
         )
@@ -1849,7 +1854,7 @@ class MooncakeConnectorWorker:
         P workers. This method also accounts for unequal P/D prefix-cache hits
         by reducing the number of remote blocks that still need to be pulled.
         """
-        prefill_tp_size = meta.remote_ptp_size if getattr(meta, "remote_ptp_size", None) else self._prefill_tp_size
+        prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
 
         if meta.remote_pcp_size * meta.remote_dcp_size * self.pcp_size * self.dcp_size == 1:
             if self._is_hma_required:
@@ -2229,7 +2234,7 @@ class MooncakeConnectorWorker:
                 )
 
             remote_req_id = meta.remote_request_id
-            prefill_tp_size = meta.remote_ptp_size if getattr(meta, "remote_ptp_size", None) else self._prefill_tp_size
+            prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
 
             (
                 remote_handshake_port_list,
@@ -2285,7 +2290,7 @@ class MooncakeConnectorWorker:
             for req_id, delay_start_time in metadata.requests_to_send.items():
                 self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
 
-    def _get_tp_num_need_pulls(self, prefill_tp_size: int) -> int:
+    def _get_tp_num_need_pulls(self, prefill_tp_size: int | None) -> int:
         if prefill_tp_size is None:
             prefill_tp_size = self._prefill_tp_size
 
@@ -2368,15 +2373,15 @@ class MooncakeConnectorWorker:
         seed = string_to_int64_hash(req_id)
         rand = random.Random(seed)
         # random split prefill tp list
-        ori_data = ori_data.reshape(self._prefill_pp_size, -1)
+        ori_data_2d = ori_data.reshape(self._prefill_pp_size, -1)
         num_groups = max(
-            1, len(ori_data[0]) // num_kv_head
+            1, len(ori_data_2d[0]) // num_kv_head
         )  # The number of redundant copies for each KV head within the PP stage
         rand_group_index = rand.sample(
             range(num_groups), (max(self._decode_tp_size // num_kv_head, 1))
         )  # random choose a group
         all_results = [
-            self._get_remote_tp_ranks(ori_data[pp_index], rand_group_index, num_groups, prefill_tp_size)
+            self._get_remote_tp_ranks(ori_data_2d[pp_index], rand_group_index, num_groups, prefill_tp_size)
             for pp_index in range(self._prefill_pp_size)
         ]
         for group_index in range(len(all_results[0])):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -681,8 +681,9 @@ class KVCacheRecvingThread(threading.Thread):
                             src_list[start_meta_idx:], dst_list[start_meta_idx:], length_list[start_meta_idx:]
                         ):
                             logger.debug(
-                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s layer_idx=%s local_block_id=%s "
-                                "remote_block_id=%s tp_num_need_pulls=%s remote_tp_offset=%s session_id=%s",
+                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s layer_idx=%s "
+                                "local_block_id=%s remote_block_id=%s tp_num_need_pulls=%s "
+                                "remote_tp_offset=%s  session_id=%s",
                                 remote_request_id,
                                 group_idx,
                                 layer_idx,
@@ -690,7 +691,7 @@ class KVCacheRecvingThread(threading.Thread):
                                 grouped_remote_block_ids[0][0],
                                 tp_num_need_pulls,
                                 inner_offset,
-                                session_id
+                                session_id,
                             )
                 continue
 
@@ -717,7 +718,7 @@ class KVCacheRecvingThread(threading.Thread):
                         grouped_remote_block_ids,
                         tp_num_need_pulls,
                         inner_offset,
-                        session_id
+                        session_id,
                     )
         if not src_list:
             return
@@ -1455,7 +1456,7 @@ class MooncakeConnectorScheduler:
         return delay_free_blocks, dict(
             do_remote_prefill=True,
             do_remote_decode=False,
-            remote_block_ids=computed_block_ids[:num_prompt_blocks],
+            remote_block_ids=computed_block_ids,
             remote_engine_id=self.engine_id,
             remote_request_id=request.request_id,
             remote_host=self.side_channel_host,
@@ -1679,7 +1680,7 @@ class MooncakeConnectorWorker:
             base_addr = min(shared_addrs)
             if has_mtp:
                 base_addr -= conv_padding
-            assert base_addr % (2*1024*1024) == 0, f"Tensor start addr {base_addr} is not align with 2M."
+            assert base_addr % (2 * 1024 * 1024) == 0, f"Tensor start addr {base_addr} is not align with 2M."
             ptrs.append(base_addr)
             lengths.append(kv_cache_tensor.size)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -26,11 +26,13 @@ from mooncake.engine import TransferEngine  # type: ignore
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed import get_pcp_group
+from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.parallel_state import (
     get_decode_context_model_parallel_rank,
@@ -44,9 +46,15 @@ from vllm.distributed.utils import get_pp_indices
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.request import RequestStatus
 
+from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value
@@ -72,16 +80,20 @@ class RemotePortInfo(TypedDict):
 class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     engine_id: str
     te_rpc_port: int
-    kv_caches_base_addr: list[int]
+    kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]]
+    block_size: int
+    kv_caches_base_addr: list[list[int]]
+    block_size_scale: list[list[int]]
     num_blocks: int
+    block_lens: list[list[int]]
     local_ip: str = ""
 
 
 @dataclass
 class ReqMeta:
-    local_block_ids: list[int]
+    local_block_ids: BlockIds
     num_external_tokens: int
-    remote_block_ids: list[int]
+    remote_block_ids: BlockIds
     remote_host: str
     remote_port: int
     remote_engine_id: str
@@ -91,6 +103,15 @@ class ReqMeta:
     remote_ptp_size: int | None
     remote_multi_nodes_meta_mapping: dict[str, dict[str, Any]]
     num_prompt_blocks: int
+
+
+@dataclass(frozen=True)
+class GroupPull:
+    group_id: int
+    remote_tp_offset: int
+    num_group_pulls: int
+    prefill_pp_rank: int = 0
+    is_group_transfer_end: bool = False
 
 
 @dataclass
@@ -141,9 +162,10 @@ class KVCacheTaskTracker:
                 self.reqs_to_process.discard(request_id)
                 self.delayed_free_requests.pop(request_id, None)
             else:
-                logger.error(
-                    "MooncakeConnector finish req not in reqs to process."
-                    "If it is a P node, this request may have been force freed."
+                logger.warning(
+                    "MooncakeConnector finish req %s not in reqs to process."
+                    "If it is a P node, this request may have been force freed.",
+                    request_id,
                 )
 
     def get_and_clear_finished_requests(self) -> set[str]:
@@ -310,12 +332,15 @@ class KVCacheRecvingThread(threading.Thread):
         local_engine_id: str,
         local_handshake_port: int,
         side_channel_port: int,
-        local_kv_caches_base_addr: list[int],
-        block_len: list[int],
-        ready_event: threading.Event,
-        vllm_config: VllmConfig,
-        kv_caches: dict[str, Any],
+        local_kv_caches_base_addr: list[list[int]],
+        block_len_per_addr: list[list[int]],
+        is_hma_required=False,
+        ready_event: threading.Event | None = None,
+        vllm_config: VllmConfig | None = None,
+        kv_caches: dict[str, Any] | None = None,
         prefill_pp_layer_partition: str | None = None,
+        kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] | None = None,
+        block_size_scale: list[list[int]] | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheRecvingThread")
         self.tp_rank = tp_rank
@@ -325,15 +350,22 @@ class KVCacheRecvingThread(threading.Thread):
         self.local_handshake_port = local_handshake_port
         self.side_channel_port = side_channel_port
         self.engine = engine
+        if ready_event is None:
+            ready_event = threading.Event()
         self.ready_event = ready_event
 
+        if kv_caches is None:
+            kv_caches = {}
         self.kv_caches = kv_caches
-        self.kv_caches_base_addr: dict[str, dict[int, list[int]]] = SizedDict()
+        self.kv_caches_base_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.kv_caches_base_addr[local_engine_id][local_handshake_port] = local_kv_caches_base_addr
+        self.block_len_per_addr = block_len_per_addr
+        if kv_group2layeridx is None:
+            kv_group2layeridx = {}
+        self.kv_group2layeridx = kv_group2layeridx
         self.remote_te_port: dict[str, dict[int, int]] = SizedDict()
-        self.block_len = block_len
-        # TODO(jianzs): find a better way to detect MLA.
-        self.use_mla = len(block_len) == 2
+        self.remote_block_size_scale: dict[str, dict[int, list[list[int]]]] = SizedDict()
+        self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
         self.executor = ThreadPoolExecutor(max_workers=32)
@@ -353,8 +385,18 @@ class KVCacheRecvingThread(threading.Thread):
 
         self.vllm_config = vllm_config
         self.model_config = self.vllm_config.model_config
+        self.num_speculative_tokens = (
+            self.vllm_config.speculative_config.num_speculative_tokens
+            if self.vllm_config.speculative_config is not None
+            else 0
+        )
+        self.use_mla = self.model_config.is_deepseek_mla
+        self.is_hma_required = is_hma_required
         self.block_size = self.vllm_config.cache_config.block_size
         self.num_layers = self.model_config.hf_text_config.num_hidden_layers
+        if block_size_scale is None:
+            block_size_scale = []
+        self.block_size_scale = block_size_scale
         self.pp_layer_indices = {
             rank: get_prefill_pp_indices(self.num_layers, rank, self._prefill_pp_size, prefill_pp_layer_partition)
             for rank in range(self._prefill_pp_size)
@@ -368,6 +410,10 @@ class KVCacheRecvingThread(threading.Thread):
                 self.k_head_dim = self.model_config.hf_text_config.head_dim
                 self.v_head_dim = self.model_config.hf_text_config.head_dim
                 self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
+        else:
+            self.k_head_dim = self.model_config.hf_text_config.head_dim
+            self.v_head_dim = self.model_config.hf_text_config.head_dim
+            self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
         self.proc_not_transfer_request: dict[str, bool] = {}
         self.failed_recv_requests: set[str] = set()
         self.invalid_block_ids: set[int] = set()
@@ -391,35 +437,32 @@ class KVCacheRecvingThread(threading.Thread):
         self,
         request_id: str,
         remote_request_id: str,
-        local_block_ids: list[int],
-        remote_block_ids: list[int],
+        local_block_ids: BlockIds,
+        remote_block_ids: BlockIds,
+        group_pulls: list[GroupPull],
         remote_engine_id: str,
         remote_host: str,
         remote_handshake_port: int,
-        offset: int,
-        tp_num_need_pulls: int,
         remote_port_send_num: dict[int, RemotePortInfo] | None = None,
         all_task_done: bool = False,
     ):
         """Add a new request to the queue for processing."""
         if remote_port_send_num is None:
             remote_port_send_num = {}
-        logger.debug("Adding request %s to the queue.", request_id)
-        self.request_queue.put(
-            {
-                "request_id": request_id,
-                "local_block_ids": local_block_ids,
-                "remote_block_ids": remote_block_ids,
-                "remote_engine_id": remote_engine_id,
-                "remote_request_id": remote_request_id,
-                "remote_host": remote_host,
-                "remote_handshake_port": remote_handshake_port,
-                "offset": offset,
-                "tp_num_need_pulls": tp_num_need_pulls,
-                "remote_port_send_num": remote_port_send_num,
-                "all_task_done": all_task_done,
-            }
-        )
+        trans_info = {
+            "request_id": request_id,
+            "local_block_ids": local_block_ids,
+            "remote_block_ids": remote_block_ids,
+            "group_pulls": group_pulls,
+            "remote_engine_id": remote_engine_id,
+            "remote_request_id": remote_request_id,
+            "remote_host": remote_host,
+            "remote_handshake_port": remote_handshake_port,
+            "remote_port_send_num": remote_port_send_num,
+            "all_task_done": all_task_done,
+        }
+        logger.debug("Adding request %s to the queue.Trans info:%s", request_id, trans_info)
+        self.request_queue.put(trans_info)
 
     def get_and_clear_finished_requests(self) -> set[str]:
         """
@@ -482,21 +525,20 @@ class KVCacheRecvingThread(threading.Thread):
             else:
                 try:
                     logger.debug("Starting to transfer KV cache for request %s.", remote_request_id)
-                    self._transfer_kv_cache(req_meta)
+                    self._transfer_kv_cache_all_groups(req_meta)
                     logger.debug("Finished transferring KV cache for request %s.", remote_request_id)
                 except Exception as e:
                     transfer_failed = True
                     self._mark_failed_recv_request(request_id, req_meta["local_block_ids"])
                     logger.exception("Failed to transfer KV cache for request %s: %s", remote_request_id, e)
         finally:
-            self._send_done_signal_to_free_remote_port(remote_request_id, remote_host, remote_port_send_num)
             if all_task_done:
-                if len(req_meta["local_block_ids"]) > 0 or transfer_failed:
-                    self.task_tracker.update_done_task_count(request_id)
+                self.task_tracker.update_done_task_count(request_id)
                 if request_id in self.proc_not_transfer_request:
                     del self.proc_not_transfer_request[request_id]
                 self._clear_failed_recv_request(request_id)
             self.request_queue.task_done()
+            self._send_done_signal_to_free_remote_port(remote_request_id, remote_host, remote_port_send_num)
             # Always send the done signal to the remote host to ensure proper
             # resource cleanup. Failing to do so may cause a memory leak on the
             # remote host.
@@ -516,27 +558,21 @@ class KVCacheRecvingThread(threading.Thread):
                     self._send_done_recv_signal(request_id, remote_host_, remote_port, remote_port_send_num)
             self.proc_not_transfer_request[request_id] = False
 
-    def _transfer_kv_cache(self, req_meta: dict[str, Any]):
+    def _transfer_kv_cache_all_groups(self, req_meta: dict[str, Any]):
         """Handle a KV cache transfer request."""
         remote_request_id = req_meta["remote_request_id"]
-        remote_block_ids = req_meta["remote_block_ids"]
-        local_block_ids = req_meta["local_block_ids"]
+        local_block_ids: BlockIds = req_meta["local_block_ids"]
+        remote_block_ids: BlockIds = req_meta["remote_block_ids"]
+        group_pulls: list[GroupPull] = req_meta["group_pulls"]
         remote_engine_id = req_meta["remote_engine_id"]
         remote_host = req_meta["remote_host"]
         remote_handshake_port = req_meta["remote_handshake_port"]
-        offset = req_meta["offset"]
-        tp_num_need_pulls = req_meta["tp_num_need_pulls"]
 
         # Full prefix cache hit: do not need to read remote blocks, just notify
         # P worker that we have the blocks we need.
-        num_local_blocks = len(local_block_ids)
+        num_local_blocks = sum(len(group_block_ids) for group_block_ids in local_block_ids)
         if num_local_blocks == 0:
             return
-
-        num_remote_blocks = len(remote_block_ids)
-        assert num_local_blocks <= num_remote_blocks
-        if num_local_blocks < num_remote_blocks:
-            remote_block_ids = remote_block_ids[-num_local_blocks:]
 
         # Check if we have the remote metadata cached.
         if (
@@ -544,54 +580,137 @@ class KVCacheRecvingThread(threading.Thread):
             or remote_handshake_port not in self.kv_caches_base_addr[remote_engine_id]
         ):
             self._get_remote_metadata(remote_host, remote_handshake_port)
-
-        if tp_num_need_pulls == 1:
-            grouped_remote_block_ids, grouped_local_block_ids = group_concurrent_contiguous(
-                remote_block_ids, local_block_ids
-            )
-        else:
-            remote_block_ids = list(map(lambda x: [x], remote_block_ids))
-            local_block_ids = list(map(lambda x: [x], local_block_ids))
-            grouped_remote_block_ids, grouped_local_block_ids = remote_block_ids, local_block_ids
-        num_transfer_groups = len(grouped_remote_block_ids)
-        # tp_num_need_pulls: number of KV caches each Decode node needs to pull from each PP stage
-        # Due to GQA, different KV heads are distributed across different ranks, so there are offsets
-        # indicating which KV head to pull
-        global_offset = offset  # Global offset of request across all ranks
-        prefill_pp_rank = offset // tp_num_need_pulls  # PP rank where current request resides
-        inner_offset = offset % tp_num_need_pulls  # Offset within each PP stage
-
         remote_kv_caches_base_addrs = self.kv_caches_base_addr[remote_engine_id][remote_handshake_port]
-        first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
-        # support MTP layer and draft model kv transfer
-        if self.vllm_config.speculative_config is not None:
-            if prefill_pp_rank == self._prefill_pp_size - 1:
-                end_layer_index = end_layer_index + self.num_draft_layers
-        num_cache_per_layer = len(list(self.kv_caches.values())[0])  # Number of KV caches per layer
-        local_kv_caches_base_addrs = self.kv_caches_base_addr[self.local_engine_id][self.local_handshake_port][
-            first_layer_index * num_cache_per_layer : end_layer_index * num_cache_per_layer
-        ]
-        logger.debug("transfer kv cache first_layer_index:%s , end_layer_index:%s", first_layer_index, end_layer_index)
+        local_kv_caches_base_addrs = self.kv_caches_base_addr[self.local_engine_id][self.local_handshake_port]
         remote_transfer_port = self.remote_te_port[remote_engine_id][remote_handshake_port]
-        num_blocks = len(local_block_ids)
+        remote_block_size_scale = self.remote_block_size_scale[remote_engine_id][remote_handshake_port]
         session_id = f"{remote_host}:{remote_transfer_port}"
 
         req_start_time = time.perf_counter()
         src_list, dst_list, length_list = [], [], []
-        block_length = len(self.block_len)
-        for k, (src_layer_base_addr, dst_layer_base_addr) in enumerate(
-            zip(local_kv_caches_base_addrs, remote_kv_caches_base_addrs)
-        ):
-            block_len = self.block_len[k % block_length]
-            inner_block_len = block_len // tp_num_need_pulls
-            for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
-                src = src_layer_base_addr + local_block_id[0] * block_len + inner_offset * inner_block_len
-                dst = dst_layer_base_addr + remote_block_id[0] * inner_block_len
-                length = inner_block_len * len(local_block_id)
-                src_list.append(src)
-                dst_list.append(dst)
-                length_list.append(length)
+        attention_group_reformat_block_ids: list[tuple[tuple[int, list[list[int]], int, list[int]], bool]] = []
 
+        def expand_block_ids(block_ids, scale):
+            return [bid * scale + offset for bid in block_ids for offset in range(scale)]
+
+        def pp_layer_indices(layer_indices: list[int], prefill_pp_rank: int) -> list[int]:
+            first_layer_index, end_layer_index = self.pp_layer_indices[prefill_pp_rank]
+            if self.vllm_config.speculative_config is not None and prefill_pp_rank == self._prefill_pp_size - 1:
+                end_layer_index += self.num_draft_layers
+            return [layer_idx for layer_idx in layer_indices if first_layer_index <= layer_idx < end_layer_index]
+
+        for group_pull in group_pulls:
+            group_idx = group_pull.group_id
+            group_spec, layer_indices = self.kv_group2layeridx[group_idx]
+            layer_indices = pp_layer_indices(layer_indices, group_pull.prefill_pp_rank)
+            if not layer_indices:
+                continue
+            tp_num_need_pulls = group_pull.num_group_pulls
+            inner_offset = group_pull.remote_tp_offset
+            is_mamba_group = group_spec["kv_cache_spec_type"] == "MambaSpec"
+            local_group_block_ids = local_block_ids[group_idx]
+            remote_group_block_ids = remote_block_ids[group_idx]
+            if not local_group_block_ids:
+                continue
+            if not is_mamba_group:
+                is_group_transfer_end = group_pull.is_group_transfer_end
+                local_scale = self.block_size_scale[layer_indices[0]][0]
+                remote_scale = remote_block_size_scale[layer_indices[0]][0]
+                kernel_local_block_ids = expand_block_ids(local_group_block_ids, local_scale)
+                kernel_remote_block_ids = expand_block_ids(remote_group_block_ids, remote_scale)
+                # For FullAttentionSpec Prefix cache
+                if len(local_group_block_ids) < len(remote_group_block_ids):
+                    kernel_remote_block_ids = kernel_remote_block_ids[-len(kernel_local_block_ids) :]
+
+                if tp_num_need_pulls == 1:
+                    grouped_remote_block_ids, grouped_local_block_ids = group_concurrent_contiguous(
+                        kernel_remote_block_ids, kernel_local_block_ids
+                    )
+                else:
+                    grouped_remote_block_ids = [[block_id] for block_id in kernel_remote_block_ids]
+                    grouped_local_block_ids = [[block_id] for block_id in kernel_local_block_ids]
+                attention_group_reformat_block_ids.append(
+                    (
+                        (group_idx, grouped_local_block_ids, tp_num_need_pulls, layer_indices),
+                        is_group_transfer_end,
+                    )
+                )
+            else:
+                # For MambaSpec Prefix cache on D node
+                if len(local_group_block_ids) < len(remote_group_block_ids):
+                    raise RuntimeError("Mooncake connector does not support prefix cache with Mamba now.")
+                transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
+                grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
+                grouped_local_block_ids = [[local_group_block_ids[0]]]
+
+            if is_mamba_group:
+                for layer_idx in layer_indices:
+                    start_meta_idx = len(src_list)
+                    self._append_mamba_transfer_meta(
+                        src_list,
+                        dst_list,
+                        length_list,
+                        group_spec=group_spec,
+                        src_layer_base_addr=local_kv_caches_base_addrs[layer_idx],
+                        dst_layer_base_addr=remote_kv_caches_base_addrs[layer_idx],
+                        block_len=self.block_len_per_addr[layer_idx],
+                        remote_block_id=grouped_remote_block_ids[0][0],
+                        local_block_id=grouped_local_block_ids[0][0],
+                        tp_num_need_pulls=tp_num_need_pulls,
+                        remote_tp_offset=inner_offset,
+                    )
+                    if logger.isEnabledFor(logging.DEBUG):
+                        for src, dst, length in zip(
+                            src_list[start_meta_idx:], dst_list[start_meta_idx:], length_list[start_meta_idx:]
+                        ):
+                            logger.debug(
+                                "Mooncake mamba transfer meta: request_id=%s group_idx=%s layer_idx=%s "
+                                "local_block_id=%s remote_block_id=%s tp_num_need_pulls=%s remote_tp_offset=%s",
+                                remote_request_id,
+                                group_idx,
+                                layer_idx,
+                                grouped_local_block_ids[0][0],
+                                grouped_remote_block_ids[0][0],
+                                tp_num_need_pulls,
+                                inner_offset,
+                            )
+                continue
+
+            for layer_idx in layer_indices:
+                for cache_idx in range(len(local_kv_caches_base_addrs[layer_idx])):
+                    src_layer_base_addr = local_kv_caches_base_addrs[layer_idx][cache_idx]
+                    dst_layer_base_addr = remote_kv_caches_base_addrs[layer_idx][cache_idx]
+                    block_len = self.block_len_per_addr[layer_idx][cache_idx]
+                    inner_block_len = block_len // tp_num_need_pulls
+                    for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
+                        src = src_layer_base_addr + local_block_id[0] * block_len + inner_offset * inner_block_len
+                        dst = dst_layer_base_addr + remote_block_id[0] * inner_block_len
+                        length = inner_block_len * len(local_block_id)
+                        src_list.append(src)
+                        dst_list.append(dst)
+                        length_list.append(length)
+                    logger.debug(
+                        "Mooncake kv transfer meta: request_id=%s group_idx=%s layer_idx=%s "
+                        "local_block_ids=%s remote_block_ids=%s tp_num_need_pulls=%s remote_tp_offset=%s",
+                        remote_request_id,
+                        group_idx,
+                        layer_idx,
+                        grouped_local_block_ids,
+                        grouped_remote_block_ids,
+                        tp_num_need_pulls,
+                        inner_offset,
+                    )
+        if not src_list:
+            return
+
+        logger.debug(
+            "Mooncake transfer request=%s session id=%s src=%s dst=%s length=%s",
+            remote_request_id,
+            session_id,
+            src_list,
+            dst_list,
+            length_list,
+        )
         ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
         if ret < 0:
             logger.error("Mooncake transfer failed for request %s", req_meta["remote_request_id"])
@@ -600,49 +719,217 @@ class KVCacheRecvingThread(threading.Thread):
         req_end_time = time.perf_counter()
         req_transfer_elapsed = (req_end_time - req_start_time) * 1000
         logger.info(
-            "KV cache transfer for request %s took %.2f ms (%d groups,"
-            " %d blocks). local_ip %s local_device_id %s remote_session_id %s",
+            "KV cache transfer for request %s took %.2f ms. local_ip %s local_device_id %s remote_session_id %s",
             remote_request_id,
             req_transfer_elapsed,
-            num_transfer_groups,
-            num_blocks,
             get_ip(),
             self.tp_rank,
             session_id,
         )
 
-        # Determine if the current position is the offset position at the end of
-        # the KV transmission.
-        is_kv_transfer_end = global_offset == tp_num_need_pulls * self._prefill_pp_size - 1
-        need_cat_cache = tp_num_need_pulls > 1 and is_kv_transfer_end
-        need_nz_cache = get_ascend_config().enable_kv_nz and is_kv_transfer_end
-        use_fused_op = get_ascend_config().enable_transpose_kv_cache_by_block
-        if need_nz_cache or need_cat_cache:
-            # use fused op to reformat kv cache, we keep original implementation to provide ability to disable it.
+        ready_attention_group_reformat_block_ids = []
+        for reformat_group, is_group_transfer_end in attention_group_reformat_block_ids:
+            if is_group_transfer_end:
+                ready_attention_group_reformat_block_ids.append(reformat_group)
+        if not ready_attention_group_reformat_block_ids:
+            return
+
+        gqa_reformat_groups = [
+            (group_idx, grouped_local_block_ids, num_group_pulls, layer_indices)
+            for (
+                group_idx,
+                grouped_local_block_ids,
+                num_group_pulls,
+                layer_indices,
+            ) in ready_attention_group_reformat_block_ids
+            if num_group_pulls > 1
+        ]
+
+        if self.is_hma_required:
+            for group_idx, grouped_local_block_ids, num_group_pulls, layer_indices in gqa_reformat_groups:
+                group_kv_caches = self._get_group_kv_caches(group_idx, layer_indices)
+                if not group_kv_caches:
+                    continue
+                self.reformat_kv_cache_hybrid_linear_torch(grouped_local_block_ids, num_group_pulls, group_kv_caches)
+            return
+
+        uniform_num_pulls = {num_group_pulls for _, _, num_group_pulls, _ in ready_attention_group_reformat_block_ids}
+        if len(uniform_num_pulls) != 1:
+            raise RuntimeError(
+                f"Non-hybrid Mooncake KV reformat expects uniform group pulls, but got {uniform_num_pulls}."
+            )
+
+        num_group_pulls = next(iter(uniform_num_pulls))
+        need_cat_cache = num_group_pulls > 1
+        need_nz_cache = get_ascend_config().enable_kv_nz
+        if not (need_cat_cache or need_nz_cache):
+            return
+
+        use_fused_op = ascend_envs.VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK
+        for group_idx, reformat_block_ids, _, layer_indices in ready_attention_group_reformat_block_ids:
+            group_kv_caches = self._get_group_kv_caches(group_idx, layer_indices)
+            if not group_kv_caches:
+                continue
             if use_fused_op and enable_custom_op():
                 if need_cat_cache:
-                    # the fused op only support cat GQA/MHA kv cache by head
-                    self.reformat_kv_cache_with_fused_op(grouped_local_block_ids, tp_num_need_pulls)
+                    self.reformat_kv_cache_with_fused_op(reformat_block_ids, num_group_pulls, group_kv_caches)
                 if need_nz_cache:
-                    # maybe use fused op to reformat kv nz too in the future.
-                    self.reformat_kv_cache(grouped_local_block_ids, tp_num_need_pulls, False, need_nz_cache)
+                    self.reformat_kv_cache(reformat_block_ids, num_group_pulls, False, need_nz_cache, group_kv_caches)
             else:
-                self.reformat_kv_cache(grouped_local_block_ids, tp_num_need_pulls, need_cat_cache, need_nz_cache)
+                self.reformat_kv_cache(
+                    reformat_block_ids,
+                    num_group_pulls,
+                    need_cat_cache,
+                    need_nz_cache,
+                    group_kv_caches,
+                )
 
-    def reformat_kv_cache_with_fused_op(self, block_ids: list[list[int]], tp_num_need_pulls: int):
+    @torch.no_grad()
+    def reformat_kv_cache_hybrid_linear_torch(
+        self, block_ids: list[list[int]], tp_num_need_pulls: int, group_kv_caches
+    ):
+        flat_block_ids = [item for sublist in block_ids for item in sublist]
+        if not flat_block_ids or tp_num_need_pulls == 1:
+            return
+        device = list(self.kv_caches.values())[0][0].device
+        block_ids_tensor = torch.tensor(flat_block_ids, dtype=torch.long, device=device)
+        num_blocks = block_ids_tensor.numel()
+
+        def _transpose_cache_by_block(cache: torch.Tensor):
+            # The transferred cache is laid out as
+            # [block, split, token, head_per_split, dim]. Restore it to
+            # [block, token, split, head_per_split, dim] in the selected blocks.
+            selected = cache.index_select(0, block_ids_tensor)
+            transposed = (
+                selected.reshape(num_blocks, tp_num_need_pulls, 128, -1)  # TODO
+                .transpose(1, 2)
+                .contiguous()
+                .reshape_as(selected)
+            )
+            cache.index_copy_(0, block_ids_tensor, transposed)
+
+        for _, (k_cache_layer, v_cache_layer) in group_kv_caches.items():
+            _transpose_cache_by_block(k_cache_layer)
+            _transpose_cache_by_block(v_cache_layer)
+
+    def _append_mamba_transfer_meta(
+        self,
+        src_list: list[int],
+        dst_list: list[int],
+        length_list: list[int],
+        group_spec: dict[str, Any],
+        src_layer_base_addr: list[int],
+        dst_layer_base_addr: list[int],
+        block_len: list[int],
+        remote_block_id: int,
+        local_block_id: int,
+        tp_num_need_pulls: int,
+        remote_tp_offset: int,
+    ) -> None:
+        remote_tp_size = self.tp_size * tp_num_need_pulls
+        assert remote_tp_size >= self.tp_size, "Mamba prefill TP size must be >= decode TP size."
+        assert remote_tp_size % self.tp_size == 0, "Mamba prefill TP size must be divisible by decode TP size."
+
+        remote_conv_addr, remote_ssm_addr = dst_layer_base_addr[:2]
+        local_conv_addr, local_ssm_addr = src_layer_base_addr[:2]
+        local_conv_len, local_ssm_len = block_len[:2]
+
+        tp_ratio = tp_num_need_pulls
+        remote_conv_len = local_conv_len // tp_ratio
+        remote_ssm_len = local_ssm_len // tp_ratio
+
+        if tp_ratio == 1:
+            src_list.extend(
+                [
+                    local_conv_addr + local_block_id * local_conv_len,
+                    local_ssm_addr + local_block_id * local_ssm_len,
+                ]
+            )
+            dst_list.extend(
+                [
+                    remote_conv_addr + remote_block_id * remote_conv_len,
+                    remote_ssm_addr + remote_block_id * remote_ssm_len,
+                ]
+            )
+            length_list.extend([remote_conv_len, remote_ssm_len])
+            return
+
+        conv_shape = group_spec["shapes"][0]
+        conv_dtype_size = group_spec["dtype_sizes"][0]
+
+        linear_key_head_dim = self.vllm_config.model_config.hf_text_config.linear_key_head_dim
+        linear_num_key_heads = self.vllm_config.model_config.hf_text_config.linear_num_key_heads
+        linear_value_head_dim = self.vllm_config.model_config.hf_text_config.linear_value_head_dim
+        linear_num_value_heads = self.vllm_config.model_config.hf_text_config.linear_num_value_heads
+        remote_num_key_heads = linear_num_key_heads // remote_tp_size
+        remote_num_value_heads = linear_num_value_heads // remote_tp_size
+        remote_conv_width = (
+            remote_num_key_heads * 2 * linear_key_head_dim + remote_num_value_heads * linear_value_head_dim
+        )
+        remote_conv_offsets = [
+            0,
+            remote_num_key_heads * linear_key_head_dim,
+            remote_num_key_heads * 2 * linear_key_head_dim,
+        ]
+        remote_conv_sizes = [
+            remote_num_key_heads * linear_key_head_dim,
+            remote_num_key_heads * linear_key_head_dim,
+            remote_num_value_heads * linear_value_head_dim,
+        ]
+
+        for i in range(conv_shape[0]):
+            for remote_conv_offset, remote_conv_size in zip(remote_conv_offsets, remote_conv_sizes):
+                remote_addr_offset = (i * remote_conv_width + remote_conv_offset) * conv_dtype_size
+                local_addr_offset = (
+                    (i * remote_conv_width + remote_conv_offset) * tp_ratio + remote_tp_offset * remote_conv_size
+                ) * conv_dtype_size
+                src_list.append(local_conv_addr + local_block_id * local_conv_len + local_addr_offset)
+                dst_list.append(remote_conv_addr + remote_block_id * remote_conv_len + remote_addr_offset)
+                length_list.append(remote_conv_size * conv_dtype_size)
+
+        src_list.append(
+            local_ssm_addr + local_block_id * local_ssm_len + remote_tp_offset * local_ssm_len // tp_num_need_pulls
+        )
+        dst_list.append(remote_ssm_addr + remote_block_id * remote_ssm_len)
+        length_list.append(remote_ssm_len)
+
+    def _get_group_kv_caches(self, group_idx: int, layer_indices: list[int] | None = None) -> dict[str, Any]:
+        if layer_indices is None:
+            _, layer_indices = self.kv_group2layeridx[group_idx]
+        layer_index_set = set(layer_indices)
+        num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
+        from vllm.v1.worker.utils import extract_layer_index
+
+        def layer_in_group(layer_name: str) -> bool:
+            if "mtp" in layer_name:
+                return any(layer_idx >= self.num_layers for layer_idx in layer_index_set)
+            return extract_layer_index(layer_name, num_attn_module) in layer_index_set
+
+        return {
+            layer_name: layer_cache for layer_name, layer_cache in self.kv_caches.items() if layer_in_group(layer_name)
+        }
+
+    def reformat_kv_cache_with_fused_op(
+        self,
+        block_ids: list[list[int]],
+        tp_num_need_pulls: int,
+        kv_caches: dict[str, Any] | None = None,
+    ):
+        if kv_caches is None:
+            kv_caches = self.kv_caches
         # Get necessary parameters
-        k_cache = list(self.kv_caches.values())[0][0]
+        k_cache = list(kv_caches.values())[0][0]
         device = k_cache.device
         head_dim = self.model_config.hf_text_config.head_dim
         block_size = self.vllm_config.cache_config.block_size
         num_kv_head = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
-        layers = len(self.kv_caches)
+        layers = len(kv_caches)
         flat_block_ids = [item for sublist in block_ids for item in sublist]
         block_ids_tensor = torch.tensor(flat_block_ids, dtype=torch.int64, device=device)
 
         k_caches = []
         v_caches = []
-        for _, (k_cache_layer, v_cache_layer) in self.kv_caches.items():
+        for _, (k_cache_layer, v_cache_layer) in kv_caches.items():
             k_caches.append(k_cache_layer)
             v_caches.append(v_cache_layer)
 
@@ -656,9 +943,12 @@ class KVCacheRecvingThread(threading.Thread):
         tp_num_need_pulls: int,
         need_cat_cache: bool = False,
         need_nz_cache: bool = False,
+        kv_caches: dict[str, Any] | None = None,
     ):
+        if kv_caches is None:
+            kv_caches = self.kv_caches
         # Get necessary parameters
-        k_cache = list(self.kv_caches.values())[0][0]
+        k_cache = list(kv_caches.values())[0][0]
         dtype = k_cache.dtype
         device = k_cache.device
 
@@ -688,7 +978,7 @@ class KVCacheRecvingThread(threading.Thread):
         torch.npu.synchronize()
 
         # Process each layer in the KV cache
-        for _, (k_cache_layer, v_cache_layer) in self.kv_caches.items():
+        for _, (k_cache_layer, v_cache_layer) in kv_caches.items():
             # Load cache data into buffers
             torch_npu.atb.npu_paged_cache_load(
                 k_cache_layer,
@@ -754,8 +1044,16 @@ class KVCacheRecvingThread(threading.Thread):
             assert engine_id != self.local_engine_id, (
                 f"Conflict engine id {engine_id} with local engine id {self.local_engine_id}."
             )
+            if agent_meta.kv_group2layeridx != self.kv_group2layeridx:
+                logger.warning(
+                    "Remote kv_group2layeridx is inconsistent with local kv_group2layeridx. remote=%s, local=%s",
+                    agent_meta.kv_group2layeridx,
+                    self.kv_group2layeridx,
+                )
+            self.remote_kv_group2layeridx[engine_id][remote_handshake_port] = agent_meta.kv_group2layeridx
             self.kv_caches_base_addr[engine_id][remote_handshake_port] = agent_meta.kv_caches_base_addr
             self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
+            self.remote_block_size_scale[engine_id][remote_handshake_port] = agent_meta.block_size_scale
         finally:
             if sock is not None:
                 self._return_remote_socket(sock, remote_host, remote_handshake_port)
@@ -838,7 +1136,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
     def add_new_req(
         self,
         request_id: str,
-        local_block_ids: list[int],
+        local_block_ids: BlockIds,
         num_external_tokens: int,
         kv_transfer_params: dict[str, Any],
     ):
@@ -858,7 +1156,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         )
 
 
-class MooncakeConnector(KVConnectorBase_V1):
+class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole, kv_cache_config: KVCacheConfig | None = None):
         assert vllm_config.kv_transfer_config is not None
         self.engine_id = vllm_config.kv_transfer_config.engine_id
@@ -866,12 +1164,12 @@ class MooncakeConnector(KVConnectorBase_V1):
 
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler: MooncakeConnectorScheduler | None = MooncakeConnectorScheduler(
-                vllm_config, str(self.engine_id)
+                vllm_config, str(self.engine_id), kv_cache_config
             )
             self.connector_worker: MooncakeConnectorWorker | None = None
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
-            self.connector_worker = MooncakeConnectorWorker(vllm_config, str(self.engine_id))
+            self.connector_worker = MooncakeConnectorWorker(vllm_config, str(self.engine_id), kv_cache_config)
 
     ############################################################
     # Scheduler Side Methods
@@ -896,6 +1194,14 @@ class MooncakeConnector(KVConnectorBase_V1):
         self,
         request: "Request",
         block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, (block_ids,))
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
@@ -963,8 +1269,9 @@ class MooncakeConnector(KVConnectorBase_V1):
 class MooncakeConnectorScheduler:
     """Implementation of Scheduler side methods"""
 
-    def __init__(self, vllm_config: VllmConfig, engine_id: str):
+    def __init__(self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: KVCacheConfig):
         self.vllm_config = vllm_config
+        self.kv_cache_config = kv_cache_config
         init_ascend_config(vllm_config)
         self.ascend_config = get_ascend_config()
         self.block_size = vllm_config.cache_config.block_size
@@ -994,12 +1301,13 @@ class MooncakeConnectorScheduler:
         # Requests that need to start recv.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[str, tuple[Request, list[int], int]] = {}
+        self._reqs_need_recv: dict[str, tuple[Request, BlockIds, int]] = {}
         self._reqs_need_send: dict[str, float] = {}
         self._reqs_in_batch: set[str] = set()
 
         # master-slave meta information for cross-nodes
         self.multi_nodes_meta_mapping: dict[str, dict[str, Any]] = {}
+        self.kv_cache_groups = kv_cache_config.kv_cache_groups
 
     def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int) -> tuple[int, bool]:
         """
@@ -1047,7 +1355,7 @@ class MooncakeConnectorScheduler:
         if params is not None and params.get("do_remote_prefill"):
             if params.get("remote_block_ids"):
                 if all(p in params for p in ("remote_engine_id", "remote_host", "remote_port", "remote_request_id")):
-                    local_block_ids = blocks.get_unhashed_block_ids() if num_external_tokens > 0 else []
+                    local_block_ids = blocks.get_unhashed_block_ids_all_groups() if num_external_tokens > 0 else []
                     # Get unhashed blocks to pull from remote.
                     self._reqs_need_recv[request.request_id] = (request, local_block_ids, num_external_tokens)
                 else:
@@ -1088,7 +1396,7 @@ class MooncakeConnectorScheduler:
     def request_finished(
         self,
         request: "Request",
-        block_ids: list[int],
+        block_ids: BlockIds,
     ) -> tuple[bool, dict[str, Any] | None]:
         """
         Once a request is finished, determine whether request blocks
@@ -1108,12 +1416,19 @@ class MooncakeConnectorScheduler:
             return False, None
 
         computed_block_ids = block_ids
-        delay_free_blocks = len(computed_block_ids) > 0
+        computed_block_lens = [len(block_id_list) for block_id_list in computed_block_ids]
+        delay_free_blocks = sum(computed_block_lens) > 0
         if delay_free_blocks:
             logger.info("Delaying free of %d blocks for request %s", len(computed_block_ids), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
+        computed_block_ids = tuple(
+            block_ids[:num_prompt_blocks]
+            if not isinstance(self.kv_cache_groups[i].kv_cache_spec, MambaSpec)
+            else block_ids
+            for i, block_ids in enumerate(computed_block_ids)
+        )
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,
@@ -1148,7 +1463,7 @@ class MooncakeConnectorScheduler:
 class MooncakeConnectorWorker:
     """Implementation of Worker side methods"""
 
-    def __init__(self, vllm_config: VllmConfig, engine_id: str):
+    def __init__(self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: KVCacheConfig):
         self._get_prefill_decode_size(vllm_config)
         os.environ["ASCEND_TRANSFER_TIMEOUT"] = str(get_transfer_timeout_value())
         if self._prefill_tp_size < self._decode_tp_size:
@@ -1171,6 +1486,7 @@ class MooncakeConnectorWorker:
         self.kv_caches: dict[str, torch.Tensor] = {}
         self.side_channel_host = get_ip()
         self.pcp_size = get_pcp_group().world_size
+        self.total_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
         # Assert that pp_size and pcp_size cannot both be greater than 1
         assert not (self.pp_size > 1 and self.pcp_size > 1), "pp and pcp cannot open in same time"
         self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
@@ -1180,6 +1496,15 @@ class MooncakeConnectorWorker:
         self.max_device_id = self.tp_size * self.dp_size * self.pcp_size * self.pp_size
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.num_key_value_heads = self.vllm_config.model_config.hf_text_config.num_key_value_heads
+
+        # kv cache config
+        self.kv_cache_config = kv_cache_config
+        self._is_hma_required = not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager and any(
+            not isinstance(g.kv_cache_spec, FullAttentionSpec) for g in kv_cache_config.kv_cache_groups
+        )
+        self._layer_specs = {
+            layer: group.kv_cache_spec for group in kv_cache_config.kv_cache_groups for layer in group.layer_names
+        }
 
         # Handshake base port
         self.side_channel_port = (
@@ -1236,63 +1561,182 @@ class MooncakeConnectorWorker:
         assert self._decode_pp_size == 1, "decode pp size must be 1"
         self._prefill_pp_layer_partition = prefill_parallel_config.get("pp_layer_partition")
 
+    @staticmethod
+    def _serialize_kv_group_spec(group_spec: Any) -> dict[str, Any]:
+        def to_msgpackable(value: Any) -> Any:
+            if value is None or isinstance(value, (str, int, float, bool)):
+                return value
+            if isinstance(value, dict):
+                return {str(k): to_msgpackable(v) for k, v in value.items()}
+            if isinstance(value, (list, tuple)):
+                return [to_msgpackable(item) for item in value]
+            try:
+                builtins_value = msgspec.to_builtins(value)
+                if builtins_value is value:
+                    return repr(value)
+                return to_msgpackable(builtins_value)
+            except TypeError:
+                return repr(value)
+
+        kv_cache_spec = group_spec.kv_cache_spec
+        spec = kv_cache_spec
+        if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+            spec = kv_cache_spec.kv_cache_specs
+        serialized = {
+            "layer_names": list(group_spec.layer_names),
+            "kv_cache_spec_type": type(kv_cache_spec).__name__,
+            "kv_cache_spec": to_msgpackable(spec),
+        }
+        if isinstance(kv_cache_spec, MambaSpec):
+            serialized["shapes"] = [list(shape) for shape in kv_cache_spec.shapes]
+            serialized["dtype_sizes"] = [
+                torch.tensor([], dtype=dtype).element_size()
+                for dtype in kv_cache_spec.dtypes  # type: ignore[misc]
+            ]
+        return serialized
+
+    def _build_kv_group2layeridx(self) -> dict[int, tuple[dict[str, Any], list[int]]]:
+        from vllm.v1.worker.utils import extract_layer_index
+
+        kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] = {}
+        num_attn_module = 2 if self.vllm_config.model_config.hf_text_config.model_type == "longcat_flash" else 1
+        next_mtp_layer_idx = self.total_layers
+        for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
+            layer_indices = []
+            for layer_name in group_spec.layer_names:
+                if "mtp" in layer_name:
+                    layer_idx = next_mtp_layer_idx
+                    next_mtp_layer_idx += 1
+                else:
+                    layer_idx = extract_layer_index(layer_name, num_attn_module)
+                layer_indices.append(layer_idx)
+            kv_group2layeridx[group_id] = (self._serialize_kv_group_spec(group_spec), layer_indices)
+        return kv_group2layeridx
+
+    def _has_mamba_group(self) -> bool:
+        return any(group_spec["kv_cache_spec_type"] == "MambaSpec" for group_spec, _ in self.kv_group2layeridx.values())
+
+    @staticmethod
+    def _as_kv_cache_tuple(kv_cache_tuple: Any) -> list[torch.Tensor]:
+        if isinstance(kv_cache_tuple, (list, tuple)):
+            return list(kv_cache_tuple)
+        return [kv_cache_tuple]
+
+    def _get_layer_spec(self, layer_name: str) -> Any:
+        layer_spec = self._layer_specs[layer_name]
+        if isinstance(layer_spec, UniformTypeKVCacheSpecs):
+            layer_spec = layer_spec.kv_cache_specs[layer_name]
+        return layer_spec
+
+    def _get_mamba_conv_padding(self, layer_spec: Any) -> int:
+        if not isinstance(layer_spec, MambaSpec):
+            return 0
+        conv_nbytes = torch.tensor([], dtype=layer_spec.dtypes[0]).element_size()  # type: ignore[misc]
+        conv_shape = torch.Size(layer_spec.shapes[0])
+        return self.num_blocks * conv_shape.numel() * conv_nbytes
+
+    def _get_registered_kv_tensor_buffers(self, kv_caches: dict[str, torch.Tensor]) -> tuple[list[int], list[int]]:
+        ptrs: list[int] = []
+        lengths: list[int] = []
+
+        for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
+            shared_addrs: list[int] = []
+            conv_padding = 0
+            has_mtp = False
+            for layer_name in kv_cache_tensor.shared_by:
+                has_mtp = has_mtp or "mtp" in layer_name
+                layer_spec = self._get_layer_spec(layer_name)
+                conv_padding = max(conv_padding, self._get_mamba_conv_padding(layer_spec))
+                for single_kv_cache in self._as_kv_cache_tuple(kv_caches[layer_name]):
+                    shared_addrs.append(single_kv_cache.data_ptr())
+
+            if not shared_addrs:
+                continue
+            base_addr = min(shared_addrs)
+            if has_mtp:
+                base_addr -= conv_padding
+            ptrs.append(base_addr)
+            lengths.append(kv_cache_tensor.size)
+
+        return ptrs, lengths
+
+    def _get_registered_layer_buffers(self, kv_caches: dict[str, torch.Tensor]) -> tuple[list[int], list[int]]:
+        ptrs: list[int] = []
+        lengths: list[int] = []
+
+        for kv_cache_tuple in kv_caches.values():
+            for single_kv_cache in self._as_kv_cache_tuple(kv_cache_tuple):
+                ptrs.append(single_kv_cache.data_ptr())
+                lengths.append(single_kv_cache.element_size() * math.prod(single_kv_cache.shape))
+
+        return ptrs, lengths
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data."""
+        self.use_mla = self.vllm_config.model_config.is_deepseek_mla
+        self.use_sparse = hasattr(self.vllm_config.model_config.hf_text_config, "index_topk")
 
-        _, first_kv_cache_tuple = next(iter(kv_caches.items()))
-        first_kv_cache = first_kv_cache_tuple[0]
-
-        # TODO(tms): Find a more robust way to detect and handle MLA
-        self.use_mla = (
-            first_kv_cache_tuple[0].size(-1) != first_kv_cache_tuple[1].size(-1) and len(first_kv_cache_tuple) == 2
-        )
-        self.use_sparse = len(first_kv_cache_tuple) == 3
-
-        self.num_blocks = first_kv_cache.shape[0]
+        self.num_blocks = self.kv_cache_config.num_blocks
         logger.info("num_blocks: %s", self.num_blocks)
-        self.block_len = []
-        if self.use_mla or self.use_sparse:
-            block_rank = 3  # [block_size, latent_dim]
-            for i in range(len(first_kv_cache_tuple)):
-                block_shape = first_kv_cache_tuple[i].shape[-block_rank:]
-                logger.info("block_shape: %s", block_shape)
-                self.block_len.append(first_kv_cache_tuple[i].element_size() * math.prod(block_shape))
-        else:
-            # eager:[num_block, block_size, num_head, hidden_dim]
-            block_rank = (
-                len(first_kv_cache.shape) - 1
-            )  # [block_size, kv_heads, head_dim] or [block_size, kv_heads*head_dim]
-            block_shape = first_kv_cache.shape[-block_rank:]
-            logger.info("block_shape: %s", block_shape)
-            self.block_len = [first_kv_cache.element_size() * math.prod(block_shape)]
-
-        logger.info(
-            "Registering KV_Caches. use_mla: %s, use_sparse: %s, shape %s",
-            self.use_mla,
-            self.use_sparse,
-            first_kv_cache.shape,
-        )
-
         self.kv_caches = kv_caches
-        kv_caches_base_addr = []
-        ptrs = []
-        lengths = []
-        length = len(self.block_len)
-        for cache_or_caches in kv_caches.values():
-            # Normalize to always be a list of caches
-            for i, cache in enumerate(cache_or_caches, 0):
-                base_addr = cache.data_ptr()
-                region_len = self.num_blocks * self.block_len[i % length]
-                kv_caches_base_addr.append(base_addr)
-                ptrs.append(base_addr)
-                lengths.append(region_len)
+        # Maps each KV cache group to its serialized group spec and physical
+        # layer indices: {group_id: (group_spec, [layer_idx0, layer_idx1, ...])}.
+        self.kv_group2layeridx = self._build_kv_group2layeridx()
+        has_mamba_group = self._has_mamba_group()
+        if has_mamba_group:
+            assert self.pcp_size * self.dcp_size == 1
+        layer_name_to_idx = {
+            layer_name: layer_idx
+            for _, (group_spec, layer_indices) in self.kv_group2layeridx.items()
+            for layer_name, layer_idx in zip(group_spec["layer_names"], layer_indices)
+        }
+        metadata_layers = max(layer_name_to_idx.values(), default=-1) + 1
+        # Per-layer registered KV cache base addresses:
+        # [layer_idx][cache_idx] -> data_ptr of one cache tensor, e.g. K/V.
+        self.kv_caches_base_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
+        # Per-layer block scaling between logical KV blocks and tensor blocks:
+        # [layer_idx][cache_idx] -> cache tensor num_blocks / logical num_blocks.
+        self.block_size_scale: list[list[int]] = [[] for _ in range(metadata_layers)]
+        # Per-layer byte length of one tensor block:
+        # [layer_idx][cache_idx] -> element_size * prod(block_shape).
+        self.block_len_per_addr: list[list[int]] = [[] for _ in range(metadata_layers)]
+
+        for layer_name, kv_cache_tuple in kv_caches.items():
+            layer_idx = layer_name_to_idx[layer_name]
+            for single_kv_cache in self._as_kv_cache_tuple(kv_cache_tuple):
+                tensor_num_blocks = single_kv_cache.shape[0]
+                block_size_scale = tensor_num_blocks // self.num_blocks
+                block_shape = single_kv_cache.shape[1:]
+                self.block_len_per_addr[layer_idx].append(single_kv_cache.element_size() * math.prod(block_shape))
+                self.block_size_scale[layer_idx].append(block_size_scale)
+                self.kv_caches_base_addr[layer_idx].append(single_kv_cache.data_ptr())
+
+        if has_mamba_group:
+            ptrs, lengths = self._get_registered_kv_tensor_buffers(kv_caches)
+        else:
+            ptrs, lengths = self._get_registered_layer_buffers(kv_caches)
+
         global_te.register_buffer(ptrs, lengths)
+        logger.debug(
+            "Mooncake register kv caches metadata: kv_group2layeridx=%s, kv_caches_base_addr=%s, "
+            "block_len_per_addr=%s, block_size_scale=%s, ptrs=%s, lengths=%s",
+            self.kv_group2layeridx,
+            self.kv_caches_base_addr,
+            self.block_len_per_addr,
+            self.block_size_scale,
+            ptrs,
+            lengths,
+        )
         # After KV Caches registered, start the sending or receiving thread.
         metadata = MooncakeAgentMetadata(
             engine_id=self.engine_id,
             te_rpc_port=self.te_rpc_port,
-            kv_caches_base_addr=kv_caches_base_addr,
+            kv_group2layeridx=self.kv_group2layeridx,
+            block_size=self.block_size,
+            kv_caches_base_addr=self.kv_caches_base_addr,
+            block_size_scale=self.block_size_scale,
             num_blocks=self.num_blocks,
+            block_lens=self.block_len_per_addr,
             local_ip=get_ip(),
         )
         self.xfer_handshake_metadata = metadata
@@ -1321,15 +1765,17 @@ class MooncakeConnectorWorker:
                 self.engine_id,
                 self.handshake_port,
                 self.side_channel_port,
-                kv_caches_base_addr,
-                self.block_len,
+                self.kv_caches_base_addr,
+                self.block_len_per_addr,
+                self._is_hma_required,
                 ready_event,
                 self.vllm_config,
                 self.kv_caches,
                 self._prefill_pp_layer_partition,
+                self.kv_group2layeridx,
+                self.block_size_scale,
             )
             self.kv_recv_thread.start()
-
         start_wait_time = time.time()
         thread = self.kv_send_thread if self.kv_role == "kv_producer" else self.kv_recv_thread
         assert thread is not None
@@ -1371,17 +1817,46 @@ class MooncakeConnectorWorker:
         self,
         req_id: str,
         meta: ReqMeta,
-    ) -> tuple[list[list[int]], list[list[int]], list[list[int]]]:
-        """
-        In cp/dcp scenario, kv_cache may be split, so we need to pull multiple blocks from multiple remote P node.
-        Use this function to calculate remote port and remote block number of each remote P node that we need to pull.
+    ) -> tuple[list[list[int]], list[BlockIds], list[BlockIds]]:
+        """Build per-transfer port and block-id metadata for remote KV reads.
+
+        Args:
+            req_id: Remote request id used as the stable hash key when choosing
+                prefill TP ranks.
+            meta: Request-level transfer metadata from the scheduler. It
+                contains remote/local block ids, remote P-side port base,
+                remote P-side PCP/DCP/PTP sizes, and prompt/prefix-cache
+                token counts.
+
+        Returns:
+            A tuple of three aligned lists. Index ``i`` describes one transfer
+            shard for this local D-side rank:
+            * remote_handshake_port_list[i]: remote P worker handshake ports
+              to pull from. The inner list length is the number of TP pulls
+              needed for that shard.
+            * local_block_ids_list[i]: local block ids, grouped by KV cache
+              group, where received blocks are written.
+            * remote_block_ids_list[i]: remote block ids, grouped by KV cache
+              group, where blocks are read from.
+
+        In PCP/DCP scenarios, prompt blocks can be split across multiple remote
+        P workers. This method also accounts for unequal P/D prefix-cache hits
+        by reducing the number of remote blocks that still need to be pulled.
         """
         prefill_tp_size = meta.remote_ptp_size if getattr(meta, "remote_ptp_size", None) else self._prefill_tp_size
+
         if meta.remote_pcp_size * meta.remote_dcp_size * self.pcp_size * self.dcp_size == 1:
-            chosen_rank_list = self._get_remote_rank(req_id, prefill_tp_size)
+            if self._is_hma_required:
+                chosen_rank_list, _ = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
+            else:
+                chosen_rank_list = self._get_remote_rank(req_id, prefill_tp_size)
             remote_handshake_port_list = [[x + meta.remote_port for x in chosen_rank_list]]
-            local_block_ids_list, remote_block_ids_list = [meta.local_block_ids], [meta.remote_block_ids]
+            local_block_ids_list = [meta.local_block_ids for _ in remote_handshake_port_list]
+            remote_block_ids_list = [meta.remote_block_ids for _ in remote_handshake_port_list]
             return remote_handshake_port_list, local_block_ids_list, remote_block_ids_list
+
+        if self._is_hma_required:
+            raise NotImplementedError("Hybrid KV transfer only supports pcp*dcp == 1 for now.")
 
         def context_parallel_parameters_check():
             assert (meta.remote_pcp_size * meta.remote_dcp_size) % (self.pcp_size * self.dcp_size) == 0
@@ -1510,9 +1985,9 @@ class MooncakeConnectorWorker:
 
         num_external_blocks = math.ceil(meta.num_external_tokens / self.block_size)
 
-        assert math.ceil(num_external_blocks / (self.pcp_size * self.dcp_size)) == len(meta.local_block_ids), (
+        assert math.ceil(num_external_blocks / (self.pcp_size * self.dcp_size)) == len(meta.local_block_ids[0]), (
             f"num_external_blocks({num_external_blocks}), cp_size({self.pcp_size * self.dcp_size}), "
-            f"local_block_ids_len ({len(meta.local_block_ids)})"
+            f"local_block_ids_len ({len(meta.local_block_ids[0])})"
         )
         assert meta.num_prompt_blocks >= num_external_blocks, (
             f"meta.num_prompt_blocks({meta.num_prompt_blocks}), num_external_blocks({num_external_blocks})"
@@ -1565,9 +2040,9 @@ class MooncakeConnectorWorker:
         local_block_offset = 0
         for remote_kv_id in range(len(remote_handshake_port_list)):
             num_blocks_to_pull = remote_block_nums[remote_kv_id]
-            remote_block_ids_list.append(meta.remote_block_ids[:num_blocks_to_pull])
+            remote_block_ids_list.append([meta.remote_block_ids[0][:num_blocks_to_pull]])
             local_block_ids_list.append(
-                meta.local_block_ids[local_block_offset : local_block_offset + num_blocks_to_pull]
+                [meta.local_block_ids[0][local_block_offset : local_block_offset + num_blocks_to_pull]]
             )
             local_block_offset += num_blocks_to_pull
 
@@ -1578,8 +2053,164 @@ class MooncakeConnectorWorker:
 
         return remote_handshake_port_list, local_block_ids_list, remote_block_ids_list
 
+    def _get_group_pulls_metadata(
+        self,
+        req_id: str,
+        remote_handshake_port_list: list[list[int]],
+        prefill_tp_size: int,
+        remote_base_port: int,
+    ) -> list[list[list[GroupPull]]]:
+        """Build per-port KV cache group pull descriptors.
+
+        Args:
+            req_id: Remote request id used to reproduce hybrid-attention rank
+                selection for the same request.
+            remote_handshake_port_list: Output from ``_get_kv_split_metadata``.
+                Each outer item is one transfer shard; each inner item is a
+                remote P worker handshake port.
+            prefill_tp_size: Effective remote prefill TP size. This may come
+                from ``meta.remote_ptp_size`` when P and D use different TP
+                sizes.
+            remote_base_port: Remote P-side handshake base port. A remote
+                worker rank is ``remote_handshake_port - remote_base_port``.
+
+        Returns:
+            A three-level list aligned with ``remote_handshake_port_list``:
+            ``result[shard_idx][remote_port_idx]`` is the list of ``GroupPull``
+            entries for that remote port. Each ``GroupPull`` identifies the KV
+            cache group, the remote TP offset to read, the number of pulls
+            needed to assemble that group, the prefill PP rank, and whether
+            this pull is the final pull for the group. The final-pull flag is
+            used by the receiver to decide when group reformatting can run.
+        """
+        if self._is_hma_required:
+            _, rank_group_pulls = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
+            return [
+                [rank_group_pulls[remote_handshake_port - remote_base_port] for remote_handshake_port in remote_ports]
+                for remote_ports in remote_handshake_port_list
+            ]
+
+        tp_num_need_pulls = self._get_tp_num_need_pulls(prefill_tp_size)
+        group_ids = [group_id for group_id, (_, layer_indices) in self.kv_group2layeridx.items() if layer_indices]
+
+        def make_group_pulls(remote_tp_offset: int, prefill_pp_rank: int) -> list[GroupPull]:
+            return [
+                GroupPull(
+                    group_id=group_id,
+                    remote_tp_offset=remote_tp_offset,
+                    num_group_pulls=tp_num_need_pulls,
+                    prefill_pp_rank=prefill_pp_rank,
+                    is_group_transfer_end=remote_tp_offset == tp_num_need_pulls - 1,
+                )
+                for group_id in group_ids
+            ]
+
+        group_pulls_list = []
+        for pcp_dcp_rank, remote_ports in enumerate(remote_handshake_port_list):
+            if len(remote_ports) == 1:
+                remote_tp_offsets = [pcp_dcp_rank % tp_num_need_pulls]
+                prefill_pp_ranks = [
+                    ((remote_ports[0] - remote_base_port) % (prefill_tp_size * self._prefill_pp_size))
+                    // prefill_tp_size
+                ]
+            else:
+                assert len(remote_ports) % tp_num_need_pulls == 0, (
+                    f"tp_num_need_pulls: {tp_num_need_pulls}, remote_ports: {remote_ports}"
+                )
+                remote_tp_offsets = [rank_idx % tp_num_need_pulls for rank_idx in range(len(remote_ports))]
+                prefill_pp_ranks = [
+                    ((remote_port - remote_base_port) % (prefill_tp_size * self._prefill_pp_size)) // prefill_tp_size
+                    for remote_port in remote_ports
+                ]
+            group_pulls_list.append(
+                [
+                    make_group_pulls(remote_tp_offset, prefill_pp_rank)
+                    for remote_tp_offset, prefill_pp_rank in zip(remote_tp_offsets, prefill_pp_ranks)
+                ]
+            )
+        return group_pulls_list
+
+    def _get_hybrid_remote_rank_group_pulls(
+        self,
+        req_id: str,
+        prefill_tp_size: int,
+    ) -> tuple[list[int], dict[int, list[GroupPull]]]:
+        rank_group_pulls: OrderedDict[int, list[GroupPull]] = OrderedDict()
+
+        def add_group_pull(remote_rank: int, group_pull: GroupPull) -> None:
+            rank_group_pulls.setdefault(remote_rank, []).append(group_pull)
+
+        for group_id, (group_spec, layer_indices) in self.kv_group2layeridx.items():
+            if not layer_indices:
+                continue
+
+            if group_spec["kv_cache_spec_type"] == "MambaSpec":
+                assert prefill_tp_size % self.tp_size == 0, (
+                    f"Hybrid Mamba prefill tp size({prefill_tp_size}) must be divisible by "
+                    f"decode tp size({self.tp_size})."
+                )
+                num_group_pulls = prefill_tp_size // self.tp_size
+                for pp_rank in range(self._prefill_pp_size):
+                    pp_rank_offset = pp_rank * prefill_tp_size
+                    local_tp_offset = self.tp_rank * num_group_pulls
+                    for remote_tp_offset in range(num_group_pulls):
+                        remote_rank = pp_rank_offset + local_tp_offset + remote_tp_offset
+                        add_group_pull(
+                            remote_rank,
+                            GroupPull(
+                                group_id=group_id,
+                                remote_tp_offset=remote_tp_offset,
+                                num_group_pulls=num_group_pulls,
+                                prefill_pp_rank=pp_rank,
+                                is_group_transfer_end=remote_tp_offset == num_group_pulls - 1,
+                            ),
+                        )
+                continue
+
+            num_group_pulls = self._get_attention_group_num_need_pulls(group_spec, prefill_tp_size)
+            chosen_rank_list = self._get_remote_rank(req_id, prefill_tp_size)
+            assert len(chosen_rank_list) == num_group_pulls * self._prefill_pp_size, (
+                f"chosen_rank_list({chosen_rank_list}) does not match num_group_pulls({num_group_pulls}) "
+                f"and prefill pp size({self._prefill_pp_size})."
+            )
+            for rank_idx, remote_rank in enumerate(chosen_rank_list):
+                prefill_pp_rank = rank_idx // num_group_pulls
+                add_group_pull(
+                    remote_rank,
+                    GroupPull(
+                        group_id=group_id,
+                        remote_tp_offset=rank_idx % num_group_pulls,
+                        num_group_pulls=num_group_pulls,
+                        prefill_pp_rank=prefill_pp_rank,
+                        is_group_transfer_end=rank_idx % num_group_pulls == num_group_pulls - 1,
+                    ),
+                )
+
+        return list(rank_group_pulls), dict(rank_group_pulls)
+
+    def _get_attention_group_num_need_pulls(self, group_spec: dict[str, Any], prefill_tp_size: int) -> int:
+        num_key_value_heads = self._get_attention_group_num_key_value_heads(group_spec)
+        num_d_block_heads = max(1, num_key_value_heads // self.tp_size)
+        num_p_block_heads = max(1, num_key_value_heads // prefill_tp_size)
+        return num_d_block_heads // num_p_block_heads
+
+    def _get_attention_group_num_key_value_heads(self, group_spec: dict[str, Any]) -> int:
+        kv_cache_spec = group_spec.get("kv_cache_spec", {})
+        if isinstance(kv_cache_spec, dict):
+            for key in ("num_kv_heads", "num_key_value_heads"):
+                num_key_value_heads = kv_cache_spec.get(key)
+                if isinstance(num_key_value_heads, int):
+                    return num_key_value_heads
+        return self.num_key_value_heads
+
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""
+        for req_id in metadata.reqs_in_batch:
+            if self.kv_send_thread is not None:
+                self.kv_send_thread.task_tracker.add_req_to_process(req_id)
+            if self.kv_recv_thread is not None:
+                self.kv_recv_thread.task_tracker.add_req_to_process(req_id)
+
         for req_id, meta in metadata.requests.items():
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
@@ -1591,70 +2222,51 @@ class MooncakeConnectorWorker:
                     len(meta.remote_block_ids),
                 )
 
-            prefill_tp_size = meta.remote_ptp_size if getattr(meta, "remote_ptp_size", None) else self._prefill_tp_size
-            tp_num_need_pulls = self._get_tp_num_need_pulls(prefill_tp_size)
             remote_req_id = meta.remote_request_id
+            prefill_tp_size = meta.remote_ptp_size if getattr(meta, "remote_ptp_size", None) else self._prefill_tp_size
 
-            if meta.remote_pcp_size * meta.remote_dcp_size > 1:
-                remote_handshake_port_list, local_block_ids_list, remote_block_ids_list = self._get_kv_split_metadata(
-                    req_id, meta
-                )
+            (
+                remote_handshake_port_list,
+                local_block_ids_list,
+                remote_block_ids_list,
+            ) = self._get_kv_split_metadata(remote_req_id, meta)
+            group_pulls_list = self._get_group_pulls_metadata(
+                remote_req_id,
+                remote_handshake_port_list,
+                prefill_tp_size,
+                meta.remote_port,
+            )
 
-                for pcp_dcp_rank in range(len(remote_handshake_port_list)):
-                    for i in range(tp_num_need_pulls):
-                        assert self.kv_recv_thread is not None
-                        remote_host, remote_engine_id = self._get_remote_host_info_by_port(
-                            meta.remote_port,
-                            remote_handshake_port_list[pcp_dcp_rank][i],
-                            meta.remote_host,
-                            meta.remote_engine_id,
-                            meta.remote_multi_nodes_meta_mapping,
-                        )
-                        self.kv_recv_thread.add_request(
-                            request_id=req_id,
-                            remote_request_id=remote_req_id,
-                            local_block_ids=local_block_ids_list[pcp_dcp_rank],
-                            remote_block_ids=remote_block_ids_list[pcp_dcp_rank],
-                            remote_engine_id=remote_engine_id,
-                            remote_host=remote_host,
-                            remote_handshake_port=remote_handshake_port_list[pcp_dcp_rank][i],
-                            offset=i,
-                            tp_num_need_pulls=tp_num_need_pulls,
-                            remote_port_send_num=self.remote_port_send_num[meta.remote_engine_id],
-                            all_task_done=(
-                                pcp_dcp_rank == len(remote_handshake_port_list) - 1 and i == tp_num_need_pulls - 1
-                            ),
-                        )
-            else:  # TODO: support prefill context parallel and pipeline parallel open at the same time
-                chosen_rank_list = self._get_remote_rank(remote_req_id, prefill_tp_size)
-                remote_handshake_port_list = [[x + meta.remote_port] for x in chosen_rank_list]
-                for i in range(tp_num_need_pulls * self._prefill_pp_size):
+            for pcp_dcp_rank, remote_ports in enumerate(remote_handshake_port_list):
+                for remote_tp_offset, remote_handshake_port in enumerate(remote_ports):
                     assert self.kv_recv_thread is not None
                     remote_host, remote_engine_id = self._get_remote_host_info_by_port(
                         meta.remote_port,
-                        remote_handshake_port_list[i][0],
+                        remote_handshake_port,
                         meta.remote_host,
                         meta.remote_engine_id,
                         meta.remote_multi_nodes_meta_mapping,
                     )
+                    remote_port_send_num = (
+                        self.remote_port_send_num[meta.remote_engine_id]
+                        if meta.remote_pcp_size * meta.remote_dcp_size > 1 and not self._has_mamba_group()
+                        else None
+                    )
                     self.kv_recv_thread.add_request(
                         request_id=req_id,
                         remote_request_id=remote_req_id,
-                        local_block_ids=meta.local_block_ids,
-                        remote_block_ids=meta.remote_block_ids,
+                        local_block_ids=local_block_ids_list[pcp_dcp_rank],
+                        remote_block_ids=remote_block_ids_list[pcp_dcp_rank],
+                        group_pulls=group_pulls_list[pcp_dcp_rank][remote_tp_offset],
                         remote_engine_id=remote_engine_id,
                         remote_host=remote_host,
-                        remote_handshake_port=remote_handshake_port_list[i][0],
-                        offset=i,
-                        tp_num_need_pulls=tp_num_need_pulls,
-                        all_task_done=(i == tp_num_need_pulls * self._prefill_pp_size - 1),
+                        remote_handshake_port=remote_handshake_port,
+                        remote_port_send_num=remote_port_send_num,
+                        all_task_done=(
+                            pcp_dcp_rank == len(remote_handshake_port_list) - 1
+                            and remote_tp_offset == len(remote_ports) - 1
+                        ),
                     )
-
-        for req_id in metadata.reqs_in_batch:
-            if self.kv_send_thread is not None:
-                self.kv_send_thread.task_tracker.add_req_to_process(req_id)
-            if self.kv_recv_thread is not None:
-                self.kv_recv_thread.task_tracker.add_req_to_process(req_id)
 
         if self.kv_send_thread is not None and self.pcp_size * self.dcp_size == 1:
             for req_id, delay_start_time in metadata.requests_to_send.items():


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adapts `MooncakeConnector` KV transfer metadata handling for hybrid KV cache layouts.

The core change is to make Mooncake KV transfer operate on KV-cache-group-aware metadata instead of assuming a single uniform attention-only KV layout. In `register_kv_caches`, this PR builds and records per-group/per-layer metadata used by the sender and receiver:

- `self.kv_group2layeridx`: maps each KV cache group to its serialized group spec and physical layer indices, e.g. `{group_id: (group_spec, [layer_idx0, layer_idx1, ...])}`.
- `self.block_size_scale`: stores per-layer cache block scaling, e.g. `[layer_idx][cache_idx] -> cache tensor num_blocks / logical num_blocks`.
- `self.block_len_per_addr`: stores per-layer byte length for each cache tensor block, e.g. `[layer_idx][cache_idx] -> cache block byte length`.
- `self.kv_caches_base_addr`: stores per-layer base addresses for each registered cache tensor, e.g. `[layer_idx][cache_idx] -> data_ptr`.

Based on this metadata, `_get_kv_split_metadata` now prepares transfer splits that can represent hybrid KV cache groups, including non-uniform group layouts. `_get_group_pulls_metadata` then builds per-remote-port group pull descriptors so each transfer task knows which KV cache group, remote TP offset, and prefill PP rank it should pull from.

This allows Mooncake connector to support hybrid KV cache transfer paths while keeping the existing non-hybrid behavior compatible.

### Does this PR introduce _any_ user-facing change?

No user-facing API change.

This changes internal KV transfer metadata construction and scheduling behavior for Mooncake connector, especially for hybrid KV cache layouts.

### How was this patch tested?

- Unit tests added/updated for Mooncake connector metadata split and group pull construction.
- Verified formatting and linting:

```bash
python -m ruff check vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py tests/ut/kv_connector/test_mooncake_connector.py
python -m ruff format --check vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py tests/ut/kv_connector/test_mooncake_connector.py


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
