### PR TITLE
[BugFix][UT] Fix CpuGpuBuffer patch target for Eagle proposer test

### DIFF
--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -2275,7 +2275,7 @@ class TestDraftProposerHelperMethods(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
-        self.mock_cpugpubuffer = patch("vllm.v1.spec_decode.eagle.CpuGpuBuffer")
+        self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
             "vllm.multimodal.registry.MultiModalRegistry.supports_multimodal_inputs", return_value=False


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a UT failure in `tests/ut/spec_decode/test_eagle_proposer.py`.

After vLLM #40732, `CpuGpuBuffer` was moved from `vllm.v1.spec_decode.eagle` to `vllm.v1.spec_decode.llm_base_proposer`. The test file already defines `_CPU_GPU_BUFFER_TARGET` to handle both old and new vLLM versions, but one newly added test still patched the old hardcoded path.

This PR changes that test to use `_CPU_GPU_BUFFER_TARGET`, matching the rest of the file and avoiding the following failure:

```text
AttributeError: <module 'vllm.v1.spec_decode.eagle' ...> does not have the attribute 'CpuGpuBuffer'
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
