### PR TITLE
[BugFix] fix kernels in sample when mask is not static or draft_token_id is invalid

### DIFF
--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -107,7 +107,7 @@ def rejection_greedy_sample_triton(
         is_greedy = tl.load(is_greedy_ptr + offset, mask=mask, other=0)
         is_greedy_mask = mask & (is_greedy != 0)
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_draft_tokens_ptr + offset - 1, is_greedy_mask))
+    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_draft_tokens_ptr + tl.maximum(offset - 1, 0), is_greedy_mask))
     end_idx = tl.load(cu_num_draft_tokens_ptr + offset, is_greedy_mask)
     num_draft_tokens = end_idx - start_idx
 
@@ -161,7 +161,9 @@ def rejection_random_sample_kernel(
     mask = offsets < vec_len
     is_greedy = tl.load(is_greedy_ptr + offsets, mask, other=1)
     not_greedy_mask = is_greedy == 0
-    start_idxs = tl.where(offsets == 0, 0, tl.load(cu_num_draft_tokens_ptr + offsets - 1, not_greedy_mask))
+    start_idxs = tl.where(
+        offsets == 0, 0, tl.load(cu_num_draft_tokens_ptr + tl.maximum(offsets - 1, 0), not_greedy_mask)
+    )
     end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets, not_greedy_mask)
     n_num_draft_tokens = end_idxs - start_idxs
     for req_i in range(BLOCK_SIZE):
@@ -174,21 +176,26 @@ def rejection_random_sample_kernel(
             for pos in range(num_draft_tokens):
                 if not rejected:
                     draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
-                    if NO_DRAFT_PROBS:
-                        draft_prob = 1
-                    else:
-                        draft_prob = tl.load(draft_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id)
-                    target_prob = tl.load(target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id)
-                    uniform_prob = tl.load(uniform_probs_ptr + start_idx + pos)
-                    # NOTE(woosuk): While the draft probability should never be 0,
-                    # we check it to avoid NaNs. If it happens to be 0, we reject.
-                    if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
-                        # Accept.
-                        token_id = draft_token_id
-                    else:
-                        # Reject. Use recovered token.
+                    if draft_token_id < 0:
+                        # Invalid draft (e.g., padded).
                         rejected = True
                         token_id = tl.load(recovered_token_ids_ptr + start_idx + pos)
+                    else:
+                        if NO_DRAFT_PROBS:
+                            draft_prob = 1
+                        else:
+                            draft_prob = tl.load(draft_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id)
+                        target_prob = tl.load(target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id)
+                        uniform_prob = tl.load(uniform_probs_ptr + start_idx + pos)
+                        # NOTE(woosuk): While the draft probability should never be 0,
+                        # we check it to avoid NaNs. If it happens to be 0, we reject.
+                        if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
+                            # Accept.
+                            token_id = draft_token_id
+                        else:
+                            # Reject. Use recovered token.
+                            rejected = True
+                            token_id = tl.load(recovered_token_ids_ptr + start_idx + pos)
                     tl.store(output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos, token_id)
             if not rejected:
                 # If all tokens are accepted, append the bonus token.
@@ -214,7 +221,7 @@ def expand_kernel(
     offset = req_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     len_mask = offset < vec_len
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_tokens_ptr + offset - 1, len_mask))
+    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_tokens_ptr + tl.maximum(offset - 1, 0), len_mask))
     end_idx = tl.load(cu_num_tokens_ptr + offset, len_mask)
     num_tokens = end_idx - start_idx
 
