### PR TITLE
[Doc]Update CANN to 9.0.0 and torch_npu to post2 for 310p

### DIFF
--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:8.5.1-310p-ubuntu22.04-py3.11
+FROM quay.io/ascend/cann:9.0.0-310p-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG SOC_VERSION="ascend310p1"
@@ -59,10 +59,10 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     PYTHON_TAG=$(python3 -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')") && \
     ARCH=$(python3 -c "import platform; m=platform.machine().lower(); map={'x86_64':'x86_64','amd64':'x86_64','aarch64':'aarch64','arm64':'aarch64'}; print(map.get(m,m))") && \
     \
-    if [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgit4c901a4-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
-    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgitdc51c2d-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
-    elif [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgita74051c-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
-    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgitee7ba04-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    if [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgit4c901a4-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgitdc51c2d-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    elif [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgita74051c-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgitee7ba04-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
     else echo "Unsupported PYTHON_TAG=$PYTHON_TAG ARCH=$ARCH"; exit 1; fi && \
     \
     python3 -m pip install "https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/${PTA_WHEEL}" && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:8.5.1-310p-openeuler24.03-py3.11
+FROM quay.io/ascend/cann:9.0.0-310p-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG SOC_VERSION="ascend310p1"
@@ -55,10 +55,10 @@ RUN export PIP_EXTRA_INDEX_URL=https://mirrors.huaweicloud.com/ascend/repos/pypi
     PYTHON_TAG=$(python3 -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')") && \
     ARCH=$(python3 -c "import platform; m=platform.machine().lower(); map={'x86_64':'x86_64','amd64':'x86_64','aarch64':'aarch64','arm64':'aarch64'}; print(map.get(m,m))") && \
     \
-    if [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgit4c901a4-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
-    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgitdc51c2d-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
-    elif [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgita74051c-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
-    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post1%2Bgitee7ba04-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    if [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgit4c901a4-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgitdc51c2d-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    elif [ "$PYTHON_TAG" = "cp310" ] && [ "$ARCH" = "x86_64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgita74051c-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
+    elif [ "$PYTHON_TAG" = "cp311" ] && [ "$ARCH" = "aarch64" ]; then PTA_WHEEL="torch_npu-2.9.0.post2%2Bgitee7ba04-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_2_28_${ARCH}.whl"; \
     else echo "Unsupported PYTHON_TAG=$PYTHON_TAG ARCH=$ARCH"; exit 1; fi && \
     \
     python3 -m pip install "https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/${PTA_WHEEL}" && \

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -75,7 +75,7 @@ docker run --rm \
 -it $IMAGE bash
 ```
 Note: High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version 
-[操作步骤](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) (this step is expected to be available in versions v0.18.0.post and later and can be ignored).
+[Operating steps](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) (this step is expected to be available in versions v0.18.0.post and later and can be ignored).
 
 Run the following steps to start the vLLM service on NPU for the Qwen3 Dense series:
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -77,8 +77,8 @@ docker run --rm \
 
 ### Note
 
-High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version
-[Operating steps](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) this step is expected to be available in versions v0.18.0.post and later and can be ignored.
+The high performance is implemented based on the latest CANN community edition and the new PTA version. Therefore, you need to manually replace the CANN version with CANN 9.0.0 and torch_npu.The following uses Ubuntu as an example to describe how to install CANN. For details, see the following steps:
+[Procedure](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) Install the new PTA version. pip install torch_npu==2.9.0.post2 This step will be supported in v0.18.0.post and later versions. You can ignore it when it is supported.
 
 Run the following steps to start the vLLM service on NPU for the Qwen3 Dense series:
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -15,7 +15,8 @@
 * If installing from source, `vllm` and `vllm-ascend` will automatically pull in `triton` and `triton-ascend` dependencies, which may cause unexpected issues on Atlas 300I DUO. Please run:
 
 ```bash
-pip uninstall -y triton && triton-ascend
+pip uninstall -y triton 
+pip uninstall -y triton-ascend
 # If you still encounter errors mentioning triton, manually remove the remaining triton directory in site-packages,
 # as uninstalling triton may leave residual files behind.
 # For example: rm -rf /usr/local/python3.11.10/lib/python3.11/site-packages/triton
@@ -49,7 +50,7 @@ Run the Docker container:
    :substitutions:
 
 # Use the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:v0.18.0rc1-310p
+export IMAGE=quay.io/ascend/vllm-ascend:v0.18.0-310p
 docker run --rm \
 --name vllm-ascend \
 --shm-size=10g \

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -15,8 +15,7 @@
 * If installing from source, `vllm` and `vllm-ascend` will automatically pull in `triton` and `triton-ascend` dependencies, which may cause unexpected issues on Atlas 300I DUO. Please run:
 
 ```bash
-pip uninstall -y triton 
-pip uninstall -y triton-ascend
+pip uninstall -y triton triton-ascend
 # If you still encounter errors mentioning triton, manually remove the remaining triton directory in site-packages,
 # as uninstalling triton may leave residual files behind.
 # For example: rm -rf /usr/local/python3.11.10/lib/python3.11/site-packages/triton

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -74,8 +74,11 @@ docker run --rm \
 -p 8000:8000 \
 -it $IMAGE bash
 ```
-Note: High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version 
-[Operating steps](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) (this step is expected to be available in versions v0.18.0.post and later and can be ignored).
+
+### Note
+
+High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version 
+[Operating steps](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) this step is expected to be available in versions v0.18.0.post and later and can be ignored. 
 
 Run the following steps to start the vLLM service on NPU for the Qwen3 Dense series:
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -74,6 +74,8 @@ docker run --rm \
 -p 8000:8000 \
 -it $IMAGE bash
 ```
+Note: High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version 
+[操作步骤](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) (this step is expected to be available in versions v0.18.0.post and later and can be ignored).
 
 Run the following steps to start the vLLM service on NPU for the Qwen3 Dense series:
 

--- a/docs/source/tutorials/hardwares/310p.md
+++ b/docs/source/tutorials/hardwares/310p.md
@@ -77,8 +77,8 @@ docker run --rm \
 
 ### Note
 
-High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version 
-[Operating steps](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) this step is expected to be available in versions v0.18.0.post and later and can be ignored. 
+High-performance implementation currently relies on the latest community version of CANN, therefore you need to manually replace it with CANN version 9.0.0. Taking Ubuntu as an example, please refer to the following steps for installing the CANN version
+[Operating steps](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0090.html?OS=Ubuntu&InstallType=localpack) this step is expected to be available in versions v0.18.0.post and later and can be ignored.
 
 Run the following steps to start the vLLM service on NPU for the Qwen3 Dense series:
 


### PR DESCRIPTION
### What this PR does / why we need it?
Running the graph mode and the W8A8SC quantized model of qwen3-dense on the 300I DUO device requires the new version of CANN (9.0.0) and the PTA component. This PR modifies the Dockerfile of the 300I DUO device to resolve the above issues.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
