### PR TITLE
"MegaGDN" kernel enabling 15% faster prefill for Qwen3.5/3.6 models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ csrc/output/
 
 # claude code skills
 .claude/skills/*
+
+# PTO chunk-GDN JIT-compiled kernels
+vllm_ascend/ops/pto_chunk_gdn/kernels/compiled_lib/*.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = csrc/third_party/catlass
 	url = https://gitcode.com/cann/catlass.git
 	branch = main
+[submodule "csrc/third_party/pto-isa"]
+	path = csrc/third_party/pto-isa
+	url = https://gitcode.com/cann/pto-isa.git

--- a/Dockerfile.pto
+++ b/Dockerfile.pto
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Minimum Dockerfile to build vllm-ascend with the PTO GDN megakernel.
+#
+# Usage:
+#   docker build \
+#     --build-arg VLLM_TAG=v0.19.1 \
+#     --build-arg SOC_VERSION=ascend910b4 \
+#     -t vllm-ascend-pto:latest \
+#     -f Dockerfile.pto .
+#
+#   docker run --rm -it --device /dev/davinci1 --device /dev/davinci_manager \
+#     --device /dev/devmm_svm --device /dev/hisi_hdc \
+#     -v /usr/local/dcmi:/usr/local/dcmi \
+#     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+#     -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+#     -v /usr/local/Ascend/driver/tools:/usr/local/Ascend/driver/tools \
+#     -v /path/to/model_weights:/models \
+#     -e VLLM_ASCEND_PTO_CHUNK_GDN=1 \
+#     vllm-ascend-pto:latest \
+#     python -m vllm.entrypoints.openai.api_server \
+#       --model /models/Qwen3.5-7B --max-model-len 8192
+#
+
+FROM quay.io/ascend/cann:8.5.1-910b-ubuntu22.04-py3.11
+
+ARG PIP_INDEX_URL="https://pypi.org/simple"
+ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
+ARG VLLM_TAG="v0.19.1"
+ARG SOC_VERSION="ascend910b4"
+
+WORKDIR /workspace
+
+# ── System packages ───────────────────────────────────────────────────────────
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        git \
+        cmake \
+        ninja-build \
+        gcc \
+        g++ \
+        wget \
+        numactl \
+        libnuma-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python index ──────────────────────────────────────────────────────────────
+RUN pip config set global.index-url ${PIP_INDEX_URL}
+
+# ── vLLM (empty device — Triton not needed on Ascend) ────────────────────────
+RUN git clone --depth 1 -b ${VLLM_TAG} ${VLLM_REPO} /workspace/vllm && \
+    VLLM_TARGET_DEVICE="empty" pip install -v -e /workspace/vllm/ \
+        --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    pip uninstall -y triton && \
+    pip cache purge
+
+# ── vllm-ascend (with PTO submodule) ─────────────────────────────────────────
+COPY . /workspace/vllm-ascend/
+
+# Initialise the pto-isa submodule that the megakernel C++ code depends on.
+# If the COPY above already includes a populated submodule this is a no-op.
+RUN cd /workspace/vllm-ascend && \
+    git submodule update --init --recursive csrc/third_party/pto-isa
+
+ENV SOC_VERSION=${SOC_VERSION} \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true && \
+    export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:\
+/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/devlib:\
+/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/lib64 && \
+    pip install -v -e /workspace/vllm-ascend/ \
+        --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    pip uninstall -y triton triton-ascend 2>/dev/null || true && \
+    pip install -v triton-ascend==3.2.0 && \
+    pip cache purge
+
+# ── Optional: pre-compile PTO megakernel for common Qwen3.5/3.6 configs ─────
+# Remove this block if you prefer JIT compilation on first request (30-90 s).
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    cmake -S /workspace/vllm-ascend/csrc \
+          -B /workspace/vllm-ascend/csrc/build \
+          -DBUILD_PTO_CHUNK_GDN=ON \
+          -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build /workspace/vllm-ascend/csrc/build \
+          --target pto_chunk_gdn_kernels -j$(nproc) && \
+    rm -rf /workspace/vllm-ascend/csrc/build
+
+# ── Runtime environment ───────────────────────────────────────────────────────
+ENV VLLM_WORKER_MULTIPROC_METHOD=spawn \
+    VLLM_ASCEND_PTO_CHUNK_GDN=1
+
+RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> ~/.bashrc && \
+    echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:\$LD_PRELOAD" >> ~/.bashrc
+
+CMD ["/bin/bash"]

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -229,6 +229,9 @@ endif ()
 
 add_subdirectory(utils)
 
+# PTO chunk-GDN kernels (optional, default OFF — set -DBUILD_PTO_CHUNK_GDN=ON to pre-compile)
+add_subdirectory(pto_chunk_gdn EXCLUDE_FROM_ALL)
+
 set(OP_LIST)
 set(OP_DIR_LIST)
 op_add_subdirectory(OP_LIST OP_DIR_LIST)

--- a/csrc/pto_chunk_gdn/CMakeLists.txt
+++ b/csrc/pto_chunk_gdn/CMakeLists.txt
@@ -1,0 +1,144 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ----------------------------------------------------------------------------
+# pto_chunk_gdn — pre-compile the fused PTO GDN megakernel via Bisheng
+# ----------------------------------------------------------------------------
+#
+# This target pre-compiles mega_kernel.cpp for a set of common model
+# configurations (H, Hg, D, C=128) used by Qwen3.5/3.6 models.
+# The compiled .so files are installed beside the Python module and loaded
+# directly at runtime, avoiding JIT compilation on the first request.
+#
+# Usage:
+#   cmake -S csrc -B csrc/build -DBUILD_PTO_CHUNK_GDN=ON
+#   cmake --build csrc/build --target pto_chunk_gdn_kernels -j8
+#
+#   Or via pip:
+#   BUILD_PTO_CHUNK_GDN=ON pip install -e .
+# ----------------------------------------------------------------------------
+
+option(BUILD_PTO_CHUNK_GDN "Pre-compile PTO GDN megakernel via Bisheng" OFF)
+
+if(NOT BUILD_PTO_CHUNK_GDN)
+    return()
+endif()
+
+# ── Locate bisheng ─────────────────────────────────────────────────────────────
+find_program(BISHENG_EXECUTABLE bisheng
+    HINTS ENV ASCEND_HOME_PATH
+    PATH_SUFFIXES bin
+    DOC "Bisheng C++ compiler for Ascend AI-Core kernels"
+)
+if(NOT BISHENG_EXECUTABLE)
+    message(WARNING "bisheng not found — PTO GDN megakernel will not be pre-compiled."
+                    "Set BISHENG_EXECUTABLE or ensure bisheng is in PATH.")
+    return()
+endif()
+message(STATUS "Found bisheng: ${BISHENG_EXECUTABLE}")
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+set(PTO_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(PTO_INC_DIR "${PTO_SRC_DIR}/include")
+set(PTO_ISA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/pto-isa")
+set(DRIVER_INC  "/usr/local/Ascend/driver/kernel/inc")
+
+if(DEFINED ENV{ASCEND_HOME_PATH})
+    set(ASCEND_HOME "$ENV{ASCEND_HOME_PATH}")
+elseif(DEFINED ENV{ASCEND_TOOLKIT_HOME})
+    set(ASCEND_HOME "$ENV{ASCEND_TOOLKIT_HOME}")
+else()
+    message(WARNING "ASCEND_HOME_PATH not set — PTO kernel may not compile correctly.")
+    set(ASCEND_HOME "")
+endif()
+
+if(NOT DEFINED Python_SITELIB)
+    execute_process(
+        COMMAND python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])"
+        OUTPUT_VARIABLE Python_SITELIB OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
+set(PTO_COMPILED_INSTALL_DIR
+    "${Python_SITELIB}/vllm_ascend/ops/pto_chunk_gdn/kernels/compiled_lib"
+)
+
+# ── Common compiler flags ──────────────────────────────────────────────────────
+set(PTO_COMMON_FLAGS
+    -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=gnu++17
+    --cce-aicore-arch=dav-c220
+    -mllvm -cce-aicore-stack-size=0x8000
+    -mllvm -cce-aicore-function-stack-size=0x8000
+    -mllvm -cce-aicore-record-overflow=true
+    -mllvm -cce-aicore-dcci-insert-for-scalar=false
+    -Wno-macro-redefined -Wno-ignored-attributes
+    -I${PTO_INC_DIR}
+    -I${PTO_ISA_DIR}/include
+    -I${ASCEND_HOME}/include
+    -I${ASCEND_HOME}/pkg_inc
+    -I${ASCEND_HOME}/pkg_inc/runtime
+    -I${ASCEND_HOME}/pkg_inc/profiling
+)
+if(EXISTS "${DRIVER_INC}")
+    list(APPEND PTO_COMMON_FLAGS -I${DRIVER_INC})
+endif()
+
+# ── Model configurations to pre-compile ───────────────────────────────────────
+# Format: "H;Hg;D;C"   (H=value heads, Hg=Q/K heads, D=head dim, C=chunk size)
+# Qwen3.5-0.8B / 1.5B / 3B: H=16, Hg=8,  D=128
+# Qwen3.5-7B / 14B:          H=16, Hg=16, D=128
+# Qwen3.6-27B:               H=32, Hg=16, D=128
+# Qwen3.6-35B-A3B-MoE:       H=32, Hg=16, D=128
+# Common extras for other models:
+set(PTO_MODEL_CONFIGS
+    "16;8;128;128"
+    "16;16;128;128"
+    "32;16;128;128"
+    "48;16;128;128"
+    "64;16;128;128"
+    "64;64;128;128"
+)
+
+set(_pto_outputs "")
+file(MAKE_DIRECTORY "${PTO_COMPILED_INSTALL_DIR}")
+
+set(_mega_src "${PTO_SRC_DIR}/mega_kernel.cpp")
+
+foreach(cfg ${PTO_MODEL_CONFIGS})
+    string(REPLACE ";" ";" _cfg_list "${cfg}")
+    list(GET _cfg_list 0 H)
+    list(GET _cfg_list 1 Hg)
+    list(GET _cfg_list 2 D)
+    list(GET _cfg_list 3 C)
+
+    set(_def_flags -DGDN_H=${H} -DGDN_HG=${Hg} -DGDN_D=${D} -DGDN_C=${C})
+    set(_out "${PTO_COMPILED_INSTALL_DIR}/mega_kernel_H${H}_Hg${Hg}_D${D}_C${C}.so")
+
+    add_custom_command(
+        OUTPUT  "${_out}"
+        COMMAND "${BISHENG_EXECUTABLE}"
+                ${PTO_COMMON_FLAGS} ${_def_flags}
+                "${_mega_src}" -o "${_out}"
+        DEPENDS "${_mega_src}"
+        COMMENT "PTO: compiling mega_kernel H=${H} Hg=${Hg} D=${D} C=${C}"
+        VERBATIM
+    )
+    list(APPEND _pto_outputs "${_out}")
+endforeach()
+
+# ── Top-level target ───────────────────────────────────────────────────────────
+add_custom_target(pto_chunk_gdn_kernels ALL
+    DEPENDS ${_pto_outputs}
+    COMMENT "Building all PTO GDN megakernel Bisheng binaries"
+)

--- a/csrc/pto_chunk_gdn/chunk_cumsum.cpp
+++ b/csrc/pto_chunk_gdn/chunk_cumsum.cpp
@@ -1,0 +1,426 @@
+// ============================================================================
+// chunk_cumsum_kernel.cpp — Prefix sum of gate values G along time dimension
+//
+// Mathematical operation (per chunk of C tokens, independently per head h):
+//   g_sum[t, h] = Σ_{i=0}^{t} g[i, h]    for t = 0 .. valid-1
+//
+// Input:  g     [total_tokens, H]  float, BSND layout  — raw gate values
+// Output: g_sum [total_tokens, H]  float               — cumulative sums
+//
+// The prefix sum enables downstream kernels to compute exponential decay
+// coefficients:  exp(g_sum[i] - g_sum[j])  gives the cumulative gate
+// from token j to token i within a chunk.
+//
+// Architecture: Vec-only kernel (no Cube/GEMM). Single Vec sub-block.
+// Pipeline: MTE2(load) → Vec(compute) → MTE3(store), serialized per chunk.
+//
+// NPU memory hierarchy used:
+//   GM (Global Memory) → UB (Unified Buffer, on-chip SRAM, Vec-accessible)
+//
+// ─── PTO / NPU Primer for This Kernel ──────────────────────────────────────
+//
+// AI Core: The basic processing unit of an NPU, analogous to a Streaming
+//   Multiprocessor (SM) on a GPU. A single chip has many AI cores, and each
+//   core runs the same kernel code on different data (SPMD model).
+//
+// Memory hierarchy (outer → inner):
+//   GM  (Global Memory) — Off-chip DRAM, like GPU HBM. Large (several GB)
+//       but high latency. All AI cores share GM.
+//   UB  (Unified Buffer) — On-chip SRAM, ~256 KB per AI core. Like GPU
+//       shared memory. Very fast, but small. The Vec engine can only operate
+//       on data that lives in UB, so every tensor must be DMA'd in first.
+//
+// Hardware pipes (execute in parallel, like independent GPU warps):
+//   Vec   — SIMD vector processor. Performs element-wise math (add, mul, etc.)
+//           on data already in UB. Think of it as a wide SIMD ALU.
+//   MTE2  — DMA engine for loads: copies data from GM → UB.
+//   MTE3  — DMA engine for stores: copies data from UB → GM.
+//   Cube  — Matrix engine for GEMMs (not used in this kernel).
+//
+// Synchronization (set_flag / wait_flag):
+//   Because Vec, MTE2, and MTE3 run in parallel on separate hardware, you
+//   must explicitly synchronize them to ensure data is ready:
+//     set_flag(SRC_PIPE, DST_PIPE, event): SRC signals that it is done.
+//     wait_flag(SRC_PIPE, DST_PIPE, event): DST blocks until the signal.
+//   Example: After MTE2 loads data into UB, Vec must wait_flag before reading
+//   it. This is like a fine-grained torch.cuda.synchronize() between pipes.
+//   Events (EVENT_ID0 .. EVENT_ID7) are semaphore indices.
+//
+// ============================================================================
+
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace pto;
+
+// GDN_H, GDN_C: Compile-time constants injected by the build system.
+//   GDN_H = number of attention heads (e.g., 16)
+//   GDN_C = chunk size in tokens (e.g., 128)
+// Using compile-time constants allows the compiler to optimize tile sizes,
+// unroll loops, and compute UB addresses at compile time.
+#ifndef GDN_H
+#define GDN_H 16
+#endif
+
+#ifndef GDN_C
+#define GDN_C 128
+#endif
+
+// ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
+// UB tile in row-major (ND) layout, used by Vec engine.
+// T=dtype, R×C=static shape, RV×CV=valid region, P=pad value for TLOAD.
+//
+// Think of UbND as: torch.empty((R, C), dtype=T) allocated in on-chip SRAM (UB).
+//   - TileType::Vec  = this tile lives in UB, operated on by the Vec (SIMD) engine
+//   - BLayout::RowMajor = row-major storage, like C arrays or numpy default
+//   - RV, CV = "valid" region within the R×C buffer (for handling partial/tail chunks)
+//   - PadValue = what to fill outside the valid region during TLOAD (Zero or Null)
+//   - 512 = alignment in bytes (hardware requirement for efficient DMA)
+#ifdef __CCE_AICORE__
+template <typename T, int R, int C, int RV = R, int CV = C,
+          pto::PadValue P = pto::PadValue::Null>
+using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
+                       RV, CV, pto::SLayout::NoneBox, 512, P>;
+#endif
+
+template <int32_t NumHeads, int32_t ChunkSize>
+AICORE void cumsum_kernel(
+    __gm__ float *g_ptr, __gm__ float *g_sum_ptr,
+    __gm__ int32_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    uint64_t ffts_addr)
+{
+  // get_block_idx(): Returns this AI core's index (0..block_num-1).
+  //   Like blockIdx.x in CUDA — identifies which core this code runs on.
+  // get_block_num(): Total number of AI cores launched (like gridDim.x in CUDA).
+  // get_subblockid(): Returns 0 or 1 — selects which Vec sub-block within the core.
+  //   Each AI core has 2 Vec sub-blocks that can run in parallel.
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
+  auto vid = get_subblockid();
+  // set_ffts_base_addr(ffts_addr): Configure the base address for FFTS
+  // (Fast Fine-grained Task Synchronization) — the cross-core signaling mechanism.
+  // Required before any cross-core sync (ffts_cross_core_sync / wait_flag_dev).
+  set_ffts_base_addr(ffts_addr);
+
+// #if defined(__DAV_C220_VEC__): This block only compiles for the Vec core pass.
+// The bisheng compiler makes 3 passes over the same source file:
+//   Pass 1: __DAV_C220_VEC__  defined → compiles Vec (SIMD) code
+//   Pass 2: __DAV_C220_CUBE__ defined → compiles Cube (matrix) code
+//   Pass 3: neither defined → compiles host (CPU) launcher code
+// Using these guards lets us put Vec, Cube, and host code in one file.
+#if defined(__DAV_C220_VEC__)
+  if (vid != 0) return;
+
+  // set_mask_norm(): Reset Vec mask to normal mode (all lanes active).
+  // set_vector_mask(-1, -1): Enable all SIMD lanes (128 lanes for fp32).
+  //   The -1 sets all 64 bits to 1 in each of the two 64-bit mask registers.
+  //   This is like setting torch's computation to operate on all elements.
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // HeadTileCols: NumHeads rounded up to 8-element alignment (32B for float)
+  // HTC = NumHeads rounded up to nearest multiple of 8.
+  // Why? The Vec engine processes data in 32-byte granularity.
+  // For float (4 bytes), that's 8 elements per SIMD "word".
+  // Rounding up ensures every row is a whole number of SIMD words,
+  // avoiding partial-lane issues. The extra columns are zero-padded.
+  // Example: NumHeads=16 → HTC=16 (already aligned), NumHeads=13 → HTC=16.
+  constexpr int32_t HTC = ((NumHeads + 7) / 8) * 8;
+  constexpr int32_t BlockBytes = ChunkSize * HTC *
+                                 static_cast<int32_t>(sizeof(float));
+  constexpr int32_t RowBytes = HTC * static_cast<int32_t>(sizeof(float));
+
+  // ── UB memory layout ──────────────────────────────────────────────────
+  //  [0            .. BlockBytes)     = g input  (ChunkSize × HTC floats)
+  //  [BlockBytes   .. 2*BlockBytes)   = g_sum output
+  //  [2*BlockBytes .. 2*BlockBytes+RowBytes) = row accumulator (1 × HTC)
+  constexpr int32_t GUbAddr   = 0;
+  constexpr int32_t SUbAddr   = BlockBytes;
+  constexpr int32_t AccUbAddr = BlockBytes * 2;
+
+  // GlobalTensor types for g/g_sum in [total_tokens, NumHeads] layout.
+  // 5D shape with last two dims dynamic; stride encodes row pitch.
+  //
+  // GlobalTensor is a "view" into GM (Global Memory), like torch.as_strided().
+  //   GlobalTensor<dtype, Shape, Stride>(base_ptr, shape)
+  // Shape<1,1,1,DYNAMIC,DYNAMIC> = 5D shape where first 3 dims are 1 (unused),
+  //   last 2 dims are set at runtime (valid rows × NumHeads).
+  // Stride<1,1,1,NumHeads,1> = stride between elements. The 4th stride = NumHeads
+  //   means consecutive rows in GM are NumHeads elements apart (BSND layout:
+  //   token[t] at offset t*NumHeads, head[h] at offset h within that token).
+  // This is equivalent to:
+  //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads], stride=[NumHeads, 1])
+  using GmShape  = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GmStride = Stride<1, 1, 1, NumHeads, 1>;
+  using GmFloat  = GlobalTensor<float, GmShape, GmStride>;
+
+  // Pre-assign row accumulator at fixed UB address
+  // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address in UB.
+  // Think of it as: tile = ub_memory[address:address+sizeof(tile)]
+  // This does NOT allocate or move data — it just tells the hardware where the tile lives.
+  // We manually manage UB memory layout (like a memory pool) via compile-time addresses.
+  UbND<float, 1, HTC> acc_ub;
+  TASSIGN(acc_ub, AccUbAddr);
+
+  int64_t num_seqs = batch_size;
+
+  // ── Fixed-length sequence path (cu_seqlens == nullptr) ────────────────
+  if (cu_seqlens == nullptr) {
+    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+    int64_t total_chunks = num_seqs * chunks_per_seq;
+
+    // Work distribution: Each AI core processes chunks in a round-robin pattern.
+    // Core `cid` handles chunks cid, cid+block_num, cid+2*block_num, ...
+    // This is the NPU equivalent of CUDA's grid-stride loop:
+    //   for (int i = blockIdx.x; i < total; i += gridDim.x)
+    for (int64_t gi = static_cast<int64_t>(cid); gi < total_chunks;
+         gi += static_cast<int64_t>(block_num)) {
+      int64_t seq_idx = gi / chunks_per_seq;
+      int64_t local_chunk = gi % chunks_per_seq;
+      int64_t bos = seq_idx * seq_len;
+      int64_t chunk_start = bos + local_chunk * ChunkSize;
+      int64_t remaining = seq_len - local_chunk * ChunkSize;
+      int32_t valid = static_cast<int32_t>(
+          remaining < ChunkSize ? remaining : ChunkSize);
+
+      // ── DMA: load g[chunk_start .. +valid] from GM → UB (MTE2 pipe) ──
+      // Constructs a GlobalTensor view over the g array, loads into UB,
+      // then zero-pads the tail region (rows beyond `valid`, cols beyond
+      // NumHeads up to the 8-aligned HTC) so downstream Vec ops see zeros.
+      {
+        GmShape gs; gs.shape[3] = valid; gs.shape[4] = NumHeads;
+        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+        UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
+            g_load(valid, NumHeads);
+        TASSIGN(g_load, GUbAddr);
+        // TLOAD(ub_tile, gm_tensor): DMA transfer from GM → UB.
+        // Equivalent to: ub_tile[:valid, :NumHeads] = gm_tensor[:valid, :NumHeads]
+        // This is an ASYNC operation on the MTE2 pipe — the CPU/Vec engine can do
+        // other work while DMA is in progress. You must call set_flag/wait_flag
+        // before reading the loaded data.
+        TLOAD(g_load, g_gm);
+        if (valid != ChunkSize || NumHeads != HTC) {
+          UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
+          TASSIGN(g_pad, GUbAddr);
+          // TFILLPAD_INPLACE(full_tile, partial_tile): Zero-fills the region outside
+          // the valid area of partial_tile.
+          // Equivalent to:
+          //   full_tile[valid:ChunkSize, :] = 0  # zero rows beyond valid
+          //   full_tile[:, NumHeads:HTC] = 0     # zero cols beyond NumHeads (alignment padding)
+          // This ensures downstream Vec operations see clean zeros in padded regions.
+          TFILLPAD_INPLACE(g_pad, g_load);
+        }
+      }
+      // ── Synchronization: MTE2 → Vec ────────────────────────────────────
+      // set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Signal from MTE2 (DMA load
+      //   engine) to Vec (SIMD engine) that the DMA transfer is complete.
+      // wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Vec waits here until MTE2
+      //   has set the flag. After this, UB data from TLOAD is safe to read.
+      // Think of it as: torch.cuda.synchronize() but fine-grained per pipe.
+      // EVENT_ID0 is a semaphore index (0-7 available).
+      // MTE2 → Vec sync: wait for DMA load to finish before Vec reads UB
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+      // ── Vec compute: prefix sum over rows (all H heads in parallel) ───
+      // Row 0: acc[h] = g[0,h];  g_sum[0,h] = acc[h]
+      UbND<float, 1, HTC> g_row_0;
+      TASSIGN(g_row_0, GUbAddr);
+      // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
+      TMOV(acc_ub, g_row_0);
+      // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations complete
+      // before the next Vec instruction begins. Needed because Vec ops are pipelined
+      // and may not finish in order. Think of it as a local __syncthreads() for the
+      // Vec engine only. Much lighter than set_flag/wait_flag (which sync across
+      // different hardware units).
+      pipe_barrier(PIPE_V);
+
+      UbND<float, 1, HTC> s_row_0;
+      TASSIGN(s_row_0, SUbAddr);
+      TMOV(s_row_0, acc_ub);
+      pipe_barrier(PIPE_V);
+
+      // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
+      for (int32_t i = 1; i < valid; ++i) {
+        UbND<float, 1, HTC> g_row_i;
+        TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+        // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
+        // Operates on all HTC elements in parallel (SIMD).
+        TADD(acc_ub, acc_ub, g_row_i);
+        pipe_barrier(PIPE_V);
+
+        UbND<float, 1, HTC> s_row_i;
+        TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+        TMOV(s_row_i, acc_ub);
+        pipe_barrier(PIPE_V);
+      }
+
+      // Zero-fill rows beyond valid (tail padding for downstream kernels)
+      // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
+      // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
+      TEXPANDS(acc_ub, 0.0f);
+      pipe_barrier(PIPE_V);
+      for (int32_t i = valid; i < ChunkSize; ++i) {
+        UbND<float, 1, HTC> s_row_i;
+        TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+        TMOV(s_row_i, acc_ub);
+        pipe_barrier(PIPE_V);
+      }
+
+      // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
+      // ── Synchronization: Vec → MTE3 ───────────────────────────────────
+      // Vec signals MTE3 that computation is done and UB data is ready to store.
+      // MTE3 (DMA store engine) waits for this before reading UB for TSTORE.
+      // Without this sync, MTE3 might read stale/partial data from UB.
+      // Vec → MTE3 sync: ensure Vec writes to UB are visible before DMA
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+      {
+        GmShape ss; ss.shape[3] = valid; ss.shape[4] = NumHeads;
+        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+        UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC>
+            s_store(valid, NumHeads);
+        TASSIGN(s_store, SUbAddr);
+        // TSTORE(gm_tensor, ub_tile): DMA transfer from UB → GM.
+        // Equivalent to: gm_tensor[:valid, :NumHeads] = ub_tile[:valid, :NumHeads]
+        // Async on MTE3 pipe. Must sync (Vec→MTE3) before calling, and sync
+        // (MTE3→Vec) after if reusing the same UB region.
+        TSTORE(gs_gm, s_store);
+      }
+      // ── Synchronization: MTE3 → Vec ───────────────────────────────────
+      // MTE3 signals Vec that the DMA store is complete and UB can be reused.
+      // Vec waits before starting the next iteration's TLOAD into the same UB region.
+      // Without this, the next TLOAD could overwrite data still being stored.
+      // MTE3 → Vec sync: wait for DMA store before reusing UB next iter
+      set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    }
+  }
+  // ── Variable-length sequence path (cu_seqlens != nullptr) ─────────────
+  else {
+    int64_t gi = 0;
+    for (int64_t si = 0; si < num_seqs; ++si) {
+      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+      int64_t slen = eos - bos;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t c = 0; c < nc; ++c) {
+        if (gi % static_cast<int64_t>(block_num) ==
+            static_cast<int64_t>(cid)) {
+          int64_t chunk_start = bos + c * ChunkSize;
+          int64_t remaining = slen - c * ChunkSize;
+          int32_t valid = static_cast<int32_t>(
+              remaining < ChunkSize ? remaining : ChunkSize);
+
+          // Load g chunk from GM → UB, zero-padded
+          {
+            GmShape gs; gs.shape[3] = valid; gs.shape[4] = NumHeads;
+            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+            UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
+                g_load(valid, NumHeads);
+            TASSIGN(g_load, GUbAddr);
+            TLOAD(g_load, g_gm);
+            if (valid != ChunkSize || NumHeads != HTC) {
+              UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero>
+                  g_pad;
+              TASSIGN(g_pad, GUbAddr);
+              TFILLPAD_INPLACE(g_pad, g_load);
+            }
+          }
+          set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+          wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+          // Prefix sum: acc = g[0]; g_sum[0] = acc
+          UbND<float, 1, HTC> g_row_0;
+          TASSIGN(g_row_0, GUbAddr);
+          TMOV(acc_ub, g_row_0);
+          pipe_barrier(PIPE_V);
+
+          UbND<float, 1, HTC> s_row_0;
+          TASSIGN(s_row_0, SUbAddr);
+          TMOV(s_row_0, acc_ub);
+          pipe_barrier(PIPE_V);
+
+          // acc += g[i]; g_sum[i] = acc
+          for (int32_t i = 1; i < valid; ++i) {
+            UbND<float, 1, HTC> g_row_i;
+            TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+            TADD(acc_ub, acc_ub, g_row_i);
+            pipe_barrier(PIPE_V);
+
+            UbND<float, 1, HTC> s_row_i;
+            TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+            TMOV(s_row_i, acc_ub);
+            pipe_barrier(PIPE_V);
+          }
+
+          // Zero-fill padding rows
+          TEXPANDS(acc_ub, 0.0f);
+          pipe_barrier(PIPE_V);
+          for (int32_t i = valid; i < ChunkSize; ++i) {
+            UbND<float, 1, HTC> s_row_i;
+            TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+            TMOV(s_row_i, acc_ub);
+            pipe_barrier(PIPE_V);
+          }
+
+          // Store g_sum to GM
+          set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+          wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+          {
+            GmShape ss; ss.shape[3] = valid; ss.shape[4] = NumHeads;
+            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+            UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC>
+                s_store(valid, NumHeads);
+            TASSIGN(s_store, SUbAddr);
+            TSTORE(gs_gm, s_store);
+          }
+          set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+          wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+        }
+        gi++;
+      }
+    }
+  }
+#endif
+}
+
+// ── Device-side kernel entry point ─────────────────────────────────
+// extern "C" __global__ AICORE: marks this as an NPU kernel function
+//   (like __global__ in CUDA). Each AI core runs one instance of this function.
+// Parameters are passed as uint8_t* (raw bytes) and reinterpret_cast'd to
+// typed pointers — this is the standard NPU kernel calling convention.
+extern "C" __global__ AICORE void launch_cumsum(
+    __gm__ uint8_t *g_ptr, __gm__ uint8_t *g_sum_ptr,
+    __gm__ uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    uint64_t ffts_addr)
+{
+  cumsum_kernel<GDN_H, GDN_C>(
+      reinterpret_cast<__gm__ float *>(g_ptr),
+      reinterpret_cast<__gm__ float *>(g_sum_ptr),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, ffts_addr);
+}
+
+// ── Host-side launcher (called from Python via ctypes) ────────────
+// call_kernel(): CPU function that launches the NPU kernel.
+//   block_dim = number of AI cores to use (like CUDA grid size)
+//   stream = NPU stream for async execution (like CUDA stream)
+//   rtGetC2cCtrlAddr: gets the FFTS control address for cross-core sync
+//   <<<block_dim, nullptr, stream>>>: NPU kernel launch syntax (like CUDA <<<>>>)
+extern "C" void call_kernel(
+    uint32_t block_dim, void *stream,
+    uint8_t *g_ptr, uint8_t *g_sum_ptr, uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len)
+{
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_cumsum<<<block_dim, nullptr, stream>>>(
+      g_ptr, g_sum_ptr, cu_seqlens, batch_size, seq_len, fftsAddr);
+}

--- a/csrc/pto_chunk_gdn/chunk_h.cpp
+++ b/csrc/pto_chunk_gdn/chunk_h.cpp
@@ -1,0 +1,919 @@
+// ============================================================================
+// chunk_h_kernel.cpp — Recurrent hidden state update for GatedDeltaNet
+//
+// Mathematical recurrence per chunk c:
+//   S_{c+1} = exp(g_last) * S_c  +  K^T @ V
+//
+// where g_last = exp(g[valid-1]) is the chunk's final gate value, S is the
+// D×D hidden state, K ∈ ℝ^{C×D}, V ∈ ℝ^{C×D}, and g ∈ ℝ^C is the per-token
+// gate.
+//
+// ── Cube phase (two GEMMs per chunk, sequentially): ──────────────────────
+//   1. WS = W @ S       project current state through W (wy_fast output)
+//      W ∈ ℝ^{C×D}, S ∈ ℝ^{D×D}  →  WS ∈ ℝ^{C×D}
+//   2. KV = K^T @ V     outer product of keys and values (transpose_A!)
+//      K stored as D×C, V ∈ ℝ^{C×D}  →  KV ∈ ℝ^{D×D}
+//
+// ── Vec phase (two sub-blocks handle upper/lower C/2 rows): ─────────────
+//   For each chunk:
+//     1. Load K, G (pre-transposed), U (from wy_fast)
+//     2. Compute coeff[i] = exp(g[i] - g[valid-1])  — time-decay scaling
+//        Uses TROWEXPAND to broadcast coefficients across D columns
+//     3. Scale K: K_scaled[i,:] = K[i,:] * coeff[i]
+//     4. Load WS from Cube workspace, compute V_new = U - WS (residual)
+//     5. Store V_new and K_scaled to workspace for Cube's next iteration
+//     6. Update state: S = exp(g_last) * S + KV (from Cube workspace)
+//     7. Store final state FS after last chunk
+//
+// Cross-core sync: Cube→Vec flags for WS/KV ready, Vec→Cube flags for
+// K/S ready.
+//
+// Inputs:
+//   K  [total_tokens, Hg, D] half   — keys (BSND layout; GQA/MQA group heads)
+//   W  [total_tokens, H, D]  half   — wy_fast output (BSND layout)
+//   U  [total_tokens, H, D]  half   — values pre-residual (BSND layout)
+//   G  [H, total_tokens]     float  — pre-transposed cumulative gates
+//   S  [total_chunks, H, D, D] half — per-chunk state snapshots (output)
+//   V  [total_tokens, H, D]  half   — residual-corrected values (output)
+//   FS [batch, H, D, D]      half   — final state per sequence (output)
+//   workspace [per-core scratch]     — Cube↔Vec communication buffer
+//
+// NPU memory hierarchy:
+//   GM → L1 (Cube-accessible) → L0A/L0B/L0C (Cube GEMM registers)
+//   GM → UB (Vec-accessible, on-chip SRAM)
+//   Cross-core sync via FFTS (Fast Fine-grained Task Synchronization)
+//
+// ── PTO / NPU Primer ──────────────────────────────────────────────────
+// This is the most complex kernel in the GDN suite. It implements the
+// recurrent state update, requiring sequential chunk processing (chunks
+// within a sequence CANNOT be parallelized — each depends on the previous).
+//
+// Key PTO APIs (numpy/torch equivalents):
+//   TLOAD(dst, gm)          — dst = gm_data        (DMA: GM→L1 or GM→UB)
+//   TSTORE(gm, src)         — gm_data = src        (DMA: UB/L0C→GM)
+//   TASSIGN(tile, addr)     — tile = memory[addr]   (bind tile to buffer address)
+//   TCVT(dst, src, mode)    — dst = src.float()/.half()
+//   TMOV(dst, src)          — dst = src.clone()
+//   TADD(d, a, b)           — d = a + b
+//   TSUB(d, a, b)           — d = a - b
+//   TMUL(d, a, b)           — d = a * b
+//   TMULS(d, s, scalar)     — d = s * scalar       (scalar multiply)
+//   TADDS(d, s, scalar)     — d = s + scalar       (scalar add)
+//   TEXP(d, s)              — d = torch.exp(s)
+//   TEXPANDS(tile, scalar)  — tile[:] = scalar     (fill with constant)
+//   TROWEXPAND(2d, col)     — 2d[i,j] = col[i]    (broadcast col across row dim)
+//   TFILLPAD(dst, src)      — zero-fill L1 tile padding (for tail chunks)
+//   TEXTRACT(l0, l1, r, c)  — L1 sub-tile → L0A/L0B
+//   TRESHAPE(zn, nz)        — reinterpret layout NZ↔ZN (logical transpose, free)
+//   TMATMUL(C, A, B)        — C = A @ B (Cube GEMM, fp16 inputs → fp32 accum)
+//   set_flag/wait_flag      — pipe sync within same core
+//   ffts_cross_core_sync    — cross-core signal Cube↔Vec
+//   wait_flag_dev(flag)     — wait for cross-core signal
+//   GetValue(idx)           — read a single scalar from a UB tile (slow, use sparingly)
+//
+// ── Workspace memory layout (shared between Cube and Vec via GM) ──────
+// Each AI core has its own workspace region to avoid contention:
+//   WS_WS [C×D]:  Cube writes WS = W @ S here → Vec reads it
+//   WS_K  [D×C]:  Vec writes K_scaled here → Cube reads it for KV = K^T @ V
+//   WS_S  [D×D]:  Vec writes current state S here → Cube reads it for GEMM 1
+//   WS_KV [D×D]:  Cube writes KV = K^T @ V here → Vec reads it to update S
+//
+// Data flow per chunk (think of it as a ping-pong between Cube and Vec):
+//   Vec: write S₀ to WS_S → signal Cube (flag 3)
+//   Cube: read S from WS_S, load W → compute WS = W@S → write WS_WS → signal Vec (flag 0)
+//   Vec: read WS, compute V_new = U - WS, compute K_scaled → write WS_K → signal Cube (flag 1)
+//   Cube: read K from WS_K, load V → compute KV = K^T@V → write WS_KV → signal Vec (flag 2)
+//   Vec: read KV, update S = exp(g_last)*S + KV → write S to WS_S → signal Cube (flag 3)
+//   ... repeat for next chunk ...
+// ============================================================================
+
+#include <pto/pto-inst.hpp>
+#include <type_traits>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace pto;
+
+#ifdef __CCE_AICORE__
+
+namespace {
+
+using GmShape2D = pto::Shape<1, 1, 1, pto::DYNAMIC, pto::DYNAMIC>;
+using GmStride2D = pto::Stride<1, 1, 1, pto::DYNAMIC, 1>;
+
+template <typename T>
+using GmTensor2D = pto::GlobalTensor<T, GmShape2D, GmStride2D>;
+
+template <typename T, int32_t Rows, int32_t Cols>
+using DynMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                           pto::BLayout::ColMajor, pto::DYNAMIC,
+                           pto::DYNAMIC, pto::SLayout::RowMajor, 512,
+                           pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols,
+          pto::PadValue PadVal = pto::PadValue::Null>
+using DynVecTile = pto::Tile<pto::TileType::Vec, T, Rows, Cols,
+                             pto::BLayout::RowMajor, pto::DYNAMIC,
+                             pto::DYNAMIC, pto::SLayout::NoneBox, 512, PadVal>;
+
+template <typename T, int32_t Rows, int32_t Cols>
+using DynAccTile = pto::TileAcc<T, Rows, Cols, pto::DYNAMIC, pto::DYNAMIC>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                            pto::BLayout::ColMajor, RowValid, ColValid,
+                            pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                              pto::BLayout::RowMajor, RowValid, ColValid,
+                              pto::SLayout::ColMajor, 512,
+                              pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::RowMajor, 512,
+                             pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::ColMajor, 512,
+                             pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols,
+          pto::PadValue PadVal = pto::PadValue::Null>
+using TileUbDataND = pto::Tile<pto::TileType::Vec, T, Rows, Cols,
+                               pto::BLayout::RowMajor, RowValid, ColValid,
+                               pto::SLayout::NoneBox, 512, PadVal>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols,
+          pto::PadValue PadVal = pto::PadValue::Null>
+using TileUbDataDN = pto::Tile<pto::TileType::Vec, T, Rows, Cols,
+                               pto::BLayout::ColMajor, RowValid, ColValid,
+                               pto::SLayout::NoneBox, 512, PadVal>;
+
+// PTO cheat sheet for the recurrent kernel:
+//   - `GlobalTensor<T>` is a GM tensor view with explicit runtime shape/stride.
+//   - `Tile<..., Mat, ...>` lives in L1 and feeds Cube matmul instructions.
+//   - `Tile<..., Vec, ...>` lives in UB for elementwise vector work.
+//   - `TileAcc<T, ...>` is a Cube accumulator tile.
+//   - `TLOAD` / `TSTORE` are DMA copies between GM and on-chip memory.
+//   - `TROWEXPAND` broadcasts a column vector across the feature dimension.
+//   - `TFILLPAD(_INPLACE)` zero-pads tail rows so full-tile code can still run.
+
+template <typename T1, typename T2, uint32_t M, uint32_t N, uint32_t K,
+          uint32_t validM = M, uint32_t validN = N, uint32_t validK = K,
+          uint32_t K_tail = K, bool transpose_A = false,
+          bool transpose_B = false>
+AICORE PTO_INLINE void
+gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
+                           TileMatL1<T1, M, K, validM, validK>> &A,
+        std::conditional_t<transpose_B, TileMatL1<T1, N, K, validN, validK>,
+                           TileMatL1<T1, K, N, validK, validN>> &B,
+        pto::TileAcc<T2, M, N, validM, validN> &C, bool clear)
+{
+  // Local K-sliced matmul helper:
+  //   C = A @ B
+  // PTO exposes the L1/L0 staging explicitly, so this stays as a tiny file-
+  // local helper instead of a shared wrapper.
+  //
+  // PyTorch mental model:
+  //   C = 0
+  //   for k0 in range(0, K, kL0Size):
+  //       C += A[:, k0:k1] @ B[k0:k1, :]
+  constexpr uint32_t kL0Size = 128;
+  const uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
+
+  auto war_event_id = (event_t)(((int)EVENT_ID0 + 1) % 8);
+  set_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+
+  for (uint32_t kL0Idx = 0; kL0Idx < kL0split; ++kL0Idx) {
+    const bool initflag = clear && (kL0Idx == 0);
+    const bool is_tail_block = (kL0Idx == kL0split - 1);
+
+    if (is_tail_block) {
+      TileMatL0A<T1, M, K_tail, M, K_tail> l0a;
+      TileMatL0B<T1, K_tail, N, K_tail, N> l0b;
+      pto::TASSIGN(l0a, 0x0);
+      pto::TASSIGN(l0b, 0x0);
+
+      set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+      wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+      if constexpr (!transpose_A) {
+        pto::TEXTRACT(l0a, A, 0, kL0Idx * K_tail);
+      } else {
+        TileMatL1ZN<T1, M, K, validM, validK> A_t;
+        pto::TRESHAPE(A_t, A);
+        pto::TEXTRACT(l0a, A_t, 0, kL0Idx * K_tail);
+      }
+
+      if constexpr (!transpose_B) {
+        pto::TEXTRACT(l0b, B, kL0Idx * K_tail, 0);
+      } else {
+        TileMatL1ZN<T1, K, N, validK, validN> B_t;
+        pto::TRESHAPE(B_t, B);
+        pto::TEXTRACT(l0b, B_t, kL0Idx * K_tail, 0);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+
+      if (initflag) {
+        pto::TMATMUL(C, l0a, l0b);
+      } else {
+        pto::TMATMUL_ACC(C, C, l0a, l0b);
+      }
+    } else {
+      TileMatL0A<T1, M, kL0Size, M, kL0Size> l0a;
+      TileMatL0B<T1, kL0Size, N, kL0Size, N> l0b;
+      pto::TASSIGN(l0a, 0x0);
+      pto::TASSIGN(l0b, 0x0);
+
+      set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+      wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+      set_flag(PIPE_FIX, PIPE_M, war_event_id);
+      wait_flag(PIPE_FIX, PIPE_M, war_event_id);
+
+      if constexpr (!transpose_A) {
+        pto::TEXTRACT(l0a, A, 0, kL0Idx * kL0Size);
+      } else {
+        TileMatL1ZN<T1, M, K, validM, validK> A_t;
+        pto::TRESHAPE(A_t, A);
+        pto::TEXTRACT(l0a, A_t, 0, kL0Idx * kL0Size);
+      }
+
+      if constexpr (!transpose_B) {
+        pto::TEXTRACT(l0b, B, kL0Idx * kL0Size, 0);
+      } else {
+        TileMatL1ZN<T1, K, N, validK, validN> B_t;
+        pto::TRESHAPE(B_t, B);
+        pto::TEXTRACT(l0b, B_t, kL0Idx * kL0Size, 0);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+
+      if (initflag) {
+        pto::TMATMUL(C, l0a, l0b);
+      } else {
+        pto::TMATMUL_ACC(C, C, l0a, l0b);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+    }
+  }
+
+  set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+  wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+
+  set_flag(PIPE_M, PIPE_FIX, war_event_id);
+  wait_flag(PIPE_M, PIPE_FIX, war_event_id);
+}
+
+} // namespace
+
+#endif
+
+template <int32_t NumHeads, int32_t NumKeyHeads, int32_t HiddenSize,
+          int32_t ChunkSize>
+AICORE void chunk_h_kernel(
+    __gm__ half *K_handle, __gm__ half *W_handle, __gm__ half *U_handle,
+    __gm__ float *G_handle,
+    __gm__ half *S_handle, __gm__ half *V_handle, __gm__ half *FS_handle,
+    __gm__ half *workspace_handle,
+    __gm__ int32_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  // chunk_h advances the recurrent hidden state chunk by chunk:
+  //   ws_i      = W_i @ S_i
+  //   v_i_new   = U_i - ws_i
+  //   k_i_tilde = exp(g_last - g_i) * K_i
+  //   S_{i+1}   = exp(g_last) * S_i + k_i_tilde^T @ v_i_new.
+  //
+  // Shapes for one (sequence, head, chunk):
+  //   W_i, U_i, K_i, V_i_new : [valid, D]
+  //   S_i, S_{i+1}           : [D, D]
+  //
+  // PyTorch / NumPy sketch:
+  //   ws = W_i @ S_i
+  //   v_new = U_i - ws
+  //   decay = exp(g_last - g_i)[:, None]
+  //   k_tilde = decay * K_i
+  //   kv = k_tilde.T @ v_new
+  //   S = exp(g_last) * S + kv
+  //
+  // PTO split:
+  //   Cube forms the two matmuls (`W_i @ S_i` and `K_i^T @ V_i_new`).
+  //   Vec does the elementwise gating/decay and carries the running state.
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
+  set_ffts_base_addr(ffts_addr);
+
+  constexpr int32_t D = HiddenSize;
+  constexpr int32_t C = ChunkSize;
+  constexpr int32_t H = NumHeads;
+  constexpr int32_t Hg = NumKeyHeads;
+  static_assert(Hg > 0 && H % Hg == 0,
+                "NumHeads must be divisible by NumKeyHeads");
+  constexpr int32_t GROUP = H / Hg;
+  constexpr int32_t HalfC = C / 2;
+  constexpr int32_t BSND_QKV_STRIDE = H * D;
+  constexpr int32_t BSND_K_STRIDE = Hg * D;
+  constexpr int32_t DD = D * D;
+
+  constexpr int32_t WS_WS = 0;
+  constexpr int32_t WS_K  = DD;
+  constexpr int32_t WS_S  = DD * 2;
+  constexpr int32_t WS_KV = DD * 3;
+  constexpr int32_t WS_PER_CORE = DD * 4;
+
+  TileMatL1<half, D, D, D, D> s_l1;
+  TASSIGN(s_l1, 0);
+  TileMatL1<half, C, D, C, D> w_l1;
+  TASSIGN(w_l1, D * D * sizeof(half));
+  TileAcc<float, C, D, C, D> ws_l0;
+  TASSIGN(ws_l0, 0);
+  TileMatL1<half, D, C, D, C> k_l1;
+  TASSIGN(k_l1, (DD + C * D) * sizeof(half));
+  TileMatL1<half, C, D, C, D> v_l1;
+  TASSIGN(v_l1, (DD + C * D + D * C) * sizeof(half));
+  TileAcc<float, D, D, D, D> kv_l0;
+  TASSIGN(kv_l0, C * D * sizeof(float));
+
+  constexpr int32_t G_BLOCK_UB = 0;
+  // Leading UB scratch: legacy kernels used ``C * NumHeads * sizeof(float)``, which overflows UB when
+  // ``NumHeads`` is 32/48/64. Keep the same slack as the historical ``GDN_H=16`` build (8192 bytes).
+  constexpr int32_t ZERO_UB =
+      ChunkSize * 16 * static_cast<int32_t>(sizeof(float));
+  constexpr int32_t S_UB = ZERO_UB + 64 * sizeof(float);
+  constexpr int32_t K_UB_HALF = S_UB + HalfC * D * sizeof(float);
+  constexpr int32_t G_UB = K_UB_HALF + HalfC * D * sizeof(half);
+  constexpr int32_t U_UB_HALF = G_UB + C * sizeof(float);
+  constexpr int32_t K_UB = U_UB_HALF + HalfC * D * sizeof(half);
+  constexpr int32_t G_V_UB = K_UB + HalfC * D * sizeof(float);
+  constexpr int32_t COEFF_UB = G_V_UB + 64 * sizeof(float);
+  constexpr int32_t U_UB = COEFF_UB + 64 * sizeof(float);
+  constexpr int32_t WS_UB = U_UB + HalfC * D * sizeof(float);
+  constexpr int32_t KV_UB = U_UB_HALF;
+  constexpr int32_t S_UB_HALF = WS_UB + HalfC * D * sizeof(float);
+
+  TileUbDataND<float, 1, 64, 1, 64> zero_ub;
+  TASSIGN(zero_ub, ZERO_UB);
+  TileUbDataND<float, HalfC, D, HalfC, D> s_ub;
+  TASSIGN(s_ub, S_UB);
+  TileUbDataND<half, HalfC, D, HalfC, D, pto::PadValue::Zero> k_ub_half;
+  TASSIGN(k_ub_half, K_UB_HALF);
+  TileUbDataND<float, 1, C, 1, C, pto::PadValue::Zero> g_ub;
+  TASSIGN(g_ub, G_UB);
+  TileUbDataND<half, HalfC, D, HalfC, D> s_ub_half;
+  TASSIGN(s_ub_half, S_UB_HALF);
+  TileUbDataND<half, HalfC, D, HalfC, D, pto::PadValue::Zero> u_ub_half;
+  TASSIGN(u_ub_half, U_UB_HALF);
+  TileUbDataND<float, HalfC, D, HalfC, D> k_ub;
+  TASSIGN(k_ub, K_UB);
+  TileUbDataND<float, 1, 64, 1, 64> g_v_ub;
+  TASSIGN(g_v_ub, G_V_UB);
+  TileUbDataND<float, 1, 64, 1, 64> coeff_ub;
+  TASSIGN(coeff_ub, COEFF_UB);
+  TileUbDataND<float, HalfC, D, HalfC, D> u_ub;
+  TASSIGN(u_ub, U_UB);
+  TileUbDataND<float, HalfC, D, HalfC, D> ws_ub;
+  TASSIGN(ws_ub, WS_UB);
+  TileUbDataND<float, HalfC, D, HalfC, D> kv_ub;
+  TASSIGN(kv_ub, KV_UB);
+
+  auto vid = get_subblockid();
+
+  int64_t num_seqs = batch_size;
+  int64_t total_work = num_seqs * H;
+
+#if defined(__DAV_C220_CUBE__)
+  for (int64_t wi = 0; wi < (total_work + block_num - 1) / block_num; ++wi) {
+    int64_t pid = wi * block_num + cid;
+    if (pid >= total_work) break;
+
+    int64_t head = pid % H;
+    int64_t seq_idx = pid / H;
+
+    int64_t bos, slen;
+    int64_t chunk_offset = 0;
+    if (cu_seqlens != nullptr) {
+      bos = static_cast<int64_t>(cu_seqlens[seq_idx]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[seq_idx + 1]);
+      slen = eos - bos;
+      for (int64_t si = 0; si < seq_idx; ++si) {
+        int64_t sb = static_cast<int64_t>(cu_seqlens[si]);
+        int64_t se = static_cast<int64_t>(cu_seqlens[si + 1]);
+        chunk_offset += (se - sb + C - 1) / C;
+      }
+    } else {
+      bos = seq_idx * seq_len;
+      slen = seq_len;
+      chunk_offset = seq_idx * ((seq_len + C - 1) / C);
+    }
+    int64_t num_chunks = (slen + C - 1) / C;
+    int64_t ws_base = static_cast<int64_t>(cid) * WS_PER_CORE;
+    // One per-core scratch region stores:
+    //   WS_WS : ws = W_i @ S_i
+    //   WS_K  : k_tilde
+    //   WS_S  : running state S_i
+    //   WS_KV : k_tilde^T @ v_i_new
+
+    for (int32_t ci = 0; ci < num_chunks; ++ci) {
+      wait_flag_dev(3);
+
+      int64_t chunk_start = bos + static_cast<int64_t>(ci) * C;
+      int64_t valid = slen - static_cast<int64_t>(ci) * C;
+      if (valid > C) valid = C;
+
+      {
+        GmShape2D s_shape(D, D);
+        GmStride2D s_stride(D);
+        GmTensor2D<half> s_global(workspace_handle + ws_base + WS_S, s_shape,
+                                  s_stride);
+        DynMatL1<half, D, D> s_l1_load(D, D);
+        TASSIGN(s_l1_load, 0);
+        // Load the previous recurrent state S_i from per-core workspace.
+        TLOAD(s_l1_load, s_global);
+      }
+
+      int64_t w_offset = ((chunk_start) * H + head) * D;
+      {
+        GmShape2D w_shape(static_cast<int32_t>(valid), D);
+        GmStride2D w_stride(BSND_QKV_STRIDE);
+        GmTensor2D<half> w_global(W_handle + w_offset, w_shape, w_stride);
+        DynMatL1<half, C, D> w_l1_load(static_cast<int32_t>(valid), D);
+        TASSIGN(w_l1_load, D * D * static_cast<int32_t>(sizeof(half)));
+        TLOAD(w_l1_load, w_global);
+        if (valid != C) {
+          TFILLPAD(w_l1_load, w_l1_load);
+        }
+      }
+
+      set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+      wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+      // Apply the carried recurrent state to every token in this chunk.
+      gemm_v0<half, float, C, D, D, C, D, D, D, false, false>(
+          w_l1, s_l1, ws_l0, (bool)1);
+
+      {
+        GmShape2D ws_shape(C, D);
+        GmStride2D ws_stride(D);
+        GmTensor2D<half> ws_global(workspace_handle + ws_base + WS_WS,
+                                   ws_shape, ws_stride);
+        DynAccTile<float, C, D> ws_store(C, D);
+        TASSIGN(ws_store, 0);
+        // Save ws_i so the Vec phase can do `v_new = U_i - ws_i`.
+        TSTORE(ws_global, ws_store);
+      }
+      ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+
+      wait_flag_dev(1);
+
+      {
+        GmShape2D k_shape(D, C);
+        GmStride2D k_stride(C);
+        GmTensor2D<half> k_global(workspace_handle + ws_base + WS_K, k_shape,
+                                  k_stride);
+        DynMatL1<half, D, C> k_l1_load(D, C);
+        TASSIGN(k_l1_load, (DD + C * D) * static_cast<int32_t>(sizeof(half)));
+        TLOAD(k_l1_load, k_global);
+      }
+
+      int64_t v_offset = ((chunk_start) * H + head) * D;
+      {
+        GmShape2D v_shape(static_cast<int32_t>(valid), D);
+        GmStride2D v_stride(BSND_QKV_STRIDE);
+        GmTensor2D<half> v_global(V_handle + v_offset, v_shape, v_stride);
+        DynMatL1<half, C, D> v_l1_load(static_cast<int32_t>(valid), D);
+        TASSIGN(v_l1_load,
+                (DD + C * D + D * C) * static_cast<int32_t>(sizeof(half)));
+        TLOAD(v_l1_load, v_global);
+        if (valid != C) {
+          TFILLPAD(v_l1_load, v_l1_load);
+        }
+      }
+
+      set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+      wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+      // This chunk contributes the additive update K_i^T V_i to the state recurrence.
+      gemm_v0<half, float, D, D, C, D, D, C, C, true, false>(
+          k_l1, v_l1, kv_l0, (bool)1);
+
+      {
+        GmShape2D kv_shape(D, D);
+        GmStride2D kv_stride(D);
+        GmTensor2D<half> kv_global(workspace_handle + ws_base + WS_KV,
+                                   kv_shape, kv_stride);
+        DynAccTile<float, D, D> kv_store(D, D);
+        TASSIGN(kv_store, C * D * static_cast<int32_t>(sizeof(float)));
+        // Save kv = k_tilde^T @ v_i_new so Vec can finish the state update.
+        TSTORE(kv_global, kv_store);
+      }
+      ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+    }
+  }
+#endif
+#if defined(__DAV_C220_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // Vec owns the running recurrent state S_i and updates it after every chunk.
+  for (int64_t wi = 0; wi < (total_work + block_num - 1) / block_num; ++wi) {
+    int64_t pid = wi * block_num + cid;
+    if (pid >= total_work) break;
+
+    int64_t head = pid % H;
+    int64_t head_g = head / GROUP;
+    int64_t seq_idx = pid / H;
+
+    int64_t bos, slen;
+    int64_t chunk_offset = 0;
+    if (cu_seqlens != nullptr) {
+      bos = static_cast<int64_t>(cu_seqlens[seq_idx]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[seq_idx + 1]);
+      slen = eos - bos;
+      for (int64_t si = 0; si < seq_idx; ++si) {
+        int64_t sb = static_cast<int64_t>(cu_seqlens[si]);
+        int64_t se = static_cast<int64_t>(cu_seqlens[si + 1]);
+        chunk_offset += (se - sb + C - 1) / C;
+      }
+    } else {
+      bos = seq_idx * seq_len;
+      slen = seq_len;
+      chunk_offset = seq_idx * ((seq_len + C - 1) / C);
+    }
+    int64_t num_chunks = (slen + C - 1) / C;
+    int64_t ws_base = static_cast<int64_t>(cid) * WS_PER_CORE;
+
+    set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+    TEXPANDS(zero_ub, 0.0f);
+    set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+    // Start each sequence/head recurrence from S_0 = 0.
+    TEXPANDS(s_ub, 0.0f);
+
+    TCVT(s_ub_half, s_ub, pto::RoundMode::CAST_NONE);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    {
+      // `workspace_handle` is a `half*`, so all offsets here are in half elements.
+      GmShape2D s_shape(HalfC, D);
+      GmStride2D s_stride(D);
+      GmTensor2D<half> s_global(
+          workspace_handle + ws_base + WS_S + vid * HalfC * D,
+          s_shape, s_stride);
+      DynVecTile<half, HalfC, D> s_store(HalfC, D);
+      TASSIGN(s_store, S_UB_HALF);
+      TSTORE(s_global, s_store);
+    }
+    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+
+    int64_t chunk_start_0 = bos;
+    int64_t valid0 = slen;
+    if (valid0 > C) valid0 = C;
+    // Vec work is split by row stripe, not by individual token.  For the first
+    // chunk we compute exactly how many live rows belong to this sub-block's
+    // HalfC stripe so short tails do not overrun the packed BSND input.
+    int32_t valid_rows_0 =
+        static_cast<int32_t>(valid0 - static_cast<int64_t>(vid) * HalfC);
+    if (valid_rows_0 < 0) valid_rows_0 = 0;
+    if (valid_rows_0 > HalfC) valid_rows_0 = HalfC;
+
+    int64_t k_offset_0 =
+        (chunk_start_0 * Hg + head_g) * D + vid * HalfC * BSND_K_STRIDE;
+    if (valid_rows_0 > 0) {
+      GmShape2D k_shape(valid_rows_0, D);
+      GmStride2D k_stride(BSND_K_STRIDE);
+      GmTensor2D<half> k_global(K_handle + k_offset_0, k_shape, k_stride);
+      DynVecTile<half, HalfC, D, pto::PadValue::Zero> k_load(valid_rows_0, D);
+      TASSIGN(k_load, K_UB_HALF);
+      TLOAD(k_load, k_global);
+      if (valid_rows_0 != HalfC) {
+        TFILLPAD_INPLACE(k_ub_half, k_load);
+      }
+    } else {
+      // Empty stripe (typically vid=1 on a very short tail chunk): synthesize
+      // a zero tile so later full-width vector math and workspace stores still
+      // observe proper padding semantics.
+      TEXPANDS(k_ub, 0.0f);
+      TCVT(k_ub_half, k_ub, pto::RoundMode::CAST_NONE);
+    }
+
+    {
+      GmShape2D g_shape(1, static_cast<int32_t>(valid0));
+      GmStride2D g_stride(1);
+      GmTensor2D<float> g_global(G_handle + head * total_tokens + chunk_start_0,
+                                 g_shape, g_stride);
+      DynVecTile<float, 1, C, pto::PadValue::Zero> g_load(
+          1, static_cast<int32_t>(valid0));
+      TASSIGN(g_load, G_UB);
+      TLOAD(g_load, g_global);
+      if (valid0 != C) {
+        TFILLPAD_INPLACE(g_ub, g_load);
+      }
+    }
+
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    for (int32_t ci = 0; ci < static_cast<int32_t>(num_chunks); ++ci) {
+      int64_t chunk_start = bos + static_cast<int64_t>(ci) * C;
+      int64_t valid = slen - static_cast<int64_t>(ci) * C;
+      if (valid > C) valid = C;
+      int32_t valid_rows =
+          static_cast<int32_t>(valid - static_cast<int64_t>(vid) * HalfC);
+      if (valid_rows < 0) valid_rows = 0;
+      if (valid_rows > HalfC) valid_rows = HalfC;
+      // Each Vec subblock owns one contiguous HalfC-row stripe of the chunk.
+      // For short tail chunks, `valid_rows` may be smaller or even zero.  This
+      // is the key fix that keeps ragged tails and dense varlen boundary mixes
+      // from reading or writing beyond the live rows in this stripe.
+
+      int64_t u_offset = (chunk_start * H + head) * D + vid * HalfC * BSND_QKV_STRIDE;
+      if (valid_rows > 0) {
+        GmShape2D u_shape(valid_rows, D);
+        GmStride2D u_stride(BSND_QKV_STRIDE);
+        GmTensor2D<half> u_global(U_handle + u_offset, u_shape, u_stride);
+        DynVecTile<half, HalfC, D, pto::PadValue::Zero> u_load(valid_rows, D);
+        TASSIGN(u_load, U_UB_HALF);
+        TLOAD(u_load, u_global);
+        if (valid_rows != HalfC) {
+          TFILLPAD_INPLACE(u_ub_half, u_load);
+        }
+      } else {
+        // No live rows for this stripe in the current chunk; keep the tile
+        // explicitly zero-padded so the remainder of the recurrence logic can
+        // run in full-tile form without special-casing every later step.
+        TEXPANDS(u_ub, 0.0f);
+        TCVT(u_ub_half, u_ub, pto::RoundMode::CAST_NONE);
+      }
+
+      TCVT(k_ub, k_ub_half, pto::RoundMode::CAST_NONE);
+
+      TileUbDataND<float, 1, 64, 1, 64> g_ub_temp;
+      TASSIGN(g_ub_temp, G_UB + vid * 64 * sizeof(float));
+      TMOV(g_v_ub, g_ub_temp);
+
+      set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+      float g_last = g_ub.GetValue(static_cast<int32_t>(valid) - 1);
+      // Rebase the chunk gate around g_last so the intra-chunk decay stays numerically local.
+      // Torch-like:
+      //   coeff = exp(g_last - g_rows_owned_by_this_subblock)
+      TADDS(coeff_ub, g_v_ub, -g_last);
+      pipe_barrier(PIPE_V);
+      TSUB(coeff_ub, zero_ub, coeff_ub);
+      pipe_barrier(PIPE_V);
+      TEXP(coeff_ub, coeff_ub);
+
+      TEXP(g_ub, g_ub);
+
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      TCVT(u_ub, u_ub_half, pto::RoundMode::CAST_NONE);
+
+      TileUbDataDN<float, HalfC, 1, HalfC, 1> coeff_col_ub;
+      TASSIGN(coeff_col_ub, COEFF_UB);
+      TileUbDataND<float, HalfC, D, HalfC, D> coeff_2d_ub;
+      TASSIGN(coeff_2d_ub, WS_UB);
+      // Broadcast one decay scalar per token row across the D feature columns:
+      //   coeff_2d[row, :] = coeff[row]
+      TROWEXPAND(coeff_2d_ub, coeff_col_ub);
+      pipe_barrier(PIPE_V);
+      // `k_ub` now holds k_tilde = exp(g_last - g_i) * K_i.
+      TMUL(k_ub, k_ub, coeff_2d_ub);
+      pipe_barrier(PIPE_V);
+
+      wait_flag_dev(0);
+      {
+        GmShape2D ws_shape(HalfC, D);
+        GmStride2D ws_stride(D);
+        GmTensor2D<half> ws_global(
+            workspace_handle + ws_base + WS_WS + vid * HalfC * D,
+            ws_shape, ws_stride);
+        DynVecTile<half, HalfC, D, pto::PadValue::Zero> ws_load(HalfC, D);
+        TASSIGN(ws_load, U_UB_HALF);
+        TLOAD(ws_load, ws_global);
+      }
+
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      TCVT(ws_ub, u_ub_half, pto::RoundMode::CAST_NONE);
+      // v_i_new = U_i - W_i @ S_i.
+      // In PyTorch notation:
+      //   u_ub = u_ub - ws_ub
+      TSUB(u_ub, u_ub, ws_ub);
+      TCVT(u_ub_half, u_ub, pto::RoundMode::CAST_NONE);
+      TCVT(k_ub_half, k_ub, pto::RoundMode::CAST_NONE);
+
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+      int64_t v_offset = (chunk_start * H + head) * D + vid * HalfC * BSND_QKV_STRIDE;
+      if (valid_rows > 0) {
+        GmShape2D v_shape(valid_rows, D);
+        GmStride2D v_stride(BSND_QKV_STRIDE);
+        GmTensor2D<half> v_global(V_handle + v_offset, v_shape, v_stride);
+        DynVecTile<half, HalfC, D> v_store(valid_rows, D);
+        TASSIGN(v_store, U_UB_HALF);
+        TSTORE(v_global, v_store);
+      }
+
+      // Spill both V_i_new and k_i_tilde so the Cube stage can form
+      // k_i_tilde^T @ V_i_new for this chunk.
+      {
+        GmShape2D k_shape(HalfC, D);
+        GmStride2D k_stride(D);
+        GmTensor2D<half> k_global(
+            workspace_handle + ws_base + WS_K + vid * HalfC * D,
+            k_shape, k_stride);
+        DynVecTile<half, HalfC, D> k_store(HalfC, D);
+        TASSIGN(k_store, K_UB_HALF);
+        TSTORE(k_global, k_store);
+      }
+
+      ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+
+      set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+      wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+      float exp_g_last = g_ub.GetValue(static_cast<int32_t>(valid) - 1);
+      // Carry the recurrence across chunks: S_{i+1} = exp(g_last) * S_i + K_i^T V_i.
+      TMULS(s_ub, s_ub, exp_g_last);
+
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+      if (ci + 1 < static_cast<int32_t>(num_chunks)) {
+        int64_t next_start = bos + static_cast<int64_t>(ci + 1) * C;
+        int64_t next_valid = slen - static_cast<int64_t>(ci + 1) * C;
+        if (next_valid > C) next_valid = C;
+        int32_t next_valid_rows = static_cast<int32_t>(
+            next_valid - static_cast<int64_t>(vid) * HalfC);
+        if (next_valid_rows < 0) next_valid_rows = 0;
+        if (next_valid_rows > HalfC) next_valid_rows = HalfC;
+
+        int64_t nk_off =
+            (next_start * Hg + head_g) * D + vid * HalfC * BSND_K_STRIDE;
+        if (next_valid_rows > 0) {
+          GmShape2D k_shape(next_valid_rows, D);
+          GmStride2D k_stride(BSND_K_STRIDE);
+          GmTensor2D<half> k_global(K_handle + nk_off, k_shape, k_stride);
+          DynVecTile<half, HalfC, D, pto::PadValue::Zero> k_load(
+              next_valid_rows, D);
+          TASSIGN(k_load, K_UB_HALF);
+          TLOAD(k_load, k_global);
+          if (next_valid_rows != HalfC) {
+            TFILLPAD_INPLACE(k_ub_half, k_load);
+          }
+        } else {
+          // Same tail-safe zero materialization for the prefetch path: the next
+          // chunk may have no rows in this stripe even though the other stripe
+          // is still active.
+          TEXPANDS(k_ub, 0.0f);
+          TCVT(k_ub_half, k_ub, pto::RoundMode::CAST_NONE);
+        }
+
+        {
+          GmShape2D g_shape(1, static_cast<int32_t>(next_valid));
+          GmStride2D g_stride(1);
+          GmTensor2D<float> g_global(G_handle + head * total_tokens + next_start,
+                                     g_shape, g_stride);
+          DynVecTile<float, 1, C, pto::PadValue::Zero> g_load(
+              1, static_cast<int32_t>(next_valid));
+          TASSIGN(g_load, G_UB);
+          TLOAD(g_load, g_global);
+          if (next_valid != C) {
+            TFILLPAD_INPLACE(g_ub, g_load);
+          }
+        }
+      }
+
+      wait_flag_dev(2);
+      {
+        GmShape2D kv_shape(HalfC, D);
+        GmStride2D kv_stride(D);
+        GmTensor2D<half> kv_global(
+            workspace_handle + ws_base + WS_KV + vid * HalfC * D,
+            kv_shape, kv_stride);
+        DynVecTile<half, HalfC, D, pto::PadValue::Zero> kv_load(HalfC, D);
+        TASSIGN(kv_load, S_UB_HALF);
+        TLOAD(kv_load, kv_global);
+      }
+
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      TCVT(kv_ub, s_ub_half, pto::RoundMode::CAST_NONE);
+      pipe_barrier(PIPE_ALL);
+      // Finish S_{i+1} = exp(g_last) * S_i + k_i_tilde^T @ v_i_new.
+      // Torch-like:
+      //   s_ub = s_ub + kv_ub
+      TADD(s_ub, s_ub, kv_ub);
+      TCVT(s_ub_half, s_ub, pto::RoundMode::CAST_NONE);
+
+      if (ci + 1 < static_cast<int32_t>(num_chunks)) {
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        {
+          GmShape2D s_shape(HalfC, D);
+          GmStride2D s_stride(D);
+          GmTensor2D<half> s_global(
+              workspace_handle + ws_base + WS_S + vid * HalfC * D,
+              s_shape, s_stride);
+          DynVecTile<half, HalfC, D> s_store(HalfC, D);
+          TASSIGN(s_store, S_UB_HALF);
+          TSTORE(s_global, s_store);
+        }
+
+        // Expose the post-chunk state so the next chunk (and debug/verification
+        // outputs) can see S_{i+1}. Conceptually:
+        //   S_handle[chunk_idx + 1, head] = S_{i+1}
+        int64_t s_out_offset = ((chunk_offset + ci + 1) * H + head) * DD;
+        {
+          GmShape2D s_out_shape(HalfC, D);
+          GmStride2D s_out_stride(D);
+          GmTensor2D<half> s_out_global(
+              S_handle + s_out_offset + vid * HalfC * D, s_out_shape,
+              s_out_stride);
+          DynVecTile<half, HalfC, D> s_out_store(HalfC, D);
+          TASSIGN(s_out_store, S_UB_HALF);
+          TSTORE(s_out_global, s_out_store);
+        }
+        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+      }
+
+      if (ci + 1 < static_cast<int32_t>(num_chunks)) {
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      }
+    }
+
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    int64_t fs_offset = (seq_idx * H + head) * DD;
+    {
+      GmShape2D fs_shape(HalfC, D);
+      GmStride2D fs_stride(D);
+      GmTensor2D<half> fs_global(FS_handle + fs_offset + vid * HalfC * D,
+                                 fs_shape, fs_stride);
+      DynVecTile<half, HalfC, D> fs_store(HalfC, D);
+      TASSIGN(fs_store, S_UB_HALF);
+      TSTORE(fs_global, fs_store);
+    }
+  }
+#endif
+}
+
+#ifndef GDN_HG
+#define GDN_HG GDN_H
+#endif
+
+extern "C" __global__ AICORE void launch_chunk_h(
+    __gm__ uint8_t *K, __gm__ uint8_t *W, __gm__ uint8_t *U,
+    __gm__ uint8_t *G,
+    __gm__ uint8_t *S, __gm__ uint8_t *V, __gm__ uint8_t *FS,
+    __gm__ uint8_t *workspace,
+    __gm__ uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  chunk_h_kernel<GDN_H, GDN_HG, GDN_D, GDN_C>(
+      reinterpret_cast<__gm__ half *>(K),
+      reinterpret_cast<__gm__ half *>(W),
+      reinterpret_cast<__gm__ half *>(U),
+      reinterpret_cast<__gm__ float *>(G),
+      reinterpret_cast<__gm__ half *>(S),
+      reinterpret_cast<__gm__ half *>(V),
+      reinterpret_cast<__gm__ half *>(FS),
+      reinterpret_cast<__gm__ half *>(workspace),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, total_tokens, ffts_addr);
+}
+
+extern "C" void call_kernel(
+    uint32_t block_dim, void *stream,
+    uint8_t *K, uint8_t *W, uint8_t *U, uint8_t *G,
+    uint8_t *S, uint8_t *V, uint8_t *FS,
+    uint8_t *workspace,
+    uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+{
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_chunk_h<<<block_dim, nullptr, stream>>>(
+      K, W, U, G, S, V, FS, workspace, cu_seqlens,
+      batch_size, seq_len, total_tokens, fftsAddr);
+}

--- a/csrc/pto_chunk_gdn/chunk_o.cpp
+++ b/csrc/pto_chunk_gdn/chunk_o.cpp
@@ -1,0 +1,1249 @@
+// ============================================================================
+// chunk_o_kernel.cpp — Output computation for GatedDeltaNet (chunk-wise)
+//
+// Mathematical operation (per chunk of C tokens, per head h):
+//
+//   O = (QK_gated @ V) + exp(g) * (Q @ S)
+//     = intra_chunk_attention + inter_chunk_state_contribution
+//
+// where:
+//   Q, K, V ∈ ℝ^{C×D}    — query/key/value projections for this chunk
+//   S ∈ ℝ^{D×D}           — accumulated hidden state entering this chunk
+//   G ∈ ℝ^{C}             — cumulative gate values (pre-transposed [H,T])
+//   Msk ∈ ℝ^{C×C}         — lower-triangular causal mask
+//
+// Cube phase (3 GEMMs per chunk):
+//   1. QK   = Q @ K^T         — intra-chunk attention scores
+//   2. QS   = Q @ S           — query applied to accumulated state
+//   3. QKV  = QK_gated @ V    — gated attention applied to values
+//
+// Vec phase (two sub-blocks process upper/lower C/2 rows):
+//   a. Load G → compute gating coefficients:
+//        coeff[i,j] = exp(min(g[i] - g[j], 0)) * mask[i,j]
+//   b. Apply gating to QK: QK_gated = QK * coeff
+//   c. Scale QS by exp(g): QS_gated = QS * exp(g_row)
+//   d. Combine: O = QS_gated + QKV
+//   e. Store O to GM in BSND layout
+//
+// Cross-core sync protocol (Cube ↔ Vec via FFTS):
+//   flag 0: Cube→Vec  — QK and QS results ready in workspace
+//   flag 1: Vec→Cube  — QK_gated written back, Cube can proceed to GEMM 3
+//   flag 2: Cube→Vec  — QKV result ready in workspace
+//   flag 3: Vec→Cube  — Vec done with this chunk, Cube can reuse workspace
+//
+// NPU memory hierarchy used:
+//   GM → L1 (Cube-accessible) → L0A/L0B (matrix engines) → L0C (accumulator)
+//   GM → UB (Vec-accessible, on-chip SRAM)
+//
+// ── PTO / NPU Primer ──────────────────────────────────────────────────
+// This kernel combines matrix multiplication (Cube) with element-wise gating
+// (Vec) in a tightly coordinated 3-GEMM + gating pipeline per chunk.
+//
+// Execution timeline for one chunk:
+//   Cube: GEMM1(Q@K^T) → GEMM2(Q@S) → store QK,QS → signal Vec ──────┐
+//   Vec:  (meanwhile) load G, compute gating coefficients                │
+//   Vec:  ←── wait for Cube signal ──── apply gating to QK → QK_gated  │
+//   Vec:  store QK_gated → signal Cube ────────────────────────────────┐│
+//   Cube: ←── wait for Vec signal ──── GEMM3(QK_gated@V) → store QKV ─┘│
+//   Vec:  ←── wait for Cube signal ──── scale QS, combine O=QKV+QS_g   │
+//   Vec:  store O → signal Cube "done" ─────────────────────────────────┘
+//
+// numpy pseudocode for the entire chunk computation:
+//   QK = Q @ K.T                                          # GEMM 1
+//   QS = Q @ S                                            # GEMM 2
+//   coeff = exp(min(g_row - g_col, 0)) * mask             # gating (dynamic PTO)
+//   (``static_baseline/run_chunk_o_static.py`` uses exp(g_row-g_col) without min.)
+//   QK_gated = QK * coeff                                 # apply gating
+//   QKV = QK_gated @ V                                    # GEMM 3
+//   O = QKV + QS * np.exp(g_row).reshape(-1, 1)           # final output
+//
+// Key PTO APIs (with numpy/torch equivalents):
+//   TLOAD(dst, gm)          — dst = gm_data      (DMA: GM→UB/L1, async)
+//   TSTORE(gm, src)         — gm = src            (DMA: UB/L0C→GM, async)
+//   TASSIGN(tile, addr)     — bind tile descriptor to buffer address
+//   TCVT(dst, src, mode)    — type cast: dst = src.float() or .half()
+//   TMOV(dst, src)          — copy: dst = src.clone()
+//   TADD(d, a, b)           — d = a + b
+//   TSUB(d, a, b)           — d = a - b
+//   TMUL(d, a, b)           — d = a * b
+//   TMINS(d, s, val)        — d = torch.clamp(s, max=val)
+//   TEXP(d, s)              — d = torch.exp(s)
+//   TROWEXPAND(2d, col)     — 2d[i,j] = col[i] (broadcast column→rows)
+//   TCOLEXPAND(2d, row)     — 2d[i,j] = row[j] (broadcast row→columns)
+//   TEXTRACT(l0, l1, r, c)  — copy L1 sub-tile → L0A/L0B (Cube input regs)
+//   TRESHAPE(zn, nz)        — reinterpret L1 fractal layout (transpose, free)
+//   TMATMUL(C, A, B)        — C = A @ B (Cube engine, fp16→fp32 accum)
+//   set_flag / wait_flag    — synchronize pipes within same AI core
+//   ffts_cross_core_sync    — signal across Cube↔Vec cores
+//   wait_flag_dev(flag)     — wait for cross-core signal
+// ============================================================================
+
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace pto;
+
+// ── Compile-time configuration (overridable at build time via -D flags) ──
+// GDN_H: number of attention heads (default 16)
+// GDN_D: hidden dimension per head (default 128)
+// GDN_C: chunk size in tokens (default 128)
+#ifndef GDN_H
+#define GDN_H 16
+#endif
+
+#ifndef GDN_HG
+#define GDN_HG GDN_H
+#endif
+
+#ifndef GDN_D
+#define GDN_D 128
+#endif
+
+#ifndef GDN_C
+#define GDN_C 128
+#endif
+
+// ── PTO type aliases (device-only, guarded for host pass safety) ────────────
+// The bisheng compiler performs 3 passes: vec core, cube core (__CCE_AICORE__
+// defined), and host (__CCE_AICORE__ NOT defined). Type aliases using PTO
+// tile types must be guarded so the host pass never sees them.
+#ifdef __CCE_AICORE__
+
+// UbND = Unified Buffer tile, row-major (ND) layout, for Vec SIMD ops.
+//   Like torch.empty((R, C), dtype=T) in fast on-chip SRAM (~256KB).
+//   RV, CV = valid region (handles dynamic shapes, partial chunks).
+//   PadValue::Zero = fill with 0 outside valid region during TLOAD.
+// T=dtype, R×C=static shape, RV×CV=valid region, P=pad fill for TLOAD.
+template <typename T, int R, int C, int RV = R, int CV = C,
+          pto::PadValue P = pto::PadValue::Null>
+using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
+                       RV, CV, pto::SLayout::NoneBox, 512, P>;
+
+// UbDN = UB tile in column-major (DN) layout.
+//   Needed as source for TROWEXPAND which requires column-format input.
+//   TROWEXPAND takes a column vector and broadcasts it across all columns
+//   of a destination ND tile: dst[i,j] = col[i] for all j.
+template <typename T, int R, int C, int RV = R, int CV = C>
+using UbDN = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::ColMajor,
+                       RV, CV, pto::SLayout::NoneBox, 512>;
+
+// L1Mat = L1 cache tile in NZ fractal format — standard Cube GEMM input.
+//   Data is loaded here from GM via TLOAD, then fed to L0A/L0B via TEXTRACT.
+template <typename T, int R, int C, int RV = R, int CV = C>
+using L1Mat = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::ColMajor,
+                        RV, CV, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+// L1MatZN = ZN fractal format — used for transposed GEMM operands.
+//   TRESHAPE(l1_zn, l1_nz) converts NZ→ZN = logical matrix transpose (free, no data movement).
+template <typename T, int R, int C, int RV = R, int CV = C>
+using L1MatZN = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::RowMajor,
+                          RV, CV, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+
+#endif  // __CCE_AICORE__
+
+template <int32_t NumHeads, int32_t NumKeyHeads, int32_t HiddenSize,
+          int32_t ChunkSize>
+AICORE void chunk_o_kernel(
+    __gm__ half *Q_handle, __gm__ half *K_handle, __gm__ half *V_handle,
+    __gm__ half *S_handle, __gm__ float *G_handle,
+    __gm__ float *Msk_handle,
+    __gm__ half *workspace_qk_handle,
+    __gm__ half *workspace_qs_qkv_handle,
+    __gm__ half *workspace_qk_gated_handle,
+    __gm__ half *O_handle,
+    __gm__ int32_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  // Half the chunk — each Vec sub-block handles C/2 rows independently.
+  constexpr int32_t HalfChunk = ChunkSize / 2;
+  // KTail / CTail: the number of valid elements in the last 128-element tile
+  // when D or C isn't a multiple of 128. Used internally by PTO for partial tiles.
+  constexpr uint32_t KTail =
+      (HiddenSize % 128 == 0) ? 128 : (HiddenSize % 128);
+  constexpr uint32_t CTail =
+      (ChunkSize % 128 == 0) ? 128 : (ChunkSize % 128);
+
+  constexpr int32_t H = NumHeads;
+  constexpr int32_t Hg = NumKeyHeads;
+  static_assert(Hg > 0 && H % Hg == 0,
+                "NumHeads must be divisible by NumKeyHeads");
+  constexpr int32_t GROUP = H / Hg;
+  constexpr int32_t BSND_V_STRIDE = H * HiddenSize;
+  constexpr int32_t BSND_QK_STRIDE = Hg * HiddenSize;
+
+  // Workspace sizes (in elements) shared between Cube and Vec via GM
+  constexpr int32_t WsQKSize = ChunkSize * ChunkSize;
+  constexpr int32_t WsQSSize = ChunkSize * HiddenSize;
+  constexpr int32_t WsGatedSize = ChunkSize * ChunkSize;
+
+  // ── UB memory map (byte addresses within Unified Buffer) ─────────────
+  constexpr int32_t GUbAddr      = 0;
+  constexpr int32_t MskUbAddr    = 512;
+  constexpr int32_t QKUbAddr     = 33280;
+  constexpr int32_t GvUbAddr     = 66048;
+  constexpr int32_t CoeffUbAddr  = 66304;
+  constexpr int32_t QKHalfUbAddr = 99072;
+  constexpr int32_t QSHalfUbAddr = 115456;
+  constexpr int32_t QSUbAddr     = 131840;
+  constexpr int32_t OHalfUbAddr  = 164608;
+  constexpr int32_t OUbAddr      = QKUbAddr;
+
+  // Initialize the cross-core FFTS signaling base address for this AI core.
+  set_ffts_base_addr(ffts_addr);
+  // cid = which AI core am I? (0..block_num-1). Used to partition work items.
+  auto cid = get_block_idx();
+  // block_num = total number of AI cores running this kernel in parallel.
+  auto block_num = get_block_num();
+  // vid = Vec sub-block ID (0 or 1). Each Vec core has 2 sub-blocks that
+  // process the upper (vid=0) and lower (vid=1) halves of C/2 rows.
+  auto vid = get_subblockid();
+
+  int64_t num_seqs = batch_size;
+
+  // ── L1 tiles for Cube GEMM operands ──────────────────────────────────
+  // L1 holds matrices in NZ (col-major fractal) format for the matrix engine.
+  // Each tile is assigned a fixed L1 byte address to avoid runtime allocation.
+  //
+  // ── L1 tile layout for Cube GEMMs ────────────────────────────────────
+  // L1 cache (~1MB) is manually partitioned for the 3 GEMMs:
+  //   q_l1   at 0:      Q [C×D]       — shared by GEMM 1 and GEMM 2
+  //   k_l1   at 32768:  K [C×D]       — used in GEMM 1 (transposed via TRESHAPE)
+  //   s_l1   at 65536:  S [D×D]       — accumulated state, used in GEMM 2
+  //   qk_gated at 98304: QK_gated [C×C] — from Vec, used in GEMM 3
+  //   v_l1   at 131072: V [C×D]       — values, used in GEMM 3
+  L1Mat<half, ChunkSize, HiddenSize> q_l1;
+  TASSIGN(q_l1, 0);
+  L1Mat<half, ChunkSize, HiddenSize> k_l1;
+  TASSIGN(k_l1, 32768);
+  TileAcc<float, ChunkSize, ChunkSize,
+          ChunkSize, ChunkSize> qk_l0;
+  TASSIGN(qk_l0, 0);
+  L1Mat<half, HiddenSize, HiddenSize> s_l1;
+  TASSIGN(s_l1, 65536);
+  TileAcc<float, ChunkSize, HiddenSize,
+          ChunkSize, HiddenSize> qs_l0;
+  TASSIGN(qs_l0, 65536);
+  L1Mat<half, ChunkSize, ChunkSize> qk_gated_l1;
+  TASSIGN(qk_gated_l1, 98304);
+  L1Mat<half, ChunkSize, HiddenSize> v_l1;
+  TASSIGN(v_l1, 131072);
+  TileAcc<float, ChunkSize, HiddenSize,
+          ChunkSize, HiddenSize> qkv_l0;
+  TASSIGN(qkv_l0, 0);
+
+  // ── UB tiles for Vec element-wise operations ─────────────────────────
+  // UB (Unified Buffer) is on-chip SRAM accessible by the Vec engine.
+  // Tiles here are row-major (ND) for standard element-wise ops.
+  //
+  // ── UB tile layout for Vec element-wise ops ──────────────────────────
+  // Each Vec sub-block (vid=0 or vid=1) processes C/2 rows of the C×C or C×D
+  // matrices. The UB layout (byte addresses) is designed so all needed tiles
+  // fit simultaneously in the ~256KB UB without overlapping:
+  //   g_ub:       gate values [1, C] float            @ 0
+  //   msk_ub:     causal mask [C/2, C] float          @ 512     (loaded once, reused)
+  //   qk_ub:      QK scores in float [C/2, C]         @ 33280   (after cast from half)
+  //   g_v_ub:     this sub-block's gate slice [1, C/2] @ 66048
+  //   coeff_ub:   gating coefficients [C/2, C] float  @ 66304
+  //   qk_ub_half: QK in half [C/2, C]                @ 99072
+  //   qs_ub_half: QS in half [C/2, D]                @ 115456
+  //   qs_ub:      QS in float [C/2, D]               @ 131840
+  //   o_ub_half:  output O in half [C/2, D]           @ 164608
+  //   o_ub:       output O in float [C/2, D]          @ QKUbAddr (reuses qk_ub space)
+  UbND<float, 1, ChunkSize> g_ub;
+  TASSIGN(g_ub, GUbAddr);
+  UbND<float, HalfChunk, ChunkSize> msk_ub;
+  TASSIGN(msk_ub, MskUbAddr);
+  UbND<float, HalfChunk, ChunkSize> qk_ub;
+  TASSIGN(qk_ub, QKUbAddr);
+  UbND<float, 1, HalfChunk> g_v_ub;
+  TASSIGN(g_v_ub, GvUbAddr);
+  UbND<float, HalfChunk, ChunkSize> coeff_ub;
+  TASSIGN(coeff_ub, CoeffUbAddr);
+  UbND<half, HalfChunk, ChunkSize, HalfChunk, ChunkSize, PadValue::Zero> qk_ub_half;
+  TASSIGN(qk_ub_half, QKHalfUbAddr);
+  UbND<half, HalfChunk, HiddenSize, HalfChunk, HiddenSize, PadValue::Zero> qs_ub_half;
+  TASSIGN(qs_ub_half, QSHalfUbAddr);
+  UbND<float, HalfChunk, HiddenSize> qs_ub;
+  TASSIGN(qs_ub, QSUbAddr);
+  UbND<half, HalfChunk, HiddenSize, HalfChunk, HiddenSize, PadValue::Zero> o_ub_half;
+  TASSIGN(o_ub_half, OHalfUbAddr);
+  UbND<float, HalfChunk, HiddenSize> o_ub;
+  TASSIGN(o_ub, OUbAddr);
+
+  // Total work items = (batches * chunks_per_sequence * heads).
+  // Each AI core (cid) picks every block_num-th work item (round-robin).
+  int64_t total_work = 0;
+  if (cu_seqlens == nullptr) {
+    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+    total_work = num_seqs * chunks_per_seq * NumHeads;
+  }
+
+// =====================================================================
+// CUBE CORE — Three GEMMs per chunk: QK, QS, QKV
+// Each AI core processes a different (chunk, head) pair. The Cube engine
+// performs the heavy matmuls, then writes results to GM workspace for
+// the Vec engine to apply gating and produce the final output.
+// =====================================================================
+#if defined(__DAV_C220_CUBE__)
+  if (cu_seqlens == nullptr) {
+    // ── Fixed-length sequence path ──────────────────────────────────────
+    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+    int64_t global_chunk_base = 0;
+    bool first_cube_iter = true;
+
+    for (int64_t work_idx = static_cast<int64_t>(cid);
+         work_idx < total_work;
+         work_idx += static_cast<int64_t>(block_num)) {
+      // Wait for Vec to finish with previous chunk's workspace (flag 3)
+      if (!first_cube_iter) wait_flag_dev(3);
+      set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+      wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+
+      int32_t head_idx = static_cast<int32_t>(work_idx % NumHeads);
+      int32_t head_g = head_idx / GROUP;
+      int64_t chunk_head_idx = work_idx / NumHeads;
+      int64_t seq_idx = chunk_head_idx / chunks_per_seq;
+      int64_t ci = chunk_head_idx % chunks_per_seq;
+
+      int64_t bos = seq_idx * seq_len;
+      int64_t slen = seq_len;
+      int64_t chunk_start = ci * ChunkSize;
+      int64_t remaining = slen - chunk_start;
+      int32_t valid_rows = static_cast<int32_t>(
+          remaining < ChunkSize ? remaining : ChunkSize);
+      int64_t chunk_token_start = bos + chunk_start;
+      int32_t row_offset = static_cast<int32_t>(vid) * HalfChunk;
+      int32_t local_rows = valid_rows - row_offset;
+      if (local_rows < 0) local_rows = 0;
+      if (local_rows > HalfChunk) local_rows = HalfChunk;
+
+      int64_t qk_off =
+          (chunk_token_start * static_cast<int64_t>(Hg) +
+           static_cast<int64_t>(head_g)) *
+          static_cast<int64_t>(HiddenSize);
+      int64_t v_off =
+          (chunk_token_start * static_cast<int64_t>(H) +
+           static_cast<int64_t>(head_idx)) *
+          static_cast<int64_t>(HiddenSize);
+
+      int64_t chunk_global_idx = seq_idx * chunks_per_seq + ci;
+      int64_t s_offset =
+          (chunk_global_idx * NumHeads + head_idx) *
+          static_cast<int64_t>(HiddenSize) *
+          static_cast<int64_t>(HiddenSize);
+
+      // ── Load Q [valid_rows × D] from GM → L1 ────────────────────────
+      // GlobalTensor describes the GM layout with BSND strides.
+      // TLOAD performs DMA (MTE2 pipe). TFILLPAD zero-pads tail rows so
+      // downstream GEMMs see a clean C×D matrix.
+      {
+        L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+        TASSIGN(_l1, 0);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_QK_STRIDE, 1>> _gm(Q_handle + qk_off, _gs);
+        TLOAD(_l1, _gm);
+        if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+      }
+      // ── Load K [valid_rows × D] from GM → L1 ────────────────────────
+      {
+        L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+        TASSIGN(_l1, 32768);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_QK_STRIDE, 1>> _gm(K_handle + qk_off, _gs);
+        TLOAD(_l1, _gm);
+        if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+      }
+
+      // ── GEMM 1: QK = Q @ K^T  (intra-chunk attention scores) ────────
+      // ── GEMM 1: QK = Q @ K^T ─────────────────────────────────────────
+      // numpy: QK = Q @ K.T  →  [C×D] @ [D×C] = [C×C]
+      //
+      // How transpose works on NPU:
+      //   K is loaded into L1 in NZ (col-major fractal) format.
+      //   TRESHAPE(l1_zn, k_l1) reinterprets it as ZN (row-major fractal) = K^T.
+      //   This is a ZERO-COST operation — no data movement, just metadata change.
+      //   TEXTRACT then loads the transposed view into L0B.
+      //
+      // Cube GEMM pipeline:
+      //   TEXTRACT(l0a, q_l1, 0, 0)  — Q → L0A (left operand)
+      //   TEXTRACT(l0b, k_zn, 0, 0)  — K^T → L0B (right operand)
+      //   TMATMUL(qk_l0, l0a, l0b)   — QK = L0A × L0B → L0C accumulator
+      //
+      // transpose_B: TRESHAPE converts k_l1 from NZ → ZN fractal layout,
+      // effectively transposing K before TEXTRACT loads it into L0B.
+      {
+        TileLeft<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0a;
+        TileRight<half, HiddenSize, ChunkSize, HiddenSize, ChunkSize> _l0b;
+        TASSIGN(_l0a, 0x0); TASSIGN(_l0b, 0x0);
+        auto _we = EVENT_ID1;
+        set_flag(PIPE_MTE2, PIPE_MTE1, _we); wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+        set_flag(PIPE_M, PIPE_MTE1, _we); wait_flag(PIPE_M, PIPE_MTE1, _we);
+        TEXTRACT(_l0a, q_l1, 0, 0);
+        L1MatZN<half, HiddenSize, ChunkSize> _bzn; TRESHAPE(_bzn, k_l1); TEXTRACT(_l0b, _bzn, 0, 0);
+        set_flag(PIPE_MTE1, PIPE_M, _we); wait_flag(PIPE_MTE1, PIPE_M, _we);
+        TMATMUL(qk_l0, _l0a, _l0b);
+        set_flag(PIPE_MTE1, PIPE_MTE2, _we); wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+        set_flag(PIPE_M, PIPE_FIX, _we); wait_flag(PIPE_M, PIPE_FIX, _we);
+      }
+
+      // ── Load S [D × D] from GM → L1  (accumulated hidden state) ─────
+      {
+        L1Mat<half, HiddenSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(HiddenSize, HiddenSize);
+        TASSIGN(_l1, 65536);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = HiddenSize; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(S_handle + s_offset, _gs);
+        TLOAD(_l1, _gm);
+      }
+
+      // ── GEMM 2: QS = Q @ S  (query applied to accumulated state) ────
+      {
+        TileLeft<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0a;
+        TileRight<half, HiddenSize, HiddenSize, HiddenSize, HiddenSize> _l0b;
+        TASSIGN(_l0a, 0x0); TASSIGN(_l0b, 0x0);
+        auto _we = EVENT_ID1;
+        set_flag(PIPE_MTE2, PIPE_MTE1, _we); wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+        set_flag(PIPE_M, PIPE_MTE1, _we); wait_flag(PIPE_M, PIPE_MTE1, _we);
+        TEXTRACT(_l0a, q_l1, 0, 0);
+        TEXTRACT(_l0b, s_l1, 0, 0);
+        set_flag(PIPE_MTE1, PIPE_M, _we); wait_flag(PIPE_MTE1, PIPE_M, _we);
+        TMATMUL(qs_l0, _l0a, _l0b);
+        set_flag(PIPE_MTE1, PIPE_MTE2, _we); wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+        set_flag(PIPE_M, PIPE_FIX, _we); wait_flag(PIPE_M, PIPE_FIX, _we);
+      }
+
+      // ── Store QK [C × C] from L0C → GM workspace (fp32→fp16 cast) ───
+      // TSTORE on TileAcc triggers MTE3 DMA with implicit type conversion.
+      {
+        TileAcc<float, ChunkSize, ChunkSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, ChunkSize);
+        TASSIGN(_l0, 0);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = ChunkSize; _gs.shape[4] = ChunkSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+            workspace_qk_handle +
+                static_cast<int64_t>(cid) * WsQKSize, _gs);
+        TSTORE(_gm, _l0);
+      }
+
+      // ── Store QS [C × D] from L0C → GM workspace ────────────────────
+      {
+        TileAcc<float, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, HiddenSize);
+        TASSIGN(_l0, 65536);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = ChunkSize; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+            workspace_qs_qkv_handle +
+                static_cast<int64_t>(cid) * WsQSSize, _gs);
+        TSTORE(_gm, _l0);
+      }
+
+      // Signal Vec: QK and QS are ready (flag 0, Cube→Vec)
+      // ── Cross-core sync protocol ──────────────────────────────────────
+      // Cube and Vec are SEPARATE physical cores. They exchange data through GM
+      // and coordinate via FFTS flags. Think of it as two processes communicating
+      // through shared memory with semaphores.
+      //
+      // ffts_cross_core_sync(PIPE_FIX, config):
+      //   config = 1 | (mode << 4) | (flag_id << 8)
+      //   mode=2: broadcast signal to all cores in this block
+      //   flag_id: identifies which signal (0, 1, 2, 3)
+      //
+      // Protocol for this kernel:
+      //   flag 0: Cube→Vec "QK and QS are ready in workspace"
+      //   flag 1: Vec→Cube "QK_gated is ready for GEMM 3"
+      //   flag 2: Cube→Vec "QKV (GEMM 3 result) is ready"
+      //   flag 3: Vec→Cube "I'm done with this chunk, you can reuse workspace"
+      ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+
+      // Wait for Vec to write QK_gated back (flag 1, Vec→Cube)
+      wait_flag_dev(1);
+
+      set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+      wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+
+      // ── Load QK_gated [C × C] from GM workspace → L1 ────────────────
+      {
+        L1Mat<half, ChunkSize, ChunkSize, DYNAMIC, DYNAMIC> _l1(ChunkSize, ChunkSize);
+        TASSIGN(_l1, 98304);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = ChunkSize; _gs.shape[4] = ChunkSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+            workspace_qk_gated_handle +
+                static_cast<int64_t>(cid) * WsGatedSize, _gs);
+        TLOAD(_l1, _gm);
+      }
+      // ── Load V [valid_rows × D] from GM → L1 ────────────────────────
+      {
+        L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+        TASSIGN(_l1, 131072);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(V_handle + v_off, _gs);
+        TLOAD(_l1, _gm);
+        if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+      }
+
+      // ── GEMM 3: QKV = QK_gated @ V  (gated attention → values) ──────
+      {
+        TileLeft<half, ChunkSize, ChunkSize, ChunkSize, ChunkSize> _l0a;
+        TileRight<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0b;
+        TASSIGN(_l0a, 0x0); TASSIGN(_l0b, 0x0);
+        auto _we = EVENT_ID1;
+        set_flag(PIPE_MTE2, PIPE_MTE1, _we); wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+        set_flag(PIPE_M, PIPE_MTE1, _we); wait_flag(PIPE_M, PIPE_MTE1, _we);
+        TEXTRACT(_l0a, qk_gated_l1, 0, 0);
+        TEXTRACT(_l0b, v_l1, 0, 0);
+        set_flag(PIPE_MTE1, PIPE_M, _we); wait_flag(PIPE_MTE1, PIPE_M, _we);
+        TMATMUL(qkv_l0, _l0a, _l0b);
+        set_flag(PIPE_MTE1, PIPE_MTE2, _we); wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+        set_flag(PIPE_M, PIPE_FIX, _we); wait_flag(PIPE_M, PIPE_FIX, _we);
+      }
+
+      // ── Store QKV [C × D] from L0C → GM workspace ───────────────────
+      // ── Workspace buffer reuse ────────────────────────────────────────
+      // workspace_qs_qkv_handle is shared between QS (GEMM 2 output) and QKV
+      // (GEMM 3 output). This is safe because:
+      //   1. Vec reads QS BEFORE Cube writes QKV to the same buffer
+      //   2. The cross-core flags ensure proper ordering:
+      //      - flag 0: QS ready (Vec reads QS)
+      //      - flag 1: QK_gated ready (Vec done reading QS, Cube can write QKV)
+      //      - flag 2: QKV ready (Vec reads QKV from same buffer)
+      {
+        TileAcc<float, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, HiddenSize);
+        TASSIGN(_l0, 0);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = ChunkSize; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+            workspace_qs_qkv_handle +
+                static_cast<int64_t>(cid) * WsQSSize, _gs);
+        TSTORE(_gm, _l0);
+      }
+
+      // Signal Vec: QKV is ready (flag 2, Cube→Vec)
+      ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+      first_cube_iter = false;
+    }
+  } else {
+    // ── Variable-length sequence path (cu_seqlens != nullptr) ──────────
+    int64_t gi = 0;
+    int64_t chunk_global_idx = 0;
+    bool first_cube_iter_v = true;
+    for (int64_t si = 0; si < num_seqs; ++si) {
+      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+      int64_t slen = eos - bos;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t ci = 0; ci < nc; ++ci) {
+        for (int32_t h = 0; h < NumHeads; ++h) {
+          if (gi % static_cast<int64_t>(block_num) ==
+              static_cast<int64_t>(cid)) {
+            if (!first_cube_iter_v) wait_flag_dev(3);
+            set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+
+            int64_t chunk_start = ci * ChunkSize;
+            int64_t remaining = slen - chunk_start;
+            int32_t valid_rows = static_cast<int32_t>(
+                remaining < ChunkSize ? remaining : ChunkSize);
+            int64_t chunk_token_start = bos + chunk_start;
+            int32_t head_idx = h;
+            int32_t head_g = head_idx / GROUP;
+
+            int64_t qk_off =
+                (chunk_token_start * static_cast<int64_t>(Hg) +
+                 static_cast<int64_t>(head_g)) *
+                static_cast<int64_t>(HiddenSize);
+            int64_t v_off =
+                (chunk_token_start * static_cast<int64_t>(H) +
+                 static_cast<int64_t>(head_idx)) *
+                static_cast<int64_t>(HiddenSize);
+            int64_t s_offset =
+                (chunk_global_idx * NumHeads + head_idx) *
+                static_cast<int64_t>(HiddenSize) *
+                static_cast<int64_t>(HiddenSize);
+
+            // Load Q
+            {
+              L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+              TASSIGN(_l1, 0);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_QK_STRIDE, 1>> _gm(Q_handle + qk_off, _gs);
+              TLOAD(_l1, _gm);
+              if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+            }
+            // Load K
+            {
+              L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+              TASSIGN(_l1, 32768);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_QK_STRIDE, 1>> _gm(K_handle + qk_off, _gs);
+              TLOAD(_l1, _gm);
+              if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+            }
+
+            // GEMM 1: QK = Q @ K^T (transpose_B via TRESHAPE NZ→ZN)
+            {
+              TileLeft<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0a;
+              TileRight<half, HiddenSize, ChunkSize, HiddenSize, ChunkSize> _l0b;
+              TASSIGN(_l0a, 0x0); TASSIGN(_l0b, 0x0);
+              auto _we = EVENT_ID1;
+              set_flag(PIPE_MTE2, PIPE_MTE1, _we); wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+              set_flag(PIPE_M, PIPE_MTE1, _we); wait_flag(PIPE_M, PIPE_MTE1, _we);
+              TEXTRACT(_l0a, q_l1, 0, 0);
+              L1MatZN<half, HiddenSize, ChunkSize> _bzn; TRESHAPE(_bzn, k_l1); TEXTRACT(_l0b, _bzn, 0, 0);
+              set_flag(PIPE_MTE1, PIPE_M, _we); wait_flag(PIPE_MTE1, PIPE_M, _we);
+              TMATMUL(qk_l0, _l0a, _l0b);
+              set_flag(PIPE_MTE1, PIPE_MTE2, _we); wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+              set_flag(PIPE_M, PIPE_FIX, _we); wait_flag(PIPE_M, PIPE_FIX, _we);
+            }
+
+            // Load S
+            {
+              L1Mat<half, HiddenSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(HiddenSize, HiddenSize);
+              TASSIGN(_l1, 65536);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = HiddenSize; _gs.shape[4] = HiddenSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(S_handle + s_offset, _gs);
+              TLOAD(_l1, _gm);
+            }
+
+            // GEMM 2: QS = Q @ S
+            {
+              TileLeft<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0a;
+              TileRight<half, HiddenSize, HiddenSize, HiddenSize, HiddenSize> _l0b;
+              TASSIGN(_l0a, 0x0); TASSIGN(_l0b, 0x0);
+              auto _we = EVENT_ID1;
+              set_flag(PIPE_MTE2, PIPE_MTE1, _we); wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+              set_flag(PIPE_M, PIPE_MTE1, _we); wait_flag(PIPE_M, PIPE_MTE1, _we);
+              TEXTRACT(_l0a, q_l1, 0, 0);
+              TEXTRACT(_l0b, s_l1, 0, 0);
+              set_flag(PIPE_MTE1, PIPE_M, _we); wait_flag(PIPE_MTE1, PIPE_M, _we);
+              TMATMUL(qs_l0, _l0a, _l0b);
+              set_flag(PIPE_MTE1, PIPE_MTE2, _we); wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+              set_flag(PIPE_M, PIPE_FIX, _we); wait_flag(PIPE_M, PIPE_FIX, _we);
+            }
+
+            // Store QK → workspace
+            {
+              TileAcc<float, ChunkSize, ChunkSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, ChunkSize);
+              TASSIGN(_l0, 0);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = ChunkSize; _gs.shape[4] = ChunkSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+                  workspace_qk_handle +
+                      static_cast<int64_t>(cid) * WsQKSize, _gs);
+              TSTORE(_gm, _l0);
+            }
+
+            // Store QS → workspace
+            {
+              TileAcc<float, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, HiddenSize);
+              TASSIGN(_l0, 65536);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = ChunkSize; _gs.shape[4] = HiddenSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+                  workspace_qs_qkv_handle +
+                      static_cast<int64_t>(cid) * WsQSSize, _gs);
+              TSTORE(_gm, _l0);
+            }
+
+            // Cube→Vec: QK & QS ready (flag 0)
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+
+            // Wait Vec→Cube: QK_gated ready (flag 1)
+            wait_flag_dev(1);
+
+            set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+
+            // Load QK_gated
+            {
+              L1Mat<half, ChunkSize, ChunkSize, DYNAMIC, DYNAMIC> _l1(ChunkSize, ChunkSize);
+              TASSIGN(_l1, 98304);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = ChunkSize; _gs.shape[4] = ChunkSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+                  workspace_qk_gated_handle +
+                      static_cast<int64_t>(cid) * WsGatedSize, _gs);
+              TLOAD(_l1, _gm);
+            }
+            // Load V
+            {
+              L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+              TASSIGN(_l1, 131072);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(V_handle + v_off, _gs);
+              TLOAD(_l1, _gm);
+              if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+            }
+
+            // GEMM 3: QKV = QK_gated @ V
+            {
+              TileLeft<half, ChunkSize, ChunkSize, ChunkSize, ChunkSize> _l0a;
+              TileRight<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0b;
+              TASSIGN(_l0a, 0x0); TASSIGN(_l0b, 0x0);
+              auto _we = EVENT_ID1;
+              set_flag(PIPE_MTE2, PIPE_MTE1, _we); wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+              set_flag(PIPE_M, PIPE_MTE1, _we); wait_flag(PIPE_M, PIPE_MTE1, _we);
+              TEXTRACT(_l0a, qk_gated_l1, 0, 0);
+              TEXTRACT(_l0b, v_l1, 0, 0);
+              set_flag(PIPE_MTE1, PIPE_M, _we); wait_flag(PIPE_MTE1, PIPE_M, _we);
+              TMATMUL(qkv_l0, _l0a, _l0b);
+              set_flag(PIPE_MTE1, PIPE_MTE2, _we); wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+              set_flag(PIPE_M, PIPE_FIX, _we); wait_flag(PIPE_M, PIPE_FIX, _we);
+            }
+
+            {
+              TileAcc<float, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, HiddenSize);
+              TASSIGN(_l0, 0);
+              Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+              _gs.shape[3] = ChunkSize; _gs.shape[4] = HiddenSize;
+              GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+                  workspace_qs_qkv_handle +
+                      static_cast<int64_t>(cid) * WsQSSize, _gs);
+              TSTORE(_gm, _l0);
+            }
+
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+            first_cube_iter_v = false;
+          }
+          gi++;
+        }
+        chunk_global_idx++;
+      }
+    }
+  }
+#endif
+
+// =====================================================================
+// VEC CORE — Gating, element-wise ops, output assembly
+// Two Vec sub-blocks (vid=0,1) process upper/lower C/2 rows in parallel.
+// Each sub-block independently:
+//   1. Computes gating coefficients from G and the causal mask
+//   2. Applies gating to the Cube's QK result → QK_gated
+//   3. Scales the Cube's QS result by exp(g)
+//   4. Combines QKV + scaled QS → final output O
+// =====================================================================
+#if defined(__DAV_C220_VEC__)
+  // Vec engine initialization: set_mask_norm selects "normal" masking mode,
+  // and set_vector_mask(-1, -1) enables ALL SIMD lanes (no masking).
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // ── Load causal mask once (reused across all chunks) ─────────────────
+  // ── Causal mask (loaded once, reused) ─────────────────────────────────
+  // The causal mask is a C×C lower-triangular matrix of 0s and 1s:
+  //   mask[i,j] = 1 if i >= j else 0
+  // Each sub-block loads its C/2 rows. Applied via TMUL to zero out
+  // non-causal (future) attention scores.
+  //
+  // Each sub-block (vid=0,1) loads its C/2 rows of the C×C lower-tri mask.
+  {
+    Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+    _gs.shape[3] = HalfChunk; _gs.shape[4] = ChunkSize;
+    GlobalTensor<float, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+        Msk_handle +
+            static_cast<int64_t>(vid) * HalfChunk * ChunkSize, _gs);
+    UbND<float, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(HalfChunk, ChunkSize);
+    TASSIGN(_ld, MskUbAddr);
+    TLOAD(_ld, _gm);
+  }
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+  if (cu_seqlens == nullptr) {
+    // ── Fixed-length sequence path ──────────────────────────────────────
+    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+
+    for (int64_t work_idx = static_cast<int64_t>(cid);
+         work_idx < total_work;
+         work_idx += static_cast<int64_t>(block_num)) {
+      int32_t head_idx = static_cast<int32_t>(work_idx % NumHeads);
+      int64_t chunk_head_idx = work_idx / NumHeads;
+      int64_t seq_idx = chunk_head_idx / chunks_per_seq;
+      int64_t ci = chunk_head_idx % chunks_per_seq;
+
+      int64_t bos = seq_idx * seq_len;
+      int64_t slen = seq_len;
+      int64_t chunk_start = ci * ChunkSize;
+      int64_t remaining = slen - chunk_start;
+      int32_t valid_rows = static_cast<int32_t>(
+          remaining < ChunkSize ? remaining : ChunkSize);
+      int64_t chunk_token_start = bos + chunk_start;
+      int32_t row_offset = static_cast<int32_t>(vid) * HalfChunk;
+      int32_t local_rows = valid_rows - row_offset;
+      if (local_rows < 0) local_rows = 0;
+      if (local_rows > HalfChunk) local_rows = HalfChunk;
+
+      if (local_rows > 0) {
+        // ── Load G [1 × valid_rows] — gate values for this chunk ────────
+        // G is pre-transposed to [H, total_tokens], contiguous per head.
+        {
+          Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+          _gs.shape[3] = 1; _gs.shape[4] = valid_rows;
+          GlobalTensor<float, decltype(_gs), Stride<1, 1, 1, 1, 1>> _gm(
+              G_handle + static_cast<int64_t>(head_idx) * total_tokens
+                       + chunk_token_start, _gs);
+          UbND<float, 1, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(1, valid_rows);
+          TASSIGN(_ld, GUbAddr);
+          TLOAD(_ld, _gm);
+          if (valid_rows != ChunkSize) {
+            UbND<float, 1, ChunkSize, 1, ChunkSize, PadValue::Zero> _pd;
+            TASSIGN(_pd, GUbAddr);
+            TFILLPAD_INPLACE(_pd, _ld);
+          }
+        }
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // ── Compute gating coefficients ──────────────────────────────────
+        // ── Gating coefficient computation (numpy pseudocode) ─────────────
+        // For this sub-block's rows (vid=0: rows 0..C/2-1, vid=1: rows C/2..C-1):
+        //
+        //   g_row = g[my_start:my_start+C/2]    # my gates (shape [C/2])
+        //   g_col = g[0:C]                       # full chunk gates (shape [C])
+        //
+        //   # Broadcast to 2D matrices:
+        //   g_r_2d = g_row[:, None] * np.ones((1, C))    # TROWEXPAND: [C/2, C]
+        //   g_c_2d = np.ones((C/2, 1)) * g_col[None, :]  # TCOLEXPAND: [C/2, C]
+        //   coeff = exp(min(g_r_2d - g_c_2d, 0)) * mask
+        //
+        //   # Also compute exp(g_row) for QS scaling:
+        //   exp_g_row = np.exp(g_row)                     # TEXP
+        UbND<float, 1, HalfChunk> g_ub_temp_0;
+        TASSIGN(g_ub_temp_0,
+                GUbAddr + static_cast<int32_t>(vid) * HalfChunk *
+                              static_cast<int32_t>(sizeof(float)));
+        TMOV(g_v_ub, g_ub_temp_0);
+
+        // Broadcast g_row into [C/2 × C] and g_col into [C/2 × C]
+        UbND<float, HalfChunk, ChunkSize> g_r_2d;
+        TASSIGN(g_r_2d, QSUbAddr);
+        UbDN<float, HalfChunk, 1> g_v_col;
+        TASSIGN(g_v_col, GvUbAddr);
+        TROWEXPAND(g_r_2d, g_v_col);       // g_r_2d[i,j] = g_row[i]
+        TCOLEXPAND(coeff_ub, g_ub);        // coeff[i,j] = g_col[j]
+        TSUB(coeff_ub, g_r_2d, coeff_ub);  // d = g_row - g_col
+        pipe_barrier(PIPE_V);
+        TMINS(coeff_ub, coeff_ub, 0.0f);
+        pipe_barrier(PIPE_V);
+        TEXP(coeff_ub, coeff_ub);
+        pipe_barrier(PIPE_V);
+        TMUL(coeff_ub, coeff_ub, msk_ub);
+        pipe_barrier(PIPE_V);
+        TEXP(g_v_ub, g_v_ub);              // exp(g_row) for QS scaling
+      }
+
+      // ── Wait for Cube→Vec flag 0: QK & QS ready ─────────────────────
+      wait_flag_dev(0);
+      if (local_rows == 0) {
+        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+        wait_flag_dev(2);
+        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+        continue;
+      }
+
+      // ── Load QK [C/2 × C] from workspace → UB ───────────────────────
+      {
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = local_rows; _gs.shape[4] = ChunkSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+            workspace_qk_handle +
+                static_cast<int64_t>(cid) * WsQKSize +
+                static_cast<int64_t>(vid) * HalfChunk * ChunkSize, _gs);
+        UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(local_rows, ChunkSize);
+        TASSIGN(_ld, QKHalfUbAddr);
+        TLOAD(_ld, _gm);
+        if (local_rows != HalfChunk) {
+          TFILLPAD_INPLACE(qk_ub_half, _ld);
+        }
+      }
+
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      TCVT(qk_ub, qk_ub_half, pto::RoundMode::CAST_NONE);
+
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+
+      // ── Load QS [C/2 × D] from workspace → UB ───────────────────────
+      {
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = local_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+            workspace_qs_qkv_handle +
+                static_cast<int64_t>(cid) * WsQSSize +
+                static_cast<int64_t>(vid) * HalfChunk * HiddenSize, _gs);
+        UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(local_rows, HiddenSize);
+        TASSIGN(_ld, QSHalfUbAddr);
+        TLOAD(_ld, _gm);
+        if (local_rows != HalfChunk) {
+          TFILLPAD_INPLACE(qs_ub_half, _ld);
+        }
+      }
+
+      // ── Apply gating: QK_gated = QK * exp(d*mask)*mask
+      TMUL(qk_ub, qk_ub, coeff_ub);
+      TCVT(qk_ub_half, qk_ub, pto::RoundMode::CAST_NONE);
+
+      // ── Store QK_gated [C/2 × C] → workspace for Cube's GEMM 3 ─────
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      {
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = local_rows; _gs.shape[4] = ChunkSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+            workspace_qk_gated_handle +
+                static_cast<int64_t>(cid) * WsGatedSize +
+                static_cast<int64_t>(vid) * HalfChunk * ChunkSize, _gs);
+        UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> _st(local_rows, ChunkSize);
+        TASSIGN(_st, QKHalfUbAddr);
+        TSTORE(_gm, _st);
+      }
+      // Vec→Cube: QK_gated ready (flag 1)
+      ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+
+      // ── Scale QS by exp(g): QS_gated = QS * exp(g_row) ──────────────
+      // ── Scale QS by exp(g): inter-chunk state contribution ────────────
+      // numpy: QS_scaled = QS * np.exp(g_row)[:, None]   (broadcast across D columns)
+      // TROWEXPAND broadcasts the scalar exp(g[i]) for each row i across all D columns,
+      // then TMUL applies it element-wise. This gates how much the accumulated state
+      // contributes to each token's output.
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      TCVT(qs_ub, qs_ub_half, pto::RoundMode::CAST_NONE);
+      UbND<float, HalfChunk, HiddenSize> g_exp_2d;
+      TASSIGN(g_exp_2d, CoeffUbAddr);
+      UbDN<float, HalfChunk, 1> g_v_col2;
+      TASSIGN(g_v_col2, GvUbAddr);
+      TROWEXPAND(g_exp_2d, g_v_col2);    // broadcast exp(g_row) across columns
+      pipe_barrier(PIPE_V);
+      TMUL(qs_ub, qs_ub, g_exp_2d);      // QS_gated = QS * exp(g_row)
+
+      // ── Wait for Cube→Vec flag 2: QKV ready ─────────────────────────
+      wait_flag_dev(2);
+
+      // ── Load QKV [C/2 × D] from workspace → UB ──────────────────────
+      {
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = local_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+            workspace_qs_qkv_handle +
+                static_cast<int64_t>(cid) * WsQSSize +
+                static_cast<int64_t>(vid) * HalfChunk * HiddenSize, _gs);
+        UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(local_rows, HiddenSize);
+        TASSIGN(_ld, OHalfUbAddr);
+        TLOAD(_ld, _gm);
+        if (local_rows != HalfChunk) {
+          TFILLPAD_INPLACE(o_ub_half, _ld);
+        }
+      }
+
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+      // ── Combine: O = QS_gated + QKV ─────────────────────────────────
+      // ── Final output: O = QKV + QS_scaled ─────────────────────────────
+      // numpy: O = (QK_gated @ V) + (Q @ S) * exp(g)[:, None]
+      //       = intra_chunk_attention + inter_chunk_state_contribution
+      // TCVT half→float for QKV, then TADD, then TCVT float→half for output.
+      TCVT(o_ub, o_ub_half, pto::RoundMode::CAST_NONE);
+      TADD(o_ub, qs_ub, o_ub);
+      TCVT(o_ub_half, o_ub, pto::RoundMode::CAST_NONE);
+
+      // ── Store O [C/2 × D] → GM in BSND layout ───────────────────────
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+      int64_t o_offset =
+          (chunk_token_start * static_cast<int64_t>(H) +
+           static_cast<int64_t>(head_idx)) *
+              static_cast<int64_t>(HiddenSize) +
+          static_cast<int64_t>(vid) * HalfChunk *
+              static_cast<int64_t>(BSND_V_STRIDE);
+
+      {
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = local_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(
+            O_handle + o_offset, _gs);
+        UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC> _st(local_rows, HiddenSize);
+        TASSIGN(_st, OHalfUbAddr);
+        TSTORE(_gm, _st);
+      }
+
+      // Vec→Cube: done with this chunk (flag 3)
+      ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+    }
+  } else {
+    // ── Variable-length sequence path (cu_seqlens != nullptr) ──────────
+    int64_t gi = 0;
+    for (int64_t si = 0; si < num_seqs; ++si) {
+      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+      int64_t slen = eos - bos;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t ci = 0; ci < nc; ++ci) {
+        for (int32_t h = 0; h < NumHeads; ++h) {
+          if (gi % static_cast<int64_t>(block_num) ==
+              static_cast<int64_t>(cid)) {
+            int64_t chunk_start = ci * ChunkSize;
+            int64_t remaining = slen - chunk_start;
+            int32_t valid_rows = static_cast<int32_t>(
+                remaining < ChunkSize ? remaining : ChunkSize);
+            int64_t chunk_token_start = bos + chunk_start;
+            int32_t head_idx = h;
+            int32_t row_offset = static_cast<int32_t>(vid) * HalfChunk;
+            int32_t local_rows = valid_rows - row_offset;
+            if (local_rows < 0) local_rows = 0;
+            if (local_rows > HalfChunk) local_rows = HalfChunk;
+
+            if (local_rows > 0) {
+              // Load G
+              {
+                Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+                _gs.shape[3] = 1; _gs.shape[4] = valid_rows;
+                GlobalTensor<float, decltype(_gs), Stride<1, 1, 1, 1, 1>> _gm(
+                    G_handle + static_cast<int64_t>(head_idx) * total_tokens
+                             + chunk_token_start, _gs);
+                UbND<float, 1, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(1, valid_rows);
+                TASSIGN(_ld, GUbAddr);
+                TLOAD(_ld, _gm);
+                if (valid_rows != ChunkSize) {
+                  UbND<float, 1, ChunkSize, 1, ChunkSize, PadValue::Zero> _pd;
+                  TASSIGN(_pd, GUbAddr);
+                  TFILLPAD_INPLACE(_pd, _ld);
+                }
+              }
+              set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+              wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+              // Compute gating coefficients (same math as fixed-length path — see detailed pseudocode above)
+              UbND<float, 1, HalfChunk> g_ub_temp_v;
+              TASSIGN(g_ub_temp_v,
+                      GUbAddr +
+                          static_cast<int32_t>(vid) * HalfChunk *
+                              static_cast<int32_t>(sizeof(float)));
+              TMOV(g_v_ub, g_ub_temp_v);
+
+              UbND<float, HalfChunk, ChunkSize> g_r_2d_v;
+              TASSIGN(g_r_2d_v, QSUbAddr);
+              UbDN<float, HalfChunk, 1> g_v_col_v;
+              TASSIGN(g_v_col_v, GvUbAddr);
+              TROWEXPAND(g_r_2d_v, g_v_col_v);
+              TCOLEXPAND(coeff_ub, g_ub);
+              TSUB(coeff_ub, g_r_2d_v, coeff_ub);  // d = g_row - g_col
+              pipe_barrier(PIPE_V);
+              TMINS(coeff_ub, coeff_ub, 0.0f);
+              pipe_barrier(PIPE_V);
+              TEXP(coeff_ub, coeff_ub);
+              pipe_barrier(PIPE_V);
+              TMUL(coeff_ub, coeff_ub, msk_ub);
+              pipe_barrier(PIPE_V);
+              TEXP(g_v_ub, g_v_ub);
+            }
+
+            wait_flag_dev(0);
+            if (local_rows == 0) {
+              ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+              wait_flag_dev(2);
+              ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+            } else {
+              // Load QK from workspace
+              {
+                Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+                _gs.shape[3] = local_rows; _gs.shape[4] = ChunkSize;
+                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+                    workspace_qk_handle +
+                        static_cast<int64_t>(cid) * WsQKSize +
+                        static_cast<int64_t>(vid) * HalfChunk * ChunkSize, _gs);
+                UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(local_rows, ChunkSize);
+                TASSIGN(_ld, QKHalfUbAddr);
+                TLOAD(_ld, _gm);
+                if (local_rows != HalfChunk) {
+                  TFILLPAD_INPLACE(qk_ub_half, _ld);
+                }
+              }
+
+              set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+              wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+              TCVT(qk_ub, qk_ub_half, pto::RoundMode::CAST_NONE);
+
+              set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+              wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+
+              // Load QS from workspace
+              {
+                Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+                _gs.shape[3] = local_rows; _gs.shape[4] = HiddenSize;
+                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+                    workspace_qs_qkv_handle +
+                        static_cast<int64_t>(cid) * WsQSSize +
+                        static_cast<int64_t>(vid) * HalfChunk * HiddenSize, _gs);
+                UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(local_rows, HiddenSize);
+                TASSIGN(_ld, QSHalfUbAddr);
+                TLOAD(_ld, _gm);
+                if (local_rows != HalfChunk) {
+                  TFILLPAD_INPLACE(qs_ub_half, _ld);
+                }
+              }
+
+              TMUL(qk_ub, qk_ub, coeff_ub);
+              TCVT(qk_ub_half, qk_ub, pto::RoundMode::CAST_NONE);  // float→half for GM store
+
+              // Store QK_gated → workspace
+              set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+              wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+              {
+                Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+                _gs.shape[3] = local_rows; _gs.shape[4] = ChunkSize;
+                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+                    workspace_qk_gated_handle +
+                        static_cast<int64_t>(cid) * WsGatedSize +
+                        static_cast<int64_t>(vid) * HalfChunk * ChunkSize, _gs);
+                UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> _st(local_rows, ChunkSize);
+                TASSIGN(_st, QKHalfUbAddr);
+                TSTORE(_gm, _st);
+              }
+              // Vec→Cube: QK_gated ready (flag 1)
+              ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+
+              // Scale QS by exp(g): QS_scaled = QS * exp(g_row)[:, None]
+              // (same inter-chunk state scaling as fixed-length path)
+              set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+              wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+              TCVT(qs_ub, qs_ub_half, pto::RoundMode::CAST_NONE);  // half→float for Vec math
+
+              UbND<float, HalfChunk, HiddenSize> g_exp_2d_v;
+              TASSIGN(g_exp_2d_v, CoeffUbAddr);
+              UbDN<float, HalfChunk, 1> g_v_col2_v;
+              TASSIGN(g_v_col2_v, GvUbAddr);
+              TROWEXPAND(g_exp_2d_v, g_v_col2_v);
+              pipe_barrier(PIPE_V);
+              TMUL(qs_ub, qs_ub, g_exp_2d_v);
+
+              wait_flag_dev(2);
+
+              // Load QKV from workspace
+              {
+                Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+                _gs.shape[3] = local_rows; _gs.shape[4] = HiddenSize;
+                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, HiddenSize, 1>> _gm(
+                    workspace_qs_qkv_handle +
+                        static_cast<int64_t>(cid) * WsQSSize +
+                        static_cast<int64_t>(vid) * HalfChunk * HiddenSize, _gs);
+                UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(local_rows, HiddenSize);
+                TASSIGN(_ld, OHalfUbAddr);
+                TLOAD(_ld, _gm);
+                if (local_rows != HalfChunk) {
+                  TFILLPAD_INPLACE(o_ub_half, _ld);
+                }
+              }
+
+              set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+              wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+              // O = QS_gated + QKV  (final output: intra-chunk attention + inter-chunk state)
+              TCVT(o_ub, o_ub_half, pto::RoundMode::CAST_NONE);  // half→float
+              TADD(o_ub, qs_ub, o_ub);                            // O = QS_scaled + QKV
+              TCVT(o_ub_half, o_ub, pto::RoundMode::CAST_NONE);  // float→half for GM store
+
+              // Store O → GM
+              set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+              wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+              int64_t o_offset =
+                  (chunk_token_start * static_cast<int64_t>(H) +
+                   static_cast<int64_t>(head_idx)) *
+                      static_cast<int64_t>(HiddenSize) +
+                  static_cast<int64_t>(vid) * HalfChunk *
+                      static_cast<int64_t>(BSND_V_STRIDE);
+
+              {
+                Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+                _gs.shape[3] = local_rows; _gs.shape[4] = HiddenSize;
+                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(
+                    O_handle + o_offset, _gs);
+                UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC> _st(local_rows, HiddenSize);
+                TASSIGN(_st, OHalfUbAddr);
+                TSTORE(_gm, _st);
+              }
+
+              // Vec→Cube: done with this chunk (flag 3)
+              ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+            }
+          }
+          gi++;
+        }
+      }
+    }
+  }
+#endif
+}
+
+// ── Device kernel entry point ─────────────────────────────────────────
+// extern "C" __global__ AICORE: NPU kernel function.
+// Runs on each AI core independently. Args are uint8_t* (type-erased)
+// because the NPU launch ABI passes all pointers as raw bytes; we
+// reinterpret_cast them to the correct types before calling the template.
+extern "C" __global__ AICORE void launch_chunk_o(
+    __gm__ uint8_t *Q_handle, __gm__ uint8_t *K_handle,
+    __gm__ uint8_t *V_handle, __gm__ uint8_t *S_handle,
+    __gm__ uint8_t *G_handle, __gm__ uint8_t *Msk_handle,
+    __gm__ uint8_t *workspace_qk, __gm__ uint8_t *workspace_qs_qkv,
+    __gm__ uint8_t *workspace_qk_gated,
+    __gm__ uint8_t *O_handle,
+    __gm__ uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  chunk_o_kernel<GDN_H, GDN_HG, GDN_D, GDN_C>(
+      reinterpret_cast<__gm__ half *>(Q_handle),
+      reinterpret_cast<__gm__ half *>(K_handle),
+      reinterpret_cast<__gm__ half *>(V_handle),
+      reinterpret_cast<__gm__ half *>(S_handle),
+      reinterpret_cast<__gm__ float *>(G_handle),
+      reinterpret_cast<__gm__ float *>(Msk_handle),
+      reinterpret_cast<__gm__ half *>(workspace_qk),
+      reinterpret_cast<__gm__ half *>(workspace_qs_qkv),
+      reinterpret_cast<__gm__ half *>(workspace_qk_gated),
+      reinterpret_cast<__gm__ half *>(O_handle),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, total_tokens, ffts_addr);
+}
+
+// ── Host launcher (called from Python ctypes) ─────────────────────────
+// Launches kernel on block_dim AI cores via NPU stream.
+// rtGetC2cCtrlAddr obtains the FFTS (cross-core sync) control address that
+// the kernel needs for Cube↔Vec flag signaling.
+extern "C" void call_kernel(
+    uint32_t block_dim, void *stream,
+    uint8_t *q, uint8_t *k, uint8_t *v, uint8_t *s, uint8_t *g_sum,
+    uint8_t *mask,
+    uint8_t *workspace_qk, uint8_t *workspace_qs_qkv,
+    uint8_t *workspace_qk_gated,
+    uint8_t *o,
+    uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens)
+{
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_chunk_o<<<block_dim, nullptr, stream>>>(
+      q, k, v, s, g_sum, mask,
+      workspace_qk, workspace_qs_qkv, workspace_qk_gated,
+      o,
+      cu_seqlens,
+      batch_size, seq_len, total_tokens, fftsAddr);
+}

--- a/csrc/pto_chunk_gdn/include/kernel_utils.h
+++ b/csrc/pto_chunk_gdn/include/kernel_utils.h
@@ -1,0 +1,47 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+#pragma once
+
+#define MEMORY_BASE
+#include <pto/pto-inst.hpp>
+#include <type_traits>
+
+namespace kernel_utils {
+/**
+ * @brief Do a sync step (set-wait flag) between two pipes.
+ *
+ * @tparam SrcPipe The pipe that sets the flag.
+ * @tparam DstPipe The pipe that waits for the flag.
+ * @param [in] id The event id to sync for.
+ */
+template <pipe_t SrcPipe, pipe_t DstPipe>
+AICORE inline void SetWaitFlag(uint32_t id) {
+  set_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+  wait_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+}
+
+/**
+ * @brief Performs a division on two integral numbers and rounds the result up
+ * to the nearest integer.
+ *
+ * @tparam T1 Data type of dividend.
+ * @tparam T2 Data type of divisor.
+ * @param [in] value Dividend.
+ * @param [in] divisor Divisor.
+ * @return Result of division.
+ */
+template <typename T1, typename T2,
+          typename std::enable_if<std::is_integral<T1>::value &&
+                                      std::is_integral<T2>::value,
+                                  int>::type = 0>
+AICORE inline T1 CeilDiv(T1 value, T2 divisor) {
+  return (value + divisor - 1) / divisor;
+}
+
+}  // namespace kernel_utils

