### PR TITLE
[v0.13.0][Bugfix] Use load token length for layerwise retrieval

### DIFF
--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -360,7 +360,7 @@ class KVPoolWorker:
             be the boolean mask indicating which tokens are retrieved and will
             only be returned in the last iteration. 
         """
-        token_len = request.token_len_chunk
+        token_len = request.load_spec.token_len
         mask_num = (
             request.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
             // self.block_size * self.block_size)

--- a/vllm_ascend/distributed/kvpool/pool_worker.py
+++ b/vllm_ascend/distributed/kvpool/pool_worker.py
@@ -360,10 +360,10 @@ class KVPoolWorker:
             be the boolean mask indicating which tokens are retrieved and will
             only be returned in the last iteration. 
         """
-        token_len = request.load_spec.token_len
-        mask_num = (
-            request.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size * self.block_size)
+        load_spec = request.load_spec
+        assert load_spec is not None
+        token_len = load_spec.token_len
+        mask_num = load_spec.vllm_cached_tokens // self.block_size * self.block_size
         num_required_tokens = token_len - mask_num
 
         ret_mask = torch.zeros(token_len, dtype=torch.bool, device="cpu")


### PR DESCRIPTION
Following #8859 fix the issue in #8858, ascendstore always reports ```Failed to get key```, I found the related bug and fixed it.
```

(Worker_TP0 pid=40246) ERROR 04-29 08:17:13 [mooncake_backend.py:78] Failed to get key ['Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@a9c081fbe227b73811b40864288fa85bdc7d6acef60a31e4777d42051e482987@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@6bd6bdc4bf3954391b60d84f73b9b68436825d70c27c13b7a149ec45b00b81bb@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@5ad269f316c7e9005cda70ca5655e6596b016b0213af4ddb2956231df9503870@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@ccd7f2121a8d27ee23bc30b2e2cec333ca3b5276273b718fa4b4a541b0dd8167@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@70248678c5b716a93fadb3cf5859190172fc794f1e36f13285f9be3c7f7d5cdd@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@21deb9b10436a3185ea2831f6fe1048cd0c528c804b72adea433daa400155513@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@cf83ade3f7a6a601aac41e161013ffd886bcce000dc7ba6cb162bacac04a7732@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@04e39d240e8ba66815830c44acb29dda5002f0b44023a45059d4803a36eaefbe@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@ab4debe5cde7f914b3c53239cf99bf70115fae31857eef52875b47d5ed52d8cb@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@dc3006080bcd9a7f2cc41bc3005c1d1fdaa2e03ec907209c8107eebebc75d67c@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@0d185a7594a39be17d54f7a3137acf72d2c0e7fb5e6ef4da49d6a72e9bdec97a@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@2afa038d52637c63ea71d5e21f220048c6b8cfbc16190df3a39f92df13431d19@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@dbbbadf3f669152330b808440dd2df8122bdcd253d23867504d37f8011625e47@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@baf060bdca260f298db6ed6aa2998c947acbe93ba7e9ae04ce60ec38fcc2b468@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@20fc9d8d8b9bc1197e0b42c8bcfac8e170c13ae784f20aec334f742965e2136d@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@f46625343cb90563f3e96660c55b872896c1a7fbf0ba1031cef502a5b8275b58@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@98ce2d5f367583e79d901494e3148627b18e300ea84d53f318304df11d955dbc@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@d7bb9f2e768af8a644ec2f5cb3e458d096588a927bb8842dc0ae5eb70e29840b@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@4c2710c2c36a5b0b476eb43be06d08c6832d131627c272397f38dc0bfa64773e@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@3f8b2780029fa85e3b6daa25417f2218d7d0de767e6473df2d49842cb07189f9@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@3b02bbab229c74adbbf09aaf42d187a10fea00c3f165215070d77d855c12a77f@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@a80d9d6fc930f0402048314abe4e78936221694d8ad074a93f1cb5c3f40f7d67@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@695b2a45f3dedcad0de0a840e481c77d1d5cb93c25eeb3b749b312fe61b2bc34@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@410c8e32209e3914832765dfde4de23ac7d2f00697fffefcdaf869e5f100fde4@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@20ac5920edc62bb6ea38befcd981b379680d68f996b15821f3d2b3fc4bcc2643@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@e76cdad752d4f386594eb909bdf43a1219ae915219e0d812b990eee3249cc924@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@f70e020d5f09eecbdea12f38cd6940480ebd38023432e4e65446ffd8296fb7b9@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@f48f0f30f33a8859aeb0e965c722611f288c18c267f995845d07dc96e7448ddd@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@05a09a475431d4290aa4d96dcbca7130d58f1b64c79af30fd09c098ae65f27b5@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@34b6c71fb37ec1c3bf599c7368eb610ff90138263bb47301af41187231879a1e@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@11d9abfc8bc7fc87e5139e600f0218b2d1d6f2eb7900395b52bb533eb7ecfce5@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@926e4081e6c9342fb0dcb79aafc94d56e8f51d113afa432621aff169b1527fc0@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@8b6c060ca13efd3cf6158308601a818645e8aa578ecda20cbb26b2e8aa003e19@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@b110e4980fd73afd5ec62b10f2b31209e77b05850e8d2946c6bf4ea157904f28@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@a885228efa5362a17bc4831f68891682c149a7b6afe8aae795c97ef97c4685de@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@1b90f51a4013842d3dd48c3714d7b52976054522d59d02b3d5a24effaeb1407c@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@0e5c9b221255229fdc771293e2f56f3b95878a1fff15b551949e3c773ece60d6@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@ce3a16d1e9de884cbcdc27c88ee4728b2b764122339dfd3801d7eb9a7e66c1fa@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@e3790e0fd826c7e9d0615b157a244f6a7465bd317c112a8b01658391fb0d2eb0@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@56303f0198caf5ce64537e0aaed9d03a67beb65919df674ebfda7fd317c6e0fd@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@28fda2d528449f6f3fc94254b0e939d8496079a873772ea1c96a1f0fc9ff3bbd@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@76cb8082113372dcb22620367766d68049ba2b3b7e9cec2ed67682bddab74650@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@29a434f03f3f57756e195344a2e59ff48a3721f5d3c17edaa83b498691ebec68@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@3a937a12e3ba8523dc13e59e1f8a85fbb7b65ec3f88ad7d3365026916c497c6f@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@4a28b34a8c9da25b12cd598b04c084c247f283aeed499bf2ff125ac47ad6aaf9@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@4e4bf6ecf337313ada7a9005a7a8eca294bd61586cefd40b607b4d3b3c17cf2f@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@6a3080d6479f5a1f633038c252a1b561349a9288bdcfde2df7955e22ad57cf87@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@8b00b5755bf14dfbd4b4d015fedfba3d9dec5e55aef76f732cb96e6b2f136d9c@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@10aa65292142edea221d52985d87edbb8649e822f5547ef76a2a846e1bc6b737@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@b4740efabb6566cca2904d4392bb9e84b5991c8a952b79bc394a9d1bd7982969@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@6b563b20872cc41786716cd234df2675c557a0413b5b88b7f04602e6cee30562@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@0d39718ecebe961da55c3053fbff384e69e1a0b72affbfbcc11da30f1927a6db@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@ad38881c4f2080ad7a1ef7232e0cd45c2977ff7552b645f143c0962814f83b8f@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@c1de3e02a974a3ec4e9f81066d65e5b55014fc1b27c69a840507500919069c63@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@4dadc1a260518e73e06b4a653076f9f9dbedc7b395990bf62b4a4f528c362cf6@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@0e82ff9aa16f9a522e40193c3ad4cde6755f56e27e6768cbd37fdff6aa931367@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@48a0a768ae323a990d9d401813f0bce59981c43c11c9beb0120d5f951696e311@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@4deae36ac8a41cbf60f29b319b5413e7437659254bd86e5eb15107565337a7c1@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@a26b5f689d2627513e85c1410dfcc10c72139712e61e08d887db95be3cf008e1@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@f2e2ee0f1c0488755c406d1e27f64565af442aa788ae4214a74e61cca9bf0556@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@368fcfb238c12b0f5344bb425bfeb376750137e20e5c09e1e4c680e0bda970e8@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@6452bdb22ce4ded1929f27000b749b99a152de718c97dc12af09a15dfb7aa792@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@8ab6c04dcc81d1805aa7e64926646310a0f7f14b8789e6842a5f8cc81528d20e@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@abeba9a90f1765136883bf275381fce2d3bfb80fd7fff88377e9964a127961ca@62', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:0@e067f35d2e7f7df5e59e705792956b177f5e37567cacd25c8b17ba2e2b802523@62'], res:[262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, -704]
(Worker_TP0 pid=40246) INFO 04-29 08:17:13 [kv_transfer.py:314] Storing KV cache for 65 out of 65 blocks (skip_block_num=64) for request cmpl-a7bf28a7652dcbf7-0
I20260429 08:17:13.825202 41152 pybind_client.cpp:1276] batch_get_into_multi_buffers: 1817us
I20260429 08:17:13.825291 41151 pybind_client.cpp:1218] batch_put_from_multi_buffers: 1211us
(Worker_TP1 pid=40247) ERROR 04-29 08:17:13 [mooncake_backend.py:78] Failed to get key ['Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@6bd6bdc4bf3954391b60d84f73b9b68436825d70c27c13b7a149ec45b00b81bb@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@5ad269f316c7e9005cda70ca5655e6596b016b0213af4ddb2956231df9503870@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@ccd7f2121a8d27ee23bc30b2e2cec333ca3b5276273b718fa4b4a541b0dd8167@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@70248678c5b716a93fadb3cf5859190172fc794f1e36f13285f9be3c7f7d5cdd@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@21deb9b10436a3185ea2831f6fe1048cd0c528c804b72adea433daa400155513@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@cf83ade3f7a6a601aac41e161013ffd886bcce000dc7ba6cb162bacac04a7732@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@04e39d240e8ba66815830c44acb29dda5002f0b44023a45059d4803a36eaefbe@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@ab4debe5cde7f914b3c53239cf99bf70115fae31857eef52875b47d5ed52d8cb@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@dc3006080bcd9a7f2cc41bc3005c1d1fdaa2e03ec907209c8107eebebc75d67c@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@0d185a7594a39be17d54f7a3137acf72d2c0e7fb5e6ef4da49d6a72e9bdec97a@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@2afa038d52637c63ea71d5e21f220048c6b8cfbc16190df3a39f92df13431d19@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@dbbbadf3f669152330b808440dd2df8122bdcd253d23867504d37f8011625e47@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@baf060bdca260f298db6ed6aa2998c947acbe93ba7e9ae04ce60ec38fcc2b468@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@20fc9d8d8b9bc1197e0b42c8bcfac8e170c13ae784f20aec334f742965e2136d@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@f46625343cb90563f3e96660c55b872896c1a7fbf0ba1031cef502a5b8275b58@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@98ce2d5f367583e79d901494e3148627b18e300ea84d53f318304df11d955dbc@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@d7bb9f2e768af8a644ec2f5cb3e458d096588a927bb8842dc0ae5eb70e29840b@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@4c2710c2c36a5b0b476eb43be06d08c6832d131627c272397f38dc0bfa64773e@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@3f8b2780029fa85e3b6daa25417f2218d7d0de767e6473df2d49842cb07189f9@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@3b02bbab229c74adbbf09aaf42d187a10fea00c3f165215070d77d855c12a77f@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@a80d9d6fc930f0402048314abe4e78936221694d8ad074a93f1cb5c3f40f7d67@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@695b2a45f3dedcad0de0a840e481c77d1d5cb93c25eeb3b749b312fe61b2bc34@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@410c8e32209e3914832765dfde4de23ac7d2f00697fffefcdaf869e5f100fde4@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@20ac5920edc62bb6ea38befcd981b379680d68f996b15821f3d2b3fc4bcc2643@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@e76cdad752d4f386594eb909bdf43a1219ae915219e0d812b990eee3249cc924@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@f70e020d5f09eecbdea12f38cd6940480ebd38023432e4e65446ffd8296fb7b9@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@f48f0f30f33a8859aeb0e965c722611f288c18c267f995845d07dc96e7448ddd@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@05a09a475431d4290aa4d96dcbca7130d58f1b64c79af30fd09c098ae65f27b5@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@34b6c71fb37ec1c3bf599c7368eb610ff90138263bb47301af41187231879a1e@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@11d9abfc8bc7fc87e5139e600f0218b2d1d6f2eb7900395b52bb533eb7ecfce5@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@926e4081e6c9342fb0dcb79aafc94d56e8f51d113afa432621aff169b1527fc0@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@8b6c060ca13efd3cf6158308601a818645e8aa578ecda20cbb26b2e8aa003e19@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@b110e4980fd73afd5ec62b10f2b31209e77b05850e8d2946c6bf4ea157904f28@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@a885228efa5362a17bc4831f68891682c149a7b6afe8aae795c97ef97c4685de@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@1b90f51a4013842d3dd48c3714d7b52976054522d59d02b3d5a24effaeb1407c@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@0e5c9b221255229fdc771293e2f56f3b95878a1fff15b551949e3c773ece60d6@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@ce3a16d1e9de884cbcdc27c88ee4728b2b764122339dfd3801d7eb9a7e66c1fa@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@e3790e0fd826c7e9d0615b157a244f6a7465bd317c112a8b01658391fb0d2eb0@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@56303f0198caf5ce64537e0aaed9d03a67beb65919df674ebfda7fd317c6e0fd@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@28fda2d528449f6f3fc94254b0e939d8496079a873772ea1c96a1f0fc9ff3bbd@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@76cb8082113372dcb22620367766d68049ba2b3b7e9cec2ed67682bddab74650@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@29a434f03f3f57756e195344a2e59ff48a3721f5d3c17edaa83b498691ebec68@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@3a937a12e3ba8523dc13e59e1f8a85fbb7b65ec3f88ad7d3365026916c497c6f@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@4a28b34a8c9da25b12cd598b04c084c247f283aeed499bf2ff125ac47ad6aaf9@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@4e4bf6ecf337313ada7a9005a7a8eca294bd61586cefd40b607b4d3b3c17cf2f@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@6a3080d6479f5a1f633038c252a1b561349a9288bdcfde2df7955e22ad57cf87@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@8b00b5755bf14dfbd4b4d015fedfba3d9dec5e55aef76f732cb96e6b2f136d9c@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@10aa65292142edea221d52985d87edbb8649e822f5547ef76a2a846e1bc6b737@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@b4740efabb6566cca2904d4392bb9e84b5991c8a952b79bc394a9d1bd7982969@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@6b563b20872cc41786716cd234df2675c557a0413b5b88b7f04602e6cee30562@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@0d39718ecebe961da55c3053fbff384e69e1a0b72affbfbcc11da30f1927a6db@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@ad38881c4f2080ad7a1ef7232e0cd45c2977ff7552b645f143c0962814f83b8f@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@c1de3e02a974a3ec4e9f81066d65e5b55014fc1b27c69a840507500919069c63@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@4dadc1a260518e73e06b4a653076f9f9dbedc7b395990bf62b4a4f528c362cf6@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@0e82ff9aa16f9a522e40193c3ad4cde6755f56e27e6768cbd37fdff6aa931367@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@48a0a768ae323a990d9d401813f0bce59981c43c11c9beb0120d5f951696e311@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@4deae36ac8a41cbf60f29b319b5413e7437659254bd86e5eb15107565337a7c1@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@a26b5f689d2627513e85c1410dfcc10c72139712e61e08d887db95be3cf008e1@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@f2e2ee0f1c0488755c406d1e27f64565af442aa788ae4214a74e61cca9bf0556@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@368fcfb238c12b0f5344bb425bfeb376750137e20e5c09e1e4c680e0bda970e8@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@6452bdb22ce4ded1929f27000b749b99a152de718c97dc12af09a15dfb7aa792@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@8ab6c04dcc81d1805aa7e64926646310a0f7f14b8789e6842a5f8cc81528d20e@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@abeba9a90f1765136883bf275381fce2d3bfb80fd7fff88377e9964a127961ca@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@e067f35d2e7f7df5e59e705792956b177f5e37567cacd25c8b17ba2e2b802523@63', 'Qwen3-32B@pcp0@dcp0@head_or_tp_rank:1@a9c081fbe227b73811b40864288fa85bdc7d6acef60a31e4777d42051e482987@63'], res:[262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144, -704, 262144]
(Worker_TP1 pid=40247) INFO 04-29 08:17:13 [kv_transfer.py:314] Storing KV cache for 65 out of 65 blocks (skip_block_num=64) for request cmpl-a7bf28a7652dcbf7-0
I20260429 08:17:13.827553 41151 pybind_client.cpp:1218] batch_put_from_multi_buffers: 225us
(Worker_TP1 pid=40247) INFO 04-29 08:17:13 [kv_transfer.py:314] Storing KV cache for 65 out of 65 blocks (skip_block_num=64) for request cmpl-a7bf28a7652dcbf7-0
I20260429 08:17:13.828027 41150 pybind_client.cpp:1276] batch_get_into_multi_buffers: 1319us
```




<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

This PR fixes the token length used in layerwise KV cache retrieval.
Previously, the layerwise retrieval path used `request.token_len_chunk`, which may not match the load boundary computed during `start_load_kv()`. This PR switches the retrieval path to use `request.load_spec.token_len`, so layerwise load follows the same token boundary prepared by the load logic.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The test is same to #8859 , and no ascendstore ```get``` error reported. 