### PR TITLE
[Feature] DFlash + Qwen3.5-9B support and FDO/FULL acceptance rate fix

### DIFF
--- a/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule_tiling.cpp
@@ -49,7 +49,7 @@ const size_t DIM_1 = 1;
 const size_t DIM_2 = 2;
 const size_t DIM_3 = 3;
 
-const size_t MAX_MTP = 8;
+const size_t MAX_MTP = 12;
 
 template <typename T1, typename T2>
 static T1 CeilDiv(T1 a, T2 b)

--- a/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
+++ b/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule.h
@@ -25,7 +25,7 @@ using namespace matmul;
 using namespace AscendC;
 constexpr uint64_t BUFFER_NUM = 1;
 constexpr uint32_t MAX_OUT_BUFFER_NUM = 2;
-constexpr uint64_t MAX_MTP = 8;
+constexpr uint64_t MAX_MTP = 12;
 constexpr uint64_t BF16_NUM_PER_BLOCK = 16;
 constexpr uint64_t FP32_NUM_PER_BLOCK = 8;
 constexpr uint32_t REPEAT_LENTH = 64; // 256Byte for float

--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -212,7 +212,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(result, "test_output")
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -227,7 +227,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method captures graph for the first time"""
@@ -270,7 +270,7 @@ class TestACLGraphWrapper(TestBase):
         result = wrapper(test_tensor, "arg2")
 
         # Verify graph capture happened
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
         self.mock_runnable.assert_called_once_with(test_tensor, "arg2")
@@ -288,7 +288,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(result, "test_output")
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -303,7 +303,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method replays graph when already captured"""
@@ -348,7 +348,7 @@ class TestACLGraphWrapper(TestBase):
         first_result = wrapper(test_tensor, "arg2")
 
         # Verify graph capture happened during first call
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once()
 
@@ -370,7 +370,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(second_result, "weak_ref_output")  # Weak ref output
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -383,7 +383,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method with debug mode input address checking"""
@@ -432,7 +432,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertTrue(True)
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -445,7 +445,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method with debug mode input address mismatch raises AssertionError"""
@@ -495,7 +495,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertIn("Input addresses for aclgraphs are different", str(context.exception))
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -512,7 +512,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method captures graph with gc_disable option enabled"""
@@ -569,7 +569,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertTrue(mock_patch.called)
 
         # Verify graph capture happened
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
 
@@ -577,7 +577,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(result, "test_output")
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
-    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled")
     @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
@@ -592,7 +592,7 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform,
         mock_get_forward_context,
         mock_get_forward_context_2,
-        mock_validate_cudagraph_capturing_enabled,
+        mock_set_cudagraph_capturing_enabled,
         mock_torch,
     ):
         """Test __call__ method captures graph with weak_ref_output option enabled"""
@@ -643,7 +643,7 @@ class TestACLGraphWrapper(TestBase):
         self.assertEqual(mock_weak_ref_tensors.call_count, 2)
 
         # Verify graph capture happened
-        mock_validate_cudagraph_capturing_enabled.assert_called_once()
+        mock_set_cudagraph_capturing_enabled.assert_called_once_with(True)
         mock_torch.npu.NPUGraph.assert_called_once()
         mock_torch.npu.graph.assert_called_once_with(mock_npu_graph, pool=self.mock_graph_pool)
 
@@ -692,7 +692,7 @@ class TestACLGraphWrapper(TestBase):
                 mock_weak_ref_tensors.side_effect = ["inner_output", "weak_ref_output"]
 
                 # Mock validate_cudagraph_capturing_enabled
-                with patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled"):
+                with patch("vllm_ascend.compilation.acl_graph.set_cudagraph_capturing_enabled"):
                     wrapper = ACLGraphWrapper(
                         runnable=self.mock_runnable,
                         vllm_config=self.mock_vllm_config,

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1263,6 +1263,7 @@ class TestEagleProposerPropose:
 
 class MockCpuGpuBuffer:
     """Mock CpuGpuBuffer for testing"""
+
     def __init__(self, max_size, dtype, device="cpu", **kwargs):
         self.max_size = max_size
         self.dtype = dtype
@@ -1270,7 +1271,7 @@ class MockCpuGpuBuffer:
         self.cpu = torch.zeros(max_size, dtype=dtype, device="cpu")
         self.np = self.cpu.numpy()
         self.gpu = torch.zeros(max_size, dtype=dtype, device=device)
-    
+
     def copy_to_gpu(self, size=None):
         if size is None:
             size = self.max_size
@@ -1279,10 +1280,11 @@ class MockCpuGpuBuffer:
 
 class MockCachedRequestState:
     """Mock CachedRequestState for testing"""
+
     def __init__(self, req_id, token_ids):
         self.req_id = req_id
         self.token_ids = token_ids
-    
+
     def get_token_id(self, position):
         if position < len(self.token_ids):
             return self.token_ids[position]
@@ -1291,6 +1293,7 @@ class MockCachedRequestState:
 
 class MockInputBatch:
     """Mock InputBatch for testing"""
+
     def __init__(self, num_reqs, req_ids, vocab_size):
         self.num_reqs = num_reqs
         self.req_ids = req_ids
@@ -1299,7 +1302,7 @@ class MockInputBatch:
 
 class TestPrepareNextTokenIdsPadded(TestBase):
     """Test prepare_next_token_ids_padded method with precision validation"""
-    
+
     def setUp(self):
         self.vllm_config = MagicMock(spec=VllmConfig)
         self.vllm_config.speculative_config = MagicMock()
@@ -1355,30 +1358,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case where all requests have valid sampled tokens"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, 102, 103, 104],
-            [200, 201, 202, 203, 204],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, 102, 103, 104],
+                [200, 201, 202, 203, 204],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(10))),
             "req_1": MockCachedRequestState("req_1", list(range(15))),
             "req_2": MockCachedRequestState("req_2", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1387,13 +1389,13 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         self.assertEqual(next_token_ids.shape[0], num_reqs)
         self.assertEqual(valid_sampled_tokens_count.shape[0], num_reqs)
-        
+
         expected_valid_counts = torch.tensor([5, 5, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_next_tokens = torch.tensor([104, 204, 304], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
 
@@ -1401,30 +1403,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case where some tokens are rejected (marked as -1)"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, -1, -1, -1],
-            [200, 201, 202, 203, -1],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, -1, -1, -1],
+                [200, 201, 202, 203, -1],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(10))),
             "req_1": MockCachedRequestState("req_1", list(range(15))),
             "req_2": MockCachedRequestState("req_2", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1433,10 +1434,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([2, 4, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_next_tokens = torch.tensor([101, 203, 304], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
 
@@ -1444,30 +1445,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case where all tokens are rejected, should use backup token"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [-1, -1, -1, -1, -1],
-            [-1, -1, -1, -1, -1],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
             "req_2": MockCachedRequestState("req_2", list(range(25))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1476,10 +1476,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([0, 0, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_backup_token_0 = requests["req_0"].get_token_id(10)
         expected_backup_token_1 = requests["req_1"].get_token_id(15)
         expected_next_tokens = torch.tensor([expected_backup_token_0, expected_backup_token_1, 304], dtype=torch.int64)
@@ -1489,30 +1489,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test case with discarded requests"""
         num_reqs = 3
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, 102, 103, 104],
-            [200, 201, 202, 203, 204],
-            [300, 301, 302, 303, 304],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, 102, 103, 104],
+                [200, 201, 202, 203, 204],
+                [300, 301, 302, 303, 304],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
             "req_2": MockCachedRequestState("req_2", list(range(25))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([0, 2], dtype=torch.int64)
         num_discarded_requests = 2
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1521,10 +1520,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([0, 5, 0], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_backup_token_0 = requests["req_0"].get_token_id(10)
         expected_backup_token_2 = requests["req_2"].get_token_id(20)
         expected_next_tokens = torch.tensor([expected_backup_token_0, 204, expected_backup_token_2], dtype=torch.int64)
@@ -1534,32 +1533,33 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test mixed scenario: some rejected tokens, some discarded requests, some all-rejected"""
         num_reqs = 4
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15, 20, 25], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, -1, -1, -1],
-            [-1, -1, -1, -1, -1],
-            [300, 301, 302, 303, 304],
-            [400, 401, 402, -1, -1],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [300, 301, 302, 303, 304],
+                [400, 401, 402, -1, -1],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
             "req_2": MockCachedRequestState("req_2", list(range(25))),
             "req_3": MockCachedRequestState("req_3", list(range(30))),
         }
-        
+
         gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1", "req_2", "req_3"],
-            vocab_size=vocab_size
+            num_reqs=num_reqs, req_ids=["req_0", "req_1", "req_2", "req_3"], vocab_size=vocab_size
         )
-        
+
         discard_request_indices = torch.tensor([1], dtype=torch.int64)
         num_discarded_requests = 1
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1568,10 +1568,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([2, 0, 5, 3], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_backup_token_1 = requests["req_1"].get_token_id(15)
         expected_next_tokens = torch.tensor([101, expected_backup_token_1, 304, 402], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
@@ -1580,24 +1580,20 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test with single request"""
         num_reqs = 1
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10], dtype=torch.int32)
-        
+
         sampled_token_ids = torch.tensor([[100, 101, 102, 103, 104]], dtype=torch.int64)
