### PR TITLE
[P/D][BugFix] Fix for transmit kv cache failure

### DIFF
--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -277,6 +277,23 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
         self.assertEqual(queued["request_id"], "req1")
         self.assertEqual(queued["remote_host"], "localhost")
 
+    def test_mark_and_is_failed(self):
+        self.thread._mark_failed_recv_request("req1", [10, 20])
+        self.assertTrue(self.thread._is_failed_recv_request("req1"))
+        self.assertIn(10, self.thread.invalid_block_ids)
+        self.assertIn(20, self.thread.invalid_block_ids)
+
+    def test_clear_failed_recv_request(self):
+        self.thread._mark_failed_recv_request("req2", [30])
+        self.thread._clear_failed_recv_request("req2")
+        self.assertFalse(self.thread._is_failed_recv_request("req2"))
+
+    def test_get_and_clear_invalid_block_ids(self):
+        self.thread.invalid_block_ids = {1, 2, 3}
+        result = self.thread.get_and_clear_invalid_block_ids()
+        self.assertSetEqual(result, {1, 2, 3})
+        self.assertEqual(self.thread.invalid_block_ids, set())
+
     @patch.object(KVCacheTaskTracker, "get_and_clear_finished_requests")
     def test_get_finished_requests(self, mock_tracker):
         mock_tracker.return_value = {"req1", "req2"}

--- a/tests/ut/kv_connector/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_layerwise_connector.py
@@ -211,6 +211,25 @@ class TestKVCacheRecvingLayerThread(unittest.TestCase):
         self.meta = MooncakeAgentMetadata(te_rpc_port=6000, kv_caches_base_addr=[0x1, 0x2])
         self.ready_event = threading.Event()
 
