### PR TITLE
[v0.13.0][Bugfix] Fix layerwise kvpool completion tracking

### DIFF
--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -484,30 +484,41 @@ class KVPoolWorker:
 
     def get_and_clear_finished_requests(
             self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
-        finished_sending = set()
-        for req_id in meta.preempted_req_ids:
-            self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
-                req_id)
-        for req_id in self.kv_send_thread.stored_requests.copy(  # type: ignore[union-attr]
-        ):
-            if self.kv_send_thread.stored_requests[  # type: ignore[union-attr]
-                    req_id] == 0 and req_id in self.finished_store_req:
-                self.finished_store_req.remove(req_id)
-                finished_sending.add(req_id)
+        if self.use_layerwise:
+            self.finished_store_req.update(
+                self.kv_send_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
+                ))
+            self.finished_store_req.difference_update(meta.preempted_req_ids)
+
+            finished_sending = self.finished_store_req.intersection(
+                finished_req_ids)
+            self.finished_store_req.difference_update(finished_sending)
+            return finished_sending
+        else:
+            finished_sending = set()
+            for req_id in meta.preempted_req_ids:
                 self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
                     req_id)
+            for req_id in self.kv_send_thread.stored_requests.copy(  # type: ignore[union-attr]
+            ):
+                if self.kv_send_thread.stored_requests[  # type: ignore[union-attr]
+                        req_id] == 0 and req_id in self.finished_store_req:
+                    self.finished_store_req.remove(req_id)
+                    finished_sending.add(req_id)
+                    self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
+                        req_id)
 
-        for req_id in finished_req_ids:
-            req_remain_jobs = self.kv_send_thread.stored_requests.get(  # type: ignore[union-attr]
-                req_id)
-            if req_remain_jobs == 0:
-                finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
+            for req_id in finished_req_ids:
+                req_remain_jobs = self.kv_send_thread.stored_requests.get(  # type: ignore[union-attr]
                     req_id)
-            elif req_remain_jobs is not None:
-                self.finished_store_req.add(req_id)
+                if req_remain_jobs == 0:
+                    finished_sending.add(req_id)
+                    self.kv_send_thread.delete_finished_stored_request(  # type: ignore[union-attr]
+                        req_id)
+                elif req_remain_jobs is not None:
+                    self.finished_store_req.add(req_id)
 
-        return finished_sending
+            return finished_sending
 
     def lookup(
         self,

--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -485,10 +485,9 @@ class KVPoolWorker:
     def get_and_clear_finished_requests(
             self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
         if self.use_layerwise:
-            kv_send_thread = self.kv_send_thread
-            assert kv_send_thread is not None
             self.finished_store_req.update(
-                kv_send_thread.get_and_clear_finished_requests())
+                self.kv_send_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
+                ))
             self.finished_store_req.difference_update(meta.preempted_req_ids)
 
             finished_sending = self.finished_store_req.intersection(

--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -360,10 +360,10 @@ class KVPoolWorker:
             be the boolean mask indicating which tokens are retrieved and will
             only be returned in the last iteration. 
         """
-        token_len = request.token_len_chunk
-        mask_num = (
-            request.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size * self.block_size)
+        load_spec = request.load_spec
+        assert load_spec is not None
+        token_len = load_spec.token_len
+        mask_num = load_spec.vllm_cached_tokens // self.block_size * self.block_size
         num_required_tokens = token_len - mask_num
 
         ret_mask = torch.zeros(token_len, dtype=torch.bool, device="cpu")

--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -485,9 +485,10 @@ class KVPoolWorker:
     def get_and_clear_finished_requests(
             self, finished_req_ids, meta: AscendConnectorMetadata) -> set[str]:
         if self.use_layerwise:
+            kv_send_thread = self.kv_send_thread
+            assert kv_send_thread is not None
             self.finished_store_req.update(
-                self.kv_send_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
-                ))
+                kv_send_thread.get_and_clear_finished_requests())
             self.finished_store_req.difference_update(meta.preempted_req_ids)
 
             finished_sending = self.finished_store_req.intersection(


### PR DESCRIPTION
Fix issue #8858 
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

This PR fixes completion tracking for the layerwise kvpool store path.
The non-layerwise path uses `stored_requests` to track pending store jobs, but the layerwise path does not have the same bookkeeping. As a result, completion could be handled incorrectly in `get_and_clear_finished_requests()`. This PR adds an explicit layerwise branch so a request is only reported finished after the layerwise send thread reports completion and the scheduler also marks the request as finished.

It's also ok to add ```stored_requests``` member in ```KVCacheStoreLayerSendingThread```, however, considering the existing finished mechanism in ```_handle_request``` of ```KVCacheStoreLayerSendingThread```, I only modify the logic of ```get_and_clear_finished_requests```.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I have tested different prefixes (1K,4k,16k) and suffixes (1k,4k,16k) input prompt length of Qwen3-32B, and as a result, vllm-ascend reports no errors in issue #8858 . 