-        
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1606,10 +1602,10 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         expected_valid_counts = torch.tensor([5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         expected_next_tokens = torch.tensor([104], dtype=torch.int64)
         self.assertTrue(torch.equal(next_token_ids, expected_next_tokens))
 
@@ -1617,28 +1613,27 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test with tokens at vocab size boundary"""
         num_reqs = 2
         vocab_size = 100
-        
+
         seq_lens_cpu = torch.tensor([10, 15], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [99, 100, 101, -1, -1],
-            [50, 51, 52, 53, 54],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [99, 100, 101, -1, -1],
+                [50, 51, 52, 53, 54],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1647,12 +1642,12 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         # Token 100 and 101 are >= vocab_size (100), so they are invalid
         # Only token 99 is valid for the first request
         expected_valid_counts = torch.tensor([1, 5], dtype=torch.int64)
         self.assertTrue(torch.equal(valid_sampled_tokens_count, expected_valid_counts))
-        
+
         # Next token should be 99 (last valid token) for first request
         # and 54 for second request
         expected_next_tokens = torch.tensor([99, 54], dtype=torch.int64)
@@ -1662,28 +1657,27 @@ class TestPrepareNextTokenIdsPadded(TestBase):
         """Test to verify key variables that affect downstream computation"""
         num_reqs = 2
         vocab_size = 1000
-        
+
         seq_lens_cpu = torch.tensor([10, 15], dtype=torch.int32)
-        
-        sampled_token_ids = torch.tensor([
-            [100, 101, -1, -1, -1],
-            [200, 201, 202, -1, -1],
-        ], dtype=torch.int64)
-        
+
+        sampled_token_ids = torch.tensor(
+            [
+                [100, 101, -1, -1, -1],
+                [200, 201, 202, -1, -1],
+            ],
+            dtype=torch.int64,
+        )
+
         requests = {
             "req_0": MockCachedRequestState("req_0", list(range(15))),
             "req_1": MockCachedRequestState("req_1", list(range(20))),
         }
-        
-        gpu_input_batch = MockInputBatch(
-            num_reqs=num_reqs,
-            req_ids=["req_0", "req_1"],
-            vocab_size=vocab_size
-        )
-        
+
+        gpu_input_batch = MockInputBatch(num_reqs=num_reqs, req_ids=["req_0", "req_1"], vocab_size=vocab_size)
+
         discard_request_indices = torch.tensor([], dtype=torch.int64)
         num_discarded_requests = 0
-        
+
         next_token_ids, valid_sampled_tokens_count = self.proposer.prepare_next_token_ids_padded(
             seq_lens_cpu=seq_lens_cpu,
             sampled_token_ids=sampled_token_ids,
@@ -1692,27 +1686,29 @@ class TestPrepareNextTokenIdsPadded(TestBase):
             discard_request_indices=discard_request_indices,
             num_discarded_requests=num_discarded_requests,
         )
-        
+
         # Verify return values
         self.assertEqual(next_token_ids[0].item(), 101, "next_token_ids[0] should be 101")
         self.assertEqual(next_token_ids[1].item(), 202, "next_token_ids[1] should be 202")
         self.assertEqual(valid_sampled_tokens_count[0].item(), 2, "valid_sampled_tokens_count[0] should be 2")
         self.assertEqual(valid_sampled_tokens_count[1].item(), 3, "valid_sampled_tokens_count[1] should be 3")
-        
+
         # Verify public member that affects downstream computation
         expected_backup_0 = requests["req_0"].get_token_id(10)
         expected_backup_1 = requests["req_1"].get_token_id(15)
         self.assertEqual(
-            self.proposer.backup_next_token_ids.np[0], 
+            self.proposer.backup_next_token_ids.np[0],
             expected_backup_0,
-            f"backup_next_token_ids[0] should be {expected_backup_0}"
+            f"backup_next_token_ids[0] should be {expected_backup_0}",
         )
         self.assertEqual(
-            self.proposer.backup_next_token_ids.np[1], 
+            self.proposer.backup_next_token_ids.np[1],
             expected_backup_1,
-            f"backup_next_token_ids[1] should be {expected_backup_1}"
+            f"backup_next_token_ids[1] should be {expected_backup_1}",
         )
-        
+
         # Verify data types
         self.assertEqual(next_token_ids.dtype, torch.int64, "next_token_ids dtype should be torch.int64")
-        self.assertEqual(valid_sampled_tokens_count.dtype, torch.int64, "valid_sampled_tokens_count dtype should be torch.int64")
+        self.assertEqual(
+            valid_sampled_tokens_count.dtype, torch.int64, "valid_sampled_tokens_count dtype should be torch.int64"
+        )

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -509,13 +509,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         scale,
                         attn_output,
                         softmax_lse,
+                        sparse_mode,
                         c8_k_aq_scale,
                         c8_k_aq_offset,
                         c8_v_aq_scale,
                         c8_v_aq_offset,
                     ) = param
 
-                    sparse_mode = 3
                     if _EXTRA_CTX.is_draft_model:
                         draft_step = attn_count // num_layers
                         seq_lens = attn_metadata[draft_step][key].seq_lens_list
@@ -528,6 +528,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         seq_lens = attn_metadata[key].seq_lens_list
                         actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
                         block_tables = attn_metadata[key].block_tables
+
+                    # TND layout constraint: queryT must equal
+                    # actual_seq_lengths_q[-1]. When the graph was captured
+                    # with a padded num_tokens (e.g. 16) but the live batch
+                    # produces fewer actual tokens (e.g. 9), the mismatch
+                    # causes FIA kernel validation failure.
+                    if actual_seq_lengths_q and actual_seq_lengths_q[-1] != num_tokens:
+                        actual_seq_lengths_q = list(actual_seq_lengths_q)
+                        actual_seq_lengths_q[-1] = num_tokens
 
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
@@ -597,7 +606,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         workspace = graph_params.workspaces.get(num_tokens)
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
-        attn_mask = attn_metadata.attn_mask
+        attn_mask = attn_metadata.attn_mask if attn_metadata.causal else None
         sparse_mode = 3 if attn_metadata.causal else 0
         extra_args = {}
         if self.enable_c8_quant:
@@ -658,6 +667,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             self.scale,
             weak_ref_tensors(output),
             weak_ref_tensors(softmax_lse),
+            sparse_mode,
         )
         if self.enable_c8_quant:
             attn_params = attn_params + (

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+from collections import defaultdict
 from collections.abc import Callable
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -13,7 +14,7 @@ import torch_npu
 import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphOptions
-from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
@@ -134,8 +135,8 @@ class ACLGraphWrapper:
                 # shape. E.g. we only log it for the first subgraph in
                 # piecewise mode.
                 logger.debug("Capturing a aclgraph on (%s,%s)", self.runtime_mode.name, entry.batch_descriptor)
-            # validate that aclgraph capturing is legal at this point.
-            validate_cudagraph_capturing_enabled()
+            # enable aclgraph capturing for lazy capture path (draft model)
+            set_cudagraph_capturing_enabled(True)
 
             input_addresses = [x.data_ptr() for x in args if isinstance(x, torch.Tensor)]
             entry.input_addresses = input_addresses
@@ -246,10 +247,10 @@ def update_full_graph_params(
 
 @dataclass
 class GraphParams:
-    events: dict[int, list[torch.npu.ExternalEvent]]
+    events: defaultdict[int, list[torch.npu.ExternalEvent]]
     workspaces: dict[int, torch.Tensor]
-    handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
-    attn_params: dict[int, list[tuple]]
+    handles: defaultdict[int, list[torch_npu._C._NPUTaskGroupHandle]]
+    attn_params: defaultdict[int, list[tuple]]
 
 
 _graph_params: GraphParams | None = None
@@ -260,10 +261,10 @@ def set_graph_params(aclgraph_capture_sizes: list[int]):
     if _graph_params is not None:
         raise ValueError("Graph parameters have already been set!")
     _graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
         {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
     )
 
 
@@ -285,10 +286,10 @@ def set_draft_graph_params(aclgraph_capture_sizes: list[int]):
     if _draft_graph_params is not None:
         raise ValueError("DraftGraph parameters have already been set!")
     _draft_graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
         {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
     )
 
 
@@ -310,10 +311,10 @@ def set_draft_graph_prefill_params(aclgraph_capture_sizes: list[int]):
     if _draft_graph_prefill_params is not None:
         raise ValueError("DraftGraph preill parameters have already been set!")
     _draft_graph_prefill_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
         {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
+        defaultdict(list, {size: [] for size in aclgraph_capture_sizes}),
     )
 
 

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -259,16 +259,16 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             g_non_spec = g
             beta_non_spec = beta
 
-        # 2.1: Process the multi-query part
+        # 2.1: Process the multi-query part (spec decode path)
+        # Uses the AscendC custom operator (via ASCEND_CUSTOM_OPP_PATH).
+        # Requires MAX_MTP >= num_speculative_tokens + 1 in the kernel.
         if spec_sequence_masks is not None:
             cu_seqlens = spec_query_start_loc[: attn_metadata.num_spec_decodes + 1]
             actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
             query_spec = l2norm_fwd(query_spec)
             key_spec = l2norm_fwd(key_spec)
-            # Dispatches to the vllm-ascend AscendC custom operator
-            # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
-            # The custom op extends dtype support (e.g. float32 state) and is
-            # loaded at runtime via ASCEND_CUSTOM_OPP_PATH.
+            scale = key_spec.shape[-1] ** -0.5
+            flat_state_indices = spec_state_indices_tensor.flatten()
             core_attn_out_spec = torch_npu.npu_recurrent_gated_delta_rule(
                 query=query_spec.squeeze(0),
                 key=key_spec.squeeze(0),
@@ -276,9 +276,9 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 g=g_spec.squeeze(0),
                 beta=beta_spec.squeeze(0),
                 state=ssm_state,
-                scale=key_spec.shape[-1] ** -0.5,
+                scale=scale,
                 actual_seq_lengths=actual_seq_lengths,
-                ssm_state_indices=spec_state_indices_tensor.flatten(),
+                ssm_state_indices=flat_state_indices,
                 num_accepted_tokens=num_accepted_tokens.to(torch.int32),
             ).unsqueeze(0)
         else:

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -280,6 +280,8 @@ class AscendYaRNRotaryEmbedding(YaRNScalingRotaryEmbedding):
         super().__init__(
             head_size, rotary_dim, max_position_embeddings, base, is_neox_style, scaling_factor, dtype, **extra_kwargs
         )
+        vllm_config = get_current_vllm_config()
+        self.use_mtp = vllm_config.speculative_config and vllm_config.speculative_config.method == "mtp"
         _record_cos_sin_cache(self.cos_sin_cache)
 
     def forward_oot(

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -107,7 +107,7 @@ class AscendDflashProposer(AscendEagleProposer):
             num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.block_size,
+            block_size=self.kernel_block_size,
             num_query_per_req=num_query_per_req,
             num_speculative_tokens=self.num_speculative_tokens,
             total_input_tokens=num_context,

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -289,6 +289,18 @@ class AscendDflashProposer(AscendEagleProposer):
             self._context_slot_mapping_buffer[:num_context],
         )
 
+    def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
+        """DFlash reads use_aux_hidden_state from dflash_config."""
+        use_aux_hidden_state = True
+        dflash_config = getattr(
+            self.draft_model_config.hf_config, "dflash_config", None
+        )
+        if dflash_config is not None:
+            use_aux_hidden_state = dflash_config.get(
+                "use_aux_hidden_state", True
+            )
+        return use_aux_hidden_state
+
     def _raise_if_multimodal(self):
         # Allow DFlash on multimodal models running in text-only mode
         # (e.g., Qwen3.5 with --language-model-only).

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -129,7 +129,9 @@ class AscendDflashProposer(AscendEagleProposer):
         ).to(torch.int32)
 
         if hasattr(cad, "actual_seq_lengths_q"):
-            cad.actual_seq_lengths_q = [num_query_per_req] * batch_size
+            # Keep runtime metadata consistent with graph capture and FIA TND
+            # expectations by storing cumulative query lengths per request.
+            cad.actual_seq_lengths_q = new_query_start_loc[1:].tolist()
         if hasattr(cad, "decode_token_per_req"):
             cad.decode_token_per_req = num_query_per_req
 

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -166,35 +166,61 @@ class AscendDflashProposer(AscendEagleProposer):
         num_query_per_req = 1 + self.num_speculative_tokens
         num_query_total = num_reqs * num_query_per_req
 
+        # init block table tensor clone is only available after profile run
+        # and is only used for graph mode
+        if self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
+            self.block_table_tensor_clone = torch.zeros(
+                (
+                    self.runner.max_num_tokens + 2 * self.pcp_size * self.runner.max_num_reqs,
+                    self.runner.input_batch.block_table[0].get_device_tensor().shape[1],
+                ),
+                dtype=torch.int32,
+                device=self.device,
+                pin_memory=self.runner.pin_memory,
+            )
+
         context_positions = self._context_positions_buffer[:num_input_tokens]
         context_states = self.hidden_states[:num_input_tokens]
 
+        # Build attn_metadata for FULL graph capture so that FIA operators
+        # are properly included in the captured graph (DFlash needs non-causal attention).
         multi_steps_attn_metadata = []
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
-            builder = self.draft_attn_groups[0].get_metadata_builder()
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.draft_attn_groups) > 0:
+            # DFlash uses num_query_per_req tokens per request
+            num_query_per_req = 1 + self.num_speculative_tokens
+            batch_size = max(num_input_tokens // num_query_per_req, 1)
+
+            # Build correct DFlash query_start_loc: [0, nq, 2*nq, ...]
+            dflash_qsl = self.arange_dflash[: batch_size + 1] * num_query_per_req
+            dflash_qsl_cpu = torch.arange(batch_size + 1, dtype=torch.int32) * num_query_per_req
+            # Correct actual_seq_lengths_q for DFlash: cumulative query lengths
+            dflash_actual_seq_q = self.arange_dflash[1 : batch_size + 1] * num_query_per_req
+
             common_attn_metadata = AscendCommonAttentionMetadata(
-                query_start_loc=self.arange_dflash[: num_reqs + 1] * num_query_per_req,
-                query_start_loc_cpu=torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * num_query_per_req,
+                query_start_loc=dflash_qsl,
+                query_start_loc_cpu=dflash_qsl_cpu,
                 seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
-                seq_lens=self.runner.seq_lens[:num_reqs],
-                num_reqs=num_reqs,
-                num_actual_tokens=num_query_tokens,
+                seq_lens=self.runner.seq_lens[:batch_size],
+                num_reqs=batch_size,
+                num_actual_tokens=num_input_tokens,
+                num_input_tokens=num_input_tokens,
                 max_query_len=num_query_per_req,
-                max_seq_len=0,
-                slot_mapping=self._slot_mapping_buffer[:num_query_total],
+                num_computed_tokens_cpu=None,
+                actual_seq_lengths_q=dflash_actual_seq_q,
+                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:batch_size],
+                slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
+                positions=self.runner.positions,
                 attn_state=AscendAttentionState.ChunkedPrefill,
+                decode_token_per_req=num_query_per_req,
+                max_seq_len=0,
                 causal=False,
-                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
             )
 
+            builder = self.draft_attn_groups[0].get_metadata_builder()
             attn_metadata_dflash = builder.build_for_graph_capture(
                 common_attn_metadata,
                 AscendAttentionState.ChunkedPrefill,
             )
-
-            attn_metadata_dflash.attn_mask = None
-            attn_metadata_dflash.attn_state = AscendAttentionState.ChunkedPrefill
-
             per_layer_attn_metadata = dict()
             for layer_name in self.attn_layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata_dflash
@@ -210,7 +236,7 @@ class AscendDflashProposer(AscendEagleProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=multi_steps_attn_metadata,
+            draft_attn_metadatas=multi_steps_attn_metadata if multi_steps_attn_metadata else None,
         ):
             self.model.precompute_and_store_context_kv(context_states, context_positions)
 
@@ -219,23 +245,54 @@ class AscendDflashProposer(AscendEagleProposer):
                 positions=self._get_positions(num_query_total),
                 inputs_embeds=None,
             )
+            if multi_steps_attn_metadata:
+                forward_context = get_forward_context()
+                if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                    self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
-            forward_context = get_forward_context()
-            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
-                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
+        # Clear ALL draft_graph_params stored during dummy_run warmup.
+        # Issues with keeping dummy_run's params:
+        # 1. attn_params: duplicate entries when real call uses same key
+        # 2. workspaces: computed with stale seq_lens (near 0), too small for
+        #    real inference (e.g. seq_lens=118) → NPU buffer overflow (error 507057)
+        # 3. events/handles: stale references
+        # The first real ACLGraphWrapper capture will re-populate everything correctly.
+        if multi_steps_attn_metadata:
+            from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, get_draft_graph_params
 
-    def build_model_inputs_first_pass(
-        self,
-        num_input_tokens: int,
-    ) -> dict[str, Any]:
+            draft_gp = get_draft_graph_params()
+            if draft_gp is not None:
+                for key in list(draft_gp.attn_params.keys()):
+                    draft_gp.attn_params[key] = []
+                    draft_gp.events[key] = []
+                    draft_gp.handles[key] = []
+                for key in list(draft_gp.workspaces.keys()):
+                    draft_gp.workspaces[key] = None
+            # Invalidate ACLGraphWrapper's captured graph entries so the first
+            # real _propose() call re-captures with correct runtime params.
+            # During dummy_run, self.model (ACLGraphWrapper) captured a graph
+            # with stale dummy values. Without clearing, the first real call
+            # would replay that stale graph instead of re-capturing.
+            if isinstance(self.model, ACLGraphWrapper):
+                self.model.concrete_aclgraph_entries.clear()
+
+    def prepare_context_kv(self) -> None:
+        """Precompute and store context KV OUTSIDE the graph boundary.
+
+        This must run eagerly (before graph replay) because num_context varies
+        between calls, making it incompatible with fixed-shape graph replay.
+        """
         num_context = self._dflash_num_context
-
         self.model.precompute_and_store_context_kv(
             self._dflash_hidden_states,
             self._context_positions_buffer[:num_context],
             self._context_slot_mapping_buffer[:num_context],
         )
 
+    def build_model_inputs_first_pass(
+        self,
+        num_input_tokens: int,
+    ) -> dict[str, Any]:
         return dict(
             input_ids=self.input_ids[:num_input_tokens], positions=self.positions[:num_input_tokens], inputs_embeds=None
         )

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -289,6 +289,11 @@ class AscendDflashProposer(AscendEagleProposer):
             self._context_slot_mapping_buffer[:num_context],
         )
 
+    def _raise_if_multimodal(self):
+        # Allow DFlash on multimodal models running in text-only mode
+        # (e.g., Qwen3.5 with --language-model-only).
+        pass
+
     def build_model_inputs_first_pass(
         self,
         num_input_tokens: int,

--- a/vllm_ascend/spec_decode/draft_proposer.py
+++ b/vllm_ascend/spec_decode/draft_proposer.py
@@ -1,5 +1,5 @@
 import torch
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 
 from vllm_ascend.spec_decode.eagle_proposer import AscendSpecDecodeBaseProposer
@@ -15,3 +15,11 @@ class AscendDraftModelProposer(DraftModelProposer, AscendSpecDecodeBaseProposer)
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, False, runner=runner)
         self._raise_if_vocab_size_mismatch()
         self._raise_if_draft_tp_mismatch()
+
+    def _maybe_share_lm_head(self, target_language_model) -> None:
+        # Draft models don't share lm_head with the target model.
+        # But we still need to initialize full graph support if enabled.
+        if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
+            from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
+            self.update_stream = torch.npu.Stream()
+            self._runnable = ACLGraphWrapper(self._run_merged_draft, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)

--- a/vllm_ascend/spec_decode/draft_proposer.py
+++ b/vllm_ascend/spec_decode/draft_proposer.py
@@ -21,5 +21,6 @@ class AscendDraftModelProposer(DraftModelProposer, AscendSpecDecodeBaseProposer)
         # But we still need to initialize full graph support if enabled.
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
             from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
+
             self.update_stream = torch.npu.Stream()
             self._runnable = ACLGraphWrapper(self._run_merged_draft, self.vllm_config, runtime_mode=CUDAGraphMode.FULL)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -845,14 +845,38 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "num_tokens": num_tokens,
                 "is_prefill": attn_metadata_i.num_prefills,
             }
-            run_draft = partial(self._runnable, **model_inputs)
+            use_eager_draft = (
+                self.method == "dflash"
+                and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+                and not sampling_metadata.all_greedy
+            )
+            # For stochastic decoding paths (e.g. thinking high with
+            # temperature/top-p sampling), DFlash draft graph replay can
+            # corrupt acceptance behavior on Qwen3.5 hybrid attention.
+            # Keep the target model on FDO graph while running the draft path
+            # eagerly for correctness.
+            run_draft = partial(
+                self._run_merged_draft if use_eager_draft else self._runnable,
+                **model_inputs,
+            )
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
                 draft_token_ids = run_draft()
             else:
+                if self.method == "dflash" and not use_eager_draft:
+                    # DFlash draft graph replay depends on the live non-causal
+                    # attention metadata for the current step. Refresh graph
+                    # params before replay so it does not consume stale state
+                    # from the previous step.
+                    self._update_full_graph_params_if_needed(
+                        forward_context, num_input_tokens, multi_steps_attn_metadata
+                    )
                 draft_token_ids = run_draft()
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+                if self.method != "dflash":
+                    self._update_full_graph_params_if_needed(
+                        forward_context, num_input_tokens, multi_steps_attn_metadata
+                    )
 
             # NPU graph capture does not execute kernels — only records
             # operations. The first ACLGraphWrapper call (capture) returns

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -328,12 +328,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     def _maybe_share_lm_head(self, model: nn.Module) -> None:
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
-        if self.method in ("eagle", "dflash") and hasattr(model, "lm_head"):
+        if self.method in ("eagle", "dflash"):
             logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
-            if supports_multimodal(model):
+            if hasattr(model, "lm_head"):
+                self.model.lm_head = model.lm_head
+            elif hasattr(model, "get_language_model") and hasattr(
+                model.get_language_model(), "lm_head"
+            ):
                 self.model.lm_head = model.get_language_model().lm_head
             else:
-                self.model.lm_head = model.lm_head
+                logger.warning(
+                    "Target model has no accessible lm_head for sharing."
+                )
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -342,22 +342,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
             self.update_stream = torch.npu.Stream()
-            if self.method == "dflash":
-                self.model = ACLGraphWrapper(
-                    self.model,
-                    self.vllm_config,
-                    runtime_mode=CUDAGraphMode.FULL,
-                    use_eagle=self.use_eagle,
-                    enable_enpu=self.enable_enpu,
-                )
-            else:
-                self._runnable = ACLGraphWrapper(
-                    self._run_merged_draft,
-                    self.vllm_config,
-                    runtime_mode=CUDAGraphMode.FULL,
-                    use_eagle=self.use_eagle,
-                    enable_enpu=self.enable_enpu,
-                )
+            self._runnable = ACLGraphWrapper(
+                self._run_merged_draft,
+                self.vllm_config,
+                runtime_mode=CUDAGraphMode.FULL,
+                use_eagle=self.use_eagle,
+                enable_enpu=self.enable_enpu,
+            )
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -58,129 +58,6 @@ else:
 _PREPARE_INPUTS_BLOCK_SIZE = 4
 
 
-def _copy_and_expand_eagle_inputs_fallback(
-    target_token_ids: "torch.Tensor",
-    target_positions: "torch.Tensor",
-    next_token_ids: "torch.Tensor",
-    query_start_loc: "torch.Tensor",
-    query_end_loc: "torch.Tensor",
-    padding_token_id: int,
-    parallel_drafting_token_id: int,
-    num_padding_slots: int,
-    shift_input_ids: bool,
-    total_draft_tokens: int,
-) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]":
-    """Pure-Python fallback for npu_copy_and_expand_eagle_inputs.
-    Uses caller's total_draft_tokens for output size with bounds checking."""
-    device = target_token_ids.device
-    tid = target_token_ids.cpu().numpy()
-    target_pos = target_positions.cpu().numpy()
-    ntid = next_token_ids.cpu().numpy()
-    qsl = query_start_loc.cpu().numpy()
-    qel = query_end_loc.cpu().numpy()
-
-    num_reqs = len(qsl) - 1
-    total_input_tokens = len(tid)
-
-    out_ids = np.zeros(total_draft_tokens, dtype=np.int32)
-    out_pos = np.zeros(total_draft_tokens, dtype=np.int32)
-    out_rej = np.zeros(total_draft_tokens, dtype=np.int8)
-    out_msk = np.zeros(total_draft_tokens, dtype=np.int8)
-    out_nti = np.zeros(num_reqs * num_padding_slots, dtype=np.int32)
-    out_hsm = np.zeros(total_input_tokens, dtype=np.int32)
-
-    for r in range(num_reqs):
-        qs = int(qsl[r])
-        nqs = int(qsl[r + 1])
-        qe = int(qel[r])
-
-        num_rejected = max(nqs - qe - 1, 0)
-
-        if shift_input_ids:
-            num_valid = max(qe - qs, 0)
-            output_start = qs + r * (num_padding_slots - 1)
-        else:
-            num_valid = max(qe - qs + 1, 0)
-            output_start = qs + r * num_padding_slots
-
-        start_pos = int(target_pos[qs]) if qs < len(target_pos) else 0
-        next_token_id = int(ntid[r]) if r < len(ntid) else 0
-
-        # Valid region
-        if shift_input_ids:
-            read_start = qs + 1
-            read_count = min(num_valid, total_input_tokens - read_start)
-            if read_count < 0:
-                read_count = 0
-            for j in range(num_valid):
-                w = output_start + j
-                if w >= total_draft_tokens:
-                    break
-                idx = min(j, read_count - 1) if read_count > 0 else 0
-                out_ids[w] = tid[read_start + idx] if read_count > 0 else 0
-                out_pos[w] = start_pos + j
-        else:
-            num_input = nqs - qs
-            for j in range(num_valid):
-                w = output_start + j
-                if w >= total_draft_tokens:
-                    break
-                idx = min(j, num_input - 1)
-                out_ids[w] = tid[qs + idx]
-                out_pos[w] = start_pos + j
-
-        # Bonus token
-        w = output_start + num_valid
-        if w < total_draft_tokens:
-            out_ids[w] = next_token_id
-            out_pos[w] = start_pos + num_valid
-
-        # Parallel draft tokens
-        for k in range(1, num_padding_slots):
-            j = num_valid + k
-            w = output_start + j
-            if w >= total_draft_tokens:
-                break
-            out_ids[w] = parallel_drafting_token_id
-            out_pos[w] = start_pos + j
-            out_msk[w] = 1
-
-        # Rejected tokens
-        for k in range(num_rejected):
-            j = num_valid + num_padding_slots + k
-            w = output_start + j
-            if w >= total_draft_tokens:
-                break
-            out_ids[w] = padding_token_id
-            out_pos[w] = 0
-            out_rej[w] = 1
-
-        # New token indices
-        for k in range(num_padding_slots):
-            nti_w = output_start + num_valid + k
-            if nti_w >= total_draft_tokens:
-                nti_w = total_draft_tokens - 1
-            out_nti[r * num_padding_slots + k] = nti_w
-
-        # Hidden state mapping
-        if shift_input_ids:
-            num_input = nqs - qs
-            for j in range(num_input):
-                hsm_w = output_start + j
-                if hsm_w >= total_draft_tokens:
-                    hsm_w = total_draft_tokens - 1
-                out_hsm[qs + j] = hsm_w
-
-    return (
-        torch.from_numpy(out_ids).to(device),
-        torch.from_numpy(out_pos).to(device),
-        torch.from_numpy(out_rej).to(device),
-        torch.from_numpy(out_msk).to(device),
-        torch.from_numpy(out_nti).to(device),
-        torch.from_numpy(out_hsm).to(device),
-    )
-
-
 # TODO: Remove it when the bug of fx-graph is solved
 # patch vllm_config to be in CompilationMode.NONE temporarily
 @contextmanager
@@ -1322,46 +1199,25 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if num_rejected_tokens_gpu is not None:
                 query_end_loc = query_end_loc - num_rejected_tokens_gpu
 
-            try:
-                (
-                    out_input_ids,
-                    out_positions,
-                    out_is_rejected_token_mask,
-                    out_is_masked_token_mask,
-                    token_indices_to_sample,
-                    out_hidden_state_mapping,
-                ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
-                    target_token_ids,
-                    target_positions.to(torch.int32),
-                    next_token_ids,
-                    query_start_loc,
-                    query_end_loc,
-                    0,  # padding_token_id
-                    self.parallel_drafting_token_id,
-                    self.extra_slots_per_request,
-                    self.pass_hidden_states_to_model,
-                    total_num_output_tokens,
-                )
-            except (AttributeError, RuntimeError):
-                (
-                    out_input_ids,
-                    out_positions,
-                    out_is_rejected_token_mask,
-                    out_is_masked_token_mask,
-                    token_indices_to_sample,
-                    out_hidden_state_mapping,
-                ) = _copy_and_expand_eagle_inputs_fallback(
-                    target_token_ids,
-                    target_positions.to(torch.int32),
-                    next_token_ids,
-                    query_start_loc,
-                    query_end_loc,
-                    0,  # padding_token_id
-                    self.parallel_drafting_token_id,
-                    self.extra_slots_per_request,
-                    self.pass_hidden_states_to_model,
-                    total_num_output_tokens,
-                )
+            (
+                out_input_ids,
+                out_positions,
+                out_is_rejected_token_mask,
+                out_is_masked_token_mask,
+                token_indices_to_sample,
+                out_hidden_state_mapping,
+            ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
+                target_token_ids,
+                target_positions.to(torch.int32),
+                next_token_ids,
+                query_start_loc,
+                query_end_loc,
+                0,  # padding_token_id
+                self.parallel_drafting_token_id,
+                self.extra_slots_per_request,
+                self.pass_hidden_states_to_model,
+                total_num_output_tokens,
+            )
 
             # Copy returned tensors into pre-allocated buffers
             self.input_ids[:total_num_output_tokens].copy_(out_input_ids)

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -728,6 +728,16 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # is run in eager mode currently, which means `_pad_query_start_loc_for_fia` is not called,
             # while draft model is run in graph model, which means we should pad the `query_start_loc`.
             # Need to be fixed in the future.
+            #
+            # For DFlash: sync proposer's query_start_loc into runner's buffer before padding,
+            # because DFlash rebuilds query_start_loc in set_inputs_first_pass with different
+            # values (num_query_per_req per request) than what the target model runner has.
+            # Without this, _pad_query_start_loc_for_fia operates on stale target model values.
+            if self.method == "dflash":
+                num_reqs = common_attn_metadata.num_reqs
+                self.runner.query_start_loc.np[: num_reqs + 1] = common_attn_metadata.query_start_loc_cpu[
+                    : num_reqs + 1
+                ].numpy()
             num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
                 num_input_tokens,
                 batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
@@ -946,6 +956,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if forward_context is not None:
                 forward_context.moe_layer_index = 0
 
+            # DFlash: precompute context KV OUTSIDE graph boundary because
+            # num_context varies between calls (incompatible with graph replay).
+            if self.method == "dflash":
+                self.prepare_context_kv()
+
             model_inputs: dict[str, Any] = {
                 "num_input_tokens": num_input_tokens,
                 "batch_size": batch_size,
@@ -964,6 +979,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             else:
                 draft_token_ids = run_draft()
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+
+            # NPU graph capture does not execute kernels — only records
+            # operations. The first ACLGraphWrapper call (capture) returns
+            # uninitialized garbage in the output tensor. Clamp token IDs
+            # to valid vocabulary range to prevent OOB embedding access
+            # in the target model (which would cause NPU error 507057).
+            vocab_size = self.vllm_config.model_config.get_vocab_size()
+            if draft_token_ids is not None and isinstance(draft_token_ids, torch.Tensor):
+                draft_token_ids.clamp_(0, vocab_size - 1)
         return draft_token_ids
 
     def _run_merged_draft(
@@ -1278,7 +1302,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 target_positions = target_positions[0]
 
             self._set_positions(num_tokens, target_positions)
-            self.hidden_states[:num_tokens] = target_hidden_states
+            if self.pass_hidden_states_to_model:
+                self.hidden_states[:num_tokens] = target_hidden_states
 
             return num_tokens, token_indices_to_sample, cad, (query_lens_d, ori_token_indices_to_sample)
         else:

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -58,6 +58,129 @@ else:
 _PREPARE_INPUTS_BLOCK_SIZE = 4
 
 
+def _copy_and_expand_eagle_inputs_fallback(
+    target_token_ids: "torch.Tensor",
+    target_positions: "torch.Tensor",
+    next_token_ids: "torch.Tensor",
+    query_start_loc: "torch.Tensor",
+    query_end_loc: "torch.Tensor",
+    padding_token_id: int,
+    parallel_drafting_token_id: int,
+    num_padding_slots: int,
+    shift_input_ids: bool,
+    total_draft_tokens: int,
+) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]":
+    """Pure-Python fallback for npu_copy_and_expand_eagle_inputs.
+    Uses caller's total_draft_tokens for output size with bounds checking."""
+    device = target_token_ids.device
+    tid = target_token_ids.cpu().numpy()
+    target_pos = target_positions.cpu().numpy()
+    ntid = next_token_ids.cpu().numpy()
+    qsl = query_start_loc.cpu().numpy()
+    qel = query_end_loc.cpu().numpy()
+
+    num_reqs = len(qsl) - 1
+    total_input_tokens = len(tid)
+
+    out_ids = np.zeros(total_draft_tokens, dtype=np.int32)
+    out_pos = np.zeros(total_draft_tokens, dtype=np.int32)
+    out_rej = np.zeros(total_draft_tokens, dtype=np.int8)
+    out_msk = np.zeros(total_draft_tokens, dtype=np.int8)
+    out_nti = np.zeros(num_reqs * num_padding_slots, dtype=np.int32)
+    out_hsm = np.zeros(total_input_tokens, dtype=np.int32)
+
+    for r in range(num_reqs):
+        qs = int(qsl[r])
+        nqs = int(qsl[r + 1])
+        qe = int(qel[r])
+
+        num_rejected = max(nqs - qe - 1, 0)
+
+        if shift_input_ids:
+            num_valid = max(qe - qs, 0)
+            output_start = qs + r * (num_padding_slots - 1)
+        else:
+            num_valid = max(qe - qs + 1, 0)
+            output_start = qs + r * num_padding_slots
+
+        start_pos = int(target_pos[qs]) if qs < len(target_pos) else 0
+        next_token_id = int(ntid[r]) if r < len(ntid) else 0
+
+        # Valid region
+        if shift_input_ids:
+            read_start = qs + 1
+            read_count = min(num_valid, total_input_tokens - read_start)
+            if read_count < 0:
+                read_count = 0
+            for j in range(num_valid):
+                w = output_start + j
+                if w >= total_draft_tokens:
+                    break
+                idx = min(j, read_count - 1) if read_count > 0 else 0
+                out_ids[w] = tid[read_start + idx] if read_count > 0 else 0
+                out_pos[w] = start_pos + j
+        else:
+            num_input = nqs - qs
+            for j in range(num_valid):
+                w = output_start + j
+                if w >= total_draft_tokens:
+                    break
+                idx = min(j, num_input - 1)
+                out_ids[w] = tid[qs + idx]
+                out_pos[w] = start_pos + j
+
+        # Bonus token
+        w = output_start + num_valid
+        if w < total_draft_tokens:
+            out_ids[w] = next_token_id
+            out_pos[w] = start_pos + num_valid
+
+        # Parallel draft tokens
+        for k in range(1, num_padding_slots):
+            j = num_valid + k
+            w = output_start + j
+            if w >= total_draft_tokens:
+                break
+            out_ids[w] = parallel_drafting_token_id
+            out_pos[w] = start_pos + j
+            out_msk[w] = 1
+
+        # Rejected tokens
+        for k in range(num_rejected):
+            j = num_valid + num_padding_slots + k
+            w = output_start + j
+            if w >= total_draft_tokens:
+                break
+            out_ids[w] = padding_token_id
+            out_pos[w] = 0
+            out_rej[w] = 1
+
+        # New token indices
+        for k in range(num_padding_slots):
+            nti_w = output_start + num_valid + k
+            if nti_w >= total_draft_tokens:
+                nti_w = total_draft_tokens - 1
+            out_nti[r * num_padding_slots + k] = nti_w
+
+        # Hidden state mapping
+        if shift_input_ids:
+            num_input = nqs - qs
+            for j in range(num_input):
+                hsm_w = output_start + j
+                if hsm_w >= total_draft_tokens:
+                    hsm_w = total_draft_tokens - 1
+                out_hsm[qs + j] = hsm_w
+
+    return (
+        torch.from_numpy(out_ids).to(device),
+        torch.from_numpy(out_pos).to(device),
+        torch.from_numpy(out_rej).to(device),
+        torch.from_numpy(out_msk).to(device),
+        torch.from_numpy(out_nti).to(device),
+        torch.from_numpy(out_hsm).to(device),
+    )
+
+
 # TODO: Remove it when the bug of fx-graph is solved
 # patch vllm_config to be in CompilationMode.NONE temporarily
 @contextmanager
@@ -1174,25 +1297,46 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if num_rejected_tokens_gpu is not None:
                 query_end_loc = query_end_loc - num_rejected_tokens_gpu
 
-            (
-                out_input_ids,
-                out_positions,
-                out_is_rejected_token_mask,
-                out_is_masked_token_mask,
-                token_indices_to_sample,
-                out_hidden_state_mapping,
-            ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
-                target_token_ids,
-                target_positions.to(torch.int32),
-                next_token_ids,
-                query_start_loc,
-                query_end_loc,
-                0,  # padding_token_id
-                self.parallel_drafting_token_id,
-                self.extra_slots_per_request,
-                self.pass_hidden_states_to_model,
-                total_num_output_tokens,
-            )
+            try:
+                (
+                    out_input_ids,
+                    out_positions,
+                    out_is_rejected_token_mask,
+                    out_is_masked_token_mask,
+                    token_indices_to_sample,
+                    out_hidden_state_mapping,
+                ) = torch.ops._C_ascend.npu_copy_and_expand_eagle_inputs(
+                    target_token_ids,
+                    target_positions.to(torch.int32),
+                    next_token_ids,
+                    query_start_loc,
+                    query_end_loc,
+                    0,  # padding_token_id
+                    self.parallel_drafting_token_id,
+                    self.extra_slots_per_request,
+                    self.pass_hidden_states_to_model,
+                    total_num_output_tokens,
+                )
+            except (AttributeError, RuntimeError):
+                (
+                    out_input_ids,
+                    out_positions,
+                    out_is_rejected_token_mask,
+                    out_is_masked_token_mask,
+                    token_indices_to_sample,
+                    out_hidden_state_mapping,
+                ) = _copy_and_expand_eagle_inputs_fallback(
+                    target_token_ids,
+                    target_positions.to(torch.int32),
+                    next_token_ids,
+                    query_start_loc,
+                    query_end_loc,
+                    0,  # padding_token_id
+                    self.parallel_drafting_token_id,
+                    self.extra_slots_per_request,
+                    self.pass_hidden_states_to_model,
+                    total_num_output_tokens,
+                )
 
             # Copy returned tensors into pre-allocated buffers
             self.input_ids[:total_num_output_tokens].copy_(out_input_ids)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3577,26 +3577,26 @@ class NPUModelRunner(GPUModelRunner):
 
     def calculate_reorder_batch_threshold(self) -> None:
         """
-        Check that if any backends reorder batches; that the reordering
-        is compatible (e.g., decode threshold is the same)
+        Choose the minimum reorder batch threshold from all attention groups.
+        Backends can support lower thresholds than what they request, with a
+        possible performance penalty from treating decodes as prefills.
         """
+        min_none_high = lambda a, b: a if b is None else b if a is None else min(a, b)
+
+        reorder_batch_thresholds: list[int | None] = []
         for group in self._attn_group_iterator():
             attn_metadata_builder_i = group.get_metadata_builder()
-            if hasattr(attn_metadata_builder_i, "reorder_batch_threshold"):  # noqa
-                # check that if any backends reorder batches; that the reordering
-                # is compatible (e.g., decode threshold is the same)
-                reorder_batch_threshold_i = attn_metadata_builder_i.reorder_batch_threshold
-                if reorder_batch_threshold_i is not None:  # noqa
-                    if self.reorder_batch_threshold is not None:
-                        if reorder_batch_threshold_i != self.reorder_batch_threshold:
-                            raise ValueError(
-                                f"Attention backend reorders decodes with "
-                                f"threshold {reorder_batch_threshold_i} but other "
-                                f"backend uses threshold "
-                                f"{self.reorder_batch_threshold}"
-                            )
-                    else:
-                        self.reorder_batch_threshold = reorder_batch_threshold_i  # noqa
+            if hasattr(attn_metadata_builder_i, "reorder_batch_threshold"):
+                reorder_batch_thresholds.append(
+                    attn_metadata_builder_i.reorder_batch_threshold
+                )
+
+        if len(reorder_batch_thresholds) == 0:
+            self.reorder_batch_threshold = None
+            return
+
+        from functools import reduce
+        self.reorder_batch_threshold = reduce(min_none_high, reorder_batch_thresholds)
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -493,7 +493,7 @@ class NPUModelRunner(GPUModelRunner):
             self.decode_token_per_req = 1 + spec_token_num
             if get_pp_group().is_last_rank:
                 self.drafter = self._get_drafter()
-                if self.speculative_config.method == "eagle3":
+                if self.speculative_config.method in ("eagle3", "dflash"):
                     assert isinstance(self.drafter, AscendEagleProposer)
                     self.use_aux_hidden_state_outputs = self.drafter.eagle3_use_aux_hidden_state
                 self.rejection_sampler = RejectionSampler(self.sampler)
@@ -1695,7 +1695,8 @@ class NPUModelRunner(GPUModelRunner):
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
-                hidden_states, aux_hidden_states = hidden_states
+                if isinstance(hidden_states, tuple):
+                    hidden_states, aux_hidden_states = hidden_states
             if self.pcp_size > 1:
                 # NOTE we must `slice` hidden_states because pcp_allgather_restore_idx
                 # ignores the padding from CUDA Graph.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2771,7 +2771,7 @@ class NPUModelRunner(GPUModelRunner):
         ):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens
-            if self.is_multimodal_model and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
+            if self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
                 input_ids = None
                 inputs_embeds = self.inputs_embeds.gpu[:num_tokens_padded]
             else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1639,6 +1639,18 @@ class NPUModelRunner(GPUModelRunner):
             with record_function_or_nullcontext("EPLB weight D2D"):
                 self.eplb_updator.forward_before()
 
+        sampling_metadata = self.input_batch.sampling_metadata
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.method == "dflash"
+            and sampling_metadata is not None
+            and not sampling_metadata.all_greedy
+        ):
+            # Stochastic reasoning requests on Qwen3.5 hybrid attention are
+            # currently not graph-safe under the DFlash path. Route the whole
+            # request eagerly to preserve correctness.
+            cudagraph_mode = CUDAGraphMode.NONE
+
         # Set cudagraph mode to none if calc_kv_scales is true.
         # KV scales calculation involves dynamic operations that are incompatible
         # with CUDA graph capture.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -469,7 +469,7 @@ class NPUWorker(WorkerBase):
         with context, set_current_vllm_config(self.vllm_config):
             self.model_runner.load_model()
 
-    def compile_or_warm_up_model(self) -> float:
+    def compile_or_warm_up_model(self):
         # Note: need to adapt for graph mode.
         warmup_sizes = (self.vllm_config.compilation_config.compile_sizes or []).copy()
         if not self.model_config.enforce_eager:
@@ -549,7 +549,12 @@ class NPUWorker(WorkerBase):
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)
-        return self.vllm_config.compilation_config.compilation_time
+        from vllm.v1.worker.worker_base import CompilationTimes
+
+        return CompilationTimes(
+            language_model=self.vllm_config.compilation_config.compilation_time,
+            encoder=getattr(self.vllm_config.compilation_config, "encoder_compilation_time", 0.0),
+        )
 
     def _warm_up_atb(self):
         x = torch.rand((2, 4), dtype=torch.float16).npu()