--- a/csrc/pto_chunk_gdn/mega_kernel.cpp
+++ b/csrc/pto_chunk_gdn/mega_kernel.cpp
@@ -1,0 +1,502 @@
+// mega_kernel.cpp — GDN Mega-Kernel (group-value / GQA): all PTO stages in one launch
+//
+// Same pipeline as pto_mega_kernel, but scaled_dot_kkt / wy_fast / chunk_h / chunk_o use
+// templates (H, Hg) from dynamic_bsnd_groupvalue; cumsum still uses H (value heads) like
+// dynamic_bsnd.
+//
+// Stages:
+//   1. cumsum      (Vec)
+//   2. transpose   (Vec)
+//   3. kkt         (Cube+Vec)  — K has Hg heads; β,g,A use H value heads
+//   4. solve_tril  (Cube)
+//   5. wy_fast     (Vec+Cube)
+//   6. chunk_h     (Cube+Vec)
+//   7. chunk_o     (Cube+Vec)
+
+#ifndef GDN_H
+#define GDN_H 16
+#endif
+#ifndef GDN_HG
+#define GDN_HG GDN_H
+#endif
+#ifndef GDN_D
+#define GDN_D 128
+#endif
+#ifndef GDN_C
+#define GDN_C 128
+#endif
+#ifndef MEMORY_BASE
+#define MEMORY_BASE
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+#include <type_traits>
+using namespace pto;
+
+// ===================================================================
+// Device-only helpers (shared with standard mega-kernel)
+// ===================================================================
+#ifdef __CCE_AICORE__
+
+constexpr uint16_t SYNC_AIV_FLAG = 12;
+constexpr uint16_t SYNC_AIC_FLAG = 11;
+constexpr uint16_t SYNC_AIC_AIV_FLAG = 13;
+constexpr uint16_t SYNC_AIV_ONLY_ALL = 14;
+constexpr uint16_t SYNC_MODE_SHIFT_VALUE = 4;
+constexpr uint16_t SYNC_FLAG_SHIFT_VALUE = 8;
+
+AICORE inline uint16_t GetffstMsg(uint16_t mode, uint16_t flagId)
+{
+    return (0x1 + ((mode & 0x3) << SYNC_MODE_SHIFT_VALUE) +
+            ((flagId & 0xf) << SYNC_FLAG_SHIFT_VALUE));
+}
+
+template <bool isAIVOnly = true>
+AICORE inline void SyncAllImpl()
+{
+    pipe_barrier(PIPE_ALL);
+    if constexpr (isAIVOnly) {
+        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
+        wait_flag_dev(SYNC_AIV_ONLY_ALL);
+        return;
+    }
+#if defined(__DAV_C220_CUBE__)
+    wait_flag_dev(SYNC_AIV_FLAG);
+    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
+    wait_flag_dev(SYNC_AIC_FLAG);
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
+#elif defined(__DAV_C220_VEC__)
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
+    wait_flag_dev(SYNC_AIC_AIV_FLAG);
+#endif
+}
+
+template <typename T, int32_t H_val>
+AICORE void mega_transpose_TH_to_HT(
+    __gm__ T *src, __gm__ T *dst, int64_t T_len)
+{
+#if defined(__DAV_C220_VEC__)
+    if (get_subblockid() != 0) return;
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+
+    auto cid = get_block_idx();
+    auto block_num = get_block_num();
+
+    constexpr int32_t BLOCK = 128;
+    constexpr int32_t H = static_cast<int32_t>(H_val);
+    constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
+    constexpr int32_t SRC_UB = 0;
+    constexpr int32_t DST_UB = SRC_UB + BLOCK * H * ES;
+    constexpr int32_t TMP_UB = DST_UB + H * BLOCK * ES;
+
+    using UBSrcFull = Tile<TileType::Vec, T, BLOCK, H, BLayout::RowMajor,
+                           BLOCK, H, SLayout::NoneBox, 512, PadValue::Zero>;
+    using UBSrcDyn  = Tile<TileType::Vec, T, BLOCK, H, BLayout::RowMajor,
+                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
+    using UBDst     = Tile<TileType::Vec, T, H, BLOCK, BLayout::RowMajor,
+                           H, BLOCK, SLayout::NoneBox, 512>;
+    using UBDstDyn  = Tile<TileType::Vec, T, H, BLOCK, BLayout::RowMajor,
+                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
+    using UBTmp     = Tile<TileType::Vec, T, BLOCK, H, BLayout::RowMajor,
+                           BLOCK, H, SLayout::NoneBox, 512>;
+
+    using UBRow     = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor,
+                           1, BLOCK, SLayout::NoneBox, 512>;
+    using UBRowDyn  = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor,
+                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
+
+    using Gm2D      = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+    using Gm1D      = Shape<1, 1, 1, 1, DYNAMIC>;
+    using GmSrcS    = Stride<1, 1, 1, H, 1>;
+    using GmS1      = Stride<1, 1, 1, 1, 1>;
+
+    UBSrcFull ub_src; TASSIGN(ub_src, SRC_UB);
+    UBDst     ub_dst; TASSIGN(ub_dst, DST_UB);
+    UBTmp     ub_tmp; TASSIGN(ub_tmp, TMP_UB);
+
+    int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
+
+    for (int64_t bi = static_cast<int64_t>(cid); bi < num_tok_blocks;
+         bi += static_cast<int64_t>(block_num)) {
+        int64_t t0 = bi * BLOCK;
+        int32_t valid = (t0 + BLOCK <= T_len)
+                            ? BLOCK
+                            : static_cast<int32_t>(T_len - t0);
+
+        {
+            Gm2D gs; gs.shape[3] = valid; gs.shape[4] = H;
+            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs);
+            UBSrcDyn ld(valid, H);
+            TASSIGN(ld, SRC_UB);
+            TLOAD(ld, gm);
+            if (valid != BLOCK) TFILLPAD_INPLACE(ub_src, ld);
+        }
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        TTRANS(ub_dst, ub_src, ub_tmp);
+
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+        for (int32_t h = 0; h < H; ++h) {
+            Gm1D gs; gs.shape[4] = valid;
+            GlobalTensor<T, Gm1D, GmS1> gm(dst + h * T_len + t0, gs);
+            UBRowDyn st(1, valid);
+            TASSIGN(st, DST_UB + h * BLOCK * ES);
+            TSTORE(gm, st);
+        }
+        set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    }
+#endif
+}
+
+template <int32_t H, int32_t C>
+AICORE void mega_cast_fp32_to_fp16_bsnd(
+    __gm__ float *src, __gm__ half *dst,
+    uint32_t num_matrices, int64_t total_tokens)
+{
+#if defined(__DAV_C220_VEC__)
+    if (get_subblockid() != 0) return;
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+
+    auto cid = get_block_idx();
+    auto block_num = get_block_num();
+
+    constexpr int32_t F32_UB = 0;
+    constexpr int32_t F16_UB = C * static_cast<int32_t>(sizeof(float));
+
+    using SrcUB    = Tile<TileType::Vec, float, 1, C, BLayout::RowMajor,
+                          1, C, SLayout::NoneBox, 512, PadValue::Zero>;
+    using DynSrcUB = Tile<TileType::Vec, float, 1, C, BLayout::RowMajor,
+                          DYNAMIC, DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
+    using DstUB    = Tile<TileType::Vec, half, 1, C, BLayout::RowMajor,
+                          1, C, SLayout::NoneBox, 512>;
+    using DynDstUB = Tile<TileType::Vec, half, 1, C, BLayout::RowMajor,
+                          DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
+    using Gm1D     = Shape<1, 1, 1, 1, DYNAMIC>;
+    using GmS1     = Stride<1, 1, 1, 1, 1>;
+
+    SrcUB src_ub; TASSIGN(src_ub, F32_UB);
+    DstUB dst_ub; TASSIGN(dst_ub, F16_UB);
+
+    for (uint32_t m = cid; m < num_matrices; m += block_num) {
+        uint32_t h = m % static_cast<uint32_t>(H);
+        uint32_t chunk_idx = m / static_cast<uint32_t>(H);
+
+        for (int64_t t = 0; t < total_tokens; ++t) {
+            int64_t off = t * static_cast<int64_t>(H * C) +
+                          static_cast<int64_t>(h * C);
+
+            {
+                Gm1D gs; gs.shape[4] = C;
+                GlobalTensor<float, Gm1D, GmS1> gm(src + off, gs);
+                SrcUB ld; TASSIGN(ld, F32_UB);
+                TLOAD(ld, gm);
+            }
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            TCVT(dst_ub, src_ub, RoundMode::CAST_NONE);
+
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            {
+                Gm1D gs; gs.shape[4] = C;
+                GlobalTensor<half, Gm1D, GmS1> gm(dst + off, gs);
+                DstUB st; TASSIGN(st, F16_UB);
+                TSTORE(gm, st);
+            }
+            set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+        }
+    }
+#endif
+}
+
+#endif // __CCE_AICORE__
+
+// ===================================================================
+// Include original kernel implementations in separate namespaces.
+// ===================================================================
+
+#define call_kernel _mk_unused_gv_ck_cumsum
+namespace mk_cumsum {
+#include "chunk_cumsum.cpp"
+}
+#undef call_kernel
+
+#define call_kernel _mk_unused_gv_ck_kkt
+namespace mk_kkt {
+#include "scaled_dot_kkt.cpp"
+}
+#undef call_kernel
+
+namespace mk_solve {
+#include "tri_inverse_impl.cpp"
+}
+
+#define call_kernel _mk_unused_gv_ck_wy
+namespace mk_wy {
+#include "wy_fast.cpp"
+}
+#undef call_kernel
+
+#define call_kernel _mk_unused_gv_ck_h
+namespace mk_h {
+#include "chunk_h.cpp"
+}
+#undef call_kernel
+
+#define call_kernel _mk_unused_gv_ck_o
+namespace mk_o {
+#include "chunk_o.cpp"
+}
+#undef call_kernel
+
+AICORE void mega_solve_tril(
+    __gm__ half *out, __gm__ half *in, __gm__ half *minus_id,
+    uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads,
+    __gm__ int32_t *cu_seqlens, uint32_t is_lower)
+{
+    if (num_matrices <= get_block_num())
+        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 1, true, half>(
+            out, in, minus_id, num_matrices,
+            num_bsnd_heads, cu_seqlens, is_lower);
+    else if (num_matrices <= 2u * get_block_num())
+        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 2, true, half>(
+            out, in, minus_id, num_matrices,
+            num_bsnd_heads, cu_seqlens, is_lower);
+    else
+        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 4, true, half>(
+            out, in, minus_id, num_matrices,
+            num_bsnd_heads, cu_seqlens, is_lower);
+}
+
+extern "C" __global__ AICORE void launch_mega_kernel(
+    __gm__ uint8_t *q_ptr,
+    __gm__ uint8_t *k_ptr,
+    __gm__ uint8_t *v_ptr,
+    __gm__ uint8_t *g_in_ptr,
+    __gm__ uint8_t *beta_ptr,
+    __gm__ uint8_t *msk_lower_ptr,
+    __gm__ uint8_t *msk_full_ptr,
+    __gm__ uint8_t *minus_id_ptr,
+    __gm__ uint8_t *cu_seqlens_ptr,
+    __gm__ uint8_t *o_ptr,
+    __gm__ uint8_t *g_sum_ptr,
+    __gm__ uint8_t *g_t_ptr,
+    __gm__ uint8_t *beta_t_ptr,
+    __gm__ uint8_t *A_ptr,
+    __gm__ uint8_t *A_inv_f32_ptr,
+    __gm__ uint8_t *A_inv_ptr,
+    __gm__ uint8_t *w_ptr,
+    __gm__ uint8_t *u_ptr,
+    __gm__ uint8_t *s_ptr,
+    __gm__ uint8_t *v_new_ptr,
+    __gm__ uint8_t *fs_ptr,
+    __gm__ uint8_t *kkt_ws_ptr,
+    __gm__ uint8_t *wy_ws_a1_ptr,
+    __gm__ uint8_t *wy_ws_a2_ptr,
+    __gm__ uint8_t *h_ws_ptr,
+    __gm__ uint8_t *o_ws_qk_ptr,
+    __gm__ uint8_t *o_ws_qs_ptr,
+    __gm__ uint8_t *o_ws_gated_ptr,
+    int64_t batch_size,
+    int64_t seq_len,
+    int64_t total_tokens,
+    uint32_t num_matrices,
+    uint64_t ffts_addr)
+{
+    set_ffts_base_addr(ffts_addr);
+
+    constexpr int32_t H = GDN_H;
+    constexpr int32_t HG = GDN_HG;
+    constexpr int32_t D = GDN_D;
+    constexpr int32_t C = GDN_C;
+
+    mk_cumsum::cumsum_kernel<H, C>(
+        reinterpret_cast<__gm__ float *>(g_in_ptr),
+        reinterpret_cast<__gm__ float *>(g_sum_ptr),
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
+        batch_size, seq_len, ffts_addr);
+
+#ifdef MEGA_STOP_AFTER_CUMSUM
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+#ifdef MEGA_STOP_AFTER_SYNC1
+    return;
+#endif
+
+    mega_transpose_TH_to_HT<float, H>(
+        reinterpret_cast<__gm__ float *>(g_sum_ptr),
+        reinterpret_cast<__gm__ float *>(g_t_ptr),
+        total_tokens);
+    mega_transpose_TH_to_HT<half, H>(
+        reinterpret_cast<__gm__ half *>(beta_ptr),
+        reinterpret_cast<__gm__ half *>(beta_t_ptr),
+        total_tokens);
+
+#ifdef MEGA_STOP_AFTER_TRANSPOSE
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+    mk_kkt::kkt_kernel<H, HG, D, C>(
+        reinterpret_cast<__gm__ half *>(k_ptr),
+        reinterpret_cast<__gm__ half *>(beta_t_ptr),
+        reinterpret_cast<__gm__ float *>(g_t_ptr),
+        reinterpret_cast<__gm__ float *>(msk_lower_ptr),
+        reinterpret_cast<__gm__ half *>(kkt_ws_ptr),
+        reinterpret_cast<__gm__ half *>(A_ptr),
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
+        batch_size, seq_len, total_tokens, ffts_addr);
+
+#if defined(__DAV_C220_CUBE__)
+    pipe_barrier(PIPE_ALL);
+    wait_flag_dev(2);
+    wait_flag_dev(3);
+#endif
+
+#ifdef MEGA_STOP_AFTER_KKT
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+    mega_solve_tril(
+        reinterpret_cast<__gm__ half *>(A_inv_ptr),
+        reinterpret_cast<__gm__ half *>(A_ptr),
+        reinterpret_cast<__gm__ half *>(minus_id_ptr),
+        C, num_matrices, H,
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), 1);
+
+#ifdef MEGA_STOP_AFTER_SOLVE
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+#ifdef MEGA_STOP_AFTER_CAST
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+#ifdef MEGA_STOP_AFTER_SYNC_BEFORE_WY
+    return;
+#endif
+
+    mk_wy::wy_fast_kernel<H, HG, D, C>(
+        reinterpret_cast<__gm__ half *>(k_ptr),
+        reinterpret_cast<__gm__ half *>(v_ptr),
+        reinterpret_cast<__gm__ half *>(beta_t_ptr),
+        reinterpret_cast<__gm__ float *>(g_t_ptr),
+        reinterpret_cast<__gm__ half *>(A_inv_ptr),
+        reinterpret_cast<__gm__ half *>(wy_ws_a1_ptr),
+        reinterpret_cast<__gm__ half *>(wy_ws_a2_ptr),
+        reinterpret_cast<__gm__ half *>(w_ptr),
+        reinterpret_cast<__gm__ half *>(u_ptr),
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
+        batch_size, seq_len, total_tokens, ffts_addr);
+
+#if defined(__DAV_C220_VEC__)
+    if (get_block_idx() < num_matrices) {
+        pipe_barrier(PIPE_ALL);
+        wait_flag_dev(3);
+        wait_flag_dev(4);
+    }
+#endif
+
+#ifdef MEGA_STOP_AFTER_WY
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+    mk_h::chunk_h_kernel<H, HG, D, C>(
+        reinterpret_cast<__gm__ half *>(k_ptr),
+        reinterpret_cast<__gm__ half *>(w_ptr),
+        reinterpret_cast<__gm__ half *>(u_ptr),
+        reinterpret_cast<__gm__ float *>(g_t_ptr),
+        reinterpret_cast<__gm__ half *>(s_ptr),
+        reinterpret_cast<__gm__ half *>(v_new_ptr),
+        reinterpret_cast<__gm__ half *>(fs_ptr),
+        reinterpret_cast<__gm__ half *>(h_ws_ptr),
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
+        batch_size, seq_len, total_tokens, ffts_addr);
+
+#ifdef MEGA_STOP_AFTER_H
+    pipe_barrier(PIPE_ALL);
+    return;
+#endif
+
+    SyncAllImpl<false>();
+
+    mk_o::chunk_o_kernel<H, HG, D, C>(
+        reinterpret_cast<__gm__ half *>(q_ptr),
+        reinterpret_cast<__gm__ half *>(k_ptr),
+        reinterpret_cast<__gm__ half *>(v_new_ptr),
+        reinterpret_cast<__gm__ half *>(s_ptr),
+        reinterpret_cast<__gm__ float *>(g_t_ptr),
+        reinterpret_cast<__gm__ float *>(msk_full_ptr),
+        reinterpret_cast<__gm__ half *>(o_ws_qk_ptr),
+        reinterpret_cast<__gm__ half *>(o_ws_qs_ptr),
+        reinterpret_cast<__gm__ half *>(o_ws_gated_ptr),
+        reinterpret_cast<__gm__ half *>(o_ptr),
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
+        batch_size, seq_len, total_tokens, ffts_addr);
+
+#if defined(__DAV_C220_CUBE__)
+    if (get_block_idx() < num_matrices) {
+        pipe_barrier(PIPE_ALL);
+        wait_flag_dev(3);
+    }
+#endif
+}
+
+extern "C" void call_kernel(
+    uint32_t block_dim, void *stream,
+    uint8_t *q, uint8_t *k, uint8_t *v,
+    uint8_t *g_in, uint8_t *beta,
+    uint8_t *msk_lower, uint8_t *msk_full,
+    uint8_t *minus_id, uint8_t *cu_seqlens,
+    uint8_t *o,
+    uint8_t *g_sum, uint8_t *g_t, uint8_t *beta_t,
+    uint8_t *A, uint8_t *A_inv_f32, uint8_t *A_inv,
+    uint8_t *w, uint8_t *u, uint8_t *s, uint8_t *v_new, uint8_t *fs,
+    uint8_t *kkt_ws, uint8_t *wy_ws_a1, uint8_t *wy_ws_a2,
+    uint8_t *h_ws,
+    uint8_t *o_ws_qk, uint8_t *o_ws_qs, uint8_t *o_ws_gated,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint32_t num_matrices)
+{
+    uint32_t fftsLen{0};
+    uint64_t fftsAddr{0};
+    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+    launch_mega_kernel<<<block_dim, nullptr, stream>>>(
+        q, k, v, g_in, beta, msk_lower, msk_full, minus_id, cu_seqlens,
+        o,
+        g_sum, g_t, beta_t, A, A_inv_f32, A_inv,
+        w, u, s, v_new, fs,
+        kkt_ws, wy_ws_a1, wy_ws_a2, h_ws,
+        o_ws_qk, o_ws_qs, o_ws_gated,
+        batch_size, seq_len, total_tokens, num_matrices,
+        fftsAddr);
+}

