### PR TITLE
[CI][Bugfix] Fix the previously un-updated main2main commit

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vllm_version: [d886c26d4d4fef7d079696beb4ece1cfb4b008a8]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7]
     needs: [parse-trigger]
     if: ${{ needs.parse-trigger.outputs.allowed == 'true' }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/schedule_update_estimated_time.yaml
+++ b/.github/workflows/schedule_update_estimated_time.yaml
@@ -23,7 +23,7 @@ jobs:
     name: e2e-test
     strategy:
       matrix:
-        vllm_version: [d886c26d4d4fef7d079696beb4ece1cfb4b008a8]
+        vllm_version: [4d51588e2381018348f1022dfa3a7698899805b7]
         type: [full, light]
     uses: ./.github/workflows/_e2e_test.yaml
     with:

--- a/.github/workflows/schedule_vllm_e2e_test.yaml
+++ b/.github/workflows/schedule_vllm_e2e_test.yaml
@@ -45,7 +45,7 @@ jobs:
           fail-fast: false
           matrix:
             part: [0, 1, 2, 3]
-            vllm: [d886c26d4d4fef7d079696beb4ece1cfb4b008a8]
+            vllm: [4d51588e2381018348f1022dfa3a7698899805b7]
         container:
           image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-910b-ubuntu22.04-py3.11
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # ARG VLLM_TAG=v0.19.1
 # RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -35,7 +35,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # ARG VLLM_TAG=v0.19.1
 # RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -34,7 +34,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # ARG VLLM_TAG=v0.19.1
 # RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -52,7 +52,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # ARG VLLM_TAG=v0.19.1
 # RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -51,7 +51,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # ARG VLLM_TAG=v0.19.1
 # RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -51,7 +51,7 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # ARG VLLM_TAG=v0.19.1
 # RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-ARG VLLM_COMMIT=d886c26d4d4fef7d079696beb4ece1cfb4b008a8
+ARG VLLM_COMMIT=4d51588e2381018348f1022dfa3a7698899805b7
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the previously un-updated main2main commit caused by https://github.com/vllm-project/vllm-ascend/pull/8899

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
