### PR TITLE
[Misc][Main2Main] Upgrade vLLM to 0429(DSV4/v0.20.0)

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -27,7 +27,7 @@ on:
       continue_on_error:
         required: false
         type: boolean
-        default: false
+        default: true
       # The following inputs are used by comment-triggered E2E tests (/e2e <tests>).
       # They carry space-separated pytest paths, categorized by runner type.
       # Leave empty (default) when running label-triggered full/light suites.

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -80,7 +80,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [d886c26d4d4fef7d079696beb4ece1cfb4b008a8, v0.19.1]
+        vllm_version: [856b15c62c8a574a1a0a289444d5b9a8120433e3, v0.19.1]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -80,7 +80,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7, v0.19.1]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -80,7 +80,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [856b15c62c8a574a1a0a289444d5b9a8120433e3, v0.19.1]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7, v0.19.1]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+      vllm: 856b15c62c8a574a1a0a289444d5b9a8120433e3
   changes:
     runs-on: linux-aarch64-a2b3-0
     container:
@@ -154,7 +154,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && needs.changes.outputs.has_tests == 'true' }}
     strategy:
       matrix:
-        vllm_version: [d886c26d4d4fef7d079696beb4ece1cfb4b008a8, v0.19.1]
+        vllm_version: [856b15c62c8a574a1a0a289444d5b9a8120433e3, v0.19.1]
     uses: ./.github/workflows/_optional_smart_e2e.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -164,7 +164,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [d886c26d4d4fef7d079696beb4ece1cfb4b008a8, v0.19.1]
+        vllm_version: [856b15c62c8a574a1a0a289444d5b9a8120433e3, v0.19.1]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -154,7 +154,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && needs.changes.outputs.has_tests == 'true' }}
     strategy:
       matrix:
-        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7, v0.19.1]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7]
     uses: ./.github/workflows/_optional_smart_e2e.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -164,7 +164,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7, v0.19.1]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 856b15c62c8a574a1a0a289444d5b9a8120433e3
+      vllm: 4d51588e2381018348f1022dfa3a7698899805b7
   changes:
     runs-on: linux-aarch64-a2b3-0
     container:
@@ -154,7 +154,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && needs.changes.outputs.has_tests == 'true' }}
     strategy:
       matrix:
-        vllm_version: [856b15c62c8a574a1a0a289444d5b9a8120433e3, v0.19.1]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7, v0.19.1]
     uses: ./.github/workflows/_optional_smart_e2e.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -164,7 +164,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [856b15c62c8a574a1a0a289444d5b9a8120433e3, v0.19.1]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7, v0.19.1]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ myst_substitutions = {
     "pip_vllm_version": "0.19.1",
     # CANN image tag
     "cann_image_tag": "8.5.1-910b-ubuntu22.04-py3.11",
-    # vLLM commit hash fo856b15c62c8a574a1a0a289444d5b9a8120433e3
+    # vLLM commit hash for 4d51588e2381018348f1022dfa3a7698899805b7
     "main_vllm_commit": "d886c26d4d4fef7d079696beb4ece1cfb4b008a8",
     # vLLM tag for main branch
     "main_vllm_tag": "v0.19.1",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ myst_substitutions = {
     "pip_vllm_version": "0.18.0",
     # CANN image tag
     "cann_image_tag": "8.5.1-910b-ubuntu22.04-py3.11",
-    # vLLM commit hash for main branch
+    # vLLM commit hash fo856b15c62c8a574a1a0a289444d5b9a8120433e3
     "main_vllm_commit": "d886c26d4d4fef7d079696beb4ece1cfb4b008a8",
     # vLLM tag for main branch
     "main_vllm_tag": "v0.19.1",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,8 +80,8 @@ myst_substitutions = {
     "pip_vllm_version": "0.19.1",
     # CANN image tag
     "cann_image_tag": "8.5.1-910b-ubuntu22.04-py3.11",
-    # vLLM commit hash for 4d51588e2381018348f1022dfa3a7698899805b7
-    "main_vllm_commit": "d886c26d4d4fef7d079696beb4ece1cfb4b008a8",
+    # vLLM commit hash for main branch
+    "main_vllm_commit": "4d51588e2381018348f1022dfa3a7698899805b7",
     # vLLM tag for main branch
     "main_vllm_tag": "v0.19.1",
     # Python version for main branch

--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -20,7 +20,6 @@ import torch.nn.functional as F
 
 from vllm_ascend._310p.fused_moe.fused_moe import (
     AscendFusedMoE310,
-    AscendSharedFusedMoE310,
 )
 
 
@@ -48,8 +47,8 @@ class _DummySharedExperts(torch.nn.Module):
         return out
 
 
-def _build_layer(shared_experts: torch.nn.Module | None) -> AscendSharedFusedMoE310:
-    layer = AscendSharedFusedMoE310.__new__(AscendSharedFusedMoE310)
+def _build_layer(shared_experts: torch.nn.Module | None) -> AscendFusedMoE310:
+    layer = AscendFusedMoE310.__new__(AscendFusedMoE310)
     # The test bypasses full layer init with __new__, so we must initialize
     # nn.Module internals before assigning child modules.
     torch.nn.Module.__init__(layer)
@@ -80,7 +79,7 @@ def test_forward_impl_with_shared_experts_returns_tuple_310():
     routed_out = torch.randn(3, 8)
 
     with patch.object(AscendFusedMoE310, "forward_impl", return_value=routed_out):
-        shared_out, routed = layer.forward_impl(hidden_states, router_logits)
+        shared_out, routed = layer.shared_forward_impl(hidden_states, router_logits)
 
     expected_shared = 0.5 * (hidden_states * 2.0 + 1.0)
     torch.testing.assert_close(shared_out, expected_shared)
@@ -100,7 +99,7 @@ def test_forward_impl_without_shared_experts_returns_routed_only_310():
     routed_out = torch.randn(3, 8)
 
     with patch.object(AscendFusedMoE310, "forward_impl", return_value=routed_out):
-        output = layer.forward_impl(hidden_states, router_logits)
+        output = layer.shared_forward_impl(hidden_states, router_logits)
 
     torch.testing.assert_close(output, routed_out)
 

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -236,6 +236,12 @@ def moe_method(mock_dist_env):
     return AscendUnquantizedFusedMoEMethod(moe)
 
 
+def test_ascend_unquantized_skips_upstream_modular_kernel_init():
+    method = AscendUnquantizedFusedMoEMethod.maybe_make_prepare_finalize
+
+    assert method(object()) is None
+
+
 class Device(TypedDict):
     device_id: int
     device_expert: list[int]

--- a/tests/ut/quantization/methods/test_moe_logical_experts.py
+++ b/tests/ut/quantization/methods/test_moe_logical_experts.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
+
+
+def test_get_moe_num_logical_experts_uses_vllm_config_field():
+    layer = SimpleNamespace(moe_config=SimpleNamespace(num_logical_experts=128))
+
+    assert get_moe_num_logical_experts(layer, num_experts=130, global_redundant_expert_num=2) == 128
+
+
+def test_get_moe_num_logical_experts_falls_back_for_older_configs():
+    layer = SimpleNamespace(moe_config=SimpleNamespace())
+
+    assert (
+        get_moe_num_logical_experts(
+            layer,
+            num_experts=133,
+            global_redundant_expert_num=2,
+            num_shared_experts=3,
+        )
+        == 128
+    )

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -62,7 +62,9 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.parallel_config.enable_expert_parallel = False
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.num_speculative_tokens = 2
+        self.vllm_config.speculative_config.parallel_drafting = False
         self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(2)])
+        self.vllm_config.speculative_config.draft_model_config.hf_config = MagicMock(spec=[])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
         self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
         self.vllm_config.speculative_config.disable_padded_drafter_batch = False
@@ -87,6 +89,7 @@ class TestEagleProposerInitialization(TestBase):
     def test_initialization_eagle_graph(self):
         self.vllm_config.speculative_config.method = "eagle"
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 4096
+        self.vllm_config.speculative_config.draft_model_config.get_inputs_embeds_size.return_value = 4096
         self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
         self.vllm_config.compilation_config.mode = CompilationMode.VLLM_COMPILE
         self.vllm_config.model_config.enforce_eager = False
@@ -110,6 +113,7 @@ class TestEagleProposerInitialization(TestBase):
     def test_initialization_eagle3_enforce_eager(self):
         self.vllm_config.speculative_config.method = "eagle3"
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 2048
+        self.vllm_config.speculative_config.draft_model_config.get_inputs_embeds_size.return_value = 2048
         self.vllm_config.compilation_config.mode = CompilationMode.NONE
         self.vllm_config.compilation_config.pass_config = MagicMock()
         self.vllm_config.compilation_config.pass_config.enable_sp = False
@@ -127,6 +131,7 @@ class TestEagleProposerInitialization(TestBase):
     def test_initialization_eagle3_full_graph_async(self):
         self.vllm_config.speculative_config.method = "eagle3"
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 2048
+        self.vllm_config.speculative_config.draft_model_config.get_inputs_embeds_size.return_value = 2048
         self.vllm_config.compilation_config.mode = CompilationMode.VLLM_COMPILE
         self.vllm_config.model_config.enforce_eager = False
         self.vllm_config.speculative_config.enforce_eager = False
@@ -144,6 +149,7 @@ class TestEagleProposerInitialization(TestBase):
     def test_initialization_mtp_full_graph_async(self):
         self.vllm_config.speculative_config.method = "mtp"
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 2048
+        self.vllm_config.speculative_config.draft_model_config.get_inputs_embeds_size.return_value = 2048
         self.vllm_config.compilation_config.mode = CompilationMode.VLLM_COMPILE
         self.vllm_config.model_config.enforce_eager = False
         self.vllm_config.speculative_config.enforce_eager = False
@@ -1758,6 +1764,7 @@ class TestRunMergedDraft(TestBase):
         self.vllm_config.speculative_config.use_local_argmax_reduction = False
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(3)])
+        self.vllm_config.speculative_config.draft_model_config.hf_config = MagicMock(spec=[])
         self.vllm_config.speculative_config.draft_model_config.get_hidden_size.return_value = 4
         self.vllm_config.speculative_config.draft_model_config.get_inputs_embeds_size.return_value = 4
         self.vllm_config.speculative_config.draft_model_config.uses_mrope = False

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -17,6 +17,17 @@ from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.utils import vllm_version_is
+
+# vLLM #40732 moved `SpecDecodeBaseProposer` (and its `CpuGpuBuffer` import)
+# out of `vllm.v1.spec_decode.eagle` into `vllm.v1.spec_decode.llm_base_proposer`.
+# Pick the right patch path depending on the installed vllm version so the
+# tests can mock the buffer factory.
+_CPU_GPU_BUFFER_TARGET = (
+    "vllm.v1.spec_decode.eagle.CpuGpuBuffer"
+    if vllm_version_is("0.19.1")
+    else "vllm.v1.spec_decode.llm_base_proposer.CpuGpuBuffer"
+)
 
 
 class TestEagleProposerInitialization(TestBase):
