### PR TITLE
[Doc][Misc] Add static kernel compilation section to graph mode guide

### DIFF
--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -126,7 +126,45 @@ outputs = llm.generate("Hello, how are you?")
 
 ### Explicit configuration
 
-To explicitly control Npugraph_ex or enable additional features like static kernel:
+To explicitly control Npugraph_ex:
+
+Offline example:
+
+```python
+from vllm import LLM
+
+model = LLM(
+    model="path/to/Qwen2-7B-Instruct",
+    additional_config={
+        "ascend_compilation_config": {
+            "enable_npugraph_ex": True,
+        }
+    }
+)
+outputs = model.generate("Hello, how are you?")
+```
+
+Online example:
+
+```bash
+vllm serve Qwen/Qwen2-7B-Instruct \
+  --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":true}}'
+```
+
+To disable Npugraph_ex explicitly:
+
+```bash
+vllm serve Qwen/Qwen2-7B-Instruct \
+  --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":false}}'
+```
+
+### Static kernel compilation
+
+Static kernel compilation is an **optional** feature that pre-compiles operator binaries with fixed shapes at compile time, reducing runtime overhead for networks with static or near-static shapes. It is **disabled by default** and must be explicitly enabled.
+
+```{note}
+Enabling static kernel triggers a compilation pass during the graph capture phase at service startup. This may add **several minutes to tens of minutes** to the startup time depending on the number of operators to compile and model complexity. Once completed, subsequent request processing is not affected.
+```
 
 Offline example:
 
@@ -152,12 +190,21 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":true, "enable_static_kernel":true}}'
 ```
 
-To disable Npugraph_ex explicitly:
+#### Verifying static kernel is active
 
-```bash
-vllm serve Qwen/Qwen2-7B-Instruct \
-  --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":false}}'
+The recommended way to verify static kernel is in effect is through **Ascend Profiling**:
+
+1. Collect a profiling trace of your running model using [Ascend PyTorch Profiler](https://www.hiascend.com/document/detail/zh/Pytorch/2600/apiref/torchnpuCustomsapi/docs/zh/custom_APIs/torch_npu-profiler/torch_npu-profiler-profile.md) (`torch_npu.profiler`).
+2. Open the generated `op_statistic.csv` file.
+3. Look for operators whose `op_type` or `name` column contains the keyword **`static_kernel`**. If such entries exist, static kernel compilation has taken effect for those operators.
+
+During the compilation phase, you will see a Python warning (visible by default):
+
+```text
+Starting static kernel compilation, the build directory is <path>
 ```
+
+This confirms that compilation has been triggered. The absence of this message means static kernel was not enabled or the cached result was reused directly.
 
 For more details about Npugraph_ex, see the [torchair guide](https://www.hiascend.com/document/detail/zh/Pytorch/730/modthirdparty/torchairuseguide/torchair_00021.html).
 


### PR DESCRIPTION
### What this PR does / why we need it?
The graph mode documentation previously included `enable_static_kernel: True` in the Npugraph_ex explicit configuration example, which could mislead users into thinking static kernel is a recommended default setting. In reality, static kernel is **disabled by default** (`enable_static_kernel: bool = False`) and has significant first-run compilation overhead.
This PR:
- Separates static kernel documentation into its own dedicated subsection
- Removes `enable_static_kernel` from the Npugraph_ex basic configuration example
- Adds a clear note about compilation time cost (several minutes to tens of minutes depending on operator count)
- Recommends accounting for this overhead in the warmup phase
- Documents how to verify static kernel is active via Ascend Profiling (`op_statistic.csv`)
- Documents the visible Python warning emitted during compilation
### Does this PR introduce _any_ user-facing change?
Documentation only. No code changes.
### How was this patch tested?
- Verified accuracy of claims against torchair source code (`static_kernel.py`)
- Confirmed `warnings.warn()` is used (visible by default) for the compilation start message
- Confirmed `enable_static_kernel` defaults to `False` in `vllm_ascend/ascend_config.py`
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
