### PR TITLE
[Ops] Add a new Ops store_kv_block

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -62,7 +62,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "causal_conv1d"
         "moe_grouped_matmul"
         "lightning_indexer_quant"
-        store_kv_block;
+        "store_kv_block"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -25,7 +25,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
     export CPATH=${ABSOLUTE_CATLASS_PATH}:${CPATH}
 
 
-    CUSTOM_OPS="moe_grouped_matmul;grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;copy_and_expand_eagle_inputs;causal_conv1d;lightning_indexer_quant;"
+    CUSTOM_OPS="moe_grouped_matmul;grouped_matmul_swiglu_quant_weight_nz_tensor_list;lightning_indexer_vllm;sparse_flash_attention;matmul_allreduce_add_rmsnorm;moe_init_routing_custom;moe_gating_top_k;add_rms_norm_bias;apply_top_k_top_p_custom;transpose_kv_cache_by_block;copy_and_expand_eagle_inputs;causal_conv1d;lightning_indexer_quant;store_kv_block;"
     SOC_ARG="ascend910b"
 elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     # ASCEND910C (A3) series
@@ -62,6 +62,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "causal_conv1d"
         "moe_grouped_matmul"
         "lightning_indexer_quant"
+        store_kv_block;
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/store_kv_block/op_host/CMakeLists.txt
+++ b/csrc/store_kv_block/op_host/CMakeLists.txt
@@ -1,0 +1,45 @@
+# This program is free software, you can redistribute it and/or modify it.
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This file is a part of the CANN Open Software.
+# Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ======================================================================================================================
+#add_definitions(-DMAX_BLOCK_NUM_=3)
+add_ops_compile_options(
+        OP_NAME StoreKVBlock
+        OPTIONS --cce-auto-sync=on
+                -Wno-deprecated-declarations
+                -Werror
+)
+
+# -o0
+# -g
+# --cce-ignore-always-inline=true
+target_sources(op_host_aclnn PRIVATE
+        store_kv_block_def.cpp
+)
+
+target_sources(optiling PRIVATE
+        store_kv_block_tiling.cpp
+        store_kv_block_common.cpp
+)
+
+if (NOT BUILD_OPEN_PROJECT)
+    target_sources(opmaster_ct PRIVATE
+        store_kv_block_tiling.cpp
+    )
+endif ()
+
+target_include_directories(optiling PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_sources(opsproto PRIVATE
+       store_kv_block_infershape.cpp
+)
+
+target_link_libraries(optiling
+    PRIVATE
+)

--- a/csrc/store_kv_block/op_host/error_log.h
+++ b/csrc/store_kv_block/op_host/error_log.h
@@ -1,0 +1,56 @@
+#ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+#define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+
+#include <string>
+#include "toolchain/slog.h"
+
+#define OP_LOGI(opname, ...)
+#define OP_LOGW(opname, ...)             \
+    do {                                 \
+        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
+        printf("\n");                    \
+    } while (0)
+
+#define OP_LOGE_WITHOUT_REPORT(opname, ...) \
+    do {                                    \
+        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
+        printf("\n");                       \
+    } while (0)
+
+#define OP_LOGE(opname, ...)              \
+    do {                                  \
+        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
+        printf("\n");                     \
+    } while (0)
+
+#define OP_LOGD(opname, ...)
+
+namespace optiling {
+
+#define VECTOR_INNER_ERR_REPORT_TILIING(op_name, err_msg, ...)   \
+    do {                                                         \
+        OP_LOGE_WITHOUT_REPORT(op_name, err_msg, ##__VA_ARGS__); \
+    } while (0)
+
+
+#define OP_CHECK_IF(cond, log_func, expr) \
+    do {                                      \
+        if (cond) {                           \
+            log_func;                         \
+            expr;                             \
+        }                                     \
+    } while (0)
+
+
+
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                          \
+    do {                                                                  \
+        if ((ptr) == nullptr) {                                           \
+            OP_LOGE(context->GetNodeType(), "%s is null", #ptr);               \
+            return ge::GRAPH_FAILED;                                      \
+        }                                                                 \
+    } while (0)
+
+}  // namespace optiling
+
+#endif  // OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_

--- a/csrc/store_kv_block/op_host/store_kv_block_common.cpp
+++ b/csrc/store_kv_block/op_host/store_kv_block_common.cpp
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file write_cache_by_group_list_common.cpp
+ * \brief
+ */
+#include "exe_graph/runtime/extended_kernel_context.h"
+#include "store_kv_block_common.h"
+#include <chrono>
+
+#include <cstdint>
+namespace optiling {
+
+void StoreKVBlockCommonTiling::PrintTilingData()
+{
+    std::cout<<context_->GetNodeName()<<" Start WriteCacheByGroupListTilingData printing"<<std::endl;
+    std::cout<<"params.blockTableSize "<< params.blockTableSize<<std::endl;
+    std::cout<<"params.typeByte "<< params.typeByte<<std::endl;
+    std::cout<<"params.tokenSize "<< params.tokenSize<<std::endl;
+    std::cout<<"params.corepernum "<< params.corepernum<<std::endl;
+    std::cout<<"params.coretail "<< params.coretail<<std::endl;
+    std::cout<<"params.numTokens "<< params.numTokens<<std::endl;
+    std::cout<<"params.numCache "<< params.numCache<<std::endl;
+    std::cout<<"params.groupInfoLen "<< params.groupInfoLen<<std::endl;
+    std::cout<<context_->GetNodeName()<<" End WriteCacheByGroupListTilingData printing"<<std::endl;
+
+}
+
+void StoreKVBlockCommonTiling::SetTiling()
+{
+    if (params.blockTableSize<=0) printf("[ZTLOG] params.blockTableSize<=0  \n");
+    else tilingData_.set_blockTableSize(params.blockTableSize);
+    if (params.typeByte<=0) printf("[ZTLOG] params.typeByte<=0 numTokens\n");
+    else  tilingData_.set_typeByte(params.typeByte);
+
+    if (params.tokenSize<=0) printf("[ZTLOG] params.tokenSize<=0 \n");
+    else tilingData_.set_tokenSize(params.tokenSize);
+    
+    if (params.corepernum<=0 && params.coretail==0) printf("[ZTLOG] params.corepernum<=0 && params.coretail==0 \n");
+    else tilingData_.set_corePerNum(params.corepernum); 
+    
+    if (params.coretail>=48) printf("[ZTLOG] params.coretail>=48 \n");
+    else tilingData_.set_coreTail(params.coretail); 
+    
+    if (params.numTokens<=0) printf("[ZTLOG] params.numTokens<=0 \n");
+    else tilingData_.set_numTokens(params.numTokens); 
+        
+    if (params.numCache<=0) printf("[ZTLOG] params.numCache<=0 \n");
+    else tilingData_.set_numCache(params.numCache); 
+
+    if (params.groupInfoLen<=0) printf("[ZTLOG] params.groupInfoLen<=0 \n");
+    else tilingData_.set_groupInfoLen(params.groupInfoLen); 
+
+    size_t* workspaceSize = context_->GetWorkspaceSizes(1);
+    *workspaceSize = params.workspaceSize + params.sysWorkspaceSize;
+    context_->SetTilingKey(params.tilingKey);
+    if (params.coreNum<=0) printf("[ZTLOG] params.coreNum<=0 \n");
+    else     context_->SetBlockDim(params.coreNum);
+
+    tilingData_.SaveToBuffer(context_->GetRawTilingData()->GetData(), context_->GetRawTilingData()->GetCapacity());
+    context_->GetRawTilingData()->SetDataSize(tilingData_.GetDataSize());
+    
+}
+
+ge::graphStatus StoreKVBlockCommonTiling::GetPlatformInfo()
+{
+    auto platformInfo = context_->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context_, platformInfo);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+    params.coreNum = ascendcPlatform.GetCoreNum();
+    OP_CHECK_IF((params.coreNum == 0),
+                    VECTOR_INNER_ERR_REPORT_TILIING(context_->GetNodeName(), "Failed to get core num."),
+                    return ge::GRAPH_FAILED);
+    params.sysWorkspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+    return ge::GRAPH_SUCCESS;
+}
+
+
+ge::graphStatus StoreKVBlockCommonTiling::DoCommonTiling()
+{
+    auto kShape = context_->GetInputShape(DIM_0);
+    auto kDimNum=kShape->GetStorageShape().GetDimNum();
+    if (kDimNum<2||kDimNum>7){
+        printf("[ERROR] StoreKVBlock Input kDimNum dim < 2 || kDimNum>7");
+    }else {
+        for (int i = 0; i < kDimNum; i++){
+            if(i==0) params.numTokens = static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i));
+            else if (i==1) params.numHeads = static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i));
+            else if(static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i))!=0)  params.headSize[i-2]=static_cast<uint32_t>(kShape->GetStorageShape().GetDim(i));
+        }
+    }
+
+    auto kCacheShape = context_->GetInputShape(DIM_1);
+    auto kCacheDimNum=kCacheShape->GetStorageShape().GetDimNum();
+    if (kCacheDimNum<2||kCacheDimNum>7){
+        printf("[ERROR] StoreKVBlock Input kCacheDimNum < 2 ");
+    }else {
+        params.numCache = kCacheShape->GetStorageShape().GetDim(0)* kCacheShape->GetStorageShape().GetDim(1);
+    }
+
+    const int64_t* blockSizePtr = context_->GetAttrs()->GetInt(0);
+    uint32_t blockSize = static_cast<uint32_t>(* blockSizePtr);
+    params.tokenSize =  params.numHeads * params.headSize[0] * params.headSize[1] * params.headSize[2] * params.headSize[3] * params.headSize[4];
+    params.blockTableSize =  blockSize;
+
+    uint32_t typeByte = 0;
+    auto xDataType = context_->GetInputDesc(DIM_0)->GetDataType();
+    if (xDataType == ge::DataType::DT_INT8) {
+        typeByte = sizeof(int8_t);
+        params.tilingKey = 1;
+    } else if (xDataType == ge::DataType::DT_FLOAT16 || xDataType == ge::DataType::DT_BF16) {
+        typeByte = sizeof(uint16_t);
+        params.tilingKey = 2;
+    } else if (xDataType == ge::DataType::DT_INT32 || xDataType == ge::DataType::DT_UINT32) {
+        typeByte = sizeof(uint32_t);
+        params.tilingKey = 4;
+    } else {
+        OP_LOGE(context_->GetNodeName(), "Unsupported type.");
+        return ge::GRAPH_FAILED;
+    }
+
+    params.typeByte = typeByte;
+
+    auto groupInfoShape = context_->GetInputShape(DIM_2);
+    params.groupInfoLen =  static_cast<uint32_t>(groupInfoShape->GetStorageShape().GetDim(0));
+    params.corepernum = params.groupInfoLen/params.coreNum;
+    params.coretail= params.groupInfoLen%params.coreNum;
+    
+    uint32_t pageBlockEleSize = params.blockTableSize*params.tokenSize;
+    if( pageBlockEleSize > MAX_UB_USE_SIZE){
+        OP_LOGE(context_->GetNodeName(), "pageBlockEleSize > MaxUBSize");
+        std::cout<<context_->GetNodeName()<< "  pageBlockEleSize > MaxUBSize"<<std::endl;
+        return ge::GRAPH_FAILED;
+    }
+    return ge::GRAPH_SUCCESS;
+
+}
+
+ge::graphStatus StoreKVBlockCommonTiling::DoTiling()
+{
+
+    auto ret = GetPlatformInfo();
+    if (ret != ge::GRAPH_SUCCESS) {
+        return ret;
+    }
+
+    ret = DoCommonTiling();
+    if (ret != ge::GRAPH_SUCCESS) {
+        return ret;
+    }
+
+    SetTiling();
+
+    // PrintTilingData();
+    return ge::GRAPH_SUCCESS;
+}
+    
+
+} // namespace optiling

