### PR TITLE
[CI] Add v0.18.0 and vv0.19.1rc1 options to build  and push image

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -31,6 +31,8 @@ on:
         type: choice
         options:
           - main
+          - v0.19.1rc1
+          - v0.18.0
           - v0.18.0rc1
           - v0.17.0rc1
           - v0.16.0rc1

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -33,6 +33,8 @@ on:
         type: choice
         options:
           - main
+          - v0.19.1rc1
+          - v0.18.0
           - v0.18.0rc1
           - v0.17.0rc1
           - v0.16.0rc1


### PR DESCRIPTION
### What this PR does / why we need it?
Add v0.18.0 and vv0.19.1rc1 options to build  and push image

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
