### PR TITLE
[BugFix] Fix `info_once` logging with `unhashable` config

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -87,7 +87,7 @@ class AscendConfig:
                 "Linear layer sharding enabled with config: %s. "
                 "Note: This feature works optimally with FLASHCOMM2 and DSA-CP enabled; "
                 "using it without these features may result in significant performance degradation.",
-                self.layer_sharding,
+                str(self.layer_sharding),
             )
 
         self.enable_shared_expert_dp = (
@@ -112,8 +112,8 @@ class AscendConfig:
                 logger.warning_once(
                     "When using FLASHCOMM1, the max_num_batched_tokens should be divisible "
                     "by tp_size * pcp_size (%s). It has been adjusted to %s.",
-                    tp_pcp_size,
-                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    str(tp_pcp_size),
+                    str(vllm_config.scheduler_config.max_num_batched_tokens),
                 )
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/cpu_offload/cpu_kv_cache_manager.py
@@ -157,7 +157,7 @@ class CPUKVCacheManager:
     def cache_and_free_slots(self, request_id: str):
         logger.debug("Cache and free slots for request %s in cpu_kv_cache_manager", request_id)
         if request_id not in self.req_to_free:
-            logger.Error(f"request {request_id} not in req_to_free, maybe bug!")
+            logger.error("request %s not in req_to_free, maybe bug!", request_id)
             return
         request = self.req_to_free[request_id]
         if not self.req_failed_to_allocate[request_id]:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a `TypeError: unhashable type: 'list'` triggered when `layer_sharding` is enabled.

`logger.info_once` may use log arguments as part of its once-only cache key. When `layer_sharding` is configured as a list, passing it as a positional logging argument can fail because lists are unhashable.

This patch updates dynamic `info_once` logs to format the message before calling `info_once`, so the logger receives a plain string and no longer hashes mutable config objects.

It also fixes an invalid `logger.Error(...)` call to use the standard `logger.error(...)` method.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