@@ -256,34 +263,33 @@ def sample_recovered_tokens_kernel(
     loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
     global_recovered_id = -1
     global_max_p = -1.0
-    prefix_prob = 1.0
-    if BLOCK_VERIFY:
-        for prev_pos in range(pos):
-            prev_token_idx = start_idx + prev_pos
-            prev_draft_token_id = tl.load(draft_token_ids_ptr + prev_token_idx)
-            prev_target_prob = tl.load(target_probs_ptr + prev_token_idx * vocab_size + prev_draft_token_id)
-            if NO_DRAFT_PROBS:
-                prev_draft_prob = 1.0
-            else:
-                prev_draft_prob = tl.load(draft_probs_ptr + prev_token_idx * vocab_size + prev_draft_token_id)
-            if prev_draft_prob > 0:
-                prefix_prob = min(prefix_prob * prev_target_prob / prev_draft_prob, 1.0)
-            else:
-                prefix_prob = 0.0
-
-    draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
-    for loop_i in range(loop):
-        vocab_start = loop_i * SUB_BLOCK
-        vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
-        target_prob = tl.load(
-            target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-            mask=vocab_offset < vocab_size,
-            other=0,
-        )
-        if NO_DRAFT_PROBS:
-            prob = prefix_prob * target_prob if BLOCK_VERIFY else target_prob
-            prob = tl.where(vocab_offset == draft_token_id, 0.0, prob)
-        else:
+    if NO_DRAFT_PROBS:
+        draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
+        for loop_i in range(loop):
+            vocab_start = loop_i * SUB_BLOCK
+            vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+            prob = tl.load(
+                target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
+                mask=vocab_offset < vocab_size,
+                other=0,
+            )
+            # Temporarily zero out the probability of the draft token.
+            # This is essentially the same as target_prob - draft_prob, except that
+            # n-gram does not have draft_prob. We regard it as 1.
+            prob = tl.where(vocab_offset == draft_token_id, 0, prob)
+            q = tl.load(
+                q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=float("-inf")
+            )
+            new_p = prob / q
+            recovered_id = tl.argmax(new_p, axis=-1)
+            max_p = get_element(new_p, (recovered_id,))
+            if max_p > global_max_p:
+                global_max_p = max_p
+                global_recovered_id = vocab_start + recovered_id
+    else:
+        for loop_i in range(loop):
+            vocab_start = loop_i * SUB_BLOCK
+            vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
             draft_prob = tl.load(
                 draft_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
                 mask=vocab_offset < vocab_size,
@@ -381,9 +387,9 @@ def rejection_random_sample_block_verify_kernel(
     mask = offsets < vec_len
     is_greedy = tl.load(is_greedy_ptr + offsets, mask, other=1)
     not_greedy_mask = is_greedy == 0
-    prev_mask = not_greedy_mask & (offsets > 0)
-    prev_end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets - 1, prev_mask, other=0)
-    start_idxs = tl.where(offsets == 0, 0, prev_end_idxs)
+    start_idxs = tl.where(
+        offsets == 0, 0, tl.load(cu_num_draft_tokens_ptr + tl.maximum(offsets - 1, 0), not_greedy_mask)
+    )
     end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets, not_greedy_mask)
     n_num_draft_tokens = end_idxs - start_idxs
     loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -42,7 +42,7 @@ def prepare_inputs_padded_kernel(
         # cumulative sum (first entry is the first value, not zero).
         cu_draft_curr = tl.load(cu_num_draft_tokens_ptr + offsets, mask=mask)
 
-        prev_indices = offsets - 1
+        prev_indices = tl.maximum(offsets - 1, 0)
         has_prev = offsets > 0
         cu_draft_prev = tl.load(
             cu_num_draft_tokens_ptr + prev_indices,


### PR DESCRIPTION

### What this PR does / why we need it?

cherry-pick by https://github.com/vllm-project/vllm-ascend/pull/8531

The triton kernels in sample encounter some problems, scenarios are shown below:

【expand_kernel/ rejection_random_sample_kernel/ prepare_inputs_padded_kernel】, these three operations will use ‘tl.load(prt + offsets -1, mask)’ in their implementations, but triton compiler reports that the masks in these scenarios are not static and contiguous. As a result, compiler will first access this memory and apply the mask. Therefore, I modified the code to ‘tl.load(prt +tl.maximum(offsets - 1, 0), mask)’ to ensure no -1 reads.

【sample_recovered_tokens_kernel/ rejection_random_sample_kernel】, this kernel uses draft_token_id as an address offset for the load operation. In the PD separation scenario, if the pad token is -1, illegal memory reads and writes can occur. Therefore, i modified the kernel and so they can do well with -1 token.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
