### PR TITLE
[BugFix] Fixed wrong RoPE implementation for GLM5 in sfa_v1.py when using non-Triton operators

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -899,7 +899,11 @@ class AscendSFAImpl(MLAAttentionImpl):
             sin = sin.view(-1, 1, 1, self.qk_rope_head_dim)
 
             k_li_pe = k_li_pe.unsqueeze(2)
-            k_li_pe = torch_npu.npu_rotary_mul(k_li_pe, cos, sin)
+            k_li_pe = (
+                torch_npu.npu_rotary_mul(k_li_pe, cos, sin)
+                if self.is_rope_neox_style
+                else torch_npu.npu_interleave_rope(k_li_pe, cos, sin)
+            )
             k_li_pe = k_li_pe.squeeze(2)
 
             k_li = torch.cat([k_li_pe, k_li_nope], dim=-1)  # [b*s,128]
@@ -939,7 +943,11 @@ class AscendSFAImpl(MLAAttentionImpl):
             )  # [b,s,64,64+64]
 
             q_li_pe = q_li_pe.unsqueeze(2)
-            q_li_pe = torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
+            q_li_pe = (
+                torch_npu.npu_rotary_mul(q_li_pe, cos, sin)
+                if self.is_rope_neox_style
+                else torch_npu.npu_interleave_rope(q_li_pe, cos, sin)
+            )
             q_li_pe = q_li_pe.squeeze(2)
             q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)  # [b*s,64,128]
 


### PR DESCRIPTION
When running the GLM5 model with HAS_TRITON=False, the code defaults to using the npu_rotary_mul operator. This operator adopts the half-format rotary computation, which results in an incorrect RoPE implementation.By reusing the existing configuration is_rope_neox_style=False for GLM5 in the same file as the judgment condition, we make GLM5 use the torch_npu.npu_interleave_rope operator correctly.

Fixes:
We reuse the existing is_rope_neox_style=False configuration for GLM5 in the same file as the judgment condition, to make GLM5 correctly adopt the torch_npu.npu_interleave_rope operator.

Does this PR introduce any user-facing change?
No. The RoPE logic in sfa_v1.py will select the corresponding implementation for v32 or GLM5 according to is_rope_neox_style. There is no impact on end users.

How was this patch tested?
Tested following the existing conventional verification process.