### PR TITLE
[CI] Fix broken CI

### DIFF
--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -10,6 +10,15 @@ from typing_extensions import Self
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
+# Redirect pickle's class lookup for the original MLAAttentionSpec so that
+# instances created by modules with stale imports (e.g. CacheOnlyAttentionLayer)
+# remain serializable after we replace vllm.v1.kv_cache_interface.MLAAttentionSpec.
+# pickle uses obj.__class__.__module__ + '.' + obj.__class__.__qualname__ to
+# locate the class; by pointing the original to this module we keep it findable.
+_OriginalMLAAttentionSpec = MLAAttentionSpec
+_OriginalMLAAttentionSpec.__module__ = __name__
+_OriginalMLAAttentionSpec.__qualname__ = "_OriginalMLAAttentionSpec"
+
 
 @dataclass(frozen=True)
 class AscendMLAAttentionSpec(MLAAttentionSpec):

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -10,15 +10,6 @@ from typing_extensions import Self
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
-# Redirect pickle's class lookup for the original MLAAttentionSpec so that
-# instances created by modules with stale imports (e.g. CacheOnlyAttentionLayer)
-# remain serializable after we replace vllm.v1.kv_cache_interface.MLAAttentionSpec.
-# pickle uses obj.__class__.__module__ + '.' + obj.__class__.__qualname__ to
-# locate the class; by pointing the original to this module we keep it findable.
-_OriginalMLAAttentionSpec = MLAAttentionSpec
-_OriginalMLAAttentionSpec.__module__ = __name__
-_OriginalMLAAttentionSpec.__qualname__ = "_OriginalMLAAttentionSpec"
-
 
 @dataclass(frozen=True)
 class AscendMLAAttentionSpec(MLAAttentionSpec):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3210,14 +3210,7 @@ class NPUModelRunner(GPUModelRunner):
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
 
-                    # Only apply the sparse MLA path for layers whose spec is
-                    # AscendMLAAttentionSpec (i.e. real sparse MLA layers).
-                    # Layers like CacheOnlyAttentionLayer carry a plain
-                    # MLAAttentionSpec that has no sparse_kv_cache_ratio and
-                    # must fall through to the generic split-factor path.
-                    from vllm.v1.kv_cache_interface import MLAAttentionSpec as _AscendMLA
-                    is_sparse_mla = self.use_sparse and isinstance(current_kv_cache_spec, _AscendMLA)
-                    if is_sparse_mla:
+                    if self.use_sparse:
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
@@ -3227,7 +3220,6 @@ class NPUModelRunner(GPUModelRunner):
                         dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
                         dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
                     else:
-                        current_sparse_c8 = False
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
                         kv_head_dim_list = [
@@ -3246,9 +3238,9 @@ class NPUModelRunner(GPUModelRunner):
                     dsa_k_tensor_size = None
                     dsa_k_scale_tensor_size = None
                     #### for deepseek sparse attention
-                    if is_sparse_mla:
+                    if self.use_sparse:
                         dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
-                    if is_sparse_mla and current_sparse_c8:
+                    if self.use_sparse and current_sparse_c8:
                         dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
 
                     # for other attentions, e.g., self_attn, sliding window attn
@@ -3284,7 +3276,7 @@ class NPUModelRunner(GPUModelRunner):
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the attn kvcache for all shared layers
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
-                            if is_sparse_mla:
+                            if self.use_sparse:
                                 if current_sparse_c8:
                                     kv_cache_raw_tensors[layer_name_inner] = (
                                         k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
@@ -3332,8 +3324,11 @@ class NPUModelRunner(GPUModelRunner):
                 # TODO: remove this after the OOM issue is located and fixed, otherwise, some model may
                 # encounter OOM issue
                 if isinstance(current_kv_cache_spec, AttentionSpec):
-                    from vllm.v1.kv_cache_interface import MLAAttentionSpec as _AscendMLA
-                    if self.use_sparse and isinstance(current_kv_cache_spec, _AscendMLA):
+                    # cache_only_layers (extract_hidden_states) carry a plain
+                    # MLAAttentionSpec and store a single tensor; route them to
+                    # the dedicated branch below before the sparse branch
+                    # tries to unpack them as a (k, v, dsa_k[, scale]) tuple.
+                    if self.use_sparse and "cache_only_layers" not in layer_name:
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
                             raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
@@ -3792,9 +3787,14 @@ class NPUModelRunner(GPUModelRunner):
             elif isinstance(attn_module, MambaBase):
                 mamba_layers[layer_name] = attn_module
 
-            else:
-                # Handle other AttentionLayerBase subclasses (e.g., CacheOnlyAttentionLayer)
-                # that are not Attention, MLAAttention, or MambaBase
+            elif isinstance(attn_module, CacheOnlyAttentionLayer):
+                # Only CacheOnlyAttentionLayer (extract_hidden_states draft model)
+                # is handled here. Other AttentionLayerBase subclasses such as
+                # DeepseekV32IndexerCache are intentionally skipped: on Ascend,
+                # the indexer's k_cache is replaced by IndexerWrapper, so its
+                # KV cache is unused. Including it would inject a plain
+                # MLAAttentionSpec (no sparse_kv_cache_ratio) into kv_cache_spec
+                # and break the sparse allocation path.
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     kv_cache_spec[layer_name] = spec
                     attn_layer_names.add(layer_name)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3324,10 +3324,11 @@ class NPUModelRunner(GPUModelRunner):
                 # TODO: remove this after the OOM issue is located and fixed, otherwise, some model may
                 # encounter OOM issue
                 if isinstance(current_kv_cache_spec, AttentionSpec):
-                    # cache_only_layers (extract_hidden_states) carry a plain
-                    # MLAAttentionSpec and store a single tensor; route them to
-                    # the dedicated branch below before the sparse branch
-                    # tries to unpack them as a (k, v, dsa_k[, scale]) tuple.
+                    # cache_only_layers (extract_hidden_states) are allocated
+                    # as a single tensor by the branch at the top of
+                    # _allocate_kv_cache_tensors; route them to the dedicated
+                    # elif branch below before the sparse branch tries to
+                    # unpack them as a (k, v, dsa_k[, scale]) tuple.
                     if self.use_sparse and "cache_only_layers" not in layer_name:
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
@@ -3792,11 +3793,22 @@ class NPUModelRunner(GPUModelRunner):
                 # is handled here. Other AttentionLayerBase subclasses such as
                 # DeepseekV32IndexerCache are intentionally skipped: on Ascend,
                 # the indexer's k_cache is replaced by IndexerWrapper, so its
-                # KV cache is unused. Including it would inject a plain
-                # MLAAttentionSpec (no sparse_kv_cache_ratio) into kv_cache_spec
-                # and break the sparse allocation path.
+                # KV cache is unused.
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
-                    kv_cache_spec[layer_name] = spec
+                    # CacheOnlyAttentionLayer's module imports MLAAttentionSpec
+                    # before the patch runs, so the spec it returns is an
+                    # instance of the original (unpatched) class. Rebuilding
+                    # with the patched AscendMLAAttentionSpec makes the spec
+                    # picklable and keeps this branch consistent with the
+                    # MLAAttention branch above.
+                    from vllm.v1.kv_cache_interface import MLAAttentionSpec as AscendMLAAttentionSpec
+                    kv_cache_spec[layer_name] = AscendMLAAttentionSpec(
+                        block_size=spec.block_size,
+                        num_kv_heads=spec.num_kv_heads,
+                        head_size=spec.head_size,
+                        dtype=spec.dtype,
+                        cache_dtype_str=spec.cache_dtype_str,
+                    )
                     attn_layer_names.add(layer_name)
 
         if len(mamba_layers) > 0:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3210,7 +3210,14 @@ class NPUModelRunner(GPUModelRunner):
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
 
-                    if self.use_sparse:
+                    # Only apply the sparse MLA path for layers whose spec is
+                    # AscendMLAAttentionSpec (i.e. real sparse MLA layers).
+                    # Layers like CacheOnlyAttentionLayer carry a plain
+                    # MLAAttentionSpec that has no sparse_kv_cache_ratio and
+                    # must fall through to the generic split-factor path.
+                    from vllm.v1.kv_cache_interface import MLAAttentionSpec as _AscendMLA
+                    is_sparse_mla = self.use_sparse and isinstance(current_kv_cache_spec, _AscendMLA)
+                    if is_sparse_mla:
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
@@ -3220,6 +3227,7 @@ class NPUModelRunner(GPUModelRunner):
                         dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
                         dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
                     else:
+                        current_sparse_c8 = False
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
                         kv_head_dim_list = [
@@ -3238,9 +3246,9 @@ class NPUModelRunner(GPUModelRunner):
                     dsa_k_tensor_size = None
                     dsa_k_scale_tensor_size = None
                     #### for deepseek sparse attention
-                    if self.use_sparse:
+                    if is_sparse_mla:
                         dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
-                    if self.use_sparse and current_sparse_c8:
+                    if is_sparse_mla and current_sparse_c8:
                         dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
 
                     # for other attentions, e.g., self_attn, sliding window attn
@@ -3276,7 +3284,7 @@ class NPUModelRunner(GPUModelRunner):
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the attn kvcache for all shared layers
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
-                            if self.use_sparse:
+                            if is_sparse_mla:
                                 if current_sparse_c8:
                                     kv_cache_raw_tensors[layer_name_inner] = (
                                         k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
@@ -3324,7 +3332,8 @@ class NPUModelRunner(GPUModelRunner):
                 # TODO: remove this after the OOM issue is located and fixed, otherwise, some model may
                 # encounter OOM issue
                 if isinstance(current_kv_cache_spec, AttentionSpec):
-                    if self.use_sparse:
+                    from vllm.v1.kv_cache_interface import MLAAttentionSpec as _AscendMLA
+                    if self.use_sparse and isinstance(current_kv_cache_spec, _AscendMLA):
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
                             raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore


### PR DESCRIPTION
### What this PR does / why we need it?
https://github.com/vllm-project/vllm-ascend/pull/8799 added from vllm.model_executor.models.extract_hidden_states import CacheOnlyAttentionLayer in NPU model runner, we should also transfer the `CacheOnlyAttentionLayer.get_attn_spec` to `AscendMLAAttentionSpec`. See: https://github.com/vllm-project/vllm/blob/713b28bd0bf4d7f8226ee20940e3ae171fabd09b/vllm/model_executor/models/extract_hidden_states.py#L38

When `patch_kv_cache_interface.py` monkey-patches `vllm.v1.kv_cache_interface.MLAAttentionSpec` to `AscendMLAAttentionSpec`, modules that imported the original class before the patch (e.g.`extract_hidden_states.py`) still hold a stale reference. As a result, `CacheOnlyAttentionLayer.get_kv_cache_spec()` returns instances of the original `MLAAttentionSpec` class.

In `get_kv_cache_spec()` of `model_runner_v1.py`, the `else` branch (handling `CacheOnlyAttentionLayer` and similar layers) stored these original instances directly into the `kv_cache_spec` dict. When the worker subsequently tried to pickle this dict to send results back to the scheduler, pickle's class-identity check failed:

```shell
  PicklingError: Can't pickle <class 'vllm.v1.kv_cache_interface.MLAAttentionSpec'>:
  it's not the same object as vllm.v1.kv_cache_interface.MLAAttentionSpec
```

Fix: 
- Rebuild CacheOnlyAttentionLayer's spec as `AscendMLAAttentionSpec` so pickle's class-identity check passes (the module's MLAAttentionSpec reference is stale relative to the patched class).
- Restrict the new else branch in get_kv_cache_spec() to CacheOnlyAttentionLayer; `DeepseekV32IndexerCache` is unused on Ascend (IndexerWrapper nulls its k_cache) and must not enter kv_cache_spec.
- In _reshape_kv_cache_tensors, skip the use_sparse branch for cache_only_layers so the dedicated single-tensor handler is reachable.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