@@ -57,7 +68,7 @@ class TestEagleProposerInitialization(TestBase):
         self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -196,7 +207,7 @@ class TestEagleProposerLoadModel(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -332,7 +343,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -483,7 +494,7 @@ class TestEagleProposerHelperMethods(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -558,7 +569,7 @@ class TestEagleProposerPropose:
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -1263,7 +1274,7 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer", MockCpuGpuBuffer)
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET, MockCpuGpuBuffer)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -1755,7 +1766,7 @@ class TestRunMergedDraft(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer", MockCpuGpuBuffer)
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET, MockCpuGpuBuffer)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False
@@ -1876,7 +1887,14 @@ class TestRunMergedDraft(TestBase):
 
         import vllm.v1.spec_decode.eagle
 
-        assert hasattr(vllm.v1.spec_decode.eagle, "CpuGpuBuffer")
+        # `CpuGpuBuffer` was re-exported from `eagle` until vLLM #40732 moved
+        # `SpecDecodeBaseProposer` (and the import) into `llm_base_proposer`.
+        if vllm_version_is("0.19.1"):
+            assert hasattr(vllm.v1.spec_decode.eagle, "CpuGpuBuffer")
+        else:
+            import vllm.v1.spec_decode.llm_base_proposer
+
+            assert hasattr(vllm.v1.spec_decode.llm_base_proposer, "CpuGpuBuffer")
         RunnerCls = vllm.v1.spec_decode.eagle.SpecDecodeBaseProposer
         for attr in ("_get_positions", "_set_positions"):
             assert hasattr(RunnerCls, attr), f"SpecDecodeBaseProposer.{attr} not found"

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -124,6 +124,8 @@ class AscendFusedMoE310(FusedMoE):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self._routed_input_transform = kwargs.get("routed_input_transform")
+        self._shared_experts = kwargs.get("shared_experts")
         self.global_num_experts = kwargs["num_experts"]
 
         if self.quant_config is None:
@@ -180,6 +182,11 @@ class AscendFusedMoE310(FusedMoE):
             self.reduce_results,
             self.vllm_config.parallel_config.enable_dbo,
         )
+
+    @property
+    def is_internal_router(self) -> bool:
+        # 310P Ascend path expects router logits from the model forward path.
+        return False
 
     def init_experts_map(self, moe_config):
         """
@@ -265,63 +272,6 @@ class AscendFusedMoE310(FusedMoE):
         )
 
         return routed_out
-
-
-class AscendSharedFusedMoE310(AscendFusedMoE310):
-    def __init__(
-        self,
-        shared_experts: torch.nn.Module,
-        gate: torch.nn.Module | None = None,
-        use_overlapped: bool = True,
-        routed_input_transform: torch.nn.Module | None = None,
-        **kwargs,
-    ):
-        AscendFusedMoE310.__init__(self, **kwargs)
-        self._routed_input_transform = routed_input_transform
-        self._shared_experts = shared_experts
-        self.use_overlapped = use_overlapped
-        self.shared_expert_stream = None
-        self._gate = gate
-        # Recreate runner after shared_experts/gate are set so custom op dispatch
-        # goes through moe_forward_shared.
-        # NOTE: must use self._shared_experts here, not self.shared_experts —
-        # FusedMoE.shared_experts is a property that reads self.runner.shared_experts,
-        # which at this point is still the stale runner built with shared_experts=None.
-        from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
-
-        is_legacy = vllm_version_is("0.19.1")
-        self.runner = AscendMoERunner(
-            self if is_legacy else self.layer_name,
-            self.moe_config,
-            self.router,
-            self._routed_input_transform,
-            self._gate,
-            self._shared_experts,
-            self.quant_method,
-            self.reduce_results,
-            self.vllm_config.parallel_config.enable_dbo,
-        )
-
-    @property
-    def is_internal_router(self) -> bool:
-        # 310P Ascend path expects router logits from the model forward path.
-        return False
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        router_logits: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        result = AscendFusedMoE310.forward(
-            self,
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-        )
-        # When shared experts are absent, the parent returns only fused_out;
-        # otherwise it returns a (shared_out, fused_out) tuple.
-        if self._shared_experts is None:
-            return None, result
-        return result
 
     def _forward_shared_experts(self, hidden_states: torch.Tensor):
         if self._shared_experts is None:

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -20,8 +20,6 @@ import torch
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFusedMoEMethod
-from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
-
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_comm_method import FusedExpertsResult, _MoECommMethods
@@ -263,7 +261,7 @@ class AscendFusedMoE310(FusedMoE):
         return routed_out
 
 
-class AscendSharedFusedMoE310(SharedFusedMoE, AscendFusedMoE310):
+class AscendSharedFusedMoE310(AscendFusedMoE310):
     def __init__(
         self,
         shared_experts: torch.nn.Module,
@@ -324,7 +322,7 @@ class AscendSharedFusedMoE310(SharedFusedMoE, AscendFusedMoE310):
             return None
         return self._shared_experts(hidden_states)
 
-    def forward_impl(  # type: ignore[override]
+    def shared_forward_impl(  # type: ignore[override]
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor
     ):
         routed_out = AscendFusedMoE310.forward_impl(

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -134,6 +134,10 @@ class AscendFusedMoE310(FusedMoE):
             self.quant_method = self.quant_config.get_quant_method(self, self.layer_name)
 
         assert self.quant_method is not None
+        # Keep base_quant_method aligned with the Ascend-replaced quant_method
+        # so FusedMoE.maybe_init_modular_kernel doesn't dispatch into the
+        # upstream UnquantizedFusedMoEMethod.maybe_make_prepare_finalize.
+        self.base_quant_method = self.quant_method
 
         self.moe_config.tp_group = get_tp_group()
         self.moe_config.dp_group = get_dp_group()

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -40,6 +40,11 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
     def is_monolithic(self) -> bool:
         return False
 
+    def maybe_make_prepare_finalize(self, routing_tables=None):
+        # Ascend 310P uses its own MoE communication and forward_impl path.
+        # Do not let upstream modular-kernel initialization replace it.
+        return None
+
     def process_weights_after_loading(self, layer):
         super().process_weights_after_loading(layer)
 

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -20,6 +20,7 @@ import torch
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFusedMoEMethod
+
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_comm_method import FusedExpertsResult, _MoECommMethods

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -15,6 +15,25 @@
 # This file is a part of the vllm-ascend project.
 #
 
+_GLOBAL_PATCH_APPLIED = False
+
+
+def _ensure_global_patch():
+    """Apply process-wide vLLM patches before engine-core initialization.
+
+    vLLM loads general plugins in engine-core subprocesses. E2E test
+    conftest hooks do not run there, so global patches that affect scheduler
+    and engine code must also be applied through these plugin entry points.
+    """
+    global _GLOBAL_PATCH_APPLIED
+    if _GLOBAL_PATCH_APPLIED:
+        return
+
+    from vllm_ascend.utils import adapt_patch
+
+    adapt_patch(is_global_patch=True)
+    _GLOBAL_PATCH_APPLIED = True
+
 
 def register():
     """Register the NPU platform."""
@@ -23,12 +42,16 @@ def register():
 
 
 def register_connector():
+    _ensure_global_patch()
+
     from vllm_ascend.distributed.kv_transfer import register_connector
 
     register_connector()
 
 
 def register_model_loader():
+    _ensure_global_patch()
+
     from .model_loader.netloader import register_netloader
     from .model_loader.rfork import register_rforkloader
 
@@ -37,6 +60,8 @@ def register_model_loader():
 
 
 def register_service_profiling():
+    _ensure_global_patch()
+
     from .profiling_config import generate_service_profiling_config
 
     generate_service_profiling_config()

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -60,19 +60,34 @@ class ProfilingChunkScheduler(Scheduler):
         kv_cache_config: KVCacheConfig,
         structured_output_manager: StructuredOutputManager,
         block_size: int,
+        # `hash_block_size` was added in vLLM #40946; keep it optional so the
+        # subclass works on both pinned vllm and main.
+        hash_block_size: int | None = None,
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
         include_finished_set: bool = False,
         log_stats: bool = False,
     ) -> None:
-        super().__init__(
-            vllm_config,
-            kv_cache_config,
-            structured_output_manager,
-            block_size,
-            mm_registry=mm_registry,
-            include_finished_set=include_finished_set,
-            log_stats=log_stats,
-        )
+        if vllm_version_is("0.19.1"):
+            super().__init__(
+                vllm_config,
+                kv_cache_config,
+                structured_output_manager,
+                block_size,
+                mm_registry=mm_registry,
+                include_finished_set=include_finished_set,
+                log_stats=log_stats,
+            )
+        else:
+            super().__init__(
+                vllm_config,
+                kv_cache_config,
+                structured_output_manager,
+                block_size,
+                hash_block_size=hash_block_size,
+                mm_registry=mm_registry,
+                include_finished_set=include_finished_set,
+                log_stats=log_stats,
+            )
 
         from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -26,6 +26,7 @@ from vllm_ascend.ops.linear import (
     AscendRowParallelLinear,
 )
 from vllm_ascend.ops.vocab_parallel_embedding import AscendVocabParallelEmbedding
+from vllm_ascend.utils import vllm_version_is
 
 
 class AscendColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
@@ -185,15 +186,27 @@ class AscendRowParallelLinearWithShardedLoRA(RowParallelLinearWithShardedLoRA):
 
 
 def refresh_all_lora_classes():
-    vllm.lora.utils._all_lora_classes.add(AscendColumnParallelLinearWithLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendMergedColumnParallelLinearWithLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendRowParallelLinearWithLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendVocabParallelEmbeddingWithLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendQKVParallelLinearWithLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendMergedQKVParallelLinearWithLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendColumnParallelLinearWithShardedLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendMergedColumnParallelLinearWithShardedLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendMergedQKVParallelLinearWithShardedLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendQKVParallelLinearWithShardedLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendRowParallelLinearWithShardedLoRA)
-    vllm.lora.utils._all_lora_classes.add(AscendReplicatedLinearWithLoRA)
+    ascend_classes = (
+        AscendColumnParallelLinearWithLoRA,
+        AscendMergedColumnParallelLinearWithLoRA,
+        AscendRowParallelLinearWithLoRA,
+        AscendVocabParallelEmbeddingWithLoRA,
+        AscendQKVParallelLinearWithLoRA,
+        AscendMergedQKVParallelLinearWithLoRA,
+        AscendColumnParallelLinearWithShardedLoRA,
+        AscendMergedColumnParallelLinearWithShardedLoRA,
+        AscendMergedQKVParallelLinearWithShardedLoRA,
+        AscendQKVParallelLinearWithShardedLoRA,
+        AscendRowParallelLinearWithShardedLoRA,
+        AscendReplicatedLinearWithLoRA,
+    )
+    if vllm_version_is("0.19.1"):
+        for cls in ascend_classes:
+            vllm.lora.utils._all_lora_classes.add(cls)
+    else:
+        # vLLM #35077 changed _all_lora_classes from set to ordered tuple.
+        # Append the Ascend classes in a deterministic order.
+        vllm.lora.utils._all_lora_classes = (
+            *vllm.lora.utils._all_lora_classes,
+            *ascend_classes,
+        )

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -219,7 +219,6 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         return final_hidden_states
 
 
-# Please remove this inheritance after extending vllm, todo(wxs)
 class AscendMoERunner(MoERunner):
     @property
     def use_dp_chunking(self) -> bool:
@@ -240,11 +239,15 @@ class AscendMoERunner(MoERunner):
         This delegates to the layer's forward_impl method which contains the
         Ascend-specific MoE computation logic.
         """
