### PR TITLE
[BugFix][310P]: allow causal mask for qwen pooling models on 310p (fixes #6471)

### DIFF
--- a/tests/ut/_310p/attention/test_attention_mask_310.py
+++ b/tests/ut/_310p/attention/test_attention_mask_310.py
@@ -29,8 +29,30 @@ class TestAttentionMaskBuilder310(TestBase):
     def test_get_attention_mask_310_for_pooling_model(self):
         model_config = MagicMock()
         model_config.runner_type = "pooling"
+        model_config.pooler_config.seq_pooling_type = "FIRST"
         with self.assertRaises(NotImplementedError):
             self.attention_mask_builder.get_attention_mask(model_config)
+
+    @patch("torch_npu.npu_format_cast")
+    def test_get_attention_mask_310_for_last_pooling_model(self, mock_format_cast):
+        mock_format_cast.side_effect = lambda x, y: x
+        model_config = MagicMock()
+        model_config.runner_type = "pooling"
+        model_config.pooler_config.seq_pooling_type = "LAST"
+        attn_mask = self.attention_mask_builder.get_attention_mask(model_config)
+        self.assertEqual(attn_mask.shape, (1, self.max_seqlen // 16, self.max_seqlen, 16))
+        self.assertEqual(attn_mask[0][-1][0][-1], torch.tensor(float("-inf"), dtype=torch.float16))
+
+    @patch("torch_npu.npu_format_cast")
+    def test_get_attention_mask_310_for_qwen_pooling_model(self, mock_format_cast):
+        mock_format_cast.side_effect = lambda x, y: x
+        model_config = MagicMock()
+        model_config.runner_type = "pooling"
+        model_config.hf_config.architectures = ["Qwen3ForCausalLM"]
+        model_config.pooler_config.seq_pooling_type = "FIRST"
+        attn_mask = self.attention_mask_builder.get_attention_mask(model_config)
+        self.assertEqual(attn_mask.shape, (1, self.max_seqlen // 16, self.max_seqlen, 16))
+        self.assertEqual(attn_mask[0][-1][0][-1], torch.tensor(float("-inf"), dtype=torch.float16))
 
     @patch("torch_npu.npu_format_cast")
     def test_get_attention_mask_310(self, mock_format_cast):

--- a/vllm_ascend/_310p/attention/attention_mask.py
+++ b/vllm_ascend/_310p/attention/attention_mask.py
@@ -92,8 +92,9 @@ class AttentionMaskBuilder310:
         """
         Retrieves the appropriate attention mask based on the model configuration.
 
-        It explicitly checks for 'pooling' runner types which are not supported
-        on 310P hardware.
+        Pooling models that use Qwen architecture or LAST sequence pooling,
+        such as Qwen3 embedding, still use causal attention on 310P. Other
+        pooling models are not supported yet.
 
         Args:
             model_config: Configuration object containing runner details.
@@ -102,9 +103,19 @@ class AttentionMaskBuilder310:
             torch.Tensor: The causal attention mask.
 
         Raises:
-            NotImplementedError: If the runner_type is 'pooling'.
+            NotImplementedError: If the runner_type is 'pooling' without LAST
+                sequence pooling.
         """
         if getattr(model_config, "runner_type", None) == "pooling":
+            hf_config = getattr(model_config, "hf_config", None)
+            pooler_config = getattr(model_config, "pooler_config", None)
+            architectures = getattr(hf_config, "architectures", None) or []
+            if isinstance(architectures, str):
+                architectures = [architectures]
+            if any("qwen" in str(architecture).lower() for architecture in architectures):
+                return self._get_causal_mask(self.max_seqlen)
+            if getattr(pooler_config, "seq_pooling_type", None) == "LAST":
+                return self._get_causal_mask(self.max_seqlen)
             # TODO: pooling model will be supported soon.
             raise NotImplementedError("310P does not support runner_type='pooling'")
         return self._get_causal_mask(self.max_seqlen)


### PR DESCRIPTION

## What this PR does / why we need it?

This PR aims at solving issue #6471

Qwen3-Embedding runs through the pooling runner, but its HF architecture is still `Qwen3ForCausalLM`, so it requires a causal attention mask on 310P.

Previously, 310P rejected all `runner_type="pooling"` models in `AttentionMaskBuilder310.get_attention_mask`, causing Qwen3-Embedding deployment to fail with `NotImplementedError`.

This PR allows pooling models to use the causal mask when:
- the model architecture contains `qwen`, or
- `pooler_config.seq_pooling_type == "LAST"`.

Other pooling models remain unsupported on 310P.

## Does this PR introduce any user-facing change?

Yes. Qwen3-Embedding models can run on 310P without failing during attention mask creation.

## How was this patch tested?
Verified on Ascend 310P by serving `Qwen3-Embedding-0.6B` and confirming the model no longer fails during attention mask creation.
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