--- a/csrc/pto_chunk_gdn/scaled_dot_kkt.cpp
+++ b/csrc/pto_chunk_gdn/scaled_dot_kkt.cpp
@@ -1,0 +1,699 @@
+// ============================================================================
+// scaled_dot_kkt_kernel.cpp — Intra-chunk attention matrix for GatedDeltaNet
+//
+// Computes A = mask(KK^T · gating_coeff) per chunk, where:
+//   KK^T ∈ ℝ^{C×C} = K @ K^T                  (Cube engine, GEMM)
+//   coeff[i,j] = exp(clamp(g[i]+log(β[i]) - g[j], max=0))  (Vec engine)
+//   A[i,j] = KK^T[i,j] · coeff[i,j] · causal_mask[i,j]
+//
+// Inputs:
+//   K       [total_tokens, Hg, D] half  — key vectors (BSND along seq; stride Hg * D)
+//   Beta    [H, total_tokens]     half  — gate bias per **value** head (pre-transposed)
+//   G       [H, total_tokens]     float — cumulative gate sum per **value** head
+//   Msk     [C, C]                float — lower-triangular causal mask
+//
+// Output:
+//   A       [total_tokens, H, C]  half  — gated attention matrix in BSND
+//
+// Architecture: Cube + Vec cross-core kernel.
+//   Cube phase: K→L1, GEMM K@K^T→L0C, store to workspace (GM)
+//   Vec phase:  load workspace KK^T, compute gating coefficients, apply mask
+//
+// Cross-core sync: Cube signals Vec via FFTS flag after each chunk's KK^T
+// is written to workspace. Vec signals back when workspace buffer is free.
+// Two workspace slots alternate (double-buffering via slot = ci & 1).
+//
+// Vec sub-blocks: Two sub-blocks (vid=0,1) process upper/lower halves of
+// the C×C attention matrix in parallel (HalfChunk rows each).
+//
+// NPU memory hierarchy:
+//   GM → L1 (Cube-accessible) → L0A/L0B (GEMM operands) → L0C (accumulator)
+//   GM → UB (Vec-accessible SRAM)
+//
+// ── PTO / NPU Primer for This Kernel ──────────────────────────────────
+// NPU Architecture (simplified):
+//   Each "AI Core" (like a GPU SM) has:
+//     - Cube engine: matrix multiply unit (like GPU Tensor Cores), works on L0A/L0B/L0C
+//     - Vec engine: SIMD vector unit (like GPU CUDA cores), works on UB (Unified Buffer)
+//     - MTE2: DMA engine for loading data: GM → L1 or GM → UB
+//     - MTE3: DMA engine for storing data: UB → GM or L0C → GM
+//     - MTE1: DMA engine for L1 → L0A/L0B transfers (internal to Cube pipeline)
+//   Memory hierarchy (fast→slow): L0 registers > L1 cache > UB (SRAM) > GM (HBM)
+//   Cube and Vec run on SEPARATE cores — they communicate via GM + cross-core flags.
+//
+// Key PTO APIs used in this kernel (with numpy/torch equivalents):
+//   TASSIGN(tile, addr)     — Bind tile to UB/L1/L0 address (tile = memory[addr])
+//   TLOAD(dst, gm_tensor)   — DMA load: dst = gm_tensor (async, MTE2 pipe)
+//   TSTORE(gm, src)         — DMA store: gm = src (async, MTE3 pipe)
+//   TFILLPAD(dst, src)      — Zero-fill padding: dst[outside valid] = 0
+//   TFILLPAD_INPLACE(d, s)  — Same but in-place for UB tiles
+//   TEXTRACT(l0, l1, r, c)  — Copy L1 sub-block → L0A or L0B (MTE1 pipe)
+//   TRESHAPE(dst, src)      — Reinterpret L1 tile layout (NZ↔ZN for transpose)
+//   TMATMUL(C, A, B)        — Matrix multiply: C = A @ B in Cube engine
+//   TCVT(dst, src, mode)    — Type conversion: like dst = src.float() or src.half()
+//   TMOV(dst, src)          — Copy: dst = src.clone()
+//   TADD(d, a, b)           — Element-wise add: d = a + b
+//   TSUB(d, a, b)           — Element-wise subtract: d = a - b
+//   TMUL(d, a, b)           — Element-wise multiply: d = a * b
+//   TMINS(d, s, val)        — Clamp max: d = torch.clamp(s, max=val)
+//   TEXP(d, s)              — Element-wise exp: d = torch.exp(s)
+//   TLOG(d, s)              — Element-wise log: d = torch.log(s)
+//   TROWEXPAND(2d, col)     — Broadcast column → rows: 2d[i,j] = col[i]
+//   TCOLEXPAND(2d, row)     — Broadcast row → cols: 2d[i,j] = row[j]
+//   set_flag(P1, P2, EVT)   — Signal from pipe P1 to pipe P2 (like a semaphore post)
+//   wait_flag(P1, P2, EVT)  — Wait for signal from P1 (like a semaphore wait)
+//   pipe_barrier(PIPE_V)    — Local Vec barrier (ensure all Vec ops complete)
+//   pipe_barrier(PIPE_ALL)  — Barrier for all local pipes
+//   ffts_cross_core_sync()  — Cross-core signal (Cube↔Vec, different physical cores)
+//   wait_flag_dev(flag)     — Wait for cross-core signal
+// ============================================================================
+
+#include <pto/pto-inst.hpp>   // PTO (Performance Tile Operator): NPU kernel API
+#include "acl/acl.h"          // ACL (Ascend Computing Language): runtime API
+#include <runtime/rt_ffts.h>  // FFTS: cross-core synchronization primitives
+using namespace pto;
+
+// ── Compile-time constants (set by the JIT compiler from Python) ──────
+// These are typically passed as -DGDN_H=16 -DGDN_D=128 -DGDN_C=128 on the
+// compiler command line. The #ifndef guards provide defaults for IDE tooling.
+#ifndef GDN_H
+#define GDN_H 16              // H = number of value heads (gates A β,g index here)
+#endif
+
+#ifndef GDN_HG
+#define GDN_HG GDN_H          // Hg = shared key-query heads (GQA); default MHA
+#endif
+
+#ifndef GDN_D
+#define GDN_D 128             // D = hidden dimension per head
+#endif
+
+#ifndef GDN_C
+#define GDN_C 128             // C = chunk size (tokens processed per chunk)
+#endif
+
+// ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
+// These are only compiled for the NPU device compiler (__CCE_AICORE__ is defined
+// when compiling for AI Core hardware, similar to __CUDA_ARCH__ in CUDA).
+#ifdef __CCE_AICORE__
+// UbND = UB tile in row-major (ND) layout for Vec engine.
+//   Think of it as: torch.empty((R, C), dtype=T) in on-chip SRAM.
+//   RV, CV = valid region (for dynamic shapes, like a[:valid_rows, :valid_cols])
+//   The Vec engine (SIMD unit) reads/writes these tiles for element-wise ops.
+template <typename T, int R, int C, int RV = R, int CV = C,
+          pto::PadValue P = pto::PadValue::Null>
+using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
+                       RV, CV, pto::SLayout::NoneBox, 512, P>;
+
+// UbDN = UB tile in column-major (DN) layout — needed for TROWEXPAND source.
+//   TROWEXPAND requires its source vector in column-major (transposed) format.
+//   Same physical memory (UB SRAM), just different indexing convention.
+template <typename T, int R, int C, int RV = R, int CV = C>
+using UbDN = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::ColMajor,
+                       RV, CV, pto::SLayout::NoneBox, 512>;
+
+// L1Mat = L1 cache tile in NZ fractal format (col-major blocks, row-major within).
+//   This is the standard input format for the Cube matrix engine.
+//   Think of it as a matrix in L1 cache ready for GEMM.
+//   NZ = "Normal-Z": the default fractal layout that Cube expects for left/right operands.
+template <typename T, int R, int C, int RV = R, int CV = C>
+using L1Mat = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::ColMajor,
+                        RV, CV, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+// L1MatZN = L1 tile in ZN fractal format (row-major blocks, col-major within).
+//   Used when you need to transpose a matrix before GEMM:
+//   TRESHAPE(l1_zn, l1_nz) reinterprets NZ→ZN layout = logical transpose.
+//   This is FREE (no data movement) — it just changes how the Cube reads the bits.
+template <typename T, int R, int C, int RV = R, int CV = C>
+using L1MatZN = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::RowMajor,
+                          RV, CV, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+#endif
+
+// ── Main kernel function (runs on each AI core) ──────────────────────
+// Template parameters: NumHeads (H value), NumKeyHeads (Hg), HiddenSize, ChunkSize.
+// GROUP = H/Hg; Cube loads K at head_g = head_idx / GROUP.
+//
+// __gm__: Marks pointers as Global Memory (HBM) — the NPU equivalent of
+// CUDA's device memory. All input/output tensors live in GM.
+template <int32_t NumHeads, int32_t NumKeyHeads, int32_t HiddenSize,
+          int32_t ChunkSize>
+AICORE void kkt_kernel(
+    __gm__ half *K_handle, __gm__ half *Beta_handle,
+    __gm__ float *G_handle, __gm__ float *Msk_handle,
+    __gm__ half *workspace_handle, __gm__ half *A_handle,
+    __gm__ int32_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  constexpr int32_t HalfChunk = ChunkSize / 2;
+  constexpr int32_t ChunkSquare = ChunkSize * ChunkSize;
+  static_assert(NumHeads % NumKeyHeads == 0,
+                "NumHeads must be divisible by NumKeyHeads (GQA grouping)");
+  constexpr int32_t GROUP = NumHeads / NumKeyHeads;
+  constexpr int32_t BSND_QK_STRIDE = NumKeyHeads * HiddenSize;
+  // KTail: number of valid columns in the last 128-wide fractal block of K.
+  // If HiddenSize is a multiple of 128, the last block is fully used (128).
+  // Otherwise it's the remainder. Used internally by TLOAD for partial blocks.
+  constexpr uint32_t KTail =
+      (HiddenSize % 128 == 0) ? 128 : (HiddenSize % 128);
+
+  // ── UB address map (manual memory planning) ─────────────────────────
+  // The UB is a flat SRAM; we manually assign byte offsets for each tile.
+  // This is like malloc'ing fixed regions — no dynamic allocator on NPU.
+  constexpr int32_t GUbAddr      = 0;       // g_ub: cumulative gates [1×C]
+  constexpr int32_t BetaHalfUbAddr = 512;   // beta_ub_half: gate bias fp16 [1×C/2]
+  constexpr int32_t BetaUbAddr   = 640;     // beta_ub: gate bias fp32 [1×C/2]
+  constexpr int32_t GvUbAddr     = 896;     // g_v_ub: combined gate+bias [1×C/2]
+  constexpr int32_t AUbAddr      = 1152;    // a_ub: attention sub-block fp32 [C/2×C]
+  constexpr int32_t GRUbAddr     = 33920;   // g_r_ub: row gates [1×C/2]
+  constexpr int32_t GCUbAddr     = 34176;   // g_c_ub: column gates [1×C]
+  constexpr int32_t MskUbAddr    = 34688;   // msk_ub: causal mask [C/2×C]
+  constexpr int32_t GR2dUbAddr   = 67456;   // g_r_2d_ub: broadcast row gates [C/2×C]
+  constexpr int32_t GC2dUbAddr   = 124800;  // g_c_2d_ub: broadcast col gates [C/2×C]
+  constexpr int32_t CoeffUbAddr  = 157568;  // coeff_ub: gating coefficient [C/2×C]
+  // a_ub_half overlaps g_r_2d — safe because they're never live simultaneously
+  constexpr int32_t AUbHalfAddr  = GR2dUbAddr;
+
+  // set_ffts_base_addr: Tell the hardware where the cross-core flag table lives.
+  // This is a one-time setup so ffts_cross_core_sync / wait_flag_dev know
+  // which memory region to read/write for inter-core signaling.
+  set_ffts_base_addr(ffts_addr);
+  auto cid = get_block_idx();       // Which AI core am I? (like CUDA blockIdx.x)
+  auto block_num = get_block_num();  // Total AI cores launched (like CUDA gridDim.x)
+  // ── Vec sub-block parallelism ─────────────────────────────────────────
+  // Each AI core has 2 Vec sub-blocks (vid=0 and vid=1).
+  // They share the same UB memory but run independently in parallel.
+  // Here, vid=0 processes rows [0, C/2) and vid=1 processes rows [C/2, C).
+  // This halves the per-sub-block work and doubles Vec throughput.
+  auto vid = get_subblockid();       // 0 or 1: which Vec sub-block am I?
+
+  // Work distribution: each (sequence, head) pair is one "work item".
+  // AI cores split work round-robin, just like CUDA blocks split a grid.
+  int64_t num_seqs = batch_size;
+  int64_t total_work = num_seqs * NumHeads;
+
+  // ── Cube-side tile declarations ─────────────────────────────────────
+  // Cube-side tiles: K in L1 (NZ format), accumulator in L0C
+  L1Mat<half, ChunkSize, HiddenSize,
+        ChunkSize, HiddenSize> k_l1;
+  TASSIGN(k_l1, 0);
+  // TileAcc<float, C, C>: L0C accumulator tile for GEMM results.
+  // The Cube engine always accumulates in float32 for precision, even when
+  // inputs are fp16. Think of it as: result = torch.matmul(a.half(), b.half()).float()
+  // When stored to GM via TSTORE with a half GlobalTensor, automatic fp32→fp16 cast occurs.
+  TileAcc<float, ChunkSize, ChunkSize, ChunkSize, ChunkSize> a_l0;
+  TASSIGN(a_l0, 0);
+
+  // ── Vec-side UB tile declarations ────────────────────────────────────
+  // These tiles live in UB (Unified Buffer, the Vec engine's SRAM scratchpad).
+  // Each TASSIGN binds a tile handle to a fixed UB byte offset (our manual alloc).
+  // Vec-side UB tiles for gating computation
+  UbND<float, 1, ChunkSize, 1, ChunkSize> g_ub;
+  TASSIGN(g_ub, GUbAddr);
+  UbND<half, 1, HalfChunk, 1, HalfChunk> beta_ub_half;
+  TASSIGN(beta_ub_half, BetaHalfUbAddr);
+  UbND<float, 1, HalfChunk, 1, HalfChunk> beta_ub;
+  TASSIGN(beta_ub, BetaUbAddr);
+  UbND<float, 1, HalfChunk, 1, HalfChunk> g_v_ub;
+  TASSIGN(g_v_ub, GvUbAddr);
+  UbND<float, HalfChunk, ChunkSize,
+       HalfChunk, ChunkSize> a_ub;
+  TASSIGN(a_ub, AUbAddr);
+  UbND<float, 1, HalfChunk, 1, HalfChunk> g_r_ub;
+  TASSIGN(g_r_ub, GRUbAddr);
+  UbND<float, 1, ChunkSize, 1, ChunkSize> g_c_ub;
+  TASSIGN(g_c_ub, GCUbAddr);
+  UbND<float, HalfChunk, ChunkSize,
+       HalfChunk, ChunkSize> msk_ub;
+  TASSIGN(msk_ub, MskUbAddr);
+  UbND<float, HalfChunk, ChunkSize,
+       HalfChunk, ChunkSize> g_r_2d_ub;
+  TASSIGN(g_r_2d_ub, GR2dUbAddr);
+  UbND<float, HalfChunk, ChunkSize,
+       HalfChunk, ChunkSize> g_c_2d_ub;
+  TASSIGN(g_c_2d_ub, GC2dUbAddr);
+  UbND<float, HalfChunk, ChunkSize,
+       HalfChunk, ChunkSize> coeff_ub;
+  TASSIGN(coeff_ub, CoeffUbAddr);
+  UbND<half, HalfChunk, ChunkSize,
+       HalfChunk, ChunkSize> a_ub_half;
+  TASSIGN(a_ub_half, AUbHalfAddr);
+
+  // ========================================================================
+  // CUBE PHASE: Compute KK^T = K @ K^T for each chunk via GEMM
+  //
+  // ── How GEMM works on NPU (the "Cube pipeline") ──────────────────────
+  // The matrix multiply pipeline has 3 stages:
+  //   Step 1: TLOAD loads data from GM → L1 (MTE2 pipe)
+  //   Step 2: TEXTRACT copies sub-blocks from L1 → L0A/L0B (MTE1 pipe)
+  //     L0A holds the left operand, L0B holds the right operand
+  //   Step 3: TMATMUL multiplies L0A × L0B → L0C accumulator (M pipe)
+  //
+  // For K @ K^T:  (numpy: KK_T = K @ K.T)
+  //   Left operand: K [C×D] loaded into L1 in NZ format
+  //   Right operand: K^T — same data, but we TRESHAPE to ZN format
+  //     (TRESHAPE is FREE — it just reinterprets the fractal layout as transposed)
+  //   Result: KK^T [C×C] in L0C (float32 accumulator, even though inputs are fp16)
+  // ========================================================================
+  // __DAV_C220_CUBE__: This code only compiles for the Cube core.
+  // On NPU, Cube and Vec are separate compilation targets (like two different GPUs).
+#if defined(__DAV_C220_CUBE__)
+  // Outer loop: iterate over all (sequence, head) work items assigned to this core
+  for (int64_t work_idx = 0;
+       work_idx < (total_work + block_num - 1) / block_num; ++work_idx) {
+    int64_t pid = work_idx * static_cast<int64_t>(block_num) +
+                  static_cast<int64_t>(cid);
+    if (pid >= total_work) continue;
+
+    // Map linear work index → (sequence, head) pair
+    int32_t head_idx = static_cast<int32_t>(pid % NumHeads);
+    int64_t seq_idx = pid / NumHeads;
+
+    // Resolve sequence boundaries: cu_seqlens for variable-length, else fixed stride
+    int64_t bos, slen;
+    if (cu_seqlens != nullptr) {
+      // Variable-length sequences (packed tensor): cu_seqlens = [0, len0, len0+len1, ...]
+      bos = static_cast<int64_t>(cu_seqlens[seq_idx]);
+      slen = static_cast<int64_t>(cu_seqlens[seq_idx + 1]) - bos;
+    } else {
+      // Fixed-length sequences: each is seq_len tokens starting at seq_idx*seq_len
+      bos = seq_idx * seq_len;
+      slen = seq_len;
+    }
+    // Ceiling division: how many ChunkSize-sized chunks cover this sequence
+    int64_t num_chunks = (slen + ChunkSize - 1) / ChunkSize;
+
+    // ── Double-buffering via workspace slots ──────────────────────────
+    // slot = ci & 1: alternates between 0 and 1 each chunk iteration.
+    // Cube writes KK^T to workspace[slot], then signals Vec.
+    // While Vec processes slot[0], Cube can write slot[1] (next chunk).
+    // This overlaps Cube computation with Vec computation for pipelining.
+    for (int64_t ci = 0; ci < num_chunks; ++ci) {
+      int32_t slot = static_cast<int32_t>(ci & 1);
+      // Wait for Vec to finish reading the previous KK^T from this slot
+      wait_flag_dev(2 + slot);
+      pipe_barrier(PIPE_ALL);
+
+      int64_t chunk_start = ci * ChunkSize;
+      int64_t remaining = slen - chunk_start;
+      int32_t valid_rows = static_cast<int32_t>(
+          remaining < ChunkSize ? remaining : ChunkSize);
+
+      // BSND key layout [Seq, Hg, D]: token stride Hg * D (see BSND_QK_STRIDE).
+      // Value head head_idx maps to head_g = head_idx / GROUP for shared K rows.
+      int32_t head_g = head_idx / GROUP;
+      int64_t k_offset =
+          ((bos + chunk_start) * static_cast<int64_t>(NumKeyHeads) +
+           static_cast<int64_t>(head_g)) *
+          static_cast<int64_t>(HiddenSize);
+
+      // ── Load K chunk from GM → L1 (MTE2 pipe) ──────────────────────
+      // DYNAMIC shape: valid_rows may be < ChunkSize for the last chunk.
+      // GlobalTensor describes the GM layout with strides (BSND interleaved).
+      // TLOAD triggers the MTE2 DMA engine to copy from GM (HBM) → L1 (on-chip cache).
+      // If the chunk is partial, TFILLPAD zero-fills the padding region
+      // so the GEMM doesn't produce garbage from uninitialized memory.
+      {
+        L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
+        TASSIGN(_l1, 0);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = valid_rows; _gs.shape[4] = HiddenSize;
+        GlobalTensor<half, decltype(_gs),
+                     Stride<1, 1, 1, BSND_QK_STRIDE, 1>>
+            _gm(K_handle + k_offset, _gs);
+        TLOAD(_l1, _gm);
+        if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
+      }
+
+      // ── GEMM: KK^T = K @ K^T (L1→L0A/L0B→L0C) ────────────────────
+      // K is [C×D] in L1 NZ; K^T obtained via ZN reshape of same tile.
+      //
+      // ── WAR (Write-After-Read) synchronization ────────────────────────
+      // Before TEXTRACT (MTE1) writes new data to L0A/L0B, we must ensure:
+      //   1. MTE2 has finished loading L1 (MTE2→MTE1 sync)
+      //   2. Cube M pipe has finished reading previous L0A/L0B data (M→MTE1 sync)
+      // After TEXTRACT, before TMATMUL:
+      //   3. MTE1→M sync ensures L0A/L0B data is ready for the matrix engine
+      // After TMATMUL completes:
+      //   4. M→FIX sync ensures the L0C accumulator can be read
+      // This is like ensuring a producer-consumer chain is properly ordered.
+      // WAR sync: MTE2→MTE1, M→MTE1 before extract; MTE1→M before matmul.
+      {
+        TileLeft<half, ChunkSize, HiddenSize, ChunkSize, HiddenSize> _l0a;
+        TileRight<half, HiddenSize, ChunkSize, HiddenSize, ChunkSize> _l0b;
+        TASSIGN(_l0a, 0x0);
+        TASSIGN(_l0b, 0x0);
+        auto _we = EVENT_ID1;
+        set_flag(PIPE_MTE2, PIPE_MTE1, _we);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, _we);
+        set_flag(PIPE_M, PIPE_MTE1, _we);
+        wait_flag(PIPE_M, PIPE_MTE1, _we);
+        // Left operand: K in NZ format, extract directly to L0A
+        TEXTRACT(_l0a, k_l1, 0, 0);
+        // Right operand: K^T via ZN reshape of same L1 tile, extract to L0B
+        L1MatZN<half, HiddenSize, ChunkSize> _bzn;
+        TRESHAPE(_bzn, k_l1);
+        TEXTRACT(_l0b, _bzn, 0, 0);
+        set_flag(PIPE_MTE1, PIPE_M, _we);
+        wait_flag(PIPE_MTE1, PIPE_M, _we);
+        TMATMUL(a_l0, _l0a, _l0b);
+        set_flag(PIPE_MTE1, PIPE_MTE2, _we);
+        wait_flag(PIPE_MTE1, PIPE_MTE2, _we);
+        set_flag(PIPE_M, PIPE_FIX, _we);
+        wait_flag(PIPE_M, PIPE_FIX, _we);
+      }
+
+      // ── Store KK^T from L0C → workspace GM (with fp32→fp16 cast) ───
+      {
+        TileAcc<float, ChunkSize, ChunkSize, DYNAMIC, DYNAMIC> _l0(ChunkSize, ChunkSize);
+        TASSIGN(_l0, 0);
+        Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+        _gs.shape[3] = ChunkSize; _gs.shape[4] = ChunkSize;
+        GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+            workspace_handle +
+                (static_cast<int64_t>(cid) * 2 + slot) * ChunkSquare,
+            _gs);
+        TSTORE(_gm, _l0);
+      }
+
+      // ── Cross-core synchronization (Cube → Vec) ──────────────────────
+      // ffts_cross_core_sync(pipe, config): Signal across physical cores.
+      // Unlike set_flag/wait_flag (which sync pipes within ONE core), this syncs
+      // between the Cube core and Vec core (they are separate hardware units).
+      //
+      // Config encoding: 1 | (mode << 4) | (flag_id << 8)
+      //   mode=2: broadcast to all cores on same block
+      //   flag_id: which flag to set (0,1,2,3...)
+      //
+      // The receiving side calls wait_flag_dev(flag_id) to wait for this signal.
+      //
+      // In this kernel:
+      //   Cube sets flag 0/1 → Vec waits on wait_flag_dev(0/1) (KK^T ready)
+      //   Vec sets flag 2/3 → Cube waits on wait_flag_dev(2/3) (workspace free)
+      //
+      // Signal Vec that this slot's KK^T is ready
+      ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (slot << 8));
+    }
+  }
+#endif
+
+  // ========================================================================
+  // VEC PHASE: Apply gating and causal mask to KK^T
+  //   coeff[i,j] = exp(min(g[i]+log(β[i]) - g[j], 0))
+  //   A[i,j] = KK^T[i,j] · coeff[i,j] · mask[i,j]
+  // Each sub-block (vid=0,1) handles HalfChunk rows of the C×C matrix.
+  //
+  // ── Gating computation (numpy pseudocode) ─────────────────────────────
+  // # For each sub-block's C/2 rows (vid selects upper or lower half):
+  // g_row = g_sum[row_offset:row_offset+C/2]           # this sub-block's gates
+  // g_v = g_row + np.log(beta[row_offset:row_offset+C/2])  # combined gate+bias
+  // g_col = g_sum[0:C]                                  # full chunk gates
+  //
+  // # Broadcast to 2D matrices for element-wise ops:
+  // g_r_2d = np.tile(g_v.reshape(-1, 1), (1, C))       # TROWEXPAND
+  // g_c_2d = np.tile(g_col.reshape(1, -1), (C/2, 1))   # TCOLEXPAND
+  //
+  // # Gating coefficient: exponential decay, clamped to ≤ 1
+  // coeff = np.exp(np.minimum(g_r_2d - g_c_2d, 0))     # TSUB → TMINS → TEXP
+  //
+  // # Final: A = KK_T * coeff * causal_mask
+  // A = KK_T[my_rows] * coeff * mask[my_rows]           # TMUL × 2
+  // ========================================================================
+  // __DAV_C220_VEC__: This code only compiles for the Vec core.
+#if defined(__DAV_C220_VEC__)
+  // set_mask_norm / set_vector_mask: configure the SIMD mask for Vec ops.
+  // (-1, -1) means "all lanes active" — process every element.
+  // (Like CUDA's __activemask() returning all 1s for a full warp.)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // ── Load causal mask (lower triangular) once, reused across all chunks ──
+  // vid=0 loads the top half (rows 0..C/2-1), vid=1 loads the bottom half.
+  // The mask is [C×C] in GM; each sub-block loads its [C/2×C] portion.
+  {
+    Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+    _gs.shape[3] = HalfChunk; _gs.shape[4] = ChunkSize;
+    GlobalTensor<float, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+        Msk_handle +
+            static_cast<int64_t>(vid) * HalfChunk * ChunkSize,
+        _gs);
+    UbND<float, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(HalfChunk, ChunkSize);
+    TASSIGN(_ld, MskUbAddr);
+    TLOAD(_ld, _gm);
+  }
+  // MTE2→V sync: ensure mask DMA is complete before Vec reads it
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+  // Initial cross-core sync: release both workspace slots so Cube can start.
+  // Vec tells Cube "slots 0 and 1 are free" by setting flags 2 and 3.
+  // Without this, Cube would hang on wait_flag_dev(2/3) at the first iteration.
+  ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+  ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+
+  for (int64_t work_idx = 0;
+       work_idx < (total_work + block_num - 1) / block_num; ++work_idx) {
+    int64_t pid = work_idx * static_cast<int64_t>(block_num) +
+                  static_cast<int64_t>(cid);
+    if (pid >= total_work) continue;
+
+    int32_t head_idx = static_cast<int32_t>(pid % NumHeads);
+    int64_t seq_idx = pid / NumHeads;
+
+    int64_t bos, slen;
+    if (cu_seqlens != nullptr) {
+      bos = static_cast<int64_t>(cu_seqlens[seq_idx]);
+      slen = static_cast<int64_t>(cu_seqlens[seq_idx + 1]) - bos;
+    } else {
+      bos = seq_idx * seq_len;
+      slen = seq_len;
+    }
+    int64_t num_chunks = (slen + ChunkSize - 1) / ChunkSize;
+
+    for (int64_t ci = 0; ci < num_chunks; ++ci) {
+      int32_t slot = static_cast<int32_t>(ci & 1);
+
+      int64_t chunk_start = ci * ChunkSize;
+      int64_t remaining = slen - chunk_start;
+      int32_t valid_rows = static_cast<int32_t>(
+          remaining < ChunkSize ? remaining : ChunkSize);
+      // row_offset: which half of the C×C matrix this sub-block handles
+      //   vid=0 → rows [0, C/2),  vid=1 → rows [C/2, C)
+      int32_t row_offset = static_cast<int32_t>(vid) * HalfChunk;
+      // local_valid: how many rows in this sub-block are real (not padding)
+      //   Handles the case where the last chunk has fewer than C valid rows
+      int32_t local_valid =
+          valid_rows > row_offset
+              ? (valid_rows - row_offset < HalfChunk
+                     ? valid_rows - row_offset
+                     : HalfChunk)
+              : 0;
+
+      if (local_valid > 0) {
+        // ── Load G (full chunk, 1×C) and Beta (sub-block rows, 1×HalfC) ──
+        // G is [H, total_tokens] float — contiguous per head
+        {
+          Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+          _gs.shape[3] = 1; _gs.shape[4] = valid_rows;
+          GlobalTensor<float, decltype(_gs), Stride<1, 1, 1, 1, 1>> _gm(
+              G_handle + static_cast<int64_t>(head_idx) * total_tokens
+                       + (bos + chunk_start),
+              _gs);
+          UbND<float, 1, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(1, valid_rows);
+          TASSIGN(_ld, GUbAddr);
+          TLOAD(_ld, _gm);
+          if (valid_rows != ChunkSize) {
+            UbND<float, 1, ChunkSize, 1, ChunkSize, PadValue::Zero> _pd;
+            TASSIGN(_pd, GUbAddr);
+            TFILLPAD_INPLACE(_pd, _ld);
+          }
+        }
+
+        // Beta is [H, total_tokens] half — contiguous per head
+        {
+          Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+          _gs.shape[3] = 1; _gs.shape[4] = local_valid;
+          GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, 1, 1>> _gm(
+              Beta_handle + static_cast<int64_t>(head_idx) * total_tokens
+                          + (bos + chunk_start + row_offset),
+              _gs);
+          UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(1, local_valid);
+          TASSIGN(_ld, BetaHalfUbAddr);
+          TLOAD(_ld, _gm);
+          if (local_valid != HalfChunk) {
+            UbND<half, 1, HalfChunk, 1, HalfChunk, PadValue::Zero> _pd;
+            TASSIGN(_pd, BetaHalfUbAddr);
+            TFILLPAD_INPLACE(_pd, _ld);
+          }
+        }
+      }
+
+      // Wait for Cube to finish writing KK^T for this slot
+      wait_flag_dev(slot);
+      pipe_barrier(PIPE_ALL);
+
+      if (local_valid > 0) {
+        // ── Compute gating coefficient ────────────────────────────────
+        // Step 1: Convert beta from fp16→fp32 for precision
+        // Step 2: g_v[i] = g[row_offset+i] + log(β[i])  — combined row gate
+        // Step 3: Broadcast g_v (rows) and g (cols) to 2D matrices
+        // Step 4: coeff = exp(min(g_v_2d - g_2d, 0)) — clamped exponential gating
+        // g_v[i] = g[row_offset+i] + log(β[i])  — combined row gate
+        TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
+        // g_ub_temp points to the sub-block's portion of g within the full g_ub.
+        // row_offset * sizeof(float) is the byte offset into the g_ub tile.
+        UbND<float, 1, HalfChunk, 1, HalfChunk>
+            g_ub_temp;
+        TASSIGN(g_ub_temp,
+                GUbAddr + row_offset *
+                              static_cast<int32_t>(sizeof(float)));
+        TMOV(g_v_ub, g_ub_temp);   // g_v = g[row_offset:row_offset+C/2]
+        pipe_barrier(PIPE_V);       // Wait for TMOV to complete
+
+        TLOG(beta_ub, beta_ub);     // beta_ub = log(beta) in-place
+        pipe_barrier(PIPE_V);
+        TADD(g_v_ub, g_v_ub, beta_ub);  // g_v = g_sub + log(beta) — the combined gate
+        pipe_barrier(PIPE_V);
+        TMOV(g_r_ub, g_v_ub);      // Copy to g_r for row-broadcast
+        TMOV(g_c_ub, g_ub);        // Copy full g to g_c for col-broadcast
+        pipe_barrier(PIPE_V);
+
+        // Broadcast g_v to rows, g to columns → 2D gating matrix
+        // coeff[i,j] = exp(min(g_v[i] - g[j], 0))
+        //
+        // g_r_ub_temp is a column-major (DN) alias of g_r_ub, required because
+        // TROWEXPAND expects its source in column-major layout.
+        UbDN<float, HalfChunk, 1,
+             HalfChunk, 1> g_r_ub_temp;
+        TASSIGN(g_r_ub_temp, GRUbAddr);
+        TROWEXPAND(g_r_2d_ub, g_r_ub_temp);  // g_r_2d[i,j] = g_v[i] for all j
+        TCOLEXPAND(g_c_2d_ub, g_c_ub);       // g_c_2d[i,j] = g[j] for all i
+        pipe_barrier(PIPE_V);
+        TSUB(coeff_ub, g_r_2d_ub, g_c_2d_ub);  // coeff[i,j] = g_v[i] - g[j]
+        pipe_barrier(PIPE_V);
+        TMINS(coeff_ub, coeff_ub, 0.0f);        // clamp to ≤ 0 (coeff will be ≤ 1 after exp)
+        pipe_barrier(PIPE_V);
+        TEXP(coeff_ub, coeff_ub);                // coeff = exp(clamped_diff) ∈ (0, 1]
+
+        // V→MTE2 sync: ensure gating computation is done before we start
+        // loading KK^T from workspace (we need coeff ready for the multiply later,
+        // and we want to overlap the DMA load with the preceding Vec work).
+        set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+
+        // ── Load KK^T sub-block from workspace (fp16) ────────────────
+        // workspace layout: [core_id * 2 + slot][C×C], we load our sub-block's
+        // [C/2×C] portion (offset by vid * HalfChunk * ChunkSize elements).
+        {
+          Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+          _gs.shape[3] = HalfChunk; _gs.shape[4] = ChunkSize;
+          GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, ChunkSize, 1>> _gm(
+              workspace_handle +
+                  (static_cast<int64_t>(cid) * 2 + slot) * ChunkSquare +
+                  static_cast<int64_t>(vid) * HalfChunk * ChunkSize,
+              _gs);
+          UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero> _ld(HalfChunk, ChunkSize);
+          TASSIGN(_ld, AUbHalfAddr);
+          TLOAD(_ld, _gm);
+        }
+
+        // MTE2→V sync: KK^T data is now in UB, safe for Vec to read
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // ── Apply gating and mask: A = KK^T · coeff · mask ───────────
+        // 1. Convert KK^T from fp16 → fp32 (Cube stored it as fp16 to save GM bandwidth)
+        TCVT(a_ub, a_ub_half, pto::RoundMode::CAST_NONE);
+        // 2. Element-wise multiply by gating coefficient
+        TMUL(a_ub, a_ub, coeff_ub);
+        // 3. Element-wise multiply by causal mask (lower triangular, zeros above diagonal)
+        TMUL(a_ub, a_ub, msk_ub);
+        // 4. Convert result back to fp16 for output
+        TCVT(a_ub_half, a_ub, pto::RoundMode::CAST_NONE);
+
+        // V→MTE3 sync: Vec computation done, safe for DMA store to begin
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+        // ── Store A sub-block to output GM ────────────────────────────
+        // Output A is in BSND layout: [total_tokens, NumHeads, ChunkSize]
+        // Each row of A corresponds to one token's attention weights for this head.
+        // Stride between consecutive tokens = NumHeads * ChunkSize (BSND interleaved).
+        int64_t a_gm_offset =
+            ((bos + chunk_start + row_offset) * NumHeads +
+             head_idx) *
+            static_cast<int64_t>(ChunkSize);
+
+        {
+          Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
+          _gs.shape[3] = local_valid; _gs.shape[4] = ChunkSize;
+          GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, NumHeads * ChunkSize, 1>> _gm(A_handle + a_gm_offset, _gs);
+          UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> _st(local_valid, ChunkSize);
+          TASSIGN(_st, AUbHalfAddr);
+          TSTORE(_gm, _st);
+        }
+      }
+
+      pipe_barrier(PIPE_ALL);
+      // Signal Cube that this workspace slot is free for reuse.
+      // Flag (2+slot): slot 0 → flag 2, slot 1 → flag 3.
+      // Cube is waiting on wait_flag_dev(2+slot) before writing the next chunk.
+      ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | ((2 + slot) << 8));
+    }
+  }
+#endif
+}
+
+// ── NPU kernel entry point ────────────────────────────────────────────
+// extern "C" __global__ AICORE: NPU kernel entry point (like CUDA __global__).
+// Parameters passed as uint8_t* and reinterpret_cast'd — standard NPU convention.
+// The NPU runtime passes raw byte pointers; we cast them to typed pointers here.
+// GDN_H, GDN_D, GDN_C are compile-time constants set by #define at the top.
+extern "C" __global__ AICORE void launch_scaled_dot_kkt(
+    __gm__ uint8_t *K_handle, __gm__ uint8_t *Beta_handle,
+    __gm__ uint8_t *G_handle, __gm__ uint8_t *Msk_handle,
+    __gm__ uint8_t *workspace_handle, __gm__ uint8_t *A_handle,
+    __gm__ uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  kkt_kernel<GDN_H, GDN_HG, GDN_D, GDN_C>(
+      reinterpret_cast<__gm__ half *>(K_handle),
+      reinterpret_cast<__gm__ half *>(Beta_handle),
+      reinterpret_cast<__gm__ float *>(G_handle),
+      reinterpret_cast<__gm__ float *>(Msk_handle),
+      reinterpret_cast<__gm__ half *>(workspace_handle),
+      reinterpret_cast<__gm__ half *>(A_handle),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, total_tokens, ffts_addr);
+}
+
+// ── Host-side launcher ────────────────────────────────────────────────
+// call_kernel(): Host-side launcher invoked from Python via ctypes.
+//   block_dim = number of AI cores (like CUDA grid size)
+//   <<<block_dim, nullptr, stream>>>: NPU kernel launch syntax
+//     - block_dim: how many AI cores to use (each runs kkt_kernel independently)
+//     - nullptr: no shared memory (NPU doesn't have CUDA-style shared mem)
+//     - stream: async execution stream (like CUDA streams)
+//
+// rtGetC2cCtrlAddr: Get the hardware address of the cross-core (Cube↔Vec) flag
+// table. This address is passed to the kernel so it can call ffts_cross_core_sync.
+extern "C" void call_kernel(
+    uint32_t block_dim, void *stream,
+    uint8_t *K_handle, uint8_t *Beta_handle,
+    uint8_t *G_handle, uint8_t *Msk_handle,
+    uint8_t *workspace_handle, uint8_t *A_handle,
+    uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens)
+{
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_scaled_dot_kkt<<<block_dim, nullptr, stream>>>(
+      K_handle, Beta_handle, G_handle, Msk_handle,
+      workspace_handle, A_handle, cu_seqlens,
+      batch_size, seq_len, total_tokens, fftsAddr);
+}

