### PR TITLE
[BugFix][310P] Align MoE finalize path with upstream FusedMoE refactor

### DIFF
--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -74,8 +74,8 @@ class TestMoECommMethod(TestBase):
         mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
 
         # Test finalize method
-        comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
-        mock_pf_instance.finalize.assert_called_once_with(h_out, True, None)
+        comm_impl.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
+        mock_pf_instance.finalize.assert_called_once_with(h_out, padded_hidden_states_shape=None)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithMC2")
@@ -115,8 +115,8 @@ class TestMoECommMethod(TestBase):
         mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
 
         # Test finalize method
-        comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
-        mock_pf_instance.finalize.assert_called_once_with(h_out, True, None)
+        comm_impl.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
+        mock_pf_instance.finalize.assert_called_once_with(h_out, padded_hidden_states_shape=None)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAll2All")

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -54,7 +54,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         self.assertEqual(padded_hidden_states_shape, torch.Size([4, 8]))
 
         # Finalize
-        result = layer.finalize(h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape)
+        result = layer.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
         self.assertEqual(result.shape[0], 3)
 
     @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=2)
@@ -89,9 +89,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         mock_all_gather.side_effect = mock_all_gather_func
 
         layer.split_hidden_states = [torch.zeros_like(h_out), torch.zeros_like(h_out)]
-        final_result = layer.finalize(
-            h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape
-        )
+        final_result = layer.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
 
         # Should concat back to original size
         self.assertEqual(final_result.shape[0], 4)
@@ -111,7 +109,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         self.assertEqual(h_out.shape[0], 3)
         self.assertEqual(padded_hidden_states_shape, torch.Size([3, 8]))
 
-        result = layer.finalize(h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape)
+        result = layer.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
         self.assertEqual(result.shape[0], 3)
 
     @patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_tensor_model_parallel_world_size", return_value=2)
@@ -140,9 +138,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         mock_all_gather.side_effect = mock_all_gather_func
 
         layer.split_hidden_states = [torch.zeros_like(h_out), torch.zeros_like(h_out)]
-        final_result = layer.finalize(
-            h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape
-        )
+        final_result = layer.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
 
         # Should concat back
         self.assertEqual(final_result.shape[0], 2)
@@ -195,9 +191,9 @@ class TestPrepareAndFinalize(unittest.TestCase):
             return tensor[:3]
 
         mock_dp_group.reduce_scatter = mock_reduce_scatter_func
-        result = layer.finalize(h_out, reduce_results=False, padded_hidden_states_shape=padded_hidden_states_shape)
+        result = layer.finalize(h_out, padded_hidden_states_shape=padded_hidden_states_shape)
 
         self.assertEqual(result.shape[0], 3)
 
-        result_with_tp = layer.finalize(h_out, reduce_results=True)
+        result_with_tp = layer.finalize(h_out)
         self.assertEqual(result_with_tp.shape[0], 3)

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -181,7 +181,6 @@ class AscendFusedMoE310(FusedMoE):
             kwargs.pop("gate", None),
             kwargs.pop("shared_experts", None),
             self.quant_method,
-            self.reduce_results,
             self.vllm_config.parallel_config.enable_dbo,
         )
 
@@ -267,9 +266,9 @@ class AscendFusedMoE310(FusedMoE):
             pertoken_scale=pertoken_scale,
         )
 
-        routed_out = _EXTRA_CTX.moe_comm_method.finalize(
+        moe_comm_method = _EXTRA_CTX.moe_comm_method
+        routed_out = moe_comm_method.finalize(
             hidden_states=fused_experts_results.routed_out,
-            reduce_results=self.reduce_results,
             padded_hidden_states_shape=padded_hidden_states_shape,
         )
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -653,7 +653,6 @@ class AscendFusedMoE(FusedMoE):
 
         routed_out = _EXTRA_CTX.moe_comm_method.finalize(
             hidden_states=fused_experts_results.routed_out,
-            reduce_results=isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl),
             padded_hidden_states_shape=padded_hidden_states_shape,
         )
 

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -108,10 +108,12 @@ class MoECommMethod(ABC):
     def finalize(
         self,
         hidden_states: torch.Tensor,
-        reduce_results: bool,
         padded_hidden_states_shape: torch.Size | None = None,
     ) -> torch.Tensor:
