### PR TITLE
[Performance] add op `chunk_fwd_o` and `chunk_gated_delta_rule_fwd_h`

### DIFF
--- a/.github/workflows/_optional_smart_e2e.yaml
+++ b/.github/workflows/_optional_smart_e2e.yaml
@@ -62,6 +62,15 @@ jobs:
         UV_SYSTEM_PYTHON: 1
         UV_PYTHON: python3
     steps:
+      - name: Check NPU availability
+        id: check_npu
+        run: |
+          if npu-smi info > /dev/null 2>&1; then
+            echo "has_npu=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_npu=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install packages
         run: |
           sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
@@ -82,7 +91,7 @@ jobs:
       - name: Install vllm-project/vllm from source
         working-directory: ./vllm-empty
         run: |
-          VLLM_TARGET_DEVICE=empty uv pip install . ${{ runner.arch == 'X64' && '--extra-index-url https://download.pytorch.org/whl/cpu/' || '' }}
+          VLLM_TARGET_DEVICE=empty uv pip install . ${{ steps.check_npu.outputs.has_npu == 'false' && '--extra-index-url https://download.pytorch.org/whl/cpu/' || '' }}
           uv pip uninstall triton
 
       - name: Checkout vllm-project/vllm-ascend repo
@@ -96,7 +105,8 @@ jobs:
           echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
 
       - name: Cache vllm-ascend csrc
-        if: ${{ runner.arch != 'X64' }}
+        id: cache-csrc
+        if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
         uses: runs-on/cache@v4
         with:
           path: |
@@ -108,8 +118,8 @@ jobs:
           restore-keys: |
             vllm-ascend-build-v1-${{ runner.os }}-swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
-      - name: Install vllm-project/vllm-ascend
-        if: ${{ runner.arch != 'X64' }}
+      - name: Install vllm-project/vllm-ascend with device
+        if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
         env:
           PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
         run: |
@@ -121,8 +131,8 @@ jobs:
             uv pip install -v -e .
           fi
 
-      - name: Install vllm-project/vllm-ascend
-        if: ${{ runner.arch == 'X64' }}
+      - name: Install vllm-project/vllm-ascend no device
+        if: ${{ steps.check_npu.outputs.has_npu == 'false' }}
         env:
           SOC_VERSION: ascend910b1
           COMPILE_CUSTOM_KERNELS: 0
@@ -133,7 +143,7 @@ jobs:
           uv pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu/
 
       - name: Run smart UT with device
-        if: ${{ runner.arch != 'X64' }}
+        if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
@@ -151,7 +161,7 @@ jobs:
           pytest -sv --color=yes ${{ matrix.group.tests }}
 
       - name: Run smart UT without device
-        if: ${{ runner.arch == 'X64' }}
+        if: ${{ steps.check_npu.outputs.has_npu == 'false' }}
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           TORCH_DEVICE_BACKEND_AUTOLOAD: 0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "csrc/third_party/catlass"]
 	path = csrc/third_party/catlass
 	url = https://gitcode.com/cann/catlass.git
-	branch = main
+	branch = master
+	commit = 41bf90da655bba3c66d0acd7e00abe33960ecfd6

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -98,6 +98,9 @@ set_directory_properties(PROPERTIES
     ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_BINARY_DIR}/_CPack_Packages"
 )
 
+# Suppress warnings from catlass/tla third-party headers for CANN kernel compilation
+list(APPEND OPS_COMPILE_OPTIONS -Wno-ignored-attributes)
+
 include(cmake/config.cmake)
 include(cmake/func.cmake)
 include(cmake/third_party/json.cmake)

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -16,12 +16,18 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     # dependency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
+    CATLASS_COMMIT=$(git config -f "${ROOT_DIR}/.gitmodules" --get submodule.csrc/third_party/catlass.commit)
     if [[ ! -d "${CATLASS_PATH}" ]]; then
         echo "dependency catlass is missing, try to fetch it..."
+        git submodule sync
         if ! git submodule update --init --recursive; then
             echo "fetch failed"
             exit 1
         fi
+        cd "${ROOT_DIR}/csrc/third_party/catlass" || exit 1
+        git fetch origin
+        git checkout "${CATLASS_COMMIT}" || exit 1
+        cd - || exit 1
     fi
     ABSOLUTE_CATLASS_PATH=$(cd "${CATLASS_PATH}" && pwd)
     export CPATH=${ABSOLUTE_CATLASS_PATH}:${CPATH}
@@ -43,6 +49,8 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "hamming_dist_top_k"
         "reshape_and_cache_bnsd"
         "recurrent_gated_delta_rule"
+        "chunk_fwd_o"
+        "chunk_gated_delta_rule_fwd_h"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
@@ -52,12 +60,18 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # dependency: catlass
     git config --global --add safe.directory "$ROOT_DIR"
     CATLASS_PATH=${ROOT_DIR}/csrc/third_party/catlass/include
+    CATLASS_COMMIT=$(git config -f "${ROOT_DIR}/.gitmodules" --get submodule.csrc/third_party/catlass.commit)
     if [[ ! -d "${CATLASS_PATH}" ]]; then
         echo "dependency catlass is missing, try to fetch it..."
+        git submodule sync
         if ! git submodule update --init --recursive; then
             echo "fetch failed"
             exit 1
         fi
+        cd "${ROOT_DIR}/csrc/third_party/catlass" || exit 1
+        git fetch origin
+        git checkout "${CATLASS_COMMIT}" || exit 1
+        cd - || exit 1
     fi
     # dependency: cann-toolkit file moe_distribute_base.h
     HCCL_STRUCT_FILE_PATH=$(find -L "${ASCEND_TOOLKIT_HOME}" -name "moe_distribute_base.h" 2>/dev/null | head -n1)
@@ -124,6 +138,8 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "hamming_dist_top_k"
         "reshape_and_cache_bnsd"
         "recurrent_gated_delta_rule"
+        "chunk_fwd_o"
+        "chunk_gated_delta_rule_fwd_h"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/moe/chunk_fwd_o/CMakeLists.txt
+++ b/csrc/moe/chunk_fwd_o/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/moe/chunk_fwd_o/op_host/CMakeLists.txt
+++ b/csrc/moe/chunk_fwd_o/op_host/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(CURRENT_CMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(CATLASS_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/third_party/catlass/include")
+get_filename_component(CATLASS_INCLUDE_DIR_ABS ${CATLASS_INCLUDE_DIR} ABSOLUTE)
+
+set(COMMON_KERNEL_UTILS_DIR "${CMAKE_SOURCE_DIR}/moe/common")
+get_filename_component(COMMON_KERNEL_UTILS_DIR_ABS ${COMMON_KERNEL_UTILS_DIR} ABSOLUTE)
+
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        chunk_fwd_o_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME ChunkFwdO
+    OPTIONS
+        --cce-auto-sync=off
+        -Wno-deprecated-declarations
+        -Werror
+        -I${CATLASS_INCLUDE_DIR_ABS}
+        -I${COMMON_KERNEL_UTILS_DIR_ABS}
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE chunk_fwd_o ACLNNTYPE aclnn_exclude)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CATLASS_INCLUDE_DIR_ABS}
+    )
+endif()

--- a/csrc/moe/chunk_fwd_o/op_host/chunk_fwd_o_def.cpp
+++ b/csrc/moe/chunk_fwd_o/op_host/chunk_fwd_o_def.cpp
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ *\file chunk_fwd_o_def.cpp
+ *\brief
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+
+class ChunkFwdO : public OpDef {
+
+public:
+    explicit ChunkFwdO(const char *name) : OpDef(name)
+    {
+        // Define inputs
+        this->Input("q")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("k")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("v")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("h")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("g")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("chunk_offsets")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Output("o")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Attr("scale").AttrType(REQUIRED).Float(1.0);
+        this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+
+        OpAICoreConfig aicore_config;
+        aicore_config.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("jitCompile.flag", "static_false,dynamic_false");
+
+        this->AICore().AddConfig("ascend910b", aicore_config);
+        this->AICore().AddConfig("ascend910_93", aicore_config);
+        // this->AICore().AddConfig("ascend950", aicore_config);
+    }
+};
+
+OP_ADD(ChunkFwdO);
+
+} // namespace ops