-        result = layer.forward_impl(hidden_states, router_logits)
-        # If the layer has shared experts, forward_impl returns a tuple (shared_out, routed_out)
-        # Otherwise, it returns just routed_out
-        # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
+        if self.shared_experts is None:
+            result = layer.forward_impl(hidden_states, router_logits)
+            # If the layer has shared experts, forward_impl returns a tuple (shared_out, routed_out)
+            # Otherwise, it returns just routed_out
+            # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
+        else:
+            result = layer.shared_forward_impl(hidden_states, router_logits)
         return result
+    
 
     def _forward_impl(
         self,
@@ -252,6 +255,7 @@ class AscendMoERunner(MoERunner):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
+        input_ids: torch.Tensor | None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         with self._sequence_parallel_context():
             return self.forward_impl(
@@ -261,14 +265,17 @@ class AscendMoERunner(MoERunner):
                 shared_experts_input,
             )
 
-
 class AscendFusedMoE(FusedMoE):
     moe_counter = -1
     gate_stream: torch.npu.Stream | None = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
+        self.use_overlapped = True
+        self._routed_input_transform = kwargs.get("routed_input_transform", None)
+        self._shared_experts = kwargs.get("shared_experts", None)
+        self.shared_expert_stream = None
+        has_shared_experts = self._shared_experts is not None
         num_experts = kwargs["num_experts"]
         intermediate_size = kwargs["intermediate_size"]
         num_shared_experts = kwargs.get("n_shared_experts", 0)
@@ -292,6 +299,11 @@ class AscendFusedMoE(FusedMoE):
         self.moe_config.mc2_group = get_mc2_group()
         self.moe_config.supports_eplb = self.quant_method.supports_eplb
         ascend_config = get_ascend_config()
+        self.multistream_overlap_shared_expert = ascend_config.multistream_overlap_shared_expert and has_shared_experts
+        self.shared_multistream_overlap_gate = ascend_config.multistream_overlap_gate and has_shared_experts
+        if enable_sp and has_shared_experts:
+            logger.info_once("Sequence parallelism is enabled, shared experts are replicated for best performance.")
+        
         # flashcommon3 gate stream
         self.multistream_overlap_gate = ascend_config.multistream_overlap_gate
         if self.multistream_overlap_gate and AscendFusedMoE.gate_stream is None:
@@ -301,6 +313,7 @@ class AscendFusedMoE(FusedMoE):
             self.e_score_correction_bias.data = self.e_score_correction_bias.data.to(
                 dtype=vllm_config.model_config.dtype
             )
+        self._gate = kwargs.get("gate", None)
 
         # init moe
         eplb_config = ascend_config.eplb_config
@@ -363,11 +376,64 @@ class AscendFusedMoE(FusedMoE):
             self.router,
             self._routed_input_transform,
             self.gate if is_legacy else kwargs.pop("gate", None),
-            self.shared_experts if is_legacy else kwargs.pop("shared_experts", None),
+            self._shared_experts if is_legacy else kwargs.pop("shared_experts", None),
             self.quant_method,
-            self.reduce_results,
             self.vllm_config.parallel_config.enable_dbo,
         )
+        
+        if self.multistream_overlap_shared_expert:
+            # Wrap the quant_method's process_weights_after_loading to validate that
+            # splitting shared expert computation (gate_up projection + activation,
+            # then down projection) yields identical results to integrated
+            # computation after weight loading.
+            original_process_weights = self.quant_method.process_weights_after_loading
+
+            @wraps(original_process_weights)
+            def wrapped_process_weights(*args, **kwargs):
+                result = original_process_weights(*args, **kwargs)
+                self._validate_shared_expert_consistency()
+                return result
+
+            self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
+            
+    def _validate_shared_expert_consistency(self):
+        """Validate that split shared expert computation matches integrated
+        computation."""
+        test_input = (
+            torch.rand(10, self.hidden_size, device="npu", dtype=self.moe_config.in_dtype) * 2 - 1
+        )  # Random input for testing, scoped to [-1, 1]
+
+        integrated_out = self._shared_experts(test_input)
+        part1_out = self._shared_experts_part1(test_input)
+        split_out = self._shared_experts_part2(test_input, part1_out)
+
+        if not torch.allclose(integrated_out, split_out):
+            diff = (integrated_out - split_out).abs()
+            logger.error("SharedFusedMoE shared experts split computation does not match the integrated computation.")
+            logger.error("Max absolute difference: %s", diff.max().item())
+            logger.error(
+                "Integrated output - sum: %s, norm: %s", integrated_out.sum().item(), integrated_out.norm().item()
+            )
+            logger.error("Split output - sum: %s, norm: %s", split_out.sum().item(), split_out.norm().item())
+            raise ValueError(
+                "SharedFusedMoE shared experts split computation does not match the integrated computation."
+            )
+        logger.info_once("SharedFusedMoE shared experts split computation matches the integrated computation.")
+
+    def _shared_experts_part1(self, hidden_states: torch.Tensor):
+        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
+        return shared_gate_up
+
+    def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
+        shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore
+        shared_out, _ = self._shared_experts.down_proj(shared_act)  # type: ignore
+        
+        # Qwen3-Next specific gating mechanism
+        if hasattr(self._shared_experts, "expert_gate") and self._shared_experts.expert_gate is not None:
+            gate_out, _ = self._shared_experts.expert_gate(hidden_states)  # type: ignore
+            shared_out = F.sigmoid(gate_out) * shared_out
+        return shared_out
+
 
     def _get_quant_type(self) -> QuantType:
         quant_type = QuantType.NONE