--- a/csrc/store_kv_block/op_host/store_kv_block_common.h
+++ b/csrc/store_kv_block/op_host/store_kv_block_common.h
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*!
+ * \file reshape_and_cache_common.h
+ * \brief
+ */
+
+#ifndef ASCEND_OPS_STORE_KV_BLOCK_COMMON_H
+#define ASCEND_OPS_STORE_KV_BLOCK_COMMON_H
+
+#include <climits>
+#include "register/tilingdata_base.h"
+#include "tiling/tiling_base.h"
+#include "error_log.h"
+#include "../tiling_base/tiling_base.h"
+#include "../tiling_base/tiling_templates_registry.h"
+#include "platform/platform_info.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "register/op_def_registry.h"
+#include "tiling/tiling_api.h"
+
+namespace optiling {
+
+constexpr uint32_t DIM_0 = 0;
+constexpr uint32_t DIM_1 = 1;
+constexpr uint32_t DIM_2 = 2;
+constexpr uint32_t DIM_3 = 3;
+constexpr uint32_t DIM_4 = 4;
+constexpr uint32_t DIM_5 = 5;
+constexpr uint32_t DIM_6 = 6;
+
+constexpr int32_t MAX_UB_USE_SIZE = 180 * 1024;
+
+
+BEGIN_TILING_DATA_DEF(StoreKVBlockTilingData)
+    TILING_DATA_FIELD_DEF(uint32_t, blockTableSize);
+    TILING_DATA_FIELD_DEF(uint32_t, typeByte);
+    TILING_DATA_FIELD_DEF(uint32_t, tokenSize);
+    TILING_DATA_FIELD_DEF(uint32_t, corePerNum);
+    TILING_DATA_FIELD_DEF(uint32_t, coreTail);
+    TILING_DATA_FIELD_DEF(uint32_t, numTokens);
+    TILING_DATA_FIELD_DEF(uint32_t, numCache);
+    TILING_DATA_FIELD_DEF(uint32_t, groupInfoLen);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(StoreKVBlock,  StoreKVBlockTilingData)
+
+
+struct  StoreKVBlockParams {
+    uint32_t numTokens{0};
+    uint32_t numCache{0};
+    uint32_t numHeads{1};
+    uint32_t headSize[5]{1,1,1,1,1};
+    uint32_t blockTableSize{0};
+    uint32_t typeByte{0};
+    uint32_t tokenSize{1};
+    uint32_t tilingKey{0};
+    uint64_t workspaceSize{0};
+    uint64_t groupInfoLen{0};
+    uint32_t corepernum{0};
+    uint32_t coretail{0};
+    uint64_t sysWorkspaceSize{0};
+    uint32_t coreNum{0};
+};
+
+class StoreKVBlockCommonTiling {
+public:
+    explicit StoreKVBlockCommonTiling(gert::TilingContext* context) : context_(context) {};
+    virtual ~StoreKVBlockCommonTiling() = default;
+
+    ge::graphStatus GetPlatformInfo();
+    ge::graphStatus DoCommonTiling();
+    ge::graphStatus DoTiling();
+    void SetTiling();
+    void PrintTilingData();
+
+protected:
+    gert::TilingContext *context_ = nullptr;
+    StoreKVBlockParams params;
+    StoreKVBlockTilingData tilingData_;
+    platform_ascendc::SocVersion socVersion_ = platform_ascendc::SocVersion::ASCEND910B;
+};
+
+}
+#endif // ASCEND_OPS_RESHAPE_AND_CACHE_COMMON_H

--- a/csrc/store_kv_block/op_host/store_kv_block_def.cpp
+++ b/csrc/store_kv_block/op_host/store_kv_block_def.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file reshape_and_cache.cpp
+ * \brief
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class StoreKVBlock : public OpDef {
+ public:
+  explicit StoreKVBlock(const char* name) : OpDef(name) {
+    this->Input("keyIn")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT8, ge::DT_FLOAT16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("keyCacheIn")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT8, ge::DT_FLOAT16, ge::DT_BF16})
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("groupLen")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32 , ge::DT_INT32 , ge::DT_INT32 })
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("groupKeyIdx")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32 , ge::DT_INT32 , ge::DT_INT32 })
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Input("groupKeyCacheIdx")
+        .ParamType(REQUIRED)
+        .DataType({ge::DT_INT32 , ge::DT_INT32 , ge::DT_INT32 })
+        .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+        .AutoContiguous();
+    this->Attr("blockSize").Int();
+    this->AICore().AddConfig("ascend910b");
+    this->AICore().AddConfig("ascend910_93");
+  }
+};
+
+OP_ADD(StoreKVBlock);
+}  // namespace ops

