### PR TITLE
[Doc]Update Qwen3.5 tutorial image versions to v0.19.1rc1

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B.md
@@ -32,7 +32,7 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 :::::{tab-set}
 ::::{tab-item} Use docker image
 
-For example, using images `quay.io/ascend/vllm-ascend:v0.17.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.17.0rc1-a3`(for Atlas 800 A3).
+For example, using images `quay.io/ascend/vllm-ascend:v0.18.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.18.0rc1-a3`(for Atlas 800 A3).
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 

--- a/docs/source/tutorials/models/Qwen3.5-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B.md
@@ -32,7 +32,7 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 :::::{tab-set}
 ::::{tab-item} Use docker image
 
-For example, using images `quay.io/ascend/vllm-ascend:v0.18.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.18.0rc1-a3`(for Atlas 800 A3).
+For example, using images `quay.io/ascend/vllm-ascend:v0.19.1rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.19.1rc1-a3`(for Atlas 800 A3).
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 

--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -32,7 +32,7 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 :::::{tab-set}
 ::::{tab-item} Use docker image
 
-For example, using images `quay.io/ascend/vllm-ascend:v0.17.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.17.0rc1-a3`(for Atlas 800 A3).
+For example, using images `quay.io/ascend/vllm-ascend:v0.18.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.18.0rc1-a3`(for Atlas 800 A3).
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 

--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -32,7 +32,7 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 :::::{tab-set}
 ::::{tab-item} Use docker image
 
-For example, using images `quay.io/ascend/vllm-ascend:v0.18.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.18.0rc1-a3`(for Atlas 800 A3).
+For example, using images `quay.io/ascend/vllm-ascend:v0.19.1rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.19.1rc1-a3`(for Atlas 800 A3).
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the inconsistent vllm-ascend image version in the Qwen3.5-27B and Qwen3.5-397B deployment tutorial. Update the outdated image tag v0.17.0rc1 to the correct and available v0.19.1rc1 for Atlas 800 A2 and A3, aligning with the official installation documentation. This avoids users pulling an invalid image and encountering deployment startup failures.

This change is made based on user feedback from Issue #8772, where users reported that the old image version cannot be pulled or started correctly. Updating the document ensures users can use the valid image and avoid deployment failures.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified that the v0.19.1rc1 image can be pulled and started normally.


- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