+    def test_get_and_clear_done_requests(self):
+        th = KVCacheRecvingLayerThread(
+            tp_rank=0,
+            side_channel_port=5555,
+            tp_size=2,
+            pd_head_ratio=1,
+            local_engine_id="engineA",
+            metadata=self.meta,
+            ready_event=self.ready_event,
+        )
+
+        with th.lock:
+            th.done_requests.update({"r1", "r2"})
+        got = th.get_and_clear_done_requests()
+        self.assertEqual(got, {"r1", "r2"})
+
+        got2 = th.get_and_clear_done_requests()
+        self.assertEqual(got2, set())
+
     def test_get_and_clear_finished_requests(self):
         th = KVCacheRecvingLayerThread(
             tp_rank=0,
@@ -224,13 +243,13 @@ class TestKVCacheRecvingLayerThread(unittest.TestCase):
 
         with th.lock:
             th.done_requests.update({"r1", "r2"})
-        got = th.get_and_clear_finished_requests()
+        got = th.get_and_clear_failed_requests()
         self.assertEqual(got, {"r1", "r2"})
 
-        got2 = th.get_and_clear_finished_requests()
+        got2 = th.get_and_clear_failed_requests()
         self.assertEqual(got2, set())
 
-    def test_update_task_aggregates_by_pd_head_ratio(self):
+    def test_update_failed_task_aggregates_by_pd_head_ratio(self):
         th = KVCacheRecvingLayerThread(
             tp_rank=0,
             side_channel_port=5555,
@@ -245,12 +264,32 @@ class TestKVCacheRecvingLayerThread(unittest.TestCase):
             th.task_tracker["reqX"] = 0
             th.request_map["reqX"] = "reqX"
 
-        th.update_task("reqX", 2)
+        th.update_failed_task("reqX")
+        with th.lock:
+            self.assertNotIn("reqX", th.task_tracker)
+            self.assertIn("reqX", th.failed_requests)
+
+    def test_update_done_task_aggregates_by_pd_head_ratio(self):
+        th = KVCacheRecvingLayerThread(
+            tp_rank=0,
+            side_channel_port=5555,
+            tp_size=2,
+            pd_head_ratio=2,
+            local_engine_id="engineA",
+            metadata=self.meta,
+            ready_event=self.ready_event,
+        )
+
+        with th.lock:
+            th.task_tracker["reqX"] = 0
+            th.request_map["reqX"] = "reqX"
+
+        th.update_done_task("reqX", 2)
         with th.lock:
             self.assertIn("reqX", th.task_tracker)
             self.assertNotIn("reqX", th.done_requests)
 
-        th.update_task("reqX", 2)
+        th.update_done_task("reqX", 2)
         with th.lock:
             self.assertNotIn("reqX", th.task_tracker)
             self.assertIn("reqX", th.done_requests)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -370,6 +370,9 @@ class KVCacheRecvingThread(threading.Thread):
                 self.v_head_dim = self.model_config.hf_text_config.head_dim
                 self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
         self.proc_not_transfer_request: dict[str, bool] = {}
+        self.failed_recv_requests: set[str] = set()
+        self.invalid_block_ids: set[int] = set()
+        self.failed_recv_requests_lock = threading.Lock()
 
     def add_request(
         self,
@@ -413,6 +416,26 @@ class KVCacheRecvingThread(threading.Thread):
         """
         return self.task_tracker.get_and_clear_finished_requests()
 
+    def get_and_clear_invalid_block_ids(self) -> set[int]:
+        """Get and clear block ids that failed to load."""
+        with self.failed_recv_requests_lock:
+            invalid_block_ids = self.invalid_block_ids
+            self.invalid_block_ids = set()
+        return invalid_block_ids
+
+    def _is_failed_recv_request(self, request_id: str) -> bool:
+        with self.failed_recv_requests_lock:
+            return request_id in self.failed_recv_requests
+
+    def _mark_failed_recv_request(self, request_id: str, local_block_ids: list[int]) -> None:
+        with self.failed_recv_requests_lock:
+            self.failed_recv_requests.add(request_id)
+            self.invalid_block_ids.update(local_block_ids)
+
+    def _clear_failed_recv_request(self, request_id: str) -> None:
+        with self.failed_recv_requests_lock:
+            self.failed_recv_requests.discard(request_id)
+
     def run(self):
         """Run the thread to handle KV cache transfer requests."""
         self.ready_event.set()
@@ -434,20 +457,32 @@ class KVCacheRecvingThread(threading.Thread):
         remote_handshake_port = req_meta["remote_handshake_port"]
         remote_port_send_num = req_meta["remote_port_send_num"]
         all_task_done = req_meta["all_task_done"]
+        transfer_failed = self._is_failed_recv_request(request_id)
 
         try:
-            logger.debug("Starting to transfer KV cache for request %s.", remote_request_id)
-            self._transfer_kv_cache(req_meta)
-            logger.debug("Finished transferring KV cache for request %s.", remote_request_id)
-        except Exception as e:
-            logger.exception("Failed to transfer KV cache for request %s: %s", remote_request_id, e)
+            if transfer_failed:
+                self._mark_failed_recv_request(request_id, req_meta["local_block_ids"])
+                logger.warning(
+                    "Skipping KV cache transfer for request %s because a previous transfer failed.",
+                    remote_request_id,
+                )
+            else:
+                try:
+                    logger.debug("Starting to transfer KV cache for request %s.", remote_request_id)
+                    self._transfer_kv_cache(req_meta)
+                    logger.debug("Finished transferring KV cache for request %s.", remote_request_id)
+                except Exception as e:
+                    transfer_failed = True
+                    self._mark_failed_recv_request(request_id, req_meta["local_block_ids"])
+                    logger.exception("Failed to transfer KV cache for request %s: %s", remote_request_id, e)
         finally:
             self._send_done_signal_to_free_remote_port(remote_request_id, remote_host, remote_port_send_num)
             if all_task_done:
-                if len(req_meta["local_block_ids"]) > 0:
+                if len(req_meta["local_block_ids"]) > 0 or transfer_failed:
                     self.task_tracker.update_done_task_count(request_id)
                 if request_id in self.proc_not_transfer_request:
                     del self.proc_not_transfer_request[request_id]
+                self._clear_failed_recv_request(request_id)
             self.request_queue.task_done()
             # Always send the done signal to the remote host to ensure proper
             # resource cleanup. Failing to do so may cause a memory leak on the
@@ -864,6 +899,11 @@ class MooncakeConnector(KVConnectorBase_V1):
         """Get the finished recving and sending requests."""
         assert self.connector_worker is not None
         return self.connector_worker.get_finished()
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Get the block ids whose KV load failed."""
+        assert self.connector_worker is not None
+        return self.connector_worker.get_block_ids_with_load_errors()
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
@@ -1309,6 +1349,11 @@ class MooncakeConnectorWorker:
                     len(done_recving),
                 )
         return done_sending, done_recving
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        if self.kv_role == "kv_consumer" and self.kv_recv_thread is not None:
+            return self.kv_recv_thread.get_and_clear_invalid_block_ids()
+        return set()
 
     def _get_kv_split_metadata(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
 # isort: on
 
 DONE_SENDING_MSG = b"done_sending_msg"
+FAILED_SENDING_MSG = b"failed_sending_msg"
 
 
 @dataclass
@@ -251,6 +252,7 @@ class KVCacheSendingLayerThread(threading.Thread):
             else:
                 send_queue_size = 1
         self.send_queue = queue.Queue[SendTask](maxsize=send_queue_size)
+        self.failed_reqs: set[str] = set()
         self.k_buffer = k_buffer
         self.v_buffer = v_buffer
         self.enable_kv_quant = enable_kv_quant
@@ -487,13 +489,7 @@ class KVCacheSendingLayerThread(threading.Thread):
                         transfer_meta.req_ids,
                         session_id,
                     )
-                    if send_task.layer_idx == (self.total_layers - 1):
-                        for req_id in transfer_meta.req_ids:
-                            req_meta = send_task.send_request[req_id]
-                            if req_meta.chunk_finish:
-                                self.callback_func(
-                                    req_id, req_meta, layer_group_idx
-                                )  # TODO Send a signal indicating transmission failure
+                    self.failed_reqs.add(req_id)
                 else:
                     req_end_time = time.perf_counter()
                     total_transfer_size = sum(transfer_meta.length) / 1024
@@ -505,11 +501,15 @@ class KVCacheSendingLayerThread(threading.Thread):
                         session_id,
                         req_transfer_elapsed,
                     )
-                    if send_task.layer_idx == (self.total_layers - 1):
-                        for req_id in transfer_meta.req_ids:
-                            req_meta = send_task.send_request[req_id]
-                            if req_meta.chunk_finish:
-                                self.callback_func(req_id, req_meta, layer_group_idx)
+                if send_task.layer_idx == (self.total_layers - 1):
+                    for req_id in transfer_meta.req_ids:
+                        req_meta = send_task.send_request[req_id]
+                        if req_meta.chunk_finish:
+                            if req_id in self.failed_reqs:
+                                self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=False)
+                                self.failed_reqs.discard(req_id)
+                            else:
+                                self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=True)
 
 
 class KVCacheRecvingLayerThread(threading.Thread):