@@ -398,6 +464,22 @@ class AscendFusedMoE(FusedMoE):
         outputs since each rank only has partial outputs.
         """
         return torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
+    
+    
+    @property
+    def gate(self) -> torch.nn.Module | None:
+        return self._gate if self.use_overlapped else None
+
+    @property
+    def is_internal_router(self) -> bool:
+        return False
+
+    @property
+    def use_dp_chunking(self) -> bool:
+        """This func routes to the chunked forward path using the FlashInfer Cutlass kernel
+        only when data parallelism (DP) is enabled. Thus just returning False in vllm-ascend
+        """
+        return False
 
     def forward(
         self,
@@ -409,6 +491,7 @@ class AscendFusedMoE(FusedMoE):
             hidden_states,
             router_logits,
         )
+
 
     def forward_impl(  # type: ignore[override]
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor, return_with_event: bool = False
@@ -528,12 +611,13 @@ class AscendFusedMoE(FusedMoE):
                 self.load_counter.add_(1)
             else:
                 self.moe_load.add_(local_load)
+        # 这个地方要怎么改
         routed_out = _EXTRA_CTX.moe_comm_method.finalize(
             hidden_states=fused_experts_results.routed_out,
-            reduce_results=self.reduce_results,
+            reduce_results=isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl),
             padded_hidden_states_shape=padded_hidden_states_shape,
         )
-
+        # 这个地方要思考一下
         if return_with_event:
             return FusedMoEResult(
                 routed_out=routed_out,
@@ -543,4 +627,73 @@ class AscendFusedMoE(FusedMoE):
         else:
             # The vLLM FusedMoE forward_impl does not return events.
             return routed_out
+
+    def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
+        if self._shared_experts is None:
+            return None
+
+        def maybe_wait_event(evt: torch.npu.Event | None):
+            if evt is not None:
+                torch.npu.current_stream().wait_event(evt)
+
+        with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
+            # Ensure the shared experts wait for hidden_states to be ready.
+            torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+            # Execute the gate projection and activation concurrently with the
+            # dispatch communication.
+            maybe_wait_event(fused_moe_evts.before_dispatch)
+            part1_out = self._shared_experts_part1(hidden_states)
+            # Execute the down projection concurrently with the combine
+            # communication.
+            maybe_wait_event(fused_moe_evts.before_combine)
+            shared_out = self._shared_experts_part2(hidden_states, part1_out)
+
+        # Make sure the default stream waits for the shared experts stream to
+        # finish.
+        if self.multistream_overlap_shared_expert:
+            torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
+
+        # NOTE: This is exactly the opposite of
+        # `maybe_all_reduce_tensor_model_parallel`
+        moe_comm_type = _EXTRA_CTX.moe_comm_type
+        if (
+            moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
+            and not shared_expert_dp_enabled()
+        ):
+            shared_out = tensor_model_parallel_all_reduce(shared_out)
+        return shared_out
+
+    def shared_forward_impl(  # type: ignore[override]
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor
+    ):
+        if self.shared_multistream_overlap_gate:
+            set_flash_common3_context(shared_experts=self._shared_experts)
+
+        before_routed_experts = torch.npu.current_stream().record_event()
+
+        fused_moe_results = self.forward_impl(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            return_with_event=True,
+        )
+        routed_out = fused_moe_results.routed_out
+
+        if self._shared_experts is None:
+            return routed_out
+
+        if self.shared_multistream_overlap_gate:
+            fc3_context = get_flash_common3_context()
+            assert fc3_context is not None
+            shared_out = fc3_context.shared_out
+        else:
+            shared_out = self._forward_shared_experts(
+                hidden_states,
+                FusedMoEEvents(
+                    before_routed_experts=before_routed_experts,
+                    before_dispatch=fused_moe_results.before_dispatch_evt,
+                    before_combine=fused_moe_results.before_combine_evt,
+                ),
+            )
+        return shared_out, routed_out
+
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -21,7 +21,6 @@ from functools import wraps
 import torch
 import torch.nn.functional as F
 import torch_npu
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group, tensor_model_parallel_all_reduce
 from vllm.forward_context import get_forward_context
@@ -247,7 +246,6 @@ class AscendMoERunner(MoERunner):
         else:
             result = layer.shared_forward_impl(hidden_states, router_logits)
         return result
-    
 
     def _forward_impl(
         self,
@@ -265,6 +263,7 @@ class AscendMoERunner(MoERunner):
                 shared_experts_input,
             )
 
+
 class AscendFusedMoE(FusedMoE):
     moe_counter = -1
     gate_stream: torch.npu.Stream | None = None
@@ -272,8 +271,8 @@ class AscendFusedMoE(FusedMoE):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.use_overlapped = True
-        self._routed_input_transform = kwargs.get("routed_input_transform", None)
-        self._shared_experts = kwargs.get("shared_experts", None)
+        self._routed_input_transform = kwargs.get("routed_input_transform")
+        self._shared_experts = kwargs.get("shared_experts")
         self.shared_expert_stream = None
         has_shared_experts = self._shared_experts is not None
         num_experts = kwargs["num_experts"]
@@ -303,7 +302,7 @@ class AscendFusedMoE(FusedMoE):
         self.shared_multistream_overlap_gate = ascend_config.multistream_overlap_gate and has_shared_experts
         if enable_sp and has_shared_experts:
             logger.info_once("Sequence parallelism is enabled, shared experts are replicated for best performance.")
-        
+
         # flashcommon3 gate stream
         self.multistream_overlap_gate = ascend_config.multistream_overlap_gate
         if self.multistream_overlap_gate and AscendFusedMoE.gate_stream is None:
@@ -313,7 +312,7 @@ class AscendFusedMoE(FusedMoE):
             self.e_score_correction_bias.data = self.e_score_correction_bias.data.to(
                 dtype=vllm_config.model_config.dtype
             )
-        self._gate = kwargs.get("gate", None)
+        self._gate = kwargs.get("gate")
 
         # init moe
         eplb_config = ascend_config.eplb_config
@@ -380,7 +379,7 @@ class AscendFusedMoE(FusedMoE):
             self.quant_method,
             self.vllm_config.parallel_config.enable_dbo,
         )
-        
+
         if self.multistream_overlap_shared_expert:
             # Wrap the quant_method's process_weights_after_loading to validate that
             # splitting shared expert computation (gate_up projection + activation,
@@ -395,7 +394,7 @@ class AscendFusedMoE(FusedMoE):
                 return result
 
             self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
-            
+
     def _validate_shared_expert_consistency(self):
         """Validate that split shared expert computation matches integrated
         computation."""
@@ -427,13 +426,12 @@ class AscendFusedMoE(FusedMoE):
     def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
         shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore
         shared_out, _ = self._shared_experts.down_proj(shared_act)  # type: ignore
-        
+
         # Qwen3-Next specific gating mechanism
         if hasattr(self._shared_experts, "expert_gate") and self._shared_experts.expert_gate is not None:
             gate_out, _ = self._shared_experts.expert_gate(hidden_states)  # type: ignore
             shared_out = F.sigmoid(gate_out) * shared_out
         return shared_out
-
 
     def _get_quant_type(self) -> QuantType:
         quant_type = QuantType.NONE
@@ -464,8 +462,7 @@ class AscendFusedMoE(FusedMoE):
         outputs since each rank only has partial outputs.
         """
         return torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
-    
-    
+
     @property
     def gate(self) -> torch.nn.Module | None:
         return self._gate if self.use_overlapped else None
@@ -491,7 +488,6 @@ class AscendFusedMoE(FusedMoE):
             hidden_states,
             router_logits,
         )
-
 
     def forward_impl(  # type: ignore[override]
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor, return_with_event: bool = False
@@ -695,5 +691,3 @@ class AscendFusedMoE(FusedMoE):
                 ),
             )
         return shared_out, routed_out
-
-

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -624,13 +624,13 @@ class AscendFusedMoE(FusedMoE):
                 self.load_counter.add_(1)
             else:
                 self.moe_load.add_(local_load)
-        # 这个地方要怎么改
+
         routed_out = _EXTRA_CTX.moe_comm_method.finalize(
             hidden_states=fused_experts_results.routed_out,
             reduce_results=isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl),
             padded_hidden_states_shape=padded_hidden_states_shape,
         )