--- a/csrc/pto_chunk_gdn/tri_inverse_impl.cpp
+++ b/csrc/pto_chunk_gdn/tri_inverse_impl.cpp
@@ -1,0 +1,824 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+
+#ifndef MEMORY_BASE
+#define MEMORY_BASE
+#endif
+#include <pto/pto-inst.hpp>
+
+#include "kernel_utils.h"
+
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+using namespace pto;
+using namespace kernel_utils;
+
+#define BSND_OFFSET(tile_id, N, S, D) \
+  (((tile_id) / (N)) * (S) * (N) * (D) + ((tile_id) % (N)) * (D))
+
+/*
+ * For aligned BSND, tile_id enumerates chunk-major then head-major and maps to
+ * a fixed-stride address inside the dense BSND tensor.
+ */
+AICORE inline uint32_t GetBSNDFixedTileOffset(uint32_t tile_id,
+                                              uint32_t num_bsnd_heads,
+                                              uint32_t matrix_size) {
+  return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
+}
+
+/**
+ * @brief Struct containing starting address and size of a single tile
+ */
+struct BSNDVarlenTileInfo {
+  uint32_t bsnd_offset; /**< Contains the starting index in the global tensor */
+  uint32_t valid_size;  /**< This is the size (num_rows/cols) of the tile */
+};
+
+/*
+ * For cu_seqlens-based varlen BSND, tile_id still enumerates chunk-major then
+ * head-major. We recover the owning sequence by scanning cu_seqlens and
+ * counting chunks per sequence.
+ */
+AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(
+    uint32_t tile_id, uint32_t num_bsnd_heads, uint32_t matrix_size,
+    __gm__ int32_t* cu_seqlens) {
+  const uint32_t head_idx = tile_id % num_bsnd_heads;
+  const uint32_t chunk_idx = tile_id / num_bsnd_heads;
+
+  uint32_t seq_start = static_cast<uint32_t>(cu_seqlens[0]);
+  uint32_t accumulated_chunks = 0;
+  for (uint32_t seq_idx = 0;; ++seq_idx) {
+    const uint32_t seq_end = static_cast<uint32_t>(cu_seqlens[seq_idx + 1]);
+    const uint32_t seq_len = seq_end - seq_start;
+    const uint32_t seq_num_chunks = CeilDiv(seq_len, matrix_size);
+    if (chunk_idx < accumulated_chunks + seq_num_chunks) {
+      const uint32_t local_chunk_idx = chunk_idx - accumulated_chunks;
+      const uint32_t row_start = seq_start + local_chunk_idx * matrix_size;
+      const uint32_t valid_size =
+          min(static_cast<uint32_t>(seq_end - row_start), matrix_size);
+      return {row_start * num_bsnd_heads * matrix_size + head_idx * matrix_size,
+              valid_size};
+    }
+    accumulated_chunks += seq_num_chunks;
+    seq_start = seq_end;
+  }
+}
+
+/*
+ * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
+ * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
+ * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
+ * FractalSize from the src matrix to the dst matrix.
+ *
+ * @tparam InputT Input data type (fp16).
+ * @tparam FractalSize Size of each fractal matrix (diagonal block).
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam SrcL1TileT The actual tile type of the src matrix.
+ * @tparam DstL0TileT The actual tile type of the dst matrix.
+ *
+ * @param src Tile in L1 memory.
+ * @param dst Tile in L0A or L0B memory.
+ */
+template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
+          typename SrcL1TileT, typename DstL0TileT>
+AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
+  constexpr uint32_t NumFractals = MatrixSize / FractalSize;
+  constexpr bool is_left =
+      std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
+  constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
+  constexpr SLayout InnerLayout =
+      is_left ? SLayout::RowMajor : SLayout::ColMajor;
+
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
+       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+      fractals[NumFractals];
+  const std::uintptr_t starting_address =
+      reinterpret_cast<std::uintptr_t>(dst.data());
+  for (uint32_t i = 0; i < NumFractals; ++i) {
+    TASSIGN(fractals[i], starting_address + i * FractalSize *
+                                                (MatrixSize + FractalSize) *
+                                                sizeof(InputT));
+    TEXTRACT(fractals[i], src, i * FractalSize, i * FractalSize);
+  }
+}
+
+/*
+ * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each,
+ * and an integer block_size. The src matrix lies in L1, while the dst matrix
+ * either in L0A or L0B. This method copies some of the diagonal blocks from the
+ * input to the output as follows:
+ * - If dst is in L0A (left): copy even diagonal blocks 0, 2, 4, ...
+ * - If dst is in L0B (right): copy odd blocks 1, 3, 5, ...
+ * Important note: the dst matrix should be initialized to all-zeros before
+ * calling this method
+ *
+ * @tparam InputT Input data type (fp16).
+ * @tparam FractalSize Size of each fractal matrix (diagonal block).
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam SrcL1TileT The actual tile type of the src matrix.
+ * @tparam DstL0TileT The actual tile type of the dst matrix.
+ *
+ * @param src Tile in L1 memory.
+ * @param dst Tile in L0A or L0B memory.
+ * @param block_size Size of diagonal blocks. Needs: block_size >= FractalSize.
+ */
+template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
+          typename SrcL1TileT, typename DstL0TileT>
+AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
+                                             uint32_t block_size,
+                                             bool swap_parity = false) {
+  constexpr bool is_left =
+      std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
+  constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
+  constexpr SLayout InnerLayout =
+      is_left ? SLayout::RowMajor : SLayout::ColMajor;
+
+  // Default: left→even(0), right→odd(1). swap_parity flips this.
+  const uint32_t starting_block_index = (is_left ? 0u : 1u) ^ (swap_parity ? 1u : 0u);
+
+  const uint32_t num_blocks = MatrixSize / block_size;
+  const uint32_t num_fractals_per_block = block_size / FractalSize;
+
+  // might need fewer fractals if block_size < FractalSize
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
+       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+      fractals[MatrixSize / FractalSize];
+
+  const std::uintptr_t starting_address =
+      reinterpret_cast<std::uintptr_t>(dst.data());
+  for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
+    for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
+      for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
+        const uint32_t offset =
+            b * (MatrixSize + FractalSize) * block_size /* block_offset */ +
+            i * MatrixSize * FractalSize /* col_fractal_offset */ +
+            j * FractalSize * FractalSize /* row_fractal_offset */;
+        TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
+        TEXTRACT(fractals[b], src, b * block_size + i * FractalSize,
+                 b * block_size + j * FractalSize);
+      }
+    }
+  }
+}
+
+/*
+ * @brief: Prepares Identity and Zeros matrix.
+ *
+ * @tparam TileL1AB The type of the input tiles in L1.
+ * @tparam TileL0A The type of the input tiles in L0A.
+ * @tparam TileL0B The type of the input tiles in L0B.
+ * @tparam TileL0C The type of the input tiles in L0C.
+ *
+ * @param I_neg_l1_tile Tile containing the -I (negative identity) matrix.
+ * @param Zero_l1_tile Tile to store the all-zero matrix.
+ * @param I_l1_tile Tile to store the identity matrix.
+ * @param a_l0_tile Tile in L0A for matmuls.
+ * @param b_l0_tile Tile in L0B for matmuls.
+ * @param c_l0_tile Tile in L0C for matmuls.
+ */
+template <typename TileL1AB, typename TileL0A, typename TileL0B,
+          typename TileL0C>
+AICORE inline void PrepareAuxiliaryMatrices(
+    TileL1AB I_neg_l1_tile, TileL1AB Zero_l1_tile, TileL1AB I_l1_tile,
+    TileL0A a_l0_tile, TileL0B b_l0_tile, TileL0C c_l0_tile) {
+  TMOV(a_l0_tile, I_neg_l1_tile);  // a_l0 initialized with I_neg
+  TMOV(b_l0_tile, I_neg_l1_tile);  // b_l0 initialized with I_neg
+  set_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+
+  TMATMUL(c_l0_tile, a_l0_tile, b_l0_tile);  // c_l0 contains I
+  set_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+  wait_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+
+  TMOV(I_l1_tile, c_l0_tile);  // I_l1 now contains I
+  set_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+
+  TMOV(b_l0_tile, I_l1_tile);  // b_l0 contains I
+  set_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+
+  TMATMUL_ACC(c_l0_tile, c_l0_tile, a_l0_tile,
+              b_l0_tile);  // c_l0 contains zeros
+  set_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+  wait_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+
+  TMOV(Zero_l1_tile, c_l0_tile);  // Zeros_l1 now contains zeros
+  set_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+}
+
+/*
+ * @brief: Inverts a single matrix / tile of the global tensor.
+ * The first part of the algorithm inverts the FractalSize * FractalSize
+ * diagonal blocks of the input matrix (inv_trick part). The second phase
+ * assembles the partial inverses using the cube unig (recursive part).
+ *
+ * @tparam InputT The type of the input elements.
+ * @tparam TileL1AB The type of the input tiles in L1.
+ * @tparam TileL0A The type of the input tiles in L0A.
+ * @tparam TileL0B The type of the input tiles in L0B.
+ * @tparam TileL0C The type of the input tiles in L0C.
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam FractalSize Size of matrix fractals.
+ * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
+ * cube iteration.
+ *
+ * @param X_l1_tile Tile in L1 used for intermediate computations.
+ * @param I_l1_tile Tile containing the identity matrix.
+ * @param I_neg_l1_tile Tile containing the negative identity matrix.
+ * @param M_neg_l1_tile Tile containing the negative input matrix.
+ * @param Zero_l1_tile Tile containing the all-zero matrix.
+ * @param Y_l1_tile Tile in L1 used for intermediate computations.
+ * @param a_l0_tile* Array of two tiles in L0A (for double-buffering).
+ * @param b_l0_tile* Array of two tiles in L0B (for double-buffering).
+ * @param c_l0_tile* Tile in L0C for matmuls.
+ * @param tile_id Index of the current tile (used for sync).
+ */
+template <typename InputT, typename TileL1AB, typename TileL0A,
+          typename TileL0B, typename TileL0C, uint32_t MatrixSize,
+          uint32_t FractalSize, uint32_t NumTilesPerCubeIter>
+AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
+                                    TileL1AB I_neg_l1_tile,
+                                    TileL1AB M_neg_l1_tile,
+                                    TileL1AB Zero_l1_tile, TileL1AB Y_l1_tile,
+                                    TileL0A* a_l0_tile, TileL0B* b_l0_tile,
+                                    TileL0C* c_l0_tile,
+                                    const uint32_t tile_id,
+                                    const bool swap_parity = false) {
+  const event_t event_0 = static_cast<event_t>(tile_id);
+  const event_t event_1 = static_cast<event_t>(tile_id + NumTilesPerCubeIter);
+
+  TMOV(b_l0_tile[0], Y_l1_tile);      // b_l0[0] contains M
+  TMOV(a_l0_tile[0], I_neg_l1_tile);  // a_l0[0] contains I_neg
+  set_flag(PIPE_MTE1, PIPE_M, event_0);
+  TMOV(a_l0_tile[1], Zero_l1_tile);
+  TMOV(b_l0_tile[1], Zero_l1_tile);
+  set_flag(PIPE_MTE1, PIPE_M, event_1);
+  wait_flag(PIPE_MTE1, PIPE_M, event_1);
+  set_flag(PIPE_M, PIPE_MTE1, event_1);
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);
+  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, a_l0_tile[1]);  // a_l0[1] = diag_fractals(M)
+  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, b_l0_tile[1]);  // b_l0[1] = diag_fractals(M)
+  set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+  /* First Matmul: event_0 */
+  wait_flag(PIPE_MTE1, PIPE_M, event_0);
+  TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] contains M_neg
+  set_flag(PIPE_M, PIPE_FIX, event_0);
+  set_flag(PIPE_M, PIPE_MTE1, event_0);
+
+  wait_flag(PIPE_M, PIPE_FIX, event_0);
+  TMOV(M_neg_l1_tile, c_l0_tile[0]);  // M_neg_l1 now contains M_neg
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+
+  /* Second Matmul: event_1 */
+  wait_flag(PIPE_MTE1, PIPE_M, event_1);
+  set_flag(PIPE_MTE1, PIPE_M, event_1);
+  TMATMUL(c_l0_tile[1], a_l0_tile[1],
+          b_l0_tile[1]);  // c_l0[1] contains diag_fractals(M)^2
+  set_flag(PIPE_M, PIPE_FIX, event_1);
+  wait_flag(PIPE_M, PIPE_FIX, event_1);
+  TMOV(Y_l1_tile,
+       c_l0_tile[1]);  // Y_l1 now contains diag_fractals(M)^2
+  set_flag(PIPE_FIX, PIPE_M, event_1);
+  wait_flag(PIPE_FIX, PIPE_M, event_1);
+
+  /* Third Matmul: event_0*/
+  wait_flag(PIPE_M, PIPE_MTE1, event_0);
+  TMOV(b_l0_tile[0], I_neg_l1_tile);  // b_l0[0] contains I_neg
+  TMOV(a_l0_tile[0], I_neg_l1_tile);  // a_l0[0] contains I_neg
+  set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+  wait_flag(PIPE_MTE1, PIPE_M, event_0);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+  wait_flag(PIPE_MTE1, PIPE_M, event_1);
+  TMATMUL(c_l0_tile[0], a_l0_tile[1],
+          b_l0_tile[0]);  // c_l0[0] = diag_fractals(M_neg)
+  set_flag(PIPE_M, PIPE_FIX, event_0);
+  wait_flag(PIPE_M, PIPE_FIX, event_0);
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+
+  TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0],
+              b_l0_tile[0]);  // c_l0[0] has I-diag_fractals(M)
+  set_flag(PIPE_M, PIPE_FIX, event_1);
+  wait_flag(PIPE_M, PIPE_FIX, event_1);
+  TMOV(X_l1_tile, c_l0_tile[0]);  // X_l1 now contains I-diag_fractals(M)
+
+  /*
+   * Inv Trick part:
+   * X = I - M
+   * Y = M
+   * block_size = 1
+   * while block_size < FractalSize / 2:
+   *     Y = Y @ Y
+   *     X = X + X @ Y
+   *     block_size *= 2
+   */
+  set_flag(PIPE_FIX, PIPE_M, event_0);   // store c
+  set_flag(PIPE_M, PIPE_MTE1, event_0);  // load matrices for matmuls
+  set_flag(PIPE_FIX, PIPE_MTE1, event_0);
+  set_flag(PIPE_FIX, PIPE_M, event_1);     // only for update Y
+  set_flag(PIPE_M, PIPE_MTE1, event_1);    // only for update Y
+  set_flag(PIPE_FIX, PIPE_MTE1, event_1);  // only for update Y
+  for (uint32_t block_size = 1; block_size < FractalSize / 2; block_size *= 2) {
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);
+    TMOV(b_l0_tile[0], I_l1_tile);
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
+    TMOV(a_l0_tile[0], X_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+    TMOV(b_l0_tile[1], Y_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+    wait_flag(PIPE_FIX, PIPE_M, event_0);   // from previous iter
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);  // from loading a_l0[0], b_l0[0]
+    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] contains X
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+    set_flag(PIPE_FIX, PIPE_M, event_0);
+    wait_flag(PIPE_FIX, PIPE_M, event_0);
+
+    if (block_size < FractalSize / 4) {  // Update Y except in last iteration
+      wait_flag(PIPE_M, PIPE_MTE1, event_1);  // from previous iter
+      TMOV(a_l0_tile[1], Y_l1_tile);
+      wait_flag(PIPE_MTE1, PIPE_M, event_1);
+      set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+      wait_flag(PIPE_MTE1, PIPE_M, event_1);
+      wait_flag(PIPE_FIX, PIPE_M, event_1);  // from previous iter
+      TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[1]);
+      set_flag(PIPE_M, PIPE_MTE1, event_1);  // for next iter
+      set_flag(PIPE_M, PIPE_FIX, event_1);
+      set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+      wait_flag(PIPE_M, PIPE_FIX, event_1);
+      TMOV(Y_l1_tile, c_l0_tile[1]);
+      set_flag(PIPE_FIX, PIPE_M, event_1);  // for next iter
+    }
+    set_flag(PIPE_FIX, PIPE_MTE1, event_1);  // for next iter
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_1);
+    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0],
+                b_l0_tile[1]);  // c_l0[0] has X + X @ Y
+    set_flag(PIPE_M, PIPE_MTE1, event_0);
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+    TMOV(X_l1_tile, c_l0_tile[0]);
+    set_flag(PIPE_FIX, PIPE_M, event_0);     // for next iter
+    set_flag(PIPE_FIX, PIPE_MTE1, event_0);  // for next iter
+  }
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // only for update Y
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);    // only for update Y
+  wait_flag(PIPE_FIX, PIPE_M, event_1);     // only for update Y
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
+  wait_flag(PIPE_M, PIPE_MTE1, event_0);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+
+  /*
+   * Unrolled recursion part:
+   * Upper-tri (swap_parity=false):
+   *   LX = even_blocks(X), RX = odd_blocks(X)
+   *   Y = LX @ (-M) + I, X = Y @ RX + LX
+   * Lower-tri (swap_parity=true):
+   *   RX = even→L0A(odd via swap), LX = odd→L0B(even via swap)
+   *   Y = RX @ (-M) + I, X = Y @ LX + RX
+   */
+  TMOV(b_l0_tile[1], M_neg_l1_tile);  // b_l0[1] contains M_neg
+  TMOV(a_l0_tile[0], I_l1_tile);      // a_l0[0] contains I
+
+  if constexpr (MatrixSize > FractalSize) {
+    set_flag(PIPE_FIX, PIPE_M, event_1);
+  }
+  set_flag(PIPE_M, PIPE_MTE1, event_1);
+  set_flag(PIPE_M, PIPE_MTE1, event_0);
+  set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+  for (uint32_t block_size = FractalSize; block_size < MatrixSize;
+       block_size *= 2) {
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for last iter a_l0[1]
+    TMOV(a_l0_tile[1], Zero_l1_tile);
+
+    wait_flag(PIPE_M, PIPE_MTE1, event_1);
+    TMOV(b_l0_tile[0], I_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Wait to write last X
+    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+        X_l1_tile, a_l0_tile[1], block_size, swap_parity);  // a_l0[1]: even(LX) or odd(RX)
+    set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);
+    wait_flag(PIPE_FIX, PIPE_M, event_0);  // Wait c_l0[0] from previous iter
+    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] has I
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_1);
+    wait_flag(PIPE_FIX, PIPE_M, event_1);  // Wait c_l0[1] from previous iter
+    TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);  // c_l0[1] contains LX
+    set_flag(PIPE_M, PIPE_MTE1, event_1);  // allow to load RX on b_l0[0]
+
+    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[1],
+                b_l0_tile[1]);  // c_l0[0] <- LX * M_neg + I
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+    set_flag(PIPE_M, PIPE_MTE1, event_0);
+
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+    TMOV(Y_l1_tile, c_l0_tile[0]);  // Y_l1 contains LX * M_neg + I
+    set_flag(PIPE_FIX, PIPE_MTE1, event_0);
+    set_flag(PIPE_FIX, PIPE_M, event_0);
+
+    /* Load complementary blocks of X in L0B */
+    wait_flag(PIPE_M, PIPE_MTE1, event_1);
+    TMOV(b_l0_tile[0], Zero_l1_tile);
+    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+        X_l1_tile, b_l0_tile[0], block_size, swap_parity);  // b_l0[0]: odd(RX) or even(LX)
+
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for previous use of a_l0[1]
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_0);  // Wait for Y_l1
+    TMOV(a_l0_tile[1], Y_l1_tile);            // a_l0[1] contains LX * M_neg + I
+    set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);
+    TMATMUL_ACC(c_l0_tile[1], c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);
+    set_flag(PIPE_M, PIPE_MTE1, event_0);  // next iter can read on a_l0[1]
+    set_flag(PIPE_M, PIPE_MTE1, event_1);  // next iter can read on b_l0[0]
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+
+    if (block_size < MatrixSize / 2) {  // Update X_l1 except in last iteration
+      TMOV(X_l1_tile, c_l0_tile[1]);
+      set_flag(PIPE_FIX, PIPE_M, event_1);  // release c_l0[1] for next iter
+    }
+    set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  }
+  wait_flag(PIPE_M, PIPE_MTE1, event_0);
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Write c_l0[1] to X_l1
+}
+
+/*
+ * @brief: Runs the main kernel (inverts all matrices in the tensor)
+ *
+ * @tparam InputT The type of the input elements.
+ * @tparam OutputT The type of the output elements.
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
+ * cube iteration.
+ * @tparam IsBSND If IsBSND is false, then the last two dimensions represent a
+ * 2D triangular matrix in row-major format, while the other dimensions are
+ * batch dimensions. If IsBSND is true, then the dimensions represent in order:
+ * B batch size, S sequence length (which is chunked in tiles of size D), N
+ * number of heads (equivalent to a second batch dimension for this kernel), and
+ * D chunk size. The inverse is over the dimensions S (chunked) and D, row-major
+ * within each tile.
+ *
+ * @param M_inv pointer to the global memory to store the final inverse.
+ * @param M Pointer to the global tensor matrix in global memory.
+ * @param I_neg Pointer to global memory that contains the negative identity.
+ * @param total_tiles The total number of matrices to invert.
+ * @param num_bsnd_heads The number of heads, only for BSND format.
+ */
+template <typename InputT, typename OutputT, uint32_t MatrixSize,
+          uint32_t NumTilesPerCubeIter, bool IsBSND, typename StoreT = OutputT>
+AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
+                                         __gm__ InputT* M, __gm__ InputT* I_neg,
+                                         uint32_t total_tiles,
+                                         uint32_t num_bsnd_heads = 0,
+                                         __gm__ int32_t* cu_seqlens = nullptr,
+                                         uint32_t is_lower = 0) {
+  /* Initializations */
+  constexpr uint32_t TileLen = MatrixSize * MatrixSize;
+  constexpr uint32_t FractalSize = 16;  // fractal size for half
+  constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
+  constexpr uint32_t NumL0Buffers = 2;
+
+  if (get_block_idx() * NumTilesPerCubeIter >= total_tiles) {
+    return;
+  }
+
+  using GlobalTileShapeIn =
+      TileShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileStridesIn = typename std::conditional<
+      !IsBSND, BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>,
+      Stride<1, 1, 1, -1, 1>>::type;
+  using GlobalTileIn =
+      GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
+  using GlobalTileDynamicShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GlobalTileDynamicStride = Stride<1, 1, 1, DYNAMIC, 1>;
+  using GlobalTileDynamicIn = GlobalTensor<InputT, GlobalTileDynamicShape,
+                                           GlobalTileDynamicStride, Layout::ND>;
+  using GlobalTileStridesINeg =
+      BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn,
+                                      GlobalTileStridesINeg, Layout::ND>;
+
+  using GlobalTileShapeOut =
+      TileShape2D<StoreT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileStridesOut = typename std::conditional<
+      !IsBSND, BaseShape2D<StoreT, MatrixSize, MatrixSize, Layout::ND>,
+      Stride<1, 1, 1, -1, 1>>::type;
+  using GlobalTileOut = GlobalTensor<StoreT, GlobalTileShapeOut,
+                                     GlobalTileStridesOut, Layout::ND>;
+  using GlobalTileDynamicOut =
+      GlobalTensor<StoreT, GlobalTileDynamicShape, GlobalTileDynamicStride,
+                   Layout::ND>;
+  using TileL1AB =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
+  using TileL1ABDynamic =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           DYNAMIC, DYNAMIC, SLayout::RowMajor, 512, PadValue::Zero>;
+
+  // L0 Memory
+  using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
+  using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
+  using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
+  using TileL0CDynamic =
+      TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
+
+  GlobalTileINeg I_neg_global_in(I_neg);
+
+  TileL1AB X_l1_tile;
+  TileL1AB I_l1_tile;
+  TileL1AB I_neg_l1_tile;
+  TileL1AB M_neg_l1_tile;
+  TileL1AB Zero_l1_tile;
+  TileL1AB Y_l1_tile[NumTilesPerCubeIter];
+
+  TileL0A a_l0_tile[NumL0Buffers];
+  TileL0B b_l0_tile[NumL0Buffers];
+  TileL0C c_l0_tile[NumL0Buffers];
+
+  TASSIGN(I_l1_tile, 0x0);
+  TASSIGN(I_neg_l1_tile, 0x0 + TileLen * sizeof(InputT));
+  TASSIGN(Zero_l1_tile, 0x0 + 2 * TileLen * sizeof(InputT));
+  TASSIGN(M_neg_l1_tile, 0x0 + 3 * TileLen * sizeof(InputT));
+  TASSIGN(X_l1_tile, 0x0 + 4 * TileLen * sizeof(InputT));
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    TASSIGN(Y_l1_tile[tile_id], 0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+  }
+
+  for (uint32_t buffer_num = 0; buffer_num < NumL0Buffers; ++buffer_num) {
+    TASSIGN(a_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
+    TASSIGN(b_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
+    TASSIGN(c_l0_tile[buffer_num],
+            0x0 + buffer_num * TileLen * sizeof(OutputT));
+  }
+  TLOAD(I_neg_l1_tile, I_neg_global_in);
+  set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
+
+  PrepareAuxiliaryMatrices<TileL1AB, TileL0A, TileL0B, TileL0C>(
+      I_neg_l1_tile, Zero_l1_tile, I_l1_tile, a_l0_tile[0], b_l0_tile[0],
+      c_l0_tile[0]);
+
+  const uint32_t max_iters_per_aic =
+      CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
+
+  /* Main iteration - Compute all tiles */
+  uint32_t bsnd_tile_offsets[NumTilesPerCubeIter] = {0};
+  uint32_t bsnd_tile_valid_sizes[NumTilesPerCubeIter] = {0};
+  uint32_t next_tile_id_that_waits_for_pipe_fix_pipe_m = 0;
+  set_flag(PIPE_FIX, PIPE_M,
+           static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+  }
+  for (uint32_t cube_iter = 0; cube_iter < max_iters_per_aic; ++cube_iter) {
+    const uint32_t global_index =
+        (cube_iter * get_block_num() + get_block_idx()) * NumTilesPerCubeIter;
+    if (global_index >= total_tiles) {
+      break;
+    }
+    for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
+                               (global_index + tile_id < total_tiles);
+         ++tile_id) {
+      if constexpr (IsBSND) {
+        const uint32_t global_tile_id = global_index + tile_id;
+        if (cu_seqlens != nullptr) {
+          const BSNDVarlenTileInfo tile_info =
+              GetBSNDVarlenTileInfoFromCuSeqlens(global_tile_id, num_bsnd_heads,
+                                                 MatrixSize, cu_seqlens);
+          bsnd_tile_offsets[tile_id] = tile_info.bsnd_offset;
+          bsnd_tile_valid_sizes[tile_id] = tile_info.valid_size;
+        } else {
+          bsnd_tile_offsets[tile_id] = GetBSNDFixedTileOffset(
+              global_tile_id, num_bsnd_heads, MatrixSize);
+          bsnd_tile_valid_sizes[tile_id] = MatrixSize;
+        }
+        const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
+        const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
+        const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
+        wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+        if (valid_size < MatrixSize) {
+          TileL1ABDynamic Y_dyn_l1_tile(valid_size, valid_size);
+          TASSIGN(Y_dyn_l1_tile,
+                  0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+          GlobalTileDynamicIn M_global_in_dyn(
+              M + bsnd_offset,
+              {1, 1, 1, static_cast<int>(valid_size),
+               static_cast<int>(valid_size)},
+              {1, 1, 1, row_stride, 1});
+          TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
+          set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+          wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+          TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
+        } else {
+          GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
+          TLOAD(Y_l1_tile[tile_id], M_global_in);
+        }
+      } else {
+        GlobalTileIn M_global_in(M + (global_index + tile_id) * TileLen);
+        wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+        TLOAD(Y_l1_tile[tile_id],
+              M_global_in);  // Copies NumTilesPerCubeIter tiles at once
+      }
+      set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+    }
+
+    constexpr uint32_t final_c_buffer_index = MatrixSize > FractalSize ? 1 : 0;
+    for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
+                               (global_index + tile_id < total_tiles);
+         ++tile_id) {
+      // Wait for previous cube iter to write result
+      wait_flag(PIPE_FIX, PIPE_M, static_cast<event_t>(tile_id));
+      // Wait for loading new matrices from GM
+      wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+
+      InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
+                       FractalSize, NumTilesPerCubeIter>(
+          X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
+          Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id,
+          is_lower != 0);
+
+      // Allow next cube_iter to proceed for this tile_id
+      set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+
+      /* Store result */
+      if constexpr (IsBSND) {
+        const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
+        const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
+        const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
+        if (valid_size < MatrixSize) {
+          TileL0CDynamic c_l0_tail_tile(valid_size, valid_size);
+          TASSIGN(c_l0_tail_tile,
+                  0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+          GlobalTileDynamicOut M_inv_global_out_dyn(
+              M_inv + bsnd_offset,
+              {1, 1, 1, static_cast<int>(valid_size),
+               static_cast<int>(valid_size)},
+              {1, 1, 1, row_stride, 1});
+          TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
+        } else {
+          GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {}, {row_stride});
+          TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+        }
+      } else {
+        GlobalTileOut M_inv_global_out(M_inv +
+                                       (global_index + tile_id) * TileLen);
+        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+      }
+      next_tile_id_that_waits_for_pipe_fix_pipe_m =
+          (tile_id + 1) % NumTilesPerCubeIter;
+      set_flag(
+          PIPE_FIX, PIPE_M,
+          static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
+    }
+  }
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+  }
+  wait_flag(PIPE_FIX, PIPE_M,
+            static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
+}
+
+/*
+ * @brief: Computes the inverses of the blocks of tensor M
+ */
+template <typename InputT, typename OutputT, uint32_t MatrixSize,
+          uint32_t NumTilesPerCubeIter, bool IsBSND, typename StoreT = OutputT>
+AICORE void runKernelTriInvRecUnroll(__gm__ StoreT* M_inv, __gm__ InputT* M,
+                                     __gm__ InputT* I_neg, uint32_t total_tiles,
+                                     uint32_t num_bsnd_heads = 0,
+                                     __gm__ int32_t* cu_seqlens = nullptr,
+                                     uint32_t is_lower = 0) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // Cube compilation
+
+  TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
+                        IsBSND, StoreT>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
+                                cu_seqlens, is_lower);
+#else
+// Nothing to do on AIV
+#endif
+}
+
+template <typename InputT, uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
+                                   __gm__ InputT* tensor_in,
+                                   __gm__ InputT* minus_identity_in,
+                                   uint32_t matrix_size, uint32_t num_matrices,
+                                   uint32_t num_bsnd_heads,
+                                   __gm__ int32_t* cu_seqlens = nullptr,
+                                   uint32_t is_lower = 0) {
+  static_assert(std::is_same_v<InputT, half>,
+                "tri_inv_rec_unroll supports only fp16.");
+  switch (matrix_size) {
+    case 16:
+      runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens, is_lower);
+      break;
+    case 32:
+      runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens, is_lower);
+      break;
+    case 64:
+      runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens, is_lower);
+      break;
+    case 128:
+      runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens, is_lower);
+      break;
+  }
+}
+
+/*
+ * @brief: Wrapper for the kernel, "half" type (fp16).
+ *
+ * @param tensor_out pointer to the global memory to store the final inverse.
+ * @param tensor_in Pointer to the global tensor matrix in global memory.
+ * @param minus_identity_in Pointer to global memory that contains the negative
+ * identity.
+ * @param matrix_size The size if each individual matrix / tile. Can take
+ * values: {16, 32, 64, 128}.
+ * @param num_matrices The total number of matrices / tiles in the global
+ * tensor.
+ * @param num_bsnd_heads The number of heads, which is only greater than zero
+ * if the matrix is in BSND format, that is, the tiles need to be loaded with
+ * strided accesses. If each tile is stored consecutively (and row-wise) in
+ * memory, then num_bsnd_heads=0.
+ */
+extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
+    __gm__ void* tensor_out, __gm__ void* tensor_in,
+    __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
+  const uint32_t is_lower = (num_bsnd_heads >> 16) & 1u;
+  const uint32_t actual_heads = num_bsnd_heads & 0xFFFFu;
+  if (actual_heads == 0) {
+    if (num_matrices <= get_block_num()) {
+      run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+    } else if (num_matrices <= 2 * get_block_num()) {
+      run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+    } else {
+      run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+    }
+  } else {
+    if (num_matrices <= get_block_num()) {
+      run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+    } else if (num_matrices <= 2 * get_block_num()) {
+      run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+    } else {
+      run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+    }
+  }
+}

