### PR TITLE
[CI][310P] Fixing the error reported when uninstalling Triton and fix moe bug on 310

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -822,6 +822,10 @@ jobs:
             uv pip install -v -e .
           fi
 
+      - name: Uninstall triton-ascend (310p e2e-light)
+        if: ${{ inputs.type == 'light' }}
+        run: uv pip uninstall triton-ascend
+
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}
         env:
@@ -928,6 +932,10 @@ jobs:
           else
             uv pip install -v -e .
           fi
+
+      - name: Uninstall triton-ascend (310p e2e-light)
+        if: ${{ inputs.type == 'light' }}
+        run: uv pip uninstall triton-ascend
 
       - name: Run vllm-project/vllm-ascend test
         env:

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -23,7 +23,11 @@ from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFuse
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
-from vllm_ascend.ops.fused_moe.moe_comm_method import FusedExpertsResult, _MoECommMethods
+from vllm_ascend.ops.fused_moe.moe_comm_method import (
+    AllGatherCommImpl,
+    FusedExpertsResult,
+    _MoECommMethods,
+)
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -181,7 +185,6 @@ class AscendFusedMoE310(FusedMoE):
             kwargs.pop("gate", None),
             kwargs.pop("shared_experts", None),
             self.quant_method,
-            self.reduce_results,
             self.vllm_config.parallel_config.enable_dbo,
         )
 
@@ -269,7 +272,7 @@ class AscendFusedMoE310(FusedMoE):
 
         routed_out = _EXTRA_CTX.moe_comm_method.finalize(
             hidden_states=fused_experts_results.routed_out,
-            reduce_results=self.reduce_results,
+            reduce_results=isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl),
             padded_hidden_states_shape=padded_hidden_states_shape,
         )
 

--- a/vllm_ascend/_310p/ops/fla/idex.py
+++ b/vllm_ascend/_310p/ops/fla/idex.py
@@ -22,7 +22,6 @@ from vllm.model_executor.layers.fla.ops.utils import tensor_cache
 
 @tensor_cache
 def prepare_chunk_indices_310(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
-
     seq_lens = prepare_lens(cu_seqlens)
     num_chunks = (seq_lens + chunk_size - 1) // chunk_size
 
@@ -36,7 +35,6 @@ def prepare_chunk_indices_310(cu_seqlens: torch.Tensor, chunk_size: int) -> torc
 
 @tensor_cache
 def prepare_chunk_offsets_310(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
-
     seq_lens = prepare_lens(cu_seqlens)
 
     num_chunks = (seq_lens + chunk_size - 1) // chunk_size

--- a/vllm_ascend/_310p/ops/fla/idex.py
+++ b/vllm_ascend/_310p/ops/fla/idex.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# from collections.abc import Iterable
+# mypy: ignore-errors
+import torch
+from vllm.model_executor.layers.fla.ops.index import prepare_lens
+from vllm.model_executor.layers.fla.ops.utils import tensor_cache
+
+
+@tensor_cache
+def prepare_chunk_indices_310(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+
+    seq_lens = prepare_lens(cu_seqlens)
+    num_chunks = (seq_lens + chunk_size - 1) // chunk_size
+
+    indices_list = []
+    for n in num_chunks.tolist():
+        indices_list.append(torch.arange(n, device=cu_seqlens.device))
+    indices = torch.cat(indices_list)
+
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], dim=1).to(cu_seqlens)
+
+
+@tensor_cache
+def prepare_chunk_offsets_310(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+
+    seq_lens = prepare_lens(cu_seqlens)
+
+    num_chunks = (seq_lens + chunk_size - 1) // chunk_size
+
+    return torch.cat([torch.tensor([0], device=cu_seqlens.device, dtype=cu_seqlens.dtype), num_chunks]).cumsum(dim=-1)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -38,7 +38,8 @@ if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_gdn_attn  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
-
+else:
+    import vllm_ascend.patch.worker.patch_idex_310  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa
 import vllm_ascend.patch.worker.patch_v2.patch_uva  # noqa
 import vllm_ascend.patch.worker.patch_huanyuan_vl  # noqa

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,0 +1,9 @@
+import vllm
+from vllm_ascend._310p.ops.fla.idex import (
+    prepare_chunk_indices_310,
+    prepare_chunk_offsets_310,
+)
+
+vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices=prepare_chunk_indices_310
+
+vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets=prepare_chunk_offsets_310

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,9 +1,10 @@
 import vllm
+
 from vllm_ascend._310p.ops.fla.idex import (
     prepare_chunk_indices_310,
     prepare_chunk_offsets_310,
 )
 
-vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices=prepare_chunk_indices_310
+vllm.model_executor.layers.fla.ops.index.prepare_chunk_indices = prepare_chunk_indices_310
 
-vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets=prepare_chunk_offsets_310
+vllm.model_executor.layers.fla.ops.index.prepare_chunk_offsets = prepare_chunk_offsets_310


### PR DESCRIPTION
### What this PR does / why we need it?
1. After the mainline modification of VLLM, the triton.cdiv operator is called by default. However, after unloading Triton on the 310P, it cannot be called, leading to an error. The fix involves adding a new patch file for the 310P to replace the Triton implementation with a Torch implementation.  
2. The fused_moe was refactored, but the code modifications for the 310P were missed. The fix involves synchronizing the changes made in the vllm-ascend mainline.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/4d51588e2381018348f1022dfa3a7698899805b7
