### PR TITLE
[BugFix][EPLB] Make DYNAMIC_EPLB / EXPERT_MAP_RECORD env parsing case-insensitive

### DIFF
--- a/tests/ut/test_envs.py
+++ b/tests/ut/test_envs.py
@@ -57,3 +57,55 @@ class TestEnvVariables(TestBase):
         for var_name in self.env_vars:
             with self.subTest(var=var_name):
                 getattr(envs_ascend, var_name)
+
+    def _with_env(self, name: str, value: str | None):
+        # Helper context that sets/clears one env var and restores the original.
+        original = os.environ.get(name)
+
+        class _Ctx:
+            def __enter__(_self):
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+                return _self
+
+            def __exit__(_self, exc_type, exc, tb):
+                if original is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = original
+
+        return _Ctx()
+
+    def test_dynamic_eplb_truthy_values_are_case_insensitive(self):
+        # Both DYNAMIC_EPLB and EXPERT_MAP_RECORD gate the same EPLB code paths
+        # (vllm_ascend/ascend_config.py, vllm_ascend/patch/platform/__init__.py).
+        # They must accept the same case-insensitive truthy spellings; previously
+        # only DYNAMIC_EPLB was case-insensitive while EXPERT_MAP_RECORD demanded
+        # an exact lowercase "true", which silently disabled the patch when users
+        # wrote "True" or "1".
+        truthy_inputs = ["true", "True", "TRUE", "tRuE", "1", " true ", " 1 "]
+        falsy_inputs = ["false", "False", "0", "", "yes", "no", "TRUEISH"]
+        for var_name in ("DYNAMIC_EPLB", "EXPERT_MAP_RECORD"):
+            self.assertIn(var_name, self.env_vars, f"{var_name} must be defined in vllm_ascend.envs")
+            for value in truthy_inputs:
+                with self._with_env(var_name, value):
+                    self.assertIs(
+                        getattr(envs_ascend, var_name),
+                        True,
+                        f"{var_name}={value!r} should be parsed as True",
+                    )
+            for value in falsy_inputs:
+                with self._with_env(var_name, value):
+                    self.assertIs(
+                        getattr(envs_ascend, var_name),
+                        False,
+                        f"{var_name}={value!r} should be parsed as False",
+                    )
+            with self._with_env(var_name, None):
+                self.assertIs(
+                    getattr(envs_ascend, var_name),
+                    False,
+                    f"unset {var_name} should default to False",
+                )

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend import envs
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
@@ -903,10 +905,9 @@ class EplbConfig:
         if self.eplb_policy_type not in [0, 1, 2, 3]:
             raise ValueError("eplb_policy_type must in [0, 1, 2, 3]")
         if self.config["dynamic_eplb"]:
-            assert (
-                os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
-                or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
-            ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
+            assert envs.DYNAMIC_EPLB or envs.EXPERT_MAP_RECORD, (
+                "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
+            )
         if self.eplb_heat_collection_stage not in ["all", "prefill", "decode"]:
             raise ValueError('eplb_heat_collection_stage must be one of ["all", "prefill", "decode"]')
         if self.load_collection_phase not in ["all", "prefill", "decode"]:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend import envs
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
@@ -827,10 +829,9 @@ class EplbConfig:
         if self.eplb_policy_type not in [0, 1, 2, 3]:
             raise ValueError("eplb_policy_type must in [0, 1, 2, 3]")
         if self.config["dynamic_eplb"]:
-            assert (
-                os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
-                or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
-            ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
+            assert envs.DYNAMIC_EPLB or envs.EXPERT_MAP_RECORD, (
+                "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
+            )
         if self.eplb_heat_collection_stage not in ["all", "prefill", "decode"]:
             raise ValueError('eplb_heat_collection_stage must be one of ["all", "prefill", "decode"]')
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -82,8 +82,12 @@ env_variables: dict[str, Callable[[], Any]] = {
     # 1: only quant case enable nz;
     # 2: enable nz as long as possible.
     "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
-    # Whether to anbale dynamic EPLB
-    "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
+    # Whether to enable dynamic EPLB. Accepted truthy values are case-insensitive
+    # "true" / "1"; everything else (including unset) is treated as disabled.
+    "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").strip().lower() in ("true", "1"),
+    # Whether to enable expert-map recording for EPLB. Accepts the same
+    # case-insensitive "true" / "1" values as DYNAMIC_EPLB.
+    "EXPERT_MAP_RECORD": lambda: os.getenv("EXPERT_MAP_RECORD", "false").strip().lower() in ("true", "1"),
     # Whether to enable fused MC2 (`dispatch_ffn_combine/mega_moe`).
     # 0, or not set: default ALLTOALL and MC2 will be used.
     # 1: ALLTOALL and MC2 might be replaced by `dispatch_ffn_combine/mega_moe` operator.

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
+from vllm_ascend import envs
 from vllm_ascend.utils import is_310p
 
 if not is_310p():
@@ -35,7 +34,7 @@ import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
 
-if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
+if envs.DYNAMIC_EPLB or envs.EXPERT_MAP_RECORD:
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -14,13 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
+from vllm_ascend import envs
 from vllm_ascend.utils import is_310p
 
 if not is_310p():
@@ -33,7 +32,7 @@ import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
 
-if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
+if envs.DYNAMIC_EPLB or envs.EXPERT_MAP_RECORD:
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa


### PR DESCRIPTION
### What this PR does / why we need it?

`AGENTS.md` mandates:

> All environment variables must be defined in `vllm_ascend/envs.py` using the centralized `env_variables` dictionary. **Never**: Hardcode environment variable names throughout the codebase. Reference them from the central module using `from vllm_ascend import envs`.

The two EPLB gate checks bypass this rule and parse the variables inconsistently:

- [`vllm_ascend/ascend_config.py:560`](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/ascend_config.py#L560-L563) — `DYNAMIC_EPLB` is matched case-insensitively against `("true", "1")` but `EXPERT_MAP_RECORD` is required to equal exactly `"true"`.
- [`vllm_ascend/patch/platform/__init__.py:36`](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/patch/platform/__init__.py#L36) — same asymmetric pair, so `patch_multiproc_executor` is silently skipped when `EXPERT_MAP_RECORD=True` or `EXPERT_MAP_RECORD=1`.

Concretely, a user who follows AGENTS.md naming intuitions and writes `EXPERT_MAP_RECORD=True` (Pythonic) or `EXPERT_MAP_RECORD=1` (numeric-truthy) gets:

1. An `AssertionError` from `EplbConfig._validate_config` when `dynamic_eplb` is enabled via `additional_config` or implicitly by setting `expert_map_record_path` (which sets `self.config["dynamic_eplb"] = True` at line 547), with the misleading message `"must be set to true"`.
2. The `patch_multiproc_executor` import skipped at platform-patch time, leaving the EPLB worker unpatched silently.

This PR fixes both by:

- Updating `vllm_ascend/envs.py` so `DYNAMIC_EPLB` returns a parsed `bool` (was: lowercased string; never read via the central module by any caller — verified with `grep -rn 'envs\.DYNAMIC_EPLB'` returning zero hits before this change), and adding `EXPERT_MAP_RECORD` with matching semantics. Both accept case-insensitive `"true"` / `"1"`; everything else (including unset) is `False`.
- Migrating the two call sites to `envs.DYNAMIC_EPLB or envs.EXPERT_MAP_RECORD`, matching the existing pattern for `envs.VLLM_ASCEND_BALANCE_SCHEDULING` already used three lines below in the same `patch/platform/__init__.py`.
- Removing the now-unused `import os` from `patch/platform/__init__.py`.

### Does this PR introduce _any_ user-facing change?

Behavior change is strictly more permissive — every value previously accepted is still accepted; in addition `EXPERT_MAP_RECORD=True`, `EXPERT_MAP_RECORD=TRUE`, `EXPERT_MAP_RECORD=1`, and surrounding whitespace now correctly enable the patch as users expect.

### How was this patch tested?

- Added regression test `tests/ut/test_envs.py::TestEnvVariables::test_dynamic_eplb_truthy_values_are_case_insensitive` exercising both variables across truthy (`true`, `True`, `TRUE`, `tRuE`, `1`, `" true "`, `" 1 "`) and falsy (`false`, `False`, `0`, `""`, `yes`, `no`, `TRUEISH`) inputs plus the unset default. The new test fails on `main` (because `EXPERT_MAP_RECORD` is not in `envs.env_variables` and `DYNAMIC_EPLB` returns a string) and passes on this branch.
- The pre-existing `test_env_vars_behavior` and `test_dir_and_getattr` continue to pass; the existing test logic uses `inspect.getsource` substring matching which falls through the `else` branch for the new bool lambdas and round-trips correctly.
- `ruff check` and `ruff format --check` pass on all four modified files.
- No NPU hardware required for these changes — they are pure host-side env-var parsing.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