--- a/csrc/pto_chunk_gdn/wy_fast.cpp
+++ b/csrc/pto_chunk_gdn/wy_fast.cpp
@@ -1,0 +1,1013 @@
+// ============================================================================
+// wy_fast_kernel.cpp — WY representation for GatedDeltaNet chunk recurrence
+//
+// Computes the WY update matrices U and W for each chunk of C tokens:
+//   U = A2 @ V     where A2 = A * beta_2d        (beta-scaled attention)
+//   W = A1 @ K     where A1 = A * (exp(g)*beta)_2d (gate+beta-scaled attention)
+//
+// beta is the decay factor, g is the gate value, A is the triangular attention
+// matrix (from the kkt kernel).  The column-broadcast notation x_2d means
+// expanding a 1xC vector into a C/2 x C matrix by replicating across rows.
+//
+// Architecture: Vec+Cube cooperative kernel using cross-core synchronization.
+//
+//  Vec core (two sub-blocks for upper/lower C/2 rows):
+//    For each chunk:
+//      1. Load beta [H,T] and A [B,S,H,C], compute A2 = A * beta_2d -> ws
+//      2. Load G [H,T], compute A1 = A * (exp(g)*beta)_2d -> ws
+//      3. Signal Cube via cross-core flags when workspaces are ready
+//
+//  Cube core (waits for Vec signals):
+//    For each chunk:
+//      1. Load K, V from BSND layout into L1
+//      2. Load A2 from workspace -> GEMM: U = A2 @ V
+//      3. Load A1 from workspace -> GEMM: W = A1 @ K
+//      4. Store U, W back to BSND layout
+//
+// NPU memory hierarchy used:
+//   GM -> UB (Vec), GM -> L1 -> L0A/L0B -> L0C -> GM (Cube)
+//
+// ── PTO / NPU Primer ──────────────────────────────────────────────────
+// This kernel uses BOTH the Cube engine (matrix multiply) and Vec engine
+// (SIMD element-wise ops), running on SEPARATE physical cores that
+// communicate via Global Memory (GM) + cross-core flags (FFTS).
+//
+// Execution flow:
+//   Vec core:  load A,beta,G → compute A2,A1 → store to GM workspace
+//   Cube core: wait for workspace → load A2/A1 + K/V → GEMM → store U,W
+//
+// Key PTO APIs (with numpy/torch equivalents):
+//   TLOAD(ub_tile, gm)      — ub_tile = gm[...]          (DMA: GM→UB, async MTE2)
+//   TSTORE(gm, ub_tile)     — gm[...] = ub_tile          (DMA: UB→GM, async MTE3)
+//   TCVT(dst, src, mode)    — dst = src.float() or .half() (type conversion)
+//   TMOV(dst, src)          — dst = src.clone()
+//   TMUL(d, a, b)           — d = a * b                   (element-wise)
+//   TEXP(d, s)              — d = torch.exp(s)
+//   TCOLEXPAND(2d, row)     — 2d[i,j] = row[j]  (broadcast row across all rows)
+//   TEXTRACT(l0, l1, r, c)  — L1 sub-block → L0A/L0B     (MTE1 for Cube GEMM)
+//   TMATMUL(C, A, B)        — C = A @ B in Cube engine    (fp16→fp32 accumulate)
+//   set_flag / wait_flag    — sync between pipes on SAME core
+//   ffts_cross_core_sync    — signal ACROSS Cube↔Vec cores
+//   wait_flag_dev(flag)     — wait for cross-core signal
+// ============================================================================
+
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+#include <type_traits>
+using namespace pto;
+
+#ifndef GDN_H
+#define GDN_H 16
+#endif
+
+#ifndef GDN_HG
+#define GDN_HG GDN_H
+#endif
+
+#ifndef GDN_D
+#define GDN_D 128
+#endif
+
+#ifndef GDN_C
+#define GDN_C 128
+#endif
+
+#ifdef __CCE_AICORE__
+
+namespace {
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                            pto::BLayout::ColMajor, RowValid, ColValid,
+                            pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                              pto::BLayout::RowMajor, RowValid, ColValid,
+                              pto::SLayout::ColMajor, 512,
+                              pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::RowMajor, 512,
+                             pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::ColMajor, 512,
+                             pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols, pto::PadValue PadVal = pto::PadValue::Null>
+using TileUbDataND =
+    pto::Tile<pto::TileType::Vec, T, Rows, Cols, pto::BLayout::RowMajor,
+              RowValid, ColValid, pto::SLayout::NoneBox, 512, PadVal>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols, pto::PadValue PadVal = pto::PadValue::Null>
+using TileUbDataDN =
+    pto::Tile<pto::TileType::Vec, T, Rows, Cols, pto::BLayout::ColMajor,
+              RowValid, ColValid, pto::SLayout::NoneBox, 512, PadVal>;
+
+using GmShape2D = pto::Shape<1, 1, 1, pto::DYNAMIC, pto::DYNAMIC>;
+using GmStride2D = pto::Stride<1, 1, 1, pto::DYNAMIC, 1>;
+
+template <typename T>
+using GmTensor2D = pto::GlobalTensor<T, GmShape2D, GmStride2D>;
+
+template <typename T, int32_t Rows, int32_t Cols>
+using DynMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                           pto::BLayout::ColMajor, pto::DYNAMIC,
+                           pto::DYNAMIC, pto::SLayout::RowMajor, 512,
+                           pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols,
+          pto::PadValue PadVal = pto::PadValue::Null>
+using DynVecTile = pto::Tile<pto::TileType::Vec, T, Rows, Cols,
+                             pto::BLayout::RowMajor, pto::DYNAMIC,
+                             pto::DYNAMIC, pto::SLayout::NoneBox, 512, PadVal>;
+
+template <typename T, int32_t Rows, int32_t Cols>
+using DynAccTile = pto::TileAcc<T, Rows, Cols, pto::DYNAMIC, pto::DYNAMIC>;
+
+// PTO cheat sheet for readers coming from PyTorch / NumPy:
+//   - `GlobalTensor<T>` is a GM tensor view with explicit shape/stride metadata.
+//   - `Tile<..., Mat, ...>` is an on-chip matrix tile used by Cube kernels.
+//   - `Tile<..., Vec, ...>` is an on-chip UB tile used by SIMD vector kernels.
+//   - `TileAcc<T, ...>` is the matmul accumulator tile.
+//   - `TLOAD` / `TSTORE` are DMA copies between GM and local memory.
+//   - `TCOLEXPAND` is broadcast like `x[None, :].expand(rows, -1)`.
+//   - `TMUL`, `TEXP`, `TCVT` are vector ops on UB tiles.
+
+template <typename T1, typename T2, uint32_t M, uint32_t N, uint32_t K,
+          uint32_t validM = M, uint32_t validN = N, uint32_t validK = K,
+          uint32_t K_tail, bool transpose_A = false, bool transpose_B = false>
+AICORE PTO_INLINE void
+gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
+                           TileMatL1<T1, M, K, validM, validK>> &A,
+        std::conditional_t<transpose_B, TileMatL1<T1, N, K, validN, validK>,
+                           TileMatL1<T1, K, N, validK, validN>> &B,
+        pto::TileAcc<T2, M, N, validM, validN> &C, bool clear)
+{
+  // Local K-sliced matmul helper:
+  //   C = A @ B
+  // PTO exposes the L1 -> L0 -> Cube movement explicitly, so keeping this tiny
+  // helper local lets readers see the schedule without hiding it in a repo-wide
+  // wrapper layer.
+  //
+  // PyTorch mental model:
+  //   C = 0
+  //   for k0 in range(0, K, kL0Size):
+  //       C += A[:, k0:k1] @ B[k0:k1, :]
+  constexpr uint32_t kL0Size = 128;
+  const uint32_t kL0split = (K + kL0Size - 1) / kL0Size;
+
+  auto war_event_id = (event_t)(((int)EVENT_ID0 + 1) % 8);
+  set_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+
+  for (uint32_t kL0Idx = 0; kL0Idx < kL0split; ++kL0Idx) {
+    const bool initflag = clear && (kL0Idx == 0);
+    const bool is_tail_block = (kL0Idx == kL0split - 1);
+
+    if (is_tail_block) {
+      TileMatL0A<T1, M, K_tail, M, K_tail> l0a;
+      TileMatL0B<T1, K_tail, N, K_tail, N> l0b;
+      pto::TASSIGN(l0a, 0x0);
+      pto::TASSIGN(l0b, 0x0);
+
+      set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+      wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+      if constexpr (!transpose_A) {
+        pto::TEXTRACT(l0a, A, 0, kL0Idx * K_tail);
+      } else {
+        TileMatL1ZN<T1, M, K, validM, validK> A_t;
+        pto::TRESHAPE(A_t, A);
+        pto::TEXTRACT(l0a, A_t, 0, kL0Idx * K_tail);
+      }
+
+      if constexpr (!transpose_B) {
+        pto::TEXTRACT(l0b, B, kL0Idx * K_tail, 0);
+      } else {
+        TileMatL1ZN<T1, K, N, validK, validN> B_t;
+        pto::TRESHAPE(B_t, B);
+        pto::TEXTRACT(l0b, B_t, kL0Idx * K_tail, 0);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+
+      if (initflag) {
+        pto::TMATMUL(C, l0a, l0b);
+      } else {
+        pto::TMATMUL_ACC(C, C, l0a, l0b);
+      }
+    } else {
+      TileMatL0A<T1, M, kL0Size, M, kL0Size> l0a;
+      TileMatL0B<T1, kL0Size, N, kL0Size, N> l0b;
+      pto::TASSIGN(l0a, 0x0);
+      pto::TASSIGN(l0b, 0x0);
+
+      set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+      wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+      set_flag(PIPE_FIX, PIPE_M, war_event_id);
+      wait_flag(PIPE_FIX, PIPE_M, war_event_id);
+
+      if constexpr (!transpose_A) {
+        pto::TEXTRACT(l0a, A, 0, kL0Idx * kL0Size);
+      } else {
+        TileMatL1ZN<T1, M, K, validM, validK> A_t;
+        pto::TRESHAPE(A_t, A);
+        pto::TEXTRACT(l0a, A_t, 0, kL0Idx * kL0Size);
+      }
+
+      if constexpr (!transpose_B) {
+        pto::TEXTRACT(l0b, B, kL0Idx * kL0Size, 0);
+      } else {
+        TileMatL1ZN<T1, K, N, validK, validN> B_t;
+        pto::TRESHAPE(B_t, B);
+        pto::TEXTRACT(l0b, B_t, kL0Idx * kL0Size, 0);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+
+      if (initflag) {
+        pto::TMATMUL(C, l0a, l0b);
+      } else {
+        pto::TMATMUL_ACC(C, C, l0a, l0b);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+    }
+  }
+
+  set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+  wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+
+  set_flag(PIPE_M, PIPE_FIX, war_event_id);
+  wait_flag(PIPE_M, PIPE_FIX, war_event_id);
+}
+
+} // namespace
+
+#endif
+
+template <int32_t NumHeads, int32_t NumKeyHeads, int32_t HiddenSize,
+          int32_t ChunkSize>
+AICORE void wy_fast_kernel(
+    __gm__ half *K_handle, __gm__ half *V_handle,
+    __gm__ half *Beta_handle, __gm__ float *G_handle,
+    __gm__ half *A_handle,
+    __gm__ half *workspace_a1_handle, __gm__ half *workspace_a2_handle,
+    __gm__ half *W_handle, __gm__ half *U_handle,
+    __gm__ int32_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  // WY recompute materializes two diagonal reweightings of the same A tile:
+  //   A2[:, j] = A[:, j] * beta_j
+  //   A1[:, j] = A[:, j] * exp(g_j) * beta_j
+  // and then forms the two branch outputs
+  //   U = A2 @ V,   W = A1 @ K.
+  //
+  // Shapes for one (sequence, head, chunk):
+  //   A_chunk : [valid, valid]
+  //   beta    : [valid]
+  //   g       : [valid]
+  //   K, V    : [valid, D]
+  //
+  // PyTorch / NumPy sketch:
+  //   A2 = A_chunk * beta[None, :]
+  //   A1 = A_chunk * (exp(g) * beta)[None, :]
+  //   U  = A2 @ V_chunk
+  //   W  = A1 @ K_chunk
+  //
+  // PTO split:
+  //   Vec builds the two reweighted A tiles in workspace.
+  //   Cube later consumes those workspaces in two GEMMs.
+  constexpr int32_t HalfChunk = ChunkSize / 2;
+  constexpr uint32_t KTail =
+      (HiddenSize % 128 == 0) ? 128 : (HiddenSize % 128);
+
+  constexpr int32_t H = NumHeads;
+  constexpr int32_t Hg = NumKeyHeads;
+  static_assert(Hg > 0 && H % Hg == 0,
+                "NumHeads must be divisible by NumKeyHeads");
+  constexpr int32_t GROUP = H / Hg;
+  constexpr int32_t BSND_V_STRIDE = H * HiddenSize;
+  constexpr int32_t BSND_QK_STRIDE = Hg * HiddenSize;
+
+  constexpr int32_t GHeadTileCols = ((NumHeads + 7) / 8) * 8;
+  constexpr int32_t BetaHeadTileCols = ((NumHeads + 15) / 16) * 16;
+
+  constexpr int32_t BetaHalfUbAddr = 0;
+  constexpr int32_t A1HalfUbAddr   = 256;
+  constexpr int32_t BetaUbAddr     = 16640;
+  constexpr int32_t BetaRUbAddr    = 17152;
+  constexpr int32_t Beta2dUbAddr   = 17664;
+  constexpr int32_t TmpUbAddr      = 50432;
+  constexpr int32_t A1UbAddr       = 75008;
+  constexpr int32_t A2UbAddr       = 107776;
+  constexpr int32_t A2HalfUbAddr   = 140544;
+  constexpr int32_t GUbAddr        = 156928;
+  constexpr int32_t GRUbAddr       = 157440;
+  constexpr int32_t G2dUbAddr      = 157952;
+
+  constexpr int32_t GBlockUbAddr    = TmpUbAddr;
+  constexpr int32_t BetaBlockUbAddr = TmpUbAddr;
+
+  constexpr int32_t WsA1Size = ChunkSize * ChunkSize;
+  constexpr int32_t WsA2Size = ChunkSize * ChunkSize;
+
+  set_ffts_base_addr(ffts_addr);
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
+  auto vid = get_subblockid();
+
+  int64_t num_seqs = batch_size;
+
+  TileUbDataND<half, 1, ChunkSize, 1, ChunkSize,
+               pto::PadValue::Zero> beta_ub_half;
+  TASSIGN(beta_ub_half, BetaHalfUbAddr);
+  TileUbDataND<half, HalfChunk, ChunkSize,
+               HalfChunk, ChunkSize, pto::PadValue::Zero> a1_ub_half;
+  TASSIGN(a1_ub_half, A1HalfUbAddr);
+  TileUbDataND<float, 1, ChunkSize, 1, ChunkSize> beta_ub;
+  TASSIGN(beta_ub, BetaUbAddr);
+  TileUbDataND<float, 1, ChunkSize, 1, ChunkSize> beta_r_ub;
+  TASSIGN(beta_r_ub, BetaRUbAddr);
+  TileUbDataND<float, HalfChunk, ChunkSize,
+               HalfChunk, ChunkSize> beta_2d_ub;
+  TASSIGN(beta_2d_ub, Beta2dUbAddr);
+  TileUbDataND<uint8_t, 1, 24576, 1, 24576> tmp_ub;
+  TASSIGN(tmp_ub, TmpUbAddr);
+  TileUbDataND<float, HalfChunk, ChunkSize,
+               HalfChunk, ChunkSize> a1_ub;
+  TASSIGN(a1_ub, A1UbAddr);
+  TileUbDataND<float, HalfChunk, ChunkSize,
+               HalfChunk, ChunkSize> a2_ub;
+  TASSIGN(a2_ub, A2UbAddr);
+  TileUbDataND<half, HalfChunk, ChunkSize,
+               HalfChunk, ChunkSize> a2_ub_half;
+  TASSIGN(a2_ub_half, A2HalfUbAddr);
+  TileUbDataND<float, 1, ChunkSize, 1, ChunkSize,
+               pto::PadValue::Zero> g_ub;
+  TASSIGN(g_ub, GUbAddr);
+  TileUbDataND<float, 1, ChunkSize, 1, ChunkSize> g_r_ub;
+  TASSIGN(g_r_ub, GRUbAddr);
+  TileUbDataND<float, HalfChunk, ChunkSize,
+               HalfChunk, ChunkSize> g_2d_ub;
+  TASSIGN(g_2d_ub, G2dUbAddr);
+
+  TileMatL1<half, ChunkSize, HiddenSize,
+            ChunkSize, HiddenSize> k_l1;
+  TASSIGN(k_l1, 0);
+  TileMatL1<half, ChunkSize, HiddenSize,
+            ChunkSize, HiddenSize> v_l1;
+  TASSIGN(v_l1, 32768);
+  TileMatL1<half, ChunkSize, ChunkSize,
+            ChunkSize, ChunkSize> a2_l1;
+  TASSIGN(a2_l1, 65536);
+  TileAcc<float, ChunkSize, HiddenSize,
+          ChunkSize, HiddenSize> u_l0;
+  TASSIGN(u_l0, 0);
+  TileMatL1<half, ChunkSize, ChunkSize,
+            ChunkSize, ChunkSize> a1_l1;
+  TASSIGN(a1_l1, 98304);
+  TileAcc<float, ChunkSize, HiddenSize,
+          ChunkSize, HiddenSize> w_l0;
+  TASSIGN(w_l0, 65536);
+
+  int64_t total_work = 0;
+  if (cu_seqlens == nullptr) {
+    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+    total_work = num_seqs * chunks_per_seq * NumHeads;
+  }
+
+#if defined(__DAV_C220_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // Vec prepares the two reweighted A workspaces (`A2` and `A1`) that the
+  // Cube phase consumes later.
+  if (cu_seqlens == nullptr) {
+    bool first_iter = true;
+    int64_t gi = 0;
+    for (int64_t seq_idx = 0; seq_idx < num_seqs; ++seq_idx) {
+      int64_t bos = seq_idx * seq_len;
+      int64_t slen = seq_len;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t ci = 0; ci < nc; ++ci) {
+        for (int32_t head_idx = 0; head_idx < NumHeads; ++head_idx) {
+          if (gi % static_cast<int64_t>(block_num) ==
+              static_cast<int64_t>(cid)) {
+            int64_t chunk_start = ci * ChunkSize;
+            int64_t remaining = slen - chunk_start;
+            int32_t valid_rows = static_cast<int32_t>(
+                remaining < ChunkSize ? remaining : ChunkSize);
+            int64_t chunk_token_start = bos + chunk_start;
+            // Each Vec sub-block owns one HalfChunk-row stripe of the chunk.
+            // For a tail chunk, the upper stripe (vid=0) may hold fewer than
+            // 64 rows, and the lower stripe (vid=1) may hold only a suffix or
+            // no rows at all.  `local_rows` is the exact number of live rows in
+            // THIS sub-block's stripe.
+            int32_t local_rows = valid_rows -
+                static_cast<int32_t>(vid) * HalfChunk;
+            if (local_rows < 0) local_rows = 0;
+            if (local_rows > HalfChunk) local_rows = HalfChunk;
+
+            // Beta is pre-transposed to [H, total_tokens] for contiguous loads.
+            {
+              GmShape2D beta_shape(1, valid_rows);
+              GmStride2D beta_stride(1);
+              GmTensor2D<half> beta_global(
+                  Beta_handle + static_cast<int64_t>(head_idx) * total_tokens +
+                      chunk_token_start,
+                  beta_shape, beta_stride);
+              DynVecTile<half, 1, ChunkSize, pto::PadValue::Zero> beta_load(
+                  1, valid_rows);
+              TASSIGN(beta_load, BetaHalfUbAddr);
+              TLOAD(beta_load, beta_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD_INPLACE(beta_ub_half, beta_load);
+              }
+            }
+
+            // Load only the live rows for this sub-block, then zero-pad the
+            // remainder of the HalfChunk tile.  The Cube phase always consumes
+            // a full [HalfChunk, ChunkSize] workspace tile, so stale rows here
+            // would leak garbage into ragged tails and cross-sequence boundaries.
+            if (local_rows > 0) {
+              int64_t a_gm_offset =
+                  ((chunk_token_start +
+                    static_cast<int64_t>(vid) * HalfChunk) *
+                   NumHeads + head_idx) *
+                  static_cast<int64_t>(ChunkSize);
+              GmShape2D a_shape(local_rows, ChunkSize);
+              GmStride2D a_stride(NumHeads * ChunkSize);
+              GmTensor2D<half> a_global(A_handle + a_gm_offset, a_shape,
+                                        a_stride);
+              DynVecTile<half, HalfChunk, ChunkSize, pto::PadValue::Zero> a_load(
+                  local_rows, ChunkSize);
+              TASSIGN(a_load, A1HalfUbAddr);
+              TLOAD(a_load, a_global);
+              if (local_rows != HalfChunk) {
+                TFILLPAD_INPLACE(a1_ub_half, a_load);
+              }
+            } else {
+              // Fully empty lower-half tail: materialize an all-zero tile so the
+              // workspace still looks like a correctly padded HalfChunk block.
+              TEXPANDS(a1_ub, 0.0f);
+              pipe_barrier(PIPE_V);
+              TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
+            }
+
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
+            pipe_barrier(PIPE_V);
+            TMOV(beta_r_ub, beta_ub);
+            pipe_barrier(PIPE_V);
+            // Replicate beta_j across rows so every column j of A gets the same beta.
+            // PyTorch-like:
+            //   beta_2d = beta[None, :].expand(HalfChunk, ChunkSize)
+            TCOLEXPAND(beta_2d_ub, beta_r_ub);
+
+            TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
+            // Form the beta-scaled tile that the later U = A2 * V matmul consumes.
+            //   a2_ub = a1_ub * beta_2d_ub
+            TMUL(a2_ub, a1_ub, beta_2d_ub);
+            TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
+
+            if (!first_iter) wait_flag_dev(3);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            {
+              GmShape2D a2_shape(HalfChunk, ChunkSize);
+              GmStride2D a2_stride(ChunkSize);
+              GmTensor2D<half> workspace_a2_global(
+                  workspace_a2_handle +
+                      static_cast<int64_t>(cid) * WsA2Size +
+                      static_cast<int64_t>(vid) * HalfChunk * ChunkSize,
+                  a2_shape, a2_stride);
+              TSTORE(workspace_a2_global, a2_ub_half);
+            }
+            pipe_barrier(PIPE_ALL);
+            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+
+            // G is pre-transposed to [H, total_tokens] for contiguous loads.
+            {
+              GmShape2D g_shape(1, valid_rows);
+              GmStride2D g_stride(1);
+              GmTensor2D<float> g_global(
+                  G_handle + static_cast<int64_t>(head_idx) * total_tokens +
+                      chunk_token_start,
+                  g_shape, g_stride);
+              DynVecTile<float, 1, ChunkSize, pto::PadValue::Zero> g_load(
+                  1, valid_rows);
+              TASSIGN(g_load, GUbAddr);
+              TLOAD(g_load, g_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD_INPLACE(g_ub, g_load);
+              }
+            }
+
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            // Build the g-based column weights before forming the W = A1 * K branch.
+            // Torch-like:
+            //   g_weight = exp(g) * beta
+            TEXP(g_ub, g_ub);
+            pipe_barrier(PIPE_V);
+            TMUL(g_ub, g_ub, beta_ub);
+            pipe_barrier(PIPE_V);
+            TMOV(g_r_ub, g_ub);
+            pipe_barrier(PIPE_V);
+            TCOLEXPAND(g_2d_ub, g_r_ub);
+            // A1 keeps the same A columns but multiplies each one by exp(g_j) * beta_j.
+            //   a1_ub = a1_ub * g_weight[None, :]
+            TMUL(a1_ub, a1_ub, g_2d_ub);
+            TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
+
+            if (!first_iter) wait_flag_dev(4);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            {
+              GmShape2D a1_shape(HalfChunk, ChunkSize);
+              GmStride2D a1_stride(ChunkSize);
+              GmTensor2D<half> workspace_a1_global(
+                  workspace_a1_handle +
+                      static_cast<int64_t>(cid) * WsA1Size +
+                      static_cast<int64_t>(vid) * HalfChunk * ChunkSize,
+                  a1_shape, a1_stride);
+              TSTORE(workspace_a1_global, a1_ub_half);
+            }
+            pipe_barrier(PIPE_ALL);
+            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+            first_iter = false;
+          }
+          gi++;
+        }
+      }
+    }
+  } else {
+    // Same WY math as above; only the work enumeration changes for varlen input.
+    int64_t gi = 0;
+    bool first_iter_v = true;
+    for (int64_t si = 0; si < num_seqs; ++si) {
+      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+      int64_t slen = eos - bos;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t ci = 0; ci < nc; ++ci) {
+        for (int32_t h = 0; h < NumHeads; ++h) {
+          if (gi % static_cast<int64_t>(block_num) ==
+              static_cast<int64_t>(cid)) {
+            int64_t chunk_start = ci * ChunkSize;
+            int64_t remaining = slen - chunk_start;
+            int32_t valid_rows = static_cast<int32_t>(
+                remaining < ChunkSize ? remaining : ChunkSize);
+            int64_t chunk_token_start = bos + chunk_start;
+            // Same HalfChunk ownership rule as the fixed-length path above:
+            // each Vec sub-block handles one 64-row stripe, and ragged varlen
+            // tails may leave that stripe partially full or fully empty.
+            int32_t local_rows = valid_rows -
+                static_cast<int32_t>(vid) * HalfChunk;
+            if (local_rows < 0) local_rows = 0;
+            if (local_rows > HalfChunk) local_rows = HalfChunk;
+            int32_t head_idx = h;
+
+            // Beta is pre-transposed to [H, total_tokens] for contiguous loads.
+            {
+              GmShape2D beta_shape(1, valid_rows);
+              GmStride2D beta_stride(1);
+              GmTensor2D<half> beta_global(
+                  Beta_handle + static_cast<int64_t>(head_idx) * total_tokens +
+                      chunk_token_start,
+                  beta_shape, beta_stride);
+              DynVecTile<half, 1, ChunkSize, pto::PadValue::Zero> beta_load(
+                  1, valid_rows);
+              TASSIGN(beta_load, BetaHalfUbAddr);
+              TLOAD(beta_load, beta_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD_INPLACE(beta_ub_half, beta_load);
+              }
+            }
+
+            // Tail-safe A loading is especially important in varlen mode because
+            // the final chunk of one sequence may be immediately followed by the
+            // first chunk of the next sequence in packed storage.
+            if (local_rows > 0) {
+              int64_t a_gm_offset =
+                  ((chunk_token_start +
+                    static_cast<int64_t>(vid) * HalfChunk) *
+                   NumHeads + head_idx) *
+                  static_cast<int64_t>(ChunkSize);
+              GmShape2D a_shape(local_rows, ChunkSize);
+              GmStride2D a_stride(NumHeads * ChunkSize);
+              GmTensor2D<half> a_global(A_handle + a_gm_offset, a_shape,
+                                        a_stride);
+              DynVecTile<half, HalfChunk, ChunkSize, pto::PadValue::Zero> a_load(
+                  local_rows, ChunkSize);
+              TASSIGN(a_load, A1HalfUbAddr);
+              TLOAD(a_load, a_global);
+              if (local_rows != HalfChunk) {
+                TFILLPAD_INPLACE(a1_ub_half, a_load);
+              }
+            } else {
+              // Empty stripe for this sub-block: write zeros so the downstream
+              // full-tile Cube GEMM sees valid padding rather than old workspace.
+              TEXPANDS(a1_ub, 0.0f);
+              pipe_barrier(PIPE_V);
+              TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
+            }
+
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
+            pipe_barrier(PIPE_V);
+            TMOV(beta_r_ub, beta_ub);
+            pipe_barrier(PIPE_V);
+            TCOLEXPAND(beta_2d_ub, beta_r_ub);
+
+            TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
+            // Form the beta-scaled tile that the later U = A2 * V matmul consumes.
+            TMUL(a2_ub, a1_ub, beta_2d_ub);
+            TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
+
+            if (!first_iter_v) wait_flag_dev(3);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            {
+              GmShape2D a2_shape(HalfChunk, ChunkSize);
+              GmStride2D a2_stride(ChunkSize);
+              GmTensor2D<half> workspace_a2_global(
+                  workspace_a2_handle +
+                      static_cast<int64_t>(cid) * WsA2Size +
+                      static_cast<int64_t>(vid) * HalfChunk * ChunkSize,
+                  a2_shape, a2_stride);
+              TSTORE(workspace_a2_global, a2_ub_half);
+            }
+            pipe_barrier(PIPE_ALL);
+            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+
+            // G is pre-transposed to [H, total_tokens] for contiguous loads.
+            {
+              GmShape2D g_shape(1, valid_rows);
+              GmStride2D g_stride(1);
+              GmTensor2D<float> g_global(
+                  G_handle + static_cast<int64_t>(head_idx) * total_tokens +
+                      chunk_token_start,
+                  g_shape, g_stride);
+              DynVecTile<float, 1, ChunkSize, pto::PadValue::Zero> g_load(
+                  1, valid_rows);
+              TASSIGN(g_load, GUbAddr);
+              TLOAD(g_load, g_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD_INPLACE(g_ub, g_load);
+              }
+            }
+
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            // Build the g-based column weights before forming the W = A1 * K branch.
+            TEXP(g_ub, g_ub);
+            pipe_barrier(PIPE_V);
+            TMUL(g_ub, g_ub, beta_ub);
+            pipe_barrier(PIPE_V);
+            TMOV(g_r_ub, g_ub);
+            pipe_barrier(PIPE_V);
+            TCOLEXPAND(g_2d_ub, g_r_ub);
+            TMUL(a1_ub, a1_ub, g_2d_ub);
+            TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
+
+            if (!first_iter_v) wait_flag_dev(4);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            {
+              GmShape2D a1_shape(HalfChunk, ChunkSize);
+              GmStride2D a1_stride(ChunkSize);
+              GmTensor2D<half> workspace_a1_global(
+                  workspace_a1_handle +
+                      static_cast<int64_t>(cid) * WsA1Size +
+                      static_cast<int64_t>(vid) * HalfChunk * ChunkSize,
+                  a1_shape, a1_stride);
+              TSTORE(workspace_a1_global, a1_ub_half);
+            }
+            pipe_barrier(PIPE_ALL);
+            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+            first_iter_v = false;
+          }
+          gi++;
+        }
+      }
+    }
+  }
+#endif
+
+#if defined(__DAV_C220_CUBE__)
+  // Cube consumes the two Vec-generated workspaces and turns them into the
+  // branch outputs U and W.
+  if (cu_seqlens == nullptr) {
+    int64_t gi = 0;
+    for (int64_t seq_idx = 0; seq_idx < num_seqs; ++seq_idx) {
+      int64_t bos = seq_idx * seq_len;
+      int64_t slen = seq_len;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t ci = 0; ci < nc; ++ci) {
+        for (int32_t head_idx = 0; head_idx < NumHeads; ++head_idx) {
+          if (gi % static_cast<int64_t>(block_num) ==
+              static_cast<int64_t>(cid)) {
+            int64_t chunk_start = ci * ChunkSize;
+            int64_t remaining = slen - chunk_start;
+            int32_t valid_rows = static_cast<int32_t>(
+                remaining < ChunkSize ? remaining : ChunkSize);
+            int64_t chunk_token_start = bos + chunk_start;
+
+            int32_t head_g = head_idx / GROUP;
+            int64_t k_off =
+                (chunk_token_start * static_cast<int64_t>(Hg) +
+                 static_cast<int64_t>(head_g)) *
+                static_cast<int64_t>(HiddenSize);
+            int64_t v_off =
+                (chunk_token_start * static_cast<int64_t>(H) +
+                 static_cast<int64_t>(head_idx)) *
+                static_cast<int64_t>(HiddenSize);
+
+            {
+              GmShape2D k_shape(valid_rows, HiddenSize);
+              GmStride2D k_stride(BSND_QK_STRIDE);
+              GmTensor2D<half> k_global(K_handle + k_off, k_shape, k_stride);
+              DynMatL1<half, ChunkSize, HiddenSize> k_l1_load(valid_rows,
+                                                              HiddenSize);
+              TASSIGN(k_l1_load, 0);
+              TLOAD(k_l1_load, k_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD(k_l1_load, k_l1_load);
+              }
+            }
+            {
+              GmShape2D v_shape(valid_rows, HiddenSize);
+              GmStride2D v_stride(BSND_V_STRIDE);
+              GmTensor2D<half> v_global(V_handle + v_off, v_shape, v_stride);
+              DynMatL1<half, ChunkSize, HiddenSize> v_l1_load(valid_rows,
+                                                              HiddenSize);
+              TASSIGN(v_l1_load, 32768);
+              TLOAD(v_l1_load, v_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD(v_l1_load, v_l1_load);
+              }
+            }
+
+            wait_flag_dev(2);
+            {
+              GmShape2D a2_shape(ChunkSize, ChunkSize);
+              GmStride2D a2_stride(ChunkSize);
+              GmTensor2D<half> workspace_a2_global(
+                  workspace_a2_handle + static_cast<int64_t>(cid) * WsA2Size,
+                  a2_shape, a2_stride);
+              // Load the Vec-prepared A2 tile:
+              //   A2 = A * beta[None, :]
+              TLOAD(a2_l1, workspace_a2_global);
+            }
+
+            set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            // U = A2 * V keeps the beta-scaled path separate from the K-side update.
+            gemm_v0<half, float,
+                ChunkSize, HiddenSize, ChunkSize,
+                ChunkSize, HiddenSize, ChunkSize,
+                KTail, false, false>(a2_l1, v_l1, u_l0, true);
+
+            {
+              GmShape2D u_shape(valid_rows, HiddenSize);
+              GmStride2D u_stride(BSND_V_STRIDE);
+              GmTensor2D<half> u_global(U_handle + v_off, u_shape, u_stride);
+              DynAccTile<float, ChunkSize, HiddenSize> u_store(valid_rows,
+                                                               HiddenSize);
+              TASSIGN(u_store, 0);
+              // Store only the valid token rows even though the accumulator tile is
+              // physically ChunkSize x HiddenSize.
+              TSTORE(u_global, u_store);
+            }
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (3 << 8));
+
+            wait_flag_dev(1);
+            {
+              GmShape2D a1_shape(ChunkSize, ChunkSize);
+              GmStride2D a1_stride(ChunkSize);
+              GmTensor2D<half> workspace_a1_global(
+                  workspace_a1_handle + static_cast<int64_t>(cid) * WsA1Size,
+                  a1_shape, a1_stride);
+              // Load the Vec-prepared A1 tile:
+              //   A1 = A * (exp(g) * beta)[None, :]
+              TLOAD(a1_l1, workspace_a1_global);
+            }
+
+            set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            // W = A1 * K uses the g-reweighted path for the complementary WY factor.
+            gemm_v0<half, float,
+                ChunkSize, HiddenSize, ChunkSize,
+                ChunkSize, HiddenSize, ChunkSize,
+                KTail, false, false>(a1_l1, k_l1, w_l0, true);
+
+            {
+              GmShape2D w_shape(valid_rows, HiddenSize);
+              GmStride2D w_stride(BSND_V_STRIDE);
+              GmTensor2D<half> w_global(W_handle + v_off, w_shape, w_stride);
+              DynAccTile<float, ChunkSize, HiddenSize> w_store(valid_rows,
+                                                               HiddenSize);
+              TASSIGN(w_store, 65536);
+              TSTORE(w_global, w_store);
+            }
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (4 << 8));
+          }
+          gi++;
+        }
+      }
+    }
+  } else {
+    int64_t gi = 0;
+    for (int64_t si = 0; si < num_seqs; ++si) {
+      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+      int64_t slen = eos - bos;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t ci = 0; ci < nc; ++ci) {
+        for (int32_t h = 0; h < NumHeads; ++h) {
+          if (gi % static_cast<int64_t>(block_num) ==
+              static_cast<int64_t>(cid)) {
+            int64_t chunk_start = ci * ChunkSize;
+            int64_t remaining = slen - chunk_start;
+            int32_t valid_rows = static_cast<int32_t>(
+                remaining < ChunkSize ? remaining : ChunkSize);
+            int64_t chunk_token_start = bos + chunk_start;
+            int32_t head_idx = h;
+
+            int32_t head_g = head_idx / GROUP;
+            int64_t k_off =
+                (chunk_token_start * static_cast<int64_t>(Hg) +
+                 static_cast<int64_t>(head_g)) *
+                static_cast<int64_t>(HiddenSize);
+            int64_t v_off =
+                (chunk_token_start * static_cast<int64_t>(H) +
+                 static_cast<int64_t>(head_idx)) *
+                static_cast<int64_t>(HiddenSize);
+
+            {
+              GmShape2D k_shape(valid_rows, HiddenSize);
+              GmStride2D k_stride(BSND_QK_STRIDE);
+              GmTensor2D<half> k_global(K_handle + k_off, k_shape,
+                                        k_stride);
+              DynMatL1<half, ChunkSize, HiddenSize> k_l1_load(valid_rows,
+                                                              HiddenSize);
+              TASSIGN(k_l1_load, 0);
+              TLOAD(k_l1_load, k_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD(k_l1_load, k_l1_load);
+              }
+            }
+            {
+              GmShape2D v_shape(valid_rows, HiddenSize);
+              GmStride2D v_stride(BSND_V_STRIDE);
+              GmTensor2D<half> v_global(V_handle + v_off, v_shape,
+                                        v_stride);
+              DynMatL1<half, ChunkSize, HiddenSize> v_l1_load(valid_rows,
+                                                              HiddenSize);
+              TASSIGN(v_l1_load, 32768);
+              TLOAD(v_l1_load, v_global);
+              if (valid_rows != ChunkSize) {
+                TFILLPAD(v_l1_load, v_l1_load);
+              }
+            }
+
+            wait_flag_dev(2);
+            {
+              GmShape2D a2_shape(ChunkSize, ChunkSize);
+              GmStride2D a2_stride(ChunkSize);
+              GmTensor2D<half> workspace_a2_global(
+                  workspace_a2_handle + static_cast<int64_t>(cid) * WsA2Size,
+                  a2_shape, a2_stride);
+              TLOAD(a2_l1, workspace_a2_global);
+            }
+
+            set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            // U = A2 * V keeps the beta-scaled path separate from the K-side update.
+            gemm_v0<half, float,
+                ChunkSize, HiddenSize, ChunkSize,
+                ChunkSize, HiddenSize, ChunkSize,
+                KTail, false, false>(a2_l1, v_l1, u_l0, true);
+
+            {
+              GmShape2D u_shape(valid_rows, HiddenSize);
+              GmStride2D u_stride(BSND_V_STRIDE);
+              GmTensor2D<half> u_global(U_handle + v_off, u_shape,
+                                        u_stride);
+              DynAccTile<float, ChunkSize, HiddenSize> u_store(valid_rows,
+                                                               HiddenSize);
+              TASSIGN(u_store, 0);
+              TSTORE(u_global, u_store);
+            }
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (3 << 8));
+
+            wait_flag_dev(1);
+            {
+              GmShape2D a1_shape(ChunkSize, ChunkSize);
+              GmStride2D a1_stride(ChunkSize);
+              GmTensor2D<half> workspace_a1_global(
+                  workspace_a1_handle + static_cast<int64_t>(cid) * WsA1Size,
+                  a1_shape, a1_stride);
+              TLOAD(a1_l1, workspace_a1_global);
+            }
+
+            set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+            // W = A1 * K uses the g-reweighted path for the complementary WY factor.
+            gemm_v0<half, float,
+                ChunkSize, HiddenSize, ChunkSize,
+                ChunkSize, HiddenSize, ChunkSize,
+                KTail, false, false>(a1_l1, k_l1, w_l0, true);
+
+            {
+              GmShape2D w_shape(valid_rows, HiddenSize);
+              GmStride2D w_stride(BSND_V_STRIDE);
+              GmTensor2D<half> w_global(W_handle + v_off, w_shape,
+                                        w_stride);
+              DynAccTile<float, ChunkSize, HiddenSize> w_store(valid_rows,
+                                                               HiddenSize);
+              TASSIGN(w_store, 65536);
+              TSTORE(w_global, w_store);
+            }
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (4 << 8));
+          }
+          gi++;
+        }
+      }
+    }
+  }
+#endif
+}
+
+extern "C" __global__ AICORE void launch_wy_fast(
+    __gm__ uint8_t *K_handle, __gm__ uint8_t *V_handle,
+    __gm__ uint8_t *Beta_handle, __gm__ uint8_t *G_handle,
+    __gm__ uint8_t *A_handle,
+    __gm__ uint8_t *workspace_a1_handle, __gm__ uint8_t *workspace_a2_handle,
+    __gm__ uint8_t *W_handle, __gm__ uint8_t *U_handle,
+    __gm__ uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint64_t ffts_addr)
+{
+  wy_fast_kernel<GDN_H, GDN_HG, GDN_D, GDN_C>(
+      reinterpret_cast<__gm__ half *>(K_handle),
+      reinterpret_cast<__gm__ half *>(V_handle),
+      reinterpret_cast<__gm__ half *>(Beta_handle),
+      reinterpret_cast<__gm__ float *>(G_handle),
+      reinterpret_cast<__gm__ half *>(A_handle),
+      reinterpret_cast<__gm__ half *>(workspace_a1_handle),
+      reinterpret_cast<__gm__ half *>(workspace_a2_handle),
+      reinterpret_cast<__gm__ half *>(W_handle),
+      reinterpret_cast<__gm__ half *>(U_handle),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, total_tokens, ffts_addr);
+}
+
+extern "C" void call_kernel(
+    uint32_t block_dim, void *stream,
+    uint8_t *k, uint8_t *v, uint8_t *beta, uint8_t *g_sum, uint8_t *A,
+    uint8_t *workspace_a1, uint8_t *workspace_a2,
+    uint8_t *w, uint8_t *u,
+    uint8_t *cu_seqlens,
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+{
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_wy_fast<<<block_dim, nullptr, stream>>>(
+      k, v, beta, g_sum, A,
+      workspace_a1, workspace_a2,
+      w, u,
+      cu_seqlens,
+      batch_size, seq_len, total_tokens, fftsAddr);
+}

--- a/docs/source/user_guide/feature_guide/enable_megagdn_kernel.md
+++ b/docs/source/user_guide/feature_guide/enable_megagdn_kernel.md
@@ -1,0 +1,162 @@
+# Enable MegaGDN PTO Kernel
+
+The PTO (Parallel Tile Operator) megakernel is a Bisheng-JIT-compiled fused
+Ascend NPU kernel that replaces the default Triton implementation of the
+**chunk GatedDeltaNet** (GDN) recurrent layer used in Qwen3.5 and Qwen3.6
+models.  Enabling PTO reduces **prefill time-to-first-token (TTFT) by 7–25%**
+on Ascend 910B, with zero impact on output accuracy.
+
+The decode phase always uses the original Triton implementation.  Normal
+inference (prefill + decode) works correctly end-to-end.
+
+## Requirements
+
+| Requirement | Details |
+|---|---|
+| NPU family | Ascend 910B (B1 / B2 / B3 / B4 and 910C / A3) |
+| CANN version | ≥ 8.0.0 (Bisheng compiler must be in `PATH`) |
+| Model | Qwen3.5 / Qwen3.6 (any size) |
+| Parallelism | Single-device only (TP=1, EP=1) |
+| Quantization | BF16 / W8A8 both supported |
+
+> **Note**: The 310P family is not supported and is excluded automatically.
+
+## Environment Variable
+
+| Variable | Default | Description |
+|---|---|---|
+| `VLLM_ASCEND_PTO_CHUNK_GDN` | `0` | Set to `1` to enable the PTO megakernel for GDN prefill. |
+
+## Quick Start
+
+```bash
+VLLM_ASCEND_PTO_CHUNK_GDN=1 python -m vllm.entrypoints.openai.api_server \
+    --model /path/to/Qwen3.5-7B \
+    --max-model-len 8192
+```
+
+> **Tip**: The first request triggers JIT compilation of the C++ megakernel
+> (30–90 s).  Subsequent requests reuse the cached `.so` file.  Use the
+> optional CMake pre-compilation step below to eliminate this delay.
+
+## How It Works
+
+The GDN recurrent layer computes a six-stage pipeline:
+
+```
+g_sum  = cumsum(g)                  chunk prefix cumulative sum
+A      = K^T @ K                    intra-chunk attention matrix
+A_inv  = solve_tril(A)              lower-triangular inverse (CubeCore)
+w, u   = wy_fast(K, V, β, A_inv)   Woodbury W/U updates
+s, V'  = chunk_h(K, w, u, g_t)     inter-chunk recurrent state
+O      = chunk_o(Q, K, V', s, g_t) final output
+```
+
+The megakernel fuses all six stages into a **single NPU kernel launch**
+(`mega_kernel.cpp`), eliminating Python-level inter-stage synchronization.
+
+During **decode** (when `initial_state` is non-zero) the function falls back
+transparently to the Triton implementation, so decode throughput is unaffected.
+
+## Prefill Performance
+
+Measured on Ascend 910B4, Qwen3.5-0.8B (BF16), eager mode, single device:
+
+| Backend | 512 tok TTFT | 1024 tok TTFT | 4096 tok TTFT |
+|---|---|---|---|
+| Triton (default)    | 127 ms | 126 ms | 135 ms |
+| PTO megakernel      | 111 ms | 112 ms | 124 ms |
+| **Speedup**         | **1.15×** | **1.12×** | **1.09×** |
+
+For larger models (Qwen3.6-35B-A3B-MoE) where GDN layers dominate prefill,
+speedups reach **~25% at 4k+ tokens**.
+
+## Accuracy
+
+PTO kernels reproduce Triton results to floating-point equivalence on all
+tested configurations.  Formal accuracy numbers for Qwen3.5-0.8B
+(256-doc wikitext subset, 6-subject MMLU):
+
+| Backend | WikiText PPL ↓ | MMLU acc ↑ |
+|---|---|---|
+| Triton (default) | 20.93 | 48.9% |
+| PTO megakernel   | 20.93 | 48.9% |
+
+Zero accuracy difference.
+
+### Running lm-eval yourself
+
+```bash
+# Install lm-eval
+pip install lm-eval sacrebleu more-itertools datasets
+
+# Triton baseline
+ASCEND_RT_VISIBLE_DEVICES=0 \
+python -m lm_eval \
+    --model vllm \
+    --model_args "pretrained=/path/to/Qwen3.5-0.8B,gpu_memory_utilization=0.85,enforce_eager=True" \
+    --tasks "mmlu_astronomy,mmlu_high_school_mathematics,mmlu_college_biology,wikitext" \
+    --limit 256 \
+    --output_path results/triton.json
+
+# PTO megakernel
+ASCEND_RT_VISIBLE_DEVICES=0 \
+VLLM_ASCEND_PTO_CHUNK_GDN=1 \
+python -m lm_eval \
+    --model vllm \
+    --model_args "pretrained=/path/to/Qwen3.5-0.8B,gpu_memory_utilization=0.85,enforce_eager=True" \
+    --tasks "mmlu_astronomy,mmlu_high_school_mathematics,mmlu_college_biology,wikitext" \
+    --limit 256 \
+    --output_path results/pto.json
+```
+
+## Optional: CMake Pre-compilation
+
+Pre-compiles megakernel `.so` files for common Qwen model configurations at
+build time, eliminating the JIT warm-up delay on first request.
+
+```bash
+# From the repository root
+cmake -S csrc -B csrc/build \
+    -DBUILD_PTO_CHUNK_GDN=ON \
+    -DCMAKE_BUILD_TYPE=Release
+cmake --build csrc/build --target pto_chunk_gdn_kernels -j8
+
+# Or during Python build
+BUILD_PTO_CHUNK_GDN=ON pip install -e .
+```
+
+Pre-compiled kernels are loaded directly; JIT compilation is skipped for
+matching `(H, Hg, D, C=128)` configurations.
+
+## Git Submodule: pto-isa
+
+The megakernel depends on the `pto-isa` header library, tracked as a git
+submodule at `csrc/third_party/pto-isa`.  Initialize after cloning:
+
+```bash
+git clone https://github.com/vllm-project/vllm-ascend.git
+cd vllm-ascend
+git submodule update --init --recursive
+```
+
+## Troubleshooting
+
+**`bisheng: command not found`**
+: Activate the Ascend CANN toolkit: `source /usr/local/Ascend/ascend-toolkit/set_env.sh`
+
+**`ASCEND_TOOLKIT_HOME` not set**
+: Set `ASCEND_TOOLKIT_HOME` to your CANN root, e.g.
+  `/usr/local/Ascend/ascend-toolkit/latest`.
+
+**Slow first request**
+: JIT compilation on first use is expected.  Use CMake pre-compilation to avoid it.
+
+**PTO not active despite `VLLM_ASCEND_PTO_CHUNK_GDN=1`**
+: Check logs for `PTO GDN megakernel active`.  Possible causes:
+  - Running on 310P hardware (excluded by design).
+  - Compilation error (set `VERBOSE_COMPILE=1` for full command).
+
+**`Unknown vLLM environment variable detected: VLLM_ASCEND_PTO_CHUNK_GDN`**
+: Harmless informational warning from vLLM core.  The variable is registered
+  in `vllm_ascend/envs.py` and processed correctly.

--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -30,4 +30,5 @@ sequence_parallelism
 batch_invariance
 lmcache_ascend_deployment
 dynamic_chunk_pipeline_parallel
+enable_megagdn_kernel
 :::

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -112,6 +112,12 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Enable PTO (Parallel Tile Operator) megakernel for the chunk GatedDeltaNet (GDN)
+    # recurrent layer used in Qwen3.5 / Qwen3.6 models.  When set, a Bisheng-JIT-compiled
+    # fused Ascend NPU megakernel replaces the default Triton implementation during
+    # **prefill**.  The decode phase always uses the Triton baseline.
+    # Only effective on Ascend 910B.  0 (default): Triton; 1: PTO megakernel.
+    "VLLM_ASCEND_PTO_CHUNK_GDN": lambda: bool(int(os.getenv("VLLM_ASCEND_PTO_CHUNK_GDN", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -27,7 +27,7 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
-from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
+import vllm_ascend.ops.triton.fla.chunk as _fla_chunk_mod  # accessed via module for PTO override
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
@@ -288,7 +288,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         if attn_metadata.num_prefills > 0:
             initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
             clear_ssm_states(initial_state, has_initial_state)
-            (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
+            (core_attn_out_non_spec, last_recurrent_state) = _fla_chunk_mod.chunk_gated_delta_rule(
                 q=query_non_spec,
                 k=key_non_spec,
                 v=value_non_spec,

--- a/vllm_ascend/ops/pto_chunk_gdn/__init__.py
+++ b/vllm_ascend/ops/pto_chunk_gdn/__init__.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""PTO chunk-GDN megakernel module for vLLM-Ascend.
+
+Provides a Bisheng-JIT-compiled fused Ascend NPU megakernel for the chunk
+GatedDeltaNet (GDN) recurrent layer used in Qwen3.5 / Qwen3.6 models,
+replacing the default Triton baseline during prefill.
+
+Enable via:
+    VLLM_ASCEND_PTO_CHUNK_GDN=1   (set before launching vLLM)
+
+The decode phase always uses the original Triton implementation.
+"""
+from vllm_ascend.ops.pto_chunk_gdn.compile import BLOCK_DIM, PTO_LIB_PATH
+from vllm_ascend.ops.pto_chunk_gdn.mega_kernel import run_mega_kernel
+from vllm_ascend.ops.pto_chunk_gdn.worker_hook import apply_pto_gdn_patch, is_pto_gdn_patch_active
+
+__all__ = [
+    "BLOCK_DIM",
+    "PTO_LIB_PATH",
+    "run_mega_kernel",
+    "apply_pto_gdn_patch",
+    "is_pto_gdn_patch_active",
+]

--- a/vllm_ascend/ops/pto_chunk_gdn/chunk_gated_delta_wrapper.py
+++ b/vllm_ascend/ops/pto_chunk_gdn/chunk_gated_delta_wrapper.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""PTO megakernel drop-in for ``chunk_gated_delta_rule`` — prefill only.
+
+Activated via ``VLLM_ASCEND_PTO_CHUNK_GDN=1``.  Falls back transparently to
+the Triton implementation for:
+  - Non-zero ``initial_state`` (decode step with prior recurrent state)
+  - Missing ``cu_seqlens`` (non-varlen path)
+  - Multi-device pipeline-parallel (PCP) groups (world_size > 1)
+  - Mismatched Q/K/V head dimensions
+  - Non-NPU device
+
+GQA is supported: if ``v.shape[2] > q.shape[2]`` the GQA path is taken.
+
+The PTO path only executes for **prefill** (zero initial_state, cu_seqlens
+present).  Decode transparently falls back to Triton so normal inference
+(prefill + decode) works correctly end-to-end.
+"""
+from __future__ import annotations
+
+import torch
+from einops import rearrange
+
+
+def _needs_triton_fallback(
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.LongTensor | None,
+) -> bool:
+    if initial_state is not None and torch.any(initial_state != 0):
+        return True
+    return cu_seqlens is None
+
+
+@torch.compiler.disable
+def chunk_gated_delta_rule_pto(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    prebuilt_meta=None,
+    head_first: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    *,
+    _triton_impl,
+):
+    """PTO megakernel drop-in for ``chunk_gated_delta_rule``.
+
+    Runs the fused Bisheng megakernel for prefill.  Falls back to Triton for
+    decode (``initial_state != 0``) so end-to-end inference is unaffected.
+    """
+    assert q.dtype == k.dtype == v.dtype
+    assert q.dtype != torch.float32, "Use bfloat16 or float16, not float32."
+    assert beta.ndim == 3, "beta must be [B, T, H] (head_first=False)."
+
+    if head_first:
+        q, k, v, beta, g = (rearrange(x, "b h t ... -> b t h ...") for x in (q, k, v, beta, g))
+
+    if scale is None:
+        scale = float(k.shape[-1] ** -0.5)
+
+    if use_qk_l2norm_in_kernel:
+        from vllm_ascend.ops.triton.fla.l2norm import l2norm_fwd
+        q, k = l2norm_fwd(q), l2norm_fwd(k)
+
+    def _triton():
+        return _triton_impl(
+            q, k, v, g, beta,
+            scale=scale, initial_state=initial_state,
+            output_final_state=output_final_state, cu_seqlens=cu_seqlens,
+            prebuilt_meta=prebuilt_meta, head_first=False,
+            use_qk_l2norm_in_kernel=False,
+        )
+
+    if q.device.type != "npu":
+        return _triton()
+    if _needs_triton_fallback(initial_state, cu_seqlens):
+        return _triton()
+    if q.shape[3] != v.shape[3]:
+        return _triton()
+    if v.shape[2] != q.shape[2] and v.shape[2] % q.shape[2] != 0:
+        return _triton()
+    try:
+        from vllm.distributed import get_pcp_group
+        if get_pcp_group().world_size > 1:
+            return _triton()
+    except Exception:
+        pass
+
+    from vllm_ascend.ops.pto_chunk_gdn.mega_kernel import run_mega_kernel
+
+    kh = q.shape[2]
+    cu32 = cu_seqlens.to(torch.int32).contiguous()
+    stream = torch.npu.current_stream()._as_parameter_
+
+    with torch.autograd.profiler.record_function("PTO_mega_kernel"):
+        result = run_mega_kernel(
+            q.to(torch.float16),
+            k.to(torch.float16),
+            v.to(torch.float16),
+            g.float(),
+            beta.to(torch.float16),
+            cu32,
+            stream=stream,
+            chunk_size=128,
+            scale=scale,
+            key_heads=kh,
+            return_final_state=output_final_state,
+        )
+
+    if output_final_state:
+        o, fs = result
+        o = o.to(q.dtype)
+        fs = fs.to(q.dtype)
+    else:
+        o = result.to(q.dtype)  # type: ignore[assignment]
+        fs = None
+
+    if head_first:
+        o = rearrange(o, "b t h ... -> b h t ...")
+    return o, fs

--- a/vllm_ascend/ops/pto_chunk_gdn/compile.py
+++ b/vllm_ascend/ops/pto_chunk_gdn/compile.py
@@ -1,0 +1,177 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Bisheng JIT compilation for the PTO GDN megakernel on Ascend NPU.
+
+The megakernel is compiled on first use and cached under
+``vllm_ascend/ops/pto_chunk_gdn/kernels/compiled_lib/``.
+Re-compilation is triggered when the C++ source mtime changes.
+
+Environment variables:
+    PTO_LIB_PATH            Path to pto-isa header directory (contains ``include/``).
+                            Auto-detected from ``csrc/third_party/pto-isa`` in the
+                            package source tree, then ``/sources/pto-isa`` fallback.
+    ASCEND_TOOLKIT_HOME     Ascend toolkit root (required).
+    GDN_NPU_DEVICE          NPU device for ``cube_core_num`` query (default ``npu:0``).
+    VERBOSE_COMPILE         Set to ``1`` to print the full bisheng command.
+    PTO_DYNAMIC_EXTRA_FLAGS Extra flags appended to every bisheng invocation.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Paths — resolved relative to this file's installed location
+# ---------------------------------------------------------------------------
+_THIS_DIR = Path(__file__).resolve().parent
+_VLLM_ASCEND_DIR = _THIS_DIR.parent.parent           # vllm_ascend/
+_PACKAGE_ROOT = _VLLM_ASCEND_DIR.parent              # site-packages root
+
+# C++ sources live in csrc/pto_chunk_gdn/ inside the source tree.
+# In editable installs (pip install -e .) _PACKAGE_ROOT == repo root.
+_CSRC_PTO = _PACKAGE_ROOT / "csrc" / "pto_chunk_gdn"
+if not _CSRC_PTO.is_dir():
+    _CSRC_PTO = _THIS_DIR / "csrc"
+
+KERNELS_PTO: str = str(_CSRC_PTO)
+KERNEL_INCLUDE: str = str(_CSRC_PTO / "include")
+
+# Compiled .so cache — writable at runtime inside the installed package.
+_COMPILED_DIR = _THIS_DIR / "kernels" / "compiled_lib"
+COMPILED_DIR: str = str(_COMPILED_DIR)
+
+_DRIVER_INC = "/usr/local/Ascend/driver/kernel/inc"
+
+ASCEND_TOOLKIT_HOME: str = (
+    os.environ.get("ASCEND_TOOLKIT_HOME") or os.environ.get("ASCEND_HOME_PATH", "")
+)
+if not ASCEND_TOOLKIT_HOME:
+    raise RuntimeError(
+        "ASCEND_TOOLKIT_HOME (or ASCEND_HOME_PATH) must be set to the Ascend toolkit root."
+    )
+
+
+def _resolve_pto_lib_path() -> str:
+    if "PTO_LIB_PATH" in os.environ:
+        return os.environ["PTO_LIB_PATH"]
+    submodule = _PACKAGE_ROOT / "csrc" / "third_party" / "pto-isa"
+    if (submodule / "include").is_dir():
+        os.environ["PTO_LIB_PATH"] = str(submodule)
+        return str(submodule)
+    fallback = "/sources/pto-isa"
+    if os.path.isdir(os.path.join(fallback, "include")):
+        os.environ["PTO_LIB_PATH"] = fallback
+        return fallback
+    return ASCEND_TOOLKIT_HOME
+
+
+PTO_LIB_PATH: str = _resolve_pto_lib_path()
+
+# ---------------------------------------------------------------------------
+# Hardware: query cube_core_num
+# ---------------------------------------------------------------------------
+_npu_dev = os.environ.get("GDN_NPU_DEVICE", "npu:0")
+try:
+    BLOCK_DIM: int = int(
+        getattr(torch.npu.get_device_properties(_npu_dev), "cube_core_num", 20)
+    )
+except (RuntimeError, AssertionError):
+    BLOCK_DIM = 24
+
+
+# ---------------------------------------------------------------------------
+# Compilation
+# ---------------------------------------------------------------------------
+
+def _common_flags(
+    *,
+    num_heads: int,
+    key_heads: int,
+    hidden_size: int,
+    chunk_size: int,
+) -> list[str]:
+    flags = [
+        "-fPIC", "-shared", "-xcce", "-DMEMORY_BASE", "-O2", "-std=gnu++17",
+        "--cce-aicore-arch=dav-c220",
+        "-mllvm", "-cce-aicore-stack-size=0x8000",
+        "-mllvm", "-cce-aicore-function-stack-size=0x8000",
+        "-mllvm", "-cce-aicore-record-overflow=true",
+        "-mllvm", "-cce-aicore-dcci-insert-for-scalar=false",
+        "-Wno-macro-redefined", "-Wno-ignored-attributes",
+        f"-I{KERNEL_INCLUDE}",
+        f"-I{os.path.join(PTO_LIB_PATH, 'include')}",
+        f"-I{ASCEND_TOOLKIT_HOME}/include",
+        f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc",
+        f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc/runtime",
+        f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc/profiling",
+        f"-DGDN_H={num_heads}",
+        f"-DGDN_HG={key_heads}",
+        f"-DGDN_D={hidden_size}",
+        f"-DGDN_C={chunk_size}",
+    ]
+    if os.path.isdir(_DRIVER_INC):
+        flags.append(f"-I{_DRIVER_INC}")
+    extra = os.environ.get("PTO_DYNAMIC_EXTRA_FLAGS", "").split()
+    flags.extend(extra)
+    return flags
+
+
+@lru_cache(maxsize=None)
+def compile_mega_kernel(
+    *,
+    num_heads: int = 16,
+    key_heads: int | None = None,
+    hidden_size: int = 128,
+    chunk_size: int = 128,
+    cpp_mtime_ns: int = 0,
+) -> str:
+    """Compile the fused PTO GDN megakernel and return the ``.so`` path.
+
+    Args:
+        num_heads:   Number of value heads H.
+        key_heads:   Number of Q/K heads Hg (GQA; defaults to H if None).
+        hidden_size: Head dimension D.
+        chunk_size:  Chunk size C (must be 128).
+        cpp_mtime_ns: Source file mtime for cache invalidation.
+
+    Returns:
+        Absolute path to the compiled ``.so`` file.
+    """
+    kh = key_heads if key_heads is not None else num_heads
+    os.makedirs(COMPILED_DIR, exist_ok=True)
+    cpp_path = os.path.join(KERNELS_PTO, "mega_kernel.cpp")
+    lib_path = os.path.join(
+        COMPILED_DIR,
+        f"mega_kernel_H{num_heads}_Hg{kh}_D{hidden_size}_C{chunk_size}.so",
+    )
+    flags = _common_flags(
+        num_heads=num_heads, key_heads=kh, hidden_size=hidden_size, chunk_size=chunk_size
+    )
+    cmd = ["bisheng", *flags, cpp_path, "-o", lib_path]
+    if os.environ.get("VERBOSE_COMPILE"):
+        print("compile:", " ".join(cmd))
+    import logging
+    logging.getLogger(__name__).info(
+        "[pto_chunk_gdn] Compiling mega_kernel H=%d Hg=%d D=%d C=%d …",
+        num_heads, kh, hidden_size, chunk_size,
+    )
+    subprocess.run(cmd, check=True, timeout=600)
+    return lib_path

--- a/vllm_ascend/ops/pto_chunk_gdn/mega_kernel.py
+++ b/vllm_ascend/ops/pto_chunk_gdn/mega_kernel.py
@@ -1,0 +1,208 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Fused PTO GDN megakernel: all six GDN pipeline stages in one NPU launch.
+
+Fuses cumsum → scaled_dot_kkt → solve_tril → wy_fast → chunk_h → chunk_o
+into a single ``call_kernel`` dispatch, eliminating Python-level inter-stage
+synchronization overhead.
+
+GQA is supported: Q/K use ``Hg`` heads while V/gates use ``H ≥ Hg`` value heads
+(``H % Hg == 0``).
+
+Usage::
+
+    from vllm_ascend.ops.pto_chunk_gdn.mega_kernel import run_mega_kernel
+
+    o = run_mega_kernel(q, k, v, g, beta, cu_seqlens, stream=stream,
+                        chunk_size=128, scale=head_dim**-0.5, key_heads=Hg)
+"""
+from __future__ import annotations
+
+import ctypes
+import os
+from functools import lru_cache
+
+import torch
+
+from vllm_ascend.ops.pto_chunk_gdn.compile import BLOCK_DIM, KERNELS_PTO, compile_mega_kernel
+
+
+# ---------------------------------------------------------------------------
+# Small utilities (self-contained, no external module dependency)
+# ---------------------------------------------------------------------------
+
+def _vp(t: torch.Tensor | None) -> ctypes.c_void_p:
+    if t is None:
+        return ctypes.c_void_p()
+    return ctypes.c_void_p(t.data_ptr())
+
+
+@lru_cache(maxsize=48)
+def _precomputed_minus_identity(
+    device_ty: str, device_index: int, chunk_size: int
+) -> torch.Tensor:
+    """``[C, C]`` fp16 buffer with diagonal ``-1``, cached per (device, C)."""
+    idx = max(device_index, 0)
+    dev = torch.device(device_ty, idx) if device_ty != "cpu" else torch.device("cpu")
+    t = torch.zeros(chunk_size, chunk_size, device=dev, dtype=torch.float16)
+    t.fill_diagonal_(-1)
+    return t
+
+
+@lru_cache(maxsize=48)
+def _causal_masks(
+    device_ty: str, device_index: int, chunk_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Lower-triangle and full causal masks, cached per (device, C)."""
+    idx = max(device_index, 0)
+    dev = torch.device(device_ty, idx) if device_ty != "cpu" else torch.device("cpu")
+    m_lower = torch.tril(torch.ones(chunk_size, chunk_size, device=dev), diagonal=-1).float()
+    m_full  = torch.tril(torch.ones(chunk_size, chunk_size, device=dev), diagonal=0).float()
+    return m_lower, m_full
+
+
+def _total_chunks(N_seq: int, cu_seqlens: torch.Tensor, chunk_size: int) -> int:
+    """Total number of chunks across all sequences in the varlen batch."""
+    cu = cu_seqlens.cpu().tolist()
+    return sum(
+        (cu[i + 1] - cu[i] + chunk_size - 1) // chunk_size
+        for i in range(N_seq)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Kernel loading
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=None)
+def _load_mega_kernel(
+    *,
+    num_heads: int,
+    key_heads: int,
+    hidden_size: int,
+    chunk_size: int,
+) -> ctypes.CDLL:
+    mtime = os.stat(os.path.join(KERNELS_PTO, "mega_kernel.cpp")).st_mtime_ns
+    lib_path = compile_mega_kernel(
+        num_heads=num_heads, key_heads=key_heads,
+        hidden_size=hidden_size, chunk_size=chunk_size,
+        cpp_mtime_ns=mtime,
+    )
+    lib = ctypes.CDLL(os.path.abspath(lib_path))
+    lib.call_kernel.argtypes = (
+        [ctypes.c_uint32, ctypes.c_void_p]
+        + [ctypes.c_void_p] * 28
+        + [ctypes.c_int64, ctypes.c_int64, ctypes.c_int64, ctypes.c_uint32]
+    )
+    lib.call_kernel.restype = None
+    return lib
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def run_mega_kernel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g_in: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    stream,
+    chunk_size: int = 128,
+    scale: float = 1.0,
+    block_dim: int | None = None,
+    key_heads: int | None = None,
+    return_final_state: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Run all six GDN pipeline stages in a single fused NPU kernel launch.
+
+    Args:
+        q, k:   ``[B, T, Hg, D]`` fp16 query / key tensors.
+        v:      ``[B, T, H, D]`` fp16 value tensor  (H ≥ Hg, H % Hg == 0).
+        g_in:   ``[B, T, H]`` float32 pre-cumsum gate logits.
+        beta:   ``[B, T, H]`` fp16 gate bias.
+        cu_seqlens: ``int32`` cumulative sequence-length boundaries ``[0, …, T]``.
+        stream: NPU stream handle (``torch.npu.current_stream()._as_parameter_``).
+        chunk_size: Tile side length C (must be 128).
+        scale:  Output scale (typically ``head_dim ** -0.5``).
+        block_dim: AI-Core block count; auto-detected from device if None.
+        key_heads: Q/K head count Hg (inferred from ``q`` if None).
+        return_final_state: Also return ``[N_seq, H, D, D]`` final recurrent states.
+
+    Returns:
+        ``O * scale`` of shape ``[B, T, H, D]`` fp16, and optionally final
+        recurrent state ``[N_seq, H, D, D]`` fp16.
+    """
+    dev = q.device
+    kh = key_heads if key_heads is not None else q.shape[2]
+    H, D = v.shape[2], q.shape[3]
+    C = chunk_size
+    T = q.shape[1]
+    N_seq = int(cu_seqlens.numel()) - 1
+    bd = block_dim or BLOCK_DIM
+
+    if cu_seqlens.dtype != torch.int32:
+        cu_seqlens = cu_seqlens.to(torch.int32)
+
+    dt, di = dev.type, dev.index if dev.index is not None else -1
+    msk_lower, msk_full = _causal_masks(dt, di, C)
+    minus_identity = _precomputed_minus_identity(dt, di, C)
+
+    tc = _total_chunks(N_seq, cu_seqlens, C)
+    num_matrices = tc * H
+
+    g_sum      = torch.empty(1, T, H, device=dev, dtype=torch.float32)
+    g_t        = torch.empty(H, T, device=dev, dtype=torch.float32)
+    beta_t     = torch.empty(H, T, device=dev, dtype=torch.float16)
+    A          = torch.zeros(1, T, H, C, device=dev, dtype=torch.float16)
+    A_inv_f32  = torch.zeros(1, T, H, C, device=dev, dtype=torch.float32)
+    A_inv      = torch.zeros(1, T, H, C, device=dev, dtype=torch.float16)
+    w          = torch.empty_like(v)
+    u          = torch.empty_like(v)
+    s          = torch.zeros(tc * H, D, D, device=dev, dtype=torch.float16)
+    v_new      = torch.empty_like(v)
+    fs         = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
+    kkt_ws     = torch.zeros(bd * 2, C, C, device=dev, dtype=torch.float16)
+    wy_ws_a1   = torch.zeros(bd, C, C, device=dev, dtype=torch.float16)
+    wy_ws_a2   = torch.zeros(bd, C, C, device=dev, dtype=torch.float16)
+    h_ws       = torch.zeros(bd * 4, D, D, device=dev, dtype=torch.float16)
+    o_ws_qk    = torch.zeros(bd, C, C, device=dev, dtype=torch.float16)
+    o_ws_qs    = torch.zeros(bd, C, D, device=dev, dtype=torch.float16)
+    o_ws_gated = torch.zeros(bd, C, C, device=dev, dtype=torch.float16)
+    o_out      = torch.empty_like(v)
+
+    lib = _load_mega_kernel(num_heads=H, key_heads=kh, hidden_size=D, chunk_size=C)
+    lib.call_kernel(
+        bd, stream,
+        _vp(q), _vp(k), _vp(v), _vp(g_in), _vp(beta),
+        _vp(msk_lower), _vp(msk_full), _vp(minus_identity), _vp(cu_seqlens),
+        _vp(o_out),
+        _vp(g_sum), _vp(g_t), _vp(beta_t),
+        _vp(A), _vp(A_inv_f32), _vp(A_inv),
+        _vp(w), _vp(u), _vp(s), _vp(v_new), _vp(fs),
+        _vp(kkt_ws), _vp(wy_ws_a1), _vp(wy_ws_a2), _vp(h_ws),
+        _vp(o_ws_qk), _vp(o_ws_qs), _vp(o_ws_gated),
+        N_seq, T, T, num_matrices,
+    )
+
+    o_scaled = o_out * scale
+    if return_final_state:
+        return o_scaled, fs.view(N_seq, H, D, D)
+    return o_scaled

--- a/vllm_ascend/ops/pto_chunk_gdn/worker_hook.py
+++ b/vllm_ascend/ops/pto_chunk_gdn/worker_hook.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Native worker hook: activate the PTO megakernel for ``chunk_gated_delta_rule``.
+
+Called from ``vllm_ascend.patch.worker.__init__`` when
+``VLLM_ASCEND_PTO_CHUNK_GDN=1``.  Must run **after** the Triton patches
+install the baseline implementation and **before** any model module imports
+``gdn.py``.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+
+_log = logging.getLogger(__name__)
+_PATCH_ACTIVE = False
+
+
+def apply_pto_gdn_patch() -> None:
+    """Replace ``chunk_gated_delta_rule`` with the PTO megakernel.
+
+    Patches three locations so all existing import paths see the PTO version:
+    1. ``vllm_ascend.ops.triton.fla.chunk`` — primary defining module.
+    2. ``vllm.model_executor.layers.fla.ops`` — vLLM public FLA namespace.
+    3. ``vllm_ascend.ops.gdn`` if already imported (refreshes module attribute).
+    """
+    global _PATCH_ACTIVE
+
+    import vllm.model_executor.layers.fla.ops as fla_ops
+    import vllm_ascend.ops.triton.fla.chunk as _ascend_chunk_mod
+    from vllm_ascend.ops.pto_chunk_gdn.chunk_gated_delta_wrapper import (
+        chunk_gated_delta_rule_pto,
+    )
+
+    triton_impl = _ascend_chunk_mod.chunk_gated_delta_rule
+
+    def _pto_bound(
+        q, k, v, g, beta,
+        scale=None, initial_state=None, output_final_state=False,
+        cu_seqlens=None, prebuilt_meta=None, head_first=False,
+        use_qk_l2norm_in_kernel=False,
+    ):
+        return chunk_gated_delta_rule_pto(
+            q, k, v, g, beta,
+            scale=scale, initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens, prebuilt_meta=prebuilt_meta,
+            head_first=head_first,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            _triton_impl=triton_impl,
+        )
+
+    _pto_bound.__name__ = "chunk_gated_delta_rule"
+    _pto_bound._vllm_ascend_pto_gdn = True
+
+    _ascend_chunk_mod.chunk_gated_delta_rule = _pto_bound
+    fla_ops.chunk_gated_delta_rule = _pto_bound
+
+    _gdn_mod = sys.modules.get("vllm_ascend.ops.gdn")
+    if _gdn_mod is not None and hasattr(_gdn_mod, "chunk_gated_delta_rule"):
+        _gdn_mod.chunk_gated_delta_rule = _pto_bound
+
+    _PATCH_ACTIVE = True
+    _log.warning(
+        "PTO GDN megakernel active (chunk_size=128, Ascend 910B)."
+    )
+
+
+def is_pto_gdn_patch_active() -> bool:
+    return _PATCH_ACTIVE

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -23,6 +23,21 @@ if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
     import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 
+# PTO GDN kernel swap: must run after Triton patches install the baseline
+# chunk_gated_delta_rule, and before any model module imports gdn.py.
+if not is_310p():
+    from vllm_ascend import envs as _ascend_envs
+    if _ascend_envs.VLLM_ASCEND_PTO_CHUNK_GDN:
+        try:
+            from vllm_ascend.ops.pto_chunk_gdn.worker_hook import apply_pto_gdn_patch
+            apply_pto_gdn_patch()
+        except Exception as _pto_exc:
+            import warnings as _pto_warnings
+            _pto_warnings.warn(
+                f"VLLM_ASCEND_PTO_CHUNK_GDN: apply_pto_gdn_patch() failed: {_pto_exc!r}",
+                stacklevel=1,
+            )
+
 
 # isort: off
 import vllm_ascend.patch.worker.patch_weight_utils  # noqa


### PR DESCRIPTION
### What this PR does / why we need it?

**3x faster** kernels than existing `chunk_gated_delta_rule` inside [vllm_ascend/ops/triton/fla](https://github.com/vllm-project/vllm-ascend/tree/v0.19.1rc1/vllm_ascend/ops/triton/fla). Measured **15% prefill speed-up (15% less TTFT)** for various Qwen3.5/3.6 models. No accuracy impact as shown by lm-eval. See our [full report](https://github.com/huawei-csl/megagdn-pto/tree/main/blog).

To verify the benefit of this new feature, it's easier to first use the [our "patch" style repo `megagdn-pto`](https://github.com/huawei-csl/megagdn-pto), to avoid rebuilding vllm-ascend from scratch. This PR brings such external patch into vllm-ascend source, for better long-term maintainability.

### Does this PR introduce _any_ user-facing change?

No, just a faster internal kernel.

### How was this patch tested?

The original standalone [`megagdn-pto` repo](https://github.com/huawei-csl/megagdn-pto) has test scripts for:
- Single-kernel unit tests and benchmarks
- Prefill TTFT benchmark
- lm-eval score evaluation

I can put some of them into this PR. Let me know which are needed.

### Notes for vllm-ascend maintainers

This is the first attempt to merge PTO-ISA kernels into vllm-ascend, so likely need a few rounds of reviews and edits. 

The current way this PR is structured:
- PTO C++ kernels are in `csrc/pto_chunk_gdn/`, the same level of directory as other AscendC kernel sources
- The torch interfaces are under `vllm_ascend/ops/pto_chunk_gdn/`
- I put a feature guide `docs/source/user_guide/feature_guide/enable_megagdn_kernel.md`
- To provide PTO-ISA dependency, I added https://gitcode.com/cann/pto-isa to `csrc/third_party/pto-isa` as git submodule, the same way as the `csrc/third_party/catlass` submodule.
- CANN installation also provides PTO-ISA headers, similar to how it provides AscendC headers. It's located in `$ASCEND_HOME_PATH/include/pto`. But the headers in 8.5.0 is not new enough, thus I pulled a more recent commit. With future newer CANN releases, this `pto-isa` git submodule might not be needed.

Let me know your preferred: (1) code organization (2) compilation procedure (3) if more docs and tests needed. Then we can make further changes to make this PR more "merge-able".

I assume the PTO torch interface needs to be the same as current AscendC build structure? i.e. Using CMake + pybind (torch C++ api). An alternative without needing to rebuild csrc directory, is to use "JIT compile" style, calling `bisheng` + `ctypes` on the fly, so it's more like triton/tilelang's way of invoking kernels.

### Known uncovered cases by this PR

- Kernels are fully tested on Atlas A2, and should also be compatible with A3 (same aicore isa), but I didn't verify directly (no A3 machine)
- A5 & Ascend 950 is not tested *yet*. Although PTO-ISA abstracts away A3 vs A5 differences, we still need slight tweaks to the kernel sources and launch interface (mostly for Cube-Vector communication). This is planned as the next PR (current one is already big enough, don't want to bloat the code)
- Multi-device inference for larger 122B/397B models are not tested yet. Will need to fuse communication to gain best speed-up, otherwise the eager communication calls will kill any single-kernel speed-up. This is planned as future PRs.

## Extended summary 

(below are AI summarized but quite correct; above are purely human written)

<details>

PR: Enable PTO GDN Megakernel for Qwen3.5 / Qwen3.6 prefill

**Target**: `vllm-project/vllm-ascend` main branch

---

## Summary

Integrate fused PTO megakernel for the **chunk GatedDeltaNet (GDN)** used in Qwen3.5 and
Qwen3.6 models, replacing the default Triton implementation during prefill.

Key outcomes:
- **7–25% TTFT reduction** on Ascend 910B, depending on model size and sequence length.
- **Zero accuracy regression**: WikiText PPL and MMLU scores match Triton to floating-point equivalence.
- **Decode unaffected**: the PTO path only activates for prefill (zero `initial_state`); decode transparently falls back to Triton.
- **Single opt-in env var**: `VLLM_ASCEND_PTO_CHUNK_GDN=1`.

---

## Background

Qwen3.5 (0.8B – 9B) and Qwen3.6 (27B, 35B-A3B-MoE) use a **GatedDeltaNet**
recurrent layer that dominates prefill cost at long context lengths.  The
existing Triton-based implementation runs with `chunk_size=64` and BF16.
The new PTO megakernel runs with `chunk_size=128` in FP16 on the Ascend
AI-Core vector unit, fusing all six pipeline stages into a **single NPU dispatch**.

### Pipeline stages (all fused into one kernel launch)

```
Q, K, V, g, β, cu_seqlens
│
├── cumsum       prefix cumulative sum of gate logits g        [Vec]
├── kkt          intra-chunk K^T K attention matrix A          [Cube+Vec]
├── solve_tril   lower-triangular solve A_inv = tril(A)^{-1}  [CubeCore]
├── wy_fast      Woodbury updates W, U from K, V, β, A_inv    [Vec+Cube]
├── chunk_h      inter-chunk recurrent state S and V'          [Cube+Vec]
└── chunk_o      output O = Q (K^T V' + S)                    [Cube+Vec]
```

GQA is fully supported: Q/K use `Hg` heads while V/gates use `H ≥ Hg` value
heads.

---

## Changes

### New: `csrc/pto_chunk_gdn/`

| File | Description |
|---|---|
| `mega_kernel.cpp` | Fused megakernel entry point (all six stages) |
| `chunk_cumsum.cpp` | Cumulative sum stage (included by mega_kernel.cpp) |
| `scaled_dot_kkt.cpp` | K^T K attention matrix (included by mega_kernel.cpp) |
| `tri_inverse_impl.cpp` | Triangular inverse implementation (included by mega_kernel.cpp) |
| `wy_fast.cpp` | Woodbury W/U updates (included by mega_kernel.cpp) |
| `chunk_h.cpp` | Inter-chunk recurrent state (included by mega_kernel.cpp) |
| `chunk_o.cpp` | Output projection (included by mega_kernel.cpp) |
| `include/kernel_utils.h` | Shared AI-Core utility templates |
| `CMakeLists.txt` | Optional `BUILD_PTO_CHUNK_GDN` target for pre-compilation |

### New: `csrc/third_party/pto-isa` (git submodule)

PTO ISA header library required by the megakernel.  Added at the same level
as the existing `catlass` submodule:
```
csrc/third_party/pto-isa   ← new  (gitcode.com/cann/pto-isa.git)
csrc/third_party/catlass    ← existing
```

### New: `vllm_ascend/ops/pto_chunk_gdn/`

| Module | Description |
|---|---|
| `compile.py` | Bisheng JIT compilation; resolves `PTO_LIB_PATH`; caches `.so` |
| `mega_kernel.py` | ctypes launcher for the fused megakernel |
| `chunk_gated_delta_wrapper.py` | Drop-in `chunk_gated_delta_rule` replacement; handles GQA and Triton fallback for decode |
| `worker_hook.py` | `apply_pto_gdn_patch()` — patches `chunk_gated_delta_rule` at worker startup |

### Modified: `vllm_ascend/envs.py`

One new environment variable:

```python
VLLM_ASCEND_PTO_CHUNK_GDN   # bool, default False; enable PTO megakernel
```

### Modified: `vllm_ascend/patch/worker/__init__.py`

Native activation hook — runs after Triton patches, before model loading:

```python
if not is_310p():
    if envs.VLLM_ASCEND_PTO_CHUNK_GDN:
        from vllm_ascend.ops.pto_chunk_gdn.worker_hook import apply_pto_gdn_patch
        apply_pto_gdn_patch()
```

### Modified: `vllm_ascend/ops/gdn.py`

Changed static import to module-level attribute access so the worker hook
patch applies correctly:

```python
# Before
from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule

# After
import vllm_ascend.ops.triton.fla.chunk as _fla_chunk_mod
# ...
(out, state) = _fla_chunk_mod.chunk_gated_delta_rule(...)
```

### New: `docs/source/user_guide/feature_guide/enable_megagdn_kernel.md`

Complete user guide covering quick-start, performance benchmarks, lm-eval
accuracy verification (with commands), CMake pre-compilation, and
troubleshooting.

---

## Performance Results

Measured on Ascend 910B4 with Qwen3.5-0.8B (BF16, eager mode, single device,
**rebuilt from source using this PR**):

| Backend | 512 tok TTFT | 1024 tok TTFT | 4096 tok TTFT |
|---|---|---|---|
| Triton (default)  | 125.8 ms | 125.3 ms | 133.8 ms |
| PTO megakernel    | 110.6 ms | 111.7 ms | 119.9 ms |
| **Speedup**       | **1.14×** | **1.12×** | **1.12×** |

For larger models (Qwen3.6-35B-A3B-MoE) where GDN layers dominate, speedups
reach **~25% at 4k+ tokens**.

---

## Accuracy Results (Qwen3.5-0.8B)

256-document wikitext subset + 6-subject MMLU
(**rebuilt from source using this PR**):

| Backend | WikiText PPL ↓ | MMLU acc ↑ |
|---|---|---|
| Triton (default) | 20.93 | 48.9% |
| PTO megakernel   | 20.93 | 48.9% |

Zero accuracy difference.

---

## Testing

```bash
# E2E inference: PTO and Triton produce identical outputs
ASCEND_RT_VISIBLE_DEVICES=0 \
VLLM_ASCEND_PTO_CHUNK_GDN=1 \
python -m vllm.entrypoints.openai.api_server \
    --model /path/to/Qwen3.5-0.8B --max-model-len 1024

# lm-eval accuracy
ASCEND_RT_VISIBLE_DEVICES=0 \
VLLM_ASCEND_PTO_CHUNK_GDN=1 \
python -m lm_eval --model vllm \
    --model_args "pretrained=/path/to/Qwen3.5-0.8B" \
    --tasks wikitext --limit 256
```

---

## Limitations

- Single-device only (TP=1, EP=1).  Multi-device support will be addressed in follow-up PRs.
- Chunk size fixed at C=128 (optimal tiling for Ascend 910B AI-Core).
- 910C/A3 uses the same code path but is not tested in the current CI environment.

---

## Notes for Reviewers

- Fully in-tree: no external dependencies beyond the `csrc/third_party/pto-isa` git submodule.
- `VLLM_ASCEND_PTO_CHUNK_GDN` is registered in `vllm_ascend/envs.py`; the
  "Unknown vLLM environment variable" warning from vLLM core is harmless.
- The JIT cache directory (`kernels/compiled_lib/*.so`) is listed in `.gitignore`.

---

## How to Rebuild from Source

### Prerequisites

- Ascend 910B device with CANN ≥ 8.0 and `bisheng` compiler in `PATH`
- Ubuntu 22.04 (recommended) with Python 3.11
- Activate the toolkit: `source /usr/local/Ascend/ascend-toolkit/set_env.sh`

### Build steps

```bash
# 1 — Clone with submodules
git clone https://github.com/vllm-project/vllm-ascend.git
cd vllm-ascend
git submodule update --init --recursive   # pulls pto-isa and catlass

# 2 — Install vLLM (empty device build — no GPU/CUDA needed)
git clone --depth 1 -b v0.19.1 https://github.com/vllm-project/vllm.git /tmp/vllm
VLLM_TARGET_DEVICE=empty pip install -e /tmp/vllm/ \
    --extra-index-url https://download.pytorch.org/whl/cpu/
pip uninstall -y triton

# 3 — Install vllm-ascend
pip install -e . \
    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
    --extra-index-url https://download.pytorch.org/whl/cpu/
pip uninstall -y triton triton-ascend
pip install triton-ascend==3.2.0

# 4 — (Optional) Pre-compile PTO megakernel for common Qwen configs
cmake -S csrc -B csrc/build -DBUILD_PTO_CHUNK_GDN=ON
cmake --build csrc/build --target pto_chunk_gdn_kernels -j$(nproc)
```

### Run inference with PTO

```bash
ASCEND_RT_VISIBLE_DEVICES=0 \
VLLM_ASCEND_PTO_CHUNK_GDN=1 \
python -m vllm.entrypoints.openai.api_server \
    --model /path/to/Qwen3.5-7B \
    --max-model-len 8192
```

### Run accuracy check (lm-eval)

```bash
pip install lm-eval sacrebleu more-itertools datasets

# Triton baseline
ASCEND_RT_VISIBLE_DEVICES=0 python -m lm_eval \
    --model vllm \
    --model_args "pretrained=/path/to/Qwen3.5-0.8B,gpu_memory_utilization=0.85,enforce_eager=True" \
    --tasks "wikitext" --limit 256 --output_path results/triton.json

# PTO megakernel
ASCEND_RT_VISIBLE_DEVICES=0 VLLM_ASCEND_PTO_CHUNK_GDN=1 python -m lm_eval \
    --model vllm \
    --model_args "pretrained=/path/to/Qwen3.5-0.8B,gpu_memory_utilization=0.85,enforce_eager=True" \
    --tasks "wikitext" --limit 256 --output_path results/pto.json
```

---

## Minimum Dockerfile

A minimum `Dockerfile.pto` is included at the repository root for building a
self-contained image with CANN 8.5.1, vLLM v0.19.1, and vllm-ascend with PTO
pre-compiled for common Qwen configurations.

```dockerfile
FROM quay.io/ascend/cann:8.5.1-910b-ubuntu22.04-py3.11

ARG PIP_INDEX_URL="https://pypi.org/simple"
ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
ARG VLLM_TAG="v0.19.1"
ARG SOC_VERSION="ascend910b4"

WORKDIR /workspace

# System packages
RUN apt-get update -y && \
    apt-get install -y --no-install-recommends \
        git cmake ninja-build gcc g++ wget numactl libnuma-dev && \
    rm -rf /var/lib/apt/lists/*

RUN pip config set global.index-url ${PIP_INDEX_URL}

# vLLM (empty-device build)
RUN git clone --depth 1 -b ${VLLM_TAG} ${VLLM_REPO} /workspace/vllm && \
    VLLM_TARGET_DEVICE="empty" pip install -v -e /workspace/vllm/ \
        --extra-index-url https://download.pytorch.org/whl/cpu/ && \
    pip uninstall -y triton && pip cache purge

# vllm-ascend with pto-isa submodule
COPY . /workspace/vllm-ascend/
RUN cd /workspace/vllm-ascend && \
    git submodule update --init --recursive csrc/third_party/pto-isa

ENV SOC_VERSION=${SOC_VERSION} TASK_QUEUE_ENABLE=1 OMP_NUM_THREADS=1

RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
    source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true && \
    export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi && \
    pip install -v -e /workspace/vllm-ascend/ \
        --extra-index-url https://download.pytorch.org/whl/cpu/ && \
    pip uninstall -y triton triton-ascend 2>/dev/null || true && \
    pip install -v triton-ascend==3.2.0 && pip cache purge

# Pre-compile PTO megakernel (optional — remove to rely on JIT)
RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
    cmake -S /workspace/vllm-ascend/csrc \
          -B /workspace/vllm-ascend/csrc/build \
          -DBUILD_PTO_CHUNK_GDN=ON -DCMAKE_BUILD_TYPE=Release && \
    cmake --build /workspace/vllm-ascend/csrc/build \
          --target pto_chunk_gdn_kernels -j$(nproc) && \
    rm -rf /workspace/vllm-ascend/csrc/build

ENV VLLM_WORKER_MULTIPROC_METHOD=spawn \
    VLLM_ASCEND_PTO_CHUNK_GDN=1

RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> ~/.bashrc

CMD ["/bin/bash"]
```

Build and run:

```bash
# Build image (from vllm-ascend repo root)
docker build --build-arg SOC_VERSION=ascend910b4 \
    -t vllm-ascend-pto:latest -f Dockerfile.pto .

# Run inference
docker run --rm -it \
    --device /dev/davinci0 --device /dev/davinci_manager \
    --device /dev/devmm_svm --device /dev/hisi_hdc \
    -v /usr/local/dcmi:/usr/local/dcmi \
    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
    -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
    -v /path/to/model:/model \
    vllm-ascend-pto:latest \
    python -m vllm.entrypoints.openai.api_server \
        --model /model --max-model-len 8192
```

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
