### PR TITLE
Preserve CPU seq lens for async MTP drafting

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -82,6 +82,32 @@ class TestAscendAttentionMetadataBuilder(TestBase):
 
         self.assertFalse(result)
 
+    def test_unpadded_preserves_internal_seq_lens_cpu(self):
+        internal_seq_lens_cpu = torch.tensor([4, 5, 6], dtype=torch.int32)
+        common_attn_metadata = AscendCommonAttentionMetadata(
+            query_start_loc=torch.tensor([0, 2, 5, 9]),
+            query_start_loc_cpu=torch.tensor([0, 2, 5, 9]),
+            seq_lens=torch.tensor([4, 5, 6], dtype=torch.int32),
+            _seq_lens_cpu=internal_seq_lens_cpu,
+            seq_lens_cpu=None,
+            num_computed_tokens_cpu=None,
+            num_reqs=3,
+            num_actual_tokens=9,
+            max_query_len=4,
+            block_table_tensor=torch.zeros((3, 1), dtype=torch.int32),
+            slot_mapping=torch.arange(9, dtype=torch.int32),
+            causal=True,
+            actual_seq_lengths_q=[2, 3, 4],
+            positions=torch.arange(9),
+            attn_state=AscendAttentionState.ChunkedPrefill,
+            max_seq_len=6,
+        )
+
+        unpadded_metadata = common_attn_metadata.unpadded(num_actual_tokens=5, num_actual_reqs=2)
+
+        self.assertTrue(torch.equal(unpadded_metadata._seq_lens_cpu, internal_seq_lens_cpu[:2]))
+        self.assertIsNone(unpadded_metadata.seq_lens_cpu)
+
     @patch("vllm_ascend.attention.attention_v1.AscendMetadata")
     def test_build(self, mock_ascend_metadata):
         common_attn_metadata = AscendCommonAttentionMetadata(

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -15,8 +15,53 @@ import vllm_ascend.spec_decode.eagle_proposer as eagle_proposer
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+
+
+def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
+    proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+    proposer.pcp_size = 1
+    proposer.arange = torch.arange(16, dtype=torch.int32)
+    proposer.runner = MagicMock()
+    proposer.runner.actual_seq_lengths_q = [3, 3]
+    proposer.runner.attn_state = AscendAttentionState.SpecDecoding
+    proposer.runner.decode_token_per_req = 4
+
+    internal_seq_lens_cpu = torch.tensor([7, 9], dtype=torch.int32)
+    common_attn_metadata = AscendCommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 3, 6], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 3, 6], dtype=torch.int32),
+        seq_lens=torch.tensor([7, 9], dtype=torch.int32),
+        _seq_lens_cpu=internal_seq_lens_cpu,
+        seq_lens_cpu=None,
+        num_computed_tokens_cpu=None,
+        num_reqs=2,
+        num_actual_tokens=6,
+        num_input_tokens=6,
+        max_query_len=3,
+        actual_seq_lengths_q=[3, 3],
+        block_table_tensor=torch.zeros((2, 1), dtype=torch.int32),
+        slot_mapping=torch.arange(6, dtype=torch.int32),
+        positions=torch.arange(6),
+        attn_state=AscendAttentionState.SpecDecoding,
+        decode_token_per_req=4,
+        max_seq_len=9,
+    )
+    spec_decode_metadata = MagicMock()
+    spec_decode_metadata.cu_num_draft_tokens = torch.tensor([2, 3], dtype=torch.int32)
+    valid_sampled_tokens_count = torch.tensor([3, 1], dtype=torch.int32)
+
+    with patch.object(eagle_proposer, "HAS_TRITON", False):
+        spec_common_attn_metadata, *_ = proposer.prepare_inputs_padded(
+            common_attn_metadata,
+            spec_decode_metadata,
+            valid_sampled_tokens_count,
+        )
+
+    assert spec_common_attn_metadata._seq_lens_cpu is internal_seq_lens_cpu
+    assert spec_common_attn_metadata.seq_lens_cpu is None
 
 
 class TestEagleProposerInitialization(TestBase):

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -193,6 +193,7 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
             query_start_loc=self.query_start_loc[: num_actual_reqs + 1],
             query_start_loc_cpu=self.query_start_loc_cpu[: num_actual_reqs + 1],
             seq_lens=self.seq_lens[:num_actual_reqs],