--- a/csrc/store_kv_block/op_host/store_kv_block_infershape.cpp
+++ b/csrc/store_kv_block/op_host/store_kv_block_infershape.cpp
@@ -1,0 +1,39 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file add_rms_norm_bias_infershape.cpp
+ * \brief
+ */
+#include "error/ops_error.h"
+#include <graph/utils/type_utils.h>
+#include <register/op_impl_registry.h>
+
+static constexpr int IDX_0 = 0;
+static constexpr int IDX_1 = 1;
+static constexpr int IDX_2 = 2;
+
+using namespace ge;
+// using namespace Ops::Base;
+
+namespace ops {
+
+static ge::graphStatus InferShape4StoreKVBlock(gert::InferShapeContext* context)
+{
+    return GRAPH_SUCCESS;
+}
+
+static graphStatus InferDataType4StoreKVBlock(gert::InferDataTypeContext* context)
+{
+    return GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(StoreKVBlock).InferShape(InferShape4StoreKVBlock).InferDataType(InferDataType4StoreKVBlock);
+} // namespace ops

--- a/csrc/store_kv_block/op_host/store_kv_block_tiling.cpp
+++ b/csrc/store_kv_block/op_host/store_kv_block_tiling.cpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file reshape_and_cache_tiling.cc
+ * \brief
+ */
+#include "store_kv_block_common.h"
+#include <chrono>
+namespace optiling {
+
+
+static ge::graphStatus StoreKVBlockTilingFunc(gert::TilingContext* context) {
+
+    std::string op_type(context->GetNodeType());
+    ge::graphStatus ret;
+    
+    if (op_type == "StoreKVBlock") {
+         StoreKVBlockCommonTiling storeKVBlockCommonTiling(context);
+        ret = storeKVBlockCommonTiling.DoTiling();
+    }else {
+        printf("[ZTLOG] no  StoreKVBlockCommonTiling\n");
+        return ge::GRAPH_FAILED;
+    }
+    return ret;
+
+}
+
+struct Tiling4StoreKVBlockCompileInfo {
+    uint32_t coreNum;
+    uint64_t ubSizePlatForm;
+    uint32_t sysWorkspaceSize;
+};
+static ge::graphStatus TilingParseForStoreKVBlock(gert::TilingParseContext* context) {
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(StoreKVBlock)
+    .Tiling(StoreKVBlockTilingFunc)
+    .TilingParse<Tiling4StoreKVBlockCompileInfo>(TilingParseForStoreKVBlock);
+} // namespace optiling

--- a/csrc/store_kv_block/op_kernel/store_kv_block.cpp
+++ b/csrc/store_kv_block/op_kernel/store_kv_block.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file reshape_and_cache.cpp
+ * \brief
+ */
+#include "store_kv_block.h"
+
+extern "C" __global__ __aicore__ void store_kv_block(
+    GM_ADDR keyIn, GM_ADDR keyCacheIn, GM_ADDR groupLen, GM_ADDR groupKeyIdx, GM_ADDR groupKeyCacheIdx, GM_ADDR workspace, GM_ADDR tiling)
+{
+    AscendC::TPipe pipe;
+    REGISTER_TILING_DEFAULT(StoreKVBlock::StoreKVBlockTilingData);
+    GET_TILING_DATA(tilingData, tiling);
+
+    if (TILING_KEY_IS(1)) {
+        StoreKVBlock::StoreKVBlockBase<uint8_t> op;
+        op.Init( &pipe, &tilingData);
+        op.Process(keyIn,keyCacheIn, groupLen, groupKeyIdx, groupKeyCacheIdx);
+    } else if (TILING_KEY_IS(2)) {
+        StoreKVBlock::StoreKVBlockBase<half> op;
+        op.Init( &pipe, &tilingData);
+        op.Process(keyIn,keyCacheIn, groupLen, groupKeyIdx, groupKeyCacheIdx);
+    } else if (TILING_KEY_IS(4)) {
+        StoreKVBlock::StoreKVBlockBase<int32_t> op;
+        op.Init( &pipe, &tilingData);
+        op.Process(keyIn,keyCacheIn, groupLen, groupKeyIdx, groupKeyCacheIdx);
+    }
+}

--- a/csrc/store_kv_block/op_kernel/store_kv_block.h
+++ b/csrc/store_kv_block/op_kernel/store_kv_block.h
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file reshape_and_cache_base.h
+ * \brief
+ */
+
+#ifndef ASCEND_STORE_KV_BLOCK_H
+#define ASCEND_STORE_KV_BLOCK_H
+
+#include "kernel_operator.h"
+
+namespace StoreKVBlock {
+using namespace AscendC;
+
+
+#ifndef STORE_KV_BLOCK_TILING_DATA_H_
+#define STORE_KV_BLOCK_TILING_DATA_H_
+struct StoreKVBlockTilingData{
+    uint32_t blockTableSize;    
+    uint32_t typeByte;
+    uint32_t tokenSize;
+    uint32_t corePerNum;
+    uint32_t coreTail;
+    uint32_t numTokens;
+    uint32_t numCache;
+    uint32_t groupInfoLen;
+
+};
+#endif
+template <typename T>
+class StoreKVBlockBase {
+public:
+
+    uint32_t tokenSize = 0;
+    uint32_t tokenByteSize = 0;
+    uint32_t blockTableSize = 0;
+    uint32_t typeByte = 0;
+    uint32_t numTokens = 0;
+    uint32_t numCache = 0;
+    uint32_t groupInfoLen = 0;
+
+    uint32_t coreId = 0;
+    uint32_t coreTail = 0;
+    uint32_t corePerNum = 0;
+    uint32_t blockNum = 0;
+    AscendC::TPipe* pipeThis;
+    AscendC::LocalTensor<T> tokenLocal;
+    AscendC::GlobalTensor<T> keyInputGt;
+    AscendC::GlobalTensor<T> keyCacheIntputGt;
+    AscendC::GlobalTensor<uint32_t> groupLenGt;
+    AscendC::GlobalTensor<uint32_t> groupKeyIdxGt;
+    AscendC::GlobalTensor<uint32_t> groupKeyCacheIdxGt;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> tokenBuf;
+    __aicore__ inline StoreKVBlockBase() {}
+
+    __aicore__ inline uint32_t RoundUp(uint32_t x, uint32_t y = 16)
+    {
+        return y == 0 ? 0 : (x + y - 1) / y * y;
+    }
+
+    __aicore__ inline void Init( AscendC::TPipe *pipe, StoreKVBlockTilingData *tilingData)
+    {
+        pipeThis = pipe;
+        typeByte = tilingData->typeByte;
+        tokenSize = tilingData->tokenSize;
+        tokenByteSize = tokenSize*typeByte;
+        blockTableSize = tilingData->blockTableSize;
+        numTokens = tilingData->numTokens;
+        numCache = tilingData->numCache;
+        groupInfoLen = tilingData->groupInfoLen;
+
+
+        coreId = AscendC::GetBlockIdx();
+        coreTail = tilingData->coreTail;
+        blockNum = AscendC::GetBlockNum();
+        if (coreId < coreTail){
+            corePerNum = tilingData->corePerNum+1;
+        }else {
+            corePerNum = tilingData->corePerNum;
+        }
+    }
+    __aicore__ inline void Process(GM_ADDR keyIn, GM_ADDR keyCacheIn, GM_ADDR groupLen, GM_ADDR groupKeyIdx, GM_ADDR groupKeyCacheIdx)
+    {
+        
+        keyInputGt.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(keyIn));
+        keyCacheIntputGt.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(keyCacheIn));
+        groupLenGt.SetGlobalBuffer(reinterpret_cast<__gm__ uint32_t*>(groupLen));
+        groupKeyIdxGt.SetGlobalBuffer(reinterpret_cast<__gm__ uint32_t*>(groupKeyIdx));
+        groupKeyCacheIdxGt.SetGlobalBuffer(reinterpret_cast<__gm__ uint32_t*>(groupKeyCacheIdx));
+
+        pipeThis->InitBuffer(tokenBuf,  blockTableSize*tokenByteSize);
+        tokenLocal = tokenBuf.Get<T>();
+
+        AscendC::DataCopyExtParams copyParams{1, 0,  0, 0, 0};//todo完整块长度
+        AscendC::DataCopyPadExtParams<T> padParams{false, 0, 0, 0};
+        for (uint32_t i = 0; i < corePerNum; i++) {
+            uint32_t idx = (coreId+i*blockNum);
+         
+            // if( groupLenGt.GetValue(idx)<= 0 || groupKeyIdxGt.GetValue(idx)<0 || groupKeyCacheIdxGt.GetValue(idx)<0){
+            //     continue;
+            // }
+           
+            copyParams.blockLen = groupLenGt.GetValue(idx)*tokenByteSize; 
+            DataCopyPad(tokenLocal, keyInputGt[ groupKeyIdxGt.GetValue(idx)*tokenSize], copyParams, padParams); 
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+            DataCopyPad(keyCacheIntputGt[groupKeyCacheIdxGt.GetValue(idx)*tokenSize], tokenLocal, copyParams);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+        }
+
+    }
+
+};
+}
+
+#endif

--- a/csrc/store_kv_block/store_kv_block_torch_adpt.h
+++ b/csrc/store_kv_block/store_kv_block_torch_adpt.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STORE_KV_BLOCK_TORCH_ADPT_H
+#define STORE_KV_BLOCK_TORCH_ADPT_H
+#include <climits>
+namespace vllm_ascend {
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> store_kv_block_pre(const at::Tensor& slot_mapping_npu,
+                                                                  at::IntArrayRef slot_mapping_list,
+                                                                  int64_t block_size) {
+  int64_t slot_mapping_len = slot_mapping_list.size();
+
+  std::vector<int32_t> length(16, 0);
+  std::vector<int32_t> key_idx(16, 0);
+  std::vector<int32_t> key_cache_idx(16, 0);
+  
+  int32_t idx_slotmap = 0;
+  int32_t idx_groups = 0;
+
+  while (idx_slotmap < slot_mapping_len) {
+    int32_t current_idx = slot_mapping_list[idx_slotmap];
+    if (current_idx < 0) {
+      idx_slotmap++;
+      continue;
+    }
+
+    int32_t block_id = current_idx / block_size;
+    int32_t y = current_idx % block_size;
+
+    key_idx[idx_groups] = idx_slotmap;
+    key_cache_idx[idx_groups] = current_idx;
+
+    int32_t next = idx_slotmap + 1;
+    bool use_block_jump = (next < slot_mapping_len && slot_mapping_list[next] == slot_mapping_list[next - 1] + 1);
+
+    if (use_block_jump) {
+      int32_t idx_stride = std::min(block_size - y, slot_mapping_len - idx_slotmap) - 1;
+      int32_t expected_last = current_idx + idx_stride;
+      int32_t expected_last_idx = idx_slotmap + idx_stride;
+
+      if (expected_last == slot_mapping_list[expected_last_idx]) {
+        next = expected_last_idx + 1;
+      } else {
+        while (next < slot_mapping_len && slot_mapping_list[next] == slot_mapping_list[next - 1] + 1 &&
+               slot_mapping_list[next] / block_size == block_id) {
+          next++;
+        }
+      }
+    }
+
+    length[idx_groups] = (next - idx_slotmap);
+    idx_slotmap = next;
+    idx_groups++;
+
+    if (idx_groups >= length.capacity()) {
+      int32_t new_capacity = length.capacity() * 2;
+      length.reserve(new_capacity);
+      key_idx.reserve(new_capacity);
+      key_cache_idx.reserve(new_capacity);
+
+      for (int32_t k = idx_groups; k < new_capacity; ++k) {
+        length.emplace_back(0);
+        key_idx.emplace_back(0);
+        key_cache_idx.emplace_back(0);
+      }
+    }
+  }
+
+  at::Tensor group_len =
+      at::empty({idx_groups}, at::TensorOptions(slot_mapping_npu.options().device()).dtype(torch::kInt32));
+  void* group_len_addr = group_len.data_ptr();
+
+  at::Tensor group_key_idx =
+      at::empty({idx_groups}, at::TensorOptions(slot_mapping_npu.options().device()).dtype(torch::kInt32));
+  void* group_key_idx_addr = group_key_idx.data_ptr();
+
+  at::Tensor group_key_cache_idx =
+      at::empty({idx_groups}, at::TensorOptions(slot_mapping_npu.options().device()).dtype(torch::kInt32));
+  void* group_key_cache_idx_addr = group_key_cache_idx.data_ptr();
+
+  uint32_t device_size = idx_groups * sizeof(length[0]);
+  aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+  aclrtMemcpyKind memcpy_type = ACL_MEMCPY_HOST_TO_DEVICE;
+  aclrtMemcpyAsync(group_len_addr, device_size, &length[0], device_size, ACL_MEMCPY_HOST_TO_DEVICE, stream);
+  aclrtMemcpyAsync(group_key_idx_addr, device_size, &key_idx[0], device_size, ACL_MEMCPY_HOST_TO_DEVICE, stream);
+  aclrtMemcpyAsync(group_key_cache_idx_addr, device_size, &key_cache_idx[0], device_size, ACL_MEMCPY_HOST_TO_DEVICE,
+                   stream);
+
+  return std::tuple<at::Tensor, at::Tensor, at::Tensor>(group_len, group_key_idx, group_key_cache_idx);
+}
+
+void store_kv_block(const at::Tensor& key_in, const at::Tensor& key_cache_in, const at::Tensor& group_len,
+                    const at::Tensor& group_key_idx, const at::Tensor& group_key_cache_idx, int64_t block_size) {
+  EXEC_NPU_CMD(aclnnStoreKVBlock, key_in, key_cache_in, group_len, group_key_idx, group_key_cache_idx, block_size);
+}
+
+}  // namespace vllm_ascend
+#endif

