### PR TITLE
[BugFix] Fix Qwen2 compiled-path outputs on Ascend

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -228,6 +228,10 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         super().__init__(head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype, init_cache)
         vllm_config = get_current_vllm_config()
         self.use_mtp = vllm_config.speculative_config and vllm_config.speculative_config.method == "mtp"
+        self.force_native_qwen2_rope = (
+            "Qwen2ForCausalLM" in getattr(vllm_config.model_config, "architectures", [])
+            and os.environ.get("VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE", "1") != "0"
+        )
         _record_cos_sin_cache(self.cos_sin_cache)
         _record_cos_and_sin_cache_interleaved(self.cos_sin_cache)
 
@@ -242,6 +246,17 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         is_neox_style = self.is_neox_style
         if is_neox_style_override is not None:
             is_neox_style = is_neox_style_override
+        if getattr(self, "force_native_qwen2_rope", False):
+            cos_sin_cache = self._match_cos_sin_cache_dtype(query)
+            return RotaryEmbedding.forward_static(
+                positions,
+                query,
+                key,
+                self.head_size,
+                self.rotary_dim,
+                cos_sin_cache,
+                is_neox_style,
+            )
         is_draft_model = _EXTRA_CTX.is_draft_model if is_forward_context_available() else False
         flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled if is_forward_context_available() else False
         if is_draft_model and self.use_mtp and flash_comm_v1_enabled:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -473,6 +473,30 @@ class NPUPlatform(Platform):
 
         from vllm.config.compilation import CUDAGraphMode
 
+        architecture = None
+        if model_config is not None:
+            architectures = getattr(model_config, "architectures", None)
+            if architectures:
+                architecture = architectures[0]
+
+        if model_config is not None and architecture == "Qwen2ForCausalLM":
+            if os.environ.get("VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE", "1") != "0":
+                logger.warning(
+                    "Using native rotary fallback for %s on NPU to avoid incorrect outputs on the compiled path.",
+                    architecture,
+                )
+            elif os.environ.get("VLLM_ASCEND_ALLOW_UNSAFE_QWEN2_ACLGRAPH", "0") != "1":
+                logger.warning(
+                    "Disabling NPU graph compilation for %s because native rotary fallback was disabled and the "
+                    "default ACL graph path can produce incorrect outputs. Set VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE=1 "
+                    "to use the default safe fix, or VLLM_ASCEND_ALLOW_UNSAFE_QWEN2_ACLGRAPH=1 to restore the "
+                    "previous behavior.",
+                    architecture,
+                )
+                enforce_eager = True
+                model_config.enforce_eager = True
+                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+
         if ascend_config.xlite_graph_config.enabled:
             if ascend_config.xlite_graph_config.full_mode and vllm_config.speculative_config is None:
                 logger.info("ACLGraph has been disabled when speculation is disabled in xlite full mode")


### PR DESCRIPTION
## Summary

- Use a native rotary fallback for Qwen2 on Ascend while keeping the compiled path enabled.
- Avoid forcing the complete Qwen2 runtime into eager mode as the default safety behavior.

## Validation

- Single-request Qwen2.5-14B-Instruct functional check on Ascend with the default compiled path after the fix.
- Performance results will only be added after a fixed-commit, repeated real-hardware comparison against the PR base is complete.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350