### PR TITLE
[Bugfix][CI] Clean up E2E server process trees

### DIFF
--- a/.github/workflows/scripts/ci_utils.py
+++ b/.github/workflows/scripts/ci_utils.py
@@ -72,7 +72,7 @@ def run_tests(
         report_path: If provided, write a Markdown timing report here.
 
     Returns:
-        (exit_code, records) — exit_code is 0 on full success, -1 otherwise.
+        (exit_code, records) — exit_code is 0 on full success, 1 otherwise.
     """
     records: list[TestRecord] = []
     all_passed = True
@@ -130,4 +130,4 @@ def run_tests(
         print(f"  {icon} {r.name}  ({r.elapsed:.0f}s)")
     print(flush=True)
 
-    return (0 if all_passed else -1), records
+    return (0 if all_passed else 1), records

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -80,6 +80,8 @@ _PromptMultiModalInput = list[_M] | list[list[_M]]
 PromptImageInput = _PromptMultiModalInput[Image.Image]
 PromptAudioInput = _PromptMultiModalInput[tuple[np.ndarray, int]]
 PromptVideoInput = _PromptMultiModalInput[np.ndarray]
+
+
 logger = logging.getLogger(__name__)
 
 _TEST_DIR = os.path.dirname(__file__)
@@ -415,12 +417,31 @@ class RemoteOpenAIServer:
 
     def _terminate_server(self) -> None:
         """Subclasses override this method to customize server process termination"""
-        self.proc.terminate()
+        self._terminate_process_tree(self.proc)
+
+    def _terminate_process_tree(self, proc: subprocess.Popen) -> None:
         try:
-            self.proc.wait(8)
-        except subprocess.TimeoutExpired:
-            # force kill if needed
-            self.proc.kill()
+            parent = psutil.Process(proc.pid)
+        except psutil.NoSuchProcess:
+            return
+
+        children = parent.children(recursive=True)
+        for child in children:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                child.terminate()
+
+        _, still_alive = psutil.wait_procs(children, timeout=10)
+
+        for child in still_alive:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                child.kill()
+
+        try:
+            parent.terminate()
+            parent.wait(timeout=10)
+        except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+            with contextlib.suppress(psutil.NoSuchProcess):
+                parent.kill()
 
     def url_for(self, *parts: str) -> str:
         return self.url_root + "/" + "/".join(parts)
@@ -550,25 +571,7 @@ class RemotePDServer(RemoteOpenAIServer):
     def _terminate_server(self) -> None:
         print("pd instance is stopping")
         for proc in self._proc_list:
-            with contextlib.suppress(psutil.NoSuchProcess):
-                parent = psutil.Process(proc.pid)
-                children = parent.children(recursive=True)
-                for child in children:
-                    with contextlib.suppress(psutil.NoSuchProcess):
-                        child.terminate()
-
-                gone, still_alive = psutil.wait_procs(children, timeout=10)
-
-                for child in still_alive:
-                    with contextlib.suppress(psutil.NoSuchProcess):
-                        child.kill()
-
-                try:
-                    parent.terminate()
-                    parent.wait(timeout=10)
-                except (psutil.NoSuchProcess, psutil.TimeoutExpired):
-                    with contextlib.suppress(psutil.NoSuchProcess):
-                        parent.kill()
+            self._terminate_process_tree(proc)
 
 
 class DisaggPDProxy(RemotePDServer):
@@ -712,7 +715,12 @@ class RemoteEPDServer(RemoteOpenAIServer):
         if env_dict is not None:
             env.update(env_dict)
         proc = subprocess.Popen(
-            server_cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, bufsize=1
+            server_cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            bufsize=1,
         )
         stdout_thread = threading.Thread(target=self._read_output, args=(proc.stdout, log_prefix), daemon=True)
         stderr_thread = threading.Thread(target=self._read_output, args=(proc.stderr, log_prefix), daemon=True)
@@ -722,27 +730,10 @@ class RemoteEPDServer(RemoteOpenAIServer):
         return proc
 
     def _terminate_server(self) -> None:
-        """kill process and its children"""
+        """Kill server processes and their children."""
         print("vllm instance is stopping")
         for proc in self._proc_list:
-            parent = psutil.Process(proc.pid)
-            children = parent.children(recursive=True)
-            for child in children:
-                with contextlib.suppress(psutil.NoSuchProcess):
-                    child.terminate()
-
-            gone, still_alive = psutil.wait_procs(children, timeout=10)
-
-            for child in still_alive:
-                with contextlib.suppress(psutil.NoSuchProcess):
-                    child.kill()
-
-            try:
-                parent.terminate()
-                parent.wait(timeout=10)
-            except (psutil.NoSuchProcess, psutil.TimeoutExpired):
-                with contextlib.suppress(psutil.NoSuchProcess):
-                    parent.kill()
+            self._terminate_process_tree(proc)
 
     def __enter__(self):
         """Context manager entry point."""

--- a/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
+++ b/tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
@@ -213,7 +213,7 @@ def test_models_aclgraph_capture_replay_metrics_dp2(
     warmup_runs = 1 + (2 * max_batch_sizes)
     soc_version = get_ascend_device_type()
     if soc_version in {AscendDeviceType.A3} and "DeepSeek" in model:
-        # An extra warmup run is needed for MC2 warmup here
+        # An extra warmup run is needed for MC2 warmup here.
         warmup_runs += 1
 
     # Part B: Alignment padding (Empty runs to hit the 32-step boundary)


### PR DESCRIPTION
### What this PR does / why we need it?
1. **Bug Analysis**

```bash
2026-05-01T14:07:29.6766400Z ##[error][1/26] FAILED tests/e2e/multicard/2-cards/test_qwen3_moe.py. Please go to the Summary section to quickly review the error overview, or expand the logs to view the error details.
2026-05-01T14:07:29.6776089Z 
2026-05-01T14:07:29.6776380Z ============================================================
2026-05-01T14:07:29.6776990Z [91mSummary: 0/26 passed  (3526.33s total)[0m
2026-05-01T14:07:29.6777329Z ============================================================
2026-05-01T14:07:29.6778048Z   [91m✗[0m tests/e2e/multicard/2-cards/test_qwen3_moe.py  (3526s)
2026-05-01T14:07:29.6778338Z 
2026-05-01T14:07:29.6778563Z Timing data written to test_timing_data.json  (0/1 passed)
2026-05-01T14:07:29.6778907Z +-----------------------+-------------+
2026-05-01T14:07:29.6779189Z | Suite                 | Partition   |
2026-05-01T14:07:29.6779478Z |-----------------------+-------------|
2026-05-01T14:07:29.6779752Z | e2e-multicard-2-cards | 1/1         |
2026-05-01T14:07:29.6780043Z +-----------------------+-------------+
2026-05-01T14:07:29.6780599Z Results: 0/1 passed  (actual total 3526.3s):
2026-05-01T14:07:29.6781159Z   ❌ FAILED  tests/e2e/multicard/2-cards/test_qwen3_moe.py  (actual=3526s  est=974s)
2026-05-01T14:07:29.6781529Z 
2026-05-01T14:07:29.6781700Z ❌ Skipped 4 test(s) (consider recovering):
2026-05-01T14:07:29.6782105Z   - tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py
2026-05-01T14:07:29.6782545Z   - tests/e2e/multicard/2-cards/spec_decode/test_spec_decode.py
2026-05-01T14:07:29.6782963Z   - tests/e2e/multicard/2-cards/test_offline_weight_load.py
2026-05-01T14:07:29.6783370Z   - tests/e2e/multicard/2-cards/test_shared_expert_dp.py
2026-05-01T14:07:29.6783607Z 
2026-05-01T18:07:29.7552658Z ##[group]Run python3 .github/workflows/scripts/ci_log_summary.py \
2026-05-01T18:07:29.7553275Z [36;1mpython3 .github/workflows/scripts/ci_log_summary.py \[0m
2026-05-01T18:07:29.7553704Z [36;1m  --step-name "Run multicard-2-full test " \[0m
2026-05-01T18:07:29.7554087Z [36;1m  --log-file /tmp/e2e-2card-full-part0.log \[0m
2026-05-01T18:07:29.7554744Z [36;1m  --output "$GITHUB_STEP_SUMMARY"[0m
2026-05-01T18:07:29.7555117Z shell: sh -e {0}
```

As indicated by the logs above, `pytest` has failed, and `run_suite.py` has printed the output: `Summary: 0/26 passed / Results: 0/1 passed`. According to the logic in `.github/workflows/scripts/run_suite.py` and `.github/workflows/scripts/ci_utils.py`, the script should have executed `sys.exit(-1)` at this point—meaning the shell environment should have observed a non-zero exit code.

However, the workflow executes the command using the pattern `python3 ... 2>&1 | tee /tmp/...log`. When `RemoteOpenAIServer` launches `vllm serve`, it passes `stdout=sys.stdout` and `stderr=sys.stderr` directly to the child process (see `tests/e2e/conftest.py`). In the CI environment, these `stdout` and `stderr` streams effectively correspond to the write-end of the `tee` pipe.

The timeout handling logic only calls `terminate` or `kill` on the immediate child process (`self.proc`); it does not create a new process group, nor does it terminate the entire process tree. Consequently, residual child processes spawned by `vllm serve` or its workers likely continued to hold open the `stdout` and `stderr` file descriptors, preventing `tee` from receiving an `EOF` signal.

As a result, the step stalled after printing the failure `summary` at `14:07:29`, and did not proceed to the final `summary step` until `18:07:29`. This four-hour hiatus indicates that the shell script did not properly reach the `exit ${PIPESTATUS[0]}` command. Subsequently, the self-hosted `runner` (or container execution layer) concluded the step with a `success` status; this explains why the `job` received a green checkmark, and why you did not observe the expected error messages such as `exit code 255` or `Process completed with exit code 1`.

2. **Changes:**

- Extract the existing `RemoteEPDServer` process-tree cleanup logic into a shared `_terminate_process_tree()` helper.
- Reuse the helper in both `RemoteOpenAIServer` and `RemoteEPDServer`.
- Return standard exit code `1` for failed suites instead of `-1`, avoiding shell-side `255` exit codes.


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
1. No automatic shutdown before fix; manually clean up containers after 3 minutes:
https://github.com/vllm-project/vllm-ascend/actions/runs/25537310947/job/74955778900?pr=8945#step:15:2789
```bash
2026-05-08T04:43:55.6500743Z =========================== short test summary info ============================
2026-05-08T04:43:55.6501663Z FAILED tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_w8a8_distributed_tp2_ep_dynamic_eplb - RuntimeError: Timeout: these nodes did not become ready: ['0.0.0.0'] in time: 2800s
2026-05-08T04:43:55.6502613Z ============ 1 failed, 4 passed, 28 warnings in 3567.75s (0:59:27) =============
===>2026-05-08T04:43:56.0662994Z sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
===>2026-05-08T04:47:05.4775068Z ##[error]Executing the custom container implementation failed. Please contact your self hosted runner administrator.
2026-05-08T04:47:05.5276192Z Post job cleanup.
2026-05-08T04:47:05.5309658Z ##[group]Run '/home/runner/k8s/index.js'
```

2. Auto-close after fix:
https://github.com/vllm-project/vllm-ascend/actions/runs/25535286956/job/74949842616#step:15:2554
```bash
2026-05-08T05:55:09.5424688Z ============================== slowest durations ===============================
2026-05-08T05:55:09.5425562Z 2980.72s call     tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_w8a8_distributed_tp2_ep_dynamic_eplb
2026-05-08T05:55:09.5426339Z 259.96s call     tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_distributed_mp_tp2_ep
2026-05-08T05:55:09.5427046Z 163.41s call     tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_distributed_aiv_tp2
2026-05-08T05:55:09.5427749Z 158.12s call     tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_w8a8_distributed_tp2
2026-05-08T05:55:09.5428609Z 89.16s call     tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_distributed_tp2_ep2_mrv2[True-5]
2026-05-08T05:55:09.5429066Z 
2026-05-08T05:55:09.5429248Z (10 durations < 0.005s hidden.  Use -vv to show these durations.)
2026-05-08T05:55:09.5429702Z =========================== short test summary info ============================
2026-05-08T05:55:09.5430609Z FAILED tests/e2e/multicard/2-cards/test_qwen3_moe.py::test_qwen3_moe_w8a8_distributed_tp2_ep_dynamic_eplb - RuntimeError: Timeout: these nodes did not become ready: ['0.0.0.0'] in time: 2800s
2026-05-08T05:55:09.5431555Z ============ 1 failed, 4 passed, 28 warnings in 3651.81s (1:00:51) =============
===>2026-05-08T05:55:09.9362175Z sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
===>2026-05-08T05:55:11.9190424Z ##[error]Error: failed to run script step: Error: command terminated with non-zero exit code: command terminated with exit code 1
2026-05-08T05:55:11.9343101Z ##[error]Process completed with exit code 1.
2026-05-08T05:55:11.9479998Z ##[error]Executing the custom container implementation failed. Please contact your self hosted runner administrator.
2026-05-08T05:55:12.0111010Z Post job cleanup.
2026-05-08T05:55:12.0161196Z ##[group]Run '/home/runner/k8s/index.js'
2026-05-08T05:55:12.0162484Z shell: /home/runner/externals/node20/bin/node {0}
2026-05-08T05:55:12.0162814Z ##[endgroup]
```

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
