### PR TITLE
[BugFix] Changed the minimax wrapper to accept **extra_kwargs

### DIFF
--- a/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
@@ -300,6 +300,7 @@ async def _wrapped_chat_completion_stream_generator(
     tokenizer,
     request_metadata: engine_protocol.RequestResponseMetadata,
     reasoning_parser=None,
+    **extra_kwargs: Any,
 ):
     num_choices = 1 if request.n is None else request.n
     state = _create_usage_tracking_state(num_choices, reasoning_parser)
@@ -314,6 +315,7 @@ async def _wrapped_chat_completion_stream_generator(
         tokenizer,
         request_metadata,
         reasoning_parser,
+        **extra_kwargs,
     ):
         yield _inject_stream_usage_details(data, state)
 


### PR DESCRIPTION
### What this PR does / why we need it?

The _wrapped_chat_completion_stream_generator in patch_minimax_usage_accounting.py:293-320](https://github.com/vllm-project/vllm-ascend/tree/main/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py#L293-L320) had an explicit signature that didn't include chat_template_kwargs. Upstream vllm added this parameter to chat_completion_stream_generator.

The call chain was:

- vllm passes chat_template_kwargs=... to the GLM wrapper (which uses *args, **kwargs)
- GLM wrapper forwards it to the minimax wrapper — which rejects it with TypeError

Fix: Changed the minimax wrapper to accept **extra_kwargs and forward them to the original, making it forward-compatible with any future new parameters.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
