### PR TITLE
[BugFix] [P/D] release proxy resources on stream cancellation

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -270,8 +270,10 @@ def parse_args():
     )
     args = parser.parse_args()
     logger.info(
-        f"Decoder hosts will access Proxy host:port/metaserver, ensure that {set(args.decoder_hosts)} "
-        f"can access {args.host}:{args.port}/metaserver"
+        "Decoder hosts will access Proxy host:port/metaserver, ensure that %s can access %s:%s/metaserver",
+        set(args.decoder_hosts),
+        args.host,
+        args.port,
     )
     # Wildcard address is not allowed for layerwise connector
     if args.host in ["0.0.0.0", "::", "0:0:0:0:0:0:0:0"]:
@@ -356,12 +358,12 @@ async def send_request_to_service(
                 result_future.set_result(response.json()["kv_transfer_params"])
             return
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning(f"Attempt {attempt} failed for {endpoint}: {str(e)}")
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for {endpoint}.")
+                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
                 raise last_exc
 
 
@@ -385,22 +387,22 @@ async def stream_service_response_with_retry(
                 return  # Success, exit after streaming
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             if attempt < max_retries:
-                logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise e
         except Exception as e:
             # If any chunk has been sent, do not retry, just log and drop
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error(f"Streaming to client interrupted after response started: {str(e)}")
+                logger.error("Streaming to client interrupted after response started: %s", e)
                 return
             else:
                 if attempt < max_retries:
-                    logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                     await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
                 else:
-                    logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                     raise e
 
 
@@ -478,7 +480,7 @@ async def _handle_completions(api: str, request: Request):
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
-                            logger.debug(f"Skipping chunk: {chunk}")
+                            logger.debug("Skipping chunk: %s", chunk)
                             yield chunk
                             continue
                         if not chunk_str:
@@ -489,7 +491,7 @@ async def _handle_completions(api: str, request: Request):
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
                             # if chunk is [done], skip it.
-                            logger.debug(f"Skipping chunk: {chunk_str}")
+                            logger.debug("Skipping chunk: %s", chunk_str)
                             yield chunk
                             continue
                         choices = chunk_json.get("choices", [])
@@ -528,13 +530,15 @@ async def _handle_completions(api: str, request: Request):
                         yield chunk
             except Exception as e:
                 logger.error(
-                    f"Error during streaming from decoder {decoder.url}: {str(e)} "
-                    f"the aborted request {request_id} will be routing to the target "
-                    "prefiller when new request is ready to dispatch to it"
+                    "Error during streaming from decoder %s: %s the aborted request %s "
+                    "will be routing to the target prefiller when new request is ready to dispatch to it",
+                    decoder.url,
+                    e,
+                    request_id,
                 )
-
-            # After streaming done, release tokens
-            proxy_state.release_decoder(decoder_idx, decoder_score)
+            finally:
+                # After streaming done, release tokens
+                proxy_state.release_decoder(decoder_idx, decoder_score)
 
         if stream_flag:
             return StreamingResponse(generate_stream(), media_type="text/event-stream")
@@ -582,12 +586,12 @@ async def metaserver(request: Request):
         request_id = get_origin_request_id(api, request_id)
         req_data["kv_transfer_params"] = kv_transfer_params
         prefiller_score = proxy_state.calculate_prefill_scores(request_length)
-        logger.debug(f"Request length: {request_length}, Prefiller score: {prefiller_score}")
+        logger.debug("Request length: %s, Prefiller score: %s", request_length, prefiller_score)
 
         # Select prefiller
         prefiller_idx = proxy_state.select_prefiller(prefiller_score)
         prefiller = proxy_state.prefillers[prefiller_idx]
-        logger.debug(f"Using prefill {prefiller.url=} {req_data=}")
+        logger.debug("Using prefill prefiller.url=%r req_data=%r", prefiller.url, req_data)
         # Send request to prefiller
         await send_request_to_service(
             prefiller.client,
@@ -598,11 +602,10 @@ async def metaserver(request: Request):
             max_retries=global_args.max_retries,
             base_delay=global_args.retry_delay,
         )
-        proxy_state.release_prefiller(prefiller_idx, prefiller_score)
-        proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 
     except Exception as e:
-        logger.error(f"Post metaserver failed with: {str(e)}")
+        logger.error("Post metaserver failed with: %s", e)
+    finally:
         proxy_state.release_prefiller(prefiller_idx, prefiller_score)
         proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
 

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -373,7 +373,7 @@ class ProxyState:
             return False
 
         if self.request_num > 0:
-            logger.warning(f"Start to taint prefill instances {instances}.")
+            logger.warning("Start to taint prefill instances %s.", instances)
             self._taint_prefillers(instances)
             return True
 
@@ -399,7 +399,7 @@ class ProxyState:
             return False
 
         if self.request_num > 0:
-            logger.warning(f"Start to taint decode instances {instances}.")
+            logger.warning("Start to taint decode instances %s.", instances)
             self._taint_decoders(instances)
             return True
 
@@ -608,12 +608,12 @@ async def send_request_to_service(
             response.raise_for_status()
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning(f"Attempt {attempt} failed for {endpoint}: {str(e)}")
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for {endpoint}.")
+                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
                 raise last_exc
 
 
@@ -637,28 +637,28 @@ async def stream_service_response_with_retry(
                 return  # Success, exit after streaming
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             if attempt < max_retries:
-                logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise e
         except Exception as e:
             # If any chunk has been sent, do not retry, just log and drop
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error(f"Streaming to client interrupted after response started: {str(e)}")
+                logger.error("Streaming to client interrupted after response started: %s", e)
                 return
             else:
                 if attempt < max_retries:
-                    logger.warning(f"Attempt {attempt} failed for streaming {endpoint}: {str(e)}")
+                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                     await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
                 else:
-                    logger.error(f"All {max_retries} attempts failed for streaming {endpoint}.")
+                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                     raise e
 
 
 async def _handle_select_instance(api: str, req_data: Any, request_length: int):
     prefiller_score = proxy_state.calculate_prefill_scores(request_length)
-    logger.debug(f"Request length: {request_length}, Prefiller score: {prefiller_score}")
+    logger.debug("Request length: %s, Prefiller score: %s", request_length, prefiller_score)
     request_id = await proxy_state.next_req_id()
     # Select prefiller
     prefiller_idx = proxy_state.select_prefiller(prefiller_score)
@@ -734,6 +734,13 @@ async def _handle_completions(api: str, request: Request):
             retry_count = 0
             retry = True
             completion_tokens = 0
+
+            def release_prefiller_kv_once():
+                nonlocal released_kv
+                if not released_kv:
+                    proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
+                    released_kv = True
+
             # Only one await per chunk, minimal logic in loop
             try:
                 while retry:
@@ -747,12 +754,11 @@ async def _handle_completions(api: str, request: Request):
                         base_delay=global_args.retry_delay,
                     ):
                         if not released_kv and chunk:
-                            proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
-                            released_kv = True
+                            release_prefiller_kv_once()
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
-                            logger.debug(f"Skipping chunk: {chunk}")
+                            logger.debug("Skipping chunk: %s", chunk)
                             yield chunk
                             continue
                         if not chunk_str:
@@ -763,7 +769,7 @@ async def _handle_completions(api: str, request: Request):
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
                             # if chunk is [done], skip it.
-                            logger.debug(f"Skipping chunk: {chunk_str}")
+                            logger.debug("Skipping chunk: %s", chunk_str)
                             yield chunk
                             continue
                         choices = chunk_json.get("choices", [])
@@ -802,17 +808,23 @@ async def _handle_completions(api: str, request: Request):
                                 choice["text"] = generated_token
                             chunk = json.dumps(chunk_json).encode("utf-8")
                         yield chunk
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 logger.error(
-                    f"Error during streaming from decoder {instance_info.decoder.url}: {str(e)} "
-                    f"the aborted request {instance_info.request_id} will be routing to the target "
-                    "prefiller when new request is ready to dispatch to it"
+                    "Error during streaming from decoder %s: %s the aborted request %s "
+                    "will be routing to the target prefiller when new request is ready to dispatch to it",
+                    instance_info.decoder.url,
+                    e,
+                    instance_info.request_id,
                 )
                 proxy_state.abort_prefiller_request(instance_info.prefiller_idx, instance_info.request_id)
-                proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
-
-            # After streaming done, release tokens
-            proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
+                release_prefiller_kv_once()
+            finally:
+                # After streaming is done or cancelled, release tokens.
+                release_prefiller_kv_once()
+                proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
+                proxy_state.request_num -= 1
 
         # Determine the correct media type based on stream flag
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
@@ -824,9 +836,8 @@ async def _handle_completions(api: str, request: Request):
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print(e)
         print("".join(traceback.format_exception(*exc_info)))
-        raise
-    finally:
         proxy_state.request_num -= 1
+        raise
 
 
 async def _handle_adjust_instances(adjust_mode: str, request: Request):
@@ -866,7 +877,7 @@ async def _handle_adjust_instances(adjust_mode: str, request: Request):
             "current_decode_instances": [str(decoder) for decoder in proxy_state.decoders],
         }
     except Exception as e:
-        logger.error(f"Failed to {adjust_mode} instances: {e}")
+        logger.error("Failed to %s instances: %s", adjust_mode, e)
         raise e
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
Solve the problem of unbalanced proxy load in the PD separation scenario. When a user cancels a request, an asyncio.CancelledError exception is thrown, which does not belong to Exception, causing the load score of the D node not to be released.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
by nightly