### PR DESCRIPTION
## Summary

Adds Qwen3.5-9B support and fixes critical DFlash issues from #8589:

- **Qwen3.5-9B adaptation**: hybrid attention (sliding window + global) + aux_hidden_state collection
- **NPU 507035 DDR fix**: use `kernel_block_size` (128) instead of physical `block_size` (1024) in Triton slot mapping
- **FDO/FULL acceptance rate fix**: unify DFlash FULL mode graph capture to wrap `_runnable`, fixing 8-11pt acceptance rate drop

## Key Commits

| Commit | Description |
|--------|-------------|
| `8c03c098` | fix: unify DFlash FULL mode graph capture to wrap _runnable |
| `8be78071` | fix: support DFlash with Qwen3.5 hybrid attention architecture |
| `741be162` | fix: align dummy_run mm input handling with upstream |
| `06aecdb2` | fix(dflash): enable aux_hidden_state collection for DFlash on Qwen3.5 |
| `f52beea7` | fix(dflash): use kernel_block_size for slot mapping in Triton kernel |

## Performance (Qwen3-8B, MATH-500, 50 prompts, concurrency=1)

| Mode | Before | After | Improvement |
|------|--------|-------|-------------|
| FDO spec=15 | 175.23 tok/s, 30% acc | **233.62 tok/s, 44% acc** | **+33%** |
| FULL spec=15 | 171.61 tok/s, 28% acc | **231.50 tok/s, 45% acc** | **+35%** |

