### PR TITLE
[Ops][Misc] Remove stream synchronization in ACL graph replay

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -197,8 +197,8 @@ class ACLGraphWrapper:
             )
 
         logger.info_once("Replaying aclgraph")
-        #FIXME(klyzhenko-vadim): There is no need synchronization.
-        #Because it significantly degrades perfomance.
+        # FIXME(klyzhenko-vadim): There is no need synchronization.
+        # Because it significantly degrades perfomance.
         entry.aclgraph.replay()
         return entry.output
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -197,18 +197,7 @@ class ACLGraphWrapper:
             )
 
         logger.info_once("Replaying aclgraph")
-        # In async scheduling or multi-threaded (MT) scenarios, it is possible that
-        # the CPU's record event (from update_attn_params) for the iteration i completes
-        # before the grph replay of iteration i-1.
-        # To ensure proper ordering, we must call synchronize here before replaying,
-        # so that update_attn_params only executes after the previous graph replay has fully completed.
-        # If we do not in main model and in full-graph mode when using merge-eagle-graph,
-        # we do not need to synchronize.
-        # When enable_enpu is on, model_runner orders update vs replay; skip here.
-        # When EAGLE draft (merge path), replay does not need this barrier.
-        is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
-        if not self.enable_enpu and not is_draft_eagle:
-            torch.npu.current_stream().synchronize()
+        #FIXME(klyzhenko-vadim): There is no need synchronization.
         entry.aclgraph.replay()
         return entry.output
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -198,6 +198,7 @@ class ACLGraphWrapper:
 
         logger.info_once("Replaying aclgraph")
         #FIXME(klyzhenko-vadim): There is no need synchronization.
+        #Because it significantly degrades perfomance.
         entry.aclgraph.replay()
         return entry.output
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -196,7 +196,7 @@ class ACLGraphWrapper:
 
         logger.info_once("Replaying aclgraph")
         # FIXME(klyzhenko-vadim): There is no need synchronization.
-        # Because it significantly degrades perfomance.
+        # Because it significantly degrades performance.
         entry.aclgraph.replay()
         return entry.output
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -19,8 +19,6 @@ from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
 from vllm.platforms import current_platform
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-
 from ..utils import weak_ref_tensors
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
```
without sync
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             128       
Benchmark duration (s):                  64.78     
Total input tokens:                      81818     
Total generated tokens:                  256000    
Request throughput (req/s):              15.44     
Output token throughput (tok/s):         3951.84   
Peak output token throughput (tok/s):    4736.00   
Peak concurrent requests:                256.00    
Total token throughput (tok/s):          5214.85   
---------------Time to First Token----------------
Mean TTFT (ms):                          397.28    
Median TTFT (ms):                        343.69    
P99 TTFT (ms):                           1092.57   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.20     
Median TPOT (ms):                        30.30     
P99 TPOT (ms):                           31.24     
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.20     
Median ITL (ms):                         28.97     
P99 ITL (ms):                            72.06     
==================================================

with sync
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             128       
Benchmark duration (s):                  91.43     
Total input tokens:                      81818     
Total generated tokens:                  256000    
Request throughput (req/s):              10.94     
Output token throughput (tok/s):         2800.03   
Peak output token throughput (tok/s):    3328.00   
Peak concurrent requests:                256.00    
Total token throughput (tok/s):          3694.93   
---------------Time to First Token----------------
Mean TTFT (ms):                          391.20    
Median TTFT (ms):                        334.79    
P99 TTFT (ms):                           1171.21   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.29     
Median TPOT (ms):                        43.30     
P99 TPOT (ms):                           45.17     
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.29     
Median ITL (ms):                         42.12     
P99 ITL (ms):                            76.70     
==================================================
```
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