--- a/csrc/store_kv_block/tiling_base/data_copy_transpose_tiling.h
+++ b/csrc/store_kv_block/tiling_base/data_copy_transpose_tiling.h
@@ -1,0 +1,51 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling.h
+ * \brief
+ */
+
+#pragma once
+
+#include <vector>
+#include <graph/tensor.h>
+#include "data_copy_transpose_tiling_def.h"
+
+namespace optiling {
+
+inline void GetDataCopyTransposeTiling(const ge::Shape &dstShape, const ge::Shape &srcShape, const uint32_t typeSize,
+                                       optiling::CopyTransposeTiling &tiling)
+{
+    constexpr int64_t B_INDEX = 0;
+    constexpr int64_t N_INDEX = 1;
+    constexpr int64_t S_INDEX = 2;
+    constexpr int64_t H_INDEX = 3;
+    std::vector<int64_t> dstShapeInfo = dstShape.GetDims();
+    std::vector<int64_t> srcShapeInfo = srcShape.GetDims();
+
+    tiling.set_dstShapeB(dstShapeInfo[B_INDEX]);
+    tiling.set_dstShapeN(dstShapeInfo[N_INDEX]);
+    tiling.set_dstShapeS(dstShapeInfo[S_INDEX]);
+    tiling.set_dstShapeH(dstShapeInfo[H_INDEX]);
+    tiling.set_dstShapeHN(tiling.get_dstShapeH() / tiling.get_dstShapeN());
+
+    tiling.set_srcShapeB(srcShapeInfo[B_INDEX]);
+    tiling.set_srcShapeN(srcShapeInfo[N_INDEX]);
+    tiling.set_srcShapeS(srcShapeInfo[S_INDEX]);
+    tiling.set_srcShapeHN(srcShapeInfo[H_INDEX]);
+    tiling.set_originalShapeNLen(tiling.get_srcShapeHN() * typeSize);
+    tiling.set_shapeSHValue(tiling.get_dstShapeS() * tiling.get_dstShapeH());
+    tiling.set_shapeNsValue(tiling.get_dstShapeN() * tiling.get_dstShapeS());
+    tiling.set_shapeNsnValue(tiling.get_dstShapeN() * tiling.get_srcShapeS() * tiling.get_srcShapeN());
+    tiling.set_shapeBHValue(tiling.get_dstShapeB() * tiling.get_dstShapeH());
+}
+
+} // namespace optiling

--- a/csrc/store_kv_block/tiling_base/data_copy_transpose_tiling_def.h
+++ b/csrc/store_kv_block/tiling_base/data_copy_transpose_tiling_def.h
@@ -1,0 +1,43 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling_def.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(CopyTransposeTiling)
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeH);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, originalShapeNLen);
+TILING_DATA_FIELD_DEF(uint32_t, shapeSHValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsnValue);
+TILING_DATA_FIELD_DEF(uint32_t, invalidParamCopyTransposeTiling);
+TILING_DATA_FIELD_DEF(uint32_t, shapeBHValue);
+TILING_DATA_FIELD_DEF(uint32_t, paramsAlign);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(CopyTransposeTilingOp, CopyTransposeTiling)
+
+} // namespace optiling

