### PR TITLE
[BugFix] Skip `DeepseekV32IndexerCache` in `get_kv_cache_spec` when `use_sparse` is enabled

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3786,6 +3786,13 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 # Handle other AttentionLayerBase subclasses (e.g., CacheOnlyAttentionLayer)
                 # that are not Attention, MLAAttention, or MambaBase
+                if self.use_sparse:
+                    from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+                    if isinstance(attn_module, DeepseekV32IndexerCache):
+                        # When use_sparse=True, the indexer k_cache is embedded in the
+                        # main attention layer's extended KV cache (dsa_k_tensor).
+                        # Ascend SFA accesses it via kv_cache[2], so skip separate allocation.
+                        continue
                 if spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     kv_cache_spec[layer_name] = spec
                     attn_layer_names.add(layer_name)


### PR DESCRIPTION
https://github.com/vllm-project/vllm-ascend/pull/8799 added an `else` branch in `get_kv_cache_spec()` to handle `CacheOnlyAttentionLayer` for the extract_hidden_states speculative decoding method. This unintentionally also captured `DeepseekV32IndexerCache`, which is likewise an `AttentionLayerBase` subclass not covered by the Attention/MLAAttention/MambaBase branches.

`DeepseekV32IndexerCache.get_kv_cache_spec()` returns an `AscendMLAAttentionSpec` without `sparse_head_dim` (None by default). When `use_sparse=True`, `_allocate_kv_cache_tensors` calls `sparse_kv_cache_ratio` on every "attn" layer, which asserts `self.sparse_head_dim is not None`, causing an AssertionError and breaking tests such as `test_deepseek3_2_w8a8_pruning_mtp_tp2_ep`.

Fix: skip `DeepseekV32IndexerCache` layers in `get_kv_cache_spec()` when `use_sparse=True`. No separate KV cache allocation is needed because the Ascend SFA backend embeds the indexer's key cache as part of the main attention layer's extended KV cache tuple (dsa_k_tensor at kv_cache[2]), and accesses it directly without relying on `DeepseekV32IndexerCache.kv_cache`.