### PR TITLE
[BugFix][Worker] Support DP in model_runner_v2 and align MoE DP comm selection

### DIFF
--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import torch
+from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 from vllm_ascend.ascend_forward_context import MoECommType, get_mrv2_in_profile_run
@@ -13,6 +15,26 @@ class TestNPUModelRunnerV2(unittest.TestCase):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.max_num_tokens = max_num_tokens
         runner.vllm_config = MagicMock()
+        return runner
+
+    @staticmethod
+    def _make_runner_for_execute_model(
+        *,
+        dp_size: int = 1,
+        dp_rank: int = 0,
+        is_encoder_decoder: bool = False,
+    ):
+        runner = TestNPUModelRunnerV2._make_runner()
+        runner.finish_requests = MagicMock()
+        runner.free_states = MagicMock()
+        runner.add_requests = MagicMock()
+        runner.update_requests = MagicMock()
+        runner.block_tables = MagicMock()
+        runner.kv_connector = MagicMock()
+        runner.cudagraph_manager = MagicMock()
+        runner.dp_size = dp_size
+        runner.dp_rank = dp_rank
+        runner.is_encoder_decoder = is_encoder_decoder
         return runner
 
     def test_profile_run_marks_only_mc2_warmup_dummy_run(self):
@@ -57,3 +79,123 @@ class TestNPUModelRunnerV2(unittest.TestCase):
             runner.profile_run()
 
         self.assertEqual(observed_runs, [(16, True)])
