### PR TITLE
[CI] Add doc linkcheck ignore rule

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,6 +160,7 @@ linkcheck_ignore = [
     r"https?://<[^>]+>.*",
     r"https://github\.com/vllm-project/vllm-ascend/issues/new/choose",
     r"https://github\.com/[^/?#]+/?$",
+    r"https?://.*\$%7B.*%7D.*",
 ]
 
 READTHEDOCS_VERSION_TYPE = os.environ.get("READTHEDOCS_VERSION_TYPE")


### PR DESCRIPTION
### What this PR does / why we need it?

Add regex pattern to ignore URLs containing URL-encoded template variables ($%7B...%7D) during Sphinx linkcheck

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
