### PR TITLE
[CI] Add csrc cache for image build

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -12,6 +12,7 @@ self-hosted-runner:
     - linux-aarch64-a3-0
     - linux-amd64-cpu-8-hk
     - linux-amd64-cpu-16-hk
+    - linux-arm64-cpu-16
     - linux-aarch64-a2b3-0
     - linux-aarch64-a2b3-1
     - linux-aarch64-a2b3-2

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -138,6 +138,32 @@ jobs:
           echo "value=buildcache-${{ matrix.tag }}" >> $GITHUB_OUTPUT
         fi
 
+    - name: Get csrc hash
+      id: get_csrc_hash
+      run: |
+        CSRC_HASH=$(find ./csrc ./setup.py ./CMakeLists.txt ./cmake \
+        -type f -not -path '*/.*' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+        echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
+
+    - name: Get Dockerfile base image tag
+      id: get_base_image_tag
+      run: |
+        DOCKERFILE="${{ inputs.dockerfile || 'Dockerfile' }}"
+        BASE_IMAGE_TAG=$(grep -m1 '^FROM' "$DOCKERFILE" | awk -F: '{print $NF}')
+        echo "BASE_IMAGE_TAG=$BASE_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Cache vllm-ascend csrc
+      id: cache-csrc
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+            vllm_ascend/_cann_ops_custom
+            vllm_ascend/*.so
+            vllm_ascend/lib
+            vllm_ascend/include
+        key: vllm-ascend-build-v1-${{ runner.arch }}-${{ steps.get_base_image_tag.outputs.BASE_IMAGE_TAG }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+
+
     - name: Build and push
       uses: docker/build-push-action@v7
       id: build
@@ -151,6 +177,7 @@ jobs:
         outputs: type=image,name=${{ env.QUAY_REPO }},push-by-digest=true,name-canonical=true,push=${{ inputs.should_push }}
         build-args: |
           PIP_INDEX_URL=https://pypi.org/simple
+          COMPILE_CUSTOM_KERNELS=${{ steps.cache-csrc.outputs.cache-hit == 'true' && '0' || '1' }}
         provenance: false
         # To speed up the build, we use registry cache. The cache tag is determined by the suffix and architecture, and shared across different workflow runs.
         # For example, the cache tag for arm64 image with suffix "openeuler" will be "buildcache-openeuler-arm64".

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -67,7 +67,7 @@ jobs:
         include:
           # arch → runner
           - arch: X64
-            runner: linux-amd64-cpu-8-hk
+            runner: linux-amd64-cpu-16-hk
           - arch: ARM64
             runner: linux-arm64-cpu-16
 

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -15,7 +15,8 @@
 # This file is a part of the vllm-ascend project.
 #
 
-# This workflow builds vllm-ascend csrc and uploads the build cache to GitHub Actions.
+# Prototype: unified csrc build matrix — arch × os × chip_type
+# Cartesian product: 2 arch × 2 os × 3 chip_type = 12 jobs
 name: 'Cache csrc Build Artifacts'
 on:
   push:
@@ -26,15 +27,12 @@ on:
       - 'CMakeLists.txt'
       - 'cmake/**'
   workflow_dispatch:
+  pull_request:
 
-# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
-# declared as "shell: bash -el {0}" on steps that need to be properly activated.
-# It's used to activate ascend-toolkit environment variables.
 defaults:
   run:
     shell: bash -el {0}
 
-# only cancel in-progress runs of the same workflow
 concurrency:
   group: ascend-csrc-build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -48,54 +46,113 @@ env:
 
 jobs:
   build-cache:
-    name: linux-aarch64-${{ matrix.platform }}-image
+    name: build-${{ matrix.arch }}-${{ matrix.chip_type }}-${{ matrix.os }}-cache
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - X64
+          - ARM64
+        os:
+          - ubuntu
+          - openeuler
+        chip_type:
+          - a2
+          - a3
+          - 310p
+
+        # ── arch → runner ────────────────────────────────────────────────────
+        # ── chip_type → soc_version ──────────────────────────────────────────
+        # ── os × chip_type → image ───────────────────────────────────────────
         include:
-          - platform: a2
-            runner: linux-aarch64-a2b3-1
+          # arch → runner
+          - arch: X64
+            runner: linux-amd64-cpu-8-hk
+          - arch: ARM64
+            runner: linux-arm64-cpu-16
+
+          # chip_type → soc_version
+          - chip_type: a2
+            soc_version: ascend910b1
+          - chip_type: a3
+            soc_version: ascend910_9391
+          - chip_type: 310p
+            soc_version: ascend310p1
+
+          # os × chip_type → image
+          - os: ubuntu
+            chip_type: a2
             image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-910b-ubuntu22.04-py3.11
-            install_clang: true
-          - platform: a3
-            runner: linux-aarch64-a3-2
+          - os: ubuntu
+            chip_type: a3
             image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-a3-ubuntu22.04-py3.11
-            install_clang: true
-          - platform: 310p
-            runner: linux-aarch64-310p-1
+          - os: ubuntu
+            chip_type: 310p
             image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-310p-ubuntu22.04-py3.11
-            install_clang: false
+          - os: openeuler
+            chip_type: a2
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-910b-openeuler24.03-py3.11
+          - os: openeuler
+            chip_type: a3
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-a3-openeuler24.03-py3.11
+          - os: openeuler
+            chip_type: 310p
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.1-310p-openeuler24.03-py3.11
+
     container:
       image: ${{ matrix.image }}
     steps:
-      - name: Checkout vllm-project/vllm-ascend repo
+      - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Check npu and CANN info
-        run: |
-          npu-smi info
-          cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
-
-      - name: Config mirrors
+      - name: Config mirrors (ubuntu)
+        if: matrix.os == 'ubuntu'
         run: |
           sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
           pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
           apt-get update -y
-          apt install git -y
+          apt-get install -y git zstd
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
+          git config --global --add safe.directory /__w/vllm-benchmarks/vllm-benchmarks
 
-      - name: Install system dependencies
+      - name: Config mirrors (openeuler)
+        if: matrix.os == 'openeuler'
+        run: |
+          pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+          pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+          sed -Ei 's@https?://[^/]+/(openeuler|centos|fedora)@http://cache-service.nginx-pypi-cache.svc.cluster.local:8081/\1@g' /etc/yum.repos.d/*.repo
+          yum install -y git zstd
+          git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
+          git config --global --add safe.directory /__w/vllm-benchmarks/vllm-benchmarks
+
+      - name: Install system dependencies (ubuntu)
+        if: matrix.os == 'ubuntu'
         run: |
           apt-get -y install `cat packages.txt`
-          apt-get -y install gcc g++ cmake libnuma-dev
-          if [ "${{ matrix.install_clang }}" = "true" ]; then
-            apt-get -y install clang-15
-            update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
-            update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
-          fi
+          apt-get -y install gcc g++ cmake libnuma-dev zstd
           pip install uv
+
+      - name: Install system dependencies (openeuler)
+        if: matrix.os == 'openeuler'
+        run: |
+          yum install -y gcc gcc-c++ cmake numactl-devel clang
+          pip install uv
+
+      - name: Install clang (ubuntu, non-310p only)
+        if: matrix.os == 'ubuntu' && matrix.chip_type != '310p'
+        run: |
+          apt-get -y install clang-15
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
+
+      - name: Get image tag
+        id: get_image_tag
+        run: |
+          IMAGE="${{ matrix.image }}"
+          IMAGE_TAG="${IMAGE##*:}"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Get csrc hash
         id: get_csrc_hash
@@ -105,23 +162,38 @@ jobs:
           echo "CSRC_HASH=$CSRC_HASH" >> $GITHUB_OUTPUT
 
       - name: Cache vllm-ascend csrc
-        uses: runs-on/cache@v4
+        id: cache-csrc
+        uses: actions/cache@v4
         with:
           path: |
             vllm_ascend/_cann_ops_custom
             vllm_ascend/*.so
             vllm_ascend/lib
             vllm_ascend/include
-          key: vllm-ascend-build-v1-${{ runner.os }}-${{ matrix.image }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
-          restore-keys: |
-            vllm-ascend-build-v1-${{ runner.os }}-${{ matrix.image }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
+          key: vllm-ascend-build-v1-${{ matrix.arch }}-${{ steps.get_image_tag.outputs.IMAGE_TAG }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
-      - name: Install vllm-project/vllm-ascend
+      - name: Install vllm-ascend
+        if: steps.cache-csrc.outputs.cache-hit != 'true'
         env:
-          PIP_EXTRA_INDEX_URL: https://mirrors.huaweicloud.com/ascend/repos/pypi
+          SOC_VERSION: ${{ matrix.soc_version }}
+          MAX_JOBS: "4"
         run: |
-          if ! find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
-            pip install uc-manager
-            uv pip install -r requirements-dev.txt
-            uv pip install -v -e .
+          source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          source /usr/local/Ascend/nnal/atb/set_env.sh
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib
+
+          # os-specific: openeuler needs C++ include path for compilation
+          if [ "${{ matrix.os }}" = "openeuler" ]; then
+            export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux
           fi
+
+          # X64 needs pytorch cpu whl index; ARM runner has no network access to it
+          if [ "${{ matrix.arch }}" = "X64" ]; then
+            EXTRA_INDEX="--extra-index-url https://download.pytorch.org/whl/cpu/"
+          else
+            EXTRA_INDEX=""
+          fi
+
+          pip install uc-manager
+          uv pip install -r requirements-dev.txt $EXTRA_INDEX
+          uv pip install -v -e . $EXTRA_INDEX

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -114,7 +114,6 @@ jobs:
           apt-get update -y
           apt-get install -y git zstd
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
-          git config --global --add safe.directory /__w/vllm-benchmarks/vllm-benchmarks
 
       - name: Config mirrors (openeuler)
         if: matrix.os == 'openeuler'
@@ -124,7 +123,6 @@ jobs:
           sed -Ei 's@https?://[^/]+/(openeuler|centos|fedora)@http://cache-service.nginx-pypi-cache.svc.cluster.local:8081/\1@g' /etc/yum.repos.d/*.repo
           yum install -y git zstd
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
-          git config --global --add safe.directory /__w/vllm-benchmarks/vllm-benchmarks
 
       - name: Install system dependencies (ubuntu)
         if: matrix.os == 'ubuntu'
@@ -175,7 +173,7 @@ jobs:
         if: steps.cache-csrc.outputs.cache-hit != 'true'
         env:
           SOC_VERSION: ${{ matrix.soc_version }}
-          MAX_JOBS: "8"
+          MAX_JOBS: "16"
         run: |
           source /usr/local/Ascend/ascend-toolkit/set_env.sh
           source /usr/local/Ascend/nnal/atb/set_env.sh

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -60,9 +60,6 @@ jobs:
           - a3
           - 310p
 
-        # ── arch → runner ────────────────────────────────────────────────────
-        # ── chip_type → soc_version ──────────────────────────────────────────
-        # ── os × chip_type → image ───────────────────────────────────────────
         include:
           # arch → runner
           - arch: X64
@@ -127,7 +124,9 @@ jobs:
         if: matrix.os == 'ubuntu'
         run: |
           apt-get -y install `cat packages.txt`
-          apt-get -y install gcc g++ cmake libnuma-dev zstd
+          apt-get -y install gcc g++ cmake libnuma-dev zstd clang-15
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
           pip install uv
 
       - name: Install system dependencies (openeuler)
@@ -135,13 +134,6 @@ jobs:
         run: |
           yum install -y gcc gcc-c++ cmake numactl-devel clang
           pip install uv
-
-      - name: Install clang (ubuntu, non-310p only)
-        if: matrix.os == 'ubuntu' && matrix.chip_type != '310p'
-        run: |
-          apt-get -y install clang-15
-          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
-          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
 
       - name: Get image tag
         id: get_image_tag

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -175,7 +175,7 @@ jobs:
         if: steps.cache-csrc.outputs.cache-hit != 'true'
         env:
           SOC_VERSION: ${{ matrix.soc_version }}
-          MAX_JOBS: "4"
+          MAX_JOBS: "8"
         run: |
           source /usr/local/Ascend/ascend-toolkit/set_env.sh
           source /usr/local/Ascend/nnal/atb/set_env.sh

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -26,7 +26,6 @@ on:
       - 'CMakeLists.txt'
       - 'cmake/**'
   workflow_dispatch:
-  pull_request:
 
 defaults:
   run:

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -15,7 +15,6 @@
 # This file is a part of the vllm-ascend project.
 #
 
-# Prototype: unified csrc build matrix — arch × os × chip_type
 # Cartesian product: 2 arch × 2 os × 3 chip_type = 12 jobs
 name: 'Cache csrc Build Artifacts'
 on:
@@ -180,11 +179,12 @@ jobs:
         run: |
           source /usr/local/Ascend/ascend-toolkit/set_env.sh
           source /usr/local/Ascend/nnal/atb/set_env.sh
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib
+          arch=$(uname -i)
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/${arch}-linux/devlib
 
           # os-specific: openeuler needs C++ include path for compilation
           if [ "${{ matrix.os }}" = "openeuler" ]; then
-            export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/`uname -i`-openEuler-linux
+            export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/c++/12:/usr/include/c++/12/${arch}-openEuler-linux
           fi
 
           # X64 needs pytorch cpu whl index; ARM runner has no network access to it

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910b1"
+ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -42,6 +42,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend310p1"
+ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -41,6 +41,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend310p1"
+ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
     OMP_NUM_THREADS=1

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -59,6 +59,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -v -e /vllm-workspace/vllm
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910_9391"
+ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -58,6 +58,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910_9391"
+ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
     OMP_NUM_THREADS=1

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -58,6 +58,7 @@ RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[a
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend910b1"
+ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
     OMP_NUM_THREADS=1

--- a/csrc/build.sh
+++ b/csrc/build.sh
@@ -31,6 +31,7 @@ CLANG="false"
 VERBOSE="false"
 OOM="false"
 THREAD_NUM=$(grep -c ^processor /proc/cpuinfo)
+MAX_JOBS=${MAX_JOBS:-}
 ENABLE_VALGRIND=FALSE
 ENABLE_CREATE_LIB=FALSE
 ENABLE_OPKERNEL=FALSE
@@ -1329,10 +1330,19 @@ else
 fi
 
 function get_cpu_num() {
-    CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2)) 
+    CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2))
     if [ -n "${OPS_CPU_NUMBER}" ]; then
         if [[ "${OPS_CPU_NUMBER}" =~ ^[0-9]+$ ]]; then
             CPU_NUM="${OPS_CPU_NUMBER}"
+        fi
+    fi
+    if [ -n "${MAX_JOBS}" ]; then
+        if [[ "${MAX_JOBS}" =~ ^[0-9]+$ ]] && [ "${MAX_JOBS}" -gt 0 ]; then
+            if [ "${CPU_NUM}" -gt "${MAX_JOBS}" ]; then
+                CPU_NUM="${MAX_JOBS}"
+            fi
+        else
+            echo "Warning: MAX_JOBS='${MAX_JOBS}' is invalid, ignored." >&2
         fi
     fi
 }
@@ -1392,7 +1402,6 @@ else
     fi
 fi
 build_ut() {
-  CORE_NUMS=$(cat /proc/cpuinfo | grep "processor" | wc -l)
   dotted_line="----------------------------------------------------------------"
   echo $dotted_line
   echo "Start to build ut"
@@ -1416,7 +1425,7 @@ build_ut() {
     for UT_TARGET in ${UT_TARGETS[@]} ; do
         if cmake --build . --target help | grep -w "$UT_TARGET"; then
             echo "Building target: $UT_TARGET."
-            if ! cmake --build . --target ${UT_TARGET} -j $CORE_NUMS; then
+            if ! cmake --build . --target ${UT_TARGET} ${JOB_NUM}; then
                 echo "[ERROR] Build failed for target: $UT_TARGET."
                 exit 1
             fi

--- a/setup.py
+++ b/setup.py
@@ -498,8 +498,6 @@ def get_requirements() -> list[str]:
     return requirements
 
 
-# For test
-# Test for 16jobs
 cmdclass = {
     "develop": custom_develop,
     "build_py": custom_build_info,

--- a/setup.py
+++ b/setup.py
@@ -498,6 +498,8 @@ def get_requirements() -> list[str]:
     return requirements
 
 
+# For test
+# Test for 16jobs
 cmdclass = {
     "develop": custom_develop,
     "build_py": custom_build_info,


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request introduces a csrc build artifact caching mechanism into image building, which is expected to reduce image build time from 50 minutes to 10 minutes.

<img width="1315" height="808" alt="image" src="https://github.com/user-attachments/assets/0441297b-24c5-46f3-9a84-7cff719e4d63" />


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
