### PR TITLE
[BugFix][0.18.0] Fix GLM5 streaming tool_calls finish_reason violating OpenAI spec

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_parser.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponseStreamChoice,
@@ -13,6 +18,9 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.tool_parsers.glm4_moe_tool_parser import Glm4MoeModelToolParser
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
+from vllm_ascend.patch.platform.patch_glm_tool_call_parser import (
+    _patched_chat_completion_stream_generator,
+)
 
 
 class FakeTokenizer:
@@ -316,3 +324,248 @@ def test_glm47_streaming_delta_serializes_tool_call_fields():
     assert serialized_deltas[-1] != {}
     assert serialized_deltas[-1]["tool_calls"][0]["index"] == 0
     assert serialized_deltas[-1]["tool_calls"][0]["function"]["arguments"] == '{"filepath":"pong.py"}'
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by streaming-split tests
+# ---------------------------------------------------------------------------
+
+def _make_serving_mock(*, use_harmony: bool = False) -> MagicMock:
+    """Return a minimal mock of OpenAIServingChat for streaming tests."""
+    serving = MagicMock()
+    serving.use_harmony = use_harmony
+    serving.tool_parser = None
+    serving.tool_call_id_type = "standard"
+    serving.enable_log_outputs = False
+    serving.enable_log_deltas = False
+    serving.enable_force_include_usage = False
+    serving._should_stream_with_auto_tool_parsing.return_value = False
+    serving.get_chat_request_role.return_value = "assistant"
+    serving._raise_if_error.return_value = None
+    serving._should_check_for_unstreamed_tool_arg_tokens.return_value = False
+    serving._make_usage_info.return_value = MagicMock()
+    serving._count_reasoning_tokens_for_usage.return_value = None
+    return serving
+
+
+def _make_request_mock(*, tool_choice: str = "required") -> MagicMock:
+    request = MagicMock()
+    request.n = 1
+    request.logprobs = False
+    request.top_logprobs = None
+    request.return_token_ids = False
+    request.return_tokens_as_token_ids = False
+    request.include_reasoning = False
+    request.echo = False
+    request._grammar_from_tool_parser = False
+    request.tool_choice = tool_choice
+    request.stream_options = None
+    request.parallel_tool_calls = True
+    request.tools = []
+    return request
+
+
+class _MockOutput:
+    def __init__(self, *, token_ids=(1,), text="", finish_reason=None, stop_reason=None):
+        self.index = 0
+        self.token_ids = token_ids
+        self.text = text
+        self.finish_reason = finish_reason
+        self.stop_reason = stop_reason
+        self.logprobs = None
+
+
+class _MockResult:
+    def __init__(self, outputs, prompt_token_ids=(1, 2, 3)):
+        self.outputs = outputs
+        self.prompt_token_ids = prompt_token_ids
+        self.encoder_prompt_token_ids = None
+        self.num_cached_tokens = None
+
+
+async def _run_stream(serving, request, outputs):
+    """Drive the patched generator and return parsed non-DONE data chunks."""
+    async def _gen():
+        for out in outputs:
+            yield out
+
+    chunks = []
+    async for item in _patched_chat_completion_stream_generator(
+        serving,
+        request=request,
+        result_generator=_gen(),
+        request_id="test-req-id",
+        model_name="glm-5",
+        conversation=[],
+        tokenizer=MagicMock(),
+        request_metadata=MagicMock(),
+        reasoning_parser=None,
+    ):
+        if item.startswith("data: ") and item.strip() != "data: [DONE]":
+            data = json.loads(item[6:].strip())
+            if data.get("choices"):
+                chunks.append(data)
+    return chunks
+
+
+def _assert_split_invariant(chunks):
+    """Assert that no chunk has both tool_calls delta data AND a non-null finish_reason."""
+    for chunk in chunks:
+        for choice in chunk["choices"]:
+            delta = choice.get("delta", {})
+            finish_reason = choice.get("finish_reason")
+            tool_calls = delta.get("tool_calls", [])
+            assert not (tool_calls and finish_reason is not None), (
+                f"Chunk carries both tool_calls data and finish_reason={finish_reason!r}: {chunk}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Streaming-split tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_streaming_final_tool_calls_chunk_is_split_from_finish_reason():
+    """
+    The last tool_calls arguments delta and finish_reason='tool_calls' must
+    be delivered in separate chunks (OpenAI streaming spec invariant).
+    """
+    serving = _make_serving_mock()
+    request = _make_request_mock(tool_choice="required")
+
+    final_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                id="call-123",
+                type="function",
+                function=DeltaFunctionCall(name="detect_text", arguments="}"),
+            )
+        ]
+    )
+    serving.extract_tool_call_required_streaming.return_value = (final_delta, True)
+
+    outputs = [_MockResult([_MockOutput(finish_reason="stop")])]
+    chunks = await _run_stream(serving, request, outputs)
+
+    _assert_split_invariant(chunks)
+
+    tool_call_chunks = [c for c in chunks if any(ch["delta"].get("tool_calls") for ch in c["choices"])]
+    finish_chunks = [c for c in chunks if any(ch.get("finish_reason") == "tool_calls" for ch in c["choices"])]
+
+    assert len(tool_call_chunks) >= 1, "Must have at least one chunk with tool_calls data"
+    assert len(finish_chunks) == 1, "Must have exactly one chunk with finish_reason='tool_calls'"
+
+    data_idx = chunks.index(tool_call_chunks[-1])
+    finish_idx = chunks.index(finish_chunks[0])
+    assert finish_idx > data_idx, "finish_reason chunk must come after the last data chunk"
+
+    # The finish chunk delta must be empty ({})
+    finish_delta = finish_chunks[0]["choices"][0].get("delta", {})
+    assert not finish_delta.get("tool_calls"), "finish chunk delta must have no tool_calls"
+    assert not finish_delta.get("content"), "finish chunk delta must have no content"
+
+
+@pytest.mark.asyncio
+async def test_streaming_multi_chunk_tool_args_split_only_at_finish():
+    """
+    When arguments arrive across several intermediate chunks, only the
+    final chunk (carrying the closing '}') triggers the split.  Intermediate
+    chunks must NOT be split.
+    """
+    serving = _make_serving_mock()
+    request = _make_request_mock(tool_choice="required")
+
+    # Intermediate chunk: first part of arguments, no finish_reason
+    intermediate_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                id="call-456",
+                type="function",
+                function=DeltaFunctionCall(name="search", arguments='{"q":"foo"'),
+            )
+        ]
+    )
+    # Final chunk: closing brace + finish_reason
+    final_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                function=DeltaFunctionCall(arguments="}"),
+            )
+        ]
+    )
+    serving.extract_tool_call_required_streaming.side_effect = [
+        (intermediate_delta, True),   # first call → no finish_reason
+        (final_delta, True),          # second call → finish_reason="stop"
+    ]
+
+    outputs = [
+        _MockResult([_MockOutput(finish_reason=None)]),   # intermediate
+        _MockResult([_MockOutput(finish_reason="stop")]), # final
+    ]
+    chunks = await _run_stream(serving, request, outputs)
+
+    _assert_split_invariant(chunks)
+
+    finish_chunks = [c for c in chunks if any(ch.get("finish_reason") == "tool_calls" for ch in c["choices"])]
+    assert len(finish_chunks) == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_multiple_tool_calls_split_invariant():
+    """
+    Multi-tool-call scenario: the invariant holds regardless of how many
+    tool calls are present in the final delta.
+    """
+    serving = _make_serving_mock()
+    request = _make_request_mock(tool_choice="required")
+
+    final_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                id="call-a",
+                type="function",
+                function=DeltaFunctionCall(name="tool_a", arguments='{"x":1}'),
+            ),
+            DeltaToolCall(
+                index=1,
+                id="call-b",
+                type="function",
+                function=DeltaFunctionCall(name="tool_b", arguments='{"y":2}'),
+            ),
+        ]
+    )
+    serving.extract_tool_call_required_streaming.return_value = (final_delta, True)
+
+    outputs = [_MockResult([_MockOutput(finish_reason="stop")])]
+    chunks = await _run_stream(serving, request, outputs)
+
+    _assert_split_invariant(chunks)
+
+    finish_chunks = [c for c in chunks if any(ch.get("finish_reason") == "tool_calls" for ch in c["choices"])]
+    assert len(finish_chunks) == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_plain_text_not_split():
+    """
+    Plain text streaming (no tool calls) is NOT affected by the split.
+    The finish chunk may still carry content with finish_reason='stop'.
+    """
+    serving = _make_serving_mock()
+    # No tool_choice → pure text path
+    request = _make_request_mock(tool_choice="none")
+    request.tool_choice = "none"  # ensure it doesn't hit required/auto paths
+
+    outputs = [_MockResult([_MockOutput(text="Hello!", finish_reason="stop")])]
+    chunks = await _run_stream(serving, request, outputs)
+
+    finish_chunks = [c for c in chunks if any(ch.get("finish_reason") == "stop" for ch in c["choices"])]
+    assert len(finish_chunks) >= 1, "Should have a chunk with finish_reason='stop'"
+
+    # No spurious extra empty-delta chunk should appear for plain text
+    tool_call_chunks = [c for c in chunks if any(ch["delta"].get("tool_calls") for ch in c["choices"])]
+    assert len(tool_call_chunks) == 0, "Plain text must not produce tool_calls chunks"