## Qwen3.5-9B (FDO spec=5, MATH-500, 50 prompts)

| Config | Throughput | TPOT | Acceptance |
|--------|-----------|------|------------|
| Baseline | 16.63 tok/s | 59.26 ms | — |
| DFlash | **41.24 tok/s** | **23.14 ms** | **70.84%** |

**2.48x speedup** with 70.84% acceptance rate.

## Compatibility

| Test | Model | Method | Compilation | Result |
|------|-------|--------|-------------|--------|
| Baseline | Qwen3-8B | — | PIECEWISE | Pass |
| DFlash | Qwen3-8B | dflash, spec=15 | PIECEWISE | Pass (50/50) |
| DFlash | Qwen3-8B | dflash, spec=15 | FDO | Pass (50/50) |
| DFlash | Qwen3-8B | dflash, spec=15 | FULL | Pass (50/50) |
| DFlash | Qwen3.5-9B | dflash, spec=5 | FDO | Pass (50/50) |

> **Note**: Qwen3.5-9B PIECEWISE/FULL not supported due to graph compilation timeout (recurrent gated delta rule + hybrid attention requires very long compile time per capture size).

## Test plan
- [x] Qwen3-8B + DFlash (PIECEWISE/FDO/FULL) all pass 50/50
- [x] Qwen3.5-9B + DFlash (FDO) passes 50/50
- [x] No regression on baseline (no spec decoding)
- [x] No regression on Qwen3-8B PIECEWISE acceptance rate
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