--- a/csrc/store_kv_block/tiling_base/error_log.h
+++ b/csrc/store_kv_block/tiling_base/error_log.h
@@ -1,0 +1,56 @@
+#ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+#define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+
+#include <string>
+#include "toolchain/slog.h"
+
+#define OP_LOGI(opname, ...)
+#define OP_LOGW(opname, ...)             \
+    do {                                 \
+        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
+        printf("\n");                    \
+    } while (0)
+
+#define OP_LOGE_WITHOUT_REPORT(opname, ...) \
+    do {                                    \
+        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
+        printf("\n");                       \
+    } while (0)
+
+#define OP_LOGE(opname, ...)              \
+    do {                                  \
+        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
+        printf("\n");                     \
+    } while (0)
+
+#define OP_LOGD(opname, ...)
+
+namespace optiling {
+
+#define VECTOR_INNER_ERR_REPORT_TILIING(op_name, err_msg, ...)   \
+    do {                                                         \
+        OP_LOGE_WITHOUT_REPORT(op_name, err_msg, ##__VA_ARGS__); \
+    } while (0)
+
+// Modify OP_TILING_CHECK macro to ensure proper handling of expressions
+#define OP_CHECK_IF(cond, log_func, expr) \
+    do {                                      \
+        if (cond) {                           \
+            log_func;                         \
+            expr;                             \
+        }                                     \
+    } while (0)
+
+
+
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                          \
+    do {                                                                  \
+        if ((ptr) == nullptr) {                                           \
+            OP_LOGE(context->GetNodeType(), "%s is null", #ptr);               \
+            return ge::GRAPH_FAILED;                                      \
+        }                                                                 \
+    } while (0)
+
+}  // namespace optiling
+
+#endif  // OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_

--- a/csrc/store_kv_block/tiling_base/tiling_base.h
+++ b/csrc/store_kv_block/tiling_base/tiling_base.h
@@ -1,0 +1,256 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_base.h
+ * \brief
+ */
+
+#pragma once
+
+#include <sstream>
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
+#include "tiling/platform/platform_ascendc.h"
+#include "error_log.h"
+
+#ifdef ASCENDC_OP_TEST
+#define ASCENDC_EXTERN_C extern "C"
+#else
+#define ASCENDC_EXTERN_C
+#endif
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+struct AiCoreParams {
+    uint64_t ubSize = 0;
+    uint64_t blockDim = 0;
+    uint64_t aicNum = 0;
+    uint64_t l1Size = 0;
+    uint64_t l0aSize = 0;
+    uint64_t l0bSize = 0;
+    uint64_t l0cSize = 0;
+};
+
+struct CompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+struct FlashAttentionScoreGradCompileInfo {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    platform_ascendc::SocVersion socVersion;
+};
+
+struct FACompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+class TilingBaseClass {
+public:
+    explicit TilingBaseClass(gert::TilingContext* context) : context_(context)
+    {}
+
+    virtual ~TilingBaseClass() = default;
+
+    // Tiling execution framework
+    //     1. GRAPH_SUCCESS: Success, and no need to continue executing subsequent Tiling class implementations
+    //     2. GRAPH_FAILED: Failure, abort the entire Tiling process
+    //     3. GRAPH_PARAM_INVALID: This class does not support, need to continue executing other Tiling class implementations
+    ge::graphStatus DoTiling()
+    {
+        auto ret = GetShapeAttrsInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetPlatformInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        if (!IsCapable()) {
+            return ge::GRAPH_PARAM_INVALID;
+        }
+        ret = DoOpTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = DoLibApiTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetWorkspaceSize();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = PostTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        context_->SetTilingKey(GetTilingKey());
+        DumpTilingInfo();
+        return ge::GRAPH_SUCCESS;
+    }
+
+    // Update context
+    virtual void Reset(gert::TilingContext* context)
+    {
+        context_ = context;
+    }
+
+protected:
+    virtual bool IsCapable() = 0;
+    // 1. Get platform information such as CoreNum, UB/L1/L0C resource sizes
+    virtual ge::graphStatus GetPlatformInfo() = 0;
+    // 2. Get INPUT/OUTPUT/ATTR information
+    virtual ge::graphStatus GetShapeAttrsInfo() = 0;
+    // 3. Calculate data splitting TilingData
+    virtual ge::graphStatus DoOpTiling() = 0;
+    // 4. Calculate high-level API TilingData
+    virtual ge::graphStatus DoLibApiTiling() = 0;
+    // 5. Calculate TilingKey
+    [[nodiscard]] virtual uint64_t GetTilingKey() const = 0;
+    // 6. Calculate Workspace size
+    virtual ge::graphStatus GetWorkspaceSize() = 0;
+    // 7. Save Tiling data
+    virtual ge::graphStatus PostTiling() = 0;
+    // 8. Dump Tiling data
+    virtual void DumpTilingInfo()
+    {
+        int32_t enable = CheckLogLevel(static_cast<int32_t>(OP), DLOG_DEBUG);
+        if (enable != 1) {
+            return;
+        }
+        auto buf = (uint32_t*)context_->GetRawTilingData()->GetData();
+        auto bufLen = context_->GetRawTilingData()->GetDataSize();
+        std::ostringstream oss;
+        oss << "Start to dump tiling info. tilingkey:" << context_->GetTilingKey() << ", tiling data size:" << bufLen
+            << ", content:";
+        for (size_t i = 0; i < bufLen / sizeof(uint32_t); i++) {
+            oss << *(buf + i) << ",";
+            if (oss.str().length() > 640) { // Split according to 640 to avoid truncation
+                OP_LOGD(context_, "%s", oss.str().c_str());
+                oss.str("");
+            }
+        }
+        OP_LOGD(context_, "%s", oss.str().c_str());
+    }
+
+    static uint32_t CalcTschBlockDim(uint32_t sliceNum, uint32_t aicCoreNum, uint32_t aivCoreNum)
+    {
+        uint32_t ration;
+        if (aicCoreNum == 0 || aivCoreNum == 0 || aicCoreNum > aivCoreNum) {
+            return sliceNum;
+        }
+        ration = aivCoreNum / aicCoreNum;
+        return (sliceNum + (ration - 1)) / ration;
+    }
+
+    template <typename T>
+    [[nodiscard]] std::string GetShapeDebugStr(const T& shape) const
+    {
+        std::ostringstream oss;
+        oss << "[";
+        if (shape.GetDimNum() > 0) {
+            for (size_t i = 0; i < shape.GetDimNum() - 1; ++i) {
+                oss << shape.GetDim(i) << ", ";
+            }
+            oss << shape.GetDim(shape.GetDimNum() - 1);
+        }
+        oss << "]";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTensorDebugStr(
+        const gert::StorageShape* shape, const gert::CompileTimeTensorDesc* tensor)
+    {
+        if (shape == nullptr || tensor == nullptr) {
+            return "nil ";
+        }
+        std::ostringstream oss;
+        oss << "(dtype: " << ge::TypeUtils::DataTypeToSerialString(tensor->GetDataType()) << "),";
+        oss << "(shape:" << GetShapeDebugStr(shape->GetStorageShape()) << "),";
+        oss << "(ori_shape:" << GetShapeDebugStr(shape->GetOriginShape()) << "),";
+        oss << "(format: "
+            << ge::TypeUtils::FormatToSerialString(
+                   static_cast<ge::Format>(ge::GetPrimaryFormat(tensor->GetStorageFormat())))
+            << "),";
+        oss << "(ori_format: " << ge::TypeUtils::FormatToSerialString(tensor->GetOriginFormat()) << ") ";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingContextDebugStr()
+    {
+        std::ostringstream oss;
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetInputsNum(); ++i) {
+            oss << "input" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetInputShape(i), context_->GetInputDesc(i));
+        }
+
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetOutputsNum(); ++i) {
+            oss << "output" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetOutputShape(i), context_->GetOutputDesc(i));
+        }
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingDataDebugStr() const
+    {
+        auto rawTilingData = context_->GetRawTilingData();
+        auto rawTilingDataSize = rawTilingData->GetDataSize();
+        auto data = reinterpret_cast<const int32_t*>(rawTilingData->GetData());
+        size_t len = rawTilingDataSize / sizeof(int32_t);
+        std::ostringstream oss;
+        for (size_t i = 0; i < len; i++) {
+            oss << data[i] << ", ";
+        }
+        return oss.str();
+    }
+
+protected:
+    gert::TilingContext* context_ = nullptr;
+    std::unique_ptr<platform_ascendc::PlatformAscendC> ascendcPlatform_{nullptr};
+    uint32_t blockDim_{0};
+    uint64_t workspaceSize_{0};
+    uint64_t tilingKey_{0};
+    AiCoreParams aicoreParams_;
+};
+
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/store_kv_block/tiling_base/tiling_key.h
+++ b/csrc/store_kv_block/tiling_base/tiling_key.h
@@ -1,0 +1,63 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_key.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr uint64_t kBase = 10; // Base-10 carry base
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + kBase * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace Optiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/store_kv_block/tiling_base/tiling_templates_registry.h
+++ b/csrc/store_kv_block/tiling_base/tiling_templates_registry.h
@@ -1,0 +1,351 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_templates_registry.h
+ * \brief
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+#include "exe_graph/runtime/tiling_context.h"
+#include "tiling_base.h"
+#include "error_log.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+template <typename T>
+std::unique_ptr<TilingBaseClass> TILING_CLASS(gert::TilingContext* context)
+{
+    return std::unique_ptr<T>(new (std::nothrow) T(context));
+}
+
+using TilingClassCase = std::unique_ptr<TilingBaseClass> (*)(gert::TilingContext*);
+
+class TilingCases {
+public:
+    explicit TilingCases(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    void AddTiling(int32_t priority)
+    {
+        OP_CHECK_IF(
+            cases_.find(priority) != cases_.end(), OP_LOGE(op_type_, "There are duplicate registrations."), return);
+        cases_[priority] = TILING_CLASS<T>;
+        OP_CHECK_IF(
+            cases_[priority] == nullptr,
+            OP_LOGE(op_type_, "Register op tiling func failed, please check the class name."), return);
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingCases()
+    {
+        return cases_;
+    }
+
+private:
+    std::map<int32_t, TilingClassCase> cases_;
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce with soc version --------------------------------
+class TilingRegistryNew {
+public:
+    TilingRegistryNew() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistryNew& GetInstance();
+#else
+    static TilingRegistryNew& GetInstance()
+    {
+        static TilingRegistryNew registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        if (soc_iter == registry_map_.end()) {
+            std::map<std::string, std::shared_ptr<TilingCases>> op_type_map;
+            op_type_map[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            registry_map_[soc_version] = op_type_map;
+        } else {
+            if (soc_iter->second.find(op_type) == soc_iter->second.end()) {
+                soc_iter->second[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            }
+        }
+
+        OP_CHECK_IF(
+            registry_map_[soc_version][op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[soc_version][op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        int32_t soc_version = (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION;
+        const char* op_type = context->GetNodeType();
+        fe::PlatFormInfos* platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = static_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+            if (soc_version == (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION) {
+                OP_LOGE(op_type, "Do op tiling failed, cannot find soc version.");
+                return ge::GRAPH_FAILED;
+            }
+        }
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        int32_t soc_version;
+        const char* op_type = context->GetNodeType();
+        auto platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = reinterpret_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+        }
+
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto priority_id : priorities) {
+            auto tilingCaseIter = tilingTemplateRegistryMap.find(priority_id);
+            if (tilingCaseIter != tilingTemplateRegistryMap.end()) {
+                auto templateFunc = tilingCaseIter->second(context);
+                if (templateFunc != nullptr) {
+                    ge::graphStatus status = templateFunc->DoTiling();
+                    if (status == ge::GRAPH_SUCCESS) {
+                        OP_LOGD(context, "Do general op tiling success priority=%d", priority_id);
+                        return status;
+                    }
+                    OP_LOGD(context, "Ignore general op tiling priority=%d", priority_id);
+                }
+            }
+        }
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        OP_CHECK_IF(
+            soc_iter == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the soc version %d", soc_version),
+            return empty_tiling_case_);
+        auto op_iter = soc_iter->second.find(op_type);
+        OP_CHECK_IF(
+            op_iter == soc_iter->second.end(), OP_LOGE(op_type, "Get op tiling func failed, please check the op name."),
+            return empty_tiling_case_);
+        return op_iter->second->GetTilingCases();
+    }
+
+private:
+    std::map<int32_t, std::map<std::string, std::shared_ptr<TilingCases>>> registry_map_; // key is socversion
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_{};
+};
+
+class RegisterNew {
+public:
+    explicit RegisterNew(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, int32_t soc_version)
+    {
+        auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, const std::vector<int32_t>& soc_versions)
+    {
+        for (int32_t soc_version : soc_versions) {
+            auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+            OP_CHECK_IF(
+                tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."),
+                return *this);
+            tilingCases->AddTiling<T>(priority);
+        }
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce without soc version --------------------------------
+class TilingRegistry {
+public:
+    TilingRegistry() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistry& GetInstance();
+#else
+    static TilingRegistry& GetInstance()
+    {
+        static TilingRegistry registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type)
+    {
+        if (registry_map_.find(op_type) == registry_map_.end()) {
+            registry_map_[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+        }
+        OP_CHECK_IF(
+            registry_map_[op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto priorityId : priorities) {
+            auto templateFunc = tilingTemplateRegistryMap[priorityId](context);
+            if (templateFunc != nullptr) {
+                ge::graphStatus status = templateFunc->DoTiling();
+                if (status == ge::GRAPH_SUCCESS) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", priorityId);
+                    return status;
+                }
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do op tiling failed");
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", priorityId);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type)
+    {
+        OP_CHECK_IF(
+            registry_map_.find(op_type) == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the op name."), return empty_tiling_case_);
+        return registry_map_[op_type]->GetTilingCases();
+    }
+
+private:
+    std::map<std::string, std::shared_ptr<TilingCases>> registry_map_;
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_;
+};
+
+class Register {
+public:
+    explicit Register(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    Register& tiling(int32_t priority)
+    {
+        auto tilingCases = TilingRegistry::GetInstance().RegisterOp(op_type_);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops
+
+// op_type: operator name, class_name: registered tiling class, soc_version: chip version number
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_WITH_SOCVERSION(op_type, class_name, soc_versions, priority)    \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_versions)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+#define REGISTER_TILING_TEMPLATE(op_type, class_name, priority)                                \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register VAR_UNUSED##op_type_##class_name##priority_register = \
+        Ops::Transformer::OpTiling::Register(op_type).tiling<class_name>(priority)
+
+// op_type: operator name, class_name: registered tiling class
+// soc_version: SOC version, used to distinguish different SOCs
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_NEW(op_type, class_name, soc_version, priority)                 \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_version)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+// Replaces REGISTER_TILING_TEMPLATE, if op_type is a string constant, remove the quotes
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register                                                  \
+        __attribute__((unused)) tiling_##op_type##_##class_name##_##priority##_register = \
+            Ops::Transformer::OpTiling::Register(#op_type).tiling<class_name>(priority)

--- a/csrc/store_kv_block/tiling_base/tiling_type.h
+++ b/csrc/store_kv_block/tiling_base/tiling_type.h
@@ -1,0 +1,139 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_type.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace optiling {
+
+enum class AxisEnum {
+    B = 0,
+    N2 = 1,
+    G = 2,
+    S1 = 3,
+    S2 = 4,
+    D = 5,
+    NONE = 9,
+};
+
+enum class DtypeEnum {
+    FLOAT16 = 0,
+    FLOAT32 = 1,
+    BFLOAT16 = 2,
+    FLOAT16_PRECISION = 3,
+};
+
+enum class PerformanceOrientedEnum {
+    BIG_BUFFER = 1,
+    BIG_DOUBLE_BUFFER = 2,
+};
+
+enum class MatmulConfig {
+    NULL_CONFIG = 0,
+    NORMAL_CONFIG = 1,
+    MDL_CONFIG = 2
+};
+
+enum class PseConfig {
+    NO_PSE = 0,
+    EXIST_PSE = 1
+};
+
+enum class AttenMaskConfig {
+    NO_ATTEN_MASK = 0,
+    EXIST_ATTEN_MASK = 1
+};
+
+enum class DropOutConfig {
+    NO_DROP_OUT = 0,
+    EXIST_DROP_OUT = 1
+};
+
+enum class CubeFormatEnum {
+    ND = 0,
+    NZ = 1
+};
+enum class LayoutEnum {
+    BSND = 0,
+    SBND = 1,
+    BNSD = 2,
+    TND = 3,
+    NTD_TND = 4
+};
+
+enum class CubeInputSourceEnum {
+    GM = 0,
+    L1 = 1
+};
+
+enum class OptionEnum {
+    DISABLE = 0,
+    ENABLE = 1
+};
+
+enum class SparseEnum {
+    ALL = 0,
+    NONE = 1,
+    ANY = 2,
+    CAUSAL = 3,
+    BAND = 4,
+    PREFIX = 5,
+    BAND_COMPRESS = 6,
+    RIGHT_DOWN_CAUSAL = 7,
+    RIGHT_DOWN_CAUSAL_BAND = 8,
+    BAND_LEFT_UP_CAUSAL = 9
+};
+
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr int64_t base10Multiplier = 10;
+
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + base10Multiplier * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace optiling

--- a/csrc/store_kv_block/tiling_base/tiling_util.h
+++ b/csrc/store_kv_block/tiling_base/tiling_util.h
@@ -1,0 +1,30 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_util.h
+ * \brief
+ */
+
+#pragma once
+
+#include "register/op_impl_registry.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+bool IsRegbaseSocVersion(const gert::TilingParseContext* context);
+
+bool IsRegbaseSocVersion(const gert::TilingContext* context);
+
+const gert::Shape& EnsureNotScalar(const gert::Shape& inShape);
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -43,6 +43,7 @@
 #include "moe_init_routing_custom/moe_init_routing_custom_torch_adpt.h"
 #include "sparse_flash_attention/sparse_flash_attention_torch_adpt.h"
 #include "lightning_indexer_quant/lightning_indexer_quant_torch_adpt.h"
+#include "store_kv_block/store_kv_block_torch_adpt.h"
 #include <c10/core/Device.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
@@ -927,4 +928,15 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                            int sparse_count=2048, int sparse_mode=3) -> Tensor"
     );
     ops.impl("npu_lightning_indexer_quant", torch::kPrivateUse1, &vllm_ascend::npu_lightning_indexer_quant);
+     //store_kv_block
+    ops.def(
+        "store_kv_block_pre(Tensor slot_mapping_npu, int[2] slot_mapping_list =[], int block_size=0)"
+         "-> (Tensor group_len ,Tensor group_key_idx, Tensor group_key_cache_idx)"
+    );
+    ops.impl("store_kv_block_pre", torch::kPrivateUse1, &vllm_ascend::store_kv_block_pre);
+
+    ops.def(
+        "store_kv_block(Tensor key_in, Tensor key_cache_in, Tensor group_len, Tensor group_key_idx,Tensor group_key_cache_idx, int block_size=0) -> ()"
+    );
+    ops.impl("store_kv_block", torch::kPrivateUse1, &vllm_ascend::store_kv_block);
 }

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -568,7 +568,30 @@ at::Tensor npu_lightning_indexer_quant_meta(
 
     return lightning_indexer_quant_output;
 }
+std::tuple<at::Tensor, at::Tensor, at::Tensor> store_kv_block_pre(
+    const at::Tensor &slot_mapping_npu,
+    at::IntArrayRef slot_mapping_list,
+    int64_t block_size)
+{
+    auto s_size = slot_mapping_npu.sizes();
+    at::Tensor group_len = at::empty({s_size[0]}, slot_mapping_npu.options());
+    at::Tensor group_key_idx = at::empty({s_size[0]}, slot_mapping_npu.options());
+    at::Tensor group_key_cache_idx = at::empty({s_size[0]}, slot_mapping_npu.options());
+    return std::tuple<at::Tensor, at::Tensor, at::Tensor>(group_len, group_key_idx, group_key_cache_idx);
 
+}
+
+void store_kv_block(
+    const at::Tensor &key_in,
+    const at::Tensor &key_cache_in,
+    const at::Tensor &group_len,
+    const at::Tensor &group_key_idx,
+    const at::Tensor &group_key_cache_idx,
+    int64_t block_size)
+{
+    return;
+
+} 
 } // namespace meta
 } // namespace vllm_ascend
 
@@ -618,5 +641,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("moe_grouped_matmul", &vllm_ascend::meta::moe_grouped_matmul_meta);
     // Lightning indexer quant
     ops.impl("npu_lightning_indexer_quant", &vllm_ascend::meta::npu_lightning_indexer_quant_meta);
+    // store_kv_block
+    ops.impl("store_kv_block_pre", &vllm_ascend::meta::store_kv_block_pre);
+    ops.impl("store_kv_block", &vllm_ascend::meta::store_kv_block);
 }
 }

--- a/tests/ut/ops/test_store_kv_block.py
+++ b/tests/ut/ops/test_store_kv_block.py
@@ -1,0 +1,567 @@
+import random
+import time
+
+import numpy as np
+import pytest
+import torch
+import torch_npu
+
+from vllm_ascend.utils import enable_custom_op  # type: ignore[import-untyped] # noqa: F401
+
+torch.set_printoptions(threshold=np.inf)
+
+_CUSTOM_OP_ENABLE_ERROR = None
+_CUSTOM_OP_ENABLE_ATTEMPTED = False
+
+
+def npu_is_available():
+    try:
+        torch.npu.synchronize()
+    except Exception:
+        return False
+    return True
+
+
+def require_npu_available():
+    if not npu_is_available():
+        pytest.skip("NPU runtime is not available")
+
+
+def enable_custom_op_if_available():
+    global _CUSTOM_OP_ENABLE_ERROR
+    global _CUSTOM_OP_ENABLE_ATTEMPTED
+
+    if _CUSTOM_OP_ENABLE_ATTEMPTED:
+        return
+
+    _CUSTOM_OP_ENABLE_ATTEMPTED = True
+    try:
+        enable_custom_op()
+    except Exception as exc:
+        _CUSTOM_OP_ENABLE_ERROR = exc
+
+
+def random_with_zero_prob(zero_prob, index):
+    if not 0 <= zero_prob <= 1:
+        raise ValueError("the probability must be in [0, 1]")
+
+    if index <= 0:
+        raise ValueError("index must be > 0")
+
+    if random.random() < zero_prob:
+        return 0
+
+    return random.randint(1, index)
+
+
+def require_store_kv_block_registered():
+    require_npu_available()
+    enable_custom_op_if_available()
+
+    if _CUSTOM_OP_ENABLE_ERROR is not None:
+        pytest.skip(f"Failed to enable custom ops: {_CUSTOM_OP_ENABLE_ERROR}")
+
+    if not hasattr(torch.ops, "_C_ascend"):
+        pytest.skip("torch.ops._C_ascend is not registered")
+
+    if not hasattr(torch.ops._C_ascend, "store_kv_block_pre"):
+        pytest.skip("torch.ops._C_ascend.store_kv_block_pre is not registered")
+
+    if not hasattr(torch.ops._C_ascend, "store_kv_block"):
+        pytest.skip("torch.ops._C_ascend.store_kv_block is not registered")
+
+
+def golden_store_kv_block(keylist, cache_table, slotmap, block_size):
+    expected_cache = cache_table.clone()
+
+    for token_idx, slot in enumerate(slotmap):
+        if slot < 0:
+            continue
+
+        block_idx = slot // block_size
+        block_offset = slot % block_size
+
+        expected_cache[block_idx, block_offset, :, :] = keylist[token_idx, :, :]
+
+    return expected_cache
+
+
+@pytest.mark.parametrize("num_tokens", [32 * 1024])
+@pytest.mark.parametrize("num_head", [1])
+@pytest.mark.parametrize("block_size", [128])
+@pytest.mark.parametrize("num_blocks", [1773])
+@pytest.mark.parametrize("head_size", [128])
+def test_storeKVBlock_with_continuous(
+    num_tokens,
+    num_head,
+    num_blocks,
+    head_size,
+    block_size,
+):
+    require_store_kv_block_registered()
+
+    # keylist = torch.randint(
+    #     low=0,
+    #     high=128,
+    #     size=(num_tokens, num_head, head_size),
+    #     dtype=torch.int8,
+    # )
+    keylist = torch.rand(
+        size=(num_tokens, num_head, head_size),
+        dtype=torch.float16,
+    )
+
+    slotmap = []
+    for i in range(0, num_tokens):
+        slotmap.append(i)
+
+    max_slot = max(slotmap)
+    total_cache_slots = num_blocks * block_size
+    assert max_slot < total_cache_slots
+
+    # cache_table = torch.randint(
+    #     low=0,
+    #     high=128,
+    #     size=(num_blocks, block_size, num_head, head_size),
+    #     dtype=torch.int8,
+    # )
+    cache_table = torch.rand(
+        size=(num_blocks, block_size, num_head, head_size),
+        dtype=torch.float16,
+    )
+
+    expected_cache = golden_store_kv_block(
+        keylist=keylist,
+        cache_table=cache_table,
+        slotmap=slotmap,
+        block_size=block_size,
+    )
+
+    slotmap_np = np.array(slotmap, dtype=np.int32)
+    slot_mapping_npu = torch.from_numpy(slotmap_np).to(torch.int32).npu()
+
+    slot_mapping_cpu = torch.empty_like(slot_mapping_npu, device="cpu").pin_memory()
+    slot_mapping_cpu.copy_(slot_mapping_npu, non_blocking=True)
+    torch.npu.synchronize()
+
+    slot_mapping_list = slot_mapping_cpu.tolist()
+
+    keylist_npu = keylist.npu()
+    cache_table_npu = cache_table.clone().npu()
+
+    epoch = 100
+    for _ in range(epoch):
+        group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+            slot_mapping_npu,
+            slot_mapping_list,
+            block_size,
+        )
+        # group_len_cpu = group_len.cpu()
+        # group_key_idx_cpu = group_key_idx.cpu()
+        # group_key_cache_idx_cpu = group_key_cache_idx.cpu()
+        torch.ops._C_ascend.store_kv_block(
+            keylist_npu,
+            cache_table_npu,
+            group_len,
+            group_key_idx,
+            group_key_cache_idx,
+            block_size,
+        )
+
+    torch.testing.assert_close(
+        cache_table_npu.cpu(),
+        expected_cache,
+        rtol=0,
+        atol=0,
+    )
+
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("num_tokens", [32 * 1024])
+@pytest.mark.parametrize("num_head", [1])
+@pytest.mark.parametrize("block_size", [128])
+@pytest.mark.parametrize("num_blocks", [1773])
+@pytest.mark.parametrize("head_size", [512])
+def test_storeKVBlock_without_continuous(
+    num_tokens,
+    num_head,
+    num_blocks,
+    head_size,
+    block_size,
+):
+    require_store_kv_block_registered()
+
+    # keylist = torch.randint(
+    #     low=0,
+    #     high=128,
+    #     size=(num_tokens, num_head, head_size),
+    #     dtype=torch.int8,
+    # )
+    keylist = torch.rand(
+        size=(num_tokens, num_head, head_size),
+        dtype=torch.float16,
+    )
+
+    slotmap = []
+    r = 0
+    for i in range(0, num_tokens):
+        r = r + random_with_zero_prob(0.992, 5)
+        slotmap.append(i + r)
+
+    max_slot = max(slotmap)
+    total_cache_slots = num_blocks * block_size
+    assert max_slot < total_cache_slots
+
+    # cache_table = torch.randint(
+    #     low=0,
+    #     high=128,
+    #     size=(num_blocks, block_size, num_head, head_size),
+    #     dtype=torch.int8,
+    # )
+    cache_table = torch.rand(
+        size=(num_blocks, block_size, num_head, head_size),
+        dtype=torch.float16,
+    )
+
+    # expected_cache = golden_store_kv_block(
+    #     keylist=keylist,
+    #     cache_table=cache_table,
+    #     slotmap=slotmap,
+    #     block_size=block_size,
+    # )
+
+    slotmap_np = np.array(slotmap, dtype=np.int32)
+    slot_mapping_npu = torch.from_numpy(slotmap_np).to(torch.int32).npu()
+
+    slot_mapping_cpu = torch.empty_like(slot_mapping_npu, device="cpu").pin_memory()
+    slot_mapping_cpu.copy_(slot_mapping_npu, non_blocking=True)
+    torch.npu.synchronize()
+
+    slot_mapping_list = slot_mapping_cpu.tolist()
+
+    keylist_npu = keylist.npu()
+    cache_table_npu = cache_table.clone().npu()
+
+    epoch = 100
+    start = time.perf_counter()
+    for _ in range(epoch):
+        group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+            slot_mapping_npu,
+            slot_mapping_list,
+            block_size,
+        )
+
+        torch.ops._C_ascend.store_kv_block(
+            keylist_npu,
+            cache_table_npu,
+            group_len,
+            group_key_idx,
+            group_key_cache_idx,
+            block_size,
+        )
+
+    #     torch.testing.assert_close(
+    #         cache_table_npu.cpu(),
+    #         expected_cache,
+    #         rtol=0,
+    #         atol=0,
+    #     )
+    end = time.perf_counter()
+    avg_ms = (end - start) / epoch * 1000
+    print(f"python 耗时: {avg_ms:.4f} ms")
+
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("num_tokens", [32 * 1024])  # 6398
+@pytest.mark.parametrize("num_head", [1])  # 512
+@pytest.mark.parametrize("block_size", [128])  # 128
+@pytest.mark.parametrize("num_blocks", [1773])  # 1599
+@pytest.mark.parametrize("head_size", [512])
+def test_siso(num_tokens, num_head, block_size, num_blocks, head_size):
+    require_npu_available()
+
+    key_cpu = torch.randint(
+        low=0,
+        high=128,
+        size=(num_tokens, num_head, head_size),
+        dtype=torch.int8,
+    )
+
+    # key_cpu = torch.rand((num_tokens, num_head, head_size), dtype=torch.float16)
+    key = key_cpu.npu()
+
+    key_cache_cpu = torch.randint(
+        low=0,
+        high=128,
+        size=(num_blocks, block_size, num_head, head_size),
+        dtype=torch.int8,
+    )
+    # key_cache_cpu = torch.rand(
+    #     (num_blocks, block_size, num_head, head_size),
+    #     dtype=torch.float16,
+    # )
+    key_cache = key_cache_cpu.clone().npu()
+
+    slot_list = []
+    r = 0
+    for i in range(0, num_tokens):
+        r = r + random_with_zero_prob(0.992, 5)
+        slot_list.append(i + r)
+
+    assert num_tokens == len(slot_list)
+
+    slot_list_np = np.array(slot_list)
+    slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+
+    key_expect = golden_store_kv_block(
+        keylist=key_cpu,
+        cache_table=key_cache_cpu,
+        slotmap=slot_list,
+        block_size=block_size,
+    )
+
+    epoch = 100
+    torch.npu.synchronize()
+    start = time.perf_counter()
+    for _ in range(epoch):
+        torch_npu._npu_reshape_and_cache_siso(key, key_cache, slot_mapping_npu)
+    torch.npu.synchronize()
+    end = time.perf_counter()
+
+    avg_ms = (end - start) / epoch * 1000
+    print(f"python 耗时: {avg_ms:.4f} ms")
+
+    # prof.stop()
+    # end = time.perf_counter()
+    # avg_ms = (end - start) / N * 1000
+    # print(f"python 耗时: {avg_ms:.4f} ms")
+    # torch.ops._C_ascend.reshape_and_cache(
+    #     key,
+    #     value,
+    #     key_cache,
+    #     value_cache,
+    #     slot_mapping,
+    # )
+    torch.testing.assert_close(key_expect, key_cache.cpu(), atol=0, rtol=0)
+    # torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
+
+
+# def cal_slot(key, key_cache, slot_mapping, block_size):
+#     key_expect = key_cache.clone()
+#     for i, slot in enumerate(slot_mapping):
+#         if slot < 0:
+#             continue
+#         token_key = key[i]
+#         block_index = slot // block_size
+#         block_offset = slot % block_size
+#         key_expect[block_index][block_offset] = token_key
+#     return key_expect.npu()
+
+
+def cal_scatternd(key, key_cache, slot_mapping, block_size):
+    key_expect = key_cache.clone()
+    for i, slot in enumerate(slot_mapping):
+        if slot < 0:
+            continue
+        token_key = key[i]
+        key_expect[slot] = token_key
+
+    return key_expect.npu()
+
+
+# @pytest.mark.parametrize("num_tokens", [16])  # 6398
+# @pytest.mark.parametrize("num_head", [1])  # 512
+# @pytest.mark.parametrize("block_size", [128])  # 128
+# @pytest.mark.parametrize("num_blocks", [1773])  # 1599
+# @pytest.mark.parametrize("count", [1])
+# def test_siso(num_tokens, num_head, block_size, num_blocks, count):
+#     head_size_k = 1
+#     key = torch.rand(
+#         (num_tokens, num_head, head_size_k),
+#         dtype=torch.float16,
+#     ).npu()
+#     # key = torch.randint(
+#     #     low=0,
+#     #     high=128,
+#     #     size=(num_tokens, head_size_k),
+#     #     dtype=torch.int8,
+#     # )
+#     key_cache = torch.rand(
+#         (num_blocks, block_size, num_head, head_size_k),
+#         dtype=torch.float16,
+#     ).npu()
+#     # key_cache = torch.randint(
+#     #     low=0,
+#     #     high=128,
+#     #     size=(num_blocks, block_size, num_head, head_size_k),
+#     #     dtype=torch.int8,
+#     # )
+#
+#     slot_list = []
+#     for i in range(0, num_tokens):
+#         slot_list.append(2 + i)
+#     assert num_tokens == len(slot_list)
+#     slot_list_np = np.array(slot_list)
+#     slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+#
+#     key_expect = cal_slot(key, key_cache, slot_mapping_npu, block_size)
+#     warm_up = 0
+#
+#     for _ in range(warm_up):
+#         torch_npu._npu_reshape_and_cache_siso(
+#             key,
+#             key_cache,
+#             slot_mapping_npu,
+#         )
+#     N = 101
+#
+#     for _ in range(N):
+#         torch_npu._npu_reshape_and_cache_siso(
+#             key,
+#             key_cache,
+#             slot_mapping_npu,
+#         )
+#
+#     torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
+
+
+@pytest.mark.parametrize("num_tokens", [32 * 1024])  # 6398
+@pytest.mark.parametrize("num_head", [1])  # 512
+@pytest.mark.parametrize("block_size", [128])  # 128
+@pytest.mark.parametrize("num_blocks", [1773])  # 1599
+@pytest.mark.parametrize("count", [1])
+def test_scatter(num_tokens, num_head, block_size, num_blocks, count):
+    require_npu_available()
+
+    head_size_k = 64
+    key = torch.randint(
+        low=0,
+        high=128,
+        size=(num_tokens, num_head, head_size_k),
+        dtype=torch.int8,
+    ).npu()
+    # key = torch.rand(
+    #     (num_tokens, num_head, head_size_k),
+    #     dtype=torch.float16,
+    # ).npu()
+
+    key_cache = torch.randint(
+        low=0,
+        high=128,
+        size=(num_blocks * block_size, num_head, head_size_k),
+        dtype=torch.int8,
+    ).npu()
+    # key_cache = torch.rand(
+    #     (num_blocks * block_size, num_head, head_size_k),
+    #     dtype=torch.float16,
+    # ).npu()
+
+    slot_list = []
+    for i in range(0, num_tokens):
+        slot_list.append([2 + i])
+
+    assert num_tokens == len(slot_list)
+
+    slot_list_np = np.array(slot_list)
+    slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+
+    key_expect = cal_scatternd(key, key_cache, slot_mapping_npu, block_size)
+
+    N = 101
+    for _ in range(N):
+        torch_npu.npu_scatter_nd_update_(key_cache, slot_mapping_npu, key)
+
+    torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
+
+
+# @pytest.mark.parametrize("num_tokens", [16])  # 6398
+# @pytest.mark.parametrize("num_head", [1])  # 512
+# @pytest.mark.parametrize("block_size", [128])  # 128
+# @pytest.mark.parametrize("num_blocks", [1773])  # 1599
+# @pytest.mark.parametrize("count", [1])
+# def test_myops(num_tokens, num_head, block_size, num_blocks, count):
+#     head_size_k = 64
+#     # key_cache = torch.rand(
+#     #     (num_blocks, block_size, num_head, head_size_k),
+#     #     dtype=torch.float16,
+#     # )
+#     key_cache = torch.randint(
+#         low=0,
+#         high=128,
+#         size=(num_blocks, block_size, num_head, head_size_k),
+#         dtype=torch.int8,
+#     )
+#     key_cache_npu = key_cache.npu()
+#
+#     slot_list = []
+#     for i in range(0, num_tokens):
+#         slot_list.append(2 + i)
+#
+#     slot_list_np = np.array(slot_list)
+#     slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
+#     # slot_mapping_cpu = slot_mapping_npu.to("cpu", non_blocking=True)
+#     # num_draft_tensor = slot_mapping_npu.to("cpu", non_blocking=True)
+#     slot_mapping_cpu = torch.empty_like(
+#         slot_mapping_npu,
+#         device="cpu",
+#     ).pin_memory()
+#     slot_mapping_cpu.copy_(slot_mapping_npu, non_blocking=True)
+#
+#     # key = torch.rand(
+#     #     (num_tokens, num_head, head_size_k),
+#     #     dtype=torch.float16,
+#     # )
+#     key = torch.randint(
+#         low=0,
+#         high=128,
+#         size=(num_tokens, head_size_k),
+#         dtype=torch.int8,
+#     )
+#     key_npu = key.npu()
+#     key_expect = cal_slot(key_npu, key_cache_npu, slot_list_np, block_size)
+#
+#     time.sleep(0.1)
+#     slot_mapping_list = slot_mapping_cpu.tolist()
+#     warm_up = 0
+#     for _ in range(warm_up):
+#         group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+#             slot_mapping_npu,
+#             slot_mapping_list,
+#             block_size,
+#         )
+#         torch.ops._C_ascend.store_kv_block(
+#             key_npu,
+#             key_cache_npu,
+#             group_len,
+#             group_key_idx,
+#             group_key_cache_idx,
+#             block_size,
+#         )
+#     N = 101
+#     for _ in range(N):
+#         group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+#             slot_mapping_npu,
+#             slot_mapping_list,
+#             block_size,
+#         )
+#         torch.ops._C_ascend.store_kv_block(
+#             key_npu,
+#             key_cache_npu,
+#             group_len,
+#             group_key_idx,
+#             group_key_cache_idx,
+#             block_size,
+#         )
+#
+#     torch.testing.assert_close(
+#         key_expect,
+#         key_cache_npu,
+#         atol=0.001,
+#         rtol=0.1,
+#     )
+#     torch.npu.empty_cache()
+#     torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -150,6 +150,11 @@ class AscendSFAMetadata:
     num_decode_tokens: int = 0
     num_prefills: int = 0
 
+    block_size: int = 0
+    group_len: torch.Tensor | None = None
+    group_key_idx: torch.Tensor | None = None
+    group_key_cache_idx: torch.Tensor | None = None
+
 
 M = TypeVar("M", bound=AscendSFAMetadata)
 
@@ -230,6 +235,12 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
+
+        block_size = 128
+        if envs.VLLM_ASCEND_ENABLE_RESHAPE_OPTIM:
+            slot_mapping_cpu = torch.empty_like(slot_mapping, device="cpu").pin_memory()
+            slot_mapping_cpu.copy_(slot_mapping, non_blocking=True)
+
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
 
         cum_query_lens = common_attn_metadata.query_start_loc[1 : num_reqs + 1]
@@ -317,6 +328,14 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 actual_seq_lengths_key=actual_seq_lengths_key,
             )
 
+        if envs.VLLM_ASCEND_ENABLE_RESHAPE_OPTIM:
+            slot_mapping_list = slot_mapping_cpu.tolist()
+            group_len, group_key_idx, group_key_cache_idx = torch.ops._C_ascend.store_kv_block_pre(
+                slot_mapping, slot_mapping_list, block_size
+            )
+        else:
+            group_len, group_key_idx, group_key_cache_idx = None, None, None
+
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=num_actual_tokens,
@@ -331,6 +350,10 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             dsa_cp_context=dsa_cp_context,
+            block_size=block_size,
+            group_len=group_len,
+            group_key_idx=group_key_idx,
+            group_key_cache_idx=group_key_cache_idx,
         )
 
     def build_for_graph_capture(
@@ -1179,32 +1202,70 @@ class AscendSFAImpl(MLAAttentionImpl):
                         )
                     else:
                         k_pe, k_nope = fused_kv_no_split.split([self.qk_rope_head_dim, self.kv_lora_rank], dim=-1)
-                    k_nope = k_nope.view(k_nope.shape[0], 1, -1)
-                    k_pe = k_pe.view(k_pe.shape[0], 1, -1)
-                    DeviceOperator.reshape_and_cache(
-                        key=k_nope[: attn_metadata.num_actual_tokens],
-                        value=k_pe[: attn_metadata.num_actual_tokens],
-                        key_cache=kv_cache[0],
-                        value_cache=kv_cache[1],
-                        slot_mapping=slot_mapping[: attn_metadata.num_actual_tokens],
-                    )
-
+                    if self.is_kv_producer and envs.VLLM_ASCEND_ENABLE_RESHAPE_OPTIM:
+                        torch.ops._C_ascend.store_kv_block(
+                            k_nope,
+                            kv_cache[0],
+                            attn_metadata.group_len,
+                            attn_metadata.group_key_idx,
+                            attn_metadata.group_key_cache_idx,
+                            attn_metadata.block_size,
+                        )
+                        torch.ops._C_ascend.store_kv_block(
+                            k_pe,
+                            kv_cache[1],
+                            attn_metadata.group_len,
+                            attn_metadata.group_key_idx,
+                            attn_metadata.group_key_cache_idx,
+                            attn_metadata.block_size,
+                        )
+                    else:
+                        k_nope = k_nope.view(k_nope.shape[0], 1, -1)
+                        k_pe = k_pe.view(k_pe.shape[0], 1, -1)
+                        DeviceOperator.reshape_and_cache(
+                            key=k_nope[: attn_metadata.num_actual_tokens],
+                            value=k_pe[: attn_metadata.num_actual_tokens],
+                            key_cache=kv_cache[0],
+                            value_cache=kv_cache[1],
+                            slot_mapping=slot_mapping[: attn_metadata.num_actual_tokens],
+                        )
             k_li = self._get_full_kv(k_li, attn_metadata)
 
         if kv_cache is not None:
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event = torch.npu.Event()
-            torch_npu.npu_scatter_nd_update_(
-                kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping.view(-1, 1), k_li.view(-1, k_li.shape[-1])
-            )  # b, s, n, d
+            if self.is_kv_producer and envs.VLLM_ASCEND_ENABLE_RESHAPE_OPTIM:
+                torch.ops._C_ascend.store_kv_block(
+                    k_li,
+                    kv_cache[2],
+                    attn_metadata.group_len,
+                    attn_metadata.group_key_idx,
+                    attn_metadata.group_key_cache_idx,
+                    attn_metadata.block_size,
+                )
+            else:
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping.view(-1, 1), k_li.view(-1, k_li.shape[-1])
+                )  # b, s, n, d
             if self.use_sparse_c8_indexer:
                 assert len(kv_cache) == 4
                 assert k_li_scale is not None
-                torch_npu.npu_scatter_nd_update_(
-                    kv_cache[3].view(-1, k_li_scale.shape[-1]),
-                    slot_mapping.view(-1, 1),
-                    k_li_scale.view(-1, k_li_scale.shape[-1]),
-                )
+
+                if self.is_kv_producer and envs.VLLM_ASCEND_ENABLE_RESHAPE_OPTIM:
+                    torch.ops._C_ascend.store_kv_block(
+                        k_li_scale,
+                        kv_cache[3],
+                        attn_metadata.group_len,
+                        attn_metadata.group_key_idx,
+                        attn_metadata.group_key_cache_idx,
+                        attn_metadata.block_size,
+                    )
+                else:
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[3].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li_scale.view(-1, k_li_scale.shape[-1]),
+                    )
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -84,6 +84,8 @@ env_variables: dict[str, Callable[[], Any]] = {
     # it will consume more NPU memory. If reducing NPU memory usage is a higher priority
     # for your DeepSeek W8A8 scene, then disable it.
     "VLLM_ASCEND_ENABLE_MLAPO": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MLAPO", "1"))),
+    # DeepSeek V3.2 only on P product on
+    "VLLM_ASCEND_ENABLE_RESHAPE_OPTIM": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_RESHAPE_OPTIM", "0"))),
     # Whether to enable weight cast format to FRACTAL_NZ.
     # 0: close nz;
     # 1: only quant case enable nz;


### PR DESCRIPTION
What this PR does / why we need it?

This PR adds a new Ascend custom operator, store_kv_block, together with its preprocessing operator, store_kv_block_pre, and the corresponding unit test file test_store_kv_block.py.

The operator is designed to store KV cache entries by grouping continuous slots within the same cache block. Compared with token-by-token storing approaches such as SISO or ScatterNdUpdate, this implementation can better exploit block-level continuity in slot_mapping.

Based on the previous contribution by @ZT-AIA, this PR also fixes logic issues in the grouping process and updates the unit tests to cover continuous and non-continuous slot mapping cases.
Does this PR introduce any user-facing change?

No public user-facing API is changed.

This PR adds internal Ascend custom operators, store_kv_block_pre and store_kv_block, for optimized KV cache storage in vLLM Ascend.
How was this patch tested?

This patch was tested with the added unit test file:

pytest tests/ut/ops/test_store_kv_block.py