--- a/tests/ut/patch/platform/test_patch_glm_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_parser.py
@@ -4,7 +4,6 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponseStreamChoice,
@@ -18,6 +17,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.tool_parsers.glm4_moe_tool_parser import Glm4MoeModelToolParser
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
+
 from vllm_ascend.patch.platform.patch_glm_tool_call_parser import (
     _patched_chat_completion_stream_generator,
 )
@@ -330,6 +330,7 @@ def test_glm47_streaming_delta_serializes_tool_call_fields():
 # Helpers shared by streaming-split tests
 # ---------------------------------------------------------------------------
 
+
 def _make_serving_mock(*, use_harmony: bool = False) -> MagicMock:
     """Return a minimal mock of OpenAIServingChat for streaming tests."""
     serving = MagicMock()
@@ -385,6 +386,7 @@ class _MockResult:
 
 async def _run_stream(serving, request, outputs):
     """Drive the patched generator and return parsed non-DONE data chunks."""
+
     async def _gen():
         for out in outputs:
             yield out
@@ -423,6 +425,7 @@ def _assert_split_invariant(chunks):
 # ---------------------------------------------------------------------------
 # Streaming-split tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_streaming_final_tool_calls_chunk_is_split_from_finish_reason():
@@ -497,13 +500,13 @@ async def test_streaming_multi_chunk_tool_args_split_only_at_finish():
         ]
     )
     serving.extract_tool_call_required_streaming.side_effect = [
-        (intermediate_delta, True),   # first call → no finish_reason
-        (final_delta, True),          # second call → finish_reason="stop"
+        (intermediate_delta, True),  # first call → no finish_reason
+        (final_delta, True),  # second call → finish_reason="stop"
     ]
 
     outputs = [
-        _MockResult([_MockOutput(finish_reason=None)]),   # intermediate
-        _MockResult([_MockOutput(finish_reason="stop")]), # final
+        _MockResult([_MockOutput(finish_reason=None)]),  # intermediate
+        _MockResult([_MockOutput(finish_reason="stop")]),  # final
     ]
     chunks = await _run_stream(serving, request, outputs)
 

