### PR TITLE
[BugFix] Fix quantization accuracy bug

### DIFF
--- a/vllm_ascend/_310p/fused_moe/experts_selector.py
+++ b/vllm_ascend/_310p/fused_moe/experts_selector.py
@@ -31,6 +31,7 @@ def select_experts(
     num_expert_group: int | None = None,
     custom_routing_function: Callable | None = None,
     scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
     e_score_correction_bias: torch.Tensor | None = None,
     global_num_experts: int = -1,
 ):
@@ -48,6 +49,7 @@ def select_experts(
         custom_routing_function: Custom routing function.
         scoring_func: Scoring function to use.
         e_score_correction_bias: Correction bias to apply to expert scores.
+        routed_scaling_factor: Scaling factor applied to routing weights.
         global_num_experts: Global number of experts.
 
     Returns:
@@ -67,4 +69,8 @@ def select_experts(
         e_score_correction_bias=e_score_correction_bias,
         num_experts=global_num_experts,
     )
+    # Apply routed scaling factor to weights
+    if routed_scaling_factor != 1.0:
+        topk_weights = topk_weights * routed_scaling_factor
+
     return topk_weights, topk_ids

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -115,6 +115,7 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             global_num_experts=num_experts,
         )

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -102,6 +102,9 @@ def select_experts(
             e_score_correction_bias=e_score_correction_bias,
             num_experts=num_experts,
         )
+        # Apply routed scaling factor to weights
+        if routed_scaling_factor != 1.0:
+            topk_weights = topk_weights * routed_scaling_factor
     if mix_placement:
         shared_expert_routing_factor = 1.0 if is_support_npu_moe_gating_top_k else (1 / routed_scaling_factor)
         batch_size = topk_ids.shape[0]

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -307,6 +307,11 @@ class AscendFusedMoE(FusedMoE):
     gate_stream: torch.npu.Stream | None = None
 
     def __init__(self, *args, **kwargs):
+        # Save original routed_scaling_factor before super().__init__ modifies it.
+        # When apply_routed_scale_to_output=True, vLLM sets self.routed_scaling_factor
+        # to 1.0 and expects the runner to apply scaling to output. But vllm-ascend
+        # uses its own forward path, so we need the original value.
+        self._original_routed_scaling_factor = kwargs.get("routed_scaling_factor", 1.0)
         super().__init__(*args, **kwargs)
         self.use_overlapped = True
         self._routed_input_transform = kwargs.get("routed_input_transform")
@@ -578,7 +583,7 @@ class AscendFusedMoE(FusedMoE):
                     num_expert_group=self.num_expert_group,
                     custom_routing_function=self.custom_routing_function,
                     scoring_func=self.scoring_func,
-                    routed_scaling_factor=self.routed_scaling_factor,
+                    routed_scaling_factor=self._original_routed_scaling_factor,
                     e_score_correction_bias=self.e_score_correction_bias,
                     num_experts=self.moe_config.num_experts,
                 )
@@ -621,7 +626,7 @@ class AscendFusedMoE(FusedMoE):
             num_expert_group=self.num_expert_group,
             custom_routing_function=self.custom_routing_function,
             scoring_func=self.scoring_func,
-            routed_scaling_factor=self.routed_scaling_factor,
+            routed_scaling_factor=self._original_routed_scaling_factor,
             e_score_correction_bias=self.e_score_correction_bias,
             activation=self.activation,
             apply_router_weight_on_input=self.apply_router_weight_on_input,

--- a/vllm_ascend/quantization/methods/w4a16.py
+++ b/vllm_ascend/quantization/methods/w4a16.py
@@ -220,6 +220,7 @@ class AscendW4A16FusedMoEMethod(AscendMoEScheme):
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             num_experts=num_logical_experts,
         )

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -207,6 +207,7 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             num_experts=num_logical_experts,
         )

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -371,6 +371,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             num_experts=num_logical_experts,
         )

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -266,6 +266,7 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             num_experts=num_logical_experts,
         )


### PR DESCRIPTION
### What this PR does / why we need it?
This PR propagates the `routed_scaling_factor` parameter from the quantization methods' `apply` functions to the expert selection logic. This is necessary for maintaining accuracy in models that use a scaling factor for routing weights (e.g., DeepSeek-V2/V3).
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Not specified in the PR description.

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