--- a/csrc/moe/chunk_fwd_o/op_host/chunk_fwd_o_tiling.cpp
+++ b/csrc/moe/chunk_fwd_o/op_host/chunk_fwd_o_tiling.cpp
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_o_tiling.cpp
+ * \brief
+ */
+
+#include "chunk_fwd_o_tiling.h"
+#include <register/op_impl_registry.h>
+#include "../tiling_base/data_copy_transpose_tiling.h"
+#include "../tiling_base/tiling_templates_registry.h"
+
+namespace optiling {
+static constexpr size_t INPUT_Q_IDX = 0;
+static constexpr size_t INPUT_K_IDX = 1;
+static constexpr size_t INPUT_V_IDX = 2;
+static constexpr size_t INPUT_H_IDX = 3;
+static constexpr size_t INPUT_G_IDX = 4;
+static constexpr size_t INPUT_SEQLENS_IDX = 5;
+static constexpr size_t INPUT_CHUNK_INDICES_IDX = 6;
+
+static constexpr size_t ATTR_SCALE_IDX = 0;
+static constexpr size_t ATTR_CHUNK_SIZE_IDX = 1;
+
+static constexpr size_t DIM_BATCH = 0;
+static constexpr size_t DIM_HEAD_NUM = 1;
+static constexpr size_t DIM_SEQLEN = 2;
+static constexpr size_t DIM_HEAD_DIM = 3;
+
+
+static void ChunkFwdOTilingDataPrint(gert::TilingContext *context, ChunkFwdOTilingData &tiling)
+{
+    auto nodeName = context->GetNodeName();
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print ChunkFwdO tiling data <<<<<<<<<<<<<<<<");
+    OP_LOGD(nodeName, "=== batch: %ld", tiling.get_shapeBatch());
+    OP_LOGD(nodeName, "=== seqlen: %ld", tiling.get_seqlen());
+    OP_LOGD(nodeName, "=== kNumHead: %ld", tiling.get_kNumHead());
+    OP_LOGD(nodeName, "=== vNumHead: %ld", tiling.get_vNumHead());
+    OP_LOGD(nodeName, "=== kHeadDim: %ld", tiling.get_kHeadDim());
+    OP_LOGD(nodeName, "=== vHeadDim: %ld", tiling.get_vHeadDim());
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
+    OP_LOGD(nodeName, "=== dataType: %ld", tiling.get_dataType());
+    OP_LOGD(nodeName, "=== isVariedLen: %ld", tiling.get_isVariedLen());
+    OP_LOGD(nodeName, "=== tokenBatch: %f", tiling.get_tokenBatch());
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print ChunkFwdO tiling data end <<<<<<<<<<<<<<<<");
+}
+
+ge::graphStatus Tiling4ChunkFwdO(gert::TilingContext *context)
+{
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkFwdO start.");
+    ChunkFwdOTilingData tiling;
+    
+    gert::Shape qStorageShape = context->GetOptionalInputShape(INPUT_Q_IDX)->GetStorageShape();
+    gert::Shape vStorageShape = context->GetOptionalInputShape(INPUT_V_IDX)->GetStorageShape();
+
+    int64_t seqlen = qStorageShape.GetDim(DIM_SEQLEN);
+    int64_t kNumHead = qStorageShape.GetDim(DIM_HEAD_NUM);
+    int64_t vNumHead = vStorageShape.GetDim(DIM_HEAD_NUM);
+    int64_t kHeadDim = qStorageShape.GetDim(DIM_HEAD_DIM);
+    int64_t vHeadDim = vStorageShape.GetDim(DIM_HEAD_DIM);
+    int64_t isVariedLen, shapeBatch, tokenBatch;
+    
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
+    if (cuSeqlensTensor == nullptr) {
+        isVariedLen = false;
+        shapeBatch = qStorageShape.GetDim(DIM_BATCH);
+        tokenBatch = 1;
+    } else {
+        isVariedLen = true;
+        shapeBatch = 1;
+        tokenBatch = cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) - 1;
+    }
+    
+    auto attrPtr = context->GetAttrs();
+    float scale = *(attrPtr->GetAttrPointer<double>(ATTR_SCALE_IDX));
+    int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
+
+    auto dtype = context->GetInputTensor(0)->GetDataType();
+    uint64_t dataType = dtype == ge::DT_BF16 ? 1 : 0;
+
+    auto gDType = context->GetOptionalInputTensor(INPUT_G_IDX)->GetDataType();
+    int64_t gDataType = 2;
+    if (gDType == ge::DT_BF16) {
+        gDataType = 1;
+    } else if (gDType == ge::DT_FLOAT16) {
+        gDataType = 0;
+    }
+   
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint32_t aicCoreNum = ascendcPlatform.GetCoreNumAic();
+    context->SetBlockDim(aicCoreNum);
+
+    constexpr size_t WORKSPACE_RSV_BYTE = 16 * 1024 * 1024;
+    constexpr size_t GM_ALIGN = 512;
+    int64_t pingpongStages = 2;
+
+    size_t workspaceOffset = ascendcPlatform.GetLibApiWorkSpaceSize();
+    workspaceOffset += WORKSPACE_RSV_BYTE;
+    
+    tiling.set_vWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * pingpongStages + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_hWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * pingpongStages + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_attnWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * chunkSize * sizeof(float) * pingpongStages + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_aftermaskWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * chunkSize * sizeof(float) * pingpongStages + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_maskWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (chunkSize * chunkSize + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    workspaceOffset += WORKSPACE_RSV_BYTE;
+    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
+    currentWorkspace[0] = (workspaceOffset - 0);
+
+    tiling.set_shapeBatch(shapeBatch);
+    tiling.set_seqlen(seqlen);
+    tiling.set_kNumHead(kNumHead);
+    tiling.set_vNumHead(vNumHead);
+    tiling.set_kHeadDim(kHeadDim);
+    tiling.set_vHeadDim(vHeadDim);
+    tiling.set_scale(scale);
+    tiling.set_chunkSize(chunkSize);
+    tiling.set_isVariedLen(isVariedLen);
+    tiling.set_tokenBatch(tokenBatch);
+    tiling.set_dataType(dataType);
+    tiling.set_gDataType(gDataType);
+
+    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+
+    ChunkFwdOTilingDataPrint(context, tiling);
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkFwdO end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepareForChunkFwdO(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(ChunkFwdO)
+    .Tiling(Tiling4ChunkFwdO)
+    .TilingParse<ChunkFwdOCompileInfo>(TilingPrepareForChunkFwdO);
+
+} // namespace optiling

--- a/csrc/moe/chunk_fwd_o/op_host/chunk_fwd_o_tiling.h
+++ b/csrc/moe/chunk_fwd_o/op_host/chunk_fwd_o_tiling.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_o_tiling.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+#include <tiling/tiling_api.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(ChunkFwdOTilingData)
+TILING_DATA_FIELD_DEF(int64_t, shapeBatch);
+TILING_DATA_FIELD_DEF(int64_t, seqlen);
+TILING_DATA_FIELD_DEF(int64_t, kNumHead);
+TILING_DATA_FIELD_DEF(int64_t, vNumHead);
+TILING_DATA_FIELD_DEF(int64_t, kHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, vHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, chunkSize);
+TILING_DATA_FIELD_DEF(int64_t, isVariedLen);
+TILING_DATA_FIELD_DEF(int64_t, tokenBatch);
+TILING_DATA_FIELD_DEF(int64_t, dataType);
+TILING_DATA_FIELD_DEF(int64_t, gDataType);
+TILING_DATA_FIELD_DEF(int64_t, vWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, hWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, attnWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, aftermaskWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, maskWorkspaceOffset);
+TILING_DATA_FIELD_DEF(float, scale);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(ChunkFwdO, ChunkFwdOTilingData)
+
+struct ChunkFwdOCompileInfo {};
+} // namespace optiling

--- a/csrc/moe/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.cpp
+++ b/csrc/moe/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.cpp
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#include "aclnn_chunk_fwd_o.h"
+#include "chunk_fwd_o.h"
+#include <dlfcn.h>
+#include <new>
+
+#include "aclnn_kernels/transdata.h"
+#include "aclnn_kernels/contiguous.h"
+#include "acl/acl.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/platform.h"
+#include "opdev/shape_utils.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/make_op_executor.h"
+
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ChunkFwdOParams {
+    const aclTensor *q = nullptr;
+    const aclTensor *k = nullptr;
+    const aclTensor *v = nullptr;
+    const aclTensor *h = nullptr;
+    const aclTensor *g = nullptr;
+    const aclIntArray *cuSeqlensOptional = nullptr;
+    const aclIntArray *chunkOffsetsOptional = nullptr;
+    double scale = 1.0;
+    int64_t chunkSize = 64;
+    const aclTensor *oOut = nullptr;
+};
+
+static aclnnStatus CheckNotNull(ChunkFwdOParams params)
+{
+    CHECK_COND(params.q != nullptr, ACLNN_ERR_PARAM_NULLPTR, "q must not be nullptr.");
+    CHECK_COND(params.k != nullptr, ACLNN_ERR_PARAM_NULLPTR, "k must not be nullptr.");
+    CHECK_COND(params.v != nullptr, ACLNN_ERR_PARAM_NULLPTR, "v must not be nullptr.");
+    CHECK_COND(params.h != nullptr, ACLNN_ERR_PARAM_NULLPTR, "h must not be nullptr.");
+    CHECK_COND(params.g != nullptr, ACLNN_ERR_PARAM_NULLPTR, "g must not be nullptr.");
+
+    CHECK_COND(params.oOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "oOut must not be nullptr.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckFormat(ChunkFwdOParams params)
+{
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckShape(ChunkFwdOParams params)
+{
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    tensor = l0op::Contiguous(tensor, executor);
+    CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus ParamsDataContiguous(ChunkFwdOParams &params, aclOpExecutor *executorPtr)
+{
+    CHECK_COND(DataContiguous(params.q, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous q failed.");
+    CHECK_COND(DataContiguous(params.k, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous k failed.");
+    CHECK_COND(DataContiguous(params.v, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous v failed.");
+    CHECK_COND(DataContiguous(params.h, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous h failed.");
+    CHECK_COND(DataContiguous(params.g, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous g failed.");
+
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckDtype(ChunkFwdOParams params)
+{
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckParams(ChunkFwdOParams params)
+{
+    CHECK_RET(CheckNotNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckFormat(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckShape(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckDtype(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnChunkFwdOGetWorkspaceSize(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *h,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkOffsetsOptional,
+    double scale,
+    int64_t chunkSize,
+    const aclTensor *oOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    ChunkFwdOParams params{q, k, v, h, g, cuSeqlensOptional, chunkOffsetsOptional, scale, chunkSize, oOut};
+    // Standard syntax, Check parameters.
+    L2_DFX_PHASE_1(aclnnChunkFwdO, DFX_IN(q, k, v, h, g, cuSeqlensOptional, chunkOffsetsOptional),
+                   DFX_OUT(oOut));
+    // 固定写法，创建OpExecutor
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto executorPtr = uniqueExecutor.get();
+    // 固定写法，参数检查
+    auto ret = CheckParams(params);
+    CHECK_RET(ret == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "ParamsDataContiguous failed.");
+    auto result = l0op::ChunkFwdO(params.q, params.k, params.v, params.h, params.g, params.cuSeqlensOptional, params.chunkOffsetsOptional, params.scale, params.chunkSize, params.oOut, executorPtr);
+    CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+
+    // If the output tensor is non-contiguous, convert the calculated contiguous tensor to non-contiguous.
+    auto viewCopyResult = l0op::ViewCopy(result[0], params.oOut, executorPtr);
+    CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    // Standard syntax, get the size of workspace needed during computation.
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+
+aclnnStatus aclnnChunkFwdO(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnChunkFwdO);
+    CHECK_COND(CommonOpExecutorRun(workspace, workspaceSize, executor, stream) == ACLNN_SUCCESS, ACLNN_ERR_INNER,
+               "This is an error in ChunkFwdO launch aicore.");
+    return ACLNN_SUCCESS;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/moe/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.h
+++ b/csrc/moe/chunk_fwd_o/op_host/op_api/aclnn_chunk_fwd_o.h
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#ifndef OP_API_INC_ACLNN_CHUNK_FWD_O_H
+#define OP_API_INC_ACLNN_CHUNK_FWD_O_H
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* function: aclnnChunkFwdOGetWorkspaceSize
+ * parameters :
+ * q : required
+ * k : required
+ * v : required
+ * h : required
+ * g : required
+ * cuSeqlensOptional : optional
+ * chunkOffsetsOptional : optional
+ * scale : required
+ * chunkSize : required
+ * oOut : required
+ * workspaceSize : size of workspace(output).
+ * executor : executor context(output).
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnChunkFwdOGetWorkspaceSize(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *h,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkOffsetsOptional,
+    double scale,
+    int64_t chunkSize,
+    const aclTensor *oOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/* function: aclnnChunkFwdO
+ * parameters :
+ * workspace : workspace memory addr(input).
+ * workspaceSize : size of workspace(input).
+ * executor : executor context(input).
+ * stream : acl stream.
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnChunkFwdO(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/csrc/moe/chunk_fwd_o/op_host/op_api/chunk_fwd_o.cpp
+++ b/csrc/moe/chunk_fwd_o/op_host/op_api/chunk_fwd_o.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#include "opdev/op_log.h"
+#include "opdev/op_dfx.h"
+#include "opdev/make_op_executor.h"
+#include "chunk_fwd_o.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(ChunkFwdO);
+
+const std::array<const aclTensor *, 1> ChunkFwdO(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *h,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkOffsetsOptional,
+    double scale,
+    int64_t chunkSize,
+    const aclTensor *oOut,
+    aclOpExecutor *executor)
+{
+    L0_DFX(ChunkFwdO, q, k, v, h, g, cuSeqlensOptional, chunkOffsetsOptional, scale, chunkSize, oOut);
+
+    const aclTensor *actualCuSeqlens = nullptr;
+    if (cuSeqlensOptional) {
+        actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
+    } else {
+        actualCuSeqlens = nullptr;
+    }
+
+    const aclTensor *actualChunkOffsets = nullptr;
+    if (chunkOffsetsOptional) {
+        actualChunkOffsets = executor->ConvertToTensor(chunkOffsetsOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualChunkOffsets)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkOffsets)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkOffsets)->SetOriginalFormat(Format::FORMAT_ND);
+    } else {
+        actualChunkOffsets = nullptr;
+    }
+
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkFwdO,
+        OP_INPUT(q, k, v, h, g, actualCuSeqlens, actualChunkOffsets),
+        OP_OUTPUT(oOut),
+        OP_ATTR(scale, chunkSize));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE failed.");
+        return {nullptr};
+    }
+    return {oOut};
+}
+
+} // namespace l0op

--- a/csrc/moe/chunk_fwd_o/op_host/op_api/chunk_fwd_o.h
+++ b/csrc/moe/chunk_fwd_o/op_host/op_api/chunk_fwd_o.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#ifndef OP_API_INC_LEVEL0_OP_CHUNK_FWD_O_H
+#define OP_API_INC_LEVEL0_OP_CHUNK_FWD_O_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const std::array<const aclTensor *, 1> ChunkFwdO(
+    const aclTensor *q,
+    const aclTensor *k,
+    const aclTensor *v,
+    const aclTensor *h,
+    const aclTensor *g,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkOffsetsOptional,
+    double scale,
+    int64_t chunkSize,
+    const aclTensor *oOut,
+    aclOpExecutor *executor);
+}
+
+#endif

--- a/csrc/moe/chunk_fwd_o/op_kernel/chunk_fwd_o.cpp
+++ b/csrc/moe/chunk_fwd_o/op_kernel/chunk_fwd_o.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_fwd_o.cpp
+ * \brief
+ */
+
+// #include "chunk_fwd_o.h"
+#include "gemm/kernel/gdn_fwd_o_kernel.hpp"
+#include "lib/matmul_intf.h"
+
+using namespace Catlass;
+
+extern "C" __global__ __aicore__ void chunk_fwd_o(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h,
+                                                         GM_ADDR g, GM_ADDR cu_seqlens, GM_ADDR chunk_offsets,
+                                                         GM_ADDR o, GM_ADDR workspace, GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+
+    GM_ADDR user = AscendC::GetUserWorkspace(workspace);
+    
+    __gm__ ChunkFwdOTilingData *__restrict gdnFwdOTilingData = reinterpret_cast<__gm__ ChunkFwdOTilingData *__restrict>(tiling);
+    using workspaceType = float;
+    // dtype: 0 - fp16, 1 - bf16, 2 - fp32
+    if (gdnFwdOTilingData->dataType == 1) {
+        if (gdnFwdOTilingData->gDataType == 2) {
+            using GDNFwdOKernel = Catlass::Gemm::Kernel::GDNFwdOKernel<bfloat16_t, float, workspaceType>;
+            GDNFwdOKernel gdnFwdO;
+            gdnFwdO.Init(q, k, v, h, g, cu_seqlens, chunk_offsets, o, tiling, user);
+            gdnFwdO.Process();
+        } else {
+            using GDNFwdOKernel = Catlass::Gemm::Kernel::GDNFwdOKernel<bfloat16_t, bfloat16_t, workspaceType>;
+            GDNFwdOKernel gdnFwdO;
+            gdnFwdO.Init(q, k, v, h, g, cu_seqlens, chunk_offsets, o, tiling, user);
+            gdnFwdO.Process();
+        }
+    } else {
+        if (gdnFwdOTilingData->gDataType == 2) {
+            using GDNFwdOKernel = Catlass::Gemm::Kernel::GDNFwdOKernel<half, float,workspaceType>;
+            GDNFwdOKernel gdnFwdO;
+            gdnFwdO.Init(q, k, v, h, g, cu_seqlens, chunk_offsets, o, tiling, user);
+            gdnFwdO.Process();
+        } else {
+            using GDNFwdOKernel = Catlass::Gemm::Kernel::GDNFwdOKernel<half, half, workspaceType>;
+            GDNFwdOKernel gdnFwdO;
+            gdnFwdO.Init(q, k, v, h, g, cu_seqlens, chunk_offsets, o, tiling, user);
+            gdnFwdO.Process();
+        }
+    }
+}

--- a/csrc/moe/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
+++ b/csrc/moe/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_output.hpp
@@ -1,0 +1,394 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_OUTPUT_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_OUTPUT_HPP
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_o_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class HOutputType_,
+    class GInputType_,
+    class AInputType_,
+    class HInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdOOutput,
+    HOutputType_,
+    GInputType_,
+    AInputType_,
+    HInputType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdOOutput;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using HElementOutput = typename HOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using AElementInput = typename AInputType_::Element;
+    using HElementInput = typename HInputType_::Element;
+ 
+    // using CopyGmToUbInput = Tile::CopyGm2Ub<ArchTag, InputType_>;
+    // using CopyUbToGmOutput = Tile::CopyUb2Gm<ArchTag, OutputType_>;
+
+    static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
+    static constexpr uint32_t FLOAT_ELENUM_PER_BLK = 8;
+    static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
+    static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
+    static constexpr uint32_t UB_TILE_SIZE = 16384;  // 64 * 128 * 2B
+    static constexpr uint32_t UB_LINE_SIZE = 512;   // 128 * 2 * 2B
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;    // 128 * 2
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;   // 128
+    static constexpr uint32_t MULTIPLIER = 2;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+        constexpr uint32_t BASE = 0;
+        constexpr uint32_t MASK_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_SIZE = 40 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t FLOAT_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t HALF_UB_TENSOR_SIZE = 16 * UB_LINE_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+        constexpr uint32_t G_FLOAT_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+
+        constexpr uint32_t MASK_UB_TENSOR_OFFSET = BASE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_OFFSET = MASK_UB_TENSOR_OFFSET + MASK_UB_TENSOR_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_OFFSET = GBRCLEFTCAST_UB_TENSOR_OFFSET + GBRCLEFTCAST_UB_TENSOR_SIZE;
+        constexpr uint32_t GCOMP_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GCOMP_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
+
+        maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
+        gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
+        gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
+        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
+        shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
+
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PING = SHARE_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PING = G_UB_TENSOR_OFFSET_PING + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PING = G_HALF_UB_TENSOR_OFFSET_PING + G_HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t H_UB_TENSOR_OFFSET_PING = A_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PING = H_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PING = OUT_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PING);
+        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PING);
+        hUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(H_UB_TENSOR_OFFSET_PING);
+        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PING);
+        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+ 
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PONG = OUT_HALF_UB_TENSOR_OFFSET_PING + HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PONG + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PONG = G_HALF_UB_TENSOR_OFFSET_PONG + G_HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t H_UB_TENSOR_OFFSET_PONG = A_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PONG = H_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PONG);
+        gUbFPTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        gUbBFTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PONG);
+        hUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(H_UB_TENSOR_OFFSET_PONG);
+        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PONG);
+        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<HElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+    }
+    CATLASS_DEVICE
+    ~BlockEpilogue()
+    {}
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<AElementInput> attnInput,
+        AscendC::GlobalTensor<HElementInput> hInput,
+        float scale,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        uint32_t &pingpongFlag
+        , uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx
+        )
+    {
+        uint32_t mActual = chunkSize;
+        uint32_t nActual = vHeadDim;
+        uint32_t alignedM = CeilDiv(nActual, 8) * 8;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t blockIdx = AscendC::GetBlockIdx();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        int64_t offsetA = mOffset * nActual + nOffset;
+
+        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        if(mActualThisSubBlock <= 32)
+        {
+            if(subBlockIdx == 0)
+            {
+                gbrcStart = 0;
+                gbrcRealStart = 0;
+                gbrcRealProcess = mActualThisSubBlock;
+            }
+            else
+            {
+                gbrcStart = mActualPerSubBlock;
+                gbrcRealStart = gbrcStart & ~7;
+                gbrcRealProcess = mActual - gbrcRealStart;
+            }
+            gbrcEffStart = gbrcStart - gbrcRealStart;
+            uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
+            uint32_t srcShape_[2] = {gbrcRealProcess, 1};
+
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
+            AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[gbrcStart * nActual];
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+            AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * nActual];
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0}; 
+
+            AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+            AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
+            AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag); 
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag); 
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag); 
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag); 
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag); 
+            AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag); 
+            AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisSubBlock * nActual);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+
+            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();    
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();    
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::Mul(gbrcUpUbTensor, hUbTensor, gbrcLeftcastUbTensor[gbrcEffStart*nActual], mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();    
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+            
+            AscendC::Add(gbrcUpUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisSubBlock * nActual); 
+            AscendC::PipeBarrier<PIPE_V>();    
+            AscendC::Muls(outUbTensor, gbrcUpUbTensor, (float)scale, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            if(std::is_same<HElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::DataCopy(hOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock * nActual);
+            }
+            else
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::DataCopy(hOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock * nActual);
+            }
+            pingpongFlag = 1 - pingpongFlag;
+        }
+        else
+        {
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0}; 
+
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag); 
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(gcompUbTensor, gcompUbTensor, mActual);
+            AscendC::PipeBarrier<PIPE_V>();    
+            uint32_t mActualPerStage = CeilDiv(mActualThisSubBlock, 2);
+            uint32_t mActualThisStage = 0;
+            for(uint32_t stage = 0; stage < 2; stage++)
+            {
+                if(stage == 0) mActualThisStage = mActualPerStage;
+                else mActualThisStage = mActualThisSubBlock - mActualPerStage;
+
+                if(subBlockIdx == 0 && stage == 0)
+                {
+                    gbrcStart = 0;
+                    gbrcRealStart = 0;
+                    gbrcRealProcess = mActualThisStage;
+                }
+                else if(subBlockIdx == 0 && stage == 1)
+                {
+                    gbrcStart = mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualThisSubBlock - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 0)
+                {
+                    gbrcStart = mActualPerSubBlock;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualPerSubBlock + mActualThisStage - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 1)
+                {
+                    gbrcStart = mActualPerSubBlock + mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActual - gbrcRealStart;
+                }
+                gbrcEffStart = gbrcStart - gbrcRealStart;
+                uint32_t dstShape_[2] = {gbrcRealProcess, nActual};
+                uint32_t srcShape_[2] = {gbrcRealProcess, 1};
+
+                AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[gbrcStart * nActual];
+                AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
+                AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[gbrcStart * nActual];
+
+                AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+                AscendC::LocalTensor<float> hUbTensor = (pingpongFlag == 0) ? hUbTensorPing : hUbTensorPong;
+                AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+                AscendC::LocalTensor<HElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+                AscendC::LocalTensor<HElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag); 
+                
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisStage * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+                AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisStage * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+
+                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstShape_, srcShape_, shareUbTensor);
+                AscendC::PipeBarrier<PIPE_V>();
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+                AscendC::Mul(gbrcUpUbTensor, hUbTensor, gbrcLeftcastUbTensor[gbrcEffStart*nActual], mActualThisStage * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+                AscendC::Add(gbrcUpUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisStage * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Muls(outUbTensor, gbrcUpUbTensor, (float)scale, mActualThisStage * nActual);
+                AscendC::PipeBarrier<PIPE_V>();
+
+                if(std::is_same<HElementOutput, half>::value)
+                {
+                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::DataCopy(hOutputThisSubBlock, outUbFPTensor, mActualThisStage * nActual);
+                }
+                else
+                {
+                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisStage * nActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::DataCopy(hOutputThisSubBlock, outUbBFTensor, mActualThisStage * nActual);
+                }
+                pingpongFlag = 1 - pingpongFlag;
+            }
+        }
+    }
+
+private:
+    AscendC::LocalTensor<float> maskUbTensor;
+    AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
+    AscendC::LocalTensor<float> gbrcUpUbTensor;
+    AscendC::LocalTensor<float> gcompUbTensor;
+    AscendC::LocalTensor<uint8_t> shareUbTensor;
+
+    AscendC::LocalTensor<float> gUbTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPing;
+    AscendC::LocalTensor<float> aUbTensorPing;
+    AscendC::LocalTensor<float> hUbTensorPing;
+    AscendC::LocalTensor<float> outUbTensorPing;
+    AscendC::LocalTensor<HElementOutput> outUbFPTensorPing;
+    AscendC::LocalTensor<HElementOutput> outUbBFTensorPing;
+
+    AscendC::LocalTensor<float> gUbTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPong;
+    AscendC::LocalTensor<float> aUbTensorPong;
+    AscendC::LocalTensor<float> hUbTensorPong;
+    AscendC::LocalTensor<float> outUbTensorPong;
+    AscendC::LocalTensor<HElementOutput> outUbFPTensorPong;
+    AscendC::LocalTensor<HElementOutput> outUbBFTensorPong;
+
+
+};
+}
+
+#endif

--- a/csrc/moe/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
+++ b/csrc/moe/chunk_fwd_o/op_kernel/epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp
@@ -1,0 +1,428 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_QKMASK_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDO_QKMASK_HPP
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_o_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class AOutputType_,
+    class GInputType_,
+    class AInputType_,
+    class MaskInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdOQkmask,
+    AOutputType_,
+    GInputType_,
+    AInputType_,
+    MaskInputType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdOQkmask;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using AElementOutput = typename AOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using AElementInput = typename AInputType_::Element;
+    using MaskElementInput = typename MaskInputType_::Element;
+
+    static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
+    static constexpr uint32_t FLOAT_ELENUM_PER_BLK = 8;
+    static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
+    static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
+    static constexpr uint32_t UB_TILE_SIZE = 16384;  // 64 * 128 * 2B
+    static constexpr uint32_t UB_LINE_SIZE = 512;   // 128 * 2 * 2B
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;    // 128 * 2
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;   // 128
+    static constexpr uint32_t MULTIPLIER = 2;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+        constexpr uint32_t BASE = 0;
+        constexpr uint32_t MASK_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_SIZE = 40 * UB_LINE_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t FLOAT_UB_TENSOR_SIZE = 32 * UB_LINE_SIZE;
+        constexpr uint32_t HALF_UB_TENSOR_SIZE = 16 * UB_LINE_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+        constexpr uint32_t G_FLOAT_UB_TENSOR_SIZE = 2 * UB_LINE_SIZE;
+
+        constexpr uint32_t MASK_UB_TENSOR_OFFSET = BASE;
+        constexpr uint32_t GBRCLEFTCAST_UB_TENSOR_OFFSET = MASK_UB_TENSOR_OFFSET + MASK_UB_TENSOR_SIZE;
+        constexpr uint32_t GBRCUP_UB_TENSOR_OFFSET = GBRCLEFTCAST_UB_TENSOR_OFFSET + GBRCLEFTCAST_UB_TENSOR_SIZE;
+        constexpr uint32_t GCOMP_UB_TENSOR_OFFSET = GBRCUP_UB_TENSOR_OFFSET + GBRCUP_UB_TENSOR_SIZE;
+        constexpr uint32_t SHARE_UB_TENSOR_OFFSET = GCOMP_UB_TENSOR_OFFSET + G_FLOAT_UB_TENSOR_SIZE;
+
+        maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(MASK_UB_TENSOR_OFFSET);
+        gbrcLeftcastUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCLEFTCAST_UB_TENSOR_OFFSET);
+        gbrcUpUbTensor = resource.ubBuf.template GetBufferByByte<float>(GBRCUP_UB_TENSOR_OFFSET);
+        gcompUbTensor = resource.ubBuf.template GetBufferByByte<float>(GCOMP_UB_TENSOR_OFFSET);
+        shareUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_UB_TENSOR_OFFSET);
+
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PING = SHARE_UB_TENSOR_OFFSET + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PING = G_UB_TENSOR_OFFSET_PING + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PING = G_HALF_UB_TENSOR_OFFSET_PING + G_HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PING = A_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PING = OUT_UB_TENSOR_OFFSET_PING + FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PING);
+        gUbFPTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        gUbBFTensorPing = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PING);
+        aUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PING);
+        outUbTensorPing = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PING);
+        outUbFPTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+        outUbBFTensorPing = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PING);
+
+        constexpr uint32_t G_UB_TENSOR_OFFSET_PONG = 32 * UB_LINE_SIZE + OUT_HALF_UB_TENSOR_OFFSET_PING + HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t G_HALF_UB_TENSOR_OFFSET_PONG = G_UB_TENSOR_OFFSET_PONG + G_FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t A_UB_TENSOR_OFFSET_PONG = G_HALF_UB_TENSOR_OFFSET_PONG + G_HALF_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_UB_TENSOR_OFFSET_PONG = A_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+        constexpr uint32_t OUT_HALF_UB_TENSOR_OFFSET_PONG = OUT_UB_TENSOR_OFFSET_PONG + FLOAT_UB_TENSOR_SIZE;
+
+        gUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(G_UB_TENSOR_OFFSET_PONG);
+        gUbFPTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        gUbBFTensorPong = resource.ubBuf.template GetBufferByByte<GElementInput>(G_HALF_UB_TENSOR_OFFSET_PONG);
+        aUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(A_UB_TENSOR_OFFSET_PONG);
+        outUbTensorPong = resource.ubBuf.template GetBufferByByte<float>(OUT_UB_TENSOR_OFFSET_PONG);
+        outUbFPTensorPong = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+        outUbBFTensorPong = resource.ubBuf.template GetBufferByByte<AElementOutput>(OUT_HALF_UB_TENSOR_OFFSET_PONG);
+    }
+
+    CATLASS_DEVICE
+    ~BlockEpilogue()
+    {}
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<AElementOutput> maskOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<AElementInput> attnInput,
+        AscendC::GlobalTensor<MaskElementInput> boolInput,
+        uint32_t fullChunkSize,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        uint32_t &pingpongFlag
+        , uint32_t batchIdx, uint32_t headIdx, uint32_t chunkIdx
+        )
+    {
+        uint32_t mActual = chunkSize;
+        uint32_t nActual = chunkSize;
+        uint32_t alignedNActual = CeilDiv(nActual, 16) * 16;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t blockIdx = AscendC::GetBlockIdx();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        int64_t offsetA = mOffset * nActual + nOffset;
+        uint16_t aInputDstStride;
+        if((nActual - 1) % 16 <= 7) aInputDstStride = 1;
+        else aInputDstStride = 0;
+
+        uint32_t gbrcStart, gbrcRealStart, gbrcRealEnd, gbrcRealProcess, gbrcEffStart, gbrcEffEnd, mulsRemain, mulsRemainIdx;
+        if(mActualThisSubBlock <= 32)
+        {   if(subBlockIdx == 0)
+            {
+                gbrcStart = 0;
+                gbrcRealStart = 0;
+                gbrcRealProcess = mActualThisSubBlock;
+            }
+            else
+            {
+                gbrcStart = mActualPerSubBlock;
+                gbrcRealStart = gbrcStart & ~7;
+                gbrcRealProcess = mActual - gbrcRealStart;
+            }
+
+            gbrcEffStart = gbrcStart - gbrcRealStart;
+            gbrcEffEnd = gbrcEffStart + mActualThisSubBlock;
+
+            uint32_t dstUpShape_[2] = {mActualThisSubBlock, alignedNActual};
+            uint32_t srcUpShape_[2] = {1, alignedNActual};
+            uint32_t dstLeftShape_[2] = {gbrcRealProcess, alignedNActual};
+            uint32_t srcLeftShape_[2] = {gbrcRealProcess, 1};
+
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<AElementOutput> maskOutputThisSubBlock = maskOutput[gbrcStart * nActual];
+            AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+
+
+            AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisSubBlock, (uint16_t)(nActual*sizeof(float)), 0, aInputDstStride};
+            AscendC::DataCopyPadParams aInputUbPadParams{false, 0, 0, 0};
+            AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisSubBlock, (uint32_t)(nActual*sizeof(half)), 0, 0, 0};
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0}; 
+
+            AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+            AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+            AscendC::LocalTensor<AElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+            AscendC::LocalTensor<AElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag); 
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();        
+
+            AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gcompUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
+            AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstLeftShape_, srcLeftShape_, shareUbTensor);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Sub(gbrcUpUbTensor, gbrcLeftcastUbTensor[gbrcEffStart*alignedNActual], gbrcUpUbTensor, mActualThisSubBlock * alignedNActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mins(gbrcUpUbTensor, gbrcUpUbTensor, (float)0.0, mActualThisSubBlock * alignedNActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Exp(gbrcUpUbTensor, gbrcUpUbTensor, mActualThisSubBlock * alignedNActual);
+            AscendC::PipeBarrier<PIPE_V>();
+            
+            gbrcRealEnd = CeilDiv(gbrcStart + mActualThisSubBlock, 8) * 8;
+            AscendC::Mul(gbrcUpUbTensor[gbrcRealStart], gbrcUpUbTensor[gbrcRealStart], maskUbTensor[gbrcEffStart * 64], gbrcRealEnd - gbrcRealStart, mActualThisSubBlock,
+            {1, 1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(64/8)});
+            AscendC::PipeBarrier<PIPE_V>();
+
+            mulsRemain = alignedNActual - gbrcRealEnd;
+            mulsRemainIdx = gbrcRealEnd;
+            while(mulsRemain > 64)
+            {
+                AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, 64, mActualThisSubBlock,
+                {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+                mulsRemain -= 64;
+                mulsRemainIdx += 64;
+            }
+            AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, mulsRemain, mActualThisSubBlock,
+            {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+            if(chunkSize==fullChunkSize) AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisSubBlock*nActual);
+            else AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+            AscendC::Mul(outUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisSubBlock * alignedNActual);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            if(std::is_same<AElementOutput, half>::value)
+            {
+                AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * alignedNActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisSubBlock*nActual);
+                else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
+            }
+            else 
+            {
+                AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * alignedNActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisSubBlock*nActual);
+                else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
+            }
+            pingpongFlag = 1 - pingpongFlag;
+        }
+        else // mActualThisSubBlock  > 32 ; <=64
+        {
+            AscendC::ResetMask();
+            AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+
+            AscendC::DataCopyParams gfloatUbParams{1, (uint16_t)(mActual*sizeof(float)), 0, 0};
+            AscendC::DataCopyParams ghalfUbParams{1, (uint16_t)(mActual*sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0}; 
+
+            AscendC::LocalTensor<float> gUbTensor = (pingpongFlag == 0) ? gUbTensorPing : gUbTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbFPTensor = (pingpongFlag == 0) ? gUbFPTensorPing : gUbFPTensorPong;
+            AscendC::LocalTensor<GElementInput> gUbBFTensor = (pingpongFlag == 0) ? gUbBFTensorPing : gUbBFTensorPong;
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag); 
+            if constexpr(std::is_same<GElementInput, float>::value) {
+                AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gfloatUbParams, gUbPadParams);
+            } else {
+                AscendC::DataCopyPad(gUbFPTensor, gInputThisSubBlock, ghalfUbParams, gUbPadParams);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+            if constexpr(!std::is_same<GElementInput, float>::value) {
+                AscendC::Cast(gUbTensor, gUbFPTensor, AscendC::RoundMode::CAST_NONE, mActual);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::Copy(gcompUbTensor, gUbTensor, 64, 2, {1, 1, 8, 8});
+            AscendC::PipeBarrier<PIPE_V>();   
+
+            uint32_t mActualPerStage = CeilDiv(mActualThisSubBlock, 2);
+            uint32_t mActualThisStage = 0;
+            for(uint32_t stage = 0; stage < 2; ++stage)
+            {
+                if(stage==0) mActualThisStage = mActualPerStage;
+                else mActualThisStage = mActualThisSubBlock - mActualPerStage;
+
+                if(subBlockIdx == 0 && stage == 0)
+                {
+                    gbrcStart = 0;
+                    gbrcRealStart = 0;
+                    gbrcRealProcess = mActualThisStage;
+                }
+                else if(subBlockIdx == 0 && stage == 1)
+                {
+                    gbrcStart = mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualThisSubBlock - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 0)
+                {
+                    gbrcStart = mActualPerSubBlock;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActualPerSubBlock + mActualThisStage - gbrcRealStart;
+                }
+                else if(subBlockIdx == 1 && stage == 1)
+                {
+                    gbrcStart = mActualPerSubBlock + mActualPerStage;
+                    gbrcRealStart = gbrcStart & ~7;
+                    gbrcRealProcess = mActual - gbrcRealStart;
+                }
+
+                gbrcEffStart = gbrcStart - gbrcRealStart;
+
+                AscendC::GlobalTensor<AElementOutput> maskOutputThisSubBlock = maskOutput[gbrcStart * nActual];
+                AscendC::GlobalTensor<AElementInput> attnInputThisSubBlock = attnInput[gbrcStart * nActual];
+
+                AscendC::DataCopyParams aInputUbParams{(uint16_t)mActualThisStage, (uint16_t)(nActual*sizeof(float)), 0, aInputDstStride};
+                AscendC::DataCopyPadParams aInputUbPadParams{false, 0, 0, 0};
+                AscendC::DataCopyExtParams aOutputUbParams{(uint16_t)mActualThisStage, (uint32_t)(nActual*sizeof(half)), 0, 0, 0};
+                
+                AscendC::LocalTensor<float> aUbTensor = (pingpongFlag == 0) ? aUbTensorPing : aUbTensorPong;
+                AscendC::LocalTensor<float> outUbTensor = (pingpongFlag == 0) ? outUbTensorPing : outUbTensorPong;
+                AscendC::LocalTensor<AElementOutput> outUbFPTensor = (pingpongFlag == 0) ? outUbFPTensorPing : outUbFPTensorPong;
+                AscendC::LocalTensor<AElementOutput> outUbBFTensor = (pingpongFlag == 0) ? outUbBFTensorPing : outUbBFTensorPong;
+
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+                if(chunkSize==fullChunkSize) AscendC::DataCopy(aUbTensor, attnInputThisSubBlock, mActualThisStage*nActual);
+                else AscendC::DataCopyPad(aUbTensor, attnInputThisSubBlock, aInputUbParams, aInputUbPadParams);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+
+                uint32_t dstUpShape_[2] = {mActualThisStage, alignedNActual};
+                uint32_t srcUpShape_[2] = {1, alignedNActual};
+                uint32_t dstLeftShape_[2] = {gbrcRealProcess, alignedNActual};
+                uint32_t srcLeftShape_[2] = {gbrcRealProcess, 1};
+
+                AscendC::Broadcast<float, 2, 0>(gbrcUpUbTensor, gcompUbTensor, dstUpShape_, srcUpShape_, shareUbTensor);
+                AscendC::Broadcast<float, 2, 1>(gbrcLeftcastUbTensor, gcompUbTensor[gbrcRealStart], dstLeftShape_, srcLeftShape_, shareUbTensor);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Sub(gbrcUpUbTensor, gbrcLeftcastUbTensor[gbrcEffStart*alignedNActual], gbrcUpUbTensor, mActualThisStage * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Mins(gbrcUpUbTensor, gbrcUpUbTensor, (float)0.0, mActualThisStage * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Exp(gbrcUpUbTensor, gbrcUpUbTensor, mActualThisStage * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                
+                gbrcRealEnd = CeilDiv(gbrcStart + mActualThisStage, 8) * 8;
+                AscendC::Mul(gbrcUpUbTensor[gbrcRealStart], gbrcUpUbTensor[gbrcRealStart], maskUbTensor[gbrcEffStart * 64], gbrcRealEnd - gbrcRealStart, mActualThisStage,
+                {1, 1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(64/8)});
+                AscendC::PipeBarrier<PIPE_V>();
+                mulsRemain = alignedNActual - gbrcRealEnd;
+                mulsRemainIdx = gbrcRealEnd;
+                while(mulsRemain > 64)
+                {
+                    AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, 64, mActualThisStage,
+                    {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+                    mulsRemain -= 64;
+                    mulsRemainIdx += 64;
+                }
+                AscendC::Muls(gbrcUpUbTensor[mulsRemainIdx], gbrcUpUbTensor[mulsRemainIdx], (float)0.0, mulsRemain, mActualThisStage,
+                {1, 1, static_cast<uint8_t>(alignedNActual/8), static_cast<uint8_t>(alignedNActual/8)});
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+                AscendC::Mul(outUbTensor, aUbTensor, gbrcUpUbTensor, mActualThisStage * alignedNActual);
+                AscendC::PipeBarrier<PIPE_V>();
+                if(std::is_same<AElementOutput, half>::value)
+                {
+                    AscendC::Cast(outUbFPTensor, outUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisStage * alignedNActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbFPTensor, mActualThisStage*nActual);
+                    else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbFPTensor, aOutputUbParams);
+                }
+                else 
+                {
+                    AscendC::Cast(outUbBFTensor, outUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisStage * alignedNActual);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+                    if(chunkSize==fullChunkSize) AscendC::DataCopy(maskOutputThisSubBlock, outUbBFTensor, mActualThisStage*nActual);
+                    else AscendC::DataCopyPad(maskOutputThisSubBlock, outUbBFTensor, aOutputUbParams);
+                }
+                pingpongFlag = 1 - pingpongFlag;
+            }
+        }
+
+    }
+
+private:
+    AscendC::LocalTensor<float> maskUbTensor;
+    AscendC::LocalTensor<float> gbrcLeftcastUbTensor;
+    AscendC::LocalTensor<float> gbrcUpUbTensor;
+    AscendC::LocalTensor<float> gcompUbTensor;
+    AscendC::LocalTensor<uint8_t> shareUbTensor;
+
+    AscendC::LocalTensor<float> gUbTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPing;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPing;
+    AscendC::LocalTensor<float> aUbTensorPing;
+    AscendC::LocalTensor<float> outUbTensorPing;
+    AscendC::LocalTensor<AElementOutput> outUbFPTensorPing;
+    AscendC::LocalTensor<AElementOutput> outUbBFTensorPing;
+
+    AscendC::LocalTensor<float> gUbTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbFPTensorPong;
+    AscendC::LocalTensor<GElementInput> gUbBFTensorPong;
+    AscendC::LocalTensor<float> aUbTensorPong;
+    AscendC::LocalTensor<float> outUbTensorPong;
+    AscendC::LocalTensor<AElementOutput> outUbFPTensorPong;
+    AscendC::LocalTensor<AElementOutput> outUbBFTensorPong;
+
+};
+}
+
+#endif

--- a/csrc/moe/chunk_fwd_o/op_kernel/epilogue/gdn_fwd_o_epilogue_policies.hpp
+++ b/csrc/moe/chunk_fwd_o/op_kernel/epilogue/gdn_fwd_o_epilogue_policies.hpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP
+#define CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP
+
+#include "catlass/catlass.hpp"
+
+namespace Catlass::Epilogue {
+
+struct EpilogueAtlasGDNFwdOQkmask {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
+    using ArchTag = Arch::AtlasA2;
+#endif
+};
+
+struct EpilogueAtlasGDNFwdOOutput {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
+    using ArchTag = Arch::AtlasA2;
+#endif
+};
+
+}  // namespace Catlass::Epilogue
+
+#endif  // CATLASS_EPILOGUE_GDN_FWD_O_EPILOGUE_POLICIES_HPP

--- a/csrc/moe/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
+++ b/csrc/moe/chunk_fwd_o/op_kernel/gemm/block/block_scheduler_gdn_fwd_o.hpp
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP
+#define CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP
+
+// constexpr uint32_t PING_PONG_STAGES = 1;
+constexpr uint32_t PING_PONG_STAGES = 2;
+constexpr uint32_t BYTE_SIZE_16_BIT = 2;
+
+template <typename T>
+CATLASS_DEVICE T AlignUp(T a, T b) {
+    return (b == 0) ? 0 : (a + b - 1) / b * b;
+}
+
+template <typename T>
+CATLASS_DEVICE T Min(T a, T b) {
+    return (a > b) ? b : a;
+}
+
+template <typename T>
+CATLASS_DEVICE T Max(T a, T b) {
+    return (a > b) ? a : b;
+}
+
+namespace Catlass::Gemm::Block {
+
+
+struct GDNFwdOOffsets {
+    uint32_t qkOffset;
+    uint32_t ovOffset;
+    uint32_t hOffset;
+    uint32_t gOffset;
+    uint32_t attnWorkOffset;
+    uint32_t hvWorkOffset;
+    bool isFinalState;
+    uint32_t blockTokens;
+    // for debug
+    uint32_t batchIdx;
+    uint32_t headIdx;
+    uint32_t chunkIdx;
+
+};
+
+struct BlockSchedulerGdnFwdO {
+    uint32_t shapeBatch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    uint32_t isVariedLen;
+    uint32_t tokenBatch;
+    uint32_t numChunks{0};
+    uint32_t vBlockSize{128};
+
+    uint32_t taskIdx;
+    uint32_t cubeCoreIdx;
+    uint32_t cubeCoreNum;
+    uint32_t vLoops;
+    uint32_t taskNum;
+    uint32_t headGroups;
+
+    bool isRunning;
+    bool processNewTask {true};
+    bool firstLoop {true};
+    bool lastLoop {false};
+    GDNFwdOOffsets offsets[PING_PONG_STAGES];
+    int32_t currStage{PING_PONG_STAGES - 1};
+
+    uint32_t vIdx;
+    uint32_t batchIdx;
+    uint32_t baseHeadIdx;
+    uint32_t chunkIdx;
+    uint32_t headInnerIdx;
+    uint32_t vHeadIdx;
+    uint32_t kHeadIdx;
+    uint32_t shapeBatchIdx;
+    uint32_t tokenBatchIdx;
+    
+    uint32_t batchChunkIdx;
+    uint32_t batchChunkStartIdx;
+    uint32_t tokenOffset;
+    uint32_t batchChunks;
+    uint32_t batchTokens;
+
+    AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmChunkOffsets;
+
+    Arch::CrossCoreFlag cube1Done{3};
+    Arch::CrossCoreFlag vec1Done{4};
+    Arch::CrossCoreFlag cube2Done{5};
+    Arch::CrossCoreFlag cube3Done{6};
+    Arch::CrossCoreFlag vec2Done{7};
+
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdO() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR tiling, uint32_t coreIdx, uint32_t coreNum) {
+        __gm__ ChunkFwdOTilingData *__restrict gdnFwdOTilingData = reinterpret_cast<__gm__ ChunkFwdOTilingData *__restrict>(tiling);
+        shapeBatch = gdnFwdOTilingData->shapeBatch;
+        seqlen = gdnFwdOTilingData->seqlen;
+        kNumHead = gdnFwdOTilingData->kNumHead;
+        vNumHead = gdnFwdOTilingData->vNumHead;
+        kHeadDim = gdnFwdOTilingData->kHeadDim;
+        vHeadDim = gdnFwdOTilingData->vHeadDim;
+        chunkSize = gdnFwdOTilingData->chunkSize;
+        isVariedLen = gdnFwdOTilingData->isVariedLen;
+        tokenBatch = gdnFwdOTilingData->tokenBatch;
+
+        gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmChunkOffsets.SetGlobalBuffer((__gm__ int64_t *)chunk_offsets);
+
+        if (isVariedLen) {
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                numChunks += (gmSeqlen.GetValue(b) - gmSeqlen.GetValue(b - 1) + chunkSize - 1) / chunkSize;
+            }
+        } else {
+            numChunks = (seqlen + chunkSize - 1) / chunkSize;
+        }
+
+        cubeCoreIdx = coreIdx;
+        cubeCoreNum = coreNum;
+        vLoops = vHeadDim / vBlockSize;
+        taskNum = vLoops * shapeBatch * numChunks * vNumHead;
+        headGroups = vNumHead / kNumHead;
+        taskIdx = cubeCoreIdx * PING_PONG_STAGES;
+        isRunning = taskIdx < taskNum;
+
+    }
+
+    CATLASS_DEVICE
+    void InitTask() {
+        if (processNewTask) {
+            if (unlikely(taskIdx >= taskNum)) {
+                isRunning = false;
+            }
+            vIdx = taskIdx / (shapeBatch * numChunks * vNumHead);
+            shapeBatchIdx = (taskIdx - vIdx * shapeBatch * numChunks * vNumHead) / (numChunks * vNumHead);
+            chunkIdx = (taskIdx - vIdx * shapeBatch * numChunks * vNumHead - shapeBatchIdx * numChunks * vNumHead) / vNumHead;
+            baseHeadIdx = taskIdx % vNumHead;
+            tokenBatchIdx = isVariedLen ? gmChunkOffsets.GetValue(2 * chunkIdx) : 0;
+            batchChunkIdx = isVariedLen ? gmChunkOffsets.GetValue(2 * chunkIdx + 1) : chunkIdx;
+            batchChunkStartIdx = chunkIdx - batchChunkIdx;
+            tokenOffset = isVariedLen ? gmSeqlen.GetValue(tokenBatchIdx) : 0;
+            batchTokens = isVariedLen ? (gmSeqlen.GetValue(tokenBatchIdx + 1) - tokenOffset) : seqlen;
+            headInnerIdx = 0;
+        } else {
+            headInnerIdx = (headInnerIdx + 1) % PING_PONG_STAGES;
+        }
+        
+        vHeadIdx = baseHeadIdx + headInnerIdx;
+        kHeadIdx = vHeadIdx / headGroups;
+        offsets[currStage].qkOffset = (shapeBatchIdx * kNumHead * seqlen + kHeadIdx * seqlen + tokenOffset + batchChunkIdx * chunkSize) * kHeadDim;
+        offsets[currStage].ovOffset = (shapeBatchIdx * vNumHead * seqlen + vHeadIdx * seqlen + tokenOffset + batchChunkIdx * chunkSize) * vHeadDim;
+        offsets[currStage].hOffset = (shapeBatchIdx * vNumHead * numChunks + vHeadIdx * numChunks + chunkIdx) * kHeadDim * vHeadDim;
+        offsets[currStage].gOffset = shapeBatchIdx * vNumHead * seqlen + vHeadIdx * seqlen + tokenOffset + batchChunkIdx * chunkSize;
+        offsets[currStage].attnWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * chunkSize * chunkSize;
+        offsets[currStage].hvWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * chunkSize * vHeadDim;
+        offsets[currStage].isFinalState = chunkIdx == (numChunks - 1) || (isVariedLen && gmChunkOffsets.GetValue(2 * chunkIdx + 3) == 0);
+        offsets[currStage].blockTokens = offsets[currStage].isFinalState ? (batchTokens - batchChunkIdx * chunkSize) : chunkSize;
+        offsets[currStage].batchIdx = batchIdx; 
+        offsets[currStage].headIdx = vHeadIdx; 
+        offsets[currStage].chunkIdx = chunkIdx; 
+
+        processNewTask = headInnerIdx == PING_PONG_STAGES - 1;
+        if (processNewTask) {
+            taskIdx += PING_PONG_STAGES * cubeCoreNum;
+        }
+        
+        currStage = (currStage + 1) % PING_PONG_STAGES;
+    }
+
+
+};
+
+struct BlockSchedulerGdnFwdOCube : public BlockSchedulerGdnFwdO {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdOCube() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR tiling) {
+        BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tiling, AscendC::GetBlockIdx(), AscendC::GetBlockNum());
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessCube1() {
+        return true;
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetCube1Offsets() {
+        return offsets[(currStage - 1) % PING_PONG_STAGES];
+    }
+
+    CATLASS_DEVICE
+    GemmCoord GetCube1Shape() {
+        GDNFwdOOffsets& cube1Offsets = GetCube1Offsets();
+        return GemmCoord{cube1Offsets.blockTokens, cube1Offsets.blockTokens, kHeadDim};
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessCube23() {
+        if (unlikely(firstLoop)) {
+            firstLoop = false;
+            return false;
+        }
+        return true;
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetCube23Offsets() {
+        return offsets[(currStage - 2) % PING_PONG_STAGES];
+    }
+
+    CATLASS_DEVICE
+    GemmCoord GetCube2Shape() {
+        GDNFwdOOffsets& cube2Offsets = GetCube23Offsets();
+        return GemmCoord{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+    }
+
+    CATLASS_DEVICE
+    GemmCoord GetCube3Shape() {
+        GDNFwdOOffsets& cube2Offsets = GetCube23Offsets();
+        return GemmCoord{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+    }
+
+};
+
+struct BlockSchedulerGdnFwdOVec : public BlockSchedulerGdnFwdO {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdOVec() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR tiling) {
+        BlockSchedulerGdnFwdO::Init(cu_seqlens, chunk_offsets, tiling, AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessVec1() {
+        return isRunning;
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessVec2() {
+        if (unlikely(firstLoop)) {
+            firstLoop = false;
+            return false;
+        }
+        return true;
+    }
+
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetVec1Offsets() {
+        return offsets[(currStage - 1) % PING_PONG_STAGES];
+    }
+    
+    CATLASS_DEVICE
+    GDNFwdOOffsets& GetVec2Offsets() {
+        return offsets[(currStage - 2) % PING_PONG_STAGES];
+    }
+
+};
+
+}  // namespace Catlass::Gemm::Block
+
+#endif // CATLASS_GEMM_SCHEDULER_GDN_FWD_O_HPP

--- a/csrc/moe/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
+++ b/csrc/moe/chunk_fwd_o/op_kernel/gemm/kernel/gdn_fwd_o_kernel.hpp
@@ -1,0 +1,404 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#define CATLASS_ARCH 3510
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/debug.hpp"
+#include "catlass/epilogue/block/block_epilogue.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdo_output.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "../block/block_scheduler_gdn_fwd_o.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "tla/tensor.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+using _0 = tla::Int<0>;
+using _1 = tla::Int<1>;
+using _2 = tla::Int<2>;
+using _4 = tla::Int<4>;
+using _8 = tla::Int<8>;
+using _16 = tla::Int<16>;
+using _32 = tla::Int<32>;
+using _64 = tla::Int<64>;
+using _128 = tla::Int<128>;
+using _256 = tla::Int<256>;
+using _512 = tla::Int<512>;
+using _1024 = tla::Int<1024>;
+using _2048 = tla::Int<2048>;
+using _4096 = tla::Int<4096>;
+using _8192 = tla::Int<8192>;
+using _16384 = tla::Int<16384>;
+using _32768 = tla::Int<32768>;
+using _65536 = tla::Int<65536>;
+
+#else
+#define CATLASS_ARCH 2201
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/debug.hpp"
+#include "catlass/epilogue/block/block_epilogue.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdo_qkmask.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdo_output.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "../block/block_scheduler_gdn_fwd_o.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "tla/tensor.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+#endif
+
+#include "kernel_operator.h"
+using namespace Catlass;
+using namespace tla;
+
+// template <>
+namespace Catlass::Gemm::Kernel {
+
+template<
+    typename INPUT_TYPE,
+    typename G_TYPE,
+    typename WORKSPACE_TYPE
+>
+class GDNFwdOKernel {
+public:
+    
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
+    using ArchTag = Arch::AtlasA2;
+#endif
+    using GDNFwdOOffsets = Catlass::Gemm::Block::GDNFwdOOffsets;
+
+    using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdOCube;
+    using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdOVec;
+
+    using DispatchPolicyTla = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+    using L1TileShapeTla = Shape<_128, _128, _128>;
+    using L0TileShapeTla = L1TileShapeTla;
+    using QType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using KType = Gemm::GemmType<INPUT_TYPE, layout::ColumnMajor>;
+    using AttenType = Gemm::GemmType<WORKSPACE_TYPE, layout::RowMajor>;
+    using AttenMaskedType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using HType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using OinterType = Gemm::GemmType<WORKSPACE_TYPE, layout::RowMajor>;
+    using VNEWType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+
+    using GType = Gemm::GemmType<G_TYPE, layout::RowMajor>;
+    using OType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using MaskType = Gemm::GemmType<bool, layout::RowMajor>;
+
+    // cube 1
+    using TileCopyQK = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::ColumnMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadQK = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQK>;
+
+    // cube 2
+    using TileCopyQH = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadQH = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyQH>;
+
+    // cube 3
+    using TileCopyAttenVNEW = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadAttenVNEW = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyAttenVNEW>;
+
+    // vec 1
+    using DispatchPolicyGDNFwdOQkmask = Epilogue::EpilogueAtlasGDNFwdOQkmask;
+    using EpilogueGDNFwdOQkmask = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOQkmask, AttenMaskedType, GType, AttenType, MaskType>;
+
+    // vec 2
+    using DispatchPolicyGDNFwdOOutput = Epilogue::EpilogueAtlasGDNFwdOOutput;
+    using EpilogueGDNFwdOOutput = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdOOutput, OType, GType, OinterType, OinterType>;
+
+    using ElementQ = typename BlockMmadQK::ElementA;
+    using LayoutQ = Catlass::layout::RowMajor;
+
+    using ElementK =  typename BlockMmadQK::ElementB;
+    using LayoutK = Catlass::layout::ColumnMajor;
+
+    using ElementAtten = typename BlockMmadQK::ElementC;
+    using LayoutAtten = Catlass::layout::RowMajor;
+    
+    using ElementAttenMasked = typename BlockMmadQH::ElementA;
+    using LayoutAttenMasked = Catlass::layout::RowMajor;
+
+    using ElementH = typename BlockMmadQH::ElementB;
+    using LayoutH = Catlass::layout::RowMajor;
+
+    using ElementOinter = typename BlockMmadQH::ElementC;
+    using LayoutOinter = Catlass::layout::RowMajor;
+
+
+    using ElementVNEW = typename BlockMmadAttenVNEW::ElementB; 
+    using LayoutVNEW = Catlass::layout::RowMajor;
+
+
+    using ElementG = G_TYPE;
+    using ElementMask = bool;
+
+    using L1TileShape = typename BlockMmadQK::L1TileShape;
+
+    uint32_t shapeBatch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    float scale;
+    uint32_t numChunks;
+    uint32_t isVariedLen;
+    uint32_t tokenBatch;
+    uint32_t vWorkspaceOffset;
+    uint32_t hWorkspaceOffset;
+    uint32_t attnWorkspaceOffset;
+    uint32_t aftermaskWorkspaceOffset;
+    uint32_t maskWorkspaceOffset;
+    
+    AscendC::GlobalTensor<ElementQ> gmQ;
+    AscendC::GlobalTensor<ElementK> gmK;
+    AscendC::GlobalTensor<ElementVNEW> gmV;
+    AscendC::GlobalTensor<ElementH> gmH;
+    AscendC::GlobalTensor<ElementG> gmG;
+    AscendC::GlobalTensor<ElementVNEW> gmO;
+    AscendC::GlobalTensor<ElementOinter> gmVWorkspace;
+    AscendC::GlobalTensor<ElementOinter> gmHWorkspace;
+    AscendC::GlobalTensor<ElementAtten> gmAttnWorkspace;
+    AscendC::GlobalTensor<ElementAttenMasked> gmAftermaskWorkspace;
+    AscendC::GlobalTensor<ElementMask> gmMask;
+
+    CubeScheduler cubeBlockScheduler;
+    VecScheduler vecBlockScheduler;
+
+    Arch::Resource<ArchTag> resource;
+
+    __aicore__ inline GDNFwdOKernel() {}
+
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR h, GM_ADDR g, 
+        GM_ADDR cu_seqlens, GM_ADDR chunk_offsets, GM_ADDR o, GM_ADDR tiling, GM_ADDR user) {
+        
+        __gm__ ChunkFwdOTilingData *__restrict gdnFwdOTilingData = reinterpret_cast<__gm__ ChunkFwdOTilingData *__restrict>(tiling);
+
+        shapeBatch = gdnFwdOTilingData->shapeBatch;
+        seqlen = gdnFwdOTilingData->seqlen;
+        kNumHead = gdnFwdOTilingData->kNumHead;
+        vNumHead = gdnFwdOTilingData->vNumHead;
+        kHeadDim = gdnFwdOTilingData->kHeadDim;
+        vHeadDim = gdnFwdOTilingData->vHeadDim;
+        scale = gdnFwdOTilingData->scale;
+        chunkSize = gdnFwdOTilingData->chunkSize;
+        isVariedLen = gdnFwdOTilingData->isVariedLen;
+        tokenBatch = gdnFwdOTilingData->tokenBatch;
+        vWorkspaceOffset = gdnFwdOTilingData->vWorkspaceOffset;
+        hWorkspaceOffset = gdnFwdOTilingData->hWorkspaceOffset;
+        attnWorkspaceOffset = gdnFwdOTilingData->attnWorkspaceOffset;
+        aftermaskWorkspaceOffset = gdnFwdOTilingData->aftermaskWorkspaceOffset;
+        maskWorkspaceOffset = gdnFwdOTilingData->maskWorkspaceOffset;
+
+        gmQ.SetGlobalBuffer((__gm__ ElementQ *)q);
+        gmK.SetGlobalBuffer((__gm__ ElementK *)k);
+        gmV.SetGlobalBuffer((__gm__ ElementVNEW *)v);
+        gmH.SetGlobalBuffer((__gm__ ElementH *)h);
+        gmG.SetGlobalBuffer((__gm__ ElementG *)g);
+        gmO.SetGlobalBuffer((__gm__ ElementVNEW *)o);
+        gmVWorkspace.SetGlobalBuffer((__gm__ ElementOinter *)(user + vWorkspaceOffset));
+        gmHWorkspace.SetGlobalBuffer((__gm__ ElementOinter *)(user + hWorkspaceOffset));
+        gmAttnWorkspace.SetGlobalBuffer((__gm__ ElementAtten *)(user + attnWorkspaceOffset));
+        gmAftermaskWorkspace.SetGlobalBuffer((__gm__ ElementAttenMasked *)(user + aftermaskWorkspaceOffset));
+        gmMask.SetGlobalBuffer((__gm__ ElementMask *)(user + maskWorkspaceOffset));
+
+        if ASCEND_IS_AIC {
+            cubeBlockScheduler.Init(cu_seqlens, chunk_offsets, tiling);
+        }
+
+        if ASCEND_IS_AIV {
+            vecBlockScheduler.Init(cu_seqlens, chunk_offsets, tiling);
+        }
+    }
+
+    __aicore__ inline void Process() {
+        if ASCEND_IS_AIC {
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+
+            BlockMmadQK blockMmadQK(resource);
+            BlockMmadQH blockMmadQH(resource);
+            BlockMmadAttenVNEW blockMmadAttenVNEW(resource);
+
+            auto qLayout = tla::MakeLayout<ElementQ, LayoutQ>(shapeBatch * kNumHead * seqlen, kHeadDim);
+            auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * seqlen);
+            auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * seqlen * kHeadDim, vHeadDim);
+            auto ointerLayout = tla::MakeLayout<ElementOinter, LayoutOinter>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
+            auto vnewLayout = tla::MakeLayout<ElementVNEW, LayoutVNEW>(shapeBatch * vNumHead * seqlen, vHeadDim);
+
+            bool needRun = false;
+            bool isFirstC3 = true;
+
+            while (cubeBlockScheduler.isRunning) {
+                cubeBlockScheduler.InitTask();
+
+                if (cubeBlockScheduler.isRunning && coreIdx < coreNum) {
+
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+
+                    GDNFwdOOffsets& cube1Offsets = cubeBlockScheduler.GetCube1Offsets();
+                    int64_t cube1OffsetQ = cube1Offsets.qkOffset; 
+                    int64_t cube1OffsetK = cube1Offsets.qkOffset; 
+                    int64_t cube1OffsetAttn = cube1Offsets.attnWorkOffset; 
+                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(coreNum * chunkSize * PING_PONG_STAGES, cube1Offsets.blockTokens);
+                    auto tensorQ = tla::MakeTensor(gmQ[cube1OffsetQ], qLayout, Catlass::Arch::PositionGM{});
+                    auto tensorK = tla::MakeTensor(gmK[cube1OffsetK], kLayout, Catlass::Arch::PositionGM{});
+                    auto tensorAttn = tla::MakeTensor(gmAttnWorkspace[cube1OffsetAttn], attenLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube1Shape{cube1Offsets.blockTokens, cube1Offsets.blockTokens, kHeadDim};
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
+                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                    auto tensorBlockAttn = GetTile(tensorAttn, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                    blockMmadQK.preSetFlags();
+                    blockMmadQK(tensorBlockQ, tensorBlockK, tensorBlockAttn, cube1Shape);
+                    blockMmadQK.finalWaitFlags();
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
+
+                }
+                // AscendC::PipeBarrier<PIPE_ALL>();
+
+                if (needRun && coreIdx < coreNum) {
+                    if(!cubeBlockScheduler.isRunning) Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
+                    GDNFwdOOffsets& cube2Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    int64_t cube2OffsetQ = cube2Offsets.qkOffset;
+                    int64_t cube2OffsetH = cube2Offsets.hOffset;
+                    int64_t cube2OffsetHWork = cube2Offsets.hvWorkOffset; 
+                    auto tensorQ = tla::MakeTensor(gmQ[cube2OffsetQ], qLayout, Catlass::Arch::PositionGM{});
+                    auto tensorH = tla::MakeTensor(gmH[cube2OffsetH], hLayout, Catlass::Arch::PositionGM{});
+                    auto tensorHWork = tla::MakeTensor(gmHWorkspace[cube2OffsetHWork], ointerLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube2Shape{cube2Offsets.blockTokens, vHeadDim, kHeadDim};
+                    auto tensorBlockQ = GetTile(tensorQ, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                    auto tensorBlockHWork = GetTile(tensorHWork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                    blockMmadQH.preSetFlags();
+                    blockMmadQH(tensorBlockQ, tensorBlockH, tensorBlockHWork, cube2Shape);
+                    blockMmadQH.finalWaitFlags();
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
+                }
+
+                if (needRun && coreIdx < coreNum) {
+                    GDNFwdOOffsets& cube3Offsets = cubeBlockScheduler.GetCube23Offsets();
+                    if(isFirstC3) Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+                    int64_t cube3OffsetAttnMask = cube3Offsets.attnWorkOffset; 
+                    int64_t cube3OffsetV = cube3Offsets.ovOffset; 
+                    int64_t cube3OffsetVWork = cube3Offsets.hvWorkOffset; 
+                    auto attenLayout = tla::MakeLayout<ElementAtten, LayoutAtten>(coreNum * chunkSize * PING_PONG_STAGES, cube3Offsets.blockTokens);
+                    auto tensorAttnMask = tla::MakeTensor(gmAftermaskWorkspace[cube3OffsetAttnMask], attenLayout, Catlass::Arch::PositionGM{});
+                    auto tensorV = tla::MakeTensor(gmV[cube3OffsetV], vnewLayout, Catlass::Arch::PositionGM{});
+                    auto tensorVWork = tla::MakeTensor(gmVWorkspace[cube3OffsetVWork], ointerLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube3Shape{cube3Offsets.blockTokens, vHeadDim, cube3Offsets.blockTokens};
+                    auto tensorBlockAttnMask = GetTile(tensorAttnMask, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.k()));
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.k(), cube3Shape.n()));
+                    auto tensorBlockVWork = GetTile(tensorVWork, tla::MakeCoord(0, 0), tla::MakeShape(cube3Shape.m(), cube3Shape.n()));
+                    blockMmadAttenVNEW.preSetFlags();
+                    blockMmadAttenVNEW(tensorBlockAttnMask, tensorBlockV, tensorBlockVWork, cube3Shape);
+                    blockMmadAttenVNEW.finalWaitFlags();
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube3Done);
+                    isFirstC3 = false;
+                }
+                needRun = true;
+                // AscendC::PipeBarrier<PIPE_ALL>();
+            }
+            if (coreIdx < coreNum) {
+                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
+
+            }
+        }
+
+        if ASCEND_IS_AIV {
+
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+            uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+            uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+            AscendC::LocalTensor<float> maskUbTensor = resource.ubBuf.template GetBufferByByte<float>(0);
+            AscendC::Duplicate<float>(maskUbTensor, (float)0.0, 64*64);
+            AscendC::PipeBarrier<PIPE_V>();
+            for(uint32_t i = 0; i < 64; ++ i) AscendC::Duplicate<float>(maskUbTensor[i * 64], (float)1.0, i + 1);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            bool needRun = false;
+            uint32_t pingpongFlag = 0;
+
+            if (coreIdx < coreNum * subBlockNum) {
+                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
+                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
+                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+            }
+
+            while (vecBlockScheduler.isRunning) {
+                vecBlockScheduler.InitTask();
+
+                if (vecBlockScheduler.isRunning && coreIdx < coreNum * subBlockNum) {
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done);
+                    GDNFwdOOffsets& vec1Offsets = vecBlockScheduler.GetVec1Offsets();
+                    int64_t vec1OffsetAttnMask = vec1Offsets.attnWorkOffset;
+                    int64_t vec1OffsetG = vec1Offsets.gOffset;
+                    int64_t vec1OffsetAttn = vec1Offsets.attnWorkOffset;
+                    EpilogueGDNFwdOQkmask epilogueGDNFwdOQkmask(resource);
+                    epilogueGDNFwdOQkmask(
+                        gmAftermaskWorkspace[vec1OffsetAttnMask], 
+                        gmG[vec1OffsetG], gmAttnWorkspace[vec1OffsetAttn], gmMask,
+                        chunkSize, vec1Offsets.blockTokens, kHeadDim, vHeadDim, pingpongFlag, vec1Offsets.batchIdx, vec1Offsets.headIdx, vec1Offsets.chunkIdx
+                    );
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
+                }
+
+                // AscendC::PipeBarrier<PIPE_ALL>();
+
+                if (needRun && coreIdx < coreNum * subBlockNum) {
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube3Done);
+                    GDNFwdOOffsets& vec2Offsets = vecBlockScheduler.GetVec2Offsets();
+                    int64_t vec2OffsetO = vec2Offsets.ovOffset;
+                    int64_t vec2OffsetG = vec2Offsets.gOffset;
+                    int64_t vec2OffsetVWork = vec2Offsets.hvWorkOffset;
+                    int64_t vec2OffsetHWork = vec2Offsets.hvWorkOffset;
+                    EpilogueGDNFwdOOutput epilogueGDNFwdOOutput(resource);
+                    epilogueGDNFwdOOutput(
+                        gmO[vec2OffsetO], 
+                        gmG[vec2OffsetG], gmVWorkspace[vec2OffsetVWork], gmHWorkspace[vec2OffsetHWork], 
+                        scale, vec2Offsets.blockTokens, kHeadDim, vHeadDim, pingpongFlag, vec2Offsets.batchIdx, vec2Offsets.headIdx, vec2Offsets.chunkIdx
+                    );
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+                }
+                
+                // AscendC::PipeBarrier<PIPE_ALL>();
+
+                needRun = true;
+            }
+        }
+    }
+    
+};
+
+}

--- a/csrc/moe/chunk_fwd_o/tiling_base/data_copy_transpose_tiling.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/data_copy_transpose_tiling.h
@@ -1,0 +1,51 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling.h
+ * \brief
+ */
+
+#pragma once
+
+#include <vector>
+#include <graph/tensor.h>
+#include "data_copy_transpose_tiling_def.h"
+
+namespace optiling {
+
+inline void GetDataCopyTransposeTiling(const ge::Shape &dstShape, const ge::Shape &srcShape, const uint32_t typeSize,
+                                       optiling::CopyTransposeTiling &tiling)
+{
+    constexpr int64_t B_INDEX = 0;
+    constexpr int64_t N_INDEX = 1;
+    constexpr int64_t S_INDEX = 2;
+    constexpr int64_t H_INDEX = 3;
+    std::vector<int64_t> dstShapeInfo = dstShape.GetDims();
+    std::vector<int64_t> srcShapeInfo = srcShape.GetDims();
+
+    tiling.set_dstShapeB(dstShapeInfo[B_INDEX]);
+    tiling.set_dstShapeN(dstShapeInfo[N_INDEX]);
+    tiling.set_dstShapeS(dstShapeInfo[S_INDEX]);
+    tiling.set_dstShapeH(dstShapeInfo[H_INDEX]);
+    tiling.set_dstShapeHN(tiling.get_dstShapeH() / tiling.get_dstShapeN());
+
+    tiling.set_srcShapeB(srcShapeInfo[B_INDEX]);
+    tiling.set_srcShapeN(srcShapeInfo[N_INDEX]);
+    tiling.set_srcShapeS(srcShapeInfo[S_INDEX]);
+    tiling.set_srcShapeHN(srcShapeInfo[H_INDEX]);
+    tiling.set_originalShapeNLen(tiling.get_srcShapeHN() * typeSize);
+    tiling.set_shapeSHValue(tiling.get_dstShapeS() * tiling.get_dstShapeH());
+    tiling.set_shapeNsValue(tiling.get_dstShapeN() * tiling.get_dstShapeS());
+    tiling.set_shapeNsnValue(tiling.get_dstShapeN() * tiling.get_srcShapeS() * tiling.get_srcShapeN());
+    tiling.set_shapeBHValue(tiling.get_dstShapeB() * tiling.get_dstShapeH());
+}
+
+} // namespace optiling

--- a/csrc/moe/chunk_fwd_o/tiling_base/data_copy_transpose_tiling_def.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/data_copy_transpose_tiling_def.h
@@ -1,0 +1,43 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling_def.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(CopyTransposeTiling)
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeH);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, originalShapeNLen);
+TILING_DATA_FIELD_DEF(uint32_t, shapeSHValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsnValue);
+TILING_DATA_FIELD_DEF(uint32_t, invalidParamCopyTransposeTiling);
+TILING_DATA_FIELD_DEF(uint32_t, shapeBHValue);
+TILING_DATA_FIELD_DEF(uint32_t, paramsAlign);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(CopyTransposeTilingOp, CopyTransposeTiling)
+
+} // namespace optiling