--- a/tests/ut/patch/platform/test_patch_glm_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_parser.py
@@ -70,7 +70,11 @@ def test_create_remaining_args_delta_uses_fallback_metadata_for_args_only_delta(
     assert tc.function.arguments == ('{"files":[{"filepath":"HumanEval-X/README.md"}]}')
 
 
-def test_create_remaining_args_delta_prefers_current_metadata_over_fallback():
+def test_create_remaining_args_delta_uses_fallback_over_original_delta():
+    # _create_remaining_args_delta ignores original_delta metadata and uses
+    # the explicit fallback_* parameters instead.  The caller is responsible
+    # for passing non-None fallback values only for the first chunk of a
+    # tool call (when the header has not yet been streamed).
     original_delta = DeltaMessage(
         tool_calls=[
             DeltaToolCall(
@@ -95,9 +99,9 @@ def test_create_remaining_args_delta_prefers_current_metadata_over_fallback():
     )
 
     tc = result.tool_calls[0]
-    assert tc.id == "call_current"
+    assert tc.id == "call_fallback"
     assert tc.type == "function"
-    assert tc.function.name == "current_name"
+    assert tc.function.name == "fallback_name"
     assert tc.function.arguments == "]}"
 
 

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
@@ -712,13 +712,50 @@ async def _patched_chat_completion_stream_generator(
                         finish_reason_ = "tool_calls"
                     else:
                         finish_reason_ = output.finish_reason if output.finish_reason else "stop"
+
+                    # Per OpenAI streaming spec: a chunk that carries delta data
+                    # must have finish_reason=None.  When the last token arrives
+                    # together with the finish signal, split into two chunks:
+                    #   1. data chunk  – delta with tool_calls/content, finish_reason=null
+                    #   2. finish chunk – empty delta, finish_reason="tool_calls"
+                    # This prevents downstream consumers from losing the final
+                    # arguments fragment because they stop reading at finish_reason.
+                    _split_done = False
+                    if finish_reason_ == "tool_calls" and delta_message is not None and (
+                        bool(delta_message.tool_calls) or bool(delta_message.content)
+                    ):
+                        _data_choice = ChatCompletionResponseStreamChoice(
+                            index=i,
+                            delta=delta_message,
+                            logprobs=logprobs,
+                            finish_reason=None,
+                            token_ids=(as_list(output.token_ids) if request.return_token_ids else None),
+                        )
+                        _data_choice = maybe_filter_parallel_tool_calls(_data_choice, request)
+                        self._record_streamed_tool_args(_data_choice.delta, streamed_tool_args[i])
+                        _data_chunk = ChatCompletionStreamResponse(
+                            id=request_id,
+                            object=chunk_object_type,
+                            created=created_time,
+                            choices=[_data_choice],
+                            model=model_name,
+                        )
+                        yield f"data: {_data_chunk.model_dump_json(exclude_unset=True)}\n\n"
+                        delta_message = DeltaMessage()
+                        logprobs = None
+                        _split_done = True
+
                     choice_data = ChatCompletionResponseStreamChoice(
                         index=i,
                         delta=delta_message,
                         logprobs=logprobs,
                         finish_reason=finish_reason_,
                         stop_reason=output.stop_reason,
-                        token_ids=(as_list(output.token_ids) if request.return_token_ids else None),
+                        token_ids=(
+                            None
+                            if _split_done
+                            else (as_list(output.token_ids) if request.return_token_ids else None)
+                        ),
                     )
 
                     finish_reason_sent[i] = True

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
@@ -721,8 +721,10 @@ async def _patched_chat_completion_stream_generator(
                     # This prevents downstream consumers from losing the final
                     # arguments fragment because they stop reading at finish_reason.
                     _split_done = False
-                    if finish_reason_ == "tool_calls" and delta_message is not None and (
-                        bool(delta_message.tool_calls) or bool(delta_message.content)
+                    if (
+                        finish_reason_ == "tool_calls"
+                        and delta_message is not None
+                        and (bool(delta_message.tool_calls) or bool(delta_message.content))
                     ):
                         _data_choice = ChatCompletionResponseStreamChoice(
                             index=i,
@@ -752,9 +754,7 @@ async def _patched_chat_completion_stream_generator(
                         finish_reason=finish_reason_,
                         stop_reason=output.stop_reason,
                         token_ids=(
-                            None
-                            if _split_done
-                            else (as_list(output.token_ids) if request.return_token_ids else None)
+                            None if _split_done else (as_list(output.token_ids) if request.return_token_ids else None)
                         ),
                     )
 

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
@@ -655,6 +655,7 @@ async def _patched_chat_completion_stream_generator(
                         index = 0
 
                     if self._should_check_for_unstreamed_tool_arg_tokens(delta_message, output) and tool_parser:
+                        already_streamed = index in streamed_tool_args[i]
                         already_streamed_args = streamed_tool_args[i].get(index, "")
                         remaining_call = self._compute_remaining_tool_args(
                             expected_args=tool_parser.prev_tool_call_arr[index].get("arguments", {}),
@@ -663,13 +664,14 @@ async def _patched_chat_completion_stream_generator(
 
                         # Per OpenAI streaming semantics, id/type/name must only
                         # appear in the *first* chunk for a tool call index.
-                        # If already_streamed_args is non-empty the header was
-                        # sent in a previous chunk, so pass None for all fallback
-                        # fields so _create_remaining_args_delta omits them.
+                        # Use `already_streamed` (key existence) rather than
+                        # `already_streamed_args` (string truthiness) so that a
+                        # first chunk with an empty arguments string does not
+                        # cause the header to be re-emitted in a later chunk.
                         fallback_tool_call_id = None
                         fallback_tool_call_type = None
                         fallback_tool_call_name = None
-                        if not already_streamed_args:
+                        if not already_streamed:
                             fallback_tool_call = (
                                 tool_parser.prev_tool_call_arr[index]
                                 if index < len(tool_parser.prev_tool_call_arr)

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
@@ -68,26 +68,38 @@ def _create_remaining_args_delta(
     fallback_tool_call_type: str | None = None,
     fallback_tool_call_name: str | None = None,
 ) -> DeltaMessage:
-    original_tc = next(
-        (tc for tc in delta_message.tool_calls if tc.index == index),
-        None,
+    """
+    Create a delta message for remaining tool arguments.
+
+    Per OpenAI streaming semantics, id/type/function.name must only appear
+    in the *first* chunk for a given tool call index.  Callers must pass
+    non-None fallback_* values only when this is genuinely the first chunk
+    (i.e. nothing has been streamed yet for this tool call).  When all
+    fallback_* are None the header fields are omitted entirely, which is the
+    correct behaviour for continuing/finishing chunks.
+    """
+    include_header = any(
+        v is not None for v in (fallback_tool_call_id, fallback_tool_call_type, fallback_tool_call_name)
     )
-    original_fn = original_tc.function if original_tc else None
-
-    original_fn_name = None
-    if isinstance(original_fn, DeltaFunctionCall):
-        original_fn_name = original_fn.name
-    elif isinstance(original_fn, dict):
-        original_fn_name = original_fn.get("name")
-
+    if not include_header:
+        return DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=index,
+                    function=DeltaFunctionCall(
+                        arguments=remaining_call,
+                    ),
+                )
+            ]
+        )
     return DeltaMessage(
         tool_calls=[
             DeltaToolCall(
                 index=index,
-                id=(original_tc.id if original_tc and original_tc.id is not None else fallback_tool_call_id),
-                type=(original_tc.type if original_tc and original_tc.type is not None else fallback_tool_call_type),
+                id=fallback_tool_call_id,
+                type=fallback_tool_call_type,
                 function=DeltaFunctionCall(
-                    name=(original_fn_name if original_fn_name is not None else fallback_tool_call_name),
+                    name=fallback_tool_call_name,
                     arguments=remaining_call,
                 ),
             )
@@ -643,34 +655,43 @@ async def _patched_chat_completion_stream_generator(
                         index = 0
 
                     if self._should_check_for_unstreamed_tool_arg_tokens(delta_message, output) and tool_parser:
+                        already_streamed_args = streamed_tool_args[i].get(index, "")
                         remaining_call = self._compute_remaining_tool_args(
                             expected_args=tool_parser.prev_tool_call_arr[index].get("arguments", {}),
-                            streamed_args=streamed_tool_args[i].get(index, ""),
+                            streamed_args=already_streamed_args,
                         )
 
-                        fallback_tool_call = (
-                            tool_parser.prev_tool_call_arr[index] if index < len(tool_parser.prev_tool_call_arr) else {}
-                        )
+                        # Per OpenAI streaming semantics, id/type/name must only
+                        # appear in the *first* chunk for a tool call index.
+                        # If already_streamed_args is non-empty the header was
+                        # sent in a previous chunk, so pass None for all fallback
+                        # fields so _create_remaining_args_delta omits them.
                         fallback_tool_call_id = None
                         fallback_tool_call_type = None
                         fallback_tool_call_name = None
-                        if isinstance(fallback_tool_call, dict):
-                            fallback_tool_call_id = fallback_tool_call.get("id")
-                            fallback_tool_call_type = fallback_tool_call.get("type")
-                            fallback_tool_call_name = fallback_tool_call.get("name")
+                        if not already_streamed_args:
+                            fallback_tool_call = (
+                                tool_parser.prev_tool_call_arr[index]
+                                if index < len(tool_parser.prev_tool_call_arr)
+                                else {}
+                            )
+                            if isinstance(fallback_tool_call, dict):
+                                fallback_tool_call_id = fallback_tool_call.get("id")
+                                fallback_tool_call_type = fallback_tool_call.get("type")
+                                fallback_tool_call_name = fallback_tool_call.get("name")
 
-                        tool_call_ids = getattr(tool_parser, "_tool_call_ids", None)
-                        if (
-                            fallback_tool_call_id is None
-                            and isinstance(tool_call_ids, list)
-                            and index < len(tool_call_ids)
-                        ):
-                            fallback_tool_call_id = tool_call_ids[index]
+                            tool_call_ids = getattr(tool_parser, "_tool_call_ids", None)
+                            if (
+                                fallback_tool_call_id is None
+                                and isinstance(tool_call_ids, list)
+                                and index < len(tool_call_ids)
+                            ):
+                                fallback_tool_call_id = tool_call_ids[index]
 
-                        if fallback_tool_call_type is None and (
-                            fallback_tool_call_id is not None or fallback_tool_call_name is not None
-                        ):
-                            fallback_tool_call_type = "function"
+                            if fallback_tool_call_type is None and (
+                                fallback_tool_call_id is not None or fallback_tool_call_name is not None
+                            ):
+                                fallback_tool_call_type = "function"
 
                         delta_message = self._create_remaining_args_delta(
                             delta_message,


### PR DESCRIPTION
  ### What this PR does / why we need it?

  When the GLM5 model streams tool-call responses with Function-Call enabled, the `finish_reason` field and the last
  data segment are bundled in a single chunk, violating the OpenAI streaming protocol standard.

  **Current (incorrect) behavior** — the final chunk carries both new tool arguments AND `finish_reason: "tool_calls"`:
  data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"finish_reason":"tool_calls","sto
  p_reason":154829}]}

  **Expected (correct) behavior** — data chunks have `finish_reason: null`, and the completion signal is sent
  separately:
  data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"finish_reason":null}]}
  data: {"choices":[{"delta":{"content":""},"finish_reason":"tool_calls"}]}

  This violates the [OpenAI streaming
  specification](https://developers.openai.com/cookbook/examples/how_to_stream_completions), which states that streaming
   responses should end with an empty delta `{}` when the stream is over. Downstream consumers that stop reading at
  `finish_reason` would lose the final arguments data.

  **Solution**: Split the final chunk into two separate SSE events:
  1. **Data chunk** – carries the delta with `tool_calls`/`content`, `finish_reason=null`
  2. **Finish chunk** – carries an empty delta, `finish_reason="tool_calls"`

  Plain-text (non-tool-call) streaming is not affected.

  Fixes #8327

  ### Does this PR introduce _any_ user-facing change?

  Yes. The streaming SSE output for GLM5 tool-call responses now correctly separates data chunks from the finish signal,
   conforming to the OpenAI standard. Downstream systems will no longer risk losing the final arguments fragment.

  ### How was this patch tested?

  Added 4 unit tests covering the split behavior:

  - `test_streaming_final_tool_calls_chunk_is_split_from_finish_reason` — basic split invariant
  - `test_streaming_multi_chunk_tool_args_split_only_at_finish` — multi-chunk arguments, split only at final
  - `test_streaming_multiple_tool_calls_split_invariant` — multiple parallel tool calls
  - `test_streaming_plain_text_not_split` — plain text streaming unaffected