-        # 这个地方要思考一下
+
         if return_with_event:
             return FusedMoEResult(
                 routed_out=routed_out,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -270,6 +270,7 @@ class AscendFusedMoE(FusedMoE):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        
         self.use_overlapped = True
         self._routed_input_transform = kwargs.get("routed_input_transform")
         self._shared_experts = kwargs.get("shared_experts")

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -83,6 +83,11 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     def is_monolithic(self) -> bool:
         return False
 
+    def maybe_make_prepare_finalize(self, routing_tables=None):
+        # Ascend uses its own MoE communication and forward_impl path.
+        # Do not let upstream modular-kernel initialization replace it.
+        return None
+
     def process_weights_after_loading(self, layer):
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -29,8 +29,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFusedMoEMethod, get_compressed_expert_map
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
-from vllm.model_executor.layers.fused_moe.runner.default_moe_runner import DefaultMoERunner  # type: ignore
-from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner  # type: ignore
 
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
@@ -221,7 +220,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
 
 # Please remove this inheritance after extending vllm, todo(wxs)
-class AscendMoERunner(DefaultMoERunner):
+class AscendMoERunner(MoERunner):
     @property
     def use_dp_chunking(self) -> bool:
         """Ascend uses its own forward_impl path, not the FlashInfer Cutlass
@@ -247,7 +246,7 @@ class AscendMoERunner(DefaultMoERunner):
         # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
         return result
 
-    def forward_dispatch(
+    def _forward_impl(
         self,
         layer: torch.nn.Module,
         hidden_states: torch.Tensor,
@@ -545,206 +544,3 @@ class AscendFusedMoE(FusedMoE):
             # The vLLM FusedMoE forward_impl does not return events.
             return routed_out
 
-
-class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
-    def __init__(
-        self,
-        shared_experts: torch.nn.Module,
-        gate: torch.nn.Module | None = None,
-        use_overlapped: bool = True,
-        routed_input_transform: torch.nn.Module | None = None,
-        **kwargs,
-    ):
-        ascend_config = get_ascend_config()
-        # TODO: Enabling the mix placement in deepseek_v2.py
-        # remove this part after the mix placement merged into vllm
-        # https://github.com/vllm-project/vllm/pull/31256
-        if ascend_config.mix_placement:
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_false
-            rocm_aiter_ops.is_fused_moe_enabled = mock_false
-        AscendFusedMoE.__init__(self, **kwargs)
-        if ascend_config.mix_placement:
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_true
-            rocm_aiter_ops.is_fused_moe_enabled = mock_true
-
-        self._routed_input_transform = routed_input_transform
-        self._shared_experts = shared_experts
-        self.use_overlapped = use_overlapped
-        self.shared_expert_stream = None
-        has_shared_experts = shared_experts is not None
-        self.multistream_overlap_shared_expert = ascend_config.multistream_overlap_shared_expert and has_shared_experts
-        self.multistream_overlap_gate = ascend_config.multistream_overlap_gate and has_shared_experts
-        if enable_sp():
-            logger.info_once("Sequence parallelism is enabled, shared experts are replicated for best performance.")
-
-        self._gate = gate
-        # Recreate the runner with the correct shared_experts parameter.
-        # The parent class created the runner before self._shared_experts was set.
-        # NOTE: must use self._shared_experts here, not self.shared_experts —
-        # FusedMoE.shared_experts is a property that reads self.runner.shared_experts,
-        # which at this point is still the stale runner built with shared_experts=None.
-        is_legacy = vllm_version_is("0.19.1")
-        self.runner = AscendMoERunner(
-            self if is_legacy else self.layer_name,
-            self.moe_config,
-            self.router,
-            self._routed_input_transform,
-            self.gate,
-            self._shared_experts,
-            self.quant_method,
-            self.reduce_results,
-            self.vllm_config.parallel_config.enable_dbo,
-        )
-
-        if self.multistream_overlap_shared_expert:
-            # Wrap the quant_method's process_weights_after_loading to validate that
-            # splitting shared expert computation (gate_up projection + activation,
-            # then down projection) yields identical results to integrated
-            # computation after weight loading.
-            original_process_weights = self.quant_method.process_weights_after_loading
-
-            @wraps(original_process_weights)
-            def wrapped_process_weights(*args, **kwargs):
-                result = original_process_weights(*args, **kwargs)
-                self._validate_shared_expert_consistency()
-                return result
-
-            self.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
-
-    def _shared_experts_part1(self, hidden_states: torch.Tensor):
-        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
-        return shared_gate_up
-
-    def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
-        shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore
-        shared_out, _ = self._shared_experts.down_proj(shared_act)  # type: ignore
-
-        # Qwen3-Next specific gating mechanism
-        if hasattr(self._shared_experts, "expert_gate") and self._shared_experts.expert_gate is not None:
-            gate_out, _ = self._shared_experts.expert_gate(hidden_states)  # type: ignore
-            shared_out = F.sigmoid(gate_out) * shared_out
-        return shared_out
-
-    def _validate_shared_expert_consistency(self):
-        """Validate that split shared expert computation matches integrated
-        computation."""
-        test_input = (
-            torch.rand(10, self.hidden_size, device="npu", dtype=self.moe_config.in_dtype) * 2 - 1
-        )  # Random input for testing, scoped to [-1, 1]
-
-        integrated_out = self._shared_experts(test_input)
-        part1_out = self._shared_experts_part1(test_input)
-        split_out = self._shared_experts_part2(test_input, part1_out)
-
-        if not torch.allclose(integrated_out, split_out):
-            diff = (integrated_out - split_out).abs()
-            logger.error("SharedFusedMoE shared experts split computation does not match the integrated computation.")
-            logger.error("Max absolute difference: %s", diff.max().item())
-            logger.error(
-                "Integrated output - sum: %s, norm: %s", integrated_out.sum().item(), integrated_out.norm().item()
-            )
-            logger.error("Split output - sum: %s, norm: %s", split_out.sum().item(), split_out.norm().item())
-            raise ValueError(
-                "SharedFusedMoE shared experts split computation does not match the integrated computation."
-            )
-        logger.info_once("SharedFusedMoE shared experts split computation matches the integrated computation.")
-
-    @property
-    def gate(self) -> torch.nn.Module | None:
-        return self._gate if self.use_overlapped else None
-
-    @property
-    def is_internal_router(self) -> bool:
-        return False
-
-    @property
-    def use_dp_chunking(self) -> bool:
-        """This func routes to the chunked forward path using the FlashInfer Cutlass kernel
-        only when data parallelism (DP) is enabled. Thus just returning False in vllm-ascend
-        """
-        return False
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        router_logits: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        result = AscendFusedMoE.forward(
-            self,
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-        )
-        # When shared experts are absent, the parent returns only fused_out;
-        # otherwise it returns a (shared_out, fused_out) tuple.
-        if self._shared_experts is None:
-            return None, result
-        return result
-
-    def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
-        if self._shared_experts is None:
-            return None
-
-        def maybe_wait_event(evt: torch.npu.Event | None):
-            if evt is not None:
-                torch.npu.current_stream().wait_event(evt)
-
-        with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
-            # Ensure the shared experts wait for hidden_states to be ready.
-            torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-            # Execute the gate projection and activation concurrently with the
-            # dispatch communication.
-            maybe_wait_event(fused_moe_evts.before_dispatch)
-            part1_out = self._shared_experts_part1(hidden_states)
-            # Execute the down projection concurrently with the combine
-            # communication.
-            maybe_wait_event(fused_moe_evts.before_combine)
-            shared_out = self._shared_experts_part2(hidden_states, part1_out)
-
-        # Make sure the default stream waits for the shared experts stream to
-        # finish.
-        if self.multistream_overlap_shared_expert:
-            torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
-
-        # NOTE: This is exactly the opposite of
-        # `maybe_all_reduce_tensor_model_parallel`
-        moe_comm_type = _EXTRA_CTX.moe_comm_type
-        if (
-            moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
-            and not shared_expert_dp_enabled()
-        ):
-            shared_out = tensor_model_parallel_all_reduce(shared_out)
-        return shared_out
-
-    def forward_impl(  # type: ignore[override]
-        self, hidden_states: torch.Tensor, router_logits: torch.Tensor
-    ):
-        if self.multistream_overlap_gate:
-            set_flash_common3_context(shared_experts=self._shared_experts)
-
-        before_routed_experts = torch.npu.current_stream().record_event()
-        fused_moe_results = AscendFusedMoE.forward_impl(
-            self,
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-            return_with_event=True,
-        )
-        routed_out = fused_moe_results.routed_out
-
-        if self._shared_experts is None:
-            return routed_out
-
-        if self.multistream_overlap_gate:
-            fc3_context = get_flash_common3_context()
-            assert fc3_context is not None
-            shared_out = fc3_context.shared_out
-        else:
-            shared_out = self._forward_shared_experts(
-                hidden_states,
-                FusedMoEEvents(
-                    before_routed_experts=before_routed_experts,
-                    before_dispatch=fused_moe_results.before_dispatch_evt,
-                    before_combine=fused_moe_results.before_combine_evt,
-                ),
-            )
-
-        return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -41,6 +41,7 @@ from vllm_ascend.flash_common3_context import get_flash_common3_context, set_fla
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_NZ,
@@ -132,6 +133,15 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     ) -> torch.Tensor:
         zero_expert_num = getattr(layer, "zero_expert_num", 0)
         zero_expert_type = getattr(layer, "zero_expert_type", None)
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
             router_logits=router_logits,
@@ -144,7 +154,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_experts,
+            num_experts=num_logical_experts,
         )
         if layer.vllm_config.model_config is not None and layer.vllm_config.model_config.enable_return_routed_experts:
             capturer = RoutedExpertsCapturer.get_instance()
@@ -158,7 +168,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
                 expert_indices=topk_ids,
                 expert_scales=topk_weights,
-                num_experts=num_experts,
+                num_experts=num_logical_experts,
                 zero_expert_type=zero_expert_type,
                 hidden_states=x,
             )
@@ -168,7 +178,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.
         if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
@@ -241,10 +251,10 @@ class AscendMoERunner(DefaultMoERunner):
         This delegates to the layer's forward_impl method which contains the
         Ascend-specific MoE computation logic.
         """
-        result = layer.forward_impl(hidden_states, router_logits)
-        # If the layer has shared experts, forward_impl returns a tuple (shared_out, routed_out)
-        # Otherwise, it returns just routed_out
-        # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
+            result = layer.forward_impl(hidden_states, router_logits)
+            # If the layer has shared experts, forward_impl returns a tuple (shared_out, routed_out)
+            # Otherwise, it returns just routed_out
+            # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
         return result
 
     def forward_dispatch(

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -270,7 +270,6 @@ class AscendFusedMoE(FusedMoE):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
         self.use_overlapped = True
         self._routed_input_transform = kwargs.get("routed_input_transform")
         self._shared_experts = kwargs.get("shared_experts")

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -306,6 +306,12 @@ class AscendFusedMoE(FusedMoE):
             self.quant_method = self.quant_config.get_quant_method(self, self.layer_name)
 
         assert self.quant_method is not None
+        # Keep base_quant_method in sync with the swapped-in Ascend method,
+        # otherwise FusedMoE.maybe_init_modular_kernel (called via the V2
+        # model runner's prepare_communication_buffer_for_model) would dispatch
+        # to the upstream UnquantizedFusedMoEMethod.maybe_make_prepare_finalize,
+        # which raises by design.
+        self.base_quant_method = self.quant_method
 
         self.moe_config.tp_group = get_tp_group()
         self.moe_config.dp_group = get_dp_group()
@@ -424,16 +430,14 @@ class AscendFusedMoE(FusedMoE):
 
         if not torch.allclose(integrated_out, split_out):
             diff = (integrated_out - split_out).abs()
-            logger.error("SharedFusedMoE shared experts split computation does not match the integrated computation.")
+            logger.error("FusedMoE shared experts split computation does not match the integrated computation.")
             logger.error("Max absolute difference: %s", diff.max().item())
             logger.error(
                 "Integrated output - sum: %s, norm: %s", integrated_out.sum().item(), integrated_out.norm().item()
             )
             logger.error("Split output - sum: %s, norm: %s", split_out.sum().item(), split_out.norm().item())
-            raise ValueError(
-                "SharedFusedMoE shared experts split computation does not match the integrated computation."
-            )
-        logger.info_once("SharedFusedMoE shared experts split computation matches the integrated computation.")
+            raise ValueError("FusedMoE shared experts split computation does not match the integrated computation.")
+        logger.info_once("FusedMoE shared experts split computation matches the integrated computation.")
 
     def _shared_experts_part1(self, hidden_states: torch.Tensor):
         shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -251,10 +251,10 @@ class AscendMoERunner(DefaultMoERunner):
         This delegates to the layer's forward_impl method which contains the
         Ascend-specific MoE computation logic.
         """
-            result = layer.forward_impl(hidden_states, router_logits)
-            # If the layer has shared experts, forward_impl returns a tuple (shared_out, routed_out)
-            # Otherwise, it returns just routed_out
-            # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
+        result = layer.forward_impl(hidden_states, router_logits)
+        # If the layer has shared experts, forward_impl returns a tuple (shared_out, routed_out)
+        # Otherwise, it returns just routed_out
+        # The torch op expects the same return type based on whether it's moe_forward or moe_forward_shared
         return result
 
     def forward_dispatch(

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -300,7 +300,7 @@ class AscendFusedMoE(FusedMoE):
         ascend_config = get_ascend_config()
         self.multistream_overlap_shared_expert = ascend_config.multistream_overlap_shared_expert and has_shared_experts
         self.shared_multistream_overlap_gate = ascend_config.multistream_overlap_gate and has_shared_experts
-        if enable_sp and has_shared_experts:
+        if enable_sp() and has_shared_experts:
             logger.info_once("Sequence parallelism is enabled, shared experts are replicated for best performance.")
 
         # flashcommon3 gate stream
@@ -402,6 +402,7 @@ class AscendFusedMoE(FusedMoE):
             torch.rand(10, self.hidden_size, device="npu", dtype=self.moe_config.in_dtype) * 2 - 1
         )  # Random input for testing, scoped to [-1, 1]
 
+        assert self._shared_experts is not None
         integrated_out = self._shared_experts(test_input)
         part1_out = self._shared_experts_part1(test_input)
         split_out = self._shared_experts_part2(test_input, part1_out)
@@ -428,6 +429,7 @@ class AscendFusedMoE(FusedMoE):
         shared_out, _ = self._shared_experts.down_proj(shared_act)  # type: ignore
 
         # Qwen3-Next specific gating mechanism
+        assert self._shared_experts is not None
         if hasattr(self._shared_experts, "expert_gate") and self._shared_experts.expert_gate is not None:
             gate_out, _ = self._shared_experts.expert_gate(hidden_states)  # type: ignore
             shared_out = F.sigmoid(gate_out) * shared_out

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -21,7 +21,7 @@ from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 
 from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
-from vllm_ascend.utils import enable_custom_op, get_weight_prefetch_method
+from vllm_ascend.utils import enable_custom_op, get_weight_prefetch_method, vllm_version_is
 
 
 class AscendRMSNorm(RMSNorm):
@@ -166,12 +166,27 @@ class AscendRMSNormGated(RMSNormGated):
         norm_before_gate: bool = False,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        # `activation` was added in vLLM #40245 (Qwen3-Next/GDN). Accept and
+        # forward it; older vllm versions did not pass this kwarg so the
+        # default keeps existing behavior.
+        activation: str = "swish",
     ):
         """If group_size is not None, we do GroupNorm with each group having group_size elements.
         group_size=None is equivalent to group_size=hidden_size (i.e. there's only 1 group).
         """
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__(hidden_size, eps, group_size, norm_before_gate, device, dtype)
+        if vllm_version_is("0.19.1"):
+            super().__init__(hidden_size, eps, group_size, norm_before_gate, device, dtype)
+        else:
+            super().__init__(
+                hidden_size,
+                eps,
+                group_size,
+                norm_before_gate,
+                device,
+                dtype,
+                activation=activation,
+            )
         self.eps = eps
         self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
         self.register_parameter("bias", None)

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -193,6 +193,25 @@
 #       Remove this patch once the runtime vLLM version contains the GLM parser
 #       and streaming finish-chunk fixes.
 #
+# ** 10a. File: platform/patch_kv_cache_utils.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
+#      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
+#    Why:
+#       vLLM PR #40860 added a restriction that hybrid KV cache groups with
+#       multiple block sizes do not support context parallelism (dcp/pcp > 1).
+#       This restriction is correct for CUDA but not for Ascend, which
+#       implements context parallelism for MLA and SWA-MLA layers separately.
+#    How：
+#       Monkey-patch resolve_kv_cache_block_sizes to handle the multiple-groups
+#       + CP case by returning lcm(block_sizes) * dcp * pcp as scheduler_block_size
+#       instead of raising ValueError.
+#    Related PR (if no, explain why):
+#       vLLM PR #40860 ([Feat] DeepSeek V4 Rebased).
+#    Future Plan:
+#       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
+#       non-CUDA backends, or exposes a platform hook for this behavior.
+#
 # ** 10. File: platform/patch_kv_cache_interface.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.kv_cache_interface.MLAAttentionSpec`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,6 +18,7 @@ import os
 
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa
+import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 from vllm_ascend import envs
 from vllm_ascend.utils import is_310p
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -3,8 +3,8 @@
 import math
 
 import vllm.v1.core.kv_cache_utils
-from vllm.v1.core.kv_cache_interface import KVCacheConfig
 from vllm.config import VllmConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig
 
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 
@@ -48,4 +48,5 @@ vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_ca
 
 # Also patch the reference used by engine/core.py which imports the function directly.
 import vllm.v1.engine.core  # noqa: E402
+
 vllm.v1.engine.core.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+import math
+
+import vllm.v1.core.kv_cache_utils
+from vllm.v1.core.kv_cache_interface import KVCacheConfig
+from vllm.config import VllmConfig
+
+_orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
+
+
+def _ascend_resolve_kv_cache_block_sizes(
+    kv_cache_config: KVCacheConfig,
+    vllm_config: VllmConfig,
+) -> tuple[int, int]:
+    """Ascend-compatible resolve_kv_cache_block_sizes.
+
+    vLLM PR #40860 added a restriction that hybrid KV cache groups with
+    multiple block sizes do not support context parallelism (dcp/pcp > 1).
+    This restriction is correct for CUDA but not for Ascend, which implements
+    context parallelism for MLA and SWA-MLA layers independently.
+
+    For multiple KV cache groups with CP, compute scheduler_block_size as
+    lcm(group_block_sizes) * dcp * pcp to maintain alignment, consistent
+    with the pre-PR-#40860 behavior of block_size * dcp * pcp.
+    """
+    cache_config = vllm_config.cache_config
+    dcp = vllm_config.parallel_config.decode_context_parallel_size
+    pcp = vllm_config.parallel_config.prefill_context_parallel_size
+    groups = kv_cache_config.kv_cache_groups
+
+    if len(groups) <= 1:
+        bs = cache_config.block_size * dcp * pcp
+        return bs, bs
+
+    if dcp != 1 or pcp != 1:
+        # Ascend supports CP with multiple KV cache groups; compute
+        # scheduler_block_size using the LCM of all group block sizes
+        # multiplied by the CP factors for proper alignment.
+        group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
+        scheduler_block_size = math.lcm(*group_block_sizes) * dcp * pcp
+        return scheduler_block_size, scheduler_block_size
+
+    return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+
+
+vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
+
+# Also patch the reference used by engine/core.py which imports the function directly.
+import vllm.v1.engine.core  # noqa: E402
+vllm.v1.engine.core.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes

--- a/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
@@ -300,6 +300,7 @@ async def _wrapped_chat_completion_stream_generator(
     tokenizer,
     request_metadata: engine_protocol.RequestResponseMetadata,
     reasoning_parser=None,
+    **extra_kwargs: Any,
 ):
     num_choices = 1 if request.n is None else request.n
     state = _create_usage_tracking_state(num_choices, reasoning_parser)
@@ -314,6 +315,7 @@ async def _wrapped_chat_completion_stream_generator(
         tokenizer,
         request_metadata,
         reasoning_parser,
+        **extra_kwargs,
     ):
         yield _inject_stream_usage_details(data, state)
 

--- a/vllm_ascend/quantization/methods/base.py
+++ b/vllm_ascend/quantization/methods/base.py
@@ -25,6 +25,20 @@ import torch
 from vllm_ascend.quantization.quant_type import QuantType
 
 
+def get_moe_num_logical_experts(
+    layer: torch.nn.Module,
+    num_experts: int,
+    global_redundant_expert_num: int = 0,
+    num_shared_experts: int = 0,
+) -> int:
+    moe_config = getattr(layer, "moe_config", None)
+    num_logical_experts = getattr(moe_config, "num_logical_experts", None)
+    if num_logical_experts is not None:
+        return int(num_logical_experts)
+
+    return int(num_experts - global_redundant_expert_num - num_shared_experts)
+
+
 class AscendLinearScheme(ABC):
     """Base class for all linear quantization schemes.
 

--- a/vllm_ascend/quantization/methods/w4a16.py
+++ b/vllm_ascend/quantization/methods/w4a16.py
@@ -27,7 +27,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendMoEScheme, QuantType
+from .base import AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
 
 
@@ -199,7 +199,16 @@ class AscendW4A16FusedMoEMethod(AscendMoEScheme):
         apply_router_weight_on_input: bool = False,
         mc2_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert router_logits.shape[1] == num_experts, "Number of global experts mismatch (excluding redundancy)"
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
+        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
 
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
@@ -212,7 +221,7 @@ class AscendW4A16FusedMoEMethod(AscendMoEScheme):
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_experts,
+            num_experts=num_logical_experts,
         )
 
         topk_ids = topk_ids.to(torch.int32)

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -33,7 +33,7 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
 
 
@@ -187,7 +187,16 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         apply_router_weight_on_input: bool = False,
         mc2_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert router_logits.shape[1] == num_experts, "Number of global experts mismatch (excluding redundancy)"
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
+        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
             router_logits=router_logits,
@@ -199,14 +208,14 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_experts,
+            num_experts=num_logical_experts,
         )
 
         # this is a naive implementation for experts load balance so as
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.
         if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         topk_weights = topk_weights.to(x.dtype)

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -31,7 +31,7 @@ from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD, maybe_trans_nz
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
 
 
@@ -349,7 +349,16 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         apply_router_weight_on_input: bool = False,
         mc2_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert router_logits.shape[1] == num_experts, "Number of global experts mismatch (excluding redundancy)"
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
+        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
 
         # NOTE: now npu_moe_gating_top_k can only support `group_count=256` pattern
         topk_weights, topk_ids = select_experts(
@@ -363,14 +372,14 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_experts,
+            num_experts=num_logical_experts,
         )
 
         # this is a naive implementation for experts load balance so as
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.
         if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         topk_weights = topk_weights.to(x.dtype)

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -32,7 +32,7 @@ from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_expe
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
 
 
@@ -193,9 +193,14 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         mix_placement = getattr(layer, "mix_placement", False)
         if n_shared_experts is None:
             n_shared_experts = 0
-        valid_global_expert_num = num_experts - n_shared_experts
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=n_shared_experts,
+        )
         if zero_expert_num == 0 or zero_expert_type is None:
-            assert router_logits.shape[1] == valid_global_expert_num, (
+            assert router_logits.shape[1] == num_logical_experts, (
                 "Number of global experts mismatch (excluding redundancy)"
             )
 
@@ -220,7 +225,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 mix_placement=mix_placement,
                 num_logical_experts=router_logits.shape[1],
                 num_shared_experts=n_shared_experts,
-                num_experts=num_experts,
+                num_experts=num_logical_experts,
             )
         assert topk_ids is not None
         assert topk_weights is not None
@@ -228,7 +233,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
                 expert_indices=topk_ids,
                 expert_scales=topk_weights,
-                num_experts=num_experts,
+                num_experts=num_logical_experts,
                 zero_expert_type=zero_expert_type,
                 hidden_states=x,
             )
@@ -236,7 +241,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.
         if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         assert topk_weights is not None

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -33,7 +33,7 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
 
 
@@ -246,7 +246,16 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         apply_router_weight_on_input: bool = False,
         mc2_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert router_logits.shape[1] == num_experts, "Number of global experts mismatch (excluding redundancy)"
+        num_shared_experts = getattr(layer, "n_shared_experts", 0)
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            layer,
+            num_experts,
+            global_redundant_expert_num=global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
+        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
             router_logits=router_logits,
@@ -258,14 +267,14 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
             e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_experts,
