### PR TITLE
[v0.18.0][Bugfix][P/D] Fix Mooncake Connector MTP accuracy bug

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1062,7 +1062,7 @@ class MooncakeConnectorScheduler:
         return delay_free_blocks, dict(
             do_remote_prefill=True,
             do_remote_decode=False,
-            remote_block_ids=computed_block_ids,
+            remote_block_ids=computed_block_ids[:num_prompt_blocks],
             remote_engine_id=self.engine_id,
             remote_request_id=request.request_id,
             remote_host=self.side_channel_host,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
When MTP is used, the prefill node allocate extra kvcache block used by MTP, while the decode node does allocate the kvcache block when waiting for KV transfer. As a result, when the prompt length is a multiple of the block size, the blocks of P and D may not be in one-to-one correspondence. This PR calculates the number of blocks occupied by the actual prompt and cuts off the extra blocks that may be generated to ensure the accuracy.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By nightly.