@@ -532,11 +532,12 @@ class KVCacheRecvingLayerThread(threading.Thread):
         self.side_channel_port = side_channel_port
         self.lock = threading.Lock()
         self.done_requests = set[str]()
+        self.failed_requests = set[str]()
         self.task_tracker = dict[str, int]()
         self.ready_event = ready_event
         self.metadata = metadata
 
-    def get_and_clear_finished_requests(self) -> set[str]:
+    def get_and_clear_done_requests(self) -> set[str]:
         """
         Get and clear the requests that have been completed.
         Returns:
@@ -547,7 +548,35 @@ class KVCacheRecvingLayerThread(threading.Thread):
             self.done_requests = set()
         return finished_requests
 
-    def update_task(self, req_id, trans_count, side_channel_path):
+    def get_and_clear_failed_requests(self) -> set[str]:
+        """
+        Get and clear the requests that have failed.
+        Returns:
+            A set of request IDs that have failed.
+        """
+        with self.lock:
+            failed_requests = self.failed_requests
+            self.failed_requests = set()
+        return failed_requests
+
+    def update_failed_task(self, req_id: str) -> None:
+        """
+        Handle a failed task by adding it to the failed_requests set and removing it from the task tracker.
+        Args:
+            req_id: The ID of the request that has failed.
+        """
+        with self.lock:
+            if req_id not in self.task_tracker:
+                self.task_tracker[req_id] = set()
+            self.task_tracker.pop(req_id, None)
+            self.failed_requests.add(req_id)
+
+    def update_done_task(self, req_id, trans_count, side_channel_path):
+        """
+        Handle a completed task by adding it to the done_requests set and removing it from the task tracker.
+        Args:
+            req_id: The ID of the request that has completed.
+        """
         with self.lock:
             if req_id not in self.task_tracker:
                 self.task_tracker[req_id] = set()
@@ -588,7 +617,12 @@ class KVCacheRecvingLayerThread(threading.Thread):
                         request_id = msg[1]
                         trans_count = msg[2]
                         side_channel_path = msg[3]
-                        self.update_task(request_id, trans_count, side_channel_path)
+                        self.update_done_task(request_id, trans_count, side_channel_path)
+                        sock.send_multipart((identity, b"", b"ACK"))
+                    elif msg[0] == FAILED_SENDING_MSG:
+                        request_id = msg[1]
+                        logger.error("Got FAILED_SENDING_MSG for request %s, abort KV load.", msg[1])
+                        self.update_failed_task(request_id)
                         sock.send_multipart((identity, b"", b"ACK"))
                     else:
                         logger.error("Connection listener got unexpected message %s", msg)
@@ -699,6 +733,11 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
         """Get the finished recving and sending requests."""
         assert self.connector_worker is not None
         return self.connector_worker.get_finished()
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Get the block ids that have load errors."""
+        assert self.connector_worker is not None
+        return self.connector_worker.get_block_ids_with_load_errors()
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
@@ -1085,6 +1124,8 @@ class MooncakeLayerwiseConnectorWorker:
         self.k_buffer: torch.Tensor | None = None
         self.v_buffer: torch.Tensor | None = None
         self.virtual_request: set[str] = set()