+            num_experts=num_logical_experts,
         )
 
         # this is a naive implementation for experts load balance so as
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.
         if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_experts, device=topk_ids.device)
+            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         topk_weights = topk_weights.to(x.dtype)

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -94,6 +94,8 @@ def rejection_sample(
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     sampling_metadata: SamplingMetadata,
+    synthetic_mode: bool = False,
+    synthetic_conditional_rates: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -624,7 +624,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
     from vllm_ascend.ops.activation import AscendQuickGELU, AscendSiluAndMul
     from vllm_ascend.ops.conv import AscendConv3dLayer
-    from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE, AscendSharedFusedMoE
+    from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
     from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
     from vllm_ascend.ops.layernorm import AscendGemmaRMSNorm, AscendRMSNorm, AscendRMSNormGated
     from vllm_ascend.ops.linear import (
@@ -670,7 +670,6 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         "RMSNorm": AscendRMSNorm,
         "GemmaRMSNorm": AscendGemmaRMSNorm,
         "FusedMoE": AscendFusedMoE,
-        "SharedFusedMoE": AscendSharedFusedMoE,
         "MultiHeadLatentAttentionWrapper": AscendMultiHeadLatentAttention,
         "MMEncoderAttention": AscendMMEncoderAttention,
         "ApplyRotaryEmb": AscendApplyRotaryEmb,

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -682,7 +682,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
     # 310P: override selected ops with 310P implementations (keep minimal changes outside _310p)
     if is_310p():
-        from vllm_ascend._310p.fused_moe.fused_moe import AscendFusedMoE310, AscendSharedFusedMoE310
+        from vllm_ascend._310p.fused_moe.fused_moe import AscendFusedMoE310
         from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
         from vllm_ascend._310p.ops.conv import AscendConv3dLayer310
         from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
@@ -706,7 +706,6 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
                 "GemmaRMSNorm": AscendGemmaRMSNorm310,
                 "RMSNormGated": AscendRMSNormGated310,
                 "FusedMoE": AscendFusedMoE310,
-                "SharedFusedMoE": AscendSharedFusedMoE310,
                 "ParallelLMHead": AscendParallelLMHead310,
                 "VocabParallelEmbedding": AscendVocabParallelEmbedding310,
                 "MMEncoderAttention": AscendMMEncoderAttention310,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -304,6 +304,16 @@ class NPUModelRunner(GPUModelRunner):
         input_ids = self.input_buffers.input_ids[:num_tokens_after_padding]
         positions = self.input_buffers.positions[:num_tokens_after_padding]
 
+        # CPU upper bound on seq_lens (num_computed_tokens + num_scheduled_tokens).
+        # Added by vLLM PR #40654 to avoid GPU->CPU sync for seq_lens.
+        seq_lens_cpu_upper_bound_np = np.zeros(num_reqs_padded, dtype=np.int32)
+        np.add(
+            self.req_states.num_computed_tokens_np[idx_mapping_np],
+            num_scheduled_tokens,
+            out=seq_lens_cpu_upper_bound_np[:num_reqs],
+        )
+        seq_lens_cpu_upper_bound = torch.from_numpy(seq_lens_cpu_upper_bound_np)
+
         self.input_batch = AscendInputBatch(
             req_ids=req_ids,
             num_reqs=num_reqs,
@@ -319,6 +329,7 @@ class NPUModelRunner(GPUModelRunner):
             query_start_loc=query_start_loc,
             query_start_loc_np=query_start_loc_np,
             seq_lens=seq_lens,
+            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             dcp_local_seq_lens=None,  # TODO(Ronald1995): support cp.
             input_ids=input_ids,
             positions=positions,

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -9,23 +9,13 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import logger
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
-
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.19.1"):
-    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
-        EagleCudaGraphManager,
-    )
-    _PrefillEagleCudaGraphManager = None
-else:
-    # vLLM #40410 split EagleCudaGraphManager into Prefill/Decode managers.
-    # EagleAclGraphManager extends DecodeEagleCudaGraphManager (decode-style
-    # signature) but also needs to handle the prefill-style capture call.
-    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
-        DecodeEagleCudaGraphManager as EagleCudaGraphManager,
-        PrefillEagleCudaGraphManager as _PrefillEagleCudaGraphManager,
-    )
+from vllm.v1.worker.gpu.input_batch import InputBuffers
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
+from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import (
@@ -66,20 +56,27 @@ class EagleAclGraphManager(EagleCudaGraphManager):
             else:
                 set_draft_graph_params(self.capture_sizes)
 
-    def capture(self, forward_fn: Callable, *args, **kwargs) -> None:
-        """Capture ACL graphs for Eagle.
-
-        vLLM #40410 split EagleCudaGraphManager into separate Prefill/Decode
-        managers with different capture() signatures:
-        - Prefill: capture(forward_fn, full_cg_attn_states, ...)
-        - Decode:  capture(forward_fn, model_state, input_buffers, ...)
-        This override dispatches to the correct parent based on is_draft_model_prefill.
-        """
+    def capture(
+        self,
+        forward_fn: Callable,
+        model_state: ModelState,
+        input_buffers: InputBuffers,
+        block_tables: BlockTables,
+        attn_groups: list[list[AttentionGroup]],
+        kv_cache_config: KVCacheConfig,
+        progress_bar_desc: str = "Capturing CUDA graphs",
+    ) -> None:
+        """Capture ACL graphs for Eagle."""
         with communicator_switch(), model_capture_wrapper(self.speculator, self.is_draft_model_prefill):
-            if _PrefillEagleCudaGraphManager is not None and self.is_draft_model_prefill:
-                _PrefillEagleCudaGraphManager.capture(self, forward_fn, *args, **kwargs)
-            else:
-                super().capture(forward_fn, *args, **kwargs)
+            super().capture(
+                forward_fn,
+                model_state,
+                input_buffers,
+                block_tables,
+                attn_groups,
+                kv_cache_config,
+                progress_bar_desc,
+            )
 
     def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         """Override run_fullgraph to update full graph params in run_fullgraph."""

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -9,12 +9,7 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import logger
-from vllm.v1.kv_cache_interface import KVCacheConfig
-from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
-from vllm.v1.worker.gpu.input_batch import InputBuffers
-from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.utils import vllm_version_is
 
@@ -22,11 +17,14 @@ if vllm_version_is("0.19.1"):
     from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
         EagleCudaGraphManager,
     )
+    _PrefillEagleCudaGraphManager = None
 else:
-    # vLLM #40410 split EagleCudaGraphManager. The Ascend manager mirrors the
-    # decode-style capture signature, so we extend DecodeEagleCudaGraphManager.
+    # vLLM #40410 split EagleCudaGraphManager into Prefill/Decode managers.
+    # EagleAclGraphManager extends DecodeEagleCudaGraphManager (decode-style
+    # signature) but also needs to handle the prefill-style capture call.
     from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
         DecodeEagleCudaGraphManager as EagleCudaGraphManager,
+        PrefillEagleCudaGraphManager as _PrefillEagleCudaGraphManager,
     )
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -68,27 +66,20 @@ class EagleAclGraphManager(EagleCudaGraphManager):
             else:
                 set_draft_graph_params(self.capture_sizes)
 
-    def capture(
-        self,
-        forward_fn: Callable,
-        model_state: ModelState,
-        input_buffers: InputBuffers,
-        block_tables: BlockTables,
-        attn_groups: list[list[AttentionGroup]],
-        kv_cache_config: KVCacheConfig,
-        progress_bar_desc: str = "Capturing CUDA graphs",
-    ) -> None:
-        """Capture ACL graphs for Eagle."""
+    def capture(self, forward_fn: Callable, *args, **kwargs) -> None:
+        """Capture ACL graphs for Eagle.
+
+        vLLM #40410 split EagleCudaGraphManager into separate Prefill/Decode
+        managers with different capture() signatures:
+        - Prefill: capture(forward_fn, full_cg_attn_states, ...)
+        - Decode:  capture(forward_fn, model_state, input_buffers, ...)
+        This override dispatches to the correct parent based on is_draft_model_prefill.
+        """
         with communicator_switch(), model_capture_wrapper(self.speculator, self.is_draft_model_prefill):
-            super().capture(
-                forward_fn,
-                model_state,
-                input_buffers,
-                block_tables,
-                attn_groups,
-                kv_cache_config,
-                progress_bar_desc,
-            )
+            if _PrefillEagleCudaGraphManager is not None and self.is_draft_model_prefill:
+                _PrefillEagleCudaGraphManager.capture(self, forward_fn, *args, **kwargs)
+            else:
+                super().capture(forward_fn, *args, **kwargs)
 
     def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         """Override run_fullgraph to update full graph params in run_fullgraph."""

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -14,8 +14,20 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
 from vllm.v1.worker.utils import AttentionGroup
