### PR TITLE
[Ops][BugFix] fix qwen2.5-omni weight loading

### DIFF
--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -243,6 +243,27 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
             "up_proj",
         ],
     },
+    "qwen2_5_omni_thinker": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "attn_qkv_proj": [
+            "attn_q_proj",
+            "attn_k_proj",
+            "attn_v_proj",
+        ],
+        "qkv": [
+            "q",
+            "k",
+            "v",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    },
     "bailing_hybrid": {
         "gate_up_proj": [
             "gate_proj",
@@ -487,6 +508,8 @@ class AscendModelSlimConfig(QuantizationConfig):
         # TODO: remove it when vllm fixes the WeightsMapper bug of qwen3-vl.
         if model_type in ["qwen3_vl"] and prefix == "lm_head":
             prefix = "language_model.lm_head"
+        if model_type in ["qwen2_5_omni_thinker", "qwen2_5_omni_text"]:
+            prefix = prefix.replace("thinker.", "")
         if model_type in ["bailing_hybrid"]:
             # Adapt to bailing_hybrid architecture: update layer names to MoE convention
             prefix = prefix.replace("linear_attn", "attention")

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -264,6 +264,27 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
             "up_proj",
         ],
     },
+    "qwen2_5_omni_text": {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "attn_qkv_proj": [
+            "attn_q_proj",
+            "attn_k_proj",
+            "attn_v_proj",
+        ],
+        "qkv": [
+            "q",
+            "k",
+            "v",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    },
     "bailing_hybrid": {
         "gate_up_proj": [
             "gate_proj",


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes weight loading for Qwen2.5-Omni models on Ascend NPUs by:
1. Adding `qwen2_5_omni_thinker` to the `packed_modules_model_mapping` to correctly handle fused layers.
2. Stripping the `thinker.` prefix from layer names for `qwen2_5_omni_thinker` and `qwen2_5_omni_text` models to match the quantization configuration.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The PR description does not specify tests, but these changes are necessary for correct weight loading of quantized Qwen2.5-Omni models.