+            _seq_lens_cpu=self._seq_lens_cpu[:num_actual_reqs] if self._seq_lens_cpu is not None else None,
             seq_lens_cpu=self.seq_lens_cpu[:num_actual_reqs] if self.seq_lens_cpu is not None else None,
             num_computed_tokens_cpu=self.num_computed_tokens_cpu[:num_actual_reqs]
             if self.num_computed_tokens_cpu is not None

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -623,6 +623,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
             else:
                 common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
+                common_attn_metadata._seq_lens_cpu = self._adjust_tensor(
+                    self.runner.optimistic_seq_lens_cpu, num_reqs_padded
+                )
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
                     self.runner.optimistic_seq_lens_cpu, num_reqs_padded
                 )
@@ -1577,6 +1580,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             query_start_loc=new_query_start_loc_cpu.to(device, non_blocking=True),
             query_start_loc_cpu=new_query_start_loc_cpu,
             seq_lens=new_seq_lens_cpu.to(device, non_blocking=True),
+            _seq_lens_cpu=new_seq_lens_cpu,
             seq_lens_cpu=new_seq_lens_cpu,
             num_computed_tokens_cpu=common_attn_metadata.num_computed_tokens_cpu,
             num_reqs=common_attn_metadata.num_reqs,
@@ -1656,6 +1660,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         spec_common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=common_attn_metadata.query_start_loc,
             query_start_loc_cpu=query_start_loc_cpu,
+            _seq_lens_cpu=common_attn_metadata._seq_lens_cpu,
             seq_lens_cpu=common_attn_metadata.seq_lens_cpu,
             num_reqs=common_attn_metadata.num_reqs,
             num_actual_tokens=common_attn_metadata.num_actual_tokens if self.pcp_size > 1 else total_num_tokens,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -900,6 +900,9 @@ class NPUModelRunner(GPUModelRunner):
         # CPU values are optimistic (all drafts accepted). The kernel
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
+        cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
+                device=self.device, non_blocking=True
+        )
         if (
             self.use_async_spec_decode
             and self.valid_sampled_token_count_gpu is not None
@@ -907,9 +910,6 @@ class NPUModelRunner(GPUModelRunner):
         ):
             self.prev_positions.copy_to_gpu(num_reqs)
             self.prev_num_draft_tokens.copy_to_gpu()
-            cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
-                device=self.device, non_blocking=True
-            )
             update_num_computed_tokens_for_batch_change(
                 self.num_computed_tokens,
                 self.num_accepted_tokens.gpu[:num_reqs],
@@ -989,9 +989,7 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
             drift = self.num_computed_tokens[req_indices_gpu].to(
                 torch.int64
-            ) - self.input_batch.num_computed_tokens_cpu_tensor[req_indices].to(
-                device=self.device, dtype=torch.int64, non_blocking=True
-            )
+            ) - cpu_values[req_indices_gpu]
             target = self.mrope_positions if self.uses_mrope else self.xdrope_positions
             target.gpu[:, :total_num_scheduled_tokens] += drift
 


### PR DESCRIPTION
### What changed

This PR preserves `_seq_lens_cpu` when attention metadata is rebuilt for async speculative decoding / MTP drafting.

### Why

`AscendAttentionMetadataBuilder.build()` prefers `_seq_lens_cpu` to avoid falling back to `common_attn_metadata.seq_lens.to("cpu")`. In async spec decode, `seq_lens_cpu` can be intentionally `None`, so losing `_seq_lens_cpu` makes MTP draft metadata builds introduce a blocking device-to-host copy.

With `num_speculative_tokens=3`, this showed up as one target-model metadata build taking the CPU path while the three MTP draft builds fell back to `.to("cpu")`.

### Fix

- Preserve `_seq_lens_cpu` in `AscendCommonAttentionMetadata.unpadded()`
- Carry `_seq_lens_cpu` through Eagle/MTP `prepare_inputs()` and `prepare_inputs_padded()`
- Keep `_seq_lens_cpu` aligned when graph padding adjusts `seq_lens`

### Validation

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/vllm_ascend_pycache python3 -m py_compile vllm_ascend/attention/utils.py vllm_ascend/spec_decode/eagle_proposer.py tests/ut/attention/test_attention_v1.py tests/ut/spec_decode/test_eagle_proposer.py`

Targeted pytest was not run locally because pytest is not installed in this environment.
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