+
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is("0.19.1"):
+    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
+        EagleCudaGraphManager,
+    )
+else:
+    # vLLM #40410 split EagleCudaGraphManager. The Ascend manager mirrors the
+    # decode-style capture signature, so we extend DecodeEagleCudaGraphManager.
+    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
+        DecodeEagleCudaGraphManager as EagleCudaGraphManager,
+    )
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import (

--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -31,8 +31,24 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator as vllm_speculator
-from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator, gumbel_sample, update_eagle_inputs
+
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is("0.19.1"):
+    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
+        EagleCudaGraphManager,
+    )
+else:
+    # vLLM #40410 split the single EagleCudaGraphManager into a prefill/decode
+    # pair. The Ascend AclGraphManager keeps the previous decode-style capture
+    # signature, so reuse the decode class as the historical alias here.
+    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (  # noqa: F401
+        DecodeEagleCudaGraphManager as EagleCudaGraphManager,
+    )
+    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
+        PrefillEagleCudaGraphManager,
+    )
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
@@ -385,13 +401,26 @@ def torch_gather_wrapper():
 @contextmanager
 def graph_manager_wrapper(speculator):
     """Context manager to override graph manager."""
-    original_graph_manager = EagleCudaGraphManager
 
     def factory(vllm_config: VllmConfig, device: torch.device, cudagraph_mode: CUDAGraphMode, decode_query_len: int):
         return EagleAclGraphManager(vllm_config, device, cudagraph_mode, decode_query_len, speculator)
 
-    try:
-        vllm_speculator.EagleCudaGraphManager = factory
-        yield
-    finally:
-        vllm_speculator.EagleCudaGraphManager = original_graph_manager
+    if vllm_version_is("0.19.1"):
+        original = vllm_speculator.EagleCudaGraphManager
+        try:
+            vllm_speculator.EagleCudaGraphManager = factory
+            yield
+        finally:
+            vllm_speculator.EagleCudaGraphManager = original
+    else:
+        # vLLM #40410: speculator constructs both Prefill and Decode managers.
+        # Patch both names so the Ascend factory replaces both.
+        original_decode = vllm_speculator.DecodeEagleCudaGraphManager
+        original_prefill = vllm_speculator.PrefillEagleCudaGraphManager
+        try:
+            vllm_speculator.DecodeEagleCudaGraphManager = factory
+            vllm_speculator.PrefillEagleCudaGraphManager = factory
+            yield
+        finally:
+            vllm_speculator.DecodeEagleCudaGraphManager = original_decode
+            vllm_speculator.PrefillEagleCudaGraphManager = original_prefill

--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -46,9 +46,6 @@ else:
     from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (  # noqa: F401
         DecodeEagleCudaGraphManager as EagleCudaGraphManager,
     )
-    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
-        PrefillEagleCudaGraphManager,
-    )
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata

--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -31,21 +31,8 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator as vllm_speculator
+from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator, gumbel_sample, update_eagle_inputs
-
-from vllm_ascend.utils import vllm_version_is
-
-if vllm_version_is("0.19.1"):
-    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
-        EagleCudaGraphManager,
-    )
-else:
-    # vLLM #40410 split the single EagleCudaGraphManager into a prefill/decode
-    # pair. The Ascend AclGraphManager keeps the previous decode-style capture
-    # signature, so reuse the decode class as the historical alias here.
-    from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (  # noqa: F401
-        DecodeEagleCudaGraphManager as EagleCudaGraphManager,
-    )
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
@@ -398,26 +385,13 @@ def torch_gather_wrapper():
 @contextmanager
 def graph_manager_wrapper(speculator):
     """Context manager to override graph manager."""
+    original_graph_manager = EagleCudaGraphManager
 
     def factory(vllm_config: VllmConfig, device: torch.device, cudagraph_mode: CUDAGraphMode, decode_query_len: int):
         return EagleAclGraphManager(vllm_config, device, cudagraph_mode, decode_query_len, speculator)
 
-    if vllm_version_is("0.19.1"):
-        original = vllm_speculator.EagleCudaGraphManager
-        try:
-            vllm_speculator.EagleCudaGraphManager = factory
-            yield
-        finally:
-            vllm_speculator.EagleCudaGraphManager = original
-    else:
-        # vLLM #40410: speculator constructs both Prefill and Decode managers.
-        # Patch both names so the Ascend factory replaces both.
-        original_decode = vllm_speculator.DecodeEagleCudaGraphManager
-        original_prefill = vllm_speculator.PrefillEagleCudaGraphManager
-        try:
-            vllm_speculator.DecodeEagleCudaGraphManager = factory
-            vllm_speculator.PrefillEagleCudaGraphManager = factory
-            yield
-        finally:
-            vllm_speculator.DecodeEagleCudaGraphManager = original_decode
-            vllm_speculator.PrefillEagleCudaGraphManager = original_prefill
+    try:
+        vllm_speculator.EagleCudaGraphManager = factory
+        yield
+    finally:
+        vllm_speculator.EagleCudaGraphManager = original_graph_manager

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -44,7 +44,7 @@ from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
-from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
+from vllm.v1.worker.worker_base import WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
 import vllm_ascend.envs as envs_ascend
@@ -66,6 +66,14 @@ from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 if not vllm_version_is("0.19.1"):
     from vllm.v1.worker.worker_base import CompilationTimes  # noqa: E402
+else:
+    # CompilationTimes was added after v0.19.1; define a compatible fallback.
+    from typing import NamedTuple
+
+    class CompilationTimes(NamedTuple):  # type: ignore[no-redef]
+        language_model: float
+        encoder: float
+
 
 torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
@@ -557,11 +565,6 @@ class NPUWorker(WorkerBase):
         return CompilationTimes(
             language_model=self.vllm_config.compilation_config.compilation_time,
             encoder=self.vllm_config.compilation_config.encoder_compilation_time,
-        )
-
-        return CompilationTimes(
-            language_model=self.vllm_config.compilation_config.compilation_time,
-            encoder=self.compilation_config.encoder_compilation_time,
         )
 
     def _warm_up_atb(self):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -564,7 +564,13 @@ class NPUWorker(WorkerBase):
         set_random_seed(self.model_config.seed)
         return CompilationTimes(
             language_model=self.vllm_config.compilation_config.compilation_time,
-            encoder=self.vllm_config.compilation_config.encoder_compilation_time,
+            # `encoder_compilation_time` was added after v0.19.1 (vLLM #39240); fall
+            # back to 0.0 so the older release still constructs CompilationTimes.
+            encoder=getattr(
+                self.vllm_config.compilation_config,
+                "encoder_compilation_time",
+                0.0,
+            ),
         )
 
     def _warm_up_atb(self):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -44,7 +44,7 @@ from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
-from vllm.v1.worker.worker_base import WorkerBase
+from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
 import vllm_ascend.envs as envs_ascend
@@ -474,7 +474,7 @@ class NPUWorker(WorkerBase):
         with context, set_current_vllm_config(self.vllm_config):
             self.model_runner.load_model()
 
-    def compile_or_warm_up_model(self):
+    def compile_or_warm_up_model(self) -> CompilationTimes:
         # Note: need to adapt for graph mode.
         warmup_sizes = (self.vllm_config.compilation_config.compile_sizes or []).copy()
         if not self.model_config.enforce_eager:
@@ -554,8 +554,10 @@ class NPUWorker(WorkerBase):
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)
-        if vllm_version_is("0.19.1"):
-            return self.vllm_config.compilation_config.compilation_time
+        return CompilationTimes(
+            language_model=self.vllm_config.compilation_config.compilation_time,
+            encoder=self.vllm_config.compilation_config.encoder_compilation_time,
+        )
 
         return CompilationTimes(
             language_model=self.vllm_config.compilation_config.compilation_time,


### PR DESCRIPTION
### What this PR does / why we need it?

Cherry pick https://github.com/vllm-project/vllm-ascend/pull/8841 and then continue to upgrading vLLM.


| #  | Error                                              | Category  | Upstream Commit                                  | Affected vllm-ascend Path                                  | Fix                                              |
| :- | :------------------------------------------------- | :-------- | :----------------------------------------------- | :--------------------------------------------------------- | :----------------------------------------------- |
| 1  | `encoder_compilation_time` AttributeError          | Code Bug  | `c08f3b2a6` ([#39240](https://github.com/vllm-project/vllm/pull/39240)) | `worker/worker.py:567`                                     | `getattr` fallback                               |
| 2  | `AscendRMSNormGated activation` TypeError          | Code Bug  | `893611813` ([#40245](https://github.com/vllm-project/vllm/pull/40245)) | `ops/layernorm.py:160`, `_310p/ops/layernorm.py:43`        | Accept `activation` kwarg                        |
| 3  | `EagleCudaGraphManager` ImportError                | Code Bug  | `4c7c69b4e` ([#40410](https://github.com/vllm-project/vllm/pull/40410)) | `worker/v2/spec_decode/eagle/{speculator,aclgraph}.py`     | Version-guard import + patch new class names     |
| 4  | `AscendFusedMoEMethod.apply topk_weights` TypeError| Code Bug  | many (e.g., `5e584ce9e` ([#35782](https://github.com/vllm-project/vllm/pull/35782)), `809d83c2d` ([#40560](https://github.com/vllm-project/vllm/pull/40560)), `4d51588e2` ([#40860](https://github.com/vllm-project/vllm/pull/40860))) | `ops/fused_moe/fused_moe.py:107`                         | Major refactor — follow-up PR                    |
| 5  | `_all_lora_classes` is tuple                       | Code Bug  | `a250f1bd5` ([#35077](https://github.com/vllm-project/vllm/pull/35077)) | `lora/utils.py:188`                                        | Rebuild tuple instead of `.add()`                |
| 6  | `ProfilingChunkScheduler hash_block_size` TypeError| Code Bug  | `7b1bc0a3e` ([#40946](https://github.com/vllm-project/vllm/pull/40946)) | `core/scheduler_profiling_chunk.py:57`                     | Forward new kwarg                                |
| 7  | `_moe_C.topk_softmax` AttributeError               | Code Bug  | MoE router refactor                              | router dispatch override needed                            | Provide `torch_npu` topk-softmax (with Issue 4)  |
| 8  | global experts shape mismatch                      | Code Bug  | follow-on of Issue 4                             | `quantization/methods/w8a8_dynamic.py:198`                 | Resolve once Issue 4 is fixed                    |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