+        self._invalid_block_ids: set[int] = set()
+        self._recving_metadata: dict[str, ReqMeta] = {}
 
     def create_kv_buffer(self, first_kv_cache_tuple):
         alignment = 2 * 1024 * 1024
@@ -1262,7 +1303,7 @@ class MooncakeLayerwiseConnectorWorker:
 
     def get_finished(self) -> tuple[set[str], set[str]]:
         done_recving = (
-            self.kv_recv_layer_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
+            self.kv_recv_layer_thread.get_and_clear_done_requests(  # type: ignore[union-attr]
             )
             if self.vllm_config.kv_transfer_config.is_kv_consumer
             else set()
@@ -1270,14 +1311,35 @@ class MooncakeLayerwiseConnectorWorker:
         done_recving = {self.request_map[s] for s in done_recving if s in self.request_map}
         done_recving.update(self.virtual_request)
         self.virtual_request = set()
-        for req_id in done_recving:
-            req_id = req_id[:-9]
-            self.request_map.pop(req_id, None)
+
+        failed_recving = (
+            self.kv_recv_layer_thread.get_and_clear_failed_requests()
+            if self.vllm_config.kv_transfer_config.is_kv_consumer and self.kv_recv_layer_thread is not None
+            else set()
+        )
+        failed_recving = {self.request_map[s] for s in failed_recving if s in self.request_map}
+        for req_id in failed_recving:
+            if meta := self._recving_metadata.get(req_id):
+                self._invalid_block_ids.update(block_id for group in meta.local_block_ids for block_id in group)
+        for req_id in done_recving.union(failed_recving):
+            org_req_id = req_id[:-9]
+            self.request_map.pop(org_req_id, None)
+            self._recving_metadata.pop(req_id, None)
         if len(done_recving) > 0:
             logger.info(
                 "Number of completed KV cache recv requests: %s, receive requests: %s", len(done_recving), done_recving
             )
         return set(), done_recving
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """
+        Return and clear the set of block IDs that failed to load.
+        This is called by the scheduler to identify blocks that need
+        to be retried after a transfer failure.
+        """
+        result = self._invalid_block_ids
+        self._invalid_block_ids = set()
+        return result
 
     # {(ip, port)]: {local_block_ids: [], remote_block_ids: {}}}
     def _get_kv_split_metadata(self, req_meta: ReqMeta, req_idx: int, req_id: str, group_idx: int):
@@ -1453,6 +1515,7 @@ class MooncakeLayerwiseConnectorWorker:
                 external_req_id = get_external_request_id(req_id)
                 assert self.kv_recv_layer_thread is not None
                 self.request_map[external_req_id] = req_id
+                self._recving_metadata[req_id] = meta
         elif self.vllm_config.kv_transfer_config.is_kv_producer:
             # update trans info
             update_metadata = {}
@@ -1752,10 +1815,12 @@ class MooncakeLayerwiseConnectorWorker:
         req_meta.remote_layer_metadata = self.remote_layer_metadata[req_meta.remote_engine_id][req_meta.remote_port]
         return req_meta
 
-    def send_done_send_signal(self, req_id, req_meta, group_idx):
+    def send_done_send_signal(self, req_id, req_meta, group_idx, trans_flag: bool = True):
         external_req_id = get_external_request_id(req_id)
+        send_msg_type = DONE_SENDING_MSG if trans_flag else FAILED_SENDING_MSG
         logger.info(
-            "Sending done sending signal for request %s to %s:%d",
+            "Sending transmitting signal %s for request %s to %s:%d",
+            send_msg_type,
             external_req_id,
             req_meta.remote_host,
             req_meta.remote_port,
@@ -1765,7 +1830,7 @@ class MooncakeLayerwiseConnectorWorker:
             msg_encoder = msgspec.msgpack.Encoder()
             side_channel_path = f"{self.side_channel_host}:{self.handshake_port}"
             encoded_data = msg_encoder.encode(
-                (DONE_SENDING_MSG, external_req_id, req_meta.trans_count[group_idx], side_channel_path)
+                (send_msg_type, external_req_id, req_meta.trans_count[group_idx], side_channel_path)
             )
             max_retries = 3
             for attempt in range(1, max_retries + 1):
@@ -1798,7 +1863,8 @@ class MooncakeLayerwiseConnectorWorker:
                         raise RuntimeError(f"Failed to receive ACK after {max_retries} attempts: {e}") from e
         except Exception as e:
             logger.error(
-                "Sending done sending signal for request %s to %s:%s fail with error: %s",
+                "Sending  signal %s for request %s to %s:%s fail with error: %s",
+                send_msg_type,
                 external_req_id,
                 req_meta.remote_host,
                 req_meta.remote_port,


### PR DESCRIPTION
### What this PR does / why we need it?
-- When kv cache transmite failed, blocks with load errors need to be marked invalid and end this request.
-- For mooncake_layerwise_connector, add a new 'FAILED_SENDING_MSG' signal to communicate transmission failures between the producer and consumer, ensuring both sides can clean up resources appropriately.
-- For recving thread, implement tracking for invalid block IDs that fail to load, providing a way for the scheduler to identify and potentially retry failed blocks.

fixes: https://github.com/vllm-project/vllm-ascend/issues/7871 & https://github.com/vllm-project/vllm-ascend/issues/8427
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Test: Use the gsm8k dataset to construct a scenario where the KV cache transmission of the first part of.
- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