+
+    def test_execute_model_returns_no_forward_when_dp_sync_yields_zero_tokens(self):
+        runner = self._make_runner_for_execute_model(
+            dp_size=2,
+            dp_rank=0,
+            is_encoder_decoder=True,
+        )
+
+        scheduler_output = MagicMock()
+        scheduler_output.total_num_scheduled_tokens = 3
+        scheduler_output.num_scheduled_tokens = {"req-1": 3}
+        scheduler_output.scheduled_encoder_inputs = {"req-1": object()}
+
+        zero_tok_batch_desc = MagicMock()
+        zero_tok_batch_desc.num_tokens = 0
+
+        with (
+            patch("vllm_ascend.worker.v2.model_runner.get_uniform_token_count", return_value=3),
+            patch(
+                "vllm_ascend.worker.v2.model_runner.dispatch_cg_and_sync_dp",
+                return_value=(zero_tok_batch_desc, 6),
+            ) as mock_dispatch,
+        ):
+            output = runner.execute_model(scheduler_output=scheduler_output, is_profile=True)
+
+        runner.kv_connector.no_forward.assert_called_once_with(scheduler_output)
+        self.assertIs(output, runner.kv_connector.no_forward.return_value)
+        mock_dispatch.assert_called_once_with(
+            runner.cudagraph_manager,
+            1,
+            3,
+            3,
+            2,
+            0,
+            need_eager=True,
+        )
+
+    def test_execute_model_runs_piecewise_path_and_persists_execute_state(self):
+        runner = self._make_runner_for_execute_model(dp_size=2, dp_rank=1)
+        runner.model_state = MagicMock()
+        runner.model_state.prepare_inputs.return_value = {}
+        runner.attn_groups = MagicMock()
+        runner.kv_cache_config = MagicMock()
+        runner.req_states = MagicMock()
+        runner.lora_config = None
+        runner.supports_mm_inputs = False
+        runner.is_first_pp_rank = True
+        runner.is_last_pp_rank = True
+        runner.use_aux_hidden_state_outputs = False
+
+        scheduler_output = MagicMock()
+        scheduler_output.total_num_scheduled_tokens = 4
+        scheduler_output.num_scheduled_tokens = {"req-1": 1, "req-2": 3}
+        scheduler_output.scheduled_encoder_inputs = {}
+
+        batch_desc = MagicMock()
+        batch_desc.num_tokens = 8
+        batch_desc.num_reqs = 2
+        batch_desc.cg_mode = CUDAGraphMode.PIECEWISE
+
+        input_batch = MagicMock()
+        input_batch.num_tokens_after_padding = 8
+        runner.prepare_inputs = MagicMock(return_value=input_batch)
+        runner.prepare_attn = MagicMock(return_value=(MagicMock(), MagicMock()))
+
+        hidden_states = torch.zeros(8, 4)
+        runner.model = MagicMock(return_value=hidden_states)
+
+        num_tokens_across_dp = torch.tensor([4, 4])
+        captured_state: list[dict] = []
+
+        def record_execute_state(**kwargs):
+            captured_state.append(kwargs)
+            return MagicMock()
+
+        with (
+            patch("vllm_ascend.worker.v2.model_runner.get_uniform_token_count", return_value=4),
+            patch(
+                "vllm_ascend.worker.v2.model_runner.dispatch_cg_and_sync_dp",
+                return_value=(batch_desc, num_tokens_across_dp),
+            ) as mock_dispatch,
+            patch(
+                "vllm_ascend.worker.v2.model_runner.build_slot_mappings_by_layer",
+                return_value="slot-by-layer",
+            ),
+            patch("vllm_ascend.worker.v2.model_runner.set_ascend_forward_context") as mock_ctx,
+            patch(
+                "vllm_ascend.worker.v2.model_runner.ExecuteModelState",
+                side_effect=record_execute_state,
+            ),
+        ):
+            output = runner.execute_model(scheduler_output=scheduler_output)
+
+        self.assertIsNone(output)
+        runner.kv_connector.pre_forward.assert_called_once_with(scheduler_output)
+        runner.kv_connector.post_forward.assert_called_once_with(scheduler_output)
+        runner.model.assert_called_once()
+        mock_dispatch.assert_called_once_with(
+            runner.cudagraph_manager,
+            2,
+            4,
+            4,
+            2,
+            1,
+            need_eager=False,
+        )
+
+        self.assertEqual(len(captured_state), 1)
+        state_kwargs = captured_state[0]
+        self.assertIs(state_kwargs["input_batch"], input_batch)
+        self.assertEqual(state_kwargs["slot_mappings_by_layer"], "slot-by-layer")
+        self.assertIs(state_kwargs["hidden_states"], hidden_states)
+
+        mock_ctx.assert_called_once()
+        ctx_kwargs = mock_ctx.call_args.kwargs
+        self.assertEqual(ctx_kwargs["num_tokens"], 8)
+        self.assertEqual(ctx_kwargs["aclgraph_runtime_mode"], CUDAGraphMode.PIECEWISE)
+        self.assertIs(ctx_kwargs["num_tokens_across_dp"], num_tokens_across_dp)
+        self.assertEqual(ctx_kwargs["slot_mapping"], "slot-by-layer")
+        self.assertFalse(ctx_kwargs["skip_compiled"])

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -65,6 +65,7 @@ def set_ascend_forward_context(
     batch_descriptor: BatchDescriptor | None = None,
     model_instance: torch.nn.Module = None,
     is_draft_model=False,
+    slot_mapping: torch.Tensor | None = None,
     skip_compiled: bool = False,
     max_tokens_across_pcp: int = 0,
     draft_attn_metadatas=None,
@@ -80,6 +81,7 @@ def set_ascend_forward_context(
         "num_tokens_across_dp": num_tokens_across_dp,
         "cudagraph_runtime_mode": aclgraph_runtime_mode,
         "batch_descriptor": batch_descriptor,
+        "slot_mapping": slot_mapping,
         "skip_compiled": skip_compiled,
     }
     with set_forward_context(**forward_context_kwargs):

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -717,12 +717,6 @@ class NPUPlatform(Platform):
         is_draft_model_prefill = False
 
         in_profile_run = get_mrv2_in_profile_run()
-        moe_comm_type = select_moe_comm_method(
-            num_tokens,
-            vllm_config,
-            is_draft_model=is_draft_model,
-        )
-        moe_comm_method = get_moe_comm_method(moe_comm_type)
 
         tp_world_size = get_tensor_model_parallel_world_size()
 
@@ -762,6 +756,15 @@ class NPUPlatform(Platform):
                 pad_size = padded_length - num_tokens
         else:
             max_tokens_across_dp = num_tokens
+
+        # NOTE: Must use max_tokens_across_dp instead of num_tokens for MoE comm method selection
+        # to ensure consistent communication method across all DP ranks.
+        moe_comm_type = select_moe_comm_method(
+            max_tokens_across_dp,
+            vllm_config,
+            is_draft_model=is_draft_model,
+        )
+        moe_comm_method = get_moe_comm_method(moe_comm_type)
         mc2_mask = None
         padded_num_tokens = None
         if num_tokens is not None:

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -22,18 +22,23 @@ import numpy as np
 import torch
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
+from vllm.sequence import IntermediateTensors
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.gpu import model_runner as vllm_model_runner
+from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
-from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor, get_uniform_token_count
+from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import (
     combine_sampled_and_draft_tokens,
     expand_idx_mapping,
     prepare_pos_seq_lens,
     prepare_prefill_inputs,
 )
-from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.model_runner import ExecuteModelState, GPUModelRunner
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import (
@@ -41,6 +46,7 @@ from vllm_ascend.ascend_forward_context import (
     get_mc2_tokens_capacity,
     override_mrv2_in_profile_run,
     select_moe_comm_method,
+    set_ascend_forward_context,
     set_mc2_mask,
     set_mc2_tokens_capacity,
 )
@@ -135,6 +141,10 @@ class NPUModelRunner(GPUModelRunner):
         # to set forward_context in `run_fullgraph`.
         # so we can inherit `execute_model` method.
         self.cudagraph_and_dp_padding: tuple[int, torch.Tensor | None, int] | None = None
+
+        # TODO(YHT): figure out the meaning of decode_token_per_req.
+        # TODO(YHT): judge if it's necessary write _set_up_drafter.
+        self.decode_token_per_req: int = 1
 
         # we need to use input_batch to set forward_context in run_fullgraph.
         # so we can inherit `execute_model` method.
@@ -366,6 +376,203 @@ class NPUModelRunner(GPUModelRunner):
                 non_blocking=True,
             )
             self.num_computed_tokens_event.record()
+
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: SchedulerOutput,
+        intermediate_tensors: IntermediateTensors | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        is_profile: bool = False,
+    ) -> ModelRunnerOutput | IntermediateTensors | None:
+        if not dummy_run:
+            # Update the request states.
+            self.finish_requests(scheduler_output)
+            self.free_states(scheduler_output)
+            self.add_requests(scheduler_output)
+            self.update_requests(scheduler_output)
+            self.block_tables.apply_staged_writes()
+            if scheduler_output.total_num_scheduled_tokens == 0:
+                # No need to run the model.
+                empty_output = self.kv_connector.no_forward(scheduler_output)
+                return empty_output
+
+        # Get batch descriptor and sync across DP ranks.
+        num_reqs = len(scheduler_output.num_scheduled_tokens)
+        num_toks = scheduler_output.total_num_scheduled_tokens
+        max_query_len = max(scheduler_output.num_scheduled_tokens.values())
+        uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+
+        skip_compiled = False
+        if self.is_encoder_decoder and scheduler_output.scheduled_encoder_inputs:
+            # Encoder-decoder models such as Whisper should run eager/non-compiled
+            # when encoder inputs are scheduled, because this step updates
+            # cross-attention cache with dynamic encoder outputs.
+            skip_compiled = True
+
+        # TODO(YHT): check if dispatch_cg_and_sync_dp need to be rewritten.
+        batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
+            self.cudagraph_manager,
+            num_reqs,
+            num_toks,
+            uniform_tok_count,
+            self.dp_size,
+            self.dp_rank,
+            need_eager=is_profile or skip_compiled,
+        )
+
+        if batch_desc.num_tokens == 0:
+            # All DP ranks have zero tokens to run.
+            empty_output = self.kv_connector.no_forward(scheduler_output)
+            return empty_output
+
+        if not dummy_run:
+            # Common case.
+            # Prepare all the inputs and copy to the input buffers.
+            input_batch = self.prepare_inputs(scheduler_output, batch_desc)
+            block_tables, slot_mappings = self.prepare_attn(input_batch)
+
+            if self.lora_config:
+                # Activate LoRA adapters.
+                lora_inputs = self.lora_state.make_lora_inputs(
+                    input_batch.req_ids,
+                    input_batch.idx_mapping_np,
+                    input_batch.num_scheduled_tokens,
+                )
+                self._set_active_loras(*lora_inputs)
+        else:
+            # No actual tokens to run. A dummy run for DP or memory profiling.
+            input_batch = AscendInputBatch.make_dummy(
+                batch_desc.num_reqs or num_reqs,
+                batch_desc.num_tokens,
+                self.input_buffers,
+            )
+            if not skip_attn_for_dummy_run:
+                block_tables, slot_mappings = self.prepare_dummy_attn(input_batch)
+            else:
+                assert batch_desc.cg_mode != CUDAGraphMode.FULL, (
+                    "Attention metadata must be prepared for dummy runs when using "
+                    "FULL cudagraph mode."
+                )
+                block_tables = None
+                slot_mappings = None
+            # FIXME(woosuk): Fix warmup for LoRA.
+
+        attn_metadata = None
+        slot_mappings_by_layer = None
+        if not (dummy_run and skip_attn_for_dummy_run):
+            assert slot_mappings is not None
+            slot_mappings_by_layer = build_slot_mappings_by_layer(
+                slot_mappings, self.kv_cache_config
+            )
+            assert block_tables is not None
+            attn_metadata = self.model_state.prepare_attn(
+                input_batch,
+                batch_desc.cg_mode,
+                block_tables,
+                slot_mappings,
+                self.attn_groups,
+                self.kv_cache_config,
+            )
+
+        inputs_embeds = None
+        if self.supports_mm_inputs and self.is_first_pp_rank:
+            # Run MM encoder (if needed) and get multimodal embeddings.
+            # Only first PP rank prepares multimodal embeddings.
+            # NOTE(woosuk): We must call get_mm_embeddings even during dummy runs
+            # to obtain inputs_embeds, because the compiled model expects this input.
+            inputs_embeds = self.model_state.get_mm_embeddings(
+                scheduler_output.scheduled_encoder_inputs,
+                input_batch,
+                self.req_states,
+            )
+
+        model_inputs = {
+            "input_ids": input_batch.input_ids,
+            "positions": input_batch.positions,
+            "inputs_embeds": inputs_embeds,
+            # NOTE: Values returned by `prepare_inputs` will override the default
+            # values above.
+            **self.model_state.prepare_inputs(input_batch, self.req_states),
+        }
+        if not self.is_first_pp_rank:
+            # Update for non-first PP ranks.
+            model_inputs["input_ids"] = None
+            model_inputs["inputs_embeds"] = None
+
+            # Prepare the intermediate tensors.
+            assert intermediate_tensors is not None
+            assert self.intermediate_tensors is not None
+            n = input_batch.num_tokens_after_padding
+            model_inputs["intermediate_tensors"] = IntermediateTensors(
+                {
+                    k: v[:n].copy_(intermediate_tensors.tensors[k][:n])
+                    for k, v in self.intermediate_tensors.tensors.items()
+                }
+            )
+            del intermediate_tensors
+
+        # Run model.
+        if batch_desc.cg_mode == CUDAGraphMode.FULL:
+            # Use explicit cudagraph replay for FULL mode.
+            # NOTE(woosuk): Here, we don't need to pass the input tensors,
+            # because they are already copied to the CUDA graph input buffers.
+            assert self.cudagraph_manager is not None
+            self.kv_connector.pre_forward(scheduler_output)
+            model_output = self.cudagraph_manager.run_fullgraph(batch_desc)
+        else:
+            # For piecewise and eager mode, just call model().
+            batch_descriptor = BatchDescriptor(
+                num_tokens=input_batch.num_tokens_after_padding,
+                has_lora=self.lora_config is not None,
+            )
+
+            # TODO(YHT): check if slot_mapping is necessary.
+            with set_ascend_forward_context(
+                attn_metadata,
+                self.vllm_config,
+                num_tokens=input_batch.num_tokens_after_padding,
+                aclgraph_runtime_mode=batch_desc.cg_mode,
+                num_tokens_across_dp=num_tokens_across_dp,
+                batch_descriptor=batch_descriptor,
+                slot_mapping=slot_mappings_by_layer,
+                skip_compiled=skip_compiled,
+            ):
+                self.kv_connector.pre_forward(scheduler_output)
+                model_output = self.model(**model_inputs)
+
+        if self.is_last_pp_rank:
+            if self.use_aux_hidden_state_outputs:
+                assert isinstance(model_output, tuple)
+                hidden_states, aux_hidden_states = model_output
+            else:
+                assert isinstance(model_output, torch.Tensor)
+                hidden_states = model_output
+                aux_hidden_states = None
+            output_intermediate_tensors = None
+        else:
+            assert isinstance(model_output, IntermediateTensors)
+            hidden_states = None
+            aux_hidden_states = None
+            output_intermediate_tensors = model_output
+
+        kv_connector_output = self.kv_connector.post_forward(scheduler_output)
+        self.execute_model_state = ExecuteModelState(
+            input_batch=input_batch,
+            attn_metadata=attn_metadata,
+            slot_mappings_by_layer=slot_mappings_by_layer,
+            hidden_states=hidden_states,
+            aux_hidden_states=aux_hidden_states,
+            kv_connector_output=kv_connector_output,
+        )
+
+        if not self.is_last_pp_rank:
+            # Non-last PP rank: return IntermediateTensors for sending.
+            assert output_intermediate_tensors is not None
+            output_intermediate_tensors.kv_connector_output = kv_connector_output
+            return output_intermediate_tensors
+        return None
 
     def _update_seq_lens_cpu(
         self,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -452,8 +452,7 @@ class NPUModelRunner(GPUModelRunner):
                 block_tables, slot_mappings = self.prepare_dummy_attn(input_batch)
             else:
                 assert batch_desc.cg_mode != CUDAGraphMode.FULL, (
-                    "Attention metadata must be prepared for dummy runs when using "
-                    "FULL cudagraph mode."
+                    "Attention metadata must be prepared for dummy runs when using FULL cudagraph mode."
                 )
                 block_tables = None
                 slot_mappings = None
@@ -463,9 +462,7 @@ class NPUModelRunner(GPUModelRunner):
         slot_mappings_by_layer = None
         if not (dummy_run and skip_attn_for_dummy_run):
             assert slot_mappings is not None
-            slot_mappings_by_layer = build_slot_mappings_by_layer(
-                slot_mappings, self.kv_cache_config
-            )
+            slot_mappings_by_layer = build_slot_mappings_by_layer(slot_mappings, self.kv_cache_config)
             assert block_tables is not None
             attn_metadata = self.model_state.prepare_attn(
                 input_batch,


### PR DESCRIPTION
What this PR does / why we need it?
This PR completes DP support for model_runner_v2 and fixes a DP-related MoE communication inconsistency, then adds regression unit tests.

Add DP execution flow in vllm_ascend/worker/v2/model_runner.py:
integrate DP sync/dispatch path in execute_model
propagate num_tokens_across_dp and slot mapping into forward context
keep behavior correct for zero-token and normal piecewise scenarios
Fix MoE communication method selection in vllm_ascend/platform.py:
choose comm method by max_tokens_across_dp instead of local num_tokens
ensure all DP ranks use consistent MoE comm strategy
Add/extend UT coverage:
tests/ut/worker/test_model_runner_v2.py
tests/ut/test_platform.py
include DP zero-token + normal path coverage and style alignment for new tests
Does this PR introduce any user-facing change?
No direct user-facing API change.
It improves correctness and stability when enabling V2 + DP, especially for MoE communication behavior across DP ranks.

How was this patch tested?
Added/updated UT:
tests/ut/worker/test_model_runner_v2.py
tests/ut/test_platform.py
Validated functional behavior in V2 + DP runtime scenario (generation runs successfully and outputs are correct).

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
