### PR TITLE
[Ops][Misc] Skip all_gather for positions in multimodal models

### DIFF
--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -1846,7 +1846,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 last_hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                     last_hidden_states.contiguous(), True
                 )
-                positions = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(positions.contiguous(), True)
+                # in mm model, positions not need allgather, because it not reduced before(see maybe_pad_and_reduce())
+                if not self.is_multimodal_model:
+                    positions = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(positions.contiguous(), True)
                 if hidden_states is not None:
                     hidden_states = last_hidden_states
         else:


### PR DESCRIPTION
### What this PR does / why we need it?
In multimodal models, the `positions` tensor is not reduced during the `maybe_pad_and_reduce` phase. Therefore, performing an `all_gather` in `maybe_all_gather_and_unpad` is redundant. This PR optimizes performance by skipping this redundant communication step when `is_multimodal_model` is enabled.

Fixes #

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed with existing tests.