--- a/csrc/moe/chunk_fwd_o/tiling_base/error_log.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/error_log.h
@@ -1,0 +1,56 @@
+#ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+#define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+
+#include <string>
+#include "toolchain/slog.h"
+
+#define OP_LOGI(opname, ...)
+#define OP_LOGW(opname, ...)             \
+    do {                                 \
+        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
+        printf("\n");                    \
+    } while (0)
+
+#define OP_LOGE_WITHOUT_REPORT(opname, ...) \
+    do {                                    \
+        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
+        printf("\n");                       \
+    } while (0)
+
+#define OP_LOGE(opname, ...)              \
+    do {                                  \
+        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
+        printf("\n");                     \
+    } while (0)
+
+#define OP_LOGD(opname, ...)
+
+namespace optiling {
+
+#define VECTOR_INNER_ERR_REPORT_TILIING(op_name, err_msg, ...)   \
+    do {                                                         \
+        OP_LOGE_WITHOUT_REPORT(op_name, err_msg, ##__VA_ARGS__); \
+    } while (0)
+
+// Modify OP_TILING_CHECK macro to ensure proper handling of expressions
+#define OP_CHECK_IF(cond, log_func, expr) \
+    do {                                      \
+        if (cond) {                           \
+            log_func;                         \
+            expr;                             \
+        }                                     \
+    } while (0)
+
+
+
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                          \
+    do {                                                                  \
+        if ((ptr) == nullptr) {                                           \
+            OP_LOGE(context->GetNodeType(), "%s is null", #ptr);               \
+            return ge::GRAPH_FAILED;                                      \
+        }                                                                 \
+    } while (0)
+
+}  // namespace optiling
+
+#endif  // OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_

--- a/csrc/moe/chunk_fwd_o/tiling_base/tiling_base.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/tiling_base.h
@@ -1,0 +1,256 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_base.h
+ * \brief
+ */
+
+#pragma once
+
+#include <sstream>
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
+#include "tiling/platform/platform_ascendc.h"
+#include "error_log.h"
+
+#ifdef ASCENDC_OP_TEST
+#define ASCENDC_EXTERN_C extern "C"
+#else
+#define ASCENDC_EXTERN_C
+#endif
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+struct AiCoreParams {
+    uint64_t ubSize = 0;
+    uint64_t blockDim = 0;
+    uint64_t aicNum = 0;
+    uint64_t l1Size = 0;
+    uint64_t l0aSize = 0;
+    uint64_t l0bSize = 0;
+    uint64_t l0cSize = 0;
+};
+
+struct CompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+struct FlashAttentionScoreGradCompileInfo {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    platform_ascendc::SocVersion socVersion;
+};
+
+struct FACompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+class TilingBaseClass {
+public:
+    explicit TilingBaseClass(gert::TilingContext* context) : context_(context)
+    {}
+
+    virtual ~TilingBaseClass() = default;
+
+    // Tiling execution framework
+    //     1. GRAPH_SUCCESS: Success, and no need to continue executing subsequent Tiling class implementations
+    //     2. GRAPH_FAILED: Failure, abort the entire Tiling process
+    //     3. GRAPH_PARAM_INVALID: This class does not support, need to continue executing other Tiling class implementations
+    ge::graphStatus DoTiling()
+    {
+        auto ret = GetShapeAttrsInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetPlatformInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        if (!IsCapable()) {
+            return ge::GRAPH_PARAM_INVALID;
+        }
+        ret = DoOpTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = DoLibApiTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetWorkspaceSize();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = PostTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        context_->SetTilingKey(GetTilingKey());
+        DumpTilingInfo();
+        return ge::GRAPH_SUCCESS;
+    }
+
+    // Update context
+    virtual void Reset(gert::TilingContext* context)
+    {
+        context_ = context;
+    }
+
+protected:
+    virtual bool IsCapable() = 0;
+    // 1. Get platform information such as CoreNum, UB/L1/L0C resource sizes
+    virtual ge::graphStatus GetPlatformInfo() = 0;
+    // 2. Get INPUT/OUTPUT/ATTR information
+    virtual ge::graphStatus GetShapeAttrsInfo() = 0;
+    // 3. Calculate data splitting TilingData
+    virtual ge::graphStatus DoOpTiling() = 0;
+    // 4. Calculate high-level API TilingData
+    virtual ge::graphStatus DoLibApiTiling() = 0;
+    // 5. Calculate TilingKey
+    [[nodiscard]] virtual uint64_t GetTilingKey() const = 0;
+    // 6. Calculate Workspace size
+    virtual ge::graphStatus GetWorkspaceSize() = 0;
+    // 7. Save Tiling data
+    virtual ge::graphStatus PostTiling() = 0;
+    // 8. Dump Tiling data
+    virtual void DumpTilingInfo()
+    {
+        int32_t enable = CheckLogLevel(static_cast<int32_t>(OP), DLOG_DEBUG);
+        if (enable != 1) {
+            return;
+        }
+        auto buf = (uint32_t*)context_->GetRawTilingData()->GetData();
+        auto bufLen = context_->GetRawTilingData()->GetDataSize();
+        std::ostringstream oss;
+        oss << "Start to dump tiling info. tilingkey:" << context_->GetTilingKey() << ", tiling data size:" << bufLen
+            << ", content:";
+        for (size_t i = 0; i < bufLen / sizeof(uint32_t); i++) {
+            oss << *(buf + i) << ",";
+            if (oss.str().length() > 640) { // Split according to 640 to avoid truncation
+                OP_LOGD(context_, "%s", oss.str().c_str());
+                oss.str("");
+            }
+        }
+        OP_LOGD(context_, "%s", oss.str().c_str());
+    }
+
+    static uint32_t CalcTschBlockDim(uint32_t sliceNum, uint32_t aicCoreNum, uint32_t aivCoreNum)
+    {
+        uint32_t ration;
+        if (aicCoreNum == 0 || aivCoreNum == 0 || aicCoreNum > aivCoreNum) {
+            return sliceNum;
+        }
+        ration = aivCoreNum / aicCoreNum;
+        return (sliceNum + (ration - 1)) / ration;
+    }
+
+    template <typename T>
+    [[nodiscard]] std::string GetShapeDebugStr(const T& shape) const
+    {
+        std::ostringstream oss;
+        oss << "[";
+        if (shape.GetDimNum() > 0) {
+            for (size_t i = 0; i < shape.GetDimNum() - 1; ++i) {
+                oss << shape.GetDim(i) << ", ";
+            }
+            oss << shape.GetDim(shape.GetDimNum() - 1);
+        }
+        oss << "]";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTensorDebugStr(
+        const gert::StorageShape* shape, const gert::CompileTimeTensorDesc* tensor)
+    {
+        if (shape == nullptr || tensor == nullptr) {
+            return "nil ";
+        }
+        std::ostringstream oss;
+        oss << "(dtype: " << ge::TypeUtils::DataTypeToSerialString(tensor->GetDataType()) << "),";
+        oss << "(shape:" << GetShapeDebugStr(shape->GetStorageShape()) << "),";
+        oss << "(ori_shape:" << GetShapeDebugStr(shape->GetOriginShape()) << "),";
+        oss << "(format: "
+            << ge::TypeUtils::FormatToSerialString(
+                   static_cast<ge::Format>(ge::GetPrimaryFormat(tensor->GetStorageFormat())))
+            << "),";
+        oss << "(ori_format: " << ge::TypeUtils::FormatToSerialString(tensor->GetOriginFormat()) << ") ";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingContextDebugStr()
+    {
+        std::ostringstream oss;
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetInputsNum(); ++i) {
+            oss << "input" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetInputShape(i), context_->GetInputDesc(i));
+        }
+
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetOutputsNum(); ++i) {
+            oss << "output" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetOutputShape(i), context_->GetOutputDesc(i));
+        }
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingDataDebugStr() const
+    {
+        auto rawTilingData = context_->GetRawTilingData();
+        auto rawTilingDataSize = rawTilingData->GetDataSize();
+        auto data = reinterpret_cast<const int32_t*>(rawTilingData->GetData());
+        size_t len = rawTilingDataSize / sizeof(int32_t);
+        std::ostringstream oss;
+        for (size_t i = 0; i < len; i++) {
+            oss << data[i] << ", ";
+        }
+        return oss.str();
+    }
+
+protected:
+    gert::TilingContext* context_ = nullptr;
+    std::unique_ptr<platform_ascendc::PlatformAscendC> ascendcPlatform_{nullptr};
+    uint32_t blockDim_{0};
+    uint64_t workspaceSize_{0};
+    uint64_t tilingKey_{0};
+    AiCoreParams aicoreParams_;
+};
+
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/moe/chunk_fwd_o/tiling_base/tiling_key.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/tiling_key.h
@@ -1,0 +1,63 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_key.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr uint64_t kBase = 10; // Base-10 carry base
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + kBase * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace Optiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/moe/chunk_fwd_o/tiling_base/tiling_templates_registry.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/tiling_templates_registry.h
@@ -1,0 +1,351 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_templates_registry.h
+ * \brief
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+#include "exe_graph/runtime/tiling_context.h"
+#include "tiling_base.h"
+#include "error_log.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+template <typename T>
+std::unique_ptr<TilingBaseClass> TILING_CLASS(gert::TilingContext* context)
+{
+    return std::unique_ptr<T>(new (std::nothrow) T(context));
+}
+
+using TilingClassCase = std::unique_ptr<TilingBaseClass> (*)(gert::TilingContext*);
+
+class TilingCases {
+public:
+    explicit TilingCases(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    void AddTiling(int32_t priority)
+    {
+        OP_CHECK_IF(
+            cases_.find(priority) != cases_.end(), OP_LOGE(op_type_, "There are duplicate registrations."), return);
+        cases_[priority] = TILING_CLASS<T>;
+        OP_CHECK_IF(
+            cases_[priority] == nullptr,
+            OP_LOGE(op_type_, "Register op tiling func failed, please check the class name."), return);
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingCases()
+    {
+        return cases_;
+    }
+
+private:
+    std::map<int32_t, TilingClassCase> cases_;
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce with soc version --------------------------------
+class TilingRegistryNew {
+public:
+    TilingRegistryNew() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistryNew& GetInstance();
+#else
+    static TilingRegistryNew& GetInstance()
+    {
+        static TilingRegistryNew registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        if (soc_iter == registry_map_.end()) {
+            std::map<std::string, std::shared_ptr<TilingCases>> op_type_map;
+            op_type_map[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            registry_map_[soc_version] = op_type_map;
+        } else {
+            if (soc_iter->second.find(op_type) == soc_iter->second.end()) {
+                soc_iter->second[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            }
+        }
+
+        OP_CHECK_IF(
+            registry_map_[soc_version][op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[soc_version][op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        int32_t soc_version = (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION;
+        const char* op_type = context->GetNodeType();
+        fe::PlatFormInfos* platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = static_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+            if (soc_version == (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION) {
+                OP_LOGE(op_type, "Do op tiling failed, cannot find soc version.");
+                return ge::GRAPH_FAILED;
+            }
+        }
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        int32_t soc_version;
+        const char* op_type = context->GetNodeType();
+        auto platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = reinterpret_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+        }
+
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto priority_id : priorities) {
+            auto tilingCaseIter = tilingTemplateRegistryMap.find(priority_id);
+            if (tilingCaseIter != tilingTemplateRegistryMap.end()) {
+                auto templateFunc = tilingCaseIter->second(context);
+                if (templateFunc != nullptr) {
+                    ge::graphStatus status = templateFunc->DoTiling();
+                    if (status == ge::GRAPH_SUCCESS) {
+                        OP_LOGD(context, "Do general op tiling success priority=%d", priority_id);
+                        return status;
+                    }
+                    OP_LOGD(context, "Ignore general op tiling priority=%d", priority_id);
+                }
+            }
+        }
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        OP_CHECK_IF(
+            soc_iter == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the soc version %d", soc_version),
+            return empty_tiling_case_);
+        auto op_iter = soc_iter->second.find(op_type);
+        OP_CHECK_IF(
+            op_iter == soc_iter->second.end(), OP_LOGE(op_type, "Get op tiling func failed, please check the op name."),
+            return empty_tiling_case_);
+        return op_iter->second->GetTilingCases();
+    }
+
+private:
+    std::map<int32_t, std::map<std::string, std::shared_ptr<TilingCases>>> registry_map_; // key is socversion
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_{};
+};
+
+class RegisterNew {
+public:
+    explicit RegisterNew(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, int32_t soc_version)
+    {
+        auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, const std::vector<int32_t>& soc_versions)
+    {
+        for (int32_t soc_version : soc_versions) {
+            auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+            OP_CHECK_IF(
+                tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."),
+                return *this);
+            tilingCases->AddTiling<T>(priority);
+        }
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce without soc version --------------------------------
+class TilingRegistry {
+public:
+    TilingRegistry() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistry& GetInstance();
+#else
+    static TilingRegistry& GetInstance()
+    {
+        static TilingRegistry registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type)
+    {
+        if (registry_map_.find(op_type) == registry_map_.end()) {
+            registry_map_[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+        }
+        OP_CHECK_IF(
+            registry_map_[op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto priorityId : priorities) {
+            auto templateFunc = tilingTemplateRegistryMap[priorityId](context);
+            if (templateFunc != nullptr) {
+                ge::graphStatus status = templateFunc->DoTiling();
+                if (status == ge::GRAPH_SUCCESS) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", priorityId);
+                    return status;
+                }
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do op tiling failed");
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", priorityId);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type)
+    {
+        OP_CHECK_IF(
+            registry_map_.find(op_type) == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the op name."), return empty_tiling_case_);
+        return registry_map_[op_type]->GetTilingCases();
+    }
+
+private:
+    std::map<std::string, std::shared_ptr<TilingCases>> registry_map_;
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_;
+};
+
+class Register {
+public:
+    explicit Register(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    Register& tiling(int32_t priority)
+    {
+        auto tilingCases = TilingRegistry::GetInstance().RegisterOp(op_type_);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops
+
+// op_type: operator name, class_name: registered tiling class, soc_version: chip version number
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_WITH_SOCVERSION(op_type, class_name, soc_versions, priority)    \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_versions)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+#define REGISTER_TILING_TEMPLATE(op_type, class_name, priority)                                \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register VAR_UNUSED##op_type_##class_name##priority_register = \
+        Ops::Transformer::OpTiling::Register(op_type).tiling<class_name>(priority)
+
+// op_type: operator name, class_name: registered tiling class
+// soc_version: SOC version, used to distinguish different SOCs
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_NEW(op_type, class_name, soc_version, priority)                 \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_version)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+// Replaces REGISTER_TILING_TEMPLATE, if op_type is a string constant, remove the quotes
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register                                                  \
+        __attribute__((unused)) tiling_##op_type##_##class_name##_##priority##_register = \
+            Ops::Transformer::OpTiling::Register(#op_type).tiling<class_name>(priority)

--- a/csrc/moe/chunk_fwd_o/tiling_base/tiling_type.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/tiling_type.h
@@ -1,0 +1,139 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_type.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace optiling {
+
+enum class AxisEnum {
+    B = 0,
+    N2 = 1,
+    G = 2,
+    S1 = 3,
+    S2 = 4,
+    D = 5,
+    NONE = 9,
+};
+
+enum class DtypeEnum {
+    FLOAT16 = 0,
+    FLOAT32 = 1,
+    BFLOAT16 = 2,
+    FLOAT16_PRECISION = 3,
+};
+
+enum class PerformanceOrientedEnum {
+    BIG_BUFFER = 1,
+    BIG_DOUBLE_BUFFER = 2,
+};
+
+enum class MatmulConfig {
+    NULL_CONFIG = 0,
+    NORMAL_CONFIG = 1,
+    MDL_CONFIG = 2
+};
+
+enum class PseConfig {
+    NO_PSE = 0,
+    EXIST_PSE = 1
+};
+
+enum class AttenMaskConfig {
+    NO_ATTEN_MASK = 0,
+    EXIST_ATTEN_MASK = 1
+};
+
+enum class DropOutConfig {
+    NO_DROP_OUT = 0,
+    EXIST_DROP_OUT = 1
+};
+
+enum class CubeFormatEnum {
+    ND = 0,
+    NZ = 1
+};
+enum class LayoutEnum {
+    BSND = 0,
+    SBND = 1,
+    BNSD = 2,
+    TND = 3,
+    NTD_TND = 4
+};
+
+enum class CubeInputSourceEnum {
+    GM = 0,
+    L1 = 1
+};
+
+enum class OptionEnum {
+    DISABLE = 0,
+    ENABLE = 1
+};
+
+enum class SparseEnum {
+    ALL = 0,
+    NONE = 1,
+    ANY = 2,
+    CAUSAL = 3,
+    BAND = 4,
+    PREFIX = 5,
+    BAND_COMPRESS = 6,
+    RIGHT_DOWN_CAUSAL = 7,
+    RIGHT_DOWN_CAUSAL_BAND = 8,
+    BAND_LEFT_UP_CAUSAL = 9
+};
+
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr int64_t base10Multiplier = 10;
+
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + base10Multiplier * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace optiling

--- a/csrc/moe/chunk_fwd_o/tiling_base/tiling_util.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/tiling_util.h
@@ -1,0 +1,30 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_util.h
+ * \brief
+ */
+
+#pragma once
+
+#include "register/op_impl_registry.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+bool IsRegbaseSocVersion(const gert::TilingParseContext* context);
+
+bool IsRegbaseSocVersion(const gert::TilingContext* context);
+
+const gert::Shape& EnsureNotScalar(const gert::Shape& inShape);
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/CMakeLists.txt
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/CMakeLists.txt
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(CURRENT_CMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(CATLASS_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/third_party/catlass/include")
+get_filename_component(CATLASS_INCLUDE_DIR_ABS ${CATLASS_INCLUDE_DIR} ABSOLUTE)
+
+set(COMMON_KERNEL_UTILS_DIR "${CMAKE_SOURCE_DIR}/moe/common")
+get_filename_component(COMMON_KERNEL_UTILS_DIR_ABS ${COMMON_KERNEL_UTILS_DIR} ABSOLUTE)
+
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        chunk_gated_delta_rule_fwd_h_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME ChunkGatedDeltaRuleFwdH
+    OPTIONS
+        --cce-auto-sync=off
+        -Wno-deprecated-declarations
+        -Werror
+        -I${CATLASS_INCLUDE_DIR_ABS}
+        -I${COMMON_KERNEL_UTILS_DIR_ABS}
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE chunk_gated_delta_rule_fwd_h ACLNNTYPE aclnn_exclude)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CATLASS_INCLUDE_DIR_ABS}
+    )
+endif()

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h_def.cpp
+ * \brief
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+
+class ChunkGatedDeltaRuleFwdH : public OpDef {
+public:
+    explicit ChunkGatedDeltaRuleFwdH(const char *name) : OpDef(name)
+    {
+        this->Input("k")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("w")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("u")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        
+        this->Input("g")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("inital_state")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Input("chunk_indices")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+
+        this->Output("h")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Output("v_new")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Output("final_state")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Attr("output_final_state").AttrType(REQUIRED).Bool(false);
+        this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+
+        OpAICoreConfig aicore_config;
+        aicore_config.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("prebuildPattern.value", "Opaque")
+            .ExtendCfgInfo("coreType.value", "AiCore")
+            .ExtendCfgInfo("jitCompile.flag", "static_false,dynamic_false");
+
+        this->AICore().AddConfig("ascend910b", aicore_config);
+        this->AICore().AddConfig("ascend910_93", aicore_config);
+        // this->AICore().AddConfig("ascend950", aicore_config);
+
+    }
+};
+
+OP_ADD(ChunkGatedDeltaRuleFwdH);
+
+} // namespace ops

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h_tiling.cpp
+ * \brief
+ */
+
+#include "chunk_gated_delta_rule_fwd_h_tiling.h"
+#include <register/op_impl_registry.h>
+#include "../tiling_base/data_copy_transpose_tiling.h"
+#include "../tiling_base/tiling_templates_registry.h"
+
+namespace optiling {
+static constexpr size_t INPUT_K_IDX = 0;
+static constexpr size_t INPUT_W_IDX = 1;
+static constexpr size_t INPUT_U_IDX = 2;
+static constexpr size_t INPUT_G_IDX = 3;
+static constexpr size_t INPUT_INITIAL_STATE_IDX = 4;
+static constexpr size_t INPUT_SEQLENS_IDX = 5;
+static constexpr size_t INPUT_CHUNK_INDICES_IDX = 6;
+
+static constexpr size_t ATTR_STORE_FINAL_STATE_IDX = 0;
+static constexpr size_t ATTR_CHUNK_SIZE_IDX = 1;
+
+static constexpr size_t DIM_BATCH = 0;
+static constexpr size_t DIM_HEAD_NUM = 1;
+static constexpr size_t DIM_SEQLEN = 2;
+static constexpr size_t DIM_HEAD_DIM = 3;
+
+
+static void ChunkGatedDeltaRuleFwdHTilingDataPrint(gert::TilingContext *context, ChunkGatedDeltaRuleFwdHTilingData &tiling)
+{
+    auto nodeName = context->GetNodeName();
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Start to print ChunkGatedDeltaRuleFwdH tiling data <<<<<<<<<<<<<<<<");
+    OP_LOGD(nodeName, "=== batch: %ld", tiling.get_batch());
+    OP_LOGD(nodeName, "=== seqlen: %ld", tiling.get_seqlen());
+    OP_LOGD(nodeName, "=== kNumHead: %ld", tiling.get_kNumHead());
+    OP_LOGD(nodeName, "=== vNumHead: %ld", tiling.get_vNumHead());
+    OP_LOGD(nodeName, "=== kHeadDim: %ld", tiling.get_kHeadDim());
+    OP_LOGD(nodeName, "=== vHeadDim: %ld", tiling.get_vHeadDim());
+    OP_LOGD(nodeName, "=== chunkSize: %ld", tiling.get_chunkSize());
+    OP_LOGD(nodeName, "=== useInitialState: %ld", tiling.get_useInitialState());
+    OP_LOGD(nodeName, "=== storeFinalState: %ld", tiling.get_storeFinalState());
+    OP_LOGD(nodeName, "=== dataType: %ld", tiling.get_dataType());
+    OP_LOGD(nodeName, "=== isVariedLen: %ld", tiling.get_isVariedLen());
+    OP_LOGD(nodeName, "=== shapeBatch: %ld", tiling.get_shapeBatch());
+    OP_LOGD(nodeName, "=== tokenBatch: %f", tiling.get_tokenBatch());
+    OP_LOGD(nodeName, ">>>>>>>>>>>>>>> Print ChunkGatedDeltaRuleFwdH tiling data end <<<<<<<<<<<<<<<<");
+}
+
+ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
+{
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkGatedDeltaRuleFwdH start.");
+    ChunkGatedDeltaRuleFwdHTilingData tiling;
+    
+    gert::Shape kStorageShape = context->GetOptionalInputShape(INPUT_K_IDX)->GetStorageShape();
+    gert::Shape uStorageShape = context->GetOptionalInputShape(INPUT_U_IDX)->GetStorageShape();
+
+    int64_t seqlen = kStorageShape.GetDim(DIM_SEQLEN);
+    int64_t kNumHead = kStorageShape.GetDim(DIM_HEAD_NUM);
+    int64_t vNumHead = uStorageShape.GetDim(DIM_HEAD_NUM);
+    int64_t kHeadDim = kStorageShape.GetDim(DIM_HEAD_DIM);
+    int64_t vHeadDim = uStorageShape.GetDim(DIM_HEAD_DIM);
+    int64_t batch, isVariedLen, shapeBatch, tokenBatch;
+    
+    auto cuSeqlensTensor = context->GetOptionalInputTensor(INPUT_SEQLENS_IDX);
+    if (cuSeqlensTensor == nullptr) {
+        isVariedLen = false;
+        shapeBatch = kStorageShape.GetDim(DIM_BATCH);
+        tokenBatch = 1;
+        batch = shapeBatch;
+    } else {
+        isVariedLen = true;
+        shapeBatch = 1;
+        tokenBatch = cuSeqlensTensor->GetStorageShape().GetDim(DIM_BATCH) - 1;
+        batch = tokenBatch;
+    }
+    
+    auto initialStateTensor = context->GetOptionalInputTensor(INPUT_INITIAL_STATE_IDX);
+    bool useInitialState = initialStateTensor != nullptr;
+    int64_t stateDataType = 2;
+    if (useInitialState) {
+        auto stateDType = initialStateTensor->GetDataType();
+        if (stateDType == ge::DT_BF16) {
+            stateDataType = 1;
+        } else if (stateDType == ge::DT_FLOAT16) {
+            stateDataType = 0;
+        }
+    }
+    
+    auto gDType = context->GetOptionalInputTensor(INPUT_G_IDX)->GetDataType();
+    int64_t gDataType = 2;
+    if (gDType == ge::DT_BF16) {
+        gDataType = 1;
+    } else if (gDType == ge::DT_FLOAT16) {
+        gDataType = 0;
+    }
+    
+    auto attrPtr = context->GetAttrs();
+    bool storeFinalState = *(attrPtr->GetAttrPointer<bool>(ATTR_STORE_FINAL_STATE_IDX));
+    int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
+
+    auto dtype = context->GetInputTensor(0)->GetDataType();
+    uint64_t dataType =  dtype == ge::DT_BF16 ? 1 : 0;
+
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
+    uint32_t aicCoreNum = ascendcPlatform.GetCoreNumAic();
+    context->SetBlockDim(aicCoreNum);
+
+    constexpr size_t WORKSPACE_RSV_BYTE = 16 * 1024 * 1024;
+    constexpr size_t GM_ALIGN = 512;
+    constexpr int64_t PING_PONG_STAGES = 2;
+
+    size_t workspaceOffset = ascendcPlatform.GetLibApiWorkSpaceSize();
+    workspaceOffset += WORKSPACE_RSV_BYTE;
+    
+    tiling.set_vWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_vUpdateWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * chunkSize * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_hWorkspaceOffset(workspaceOffset);
+    workspaceOffset += (aicCoreNum * kHeadDim * vHeadDim * sizeof(float) * PING_PONG_STAGES + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_numSeqWorkspaceOffset(workspaceOffset);
+    workspaceOffset += ((tokenBatch + 1) * sizeof(int64_t) + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    tiling.set_numChunksWorkspaceOffset(workspaceOffset);
+    workspaceOffset += ((tokenBatch + 1) * sizeof(int64_t) + GM_ALIGN) / GM_ALIGN * GM_ALIGN;
+
+    workspaceOffset += WORKSPACE_RSV_BYTE;
+    size_t *currentWorkspace = context->GetWorkspaceSizes(1);
+    currentWorkspace[0] = (workspaceOffset - 0);
+
+    tiling.set_batch(batch);
+    tiling.set_seqlen(seqlen);
+    tiling.set_kNumHead(kNumHead);
+    tiling.set_vNumHead(vNumHead);
+    tiling.set_kHeadDim(kHeadDim);
+    tiling.set_vHeadDim(vHeadDim);
+    tiling.set_chunkSize(chunkSize);
+    tiling.set_useInitialState(useInitialState);
+    tiling.set_storeFinalState(storeFinalState);
+    tiling.set_dataType(dataType);
+    tiling.set_stateDataType(stateDataType);
+    tiling.set_gDataType(gDataType);
+    tiling.set_isVariedLen(isVariedLen);
+    tiling.set_shapeBatch(shapeBatch);
+    tiling.set_tokenBatch(tokenBatch);
+
+    tiling.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tiling.GetDataSize());
+
+    ChunkGatedDeltaRuleFwdHTilingDataPrint(context, tiling);
+    OP_LOGD(context->GetNodeName(), "Tiling4ChunkGatedDeltaRuleFwdH end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepareForChunkGatedDeltaRuleFwdH(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(ChunkGatedDeltaRuleFwdH)
+    .Tiling(Tiling4ChunkGatedDeltaRuleFwdH)
+    .TilingParse<ChunkGatedDeltaRuleFwdHCompileInfo>(TilingPrepareForChunkGatedDeltaRuleFwdH);
+
+} // namespace optiling

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h_tiling.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+#include <tiling/tiling_api.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(ChunkGatedDeltaRuleFwdHTilingData)
+TILING_DATA_FIELD_DEF(int64_t, batch);
+TILING_DATA_FIELD_DEF(int64_t, seqlen);
+TILING_DATA_FIELD_DEF(int64_t, kNumHead);
+TILING_DATA_FIELD_DEF(int64_t, vNumHead);
+TILING_DATA_FIELD_DEF(int64_t, kHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, vHeadDim);
+TILING_DATA_FIELD_DEF(int64_t, chunkSize);
+TILING_DATA_FIELD_DEF(bool, useInitialState);
+TILING_DATA_FIELD_DEF(bool, storeFinalState);
+TILING_DATA_FIELD_DEF(int64_t, dataType);
+TILING_DATA_FIELD_DEF(int64_t, gDataType);
+TILING_DATA_FIELD_DEF(int64_t, stateDataType);
+TILING_DATA_FIELD_DEF(int64_t, isVariedLen);
+TILING_DATA_FIELD_DEF(int64_t, shapeBatch);
+TILING_DATA_FIELD_DEF(int64_t, tokenBatch);
+TILING_DATA_FIELD_DEF(int64_t, vWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, vUpdateWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, hWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, numSeqWorkspaceOffset);
+TILING_DATA_FIELD_DEF(int64_t, numChunksWorkspaceOffset);
+END_TILING_DATA_DEF;
+
+REGISTER_TILING_DATA_CLASS(ChunkGatedDeltaRuleFwdH, ChunkGatedDeltaRuleFwdHTilingData)
+
+struct ChunkGatedDeltaRuleFwdHCompileInfo {};
+} // namespace optiling

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#include "aclnn_chunk_gated_delta_rule_fwd_h.h"
+#include "chunk_gated_delta_rule_fwd_h.h"
+#include <dlfcn.h>
+#include <new>
+
+#include "aclnn_kernels/transdata.h"
+#include "aclnn_kernels/contiguous.h"
+#include "acl/acl.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/platform.h"
+#include "opdev/shape_utils.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/make_op_executor.h"
+
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ChunkGatedDeltaRuleFwdHParams {
+    const aclTensor *k = nullptr;
+    const aclTensor *w = nullptr;
+    const aclTensor *u = nullptr;
+    const aclTensor *gOptional = nullptr;
+    const aclTensor *gkOptional = nullptr;
+    const aclTensor *initalStateOptional = nullptr;
+    bool outputFinalState = false;
+    int64_t chunkSize = 64;
+    bool saveNewValue = true;
+    const aclIntArray *cuSeqlensOptional = nullptr;
+    const aclIntArray *chunkIndicesOptional = nullptr;
+    bool useExp2 = false;
+    bool transposeStateLayout = false;
+    const aclTensor *hOut = nullptr;
+    const aclTensor *vNewOut = nullptr;
+    const aclTensor *finalStateOut = nullptr;
+};
+
+static aclnnStatus CheckNotNull(ChunkGatedDeltaRuleFwdHParams params)
+{
+    CHECK_COND(params.k != nullptr, ACLNN_ERR_PARAM_NULLPTR, "k must not be nullptr.");
+    CHECK_COND(params.w != nullptr, ACLNN_ERR_PARAM_NULLPTR, "w must not be nullptr.");
+    CHECK_COND(params.u != nullptr, ACLNN_ERR_PARAM_NULLPTR, "u must not be nullptr.");
+
+    CHECK_COND(params.hOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "hOut must not be nullptr.");
+    CHECK_COND(params.vNewOut != nullptr, ACLNN_ERR_PARAM_NULLPTR, "vNewOut must not be nullptr.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckFormat(ChunkGatedDeltaRuleFwdHParams params)
+{
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckShape(ChunkGatedDeltaRuleFwdHParams params)
+{
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckDtype(ChunkGatedDeltaRuleFwdHParams params)
+{
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus DataContiguous(const aclTensor *&tensor, aclOpExecutor *executor)
+{
+    tensor = l0op::Contiguous(tensor, executor);
+    CHECK_RET(tensor != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus ParamsDataContiguous(ChunkGatedDeltaRuleFwdHParams &params, aclOpExecutor *executorPtr)
+{
+    CHECK_COND(DataContiguous(params.k, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous k failed.");
+    CHECK_COND(DataContiguous(params.w, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous w failed.");
+    CHECK_COND(DataContiguous(params.u, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous u failed.");
+    CHECK_COND(DataContiguous(params.gOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "Contiguous gOptional failed.");
+    if (params.initalStateOptional != nullptr) {
+        CHECK_COND(DataContiguous(params.initalStateOptional, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+                   "Contiguous initalStateOptional failed.");
+    }
+
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckGOptionalNonNull(const ChunkGatedDeltaRuleFwdHParams &params)
+{
+    CHECK_COND(params.gOptional != nullptr, ACLNN_ERR_PARAM_INVALID,
+               "g is an optional-parameter slot in the API but only a non-null aclTensor is supported; nullptr is not allowed until g=None is implemented.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckReservedOptions(const ChunkGatedDeltaRuleFwdHParams &params)
+{
+    CHECK_COND(params.gkOptional == nullptr, ACLNN_ERR_PARAM_INVALID,
+               "gk is reserved for ChunkGatedDeltaRuleFwdH and must be nullptr.");
+    CHECK_COND(params.saveNewValue, ACLNN_ERR_PARAM_INVALID,
+               "save_new_value is reserved and only true is supported.");
+    CHECK_COND(!params.useExp2, ACLNN_ERR_PARAM_INVALID,
+               "use_exp2 is reserved and only false is supported.");
+    CHECK_COND(!params.transposeStateLayout, ACLNN_ERR_PARAM_INVALID,
+               "transpose_state_layout is reserved and only false is supported.");
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus CheckParams(ChunkGatedDeltaRuleFwdHParams params)
+{
+    CHECK_RET(CheckNotNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckGOptionalNonNull(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckReservedOptions(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckFormat(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckShape(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckDtype(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *gOptional,
+    const aclTensor *gkOptional,
+    const aclTensor *initalStateOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool useExp2,
+    bool transposeStateLayout,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    ChunkGatedDeltaRuleFwdHParams params{k,
+                                         w,
+                                         u,
+                                         gOptional,
+                                         gkOptional,
+                                         initalStateOptional,
+                                         outputFinalState,
+                                         chunkSize,
+                                         saveNewValue,
+                                         cuSeqlensOptional,
+                                         chunkIndicesOptional,
+                                         useExp2,
+                                         transposeStateLayout,
+                                         hOut,
+                                         vNewOut,
+                                         finalStateOut};
+    // Standard syntax, Check parameters.
+    L2_DFX_PHASE_1(aclnnChunkGatedDeltaRuleFwdH,
+                   DFX_IN(k, w, u, gOptional, gkOptional, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional),
+                   DFX_OUT(hOut, vNewOut, finalStateOut));
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto executorPtr = uniqueExecutor.get();
+    auto ret = CheckParams(params);
+    CHECK_RET(ret == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+    CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
+               "ParamsDataContiguous failed.");
+    auto result = l0op::ChunkGatedDeltaRuleFwdH(params.k, params.w, params.u, params.gOptional, params.initalStateOptional, params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize, params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
+    CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
+
+    // If the output tensor is non-contiguous, convert the calculated contiguous tensor to non-contiguous.
+    auto viewCopyResult0 = l0op::ViewCopy(result[0], params.hOut, executorPtr);
+    CHECK_RET(viewCopyResult0 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto viewCopyResult1 = l0op::ViewCopy(result[1], params.vNewOut, executorPtr);
+    CHECK_RET(viewCopyResult1 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    if (outputFinalState && params.finalStateOut != nullptr) {
+        auto viewCopyResult2 = l0op::ViewCopy(result[2], params.finalStateOut, executorPtr);
+        CHECK_RET(viewCopyResult2 != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    // Standard syntax, get the size of workspace needed during computation.
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+
+aclnnStatus aclnnChunkGatedDeltaRuleFwdH(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnChunkGatedDeltaRuleFwdH);
+    CHECK_COND(CommonOpExecutorRun(workspace, workspaceSize, executor, stream) == ACLNN_SUCCESS, ACLNN_ERR_INNER,
+               "This is an error in ChunkGatedDeltaRuleFwdH launch aicore.");
+    return ACLNN_SUCCESS;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.h
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#ifndef OP_API_INC_ACLNN_CHUNK_GATED_DELTA_RULE_FWD_H_H
+#define OP_API_INC_ACLNN_CHUNK_GATED_DELTA_RULE_FWD_H_H
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* function: aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize
+ * parameters (order aligned with chunk_gated_delta_rule_fwd_h Python API):
+ * k : required
+ * w : required
+ * u : required
+ * gOptional : optional, only non-null aclTensor is supported
+ * gkOptional : optional, reserved (must be nullptr)
+ * initalStateOptional : optional
+ * outputFinalState : required
+ * chunkSize : required
+ * saveNewValue : reserved (must be true)
+ * cuSeqlensOptional : optional
+ * chunkIndicesOptional : optional
+ * useExp2 : reserved (must be false)
+ * transposeStateLayout : reserved (must be false)
+ * hOut : required
+ * vNewOut : required
+ * finalStateOut : optional
+ * workspaceSize : size of workspace(output).
+ * executor : executor context(output).
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *gOptional,
+    const aclTensor *gkOptional,
+    const aclTensor *initalStateOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    bool saveNewValue,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool useExp2,
+    bool transposeStateLayout,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/* function: aclnnChunkGatedDeltaRuleFwdH
+ * parameters :
+ * workspace : workspace memory addr(input).
+ * workspaceSize : size of workspace(input).
+ * executor : executor context(input).
+ * stream : acl stream.
+ */
+__attribute__((visibility("default")))
+aclnnStatus aclnnChunkGatedDeltaRuleFwdH(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#include "opdev/op_log.h"
+#include "opdev/op_dfx.h"
+#include "opdev/make_op_executor.h"
+#include "chunk_gated_delta_rule_fwd_h.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(ChunkGatedDeltaRuleFwdH);
+
+const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *g,
+    const aclTensor *initalStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    aclOpExecutor *executor)
+{
+    L0_DFX(ChunkGatedDeltaRuleFwdH, k, w, u, g, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional, outputFinalState, chunkSize, hOut, vNewOut, finalStateOut);
+
+    const aclTensor *actualCuSeqlens = nullptr;
+    if (cuSeqlensOptional) {
+        actualCuSeqlens = executor->ConvertToTensor(cuSeqlensOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualCuSeqlens)->SetOriginalFormat(Format::FORMAT_ND);
+    } else {
+        actualCuSeqlens = nullptr;
+    }
+
+    const aclTensor *actualChunkIndices = nullptr;
+    if (chunkIndicesOptional) {
+        actualChunkIndices = executor->ConvertToTensor(chunkIndicesOptional, DataType::DT_INT64);
+        const_cast<aclTensor *>(actualChunkIndices)->SetStorageFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetViewFormat(Format::FORMAT_ND);
+        const_cast<aclTensor *>(actualChunkIndices)->SetOriginalFormat(Format::FORMAT_ND);
+    } else {
+        actualChunkIndices = nullptr;
+    }
+
+    auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkGatedDeltaRuleFwdH,
+        OP_INPUT(k, w, u, g, initalStateOptional, actualCuSeqlens, actualChunkIndices),
+        OP_OUTPUT(hOut, vNewOut, finalStateOut),
+        OP_ATTR(outputFinalState, chunkSize));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE failed.");
+        return {nullptr, nullptr, nullptr};
+    }
+    return {hOut, vNewOut, finalStateOut};
+}
+
+} // namespace l0op

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+#ifndef OP_API_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE_FWD_H_H
+#define OP_API_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE_FWD_H_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
+    const aclTensor *k,
+    const aclTensor *w,
+    const aclTensor *u,
+    const aclTensor *g,
+    const aclTensor *initalStateOptional,
+    const aclIntArray *cuSeqlensOptional,
+    const aclIntArray *chunkIndicesOptional,
+    bool outputFinalState,
+    int64_t chunkSize,
+    const aclTensor *hOut,
+    const aclTensor *vNewOut,
+    const aclTensor *finalStateOut,
+    aclOpExecutor *executor);
+}
+
+#endif

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_fwd_h.cpp
+ * \brief
+ */
+
+// #include "chunk_gated_delta_rule_fwd_h.h"
+#include "gemm/kernel/gdn_fwd_h_kernel.hpp"
+#include "lib/matmul_intf.h"
+
+using namespace Catlass;
+
+extern "C" __global__ __aicore__ void chunk_gated_delta_rule_fwd_h(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g,
+                                                         GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices,
+                                                         GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state,
+                                                         GM_ADDR workspace, GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+
+    GM_ADDR user = AscendC::GetUserWorkspace(workspace);
+    
+    __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+    using workspaceType = float;
+    // dtype: 0 - fp16, 1 - bf16, 2 - fp32
+    if (gdnFwdHTilingData->dataType == 1) {
+        if (gdnFwdHTilingData->stateDataType == 2) {
+            if (gdnFwdHTilingData->gDataType == 2) {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, float, float, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            } else {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, bfloat16_t, float, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            }
+        } else {
+            if (gdnFwdHTilingData->gDataType == 2) {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, float, bfloat16_t, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            } else {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<bfloat16_t, bfloat16_t, bfloat16_t, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            }
+        }
+    } else {
+        if (gdnFwdHTilingData->stateDataType == 2) {
+            if (gdnFwdHTilingData->gDataType == 2) {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, float, float, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            } else {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, half, float, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            }
+        } else {
+            if (gdnFwdHTilingData->gDataType == 2) {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, float, half, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            } else {
+                using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, half, half, workspaceType>;
+                GDNFwdHKernel gdnFwdH;
+                gdnFwdH.Init(k, w, u, g, inital_state, cu_seqlens, chunk_indices, h, v_new, final_state, tiling, user);
+                gdnFwdH.Process();
+            }
+        }
+    }
+}

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_UPDATE_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_UPDATE_HPP
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_h_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class HOutputType_,
+    class GInputType_,
+    class HInputType_,
+    class HUpdateInputType_,
+    class FinalStateType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdHUpdate,
+    HOutputType_,
+    GInputType_,
+    HInputType_,
+    HUpdateInputType_,
+    FinalStateType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdHUpdate;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using HElementOutput = typename HOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using HElementInput = typename HInputType_::Element;
+    using HUpdateElementInput = typename HUpdateInputType_::Element;
+    using FinalStateElement = typename FinalStateType_::Element;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+
+        constexpr uint32_t CALC_BUF_OFFSET = 0;
+        constexpr uint32_t PING_BUF_0_OFFSET = 32 * 1024;
+        constexpr uint32_t PING_BUF_1_OFFSET = 64 * 1024;
+        constexpr uint32_t PING_BUF_2_OFFSET = 80 * 1024;
+        constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
+
+
+        calcUbTensor = resource.ubBuf.template GetBufferByByte<float>(CALC_BUF_OFFSET);
+
+        hUpdateUbTensor = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_1_OFFSET);
+        hUbTensor = resource.ubBuf.template GetBufferByByte<HElementInput>(PING_BUF_0_OFFSET);
+
+        hOutputUbTensor = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_1_OFFSET);
+        finalOutputUbTensor = resource.ubBuf.template GetBufferByByte<FinalStateElement>(PING_BUF_1_OFFSET);
+
+        glastUbTensor = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
+
+    }
+
+    CATLASS_DEVICE
+    ~BlockEpilogue() {}
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<HElementOutput> hOutput,
+        AscendC::GlobalTensor<FinalStateElement> finalState,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<HElementInput> hInput,
+        AscendC::GlobalTensor<float> hUpdateInput,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        Arch::CrossCoreFlag cube2Done,
+        bool isFinalState
+    )
+    {
+        uint32_t mActual = kHeadDim;
+        uint32_t nActual = vHeadDim;
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        int64_t offsetH = mOffset * nActual + nOffset;
+
+        AscendC::ResetMask();
+
+        AscendC::GlobalTensor<HElementOutput> hOutputThisSubBlock = hOutput[offsetH];
+        AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+        AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[offsetH];
+        AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
+        AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
+
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+        AscendC::DataCopy(hUbTensor, hInputThisSubBlock, mActualThisSubBlock * nActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        AscendC::Cast(calcUbTensor, hUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        
+        GElementInput gLastVal = gInputThisSubBlock.GetValue(chunkSize-1);
+        float gLastFloat = 0.0f;
+        if constexpr(std::is_same<GElementInput, float>::value) {
+            gLastFloat = gLastVal;
+        } else if constexpr(std::is_same<GElementInput, half>::value) {
+            gLastFloat = (float)gLastVal;
+        } else if constexpr(std::is_same<GElementInput, bfloat16_t>::value) {
+            gLastFloat = AscendC::ToFloat(gLastVal);
+        }
+        glastUbTensor.SetValue(0, gLastFloat);
+
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::Exp(glastUbTensor, glastUbTensor, 1);
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+        float muls = glastUbTensor.GetValue(0);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
+
+        Arch::CrossCoreWaitFlag(cube2Done);
+
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+        AscendC::DataCopy(hUpdateUbTensor, hUpdateInputThisSubBlock, mActualThisSubBlock * nActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+        AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
+
+        if (isFinalState) {
+            if constexpr(!std::is_same<FinalStateElement, float>::value) {
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::DataCopy(finalStateThisSubBlock, finalOutputUbTensor, mActualThisSubBlock * nActual);
+            } else {
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
+            }
+        } else {
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Cast(hOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::DataCopy(hOutputThisSubBlock, hOutputUbTensor, mActualThisSubBlock * nActual);
+        }
+    }
+
+private:
+    AscendC::LocalTensor<float> calcUbTensor;
+
+    AscendC::LocalTensor<HElementInput> hUbTensor;
+    AscendC::LocalTensor<float> hUpdateUbTensor;
+
+    AscendC::LocalTensor<HElementOutput> hOutputUbTensor;
+    AscendC::LocalTensor<FinalStateElement> finalOutputUbTensor;
+
+    AscendC::LocalTensor<float> glastUbTensor;
+
+};
+}
+
+#endif

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_VNEW_HPP
+#define CATLASS_EPILOGUE_BLOCK_BLOCK_EPILOGUE_GDN_FWDH_VNEW_HPP
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "../gdn_fwd_h_epilogue_policies.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+
+
+
+namespace Catlass::Epilogue::Block {
+
+template <
+    class VOutputType_,
+    class GInputType_,
+    class UInputType_,
+    class WSInputType_
+>
+class BlockEpilogue <
+    EpilogueAtlasGDNFwdHVnew,
+    VOutputType_,
+    GInputType_,
+    UInputType_,
+    WSInputType_
+> {
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasGDNFwdHVnew;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using VElementOutput = typename VOutputType_::Element;
+    using GElementInput = typename GInputType_::Element;
+    using UElementInput = typename UInputType_::Element;
+    using WSElementInput = typename WSInputType_::Element;
+
+    CATLASS_DEVICE
+    BlockEpilogue(Arch::Resource<ArchTag> &resource)
+    {
+
+        constexpr uint32_t CALC_BUF_OFFSET = 0;
+        constexpr uint32_t PING_BUF_0_OFFSET = 32 * 1024;
+        constexpr uint32_t PING_BUF_1_OFFSET = 64 * 1024;
+        constexpr uint32_t PONG_BUF_0_OFFSET = 96 * 1024;
+        constexpr uint32_t PONG_BUF_1_OFFSET = 128 * 1024;
+        constexpr uint32_t PING_G_BUF_OFFSET = 160 * 1024;
+        constexpr uint32_t PONG_G_BUF_OFFSET = 161 * 1024;
+        constexpr uint32_t PING_G_SUB_BUF_OFFSET = 162 * 1024;
+        constexpr uint32_t PONG_G_SUB_BUF_OFFSET = 163 * 1024;
+        constexpr uint32_t PING_G_INPUT_BUF_OFFSET = 164 * 1024;
+        constexpr uint32_t PONG_G_INPUT_BUF_OFFSET = 165 * 1024;
+        constexpr uint32_t SHARE_BUF_OFFSET = 166 * 1024;
+
+        calcUbTensor = resource.ubBuf.template GetBufferByByte<float>(CALC_BUF_OFFSET);
+
+        uUbTensor_ping = resource.ubBuf.template GetBufferByByte<UElementInput>(PING_BUF_1_OFFSET);
+        uUbFloatTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_0_OFFSET);
+        wsUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_BUF_1_OFFSET);
+        gUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
+        gLastUbTensor_ping = resource.ubBuf.template GetBufferByByte<float>(PING_G_SUB_BUF_OFFSET);
+        gInputUbTensor_ping = resource.ubBuf.template GetBufferByByte<GElementInput>(PING_G_INPUT_BUF_OFFSET);
+        vNewOutputUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_1_OFFSET);
+        vNewDecayUbTensor_ping = resource.ubBuf.template GetBufferByByte<VElementOutput>(PING_BUF_0_OFFSET);
+
+        uUbTensor_pong = resource.ubBuf.template GetBufferByByte<UElementInput>(PONG_BUF_1_OFFSET);
+        uUbFloatTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_0_OFFSET);
+        wsUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_BUF_1_OFFSET);
+        gUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_BUF_OFFSET);
+        gLastUbTensor_pong = resource.ubBuf.template GetBufferByByte<float>(PONG_G_SUB_BUF_OFFSET);
+        gInputUbTensor_pong = resource.ubBuf.template GetBufferByByte<GElementInput>(PONG_G_INPUT_BUF_OFFSET);
+        vNewOutputUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_1_OFFSET);
+        vNewDecayUbTensor_pong = resource.ubBuf.template GetBufferByByte<VElementOutput>(PONG_BUF_0_OFFSET);
+
+        shareBuffer_ = resource.ubBuf.template GetBufferByByte<uint8_t>(SHARE_BUF_OFFSET);
+
+    }
+
+    CATLASS_DEVICE
+    ~BlockEpilogue() {}
+
+    CATLASS_DEVICE
+    void operator()(
+        AscendC::GlobalTensor<VElementOutput> vnewOutput,
+        AscendC::GlobalTensor<VElementOutput> vnewdecayOutput,
+        AscendC::GlobalTensor<GElementInput> gInput,
+        AscendC::GlobalTensor<UElementInput> uInput,
+        AscendC::GlobalTensor<float> wsInput,
+        uint32_t chunkSize,
+        uint32_t kHeadDim,
+        uint32_t vHeadDim,
+        Arch::CrossCoreFlag cube1Done
+        // const LayoutOutput &layoutOutput,
+        // const LayoutInput &LayoutInput    
+    )
+    {
+        uint32_t mActual = chunkSize;
+        uint32_t nkActual = kHeadDim;
+        uint32_t nvActual = vHeadDim;
+
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        uint32_t mActualPerSubBlock = CeilDiv(mActual, subBlockNum);
+        uint32_t mActualThisSubBlock = (subBlockIdx == 0) ? mActualPerSubBlock : (mActual - mActualPerSubBlock);
+        uint32_t mOffset = subBlockIdx * mActualPerSubBlock;
+        uint32_t nOffset = 0;
+        // 当前场景内部一定连续
+        // k [B, H, T, D]
+        // g [B, H, T]
+        // 在外部offset的基础上进一步offset
+        // 当前asset kdim == vHeadDim
+        int64_t offsetK = mOffset * nvActual + nOffset;
+        int64_t offsetD = 0; // 因为要用最后一个数减去之前所有，所以全部读入
+
+        uint32_t gbrcStart, gbrcRealStart, gbrcReptime, gbrcEffStart, gbrcEffEnd;
+        if(subBlockIdx==0)
+        {
+            gbrcStart = 0;
+            gbrcRealStart = 0;
+            gbrcReptime = (mActualThisSubBlock + 8 - 1) / 8;
+
+        }
+        else
+        {
+            gbrcStart = mActualPerSubBlock;
+            gbrcRealStart = gbrcStart & ~15;
+            gbrcReptime = (mActual - gbrcRealStart + 8 - 1) / 8;
+        }
+        gbrcEffStart = gbrcStart-gbrcRealStart;
+        gbrcEffEnd = gbrcEffStart + mActualThisSubBlock;
+
+        AscendC::ResetMask();
+
+        AscendC::GlobalTensor<VElementOutput> vnewOutputThisSubBlock = vnewOutput[offsetK];
+        AscendC::GlobalTensor<VElementOutput> vnewdecayOutputThisSubBlock = vnewdecayOutput[offsetK];
+        AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
+        AscendC::GlobalTensor<UElementInput> uInputThisSubBlock = uInput[offsetK];
+        AscendC::GlobalTensor<float> wsInputThisSubBlock = wsInput[offsetK];
+
+        pingpongFlag = isFirst ? 0 : 4;
+        AscendC::LocalTensor<UElementInput> uUbTensor = isFirst ? uUbTensor_ping : uUbTensor_pong;
+        AscendC::LocalTensor<float> uUbFloatTensor = isFirst ? uUbFloatTensor_ping : uUbFloatTensor_pong;
+        AscendC::LocalTensor<float> wsUbTensor = isFirst ? wsUbTensor_ping : wsUbTensor_pong;
+        AscendC::LocalTensor<float> gUbTensor = isFirst ? gUbTensor_ping : gUbTensor_pong;
+        AscendC::LocalTensor<float> gLastUbTensor = isFirst ? gLastUbTensor_ping : gLastUbTensor_pong;
+        AscendC::LocalTensor<GElementInput> gInputUbTensor = isFirst ? gInputUbTensor_ping : gInputUbTensor_pong;
+        AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor = isFirst ? vNewOutputUbTensor_ping : vNewOutputUbTensor_pong;
+        AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor = isFirst ? vNewDecayUbTensor_ping : vNewDecayUbTensor_pong;
+
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
+        if constexpr(std::is_same<GElementInput, float>::value) {
+            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+            AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+        } else {
+            AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
+            AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
+            AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
+        if constexpr(!std::is_same<GElementInput, float>::value) {
+            AscendC::Cast(gUbTensor, gInputUbTensor, AscendC::RoundMode::CAST_NONE, mActual);
+        }
+
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID2 + pingpongFlag);
+        float inputVal = gUbTensor.GetValue(mActual-1);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID2 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID2 + pingpongFlag);
+
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Duplicate<float>(gLastUbTensor, inputVal, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Sub<float>(gUbTensor, gLastUbTensor, gUbTensor, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Exp(gUbTensor, gUbTensor, mActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        uint32_t dstShape_[2] = {gbrcReptime*8, nvActual};
+        uint32_t srcShape_[2] = {gbrcReptime*8, 1};
+        AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        Arch::CrossCoreWaitFlag(cube1Done);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+        
+        AscendC::DataCopy(uUbTensor, uInputThisSubBlock, mActualThisSubBlock * nvActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0 + pingpongFlag);
+        AscendC::Cast(uUbFloatTensor, uUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1 + pingpongFlag);
+        AscendC::DataCopy(wsUbTensor, wsInputThisSubBlock, mActualThisSubBlock * nvActual);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1 + pingpongFlag);
+        
+        AscendC::Sub<float>(uUbFloatTensor, uUbFloatTensor, wsUbTensor, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Cast(vNewOutputUbTensor, uUbFloatTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
+
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], uUbFloatTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
+        
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::DataCopy(vnewdecayOutputThisSubBlock, vNewDecayUbTensor, mActualThisSubBlock * nvActual);
+
+        if (isFirst) {
+            AscendC::PipeBarrier<PIPE_ALL>();
+        }
+
+        isFirst = false;
+    }
+
+private:
+    uint32_t pingpongFlag = 0;
+    bool isFirst = true;
+
+    AscendC::LocalTensor<float> calcUbTensor;
+
+    AscendC::LocalTensor<UElementInput> uUbTensor_ping;
+    AscendC::LocalTensor<float> uUbFloatTensor_ping;
+    AscendC::LocalTensor<float> wsUbTensor_ping;
+    AscendC::LocalTensor<float> gUbTensor_ping;
+    AscendC::LocalTensor<float> gLastUbTensor_ping;
+    AscendC::LocalTensor<GElementInput> gInputUbTensor_ping;
+    AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_ping;
+    AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_ping;
+
+    AscendC::LocalTensor<UElementInput> uUbTensor_pong;
+    AscendC::LocalTensor<float> uUbFloatTensor_pong;
+    AscendC::LocalTensor<float> wsUbTensor_pong;
+    AscendC::LocalTensor<float> gUbTensor_pong;
+    AscendC::LocalTensor<float> gLastUbTensor_pong;
+    AscendC::LocalTensor<GElementInput> gInputUbTensor_pong;
+    AscendC::LocalTensor<VElementOutput> vNewOutputUbTensor_pong;
+    AscendC::LocalTensor<VElementOutput> vNewDecayUbTensor_pong;
+
+    AscendC::LocalTensor<uint8_t> shareBuffer_;
+
+};
+}
+
+#endif

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/gdn_fwd_h_epilogue_policies.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/gdn_fwd_h_epilogue_policies.hpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_EPILOGUE_GDN_FWD_H_EPILOGUE_POLICIES_HPP
+#define CATLASS_EPILOGUE_GDN_FWD_H_EPILOGUE_POLICIES_HPP
+
+#include "catlass/catlass.hpp"
+
+namespace Catlass::Epilogue {
+
+struct EpilogueAtlasGDNFwdHVnew {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
+    using ArchTag = Arch::AtlasA2;
+#endif
+};
+
+struct EpilogueAtlasGDNFwdHUpdate {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
+    using ArchTag = Arch::AtlasA2;
+#endif
+};
+
+}  // namespace Catlass::Epilogue
+
+#endif  // CATLASS_EPILOGUE_GDN_FWD_H_EPILOGUE_POLICIES_HPP

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "catlass/gemm_coord.hpp"
+using namespace Catlass;
+
+#ifndef CATLASS_GEMM_SCHEDULER_GDN_FWD_H_HPP
+#define CATLASS_GEMM_SCHEDULER_GDN_FWD_H_HPP
+
+// constexpr uint32_t PING_PONG_STAGES = 1;
+constexpr uint32_t PING_PONG_STAGES = 2;
+
+template <typename T>
+CATLASS_DEVICE T AlignUp(T a, T b) {
+    return (b == 0) ? 0 : (a + b - 1) / b * b;
+}
+
+template <typename T>
+CATLASS_DEVICE T Min(T a, T b) {
+    return (a > b) ? b : a;
+}
+
+template <typename T>
+CATLASS_DEVICE T Max(T a, T b) {
+    return (a > b) ? a : b;
+}
+
+namespace Catlass::Gemm::Block {
+
+struct GDNFwdHOffsets {
+    uint32_t hSrcOffset;
+    uint32_t hDstOffset;
+    uint32_t uvOffset;
+    uint32_t wkOffset;
+    uint32_t wOffset;
+    uint32_t gOffset;
+    uint32_t hWorkOffset;
+    uint32_t vWorkOffset;
+    uint32_t initialStateOffset;
+    uint32_t finalStateOffset;
+    bool isInitialState;
+    bool isFinalState;
+    uint32_t blockTokens;
+    bool isDummyHead;
+    // for debug
+    uint32_t batchIdx;
+    uint32_t headIdx;
+    uint32_t chunkIdx;
+
+};
+
+struct BlockSchedulerGdnFwdH {
+    uint32_t batch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    uint32_t vBlockSize{128};
+    uint32_t isVariedLen;
+    uint32_t shapeBatch;
+    uint32_t tokenBatch;
+    bool useInitialState;
+    bool storeFinalState;
+    uint32_t numSeqWorkspaceOffset;
+    uint32_t numChunksWorkspaceOffset;
+
+    uint32_t taskIdx;
+    uint32_t taskLoops;
+    uint32_t cubeCoreIdx;
+    uint32_t cubeCoreNum;
+    uint32_t vLoops;
+    uint32_t taskNum;
+    uint32_t headGroups;
+    uint32_t totalChunks;
+    uint32_t totalTokens;
+    uint32_t headInnerLoop;
+
+    uint32_t iterId {0};
+    bool hasDummyHead;
+    bool isRunning;
+    bool processNewTask {true};
+    bool firstLoop {true};
+    bool lastLoop {false};
+    GDNFwdHOffsets offsets[PING_PONG_STAGES];
+    int32_t currStage{PING_PONG_STAGES - 1};
+
+    uint32_t vIdx;
+    uint32_t batchIdx;
+    uint32_t baseHeadIdx;
+    uint32_t chunkIdx;
+    uint32_t headInnerIdx;
+    uint32_t vHeadIdx;
+    uint32_t kHeadIdx;
+    uint32_t shapeBatchIdx;
+    uint32_t tokenBatchIdx;
+    
+    uint32_t chunkOffset;
+    uint32_t tokenOffset;
+    uint32_t batchChunks;
+    uint32_t batchTokens;
+
+    AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmNumSeq;
+    AscendC::GlobalTensor<int64_t> gmNumChunks;
+
+    Arch::CrossCoreFlag cube1Done{0};
+    Arch::CrossCoreFlag vec1Done{1};
+    Arch::CrossCoreFlag cube2Done{2};
+    Arch::CrossCoreFlag vec2Done{3};
+
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdH() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user, uint32_t coreIdx, uint32_t coreNum) {
+        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+
+        batch = gdnFwdHTilingData->batch;
+        seqlen = gdnFwdHTilingData->seqlen;
+        kNumHead = gdnFwdHTilingData->kNumHead;
+        vNumHead = gdnFwdHTilingData->vNumHead;
+        kHeadDim = gdnFwdHTilingData->kHeadDim;
+        vHeadDim = gdnFwdHTilingData->vHeadDim;
+        chunkSize = gdnFwdHTilingData->chunkSize;
+        isVariedLen = gdnFwdHTilingData->isVariedLen;
+        shapeBatch = gdnFwdHTilingData->shapeBatch;
+        tokenBatch = gdnFwdHTilingData->tokenBatch;
+        useInitialState = gdnFwdHTilingData->useInitialState;
+        storeFinalState = gdnFwdHTilingData->storeFinalState;
+        numSeqWorkspaceOffset = gdnFwdHTilingData->numSeqWorkspaceOffset;
+        numChunksWorkspaceOffset = gdnFwdHTilingData->numChunksWorkspaceOffset;
+
+        gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
+        gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
+
+        if (isVariedLen) {
+            gmNumChunks.SetValue(0, 0);
+            gmNumSeq.SetValue(0, 0);
+            uint32_t actualBatch = 0;
+            int64_t prevSeq = 0, currSeq;
+            for (uint32_t b = 1; b <= tokenBatch; b++) {
+                currSeq = gmSeqlen.GetValue(b);
+                int64_t batchSeqLen = currSeq - prevSeq;
+                if (batchSeqLen > 0) {
+                    actualBatch++;
+                    gmNumSeq.SetValue(actualBatch, currSeq);
+                    int64_t batchChunk = (batchSeqLen + chunkSize - 1) / chunkSize;
+                    gmNumChunks.SetValue(actualBatch, gmNumChunks.GetValue(actualBatch - 1) + batchChunk);
+                }
+                prevSeq = currSeq;
+            }
+            tokenBatch = actualBatch;
+            batch = actualBatch;
+            totalChunks = gmNumChunks.GetValue(tokenBatch);
+            totalTokens = gmNumSeq.GetValue(tokenBatch);
+        } else {
+            totalChunks = (seqlen + chunkSize - 1) / chunkSize;
+            totalTokens = seqlen;
+        }
+
+        cubeCoreIdx = coreIdx;
+        cubeCoreNum = coreNum;
+        vLoops = vHeadDim / vBlockSize;
+        taskNum = vLoops * batch * vNumHead;
+        headGroups = vNumHead / kNumHead;
+        hasDummyHead = (taskNum % (PING_PONG_STAGES * cubeCoreNum) <= cubeCoreNum) && (taskNum % (PING_PONG_STAGES * cubeCoreNum) > 0);
+        taskLoops = (taskNum + cubeCoreNum * PING_PONG_STAGES - 1) / (cubeCoreNum * PING_PONG_STAGES);
+        headInnerLoop = taskNum > cubeCoreNum ? PING_PONG_STAGES : 1;
+        taskIdx = cubeCoreIdx * headInnerLoop;
+        isRunning = taskIdx < taskNum;
+
+    }
+
+    CATLASS_DEVICE
+    void InitTask() {
+        iterId++;
+        currStage = (currStage + 1) % PING_PONG_STAGES;
+        if (processNewTask) {
+            if (taskIdx >= taskNum) {
+                lastLoop = true;
+                isRunning = false;
+                return;
+            }
+            vIdx = taskIdx / (batch * vNumHead);
+            batchIdx = (taskIdx - vIdx * batch * vNumHead) / vNumHead;
+            baseHeadIdx = taskIdx % vNumHead;
+            shapeBatchIdx = isVariedLen ? 0 : batchIdx;
+            tokenBatchIdx = isVariedLen ? batchIdx : 0;
+            chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
+            batchChunks = isVariedLen ? (gmNumChunks.GetValue(tokenBatchIdx + 1) - chunkOffset) : totalChunks;
+            tokenOffset = isVariedLen ? gmNumSeq.GetValue(tokenBatchIdx) : 0;
+            batchTokens = isVariedLen ? (gmNumSeq.GetValue(tokenBatchIdx + 1) - tokenOffset) : totalTokens;
+            chunkIdx = 0;
+            headInnerIdx = 0;
+        } else {
+            chunkIdx = headInnerIdx == PING_PONG_STAGES - 1 ? chunkIdx + 1 : chunkIdx;
+            headInnerIdx = (headInnerIdx + 1) % PING_PONG_STAGES;
+        }
+        
+        vHeadIdx = baseHeadIdx + headInnerIdx;
+        kHeadIdx = vHeadIdx / headGroups;
+        offsets[currStage].isInitialState = chunkIdx == 0; 
+        offsets[currStage].isFinalState = chunkIdx == (batchChunks - 1);
+        offsets[currStage].initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * vHeadDim; 
+        offsets[currStage].finalStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * vHeadDim;  
+        offsets[currStage].hSrcOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset + chunkIdx) * kHeadDim * vHeadDim;
+        offsets[currStage].hDstOffset = offsets[currStage].hSrcOffset + kHeadDim * vHeadDim;
+        offsets[currStage].uvOffset = (shapeBatchIdx * vNumHead * totalTokens + vHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize) * vHeadDim;
+        offsets[currStage].wkOffset = (shapeBatchIdx * kNumHead * totalTokens + kHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize) * kHeadDim;
+        offsets[currStage].wOffset = (shapeBatchIdx * vNumHead * totalTokens + vHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize) * kHeadDim;
+        offsets[currStage].gOffset = shapeBatchIdx * vNumHead * totalTokens + vHeadIdx * totalTokens + tokenOffset + chunkIdx * chunkSize;
+        offsets[currStage].hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * kHeadDim * vHeadDim;
+        offsets[currStage].vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * chunkSize * vHeadDim;
+        offsets[currStage].blockTokens = offsets[currStage].isFinalState ? (batchTokens - chunkIdx * chunkSize) : chunkSize;
+        offsets[currStage].isDummyHead = headInnerLoop < PING_PONG_STAGES && headInnerIdx >= headInnerLoop; 
+        offsets[currStage].batchIdx = batchIdx; 
+        offsets[currStage].headIdx = vHeadIdx; 
+        offsets[currStage].chunkIdx = chunkIdx; 
+
+        processNewTask = chunkIdx == batchChunks - 1 && headInnerIdx == PING_PONG_STAGES - 1;
+        if (processNewTask) {
+            uint32_t currLoopIdx = taskIdx / (PING_PONG_STAGES * cubeCoreNum);
+            headInnerLoop = ((currLoopIdx + 2 == taskLoops) && hasDummyHead) ? 1 : PING_PONG_STAGES;
+            taskIdx = (currLoopIdx + 1) * PING_PONG_STAGES * cubeCoreNum + headInnerLoop * cubeCoreIdx;
+        }
+    }
+
+    CATLASS_DEVICE
+    GDNFwdHOffsets& GetStage1Offsets() {
+        return offsets[currStage];
+    }
+    
+    CATLASS_DEVICE
+    bool NeedProcessStage1() {
+        GDNFwdHOffsets& stage1Offsets = GetStage1Offsets();
+        return !(lastLoop || stage1Offsets.isDummyHead);
+    }
+
+    CATLASS_DEVICE
+    GDNFwdHOffsets& GetStage2Offsets() {
+        return offsets[(currStage - 1) % PING_PONG_STAGES];
+    }
+
+    CATLASS_DEVICE
+    bool NeedProcessStage2() {
+        GDNFwdHOffsets& stage2Offsets = GetStage2Offsets();
+        return !(iterId == 1 || (!storeFinalState && stage2Offsets.isFinalState) || stage2Offsets.isDummyHead);
+    }
+};
+
+struct BlockSchedulerGdnFwdHCube : public BlockSchedulerGdnFwdH {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdHCube() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user) {
+        BlockSchedulerGdnFwdH::Init(cu_seqlens, chunk_indices, tiling, user, AscendC::GetBlockIdx(), AscendC::GetBlockNum());
+    }
+
+};
+
+struct BlockSchedulerGdnFwdHVec : public BlockSchedulerGdnFwdH {
+    CATLASS_DEVICE
+    BlockSchedulerGdnFwdHVec() {}
+
+    CATLASS_DEVICE
+    void Init(GM_ADDR cu_seqlens, GM_ADDR chunk_indices, GM_ADDR tiling, GM_ADDR user) {
+        BlockSchedulerGdnFwdH::Init(cu_seqlens, chunk_indices, tiling, user, AscendC::GetBlockIdx() / AscendC::GetSubBlockNum(), AscendC::GetBlockNum());
+    }
+
+};
+
+}  // namespace Catlass::Gemm::Block
+
+#endif  // CATLASS_GEMM_SCHEDULER_GDN_FWD_H_HPP

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -1,0 +1,404 @@
+/**
+ * Copyright (c) 2026 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#define CATLASS_ARCH 3510
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/debug.hpp"
+#include "catlass/epilogue/block/block_epilogue.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdh_update.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "../block/block_scheduler_gdn_fwd_h.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "tla/tensor.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+using _0 = tla::Int<0>;
+using _1 = tla::Int<1>;
+using _2 = tla::Int<2>;
+using _4 = tla::Int<4>;
+using _8 = tla::Int<8>;
+using _16 = tla::Int<16>;
+using _32 = tla::Int<32>;
+using _64 = tla::Int<64>;
+using _128 = tla::Int<128>;
+using _256 = tla::Int<256>;
+using _512 = tla::Int<512>;
+using _1024 = tla::Int<1024>;
+using _2048 = tla::Int<2048>;
+using _4096 = tla::Int<4096>;
+using _8192 = tla::Int<8192>;
+using _16384 = tla::Int<16384>;
+using _32768 = tla::Int<32768>;
+using _65536 = tla::Int<65536>;
+
+#else
+#define CATLASS_ARCH 2201
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/catlass.hpp"
+#include "catlass/debug.hpp"
+#include "catlass/epilogue/block/block_epilogue.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdh_update.hpp"
+#include "../../epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "kernel_utils/block/block_mmad_pingpong_tla_multi.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "../block/block_scheduler_gdn_fwd_h.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "tla/tensor.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+#endif
+
+
+
+#include "kernel_operator.h"
+using namespace Catlass;
+using namespace tla;
+
+namespace Catlass::Gemm::Kernel {
+
+template<
+    typename INPUT_TYPE,
+    typename G_TYPE,
+    typename STATE_TYPE,
+    typename WORKSPACE_TYPE
+>
+class GDNFwdHKernel {
+public:
+    
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+    using ArchTag = Arch::Ascend950;
+#else
+    using ArchTag = Arch::AtlasA2;
+#endif
+    using CubeScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHCube;
+    using VecScheduler = typename Catlass::Gemm::Block::BlockSchedulerGdnFwdHVec;
+
+    using DispatchPolicyTla = Gemm::MmadPingpongTlaMulti<ArchTag, true, false>;
+    using L1TileShapeTla = Shape<_128, _128, _128>;
+    using L0TileShapeTla = L1TileShapeTla;
+
+    using WType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using HType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using VworkType = Gemm::GemmType<WORKSPACE_TYPE, layout::RowMajor>;
+    using KType = Gemm::GemmType<INPUT_TYPE, layout::ColumnMajor>;
+    using HworkType = Gemm::GemmType<WORKSPACE_TYPE, layout::RowMajor>;
+    using VType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using GType = Gemm::GemmType<G_TYPE, layout::RowMajor>;
+    using UType = Gemm::GemmType<INPUT_TYPE, layout::RowMajor>;
+    using FinalStateType = Gemm::GemmType<STATE_TYPE, layout::RowMajor>;
+
+    // cube 1
+    using TileCopyWH = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::RowMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadWH = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyWH>;
+
+    // cube 2
+    using TileCopyKV = Catlass::Gemm::Tile::PackedTileCopyTla<ArchTag, INPUT_TYPE, layout::ColumnMajor, INPUT_TYPE, layout::RowMajor, WORKSPACE_TYPE, layout::RowMajor>;
+    using BlockMmadKV = Gemm::Block::BlockMmadTla<DispatchPolicyTla, L1TileShapeTla, L0TileShapeTla, INPUT_TYPE, INPUT_TYPE, WORKSPACE_TYPE, void, TileCopyKV>;
+
+    // vec 1
+    using DispatchPolicyGDNFwdHVnew = Epilogue::EpilogueAtlasGDNFwdHVnew;
+    using EpilogueGDNFwdHVnew = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHVnew, VType, GType, UType, VworkType>;
+
+    // vec 2
+    using DispatchPolicyGDNFwdHUpdate = Epilogue::EpilogueAtlasGDNFwdHUpdate;
+    using EpilogueGDNFwdHUpdate = Epilogue::Block::BlockEpilogue<DispatchPolicyGDNFwdHUpdate, HType, GType, HType, HworkType, FinalStateType>;
+
+    using GDNFwdHOffsets = Catlass::Gemm::Block::GDNFwdHOffsets;
+
+    using ElementK = INPUT_TYPE;
+    using ElementW = INPUT_TYPE;
+    using ElementU = INPUT_TYPE;
+    using ElementG = G_TYPE;
+    using ElementH = INPUT_TYPE;
+    using ElementV = INPUT_TYPE;
+    using ElementVWork = WORKSPACE_TYPE;
+    using ElementHWork = WORKSPACE_TYPE;
+    using ElementInitialState = STATE_TYPE;
+    using ElementFinalState = STATE_TYPE;
+    
+    using LayoutW = Catlass::layout::RowMajor;
+    using LayoutH = Catlass::layout::RowMajor;
+    using LayoutV = Catlass::layout::RowMajor;
+    using LayoutK = Catlass::layout::ColumnMajor;
+
+    
+    uint32_t batch;
+    uint32_t seqlen;
+    uint32_t kNumHead;
+    uint32_t vNumHead;
+    uint32_t kHeadDim;
+    uint32_t vHeadDim;
+    uint32_t chunkSize;
+    bool useInitialState;
+    bool storeFinalState;
+    uint32_t isVariedLen;
+    uint32_t shapeBatch;
+    uint32_t tokenBatch;
+    uint32_t vWorkspaceOffset;
+    uint32_t vUpdateWorkspaceOffset;
+    uint32_t hWorkspaceOffset;
+    uint32_t numSeqWorkspaceOffset;
+    uint32_t numChunksWorkspaceOffset;
+    
+    AscendC::GlobalTensor<ElementK> gmK;
+    AscendC::GlobalTensor<ElementW> gmW;
+    AscendC::GlobalTensor<ElementU> gmU;
+    AscendC::GlobalTensor<ElementG> gmG;
+    AscendC::GlobalTensor<ElementInitialState> gmInitialState;
+    AscendC::GlobalTensor<ElementH> gmH;
+    AscendC::GlobalTensor<ElementV> gmV;
+    AscendC::GlobalTensor<ElementFinalState> gmFinalState;
+    AscendC::GlobalTensor<ElementVWork> gmVWorkspace;
+    AscendC::GlobalTensor<ElementV> gmVUpdateWorkspace;
+    AscendC::GlobalTensor<ElementHWork> gmHWorkspace;
+    
+    AscendC::GlobalTensor<int64_t> gmSeqlen;
+    AscendC::GlobalTensor<int64_t> gmNumSeq;
+    AscendC::GlobalTensor<int64_t> gmNumChunks;
+
+    CubeScheduler cubeBlockScheduler;
+    VecScheduler vecBlockScheduler;
+
+    Arch::Resource<ArchTag> resource;
+
+
+    __aicore__ inline GDNFwdHKernel() {}
+
+    __aicore__ inline void Init(GM_ADDR k, GM_ADDR w, GM_ADDR u, GM_ADDR g, GM_ADDR inital_state, GM_ADDR cu_seqlens, GM_ADDR chunk_indices, 
+        GM_ADDR h, GM_ADDR v_new, GM_ADDR final_state, GM_ADDR tiling, GM_ADDR user) {
+        
+        __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+
+        batch = gdnFwdHTilingData->batch;
+        seqlen = gdnFwdHTilingData->seqlen;
+        kNumHead = gdnFwdHTilingData->kNumHead;
+        vNumHead = gdnFwdHTilingData->vNumHead;
+        kHeadDim = gdnFwdHTilingData->kHeadDim;
+        vHeadDim = gdnFwdHTilingData->vHeadDim;
+        chunkSize = gdnFwdHTilingData->chunkSize;
+        useInitialState = gdnFwdHTilingData->useInitialState;
+        storeFinalState = gdnFwdHTilingData->storeFinalState;
+        isVariedLen = gdnFwdHTilingData->isVariedLen;
+        shapeBatch = gdnFwdHTilingData->shapeBatch;
+        tokenBatch = gdnFwdHTilingData->tokenBatch;
+        vWorkspaceOffset = gdnFwdHTilingData->vWorkspaceOffset;
+        vUpdateWorkspaceOffset = gdnFwdHTilingData->vUpdateWorkspaceOffset;
+        hWorkspaceOffset = gdnFwdHTilingData->hWorkspaceOffset;
+        numSeqWorkspaceOffset = gdnFwdHTilingData->numSeqWorkspaceOffset;
+        numChunksWorkspaceOffset = gdnFwdHTilingData->numChunksWorkspaceOffset;
+        
+        gmK.SetGlobalBuffer((__gm__ ElementK *)k);
+        gmW.SetGlobalBuffer((__gm__ ElementW *)w);
+        gmU.SetGlobalBuffer((__gm__ ElementU *)u);
+        gmG.SetGlobalBuffer((__gm__ ElementG *)g);
+        gmInitialState.SetGlobalBuffer((__gm__ ElementInitialState *)inital_state);
+        gmH.SetGlobalBuffer((__gm__ ElementH *)h);
+        gmV.SetGlobalBuffer((__gm__ ElementV *)v_new);
+        gmFinalState.SetGlobalBuffer((__gm__ ElementFinalState *)final_state);
+        gmVWorkspace.SetGlobalBuffer((__gm__ ElementVWork *)(user + vWorkspaceOffset));
+        gmVUpdateWorkspace.SetGlobalBuffer((__gm__ ElementV *)(user + vUpdateWorkspaceOffset));
+        gmHWorkspace.SetGlobalBuffer((__gm__ ElementHWork *)(user + hWorkspaceOffset));
+
+        gmSeqlen.SetGlobalBuffer((__gm__ int64_t *)cu_seqlens);
+        gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
+        gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
+
+        if ASCEND_IS_AIC {
+            cubeBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
+        }
+
+        if ASCEND_IS_AIV {
+            vecBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
+        }
+    }
+    
+    __aicore__ inline void Process() {
+
+        if ASCEND_IS_AIC {
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+
+            BlockMmadWH blockMmadWH(resource);
+            BlockMmadKV blockMmadKV(resource);
+
+            auto wLayout = tla::MakeLayout<ElementW, LayoutW>(shapeBatch * kNumHead * cubeBlockScheduler.totalTokens, kHeadDim);
+            auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * cubeBlockScheduler.totalChunks * kHeadDim, vHeadDim);
+            auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
+            
+            auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * cubeBlockScheduler.totalTokens);
+            auto vworkLayout = tla::MakeLayout<ElementV, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
+            auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(coreNum * kHeadDim * PING_PONG_STAGES, vHeadDim);
+
+            while (cubeBlockScheduler.isRunning) {
+                cubeBlockScheduler.InitTask();
+                // step 1: v_work = w @ h[i]
+                GDNFwdHOffsets& cube1Offsets = cubeBlockScheduler.GetStage1Offsets();
+                Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
+                if (cubeBlockScheduler.NeedProcessStage1()) {
+                    int64_t cube1OffsetW = cube1Offsets.wOffset;
+                    int64_t cube1OffsetH = cube1Offsets.hSrcOffset;
+                    int64_t cube1OffsetVwork = cube1Offsets.vWorkOffset;
+                    auto tensorW = tla::MakeTensor(gmW[cube1OffsetW], wLayout, Catlass::Arch::PositionGM{});
+                    auto tensorH = tla::MakeTensor(gmH[cube1OffsetH], hLayout, Catlass::Arch::PositionGM{});
+                    auto tensorV = tla::MakeTensor(gmVWorkspace[cube1OffsetVwork], vLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube1Shape {cube1Offsets.blockTokens, vHeadDim, kHeadDim};
+                    auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
+                    auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                    auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                    blockMmadWH.preSetFlags();
+                    blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
+                    blockMmadWH.finalWaitFlags();
+                }
+                Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube1Done);
+
+                if (cubeBlockScheduler.iterId > 1) {
+                    Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec1Done);
+                    GDNFwdHOffsets& cube2Offsets = cubeBlockScheduler.GetStage2Offsets();
+                    if (cubeBlockScheduler.NeedProcessStage2()) {
+                        // step 3: h[i+1] = k.T @ v_work
+                        int64_t cube2OffsetK = cube2Offsets.wkOffset;
+                        int64_t cube2OffsetVwork = cube2Offsets.vWorkOffset;
+                        int64_t cube2OffsetH = cube2Offsets.hWorkOffset;
+                        auto tensorK = tla::MakeTensor(gmK[cube2OffsetK], kLayout, Catlass::Arch::PositionGM{});
+                        auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[cube2OffsetVwork], vworkLayout, Catlass::Arch::PositionGM{});
+                        auto tensorHwork = tla::MakeTensor(gmHWorkspace[cube2OffsetH], hworkLayout, Catlass::Arch::PositionGM{});
+                        GemmCoord cube2Shape{kHeadDim, vHeadDim, cube2Offsets.blockTokens};
+                        auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                        auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                        auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                        blockMmadKV.preSetFlags();
+                        blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
+                        blockMmadKV.finalWaitFlags();
+                    }
+                    Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(cubeBlockScheduler.cube2Done);
+                }
+            }
+            Arch::CrossCoreWaitFlag(cubeBlockScheduler.vec2Done);
+
+        }
+
+        if ASCEND_IS_AIV {
+            uint32_t coreIdx = AscendC::GetBlockIdx();
+            uint32_t coreNum = AscendC::GetBlockNum();
+            uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+            uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+            EpilogueGDNFwdHVnew epilogueGDNFwdHVnew(resource);
+
+            if (useInitialState) {
+                AscendC::LocalTensor<ElementInitialState> stateUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementInitialState>(0);
+                AscendC::LocalTensor<ElementInitialState> stateUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementInitialState>(96 * 1024);
+                AscendC::LocalTensor<ElementH> hUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementH>(64 * 1024);
+                AscendC::LocalTensor<ElementH> hUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementH>(160 * 1024);
+                uint32_t totalChunks = isVariedLen ? vecBlockScheduler.totalChunks : ((seqlen + chunkSize - 1) / chunkSize);
+                uint32_t stateBlockSize = kHeadDim * vHeadDim;
+                uint32_t pingpongFlag = 1;
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+                for (uint32_t shapeBatchIdx = 0; shapeBatchIdx < shapeBatch; shapeBatchIdx++) {
+                    for (uint32_t vHeadIdx = 0; vHeadIdx < vNumHead; vHeadIdx++) {
+                        for (uint32_t tokenBatchIdx = 0; tokenBatchIdx < vecBlockScheduler.tokenBatch; tokenBatchIdx++) {
+                            uint32_t batchIdx = isVariedLen ? tokenBatchIdx : shapeBatchIdx;
+                            uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
+                            uint32_t initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * stateBlockSize;
+                            uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
+                            AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
+                            AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
+                            auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
+                            if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
+                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
+                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
+                                AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
+                                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
+                                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
+                                AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
+                            } else {
+                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
+                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
+                                AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
+                            }
+                            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
+                            pingpongFlag = 1 - pingpongFlag;
+                        }
+                        
+                    }
+                }
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            }
+
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+            while (vecBlockScheduler.isRunning) {
+                vecBlockScheduler.InitTask();
+                // step 2:
+                GDNFwdHOffsets& vec1Offsets = vecBlockScheduler.GetStage1Offsets();
+                // gmV = gmU - gmVWorkspace
+                // g_buf = gmG[-1] - gmG
+                // g_buf = exp(g_buf)
+                // gmVWorkspace = g_buf * gmV
+                if (vecBlockScheduler.NeedProcessStage1()) {
+                    epilogueGDNFwdHVnew(
+                        gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], 
+                        gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
+                        vec1Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube1Done
+                    );
+                } else {
+                    Arch::CrossCoreWaitFlag(vecBlockScheduler.cube1Done);
+                }
+                Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec1Done);
+
+                if (vecBlockScheduler.iterId > 1) {
+                    GDNFwdHOffsets& vec2Offsets = vecBlockScheduler.GetStage2Offsets();
+                    if (vecBlockScheduler.NeedProcessStage2()) {
+                        // step 4:  h[i+1] += h_work if i < num_chunks - 1 else None
+                        EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
+                        epilogueGDNFwdHUpdate(
+                            gmH[vec2Offsets.hDstOffset], gmFinalState[vec2Offsets.finalStateOffset],
+                            gmG[vec2Offsets.gOffset],
+                            gmH[vec2Offsets.hSrcOffset],
+                            gmHWorkspace[vec2Offsets.hWorkOffset],
+                            vec2Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube2Done,
+                            (vec2Offsets.isFinalState && storeFinalState)
+                        );
+                    } else {
+                        Arch::CrossCoreWaitFlag(vecBlockScheduler.cube2Done);
+                    }
+                    Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vecBlockScheduler.vec2Done);
+                }
+            }
+
+        }
+    }
+
+};
+
+}

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/data_copy_transpose_tiling.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/data_copy_transpose_tiling.h
@@ -1,0 +1,51 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling.h
+ * \brief
+ */
+
+#pragma once
+
+#include <vector>
+#include <graph/tensor.h>
+#include "data_copy_transpose_tiling_def.h"
+
+namespace optiling {
+
+inline void GetDataCopyTransposeTiling(const ge::Shape &dstShape, const ge::Shape &srcShape, const uint32_t typeSize,
+                                       optiling::CopyTransposeTiling &tiling)
+{
+    constexpr int64_t B_INDEX = 0;
+    constexpr int64_t N_INDEX = 1;
+    constexpr int64_t S_INDEX = 2;
+    constexpr int64_t H_INDEX = 3;
+    std::vector<int64_t> dstShapeInfo = dstShape.GetDims();
+    std::vector<int64_t> srcShapeInfo = srcShape.GetDims();
+
+    tiling.set_dstShapeB(dstShapeInfo[B_INDEX]);
+    tiling.set_dstShapeN(dstShapeInfo[N_INDEX]);
+    tiling.set_dstShapeS(dstShapeInfo[S_INDEX]);
+    tiling.set_dstShapeH(dstShapeInfo[H_INDEX]);
+    tiling.set_dstShapeHN(tiling.get_dstShapeH() / tiling.get_dstShapeN());
+
+    tiling.set_srcShapeB(srcShapeInfo[B_INDEX]);
+    tiling.set_srcShapeN(srcShapeInfo[N_INDEX]);
+    tiling.set_srcShapeS(srcShapeInfo[S_INDEX]);
+    tiling.set_srcShapeHN(srcShapeInfo[H_INDEX]);
+    tiling.set_originalShapeNLen(tiling.get_srcShapeHN() * typeSize);
+    tiling.set_shapeSHValue(tiling.get_dstShapeS() * tiling.get_dstShapeH());
+    tiling.set_shapeNsValue(tiling.get_dstShapeN() * tiling.get_dstShapeS());
+    tiling.set_shapeNsnValue(tiling.get_dstShapeN() * tiling.get_srcShapeS() * tiling.get_srcShapeN());
+    tiling.set_shapeBHValue(tiling.get_dstShapeB() * tiling.get_dstShapeH());
+}
+
+} // namespace optiling

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/data_copy_transpose_tiling_def.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/data_copy_transpose_tiling_def.h
@@ -1,0 +1,43 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling_def.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(CopyTransposeTiling)
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeH);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, originalShapeNLen);
+TILING_DATA_FIELD_DEF(uint32_t, shapeSHValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsnValue);
+TILING_DATA_FIELD_DEF(uint32_t, invalidParamCopyTransposeTiling);
+TILING_DATA_FIELD_DEF(uint32_t, shapeBHValue);
+TILING_DATA_FIELD_DEF(uint32_t, paramsAlign);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(CopyTransposeTilingOp, CopyTransposeTiling)
+
+} // namespace optiling

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/error_log.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/error_log.h
@@ -1,0 +1,56 @@
+#ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+#define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+
+#include <string>
+#include "toolchain/slog.h"
+
+#define OP_LOGI(opname, ...)
+#define OP_LOGW(opname, ...)             \
+    do {                                 \
+        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
+        printf("\n");                    \
+    } while (0)
+
+#define OP_LOGE_WITHOUT_REPORT(opname, ...) \
+    do {                                    \
+        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
+        printf("\n");                       \
+    } while (0)
+
+#define OP_LOGE(opname, ...)              \
+    do {                                  \
+        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
+        printf("\n");                     \
+    } while (0)
+
+#define OP_LOGD(opname, ...)
+
+namespace optiling {
+
+#define VECTOR_INNER_ERR_REPORT_TILIING(op_name, err_msg, ...)   \
+    do {                                                         \
+        OP_LOGE_WITHOUT_REPORT(op_name, err_msg, ##__VA_ARGS__); \
+    } while (0)
+
+// Modify OP_TILING_CHECK macro to ensure proper handling of expressions
+#define OP_CHECK_IF(cond, log_func, expr) \
+    do {                                      \
+        if (cond) {                           \
+            log_func;                         \
+            expr;                             \
+        }                                     \
+    } while (0)
+
+
+
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                          \
+    do {                                                                  \
+        if ((ptr) == nullptr) {                                           \
+            OP_LOGE(context->GetNodeType(), "%s is null", #ptr);               \
+            return ge::GRAPH_FAILED;                                      \
+        }                                                                 \
+    } while (0)
+
+}  // namespace optiling
+
+#endif  // OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_base.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_base.h
@@ -1,0 +1,256 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_base.h
+ * \brief
+ */
+
+#pragma once
+
+#include <sstream>
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
+#include "tiling/platform/platform_ascendc.h"
+#include "error_log.h"
+
+#ifdef ASCENDC_OP_TEST
+#define ASCENDC_EXTERN_C extern "C"
+#else
+#define ASCENDC_EXTERN_C
+#endif
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+struct AiCoreParams {
+    uint64_t ubSize = 0;
+    uint64_t blockDim = 0;
+    uint64_t aicNum = 0;
+    uint64_t l1Size = 0;
+    uint64_t l0aSize = 0;
+    uint64_t l0bSize = 0;
+    uint64_t l0cSize = 0;
+};
+
+struct CompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+struct FlashAttentionScoreGradCompileInfo {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    platform_ascendc::SocVersion socVersion;
+};
+
+struct FACompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+class TilingBaseClass {
+public:
+    explicit TilingBaseClass(gert::TilingContext* context) : context_(context)
+    {}
+
+    virtual ~TilingBaseClass() = default;
+
+    // Tiling execution framework
+    //     1. GRAPH_SUCCESS: Success, and no need to continue executing subsequent Tiling class implementations
+    //     2. GRAPH_FAILED: Failure, abort the entire Tiling process
+    //     3. GRAPH_PARAM_INVALID: This class does not support, need to continue executing other Tiling class implementations
+    ge::graphStatus DoTiling()
+    {
+        auto ret = GetShapeAttrsInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetPlatformInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        if (!IsCapable()) {
+            return ge::GRAPH_PARAM_INVALID;
+        }
+        ret = DoOpTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = DoLibApiTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetWorkspaceSize();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = PostTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        context_->SetTilingKey(GetTilingKey());
+        DumpTilingInfo();
+        return ge::GRAPH_SUCCESS;
+    }
+
+    // Update context
+    virtual void Reset(gert::TilingContext* context)
+    {
+        context_ = context;
+    }
+
+protected:
+    virtual bool IsCapable() = 0;
+    // 1. Get platform information such as CoreNum, UB/L1/L0C resource sizes
+    virtual ge::graphStatus GetPlatformInfo() = 0;
+    // 2. Get INPUT/OUTPUT/ATTR information
+    virtual ge::graphStatus GetShapeAttrsInfo() = 0;
+    // 3. Calculate data splitting TilingData
+    virtual ge::graphStatus DoOpTiling() = 0;
+    // 4. Calculate high-level API TilingData
+    virtual ge::graphStatus DoLibApiTiling() = 0;
+    // 5. Calculate TilingKey
+    [[nodiscard]] virtual uint64_t GetTilingKey() const = 0;
+    // 6. Calculate Workspace size
+    virtual ge::graphStatus GetWorkspaceSize() = 0;
+    // 7. Save Tiling data
+    virtual ge::graphStatus PostTiling() = 0;
+    // 8. Dump Tiling data
+    virtual void DumpTilingInfo()
+    {
+        int32_t enable = CheckLogLevel(static_cast<int32_t>(OP), DLOG_DEBUG);
+        if (enable != 1) {
+            return;
+        }
+        auto buf = (uint32_t*)context_->GetRawTilingData()->GetData();
+        auto bufLen = context_->GetRawTilingData()->GetDataSize();
+        std::ostringstream oss;
+        oss << "Start to dump tiling info. tilingkey:" << context_->GetTilingKey() << ", tiling data size:" << bufLen
+            << ", content:";
+        for (size_t i = 0; i < bufLen / sizeof(uint32_t); i++) {
+            oss << *(buf + i) << ",";
+            if (oss.str().length() > 640) { // Split according to 640 to avoid truncation
+                OP_LOGD(context_, "%s", oss.str().c_str());
+                oss.str("");
+            }
+        }
+        OP_LOGD(context_, "%s", oss.str().c_str());
+    }
+
+    static uint32_t CalcTschBlockDim(uint32_t sliceNum, uint32_t aicCoreNum, uint32_t aivCoreNum)
+    {
+        uint32_t ration;
+        if (aicCoreNum == 0 || aivCoreNum == 0 || aicCoreNum > aivCoreNum) {
+            return sliceNum;
+        }
+        ration = aivCoreNum / aicCoreNum;
+        return (sliceNum + (ration - 1)) / ration;
+    }
+
+    template <typename T>
+    [[nodiscard]] std::string GetShapeDebugStr(const T& shape) const
+    {
+        std::ostringstream oss;
+        oss << "[";
+        if (shape.GetDimNum() > 0) {
+            for (size_t i = 0; i < shape.GetDimNum() - 1; ++i) {
+                oss << shape.GetDim(i) << ", ";
+            }
+            oss << shape.GetDim(shape.GetDimNum() - 1);
+        }
+        oss << "]";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTensorDebugStr(
+        const gert::StorageShape* shape, const gert::CompileTimeTensorDesc* tensor)
+    {
+        if (shape == nullptr || tensor == nullptr) {
+            return "nil ";
+        }
+        std::ostringstream oss;
+        oss << "(dtype: " << ge::TypeUtils::DataTypeToSerialString(tensor->GetDataType()) << "),";
+        oss << "(shape:" << GetShapeDebugStr(shape->GetStorageShape()) << "),";
+        oss << "(ori_shape:" << GetShapeDebugStr(shape->GetOriginShape()) << "),";
+        oss << "(format: "
+            << ge::TypeUtils::FormatToSerialString(
+                   static_cast<ge::Format>(ge::GetPrimaryFormat(tensor->GetStorageFormat())))
+            << "),";
+        oss << "(ori_format: " << ge::TypeUtils::FormatToSerialString(tensor->GetOriginFormat()) << ") ";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingContextDebugStr()
+    {
+        std::ostringstream oss;
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetInputsNum(); ++i) {
+            oss << "input" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetInputShape(i), context_->GetInputDesc(i));
+        }
+
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetOutputsNum(); ++i) {
+            oss << "output" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetOutputShape(i), context_->GetOutputDesc(i));
+        }
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingDataDebugStr() const
+    {
+        auto rawTilingData = context_->GetRawTilingData();
+        auto rawTilingDataSize = rawTilingData->GetDataSize();
+        auto data = reinterpret_cast<const int32_t*>(rawTilingData->GetData());
+        size_t len = rawTilingDataSize / sizeof(int32_t);
+        std::ostringstream oss;
+        for (size_t i = 0; i < len; i++) {
+            oss << data[i] << ", ";
+        }
+        return oss.str();
+    }
+
+protected:
+    gert::TilingContext* context_ = nullptr;
+    std::unique_ptr<platform_ascendc::PlatformAscendC> ascendcPlatform_{nullptr};
+    uint32_t blockDim_{0};
+    uint64_t workspaceSize_{0};
+    uint64_t tilingKey_{0};
+    AiCoreParams aicoreParams_;
+};
+
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_key.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_key.h
@@ -1,0 +1,63 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_key.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr uint64_t kBase = 10; // Base-10 carry base
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + kBase * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace Optiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_templates_registry.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_templates_registry.h
@@ -1,0 +1,351 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_templates_registry.h
+ * \brief
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+#include "exe_graph/runtime/tiling_context.h"
+#include "tiling_base.h"
+#include "error_log.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+template <typename T>
+std::unique_ptr<TilingBaseClass> TILING_CLASS(gert::TilingContext* context)
+{
+    return std::unique_ptr<T>(new (std::nothrow) T(context));
+}
+
+using TilingClassCase = std::unique_ptr<TilingBaseClass> (*)(gert::TilingContext*);
+
+class TilingCases {
+public:
+    explicit TilingCases(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    void AddTiling(int32_t priority)
+    {
+        OP_CHECK_IF(
+            cases_.find(priority) != cases_.end(), OP_LOGE(op_type_, "There are duplicate registrations."), return);
+        cases_[priority] = TILING_CLASS<T>;
+        OP_CHECK_IF(
+            cases_[priority] == nullptr,
+            OP_LOGE(op_type_, "Register op tiling func failed, please check the class name."), return);
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingCases()
+    {
+        return cases_;
+    }
+
+private:
+    std::map<int32_t, TilingClassCase> cases_;
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce with soc version --------------------------------
+class TilingRegistryNew {
+public:
+    TilingRegistryNew() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistryNew& GetInstance();
+#else
+    static TilingRegistryNew& GetInstance()
+    {
+        static TilingRegistryNew registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        if (soc_iter == registry_map_.end()) {
+            std::map<std::string, std::shared_ptr<TilingCases>> op_type_map;
+            op_type_map[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            registry_map_[soc_version] = op_type_map;
+        } else {
+            if (soc_iter->second.find(op_type) == soc_iter->second.end()) {
+                soc_iter->second[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            }
+        }
+
+        OP_CHECK_IF(
+            registry_map_[soc_version][op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[soc_version][op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        int32_t soc_version = (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION;
+        const char* op_type = context->GetNodeType();
+        fe::PlatFormInfos* platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = static_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+            if (soc_version == (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION) {
+                OP_LOGE(op_type, "Do op tiling failed, cannot find soc version.");
+                return ge::GRAPH_FAILED;
+            }
+        }
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        int32_t soc_version;
+        const char* op_type = context->GetNodeType();
+        auto platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = reinterpret_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+        }
+
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto priority_id : priorities) {
+            auto tilingCaseIter = tilingTemplateRegistryMap.find(priority_id);
+            if (tilingCaseIter != tilingTemplateRegistryMap.end()) {
+                auto templateFunc = tilingCaseIter->second(context);
+                if (templateFunc != nullptr) {
+                    ge::graphStatus status = templateFunc->DoTiling();
+                    if (status == ge::GRAPH_SUCCESS) {
+                        OP_LOGD(context, "Do general op tiling success priority=%d", priority_id);
+                        return status;
+                    }
+                    OP_LOGD(context, "Ignore general op tiling priority=%d", priority_id);
+                }
+            }
+        }
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        OP_CHECK_IF(
+            soc_iter == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the soc version %d", soc_version),
+            return empty_tiling_case_);
+        auto op_iter = soc_iter->second.find(op_type);
+        OP_CHECK_IF(
+            op_iter == soc_iter->second.end(), OP_LOGE(op_type, "Get op tiling func failed, please check the op name."),
+            return empty_tiling_case_);
+        return op_iter->second->GetTilingCases();
+    }
+
+private:
+    std::map<int32_t, std::map<std::string, std::shared_ptr<TilingCases>>> registry_map_; // key is socversion
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_{};
+};
+
+class RegisterNew {
+public:
+    explicit RegisterNew(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, int32_t soc_version)
+    {
+        auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, const std::vector<int32_t>& soc_versions)
+    {
+        for (int32_t soc_version : soc_versions) {
+            auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+            OP_CHECK_IF(
+                tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."),
+                return *this);
+            tilingCases->AddTiling<T>(priority);
+        }
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce without soc version --------------------------------
+class TilingRegistry {
+public:
+    TilingRegistry() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistry& GetInstance();
+#else
+    static TilingRegistry& GetInstance()
+    {
+        static TilingRegistry registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type)
+    {
+        if (registry_map_.find(op_type) == registry_map_.end()) {
+            registry_map_[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+        }
+        OP_CHECK_IF(
+            registry_map_[op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto priorityId : priorities) {
+            auto templateFunc = tilingTemplateRegistryMap[priorityId](context);
+            if (templateFunc != nullptr) {
+                ge::graphStatus status = templateFunc->DoTiling();
+                if (status == ge::GRAPH_SUCCESS) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", priorityId);
+                    return status;
+                }
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do op tiling failed");
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", priorityId);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type)
+    {
+        OP_CHECK_IF(
+            registry_map_.find(op_type) == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the op name."), return empty_tiling_case_);
+        return registry_map_[op_type]->GetTilingCases();
+    }
+
+private:
+    std::map<std::string, std::shared_ptr<TilingCases>> registry_map_;
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_;
+};
+
+class Register {
+public:
+    explicit Register(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    Register& tiling(int32_t priority)
+    {
+        auto tilingCases = TilingRegistry::GetInstance().RegisterOp(op_type_);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops
+
+// op_type: operator name, class_name: registered tiling class, soc_version: chip version number
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_WITH_SOCVERSION(op_type, class_name, soc_versions, priority)    \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_versions)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+#define REGISTER_TILING_TEMPLATE(op_type, class_name, priority)                                \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register VAR_UNUSED##op_type_##class_name##priority_register = \
+        Ops::Transformer::OpTiling::Register(op_type).tiling<class_name>(priority)
+
+// op_type: operator name, class_name: registered tiling class
+// soc_version: SOC version, used to distinguish different SOCs
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_NEW(op_type, class_name, soc_version, priority)                 \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_version)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+// Replaces REGISTER_TILING_TEMPLATE, if op_type is a string constant, remove the quotes
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register                                                  \
+        __attribute__((unused)) tiling_##op_type##_##class_name##_##priority##_register = \
+            Ops::Transformer::OpTiling::Register(#op_type).tiling<class_name>(priority)

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_type.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_type.h
@@ -1,0 +1,139 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_type.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace optiling {
+
+enum class AxisEnum {
+    B = 0,
+    N2 = 1,
+    G = 2,
+    S1 = 3,
+    S2 = 4,
+    D = 5,
+    NONE = 9,
+};
+
+enum class DtypeEnum {
+    FLOAT16 = 0,
+    FLOAT32 = 1,
+    BFLOAT16 = 2,
+    FLOAT16_PRECISION = 3,
+};
+
+enum class PerformanceOrientedEnum {
+    BIG_BUFFER = 1,
+    BIG_DOUBLE_BUFFER = 2,
+};
+
+enum class MatmulConfig {
+    NULL_CONFIG = 0,
+    NORMAL_CONFIG = 1,
+    MDL_CONFIG = 2
+};
+
+enum class PseConfig {
+    NO_PSE = 0,
+    EXIST_PSE = 1
+};
+
+enum class AttenMaskConfig {
+    NO_ATTEN_MASK = 0,
+    EXIST_ATTEN_MASK = 1
+};
+
+enum class DropOutConfig {
+    NO_DROP_OUT = 0,
+    EXIST_DROP_OUT = 1
+};
+
+enum class CubeFormatEnum {
+    ND = 0,
+    NZ = 1
+};
+enum class LayoutEnum {
+    BSND = 0,
+    SBND = 1,
+    BNSD = 2,
+    TND = 3,
+    NTD_TND = 4
+};
+
+enum class CubeInputSourceEnum {
+    GM = 0,
+    L1 = 1
+};
+
+enum class OptionEnum {
+    DISABLE = 0,
+    ENABLE = 1
+};
+
+enum class SparseEnum {
+    ALL = 0,
+    NONE = 1,
+    ANY = 2,
+    CAUSAL = 3,
+    BAND = 4,
+    PREFIX = 5,
+    BAND_COMPRESS = 6,
+    RIGHT_DOWN_CAUSAL = 7,
+    RIGHT_DOWN_CAUSAL_BAND = 8,
+    BAND_LEFT_UP_CAUSAL = 9
+};
+
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr int64_t base10Multiplier = 10;
+
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + base10Multiplier * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace optiling

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_util.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/tiling_util.h
@@ -1,0 +1,30 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_util.h
+ * \brief
+ */
+
+#pragma once
+
+#include "register/op_impl_registry.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+bool IsRegbaseSocVersion(const gert::TilingParseContext* context);
+
+bool IsRegbaseSocVersion(const gert::TilingContext* context);
+
+const gert::Shape& EnsureNotScalar(const gert::Shape& inShape);
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/moe/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
+++ b/csrc/moe/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
@@ -1,0 +1,680 @@
+/**
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_MULTI_HPP
+#define CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_MULTI_HPP
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/coord.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/helper.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+#include "tla/layout.hpp"
+#include "tla/tensor.hpp"
+
+namespace Catlass::Gemm {
+
+template <class ArchTag_, bool ENABLE_UNIT_FLAG_ = false, bool USE_HF32_MODE_ = false, uint32_t L0C_STAGES_ = 1,
+    bool ENABLE_L1_RESIDENT_ = false, uint32_t L1A_STAGES_ = 2, uint32_t L1B_STAGES_ = 2, uint32_t L0A_STAGES_ = 2,
+    uint32_t L0B_STAGES_ = 2>
+struct MmadPingpongTlaMulti : public MmadBase<ArchTag_, false> {
+    static constexpr uint32_t L1A_STAGES = L1A_STAGES_;
+    static constexpr uint32_t L1B_STAGES = L1B_STAGES_;
+    static constexpr uint32_t L0A_STAGES = L0A_STAGES_;
+    static constexpr uint32_t L0B_STAGES = L0B_STAGES_;
+    static constexpr uint32_t L0C_STAGES = L0C_STAGES_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+    static constexpr bool USE_HF32_MODE = USE_HF32_MODE_;
+    static constexpr bool ENABLE_L1_RESIDENT = ENABLE_L1_RESIDENT_;
+};
+
+}  // namespace Catlass::Gemm
+
+namespace Catlass::Gemm::Block {
+
+template <
+    class ArchTag_,
+    bool ENABLE_UNIT_FLAG_,
+    bool USE_HF32_MODE_,
+    uint32_t L0C_STAGES_,
+    bool ENABLE_L1_RESIDENT_,
+    uint32_t L1A_STAGES_,
+    uint32_t L1B_STAGES_,
+    uint32_t L0A_STAGES_,
+    uint32_t L0B_STAGES_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class ElementA_,
+    class ElementB_,
+    class ElementC_,
+    class ElementBias_,
+    class TileCopy_,
+    class TileMmad_
+>
+struct BlockMmadTla <
+    MmadPingpongTlaMulti<ArchTag_, ENABLE_UNIT_FLAG_, USE_HF32_MODE_, L0C_STAGES_, ENABLE_L1_RESIDENT_, L1A_STAGES_, 
+        L1B_STAGES_, L0A_STAGES_, L0B_STAGES_>,
+    L1TileShape_,
+    L0TileShape_,
+    ElementA_,
+    ElementB_,
+    ElementC_,
+    ElementBias_,
+    TileCopy_,
+    TileMmad_
+> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadPingpongTlaMulti<ArchTag_, ENABLE_UNIT_FLAG_, USE_HF32_MODE_, L0C_STAGES_, ENABLE_L1_RESIDENT_, 
+        L1A_STAGES_, L1B_STAGES_, L0A_STAGES_, L0B_STAGES_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using TileCopy = TileCopy_;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = ElementA_;
+    using LayoutA = typename TileCopy::LayoutA;
+    using ElementB = ElementB_;
+    using LayoutB = typename TileCopy::LayoutB;
+    using ElementC = ElementC_;
+    using LayoutC = typename TileCopy::LayoutC;
+    using ElementBias = ElementBias_;
+
+    using TileMmad = TileMmad_;
+
+    using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+    using CopyL1ToBT = typename TileCopy::CopyL1ToBT;
+
+    using ElementAccumulator = typename TileCopy::ElementAccumulator;
+
+    static constexpr bool HAS_BIAS = TileCopy::HAS_BIAS;
+
+    using LayoutTagL1A = typename TileCopy::LayoutTagL1A;
+    using LayoutTagL1B = typename TileCopy::LayoutTagL1B;
+    using LayoutTagL0A = typename TileCopy::LayoutTagL0A;
+    using LayoutTagL0B = typename TileCopy::LayoutTagL0B;
+
+    using L1AAlignHelper = typename TileCopy_::L1AAlignHelper;
+    using L1BAlignHelper = typename TileCopy_::L1BAlignHelper;
+
+    static_assert(tla::is_tuple<L1TileShape>::value && tla::is_static<L1TileShape>::value,
+        "L1TileShape must be tla::tuple and static!");
+    static_assert(tla::is_tuple<L0TileShape>::value && tla::is_static<L0TileShape>::value,
+        "L0TileShape must be tla::tuple and static!");
+
+    static constexpr bool ENABLE_UNIT_FLAG = DispatchPolicy::ENABLE_UNIT_FLAG;
+    static constexpr bool USE_HF32_MODE = DispatchPolicy::USE_HF32_MODE;
+    static constexpr bool ENABLE_L1_RESIDENT = DispatchPolicy::ENABLE_L1_RESIDENT;
+    static constexpr uint32_t L1A_STAGES = DispatchPolicy::L1A_STAGES;
+    static constexpr uint32_t L1B_STAGES = DispatchPolicy::L1B_STAGES;
+    static constexpr uint32_t L0A_STAGES = DispatchPolicy::L0A_STAGES;
+    static constexpr uint32_t L0B_STAGES = DispatchPolicy::L0B_STAGES;
+    static constexpr uint32_t L0C_STAGES = DispatchPolicy::L0C_STAGES;
+    static constexpr uint32_t L1_TILE_M = tla::get<0>(L1TileShape{});
+    static constexpr uint32_t L1_TILE_N = tla::get<1>(L1TileShape{});
+    static constexpr uint32_t L1_TILE_K = tla::get<2>(L1TileShape{});
+    static constexpr uint32_t L0_TILE_M = tla::get<0>(L0TileShape{});
+    static constexpr uint32_t L0_TILE_N = tla::get<1>(L0TileShape{});
+    static constexpr uint32_t L0_TILE_K = tla::get<2>(L0TileShape{});
+
+    // L1 tile size
+    static constexpr uint32_t L1A_TILE_SIZE = L1_TILE_M * L1_TILE_K * sizeof(ElementA);
+    static constexpr uint32_t L1B_TILE_SIZE = L1_TILE_N * L1_TILE_K * sizeof(ElementB);
+    // L0 tile size
+    static constexpr uint32_t L0A_TILE_SIZE = L0_TILE_M * L0_TILE_K * sizeof(ElementA);
+    static constexpr uint32_t L0B_TILE_SIZE = L0_TILE_K * L0_TILE_N * sizeof(ElementB);
+    static constexpr uint32_t L0C_TILE_SIZE = L1_TILE_M * L1_TILE_N * sizeof(ElementAccumulator);
+
+    // Check HF32_MODE
+    static_assert(
+        !USE_HF32_MODE || (USE_HF32_MODE && std::is_same_v<ElementA, float> && std::is_same_v<ElementB, float>),
+        "HF32 MODE only supports in float!"
+    );
+
+    // Check L0C_STAGES
+    static_assert(!(ENABLE_UNIT_FLAG && L0C_STAGES != 1), "L0C_STAGES must be 1 when UnitFlag is true!");
+
+    // Check LayoutC
+    static_assert(tla::detail::isRowMajor<LayoutC>::value ||
+                      ((std::is_same_v<ElementC, half> || std::is_same_v<ElementC, bfloat16_t> ||
+                          std::is_same_v<ElementC, float>) && tla::detail::iszN<ElementC, LayoutC>::value),
+        "LayoutC only supports zN in half or bfloat16 or float, RowMajor in all dtype yet!");
+
+    // Check L1TileShape
+    static_assert(L1A_TILE_SIZE * L1A_STAGES + L1B_TILE_SIZE * L1B_STAGES <= ArchTag::L1_SIZE,
+        "L1TileShape exceeding the L1 space!");
+
+    // Check L0TileShape
+    static_assert(L0A_TILE_SIZE * L0A_STAGES <= ArchTag::L0A_SIZE, "L0TileShape exceeding the L0A space!");
+    static_assert(L0B_TILE_SIZE * L0B_STAGES <= ArchTag::L0B_SIZE, "L0TileShape exceeding the L0B space!");
+    static_assert(L0C_TILE_SIZE * L0C_STAGES <= ArchTag::L0C_SIZE, "L0TileShape exceeding the L0C space!");
+
+    static constexpr uint32_t _32B = 32*8; // in bits
+    static_assert(L1_TILE_M == L0_TILE_M && L1_TILE_N == L0_TILE_N,
+        "The situation where the basic blocks of L1 and L0 differ on the m and n axes is not supported yet");
+    static_assert(L0_TILE_K <= L1_TILE_K, "L0TileShape::K cannot exceed L1TileShape::K");
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+    static_assert(L1_TILE_M * SizeOfBits<ElementA>::value % _32B == 0, "L1TileShape::M must be 32B aligned.");
+    static_assert(L1_TILE_K * SizeOfBits<ElementA>::value % _32B == 0, "L1TileShape::K must be 32B aligned.");
+    static_assert(L1_TILE_K * SizeOfBits<ElementB>::value % _32B == 0, "L1TileShape::K must be 32B aligned.");
+    static_assert(L1_TILE_N * SizeOfBits<ElementB>::value % _32B == 0, "L1TileShape::N must be 32B aligned.");
+    static_assert(L0_TILE_K * SizeOfBits<ElementB>::value % _32B == 0, "L0TileShape::K must be 32B aligned.");
+#endif
+
+    static_assert((!HAS_BIAS && (L1A_STAGES + L1B_STAGES) <= 8) || (HAS_BIAS && (L1A_STAGES + L1B_STAGES) <= 7), 
+        "L1 Buffer overflow: Exceeds the supported range of EVENT(0~7)");
+
+    static_assert((!HAS_BIAS && (L0A_STAGES + L0B_STAGES) <= 8) || (HAS_BIAS && (L0A_STAGES + L0B_STAGES) <= 7), 
+        "L0 Buffer overflow: Exceeds the supported range of EVENT_ID(0~7)");
+
+    static constexpr auto L1A_LAYOUT =
+        tla::MakeLayout<ElementA, LayoutTagL1A>(tla::Int<L1_TILE_M>{}, tla::Int<L1_TILE_K>{});
+    static constexpr auto L1B_LAYOUT =
+        tla::MakeLayout<ElementB, LayoutTagL1B>(tla::Int<L1_TILE_K>{}, tla::Int<L1_TILE_N>{});
+    static constexpr auto L1BIAS_LAYOUT = tla::MakeLayout(tla::Int<L1_TILE_N>{});
+    static constexpr auto L0BIAS_LAYOUT = tla::MakeLayout(tla::Int<L0_TILE_N>{});
+
+    // When enabling L1 resident mode, restore the pointer and coordinates that record the last state
+    // to the initial state. if two blockmmad instances need to be consecutively invoked at the kernel layer,
+    // RestoreStatus() must be inserted between them.
+    CATLASS_DEVICE
+    void RestoreStatus()
+    {
+        for (int i = 0; i < L1A_STAGES; ++i) {
+            lastAddrA[i] = nullptr;
+            lastCoordA[i] = MatrixCoord{0U, 0U};
+        }
+        for (int i = 0; i < L1B_STAGES; ++i) {
+            lastAddrB[i] = nullptr;
+            lastCoordB[i] = MatrixCoord{0U, 0U};
+        }
+    }
+
+    /// Construct
+    CATLASS_DEVICE
+    BlockMmadTla(Arch::Resource<ArchTag> &resource, uint32_t l1BufAddrStart = 0)
+    {
+        if ASCEND_IS_AIC {
+            uint32_t l1AOffset = l1BufAddrStart;
+            uint32_t l1BOffset = l1BufAddrStart + L1A_TILE_SIZE * L1A_STAGES;
+            // Init buffers
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l1ATensorList[i] = resource.l1Buf.template GetBufferByByte<ElementA>(l1AOffset + L1A_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l1AEventList[i] = i;
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l1BTensorList[i] = resource.l1Buf.template GetBufferByByte<ElementB>(l1BOffset + L1B_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l1BEventList[i] = i + L1A_STAGES;
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l0ATensorList[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l0AEventList[i] = i;
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                // Assign L1/L0A/L0B space for each stages
+                l0BTensorList[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_TILE_SIZE * i);
+                // Assign event ID for each stages
+                l0BEventList[i] = i + L0A_STAGES;
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    l0CTensorList[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_TILE_SIZE * i);
+                    l0CEventList[i] = i;
+                }
+            } else {
+                l0CTensorList[0] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(0);
+            }
+            if constexpr (HAS_BIAS) {
+                uint32_t l1BiasOffset = l1BOffset + L1B_TILE_SIZE * L1B_STAGES;
+                l1BiasTensor = resource.l1Buf.template GetBufferByByte<uint8_t>(l1BiasOffset);
+                l0BiasTensor = resource.btBuf.template GetBufferByByte<ElementAccumulator>(0);
+            }
+        }
+    }
+
+    /// Destructor
+    CATLASS_DEVICE
+    ~BlockMmadTla() {}
+
+    CATLASS_DEVICE
+    void preSetFlags() {
+
+        if ASCEND_IS_AIC {
+            // use HF32 when USE_HF32_MODE is true
+            if constexpr (USE_HF32_MODE) {
+                AscendC::SetHF32Mode(true);
+            } else {
+                AscendC::SetHF32Mode(false);
+            }
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(true);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[i]);
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList[i]);
+                }
+            }
+            if constexpr (HAS_BIAS) {
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+            }
+
+            if constexpr (ENABLE_L1_RESIDENT) {
+                RestoreStatus();
+            }
+        }
+    }
+
+    CATLASS_DEVICE
+    void finalWaitFlags() {
+        if ASCEND_IS_AIC {
+            if constexpr (USE_HF32_MODE) {
+                AscendC::SetHF32Mode(false);
+            }
+            if constexpr (ENABLE_UNIT_FLAG && tla::detail::isRowMajor<LayoutC>::value) {
+                AscendC::SetMMLayoutTransform(false);
+            }
+            for (uint32_t i = 0; i < L1A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L1B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0A_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[i]);
+            }
+            for (uint32_t i = 0; i < L0B_STAGES; i++) {
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[i]);
+            }
+            if constexpr(!ENABLE_UNIT_FLAG) {
+                for (uint32_t i = 0; i < L0C_STAGES; i++) {
+                    AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList[i]);
+                }
+            }
+            if constexpr (HAS_BIAS) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+            }
+        }
+    }
+
+    /// Perform a block-scoped matrix multiply-accumulate
+    template <class TensorA, class TensorB, class TensorC, class TensorBias = EmptyClass>
+    CATLASS_DEVICE void operator()(TensorA &tensorA, TensorB &tensorB, TensorC &tensorC, GemmCoord const &actualShape,
+        TensorBias const &tensorBias = {})
+    {
+        // Check L1TileShape
+        if constexpr (HAS_BIAS) {
+            static constexpr uint32_t BIAS_BUF_SIZE = L0_TILE_N * sizeof(ElementAccumulator);
+            static constexpr uint32_t L1BIAS_SIZE = L1_TILE_N * sizeof(ElementBias);
+            static_assert(BIAS_BUF_SIZE <= ArchTag::BIAS_SIZE,
+                "BIAS_BUF_SIZE exceeding the BT space! Reduce L0_TILE_N");
+            static_assert(L1A_TILE_SIZE * L1A_STAGES + L1B_TILE_SIZE * L1B_STAGES + L1BIAS_SIZE <= ArchTag::L1_SIZE,
+                "L1TileShape exceeding the L1 space!");
+        }
+
+        using CopyGmToL1A = typename TileCopy_::template CopyGmToL1A<TensorA>;
+        using CopyGmToL1B = typename TileCopy_::template CopyGmToL1B<TensorB>;
+        CopyGmToL1A copyGmToL1A;
+        CopyGmToL1B copyGmToL1B;
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+        using CopyL0CToGm = typename TileCopy_::template CopyL0CToGm<TensorC>;
+        CopyL0CToGm copyL0CToDst;
+#endif        
+#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 3510)
+        using CopyL0CToDst = typename TileCopy_::template CopyL0CToDst<TensorC>;
+        CopyL0CToDst copyL0CToDst;
+#endif        
+
+        uint32_t mBlockActual = actualShape.m();
+        uint32_t kBlockActual = actualShape.k();
+        uint32_t nBlockActual = actualShape.n();
+
+        uint32_t mL1Actual = mBlockActual;
+        if constexpr (std::is_same_v<ArchTag, Arch::AtlasA2>) {
+            // Avoid using the gemv mode in mmad
+            if (mL1Actual == 1) {
+                mL1Actual = 16;
+            }
+        }
+        uint32_t nL1Actual = nBlockActual;
+
+        auto layoutInL0C = tla::MakeLayoutL0C(mL1Actual, nL1Actual);
+        auto tensorL0C = tla::MakeTensor(l0CTensorList[l0CListId], layoutInL0C, Arch::PositionL0C{});
+        auto tensorL0Bias = tla::MakeTensor(l0BiasTensor, L0BIAS_LAYOUT, Arch::PositionBias{});
+
+        uint32_t kL1Actual = min(kBlockActual, L1_TILE_K);
+        // load first matrix A tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
+        auto tensorL1A = tla::MakeTensor(l1ATensorList[l1AListId], L1A_LAYOUT, Arch::PositionL1{});
+        auto tensorTileA = GetTileA(tensorA, 0, 0, mBlockActual, kL1Actual);
+        if constexpr (ENABLE_L1_RESIDENT) {
+            // If the currently loaded GM pointer and block coordinates are the same as the last loaded ones,
+            // skip this loading.
+            if (lastAddrA[l1AListId] != tensorTileA.data().GetPhyAddr()
+                || tla::get<0>(tensorTileA.coord()) != lastCoordA[l1AListId].row()
+                || tla::get<1>(tensorTileA.coord()) != lastCoordA[l1AListId].column()) {
+                copyGmToL1A(tensorL1A, tensorTileA);
+                lastCoordA[l1AListId] = MatrixCoord{tla::get<0>(tensorTileA.coord()), tla::get<1>(tensorTileA.coord())};
+                lastAddrA[l1AListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementA>::PrimType *>(
+                    tensorTileA.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1A(tensorL1A, tensorTileA);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListId]);
+
+        // load first matrix B tile from GM to L1
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListId]);
+        auto tensorL1B = tla::MakeTensor(l1BTensorList[l1BListId], L1B_LAYOUT, Arch::PositionL1{});
+        auto tensorTileB = GetTile(tensorB, tla::MakeCoord(0, 0), tla::MakeShape(kL1Actual, nBlockActual));
+        if constexpr (ENABLE_L1_RESIDENT) {
+            if (lastAddrB[l1BListId] != tensorTileB.data().GetPhyAddr()
+                || tla::get<0>(tensorTileB.coord()) != lastCoordB[l1BListId].row()
+                || tla::get<1>(tensorTileB.coord()) != lastCoordB[l1BListId].column()) {
+                copyGmToL1B(tensorL1B, tensorTileB);
+                lastCoordB[l1BListId] = MatrixCoord{tla::get<0>(tensorTileB.coord()), tla::get<1>(tensorTileB.coord())};
+                lastAddrB[l1BListId] = const_cast<__gm__ typename AscendC::GlobalTensor<ElementB>::PrimType *>(
+                    tensorTileB.data().GetPhyAddr()
+                );
+            }
+        } else {
+            copyGmToL1B(tensorL1B, tensorTileB);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListId]);
+
+        if constexpr (HAS_BIAS && !std::is_same_v<TensorBias, EmptyClass>) {
+            using CopyGmToL1Bias = typename TileCopy::template CopyGmToL1Bias<TensorBias>;
+            CopyGmToL1Bias copyGmToL1Bias;
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+            auto l1Bias = l1BiasTensor.template ReinterpretCast<ElementBias>();
+            auto tensorL1Bias = tla::MakeTensor(l1Bias, L1BIAS_LAYOUT, Arch::PositionL1{});
+            copyGmToL1Bias(tensorL1Bias, tensorBias);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(L1A_STAGES + L1B_STAGES);
+        }
+
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList[l0CListId]);
+        }
+
+        uint32_t mL0Loop = CeilDiv<L0_TILE_M>(mL1Actual);
+        uint32_t nL0Loop = CeilDiv<L0_TILE_N>(nL1Actual);
+
+        // main loop
+        uint32_t kL1Loop = CeilDiv<L1_TILE_K>(kBlockActual);
+        for (uint32_t kL1Idx = 0; kL1Idx < kL1Loop; kL1Idx++) {
+            uint32_t l1AListIdNext = (l1AListId + 1 < L1A_STAGES) ? (l1AListId + 1) : 0;
+            uint32_t l1BListIdNext = (l1BListId + 1 < L1B_STAGES) ? (l1BListId + 1) : 0;
+            uint32_t kL1ActualNext{0};
+            // preload next tile from GM to L1
+            if (kL1Idx < kL1Loop - 1) {
+                uint32_t kL1IdxNext = kL1Idx + 1;
+                kL1ActualNext = (kL1IdxNext < kL1Loop - 1) ? L1_TILE_K : (kBlockActual - kL1IdxNext * L1_TILE_K);
+
+                // Get L1 tensor for next stage
+                auto l1ATensor = l1ATensorList[l1AListIdNext];
+                auto l1BTensor = l1BTensorList[l1BListIdNext];
+                auto tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+                auto tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+                // Get GM tile for next stage
+                auto tensorTileA = GetTileA(tensorA, 0, kL1IdxNext * L1_TILE_K, mBlockActual, kL1ActualNext);
+                auto tensorTileB = GetTile(tensorB, tla::MakeCoord(kL1IdxNext * L1_TILE_K, 0),
+                    tla::MakeShape(kL1ActualNext, nBlockActual));
+
+                // load next matrix A tile from GM to L1
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListIdNext]);
+                if constexpr (ENABLE_L1_RESIDENT) {
+                    if (lastAddrA[l1AListIdNext] != tensorTileA.data().GetPhyAddr()
+                        || tla::get<0>(tensorTileA.coord()) != lastCoordA[l1AListIdNext].row()
+                        || tla::get<1>(tensorTileA.coord()) != lastCoordA[l1AListIdNext].column()) {
+                        copyGmToL1A(tensorL1A, tensorTileA);
+                        lastCoordA[l1AListIdNext] =
+                            MatrixCoord{tla::get<0>(tensorTileA.coord()), tla::get<1>(tensorTileA.coord())};
+                        lastAddrA[l1AListIdNext] =
+                            const_cast<__gm__ typename AscendC::GlobalTensor<ElementA>::PrimType *>(
+                                tensorTileA.data().GetPhyAddr()
+                            );
+                    }
+                } else {
+                    copyGmToL1A(tensorL1A, tensorTileA);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListIdNext]);
+
+                // load next matrix B tile from GM to L1
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListIdNext]);
+                if constexpr (ENABLE_L1_RESIDENT) {
+                    if (lastAddrB[l1BListIdNext] != tensorTileB.data().GetPhyAddr()
+                        || tla::get<0>(tensorTileB.coord()) != lastCoordB[l1BListIdNext].row()
+                        || tla::get<1>(tensorTileB.coord()) != lastCoordB[l1BListIdNext].column()) {
+                        copyGmToL1B(tensorL1B, tensorTileB);
+                        lastCoordB[l1BListIdNext] =
+                            MatrixCoord{tla::get<0>(tensorTileB.coord()), tla::get<1>(tensorTileB.coord())};
+                        lastAddrB[l1BListIdNext] =
+                            const_cast<__gm__ typename AscendC::GlobalTensor<ElementB>::PrimType *>(
+                                tensorTileB.data().GetPhyAddr()
+                            );
+                    }
+                } else {
+                    copyGmToL1B(tensorL1B, tensorTileB);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListIdNext]);
+            }
+
+            // Get L1 tensor for current stage
+            auto l1ATensor = l1ATensorList[l1AListId];
+            auto l1BTensor = l1BTensorList[l1BListId];
+            tensorL1A = tla::MakeTensor(l1ATensor, L1A_LAYOUT, Arch::PositionL1{});
+            tensorL1B = tla::MakeTensor(l1BTensor, L1B_LAYOUT, Arch::PositionL1{});
+            // Get the loop nums on L0
+            uint32_t kL0Loop = CeilDiv<L0_TILE_K>(kL1Actual);
+
+            for (int mL0Idx = 0; mL0Idx < mL0Loop; mL0Idx++) {
+                uint32_t mL0Actual = (mL0Idx < mL0Loop - 1) ? L0_TILE_M : (mL1Actual - mL0Idx * L0_TILE_M);
+
+                for (int kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                    uint32_t kL0Actual = (kL0Idx < kL0Loop - 1) ? L0_TILE_K : (kL1Actual - kL0Idx * L0_TILE_K);
+
+                    // Locate the current tile on L0A
+                    auto l0ATile = l0ATensorList[l0AListId];
+                    auto layoutAInL0 = tla::MakeLayout<ElementA, LayoutTagL0A>(mL0Actual, kL0Actual);
+                    auto tensorL0A = tla::MakeTensor(l0ATile, layoutAInL0, Arch::PositionL0A{});
+                    // Locate the current tile of matrix A on L1
+                    auto tensorTileL1A = GetTileA(tensorL1A, mL0Idx * L0_TILE_M, kL0Idx * L0_TILE_K, mL0Actual, kL0Actual);
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[l0AListId]);
+                    if ((mL0Idx == 0) && (kL0Idx == 0)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEventList[l1AListId]);
+                    }
+
+                    // Load current tile from L1 to L0A
+                    copyL1ToL0A(tensorL0A, tensorTileL1A);
+
+                    if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1)) {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEventList[l1AListId]);
+                    }
+
+                    bool initC = ((kL1Idx == 0) && (kL0Idx == 0));
+                    for (int nL0Idx = 0; nL0Idx < nL0Loop; nL0Idx++) {
+                        uint32_t nL0Actual = (nL0Idx < nL0Loop - 1) ? L0_TILE_N : (nL1Actual - nL0Idx * L0_TILE_N);
+
+                        // Locate the current tile on L0B
+                        auto l0BTile = l0BTensorList[l0BListId];
+                        auto layoutBInL0 = tla::MakeLayout<ElementB, LayoutTagL0B>(kL0Actual, nL0Actual);
+                        auto tensorL0B = tla::MakeTensor(l0BTile, layoutBInL0, Arch::PositionL0B{});
+                        // Locate the current tile of matrix B on L1
+                        auto tensorTileL1B = GetTile(tensorL1B,
+                                                     tla::MakeCoord(kL0Idx * L0_TILE_K, nL0Idx * L0_TILE_N),
+                                                     tla::MakeShape(kL0Actual, nL0Actual));
+
+                        // Wait for mmad finished
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[l0BListId]);
+                        // If the current tile is the first one on the k&n axis, wait for loading matrix B from GM to L1
+                        if ((mL0Idx == 0) && (kL0Idx == 0) && (nL0Idx == 0)) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList[l1BListId]);
+                        }
+
+                        // Load current tile from L1 to L0B
+                        copyL1ToL0B(tensorL0B, tensorTileL1B);
+
+                        // If the current tile is the last one on the k&n axis, notify to load matrix B from GM to L1
+                        if ((mL0Idx == mL0Loop - 1) && (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList[l1BListId]);
+                        }
+
+                        if constexpr (HAS_BIAS && !std::is_same_v<TensorBias, EmptyClass>) {
+                            if (initC) {
+                                if (nL0Idx == 0) {
+                                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(L1A_STAGES + L1B_STAGES);
+                                }
+                                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+                                auto l1Bias = l1BiasTensor.template ReinterpretCast<ElementBias>();
+                                auto tensorL1Bias = tla::MakeTensor(l1Bias, L1BIAS_LAYOUT, Arch::PositionL1{});
+                                auto tensorTileL1Bias = GetTile(tensorL1Bias,
+                                                                tla::MakeCoord(nL0Idx * L0_TILE_N),
+                                                                tla::MakeShape(nL0Actual));
+                                // Load bias to l0 biasTable
+                                copyL1ToBT(tensorL0Bias, tensorTileL1Bias);
+                                if (nL0Idx == nL0Loop - 1) {
+                                    AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(L1A_STAGES + L1B_STAGES);
+                                }
+                            }
+                        }
+
+                        // Notify to do mmad
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(l0CEventList[l0CListId]);
+
+                        // Locate the current tile on L0C
+                        auto tensorTileL0C = GetTile(tensorL0C,
+                                                     tla::MakeCoord(mL0Idx * L0_TILE_M, nL0Idx * L0_TILE_N),
+                                                     tla::MakeShape(mL0Actual, nL0Actual));
+
+                        // Compute the matrix multiplication on L0A and L0B and write the result to the accumulator
+                        // Wait for loading L0B
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(l0CEventList[l0CListId]);
+
+                        // If the unit flag is enabled, the unit flag is set according to the calculation progress
+                        uint8_t unitFlag = 0b00;
+                        if constexpr (ENABLE_UNIT_FLAG) {
+                            if ((kL1Idx == kL1Loop - 1) && (mL0Idx == mL0Loop - 1) &&
+                                (kL0Idx == kL0Loop - 1) && (nL0Idx == nL0Loop - 1)) {
+                                unitFlag = 0b11;
+                            } else {
+                                unitFlag = 0b10;
+                            }
+                        }
+
+                        if constexpr (HAS_BIAS && !std::is_same_v<TensorBias, EmptyClass>) {
+                            if (initC) {
+                                tileMmad(tensorTileL0C, tensorL0A, tensorL0B, tensorL0Bias,
+                                    mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+                                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(L0A_STAGES + L0B_STAGES);
+                            } else {
+                                tileMmad(tensorTileL0C, tensorL0A, tensorL0B,
+                                    mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+                            }
+                        } else {
+                            tileMmad(tensorTileL0C, tensorL0A, tensorL0B,
+                                mL0Actual, nL0Actual, kL0Actual, initC, unitFlag);
+                        }
+
+                        // Notify to move the next L0B tile
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList[l0BListId]);
+                        l0BListId = (l0BListId + 1 < L0B_STAGES) ? (l0BListId + 1) : 0;
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList[l0AListId]);
+                    l0AListId = (l0AListId + 1 < L0A_STAGES) ? (l0AListId + 1) : 0;
+                }
+            }
+            l1AListId = l1AListIdNext;
+            l1BListId = l1BListIdNext;
+            kL1Actual = kL1ActualNext;
+        }
+
+        // copy block out
+        if constexpr (!ENABLE_UNIT_FLAG) {
+            AscendC::SetFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
+            AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
+            copyL0CToDst(tensorC, tensorL0C);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList[l0CListId]);
+            l0CListId = (l0CListId + 1 < L0C_STAGES) ? (l0CListId + 1) : 0;
+        } else {
+            copyL0CToDst(tensorC, tensorL0C, 0b11);
+        }
+    }
+
+protected:
+    template<class TensorA>
+    CATLASS_DEVICE auto GetTileA(TensorA &tensorA, uint32_t mIndex, uint32_t kIndex, uint32_t mSize, uint32_t kSize)
+    {
+        if constexpr(tla::detail::isVector<LayoutA>::value) {
+            return GetTile(tensorA, tla::MakeCoord(kIndex), tla::MakeShape(kSize));
+        } else {
+            return GetTile(tensorA, tla::MakeCoord(mIndex, kIndex), tla::MakeShape(mSize, kSize));
+        }
+    }
+
+    // Multi-stage tensors list
+    AscendC::LocalTensor<ElementA> l1ATensorList[L1A_STAGES];
+    AscendC::LocalTensor<ElementB> l1BTensorList[L1B_STAGES];
+    AscendC::LocalTensor<ElementA> l0ATensorList[L0A_STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensorList[L0B_STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensorList[L0C_STAGES];
+    AscendC::LocalTensor<uint8_t> l1BiasTensor;
+    AscendC::LocalTensor<ElementAccumulator> l0BiasTensor;
+
+    // Multi-stage event id list
+    int32_t l1AEventList[L1A_STAGES];
+    int32_t l1BEventList[L1B_STAGES];
+    int32_t l0AEventList[L0A_STAGES];
+    int32_t l0BEventList[L0B_STAGES];
+    int32_t l0CEventList[L0C_STAGES];
+
+    __gm__ typename AscendC::GlobalTensor<ElementA>::PrimType* lastAddrA[L1A_STAGES];
+    __gm__ typename AscendC::GlobalTensor<ElementB>::PrimType* lastAddrB[L1B_STAGES];
+    MatrixCoord lastCoordA[L1A_STAGES];
+    MatrixCoord lastCoordB[L1B_STAGES];
+    
+    // The id of current stage
+    uint32_t l1AListId{0};
+    uint32_t l1BListId{0};
+    uint32_t l0AListId{0};
+    uint32_t l0BListId{0};
+    uint32_t l0CListId{0};
+
+    TileMmad tileMmad;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL1ToBT copyL1ToBT;
+};
+
+} // namespace Catlass::Gemm::Block
+
+#endif // CATLASS_GEMM_BLOCK_BLOCK_MMAD_PINGPONG_TLA_MULTI_HPP

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -987,6 +987,101 @@ std::vector<at::Tensor> moe_grouped_matmul(
     return y;
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_fwd_h(
+    const at::Tensor & k,
+    const at::Tensor & w,
+    const at::Tensor & u,
+    const c10::optional<at::Tensor> & g,
+    const c10::optional<at::Tensor> & gk,
+    const c10::optional<at::Tensor> & initial_state,
+    c10::optional<bool> output_final_state,
+    c10::optional<int64_t> chunk_size,
+    c10::optional<bool> save_new_value,
+    c10::optional<at::IntArrayRef> cu_seqlens,
+    c10::optional<at::IntArrayRef> chunk_indices,
+    c10::optional<bool> use_exp2,
+    c10::optional<bool> transpose_state_layout)
+{
+    bool output_final_state_ = output_final_state.has_value() ? output_final_state.value() : false;
+    const at::Tensor &initial_state_ = c10::value_or_else(initial_state, [] { return at::Tensor(); });
+    int64_t chunk_size_ = chunk_size.has_value() ? chunk_size.value() : 64;
+    const at::Tensor &g_ = c10::value_or_else(g, [] { return at::Tensor(); });
+    const at::Tensor &gk_ = c10::value_or_else(gk, [] { return at::Tensor(); });
+
+    auto k_sizes = k.sizes();
+    auto u_sizes = u.sizes();
+    int K = k_sizes[3];
+    int B = k_sizes[0];
+    int T = k_sizes[2];
+    int HV = u_sizes[1];
+    int V = u_sizes[3];
+
+    int NT = 0;
+    if (chunk_indices.has_value()) {
+        auto chunk_indices_ref = chunk_indices.value();
+        NT = chunk_indices_ref.size() / 2;
+    } else {
+        NT = (T + chunk_size_ - 1) / chunk_size_;
+    }
+
+    at::Tensor h_out = at::zeros({B, HV, NT, K, V}, k.options());
+    at::Tensor v_new_out = at::zeros(u.sizes(), u.options());
+    at::Tensor final_state_out;
+    if (output_final_state_) {
+        int N = cu_seqlens.has_value() ? cu_seqlens->size() - 1 : B;
+        auto state_options = initial_state.has_value() ? initial_state->options() : h_out.options();
+        final_state_out = at::empty({N, HV, K, V}, state_options);
+    } else {
+        final_state_out = at::empty({1}, k.options());
+    }
+
+    bool save_new_value_ = save_new_value.value_or(true);
+    bool use_exp2_ = use_exp2.value_or(false);
+    bool transpose_state_layout_ = transpose_state_layout.value_or(false);
+
+    EXEC_NPU_CMD(
+        aclnnChunkGatedDeltaRuleFwdH,
+        k, w, u, g_,
+        gk_, initial_state_, output_final_state_, chunk_size_, save_new_value_,
+        cu_seqlens, chunk_indices, use_exp2_, transpose_state_layout_,
+        h_out, v_new_out, final_state_out
+    );
+
+    if (output_final_state_) {
+        return std::make_tuple(h_out, v_new_out, final_state_out);
+    } else {
+        return std::make_tuple(h_out, v_new_out, at::Tensor());
+    }
+}
+
+at::Tensor chunk_fwd_o(
+    const at::Tensor & q,
+    const at::Tensor & k,
+    const at::Tensor & v,
+    const at::Tensor & h,
+    double scale,
+    const c10::optional<at::Tensor> & g,
+    const c10::optional<at::Tensor> & g_gamma,
+    c10::optional<at::IntArrayRef> cu_seqlens,
+    c10::optional<at::IntArrayRef> chunk_indices,
+    c10::optional<int64_t> chunk_size,
+    c10::optional<bool> transpose_state_layout)
+{
+    at::Tensor o = at::zeros(v.sizes(), v.options());
+    int64_t chunk_size_ = chunk_size.has_value() ? chunk_size.value() : 64;
+    const at::Tensor &g_ = c10::value_or_else(g, [] { return at::Tensor(); });
+    (void)g_gamma;
+    (void)transpose_state_layout;
+
+    EXEC_NPU_CMD(
+        aclnnChunkFwdO,
+        q, k, v, h, g_,
+        cu_seqlens, chunk_indices, scale, chunk_size_,
+        o
+    );
+    return o;
+}
+
 } // namespace vllm_ascend
 
 #ifdef ASCEND_PLATFORM_310P
@@ -1279,5 +1374,15 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                            int sparse_count=2048, int sparse_mode=3) -> Tensor"
     );
     ops.impl("npu_lightning_indexer_quant", torch::kPrivateUse1, &vllm_ascend::npu_lightning_indexer_quant);
+
+    ops.def(
+        "chunk_gated_delta_rule_fwd_h(Tensor k, Tensor w, Tensor u, Tensor? g=None, *, Tensor? gk=None, Tensor? initial_state=None, bool? output_final_state=False, int? chunk_size=None, bool? save_new_value=True, int[]? cu_seqlens=None, int[]? chunk_indices=None, bool? use_exp2=False, bool? transpose_state_layout=False) -> (Tensor h_out, Tensor v_new_out, Tensor final_state_out)"
+    );
+    ops.impl("chunk_gated_delta_rule_fwd_h", torch::kPrivateUse1, &vllm_ascend::chunk_gated_delta_rule_fwd_h);
+
+    ops.def(
+        "chunk_fwd_o(Tensor q, Tensor k, Tensor v, Tensor h, float scale, *, Tensor? g=None, Tensor? g_gamma=None, int[]? cu_seqlens=None, int[]? chunk_indices=None, int? chunk_size=None, bool? transpose_state_layout=False) -> Tensor"
+    );
+    ops.impl("chunk_fwd_o", torch::kPrivateUse1, &vllm_ascend::chunk_fwd_o);
 }
 #endif

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -665,6 +665,87 @@ at::Tensor npu_lightning_indexer_quant_meta(
     return lightning_indexer_quant_output;
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_fwd_h_meta(
+    const at::Tensor & k,
+    const at::Tensor & w,
+    const at::Tensor & u,
+    const c10::optional<at::Tensor> & g,
+    const c10::optional<at::Tensor> & gk,
+    const c10::optional<at::Tensor> & initial_state,
+    c10::optional<bool> output_final_state,
+    c10::optional<int64_t> chunk_size,
+    c10::optional<bool> save_new_value,
+    c10::optional<at::IntArrayRef> cu_seqlens,
+    c10::optional<at::IntArrayRef> chunk_indices,
+    c10::optional<bool> use_exp2,
+    c10::optional<bool> transpose_state_layout)
+{
+    bool output_final_state_ = output_final_state.has_value() ? output_final_state.value() : false;
+    const at::Tensor &initial_state_ = c10::value_or_else(initial_state, [] { return at::Tensor(); });
+    int64_t chunk_size_ = chunk_size.has_value() ? chunk_size.value() : 64;
+    const at::Tensor &g_ = c10::value_or_else(g, [] { return at::Tensor(); });
+    const at::Tensor &gk_ = c10::value_or_else(gk, [] { return at::Tensor(); });
+
+    auto k_sizes = k.sizes();
+    auto u_sizes = u.sizes();
+    int K = k_sizes[3];
+    int B = k_sizes[0];
+    int T = k_sizes[2];
+    int HV = u_sizes[1];
+    int V = u_sizes[3];
+
+    int NT = 0;
+    if (chunk_indices.has_value()) {
+        auto chunk_indices_ref = chunk_indices.value();
+        NT = chunk_indices_ref.size() / 2;
+    } else {
+        NT = (T + chunk_size_ - 1) / chunk_size_;
+    }
+
+    at::Tensor h_out = at::zeros({B, HV, NT, K, V}, k.options());
+    at::Tensor v_new_out = at::zeros(u.sizes(), u.options());
+    at::Tensor final_state_out;
+    if (output_final_state_) {
+        int N = cu_seqlens.has_value() ? cu_seqlens->size() - 1 : B;
+        auto state_options = initial_state.has_value() ? initial_state->options() : h_out.options();
+        final_state_out = at::empty({N, HV, K, V}, state_options);
+    } else {
+        final_state_out = at::empty({1}, k.options());
+    }
+
+    bool save_new_value_ = save_new_value.value_or(true);
+    bool use_exp2_ = use_exp2.value_or(false);
+    bool transpose_state_layout_ = transpose_state_layout.value_or(false);
+
+    if (output_final_state_) {
+        return std::make_tuple(h_out, v_new_out, final_state_out);
+    } else {
+        return std::make_tuple(h_out, v_new_out, at::Tensor());
+    }
+}
+
+at::Tensor chunk_fwd_o_meta(
+    const at::Tensor & q,
+    const at::Tensor & k,
+    const at::Tensor & v,
+    const at::Tensor & h,
+    double scale,
+    const c10::optional<at::Tensor> & g,
+    const c10::optional<at::Tensor> & g_gamma,
+    c10::optional<at::IntArrayRef> cu_seqlens,
+    c10::optional<at::IntArrayRef> chunk_indices,
+    c10::optional<int64_t> chunk_size,
+    c10::optional<bool> transpose_state_layout)
+{
+    at::Tensor o = at::zeros(v.sizes(), v.options());
+    int64_t chunk_size_ = chunk_size.has_value() ? chunk_size.value() : 64;
+    const at::Tensor &g_ = c10::value_or_else(g, [] { return at::Tensor(); });
+    (void)g_gamma;
+    (void)transpose_state_layout;
+
+    return o;
+}
+
 } // namespace meta
 } // namespace vllm_ascend
 
@@ -736,6 +817,10 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("moe_grouped_matmul", &vllm_ascend::meta::moe_grouped_matmul_meta);
     // Lightning indexer quant
     ops.impl("npu_lightning_indexer_quant", &vllm_ascend::meta::npu_lightning_indexer_quant_meta);
+    // chunk_gated_delta_rule_fwd_h
+    ops.impl("chunk_gated_delta_rule_fwd_h", &vllm_ascend::meta::chunk_gated_delta_rule_fwd_h_meta);
+    // chunk_fwd_o
+    ops.impl("chunk_fwd_o", &vllm_ascend::meta::chunk_fwd_o_meta);
 }
 }
 #endif

--- a/tests/e2e/multicard/2-cards/test_external_launcher.py
+++ b/tests/e2e/multicard/2-cards/test_external_launcher.py
@@ -151,7 +151,7 @@ def test_qwen3_external_launcher_with_sleepmode():
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        timeout=300,
+        timeout=600,
     )
     output = proc.stdout.decode(errors="ignore")
 
@@ -200,7 +200,7 @@ def test_qwen3_external_launcher_with_sleepmode_level2():
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        timeout=300,
+        timeout=600,
     )
     output = proc.stdout.decode(errors="ignore")
 

--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -16,9 +16,13 @@
 import pytest
 import torch
 
+from tests.ut.conftest import RunnerDeviceType, npu_test
 from vllm_ascend.ops.triton import gdn_chunk_meta
 from vllm_ascend.ops.triton.fla import chunk, chunk_o, chunk_o_update
 from vllm_ascend.ops.triton.gdn_chunk_meta import build_chunk_meta_device
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
 
 
 class _FakeKernel:
@@ -62,6 +66,9 @@ class _DummyTensor:
         return self
 
     def contiguous(self):
+        return self
+
+    def to(self, *args, **kwargs):
         return self
 
 
@@ -140,6 +147,7 @@ def test_chunk_leaf_wrappers_use_prebuilt_chunk_offsets(
     assert fake_kernel.launch_kwargs["chunk_offsets"] is sentinel
 
 
+@npu_test(num_npus=1, npu_type=RunnerDeviceType.A2)
 def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -208,6 +216,16 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
             lambda *args, **kwargs: _DummyTensor("zeros_like"),
             raising=False,
         )
+        monkeypatch.setattr(
+            torch.ops._C_ascend,
+            "chunk_gated_delta_rule_fwd_h",
+            lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
+        )
+        monkeypatch.setattr(
+            torch.ops._C_ascend,
+            "chunk_fwd_o",
+            lambda *args, **kwargs: _DummyTensor("o_ascend"),
+        )
 
         def fake_chunk_fwd_o(*args, **kwargs):
             calls.append(("o", kwargs["chunk_offsets"]))
@@ -234,10 +252,10 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
         )
 
     run_case(1, non_pcp_calls)
-    assert non_pcp_calls == [("o", chunk_offsets)]
+    assert non_pcp_calls == []
 
     run_case(2, pcp_calls)
-    assert pcp_calls == [("o_update", chunk_offsets), ("o", chunk_offsets)]
+    assert pcp_calls == [("o_update", chunk_offsets)]
 
 
 def test_build_chunk_meta_device_rejects_non_npu_input():

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -16,9 +16,9 @@ from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 
-from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
 from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
-from .chunk_o import chunk_fwd_o
+from .chunk_o import chunk_fwd_o  # noqa: F401
 from .chunk_o_update import chunk_fwd_o_update
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
@@ -85,16 +85,29 @@ def chunk_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices_chunk64,
     )
-    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
-        k=k,
-        w=w,
-        u=u,
-        g=g,
+
+    k_ascendc = k.to(torch.bfloat16).transpose(1, 2).contiguous()
+    w_ascendc = w.to(torch.bfloat16).transpose(1, 2).contiguous()
+    u_ascendc = u.to(torch.bfloat16).transpose(1, 2).contiguous()
+    g_ascendc = g.transpose(1, 2).contiguous()
+    q_ascendc = q.to(torch.bfloat16).transpose(1, 2).contiguous()
+
+    cu_seqlens = cu_seqlens.to(torch.int64)
+    chunk_indices = None if chunk_indices_chunk64 is None else chunk_indices_chunk64.to(torch.int64)
+    h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
+        k_ascendc,
+        w_ascendc,
+        u_ascendc,
+        g=g_ascendc,
+        gk=None,
         initial_state=initial_state,
-        output_final_state=output_final_state,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices_chunk64,
-        chunk_offsets=chunk_offsets_chunk64,
+        output_final_state=True,
+        chunk_size=64,
+        save_new_value=True,
+        cu_seqlens=cu_seqlens.tolist() if cu_seqlens is not None else None,
+        chunk_indices=chunk_indices.flatten().tolist() if chunk_indices is not None else None,
+        use_exp2=False,
+        transpose_state_layout=False,
     )
 
     if get_pcp_group().world_size > 1:
@@ -141,16 +154,23 @@ def chunk_gated_delta_rule_fwd(
             chunk_offsets=chunk_offsets_chunk64,
         )
 
-    o = chunk_fwd_o(
-        q=q,
-        k=k,
-        v=v_new,
-        h=h,
-        g=g,
-        scale=scale,
-        cu_seqlens=cu_seqlens,
-        chunk_offsets=chunk_offsets_chunk64,
+    o_ascendc = torch.ops._C_ascend.chunk_fwd_o(
+        q_ascendc,
+        k_ascendc,
+        v_new,
+        h,
+        scale,
+        g=g_ascendc,
+        g_gamma=None,
+        cu_seqlens=cu_seqlens.tolist() if cu_seqlens is not None else None,
+        chunk_indices=chunk_indices.flatten().tolist() if chunk_indices is not None else None,
+        chunk_size=64,
+        transpose_state_layout=False,
     )
+
+    o = o_ascendc.to(torch.bfloat16).transpose(1, 2).contiguous()
+    v_new = v_new.to(torch.bfloat16).transpose(1, 2).contiguous()
+    h = h.to(torch.bfloat16).transpose(1, 2).contiguous()
 
     if SUPPRESS_LEVEL < 3:
         return g, o, A, final_state, None, None, None


### PR DESCRIPTION
### What this PR does / why we need it?
add custom op for performance improve: chunk_fwd_o & chunk_gated_delta_rule_fwd_h
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
1、start vllm service
```
export ASCEND_RT_VISIBLE_DEVICES=8,9
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export HCCL_IF_IP="90.90.97.28"
export HCCL_OP_EXPANSION_MODE="AIV"
export HCCL_BUFFSIZE=1024
export OMP_NUM_THREADS=1
export TASK_QUEUE_ENABLE=1
export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD

vllm serve /tmp/liaobiting/weights/Qwen3.6-27B-W8A8/ \
    --served-model-name "qwen3.6" \
    --host 0.0.0.0 \
    --port 1111 \
    --quantization ascend \
    --data-parallel-size 1 \
    --tensor-parallel-size 2 \
    --max-model-len 262144 \
    --max-num-batched-tokens 25600 \
    --max-num-seqs 128 \
    --gpu-memory-utilization 0.94 \
    --compilation-config '{"cudagraph_capture_sizes":[1,2,3,4,8,12,16,24,32,48], "cudagraph_mode":"FULL_DECODE_ONLY"}' \
    --trust-remote-code \
    --async-scheduling \
    --allowed-local-media-path / \
    --no-enable-prefix-caching \
    --mm-processor-cache-gb 0 \
    --additional-config '{"enable_cpu_binding":true}'
```
2、modify ais_bench/benchmark/configs/models/vllm_api/vllm_api_general_chat.py
```
from ais_bench.benchmark.models import VLLMCustomAPIChat
from ais_bench.benchmark.utils.postprocess.model_postprocessors import extract_non_reasoning_content

models = [
    dict(
        attr="service",
        type=VLLMCustomAPIChat,
        abbr="vllm-api-general-chat",
        path="/mnt/share/weights/Qwen3.6-27B",
        model="qwen3.6",
        stream=False,
        request_rate=0,
        use_timestamp=False,
        retry=2,
        api_key="",
        host_ip="141.61.81.51",
        host_port=8888,
        url="",
        max_out_len=131072,
        batch_size=32,
        trust_remote_code=False,
        generation_kwargs=dict(
            temperature=1.0,
            top_p=0.95,
            top_k=20,
            min_p=0.0,
            presence_penalty=0.0,
            repetition_penalty=1.0,
            ignore_eos=False,
        ),
        pred_postprocessor=dict(type=extract_non_reasoning_content),
    )
]
```

3、run aisbench for GPQA dataset
```
for((i=1;i<=5;i++)) do ais_bench --models vllm_api_general_chat --datasets gpqa_gen_0_shot_cot_chat_prompt --debug --dump-eval-details; done
```

4、GPQA results
```
| GPQA_diamond | b1ed2c | accuracy | gen | 87.88 |
| GPQA_diamond | b1ed2c | accuracy | gen | 82.32 |
| GPQA_diamond | b1ed2c | accuracy | gen | 84.85 |
| GPQA_diamond | b1ed2c | accuracy | gen | 86.36 |
| GPQA_diamond | b1ed2c | accuracy | gen | 85.86 |
```

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