-        hidden_states = self.prepare_finalize.finalize(hidden_states, reduce_results, padded_hidden_states_shape)
+        hidden_states = self.prepare_finalize.finalize(
+            hidden_states,
+            padded_hidden_states_shape=padded_hidden_states_shape,
+        )
         return hidden_states
 
     def fused_experts(

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -92,7 +92,6 @@ class PrepareAndFinalize(ABC):
     def finalize(
         self,
         hidden_states: torch.Tensor,
-        reduce_results: bool,
         padded_hidden_states_shape: torch.Size | None = None,
     ) -> torch.Tensor:
         """
@@ -100,11 +99,9 @@ class PrepareAndFinalize(ABC):
           - Gathering sliced tensors across TP ranks
           - Reducing or scattering across DP ranks
           - Unpadding to original token count
-          - Applying all-reduce across TP/EP if requested
 
         Args:
             hidden_states (torch.Tensor): MoE layer output, possibly padded or sliced
-            reduce_results (bool): Whether to apply all-reduce across TP/EP groups
 
         Returns:
             torch.Tensor: Final output with shape [original_num_tokens, hidden_size]
@@ -178,7 +175,6 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
     def finalize(
         self,
         hidden_states: torch.Tensor,
-        reduce_results: bool,
         padded_hidden_states_shape: torch.Size | None = None,
     ) -> torch.Tensor:
         """
@@ -427,7 +423,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
     def finalize(
         self,
         hidden_states: torch.Tensor,
-        reduce_results: bool,
         padded_hidden_states_shape: torch.Size | None = None,
     ) -> torch.Tensor:
         """
@@ -440,28 +435,22 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         if enable_sp() or enable_sp_by_pass():
             return self._finalize_with_ep_group(hidden_states)
 
-        return self._finalize_with_dp_group(hidden_states, reduce_results)
+        return self._finalize_with_dp_group(hidden_states)
 
     def _finalize_with_ep_group(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """
-        Argument `reduce_results` is not needed in this func. Given sequence parallelism is enabled:
-        1. Reduce_results is False usually happens when models have shared experts and need to
-        allreduce hidden states after results of shared experts and routed experts are added in FusedMoe.
-        We do reduce scatter for hidden states here, then skip allreudce in FusedMoe and add it to the
-        result of shared experts.
-        2 Reduce_results is True usually happens when model has no shared experts. We still do reduce scatter
-        here, then skip allreudce in FusedMoe.
+        Given sequence parallelism is enabled, reduce scatter is handled here
+        and the final output reduction is handled by the MoE runner.
         """
         hidden_states = torch.ops.vllm.maybe_pad_and_reduce(hidden_states, True)
 
         return hidden_states
 
-    def _finalize_with_dp_group(self, hidden_states: torch.Tensor, reduce_results: bool) -> torch.Tensor:
+    def _finalize_with_dp_group(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """
         Finalization steps:
           1. If DP > 1 and not shared expert, reduce-scatter output across DP group.
           2. Slice to original local token count.
-          3. If `reduce_results=True` and TP/EP > 1, apply tensor_model_parallel_all_reduce.
 
         Returns:
             Tensor with shape [original_local_num_tokens, hidden_size]


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the 310P multicard MoE CI failure after syncing upstream vLLM.

The breakage was introduced by upstream vLLM PR https://github.com/vllm-project/vllm/pull/35949, which removed the `reduce_results` argument and `self.reduce_results` state from `FusedMoE` and moved shared/routed output reduction logic into `MoERunnerBase`.

After vLLM Ascend synced to a newer upstream vLLM commit in #8899, the 310P MoE path still referenced `self.reduce_results`, causing model initialization to fail with:

```text
AttributeError: 'AscendFusedMoE310' object has no attribute 'reduce_results'
```

This PR updates the Ascend MoE finalize path to match the new upstream interface:

- Removes reduce_results from MoE comm/finalize APIs
- Removes stale self.reduce_results usage from the 310P MoE path
- Updates common Ascend MoE finalize calls accordingly
- Updates unit tests for the new finalize signature

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
