### PR TITLE
[BugFix] Routing replay support multi dp & tp

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -28,7 +28,6 @@ from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import FusedMoEMethodBase  # type: ignore
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFusedMoEMethod, get_compressed_expert_map
-from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
 from vllm.model_executor.layers.fused_moe.router.fused_moe_router import FusedMoERouter  # type: ignore
 from vllm.model_executor.layers.fused_moe.runner.default_moe_runner import DefaultMoERunner  # type: ignore
 from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
@@ -42,6 +41,7 @@ from vllm_ascend.flash_common3_context import get_flash_common3_context, set_fla
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
+from vllm_ascend.ops.fused_moe.routed_experts_capture import AscendRoutedExpertsCapturer
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_NZ,
@@ -135,7 +135,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             global_num_experts=global_num_experts,
         )
         if layer.vllm_config.model_config is not None and layer.vllm_config.model_config.enable_return_routed_experts:
-            capturer = RoutedExpertsCapturer.get_instance()
+            capturer = AscendRoutedExpertsCapturer.get_instance()
             if capturer is not None:
                 capturer.capture(
                     layer_id=layer.layer_id,

--- a/vllm_ascend/ops/fused_moe/routed_experts_capture.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts_capture.py
@@ -1,0 +1,82 @@
+import math
+
+import torch
+from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.distributed.parallel_state import (
+    get_dp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+    RoutedExpertsCapturer,
+)
+
+
+class AscendRoutedExpertsCapturer(RoutedExpertsCapturer):
+    """
+    Capturer for routed experts with device and optional shared memory buffer.
+
+    This class captures expert routing decisions during model forward passes
+    and optionally stores them in shared memory for cross-process access.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.dp_size = get_dp_group().world_size
+
+    def capture(self, layer_id: int, topk_ids: torch.Tensor) -> None:
+        """
+        Capture expert routing decisions for a specific layer.
+
+        Args:
+            layer_id: The layer index.
+            topk_ids: Tensor of shape (batch_size, num_routed_experts).
+        """
+
+        if self._device_buffer is None:
+            raise RuntimeError("Buffer not initialized. Call init_buffer() first.")
+
+        ctx = get_forward_context()
+        if ctx.dp_metadata is None:  # single dp
+            start_loc = 0
+            end_loc = topk_ids.shape[0]
+            token_num_per_dp = topk_ids.shape[0]
+        else:  # multi dp
+            num_tokens_dp = ctx.dp_metadata.num_tokens_across_dp_cpu
+            token_num_per_dp = int(num_tokens_dp[self.dp_rank].item())
+            total = int(num_tokens_dp.sum().item())
+            n = topk_ids.shape[0]
+
+            if n == total:
+                # Naive dispatch: all DP ranks' tokens concatenated before routing.
+                cumsum = torch.cumsum(num_tokens_dp, dim=0)
+                end_loc = int(cumsum[self.dp_rank].item())
+                start_loc = end_loc - token_num_per_dp
+            elif self.tp_size > 1 or self.dp_size > 1:
+                # multi dp & tp
+                # when use multi tp, token_per_dp will be padded,
+                # we should to unpad it
+                token_num_per_tp = math.ceil(token_num_per_dp / self.tp_size)
+                pad_size = token_num_per_tp - topk_ids.shape[0]
+                if pad_size > 0:
+                    # when use mc2, pad_size <= 0
+                    # when use alltoall, tail tp rank's pad_size >= 0
+                    topk_ids = torch.nn.functional.pad(topk_ids, (0, 0, 0, pad_size))
+                full_topk_ids = tensor_model_parallel_all_gather(topk_ids, dim=0)
+                topk_ids = full_topk_ids[:token_num_per_dp]
+                start_loc = 0
+                end_loc = token_num_per_dp
+            else:
+                raise AssertionError(
+                    "AscendRoutedExpertsCapturer: unexpected topk_ids batch dim "
+                    f"{n} (expected {total} or {token_num_per_dp} "
+                    f"for dp_rank={self.dp_rank})"
+                )
+
+        if layer_id >= self._device_buffer.shape[1]:
+            return
+
+        self._device_buffer[:token_num_per_dp, layer_id, :] = topk_ids[start_loc:end_loc, :]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -140,7 +140,9 @@ from vllm_ascend.ascend_forward_context import (  # isort: skip
     set_mc2_mask,
     set_mc2_tokens_capacity,
 )
-from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
+from vllm_ascend.ops.fused_moe.routed_experts_capture import (
+    AscendRoutedExpertsCapturer,
+)
 
 if TYPE_CHECKING:
     import xgrammar as xgr  # type: ignore[import-untyped]
@@ -1111,11 +1113,11 @@ class NPUModelRunner(GPUModelRunner):
         intermediate_tensors: IntermediateTensors | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         if self.vllm_config.model_config.enable_return_routed_experts:
-            capturer = RoutedExpertsCapturer.get_instance()
+            capturer = AscendRoutedExpertsCapturer.get_instance()
             if capturer is not None:
                 capturer.clear_buffer()
             else:
-                logger.warning("RoutedExpertsCapturer is not initialized.")
+                logger.warning("AscendRoutedExpertsCapturer is not initialized.")
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called after execute_model() returns None.")
         # self._draft_token_ids is None when `input_fits_in_drafter=False`
@@ -1554,11 +1556,11 @@ class NPUModelRunner(GPUModelRunner):
                 self.finalize_kv_connector()
 
         if self.model_config.enable_return_routed_experts:
-            capturer = RoutedExpertsCapturer.get_instance()
+            capturer = AscendRoutedExpertsCapturer.get_instance()
             if capturer is not None:
                 capturer.save_captured_experts(indices=self.cpu_slot_mapping)
             else:
-                logger.warning("RoutedExpertsCapturer is not initialized.")
+                logger.warning("AscendRoutedExpertsCapturer is not initialized.")
 
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids_output_copy,
@@ -3226,6 +3228,36 @@ class NPUModelRunner(GPUModelRunner):
                             )
                     else:
                         self.reorder_batch_threshold = reorder_batch_threshold_i  # noqa
+    
+    def init_routed_experts_capturer(self):
+        logger.info(
+            "Initializing routed experts capturer, enable_return_routed_experts: %s",
+            self.model_config.enable_return_routed_experts,
+        )
+        routed_experts_capturer = AscendRoutedExpertsCapturer.create()
+        self.routed_experts_attn_gid = self._get_attention_kv_cache_gid()
+        max_block_size = max(
+            [
+                group.kv_cache_spec.block_size
+                for group in self.kv_cache_config.kv_cache_groups
+            ]
+        )
+
+        self.max_num_kv_tokens = (
+            self.kv_cache_config.num_blocks
+        ) * max_block_size
+        dcp_size = self.vllm_config.parallel_config.decode_context_parallel_size
+        pcp_size = self.vllm_config.parallel_config.prefill_context_parallel_size
+        if pcp_size * dcp_size > 1:
+            self.max_num_kv_tokens *= pcp_size * dcp_size
+
+        routed_experts_capturer.init_buffer(
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            max_num_kv_tokens=self.max_num_kv_tokens,
+            vllm_config=self.vllm_config,
+        )
+        self._bind_routed_experts_capturer(routed_experts_capturer)
+        self.routed_experts_initialized = True
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
This PR fixes a bug in the MoE routing replay feature for Ascend NPUs by introducing `AscendRoutedExpertsCapturer` and ensuring correct padding and buffer handling during expert routing capture in multi-DP/TP scenarios.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- vLLM version: v0.18.0
