### PR TITLE
[Misc] Make build JOB_NUM configurable

### DIFF
--- a/csrc/build.sh
+++ b/csrc/build.sh
@@ -169,8 +169,12 @@ else
 fi
 
 if [ "${PARENT_JOB}" == "false" ];then
-    CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2))
-    JOB_NUM="-j${CPU_NUM}"
+    if [ -n "${MAX_JOBS}" ]; then
+        JOB_NUM="-j${MAX_JOBS}"
+    else
+        CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2))
+        JOB_NUM="-j${CPU_NUM}"
+    fi
 fi
 
 CUSTOM_OPTION="${CUSTOM_OPTION} -DCUSTOM_ASCEND_CANN_PACKAGE_PATH=${ASCEND_CANN_PACKAGE_PATH} -DCHECK_COMPATIBLE=${CHECK_COMPATIBLE}"


### PR DESCRIPTION
### What this PR does / why we need it?
This PR allows users to configure the number of parallel build jobs by setting the `MAX_JOBS` environment variable in `csrc/build.sh`. If `MAX_JOBS` is not set, the script defaults to using twice the number of available processors. This is useful for managing system resources during compilation.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
