### PR TITLE
[Refactor]: migrate env vars to AscendConfig

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -598,6 +598,7 @@ jobs:
           set -o pipefail
           # we must uninstall triton-ascend first, then triton. Otherwise, the triton folder will be left behind.
           python3 -m pip uninstall -y triton-ascend triton
+          python3 -m pip install regex
           pytest -sv --durations=0 tests/e2e/multicard/2-cards/test_aclgraph_capture_replay.py \
             2>&1 | tee /tmp/e2e-non-triton.log
           exit ${PIPESTATUS[0]}

--- a/.github/workflows/scripts/ci_log_summary.py
+++ b/.github/workflows/scripts/ci_log_summary.py
@@ -4,12 +4,13 @@ import argparse
 import base64
 import copy
 import json
-import re
 import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
+
+import regex as re
 
 """
 Generate CI failure summaries from a local pytest log or a GitHub Actions run.

--- a/.github/workflows/scripts/ci_log_summary.py
+++ b/.github/workflows/scripts/ci_log_summary.py
@@ -4,13 +4,12 @@ import argparse
 import base64
 import copy
 import json
+import re
 import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
-
-import regex as re
 
 """
 Generate CI failure summaries from a local pytest log or a GitHub Actions run.

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -213,9 +213,11 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
+    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp", return_value=False)
+    @patch("vllm.distributed.parallel_state.get_tp_group")
     @patch_distributed_groups(dcp_size=2, pcp_size=2, needs_mocks=False)
     def test_ascend_sfa_metadata_builder_build_for_graph_capture(
-        self, mock_get_cos_and_sin_mla, mock_get_current_vllm_config
+        self, mock_get_tp_group, mock_enable_dsa_cp, mock_get_cos_and_sin_mla, mock_get_current_vllm_config
     ):
         cfg = MagicMock()
         cfg.model_config = MagicMock()

--- a/tests/ut/batch_invariant/test_batch_invariant.py
+++ b/tests/ut/batch_invariant/test_batch_invariant.py
@@ -28,18 +28,13 @@ class TestBatchInvariant:
     """Complete test suite for batch_invariant.py"""
 
     def test_override_envs_for_invariance(self):
-        """Test environment variable override"""
-        # Clear environment variables
-        env_vars = ["VLLM_ASCEND_ENABLE_NZ", "HCCL_DETERMINISTIC", "LCCL_DETERMINISTIC"]
-        for var in env_vars:
-            if var in os.environ:
-                del os.environ[var]
+        """Test Config and environment variable override"""
+        mock_config = MagicMock()
+        with patch("vllm_ascend.ascend_config.get_ascend_config", return_value=mock_config):
+            batch_invariant.override_envs_for_invariance()
 
-        # Call function
-        batch_invariant.override_envs_for_invariance()
-
-        # Verify environment variables
-        assert os.environ["VLLM_ASCEND_ENABLE_NZ"] == "0"
+        assert mock_config.weight_nz_mode == 0
+        assert not mock_config.enable_matmul_allreduce
         assert os.environ["HCCL_DETERMINISTIC"] == "strict"
         assert os.environ["LCCL_DETERMINISTIC"] == "1"
 

--- a/tests/ut/distributed/test_parallel_state.py
+++ b/tests/ut/distributed/test_parallel_state.py
@@ -55,17 +55,15 @@ def test_init_ascend_model_parallel(mock_distributed, parallel_config):
     mock_ascend_config.pd_tp_ratio = 2
     mock_ascend_config.num_head_replica = 0
     mock_ascend_config.pd_head_ratio = 2
+    mock_ascend_config.enable_flashcomm2_parallel_size = 2
+    mock_ascend_config.enable_context_parallel = False
     mock_vllm_config = MagicMock()
     mock_vllm_config.kv_transfer_config.is_kv_producer = True
-    mock_envs_ascend = MagicMock()
-    mock_envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE = 2
-    mock_envs_ascend.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL = 0
     with (
         patch("vllm_ascend.distributed.parallel_state.model_parallel_initialized", return_value=False),
         patch("vllm_ascend.distributed.parallel_state.init_model_parallel_group"),
         patch("vllm_ascend.distributed.parallel_state.get_current_vllm_config", return_value=mock_vllm_config),
         patch("vllm_ascend.distributed.parallel_state.get_ascend_config", return_value=mock_ascend_config),
-        patch("vllm_ascend.utils.envs_ascend", new=mock_envs_ascend),
         patch("vllm_ascend.utils.get_ascend_config", return_value=mock_ascend_config),
     ):
         init_ascend_model_parallel(parallel_config)

--- a/tests/ut/eplb/adaptor/test_vllm_adaptor.py
+++ b/tests/ut/eplb/adaptor/test_vllm_adaptor.py
@@ -31,11 +31,19 @@ class TestVllmAdaptor(unittest.TestCase):
         VllmEplbAdaptor(self.model)
 
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
-    def test_init_w8a8(self, mock_func):
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_init_w8a8(self, mock_get_config, mock_func):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 0
+        mock_get_config.return_value = mock_config
         VllmEplbAdaptor(self.model)
 
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
-    def test_language_model_w8a8(self, mock_func):
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_language_model_w8a8(self, mock_get_config, mock_func):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 0
+        mock_get_config.return_value = mock_config
         model = MagicMock()
         model.language_model = self.model
         model.config.text_config = self.model.config

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -383,7 +383,9 @@ class TestAscendUnquantizedFusedMoEMethod:
         format_cast = MagicMock(side_effect=lambda weight, _: weight)
         maybe_trans_nz = MagicMock(side_effect=lambda weight: weight)
 
-        monkeypatch.setattr(fused_moe_module.envs_ascend, "VLLM_ASCEND_ENABLE_FUSED_MC2", enable_fused_mc2)
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.enable_fused_mc2 = enable_fused_mc2
+        monkeypatch.setattr(fused_moe_module, "get_ascend_config", lambda: mock_ascend_config)
         monkeypatch.setattr(fused_moe_module.torch_npu, "npu_format_cast", format_cast)
         monkeypatch.setattr(fused_moe_module, "maybe_trans_nz", maybe_trans_nz)
 

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -40,6 +39,8 @@ class BaseLinearTest(unittest.TestCase):
             ),
             patch("vllm_ascend.utils.mlp_tp_enable", return_value=True),
             patch("vllm_ascend.utils.oproj_tp_enable", return_value=True),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp_with_layer_shard", return_value=False),
         ]
 
         for p in self.patches:
@@ -57,33 +58,43 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_dtype = mock.PropertyMock(return_value=torch.float16)
         type(self.layer.weight.data).dtype = mock_dtype
 
-    @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    @patch("vllm_ascend.utils.get_ascend_config")
     @mock.patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_nz0(self, mock_format_cast):
+    def test_process_weights_after_loading_with_nz0(self, mock_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 0
+        mock_get_config.return_value = mock_config
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_not_called()
 
-    @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    @patch("vllm_ascend.utils.get_ascend_config")
     @mock.patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_nz1(self, mock_format_cast):
+    def test_process_weights_after_loading_with_nz1(self, mock_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 1
+        mock_get_config.return_value = mock_config
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_not_called()
 
-    @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"})
+    @patch("vllm_ascend.utils.get_ascend_config")
     @mock.patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_nz2(self, mock_format_cast):
+    def test_process_weights_after_loading_with_nz2(self, mock_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 2
+        mock_get_config.return_value = mock_config
         self.method.process_weights_after_loading(self.layer)
         mock_format_cast.assert_called_once()
 
 
 class TestAscendRowParallelLinear(BaseLinearTest):
     @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method", return_value=MagicMock())
-    @patch("vllm.config.get_current_vllm_config", return_value=MagicMock())
+    @patch("vllm_ascend.ops.linear.get_current_vllm_config", return_value=MagicMock())
+    @patch("vllm_ascend.ops.linear.enable_sp", return_value=False)
     @patch(
         "vllm_ascend.ops.linear.AscendUnquantizedLinearMethod.apply",
         new=lambda self, layer, x, bias=None: torch.nn.functional.linear(x, layer.weight, bias),
     )
-    def test_mlp_optimize(self, mock_get_current_vllm_config, mock_get_weight_prefetch_method):
+    def test_mlp_optimize(self, mock_enable_sp, mock_get_current_vllm_config, mock_get_weight_prefetch_method):
         ascend_config._ASCEND_CONFIG = MagicMock()
         ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.mlp_tensor_parallel_size = 2
@@ -100,12 +111,13 @@ class TestAscendRowParallelLinear(BaseLinearTest):
         linear(input_tensor)
 
     @patch("vllm_ascend.ops.linear_op.get_weight_prefetch_method", return_value=MagicMock())
-    @patch("vllm.config.get_current_vllm_config", return_value=MagicMock())
+    @patch("vllm_ascend.ops.linear.get_current_vllm_config", return_value=MagicMock())
+    @patch("vllm_ascend.ops.linear.enable_sp", return_value=False)
     @patch(
         "vllm_ascend.ops.linear.AscendUnquantizedLinearMethod.apply",
         new=lambda self, layer, x, bias=None: torch.nn.functional.linear(x, layer.weight, bias),
     )
-    def test_oproj_tp(self, mock_get_current_vllm_config, mock_get_weight_prefetch_method):
+    def test_oproj_tp(self, mock_enable_sp, mock_get_current_vllm_config, mock_get_weight_prefetch_method):
         ascend_config._ASCEND_CONFIG = MagicMock()
         ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.oproj_tensor_parallel_size = 2

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -18,6 +18,18 @@ class TestPrepareAndFinalize(unittest.TestCase):
         patcher = patch("torch.npu.Stream", return_value=fake_stream)
         patcher.start()
         self.addCleanup(patcher.stop)
+        self.mock_get_config = patch("vllm_ascend.ops.fused_moe.prepare_finalize.get_ascend_config")
+        mock_config = self.mock_get_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.multistream_overlap_gate = False
+        mock_ascend_config.enable_context_parallel = False
+        mock_ascend_config.enable_flashcomm2_parallel_size = 0
+        mock_config.return_value = mock_ascend_config
+        self.addCleanup(self.mock_get_config.stop)
+        self.mock_get_config_utils = patch("vllm_ascend.utils.get_ascend_config")
+        mock_config_utils = self.mock_get_config_utils.start()
+        mock_config_utils.return_value = mock_ascend_config
+        self.addCleanup(self.mock_get_config_utils.stop)
         self.moe_config = MagicMock(spec=FusedMoEConfig)
         self.moe_config.tp_group = MagicMock()
         self.moe_config.tp_group.device_group = MagicMock()

--- a/tests/ut/profiler/test_torch_npu_profiler.py
+++ b/tests/ut/profiler/test_torch_npu_profiler.py
@@ -137,10 +137,77 @@ class TestTorchNPUProfilerWrapper(TestBase):
         self.assertIn("torch_profiler_dir cannot be empty", str(cm.exception))
 
     @patch("vllm_ascend.profiler.torch_npu_profiler.envs_ascend")
-    def test_create_profiler_raises_when_msmonitor_enabled(self, mock_envs_ascend):
+    @patch("vllm_ascend.profiler.torch_npu_profiler.get_ascend_config")
+    def test_create_profiler_raises_when_msmonitor_env_enabled(self, mock_get_ascend_config, mock_envs_ascend):
         from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 
         mock_envs_ascend.MSMONITOR_USE_DAEMON = 1
+        mock_get_ascend_config.side_effect = RuntimeError("Ascend config is not initialized")
+        profiler_config = ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir="/path/to/traces",
+        )
+
+        with self.assertRaises(RuntimeError) as cm:
+            TorchNPUProfilerWrapper._create_profiler(profiler_config, "test_trace")
+
+        self.assertIn(
+            "MSMONITOR_USE_DAEMON and torch profiler cannot be both enabled at the same time.",
+            str(cm.exception),
+        )
+
+    @patch("vllm_ascend.profiler.torch_npu_profiler.envs_ascend")
+    @patch("torch_npu.profiler._ExperimentalConfig")
+    @patch("torch_npu.profiler.profile")
+    @patch("torch_npu.profiler.tensorboard_trace_handler")
+    @patch("torch_npu.profiler.ExportType")
+    @patch("torch_npu.profiler.ProfilerLevel")
+    @patch("torch_npu.profiler.AiCMetrics")
+    @patch("torch_npu.profiler.ProfilerActivity")
+    @patch("vllm_ascend.profiler.torch_npu_profiler.get_ascend_config")
+    def test_create_profiler_config_overrides_msmonitor_env(
+        self,
+        mock_get_ascend_config,
+        mock_profiler_activity,
+        mock_aic_metrics,
+        mock_profiler_level,
+        mock_export_type,
+        mock_trace_handler,
+        mock_profile,
+        mock_experimental_config,
+        mock_envs_ascend,
+    ):
+        from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
+
+        mock_envs_ascend.MSMONITOR_USE_DAEMON = 1
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.msmonitor_use_daemon = False
+        mock_get_ascend_config.return_value = mock_ascend_config
+
+        profiler_config = ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir="/path/to/traces",
+        )
+        mock_export_type.Text = "Text"
+        mock_profiler_level.Level1 = "Level1"
+        mock_aic_metrics.AiCoreNone = "AiCoreNone"
+        mock_profiler_activity.CPU = "CPU"
+        mock_profiler_activity.NPU = "NPU"
+        mock_profile.return_value = MagicMock()
+
+        TorchNPUProfilerWrapper._create_profiler(profiler_config, "test_trace")
+
+        mock_profile.assert_called_once()
+
+    @patch("vllm_ascend.profiler.torch_npu_profiler.envs_ascend")
+    @patch("vllm_ascend.profiler.torch_npu_profiler.get_ascend_config")
+    def test_create_profiler_config_enables_msmonitor_over_env(self, mock_get_ascend_config, mock_envs_ascend):
+        from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
+
+        mock_envs_ascend.MSMONITOR_USE_DAEMON = 0
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.msmonitor_use_daemon = True
+        mock_get_ascend_config.return_value = mock_ascend_config
         profiler_config = ProfilerConfig(
             profiler="torch",
             torch_profiler_dir="/path/to/traces",

--- a/tests/ut/quantization/methods/test_w8a16.py
+++ b/tests/ut/quantization/methods/test_w8a16.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -50,9 +49,12 @@ class TestAscendW8A16LinearMethod(TestBase):
         self.assertTrue(torch.equal(output, expected_y_output))
         mock_npu_weight_quant_batchmatmul.assert_called_once()
 
-    @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    @patch("vllm_ascend.utils.get_ascend_config")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_nz1(self, mock_npu_format_cast):
+    def test_process_weights_after_loading_with_nz1(self, mock_npu_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 1
+        mock_get_config.return_value = mock_config
         layer = MagicMock()
 
         layer.weight.data = torch.randint(-128, 127, (128, 256), dtype=torch.int8)
@@ -72,6 +74,14 @@ class TestAscendW8A16LinearMethod(TestBase):
 class TestAscendW8A16LinearMethodWithNpu(TestBase):
     def setUp(self):
         self.method = AscendW8A16LinearMethod()
+        self.mock_get_config = patch("vllm_ascend.utils.get_ascend_config")
+        mock_config = self.mock_get_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.weight_nz_mode = 0
+        mock_config.return_value = mock_ascend_config
+
+    def tearDown(self):
+        self.mock_get_config.stop()
 
     def test_apply_with_npu(self):
         input_size, output_size = 128, 256

--- a/tests/ut/quantization/methods/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8_dynamic.py
@@ -71,6 +71,14 @@ class TestAscendW8A8DynamicLinearMethod(TestBase):
 class TestAscendW8A8DynamicLinearMethodWithNpu(TestBase):
     def setUp(self):
         self.method = AscendW8A8DynamicLinearMethod()
+        self.mock_get_config = patch("vllm_ascend.utils.get_ascend_config")
+        mock_config = self.mock_get_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.weight_nz_mode = 0
+        mock_config.return_value = mock_ascend_config
+
+    def tearDown(self):
+        self.mock_get_config.stop()
 
     def test_apply_with_npu(self):
         input_size, output_size = 128, 256
@@ -184,9 +192,11 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertIs(fused_experts_input.topk_ids, topk_ids)
 
     @patch("torch_npu.npu_format_cast")
-    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.envs_ascend")
-    def test_process_weights_after_loading(self, mock_envs, mock_format_cast):
-        mock_envs.VLLM_ASCEND_ENABLE_FUSED_MC2 = 1
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
+    def test_process_weights_after_loading(self, mock_get_config, mock_format_cast):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 1
+        mock_get_config.return_value = mock_config
         self.quant_method.dynamic_eplb = True
         mock_format_cast.return_value = torch.randint(
             -8, 8, (self.num_experts, self.hidden_size, 2 * self.intermediate_size), dtype=torch.int8

--- a/tests/ut/quantization/methods/test_w8a8_static.py
+++ b/tests/ut/quantization/methods/test_w8a8_static.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -101,9 +100,12 @@ class TestAscendW8A8LinearMethod(TestBase):
         call_kwargs = mock_npu_quant_matmul.call_args.kwargs
         self.assertTrue(torch.equal(call_kwargs["bias"], bias))
 
-    @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    @patch("vllm_ascend.utils.get_ascend_config")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_nz1(self, mock_npu_format_cast):
+    def test_process_weights_after_loading_with_nz1(self, mock_npu_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 1
+        mock_get_config.return_value = mock_config
         layer = MagicMock()
 
         layer.weight.data = torch.randint(-128, 127, (128, 256), dtype=torch.int8)
@@ -125,9 +127,12 @@ class TestAscendW8A8LinearMethod(TestBase):
         mock_npu_format_cast.assert_called_once()
         self.assertTrue(isinstance(layer.deq_scale, MagicMock))
 
-    @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"})
+    @patch("vllm_ascend.utils.get_ascend_config")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_nz2_and_compressed_tensors(self, mock_npu_format_cast):
+    def test_process_weights_after_loading_with_nz2_and_compressed_tensors(self, mock_npu_format_cast, mock_get_config):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 2
+        mock_get_config.return_value = mock_config
         layer = MagicMock()
 
         layer.weight.data = torch.randint(-128, 127, (128, 256), dtype=torch.int8)
@@ -155,6 +160,14 @@ class TestAscendW8A8LinearMethod(TestBase):
 class TestAscendW8A8LinearMethodWithNpu(TestBase):
     def setUp(self):
         self.method = AscendW8A8LinearMethod()
+        self.mock_get_config = patch("vllm_ascend.utils.get_ascend_config")
+        mock_config = self.mock_get_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.weight_nz_mode = 0
+        mock_config.return_value = mock_ascend_config
+
+    def tearDown(self):
+        self.mock_get_config.stop()
 
     @patch("vllm_ascend.quantization.methods.w8a8_static.get_weight_prefetch_method")
     def test_apply_with_npu(self, mock_get_weight_prefetch_method):

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -17,7 +17,7 @@ from vllm.v1.spec_decode.draft_model import DraftModelProposer
 import vllm_ascend.spec_decode.eagle_proposer as eagle_proposer
 from tests.ut.base import TestBase
 from tests.ut.conftest import npu_test
-from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.ascend_config import clear_ascend_config, init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
@@ -326,6 +326,21 @@ class TestEagleProposerLoadModel(TestBase):
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
 
+        # Mock get_ascend_config to return a properly configured mock
+        self.mock_get_ascend_config = patch("vllm_ascend.utils.get_ascend_config")
+        mock_config = self.mock_get_ascend_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.enable_flashcomm2_parallel_size = 0
+        mock_ascend_config.enable_context_parallel = False
+        mock_ascend_config.enable_flashcomm1 = False
+        mock_ascend_config.enable_matmul_allreduce = False
+        mock_ascend_config.weight_nz_mode = 1
+        mock_ascend_config.enable_mlapo = True
+        mock_ascend_config.enable_fused_mc2 = 0
+        mock_ascend_config.msmonitor_use_daemon = False
+        mock_ascend_config.enable_transpose_kv_cache_by_block = True
+        mock_config.return_value = mock_ascend_config
+
         self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
         self.mock_supports_multimodal_inputs = patch(
@@ -339,6 +354,7 @@ class TestEagleProposerLoadModel(TestBase):
         self.proposer.parallel_drafting = False
 
     def tearDown(self):
+        self.mock_get_ascend_config.stop()
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
         # Clear the current vllm config
@@ -454,6 +470,16 @@ class TestEagleProposerDummyRun(TestBase):
         self.vllm_config.parallel_config.data_parallel_rank = 0
         self.vllm_config.parallel_config.data_parallel_size = 1
         self.vllm_config.parallel_config.prefill_context_parallel_size = 1
+        self.vllm_config.parallel_config.enable_expert_parallel = False
+        self.vllm_config.parallel_config.pipeline_parallel_size = 1
+        self.vllm_config.model_config.enforce_eager = True
+        self.vllm_config.model_config.is_deepseek_mla = False
+        self.vllm_config.kv_transfer_config = None
+        self.vllm_config.compilation_config = MagicMock()
+        self.vllm_config.compilation_config.pass_config = MagicMock()
+        self.vllm_config.compilation_config.pass_config.enable_sp = False
+        self.vllm_config.cache_config = MagicMock()
+        self.vllm_config.cache_config.block_size = 16
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(4)])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
@@ -461,6 +487,21 @@ class TestEagleProposerDummyRun(TestBase):
         self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
         init_ascend_config(self.vllm_config)
+
+        # Mock get_ascend_config to return a properly configured mock
+        self.mock_get_ascend_config = patch("vllm_ascend.utils.get_ascend_config")
+        mock_config = self.mock_get_ascend_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.enable_flashcomm2_parallel_size = 0
+        mock_ascend_config.enable_context_parallel = False
+        mock_ascend_config.enable_flashcomm1 = False
+        mock_ascend_config.enable_matmul_allreduce = False
+        mock_ascend_config.weight_nz_mode = 1
+        mock_ascend_config.enable_mlapo = True
+        mock_ascend_config.enable_fused_mc2 = 0
+        mock_ascend_config.msmonitor_use_daemon = False
+        mock_ascend_config.enable_transpose_kv_cache_by_block = True
+        mock_config.return_value = mock_ascend_config
 
         self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
@@ -488,6 +529,7 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.update_stream = MagicMock()
 
     def tearDown(self):
+        self.mock_get_ascend_config.stop()
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
         self.mock_tp_world_size.stop()
@@ -881,6 +923,21 @@ class TestEagleProposerPropose:
         # that the mocked functions and parameters exist
         self.check_mock()
 
+        clear_ascend_config()
+        self.mock_get_ascend_config = patch("vllm_ascend.utils.get_ascend_config")
+        mock_get_ascend_config = self.mock_get_ascend_config.start()
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.enable_flashcomm2_parallel_size = 0
+        mock_ascend_config.enable_context_parallel = False
+        mock_ascend_config.enable_flashcomm1 = False
+        mock_ascend_config.enable_matmul_allreduce = False
+        mock_ascend_config.weight_nz_mode = 1
+        mock_ascend_config.enable_mlapo = True
+        mock_ascend_config.enable_fused_mc2 = 0
+        mock_ascend_config.msmonitor_use_daemon = False
+        mock_ascend_config.enable_transpose_kv_cache_by_block = True
+        mock_get_ascend_config.return_value = mock_ascend_config
+
         self.vllm_config = MagicMock(spec=VllmConfig)
         self.vllm_config.speculative_config = MagicMock()
         self.vllm_config.speculative_config.num_speculative_tokens = 3
@@ -905,13 +962,24 @@ class TestEagleProposerPropose:
         self.vllm_config.parallel_config.data_parallel_rank = 0
         self.vllm_config.parallel_config.data_parallel_size = 1
         self.vllm_config.parallel_config.prefill_context_parallel_size = 1
+        self.vllm_config.parallel_config.enable_expert_parallel = False
+        self.vllm_config.parallel_config.pipeline_parallel_size = 1
+        self.vllm_config.model_config.enforce_eager = True
+        self.vllm_config.model_config.is_deepseek_mla = False
+        self.vllm_config.kv_transfer_config = None
+        self.vllm_config.compilation_config = MagicMock()
+        self.vllm_config.compilation_config.pass_config = MagicMock()
+        self.vllm_config.compilation_config.pass_config.enable_sp = False
+        self.vllm_config.cache_config = MagicMock()
+        self.vllm_config.cache_config.block_size = 16
         self.vllm_config.speculative_config.draft_tensor_parallel_size = 1
         self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(4)])
         self.vllm_config.speculative_config.draft_model_config.uses_xdrope_dim = 0
         self.vllm_config.speculative_config.draft_model_config.uses_mrope = False
         self.vllm_config.speculative_config.disable_padded_drafter_batch = False
         self.vllm_config.additional_config = None
-        init_ascend_config(self.vllm_config)
+        self.ascend_config = init_ascend_config(self.vllm_config)
+        self.ascend_config.enable_flashcomm2_parallel_size = 0
 
         self.mock_cpugpubuffer = patch(_CPU_GPU_BUFFER_TARGET)
         self.mock_cpugpubuffer.start()
@@ -947,8 +1015,10 @@ class TestEagleProposerPropose:
         self.mock_supports_multimodal_inputs.stop()
         self.mock_tp_world_size.stop()
         self.mock_dp_group.stop()
+        self.mock_get_ascend_config.stop()
         # Clear the current vllm config
         set_current_vllm_config(None)
+        clear_ascend_config()
 
     # config: prefill and decode, Qwen3-8B, tp1, enforce_eager, no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
     @pytest.mark.parametrize(

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -122,11 +122,28 @@ class TestAscendConfig(TestBase):
         self.assertFalse(ascend_config.enable_transpose_kv_cache_by_block)
         self.assertEqual(ascend_config.weight_nz_mode, 2)
         mock_info_once.assert_any_call(
-            "AscendConfig.enable_mlapo falls back to environment variable VLLM_ASCEND_ENABLE_MLAPO with value False."
+            "AscendConfig.enable_mlapo falls back to environment variable VLLM_ASCEND_ENABLE_MLAPO with value False. "
+            "Please use additional_config.enable_mlapo instead, because VLLM_ASCEND_ENABLE_MLAPO will be removed in the next release."
         )
         mock_info_once.assert_any_call(
-            "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2."
+            "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2. "
+            "Please use additional_config.weight_nz_mode instead, because VLLM_ASCEND_ENABLE_NZ will be removed in the next release."
         )
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.info_once")
+    @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
+    def test_migrated_config_skips_default_env_fallback_logs(self, mock_fix_incompatible_config, mock_info_once):
+        test_vllm_config = VllmConfig()
+        with patch.dict(os.environ, {}, clear=True):
+            init_ascend_config(test_vllm_config)
+
+        fallback_logs = [
+            call.args[0]
+            for call in mock_info_once.call_args_list
+            if "falls back to environment variable" in call.args[0]
+        ]
+        self.assertEqual(fallback_logs, [])
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.ascend_config.logger.info_once")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -21,6 +21,7 @@ from vllm.config import VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import clear_ascend_config, get_ascend_config, init_ascend_config
+from vllm_ascend.utils import clear_enable_sp, enable_sp, get_flashcomm2_config_and_validate
 
 
 class TestAscendConfig(TestBase):
@@ -88,6 +89,133 @@ class TestAscendConfig(TestBase):
         ascend_compilation_config = init_ascend_config(test_vllm_config).ascend_compilation_config
         self.assertTrue(ascend_compilation_config.enable_npugraph_ex)
         self.assertTrue(ascend_compilation_config.enable_static_kernel)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.info_once")
+    @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
+    def test_migrated_config_falls_back_to_envs(self, mock_fix_incompatible_config, mock_info_once):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.parallel_config.tensor_parallel_size = 4
+        with patch.dict(
+            os.environ,
+            {
+                "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": "1",
+                "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
+                "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
+                "VLLM_ASCEND_ENABLE_MLAPO": "0",
+                "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
+                "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "2",
+                "MSMONITOR_USE_DAEMON": "1",
+                "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": "0",
+                "VLLM_ASCEND_ENABLE_NZ": "2",
+            },
+        ):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertTrue(ascend_config.enable_context_parallel)
+        self.assertTrue(ascend_config.enable_matmul_allreduce)
+        self.assertEqual(ascend_config.enable_fused_mc2, 2)
+        self.assertFalse(ascend_config.enable_mlapo)
+        self.assertTrue(ascend_config.enable_flashcomm1)
+        self.assertEqual(ascend_config.enable_flashcomm2_parallel_size, 2)
+        self.assertTrue(ascend_config.msmonitor_use_daemon)
+        self.assertFalse(ascend_config.enable_transpose_kv_cache_by_block)
+        self.assertEqual(ascend_config.weight_nz_mode, 2)
+        mock_info_once.assert_any_call(
+            "AscendConfig.enable_mlapo falls back to environment variable VLLM_ASCEND_ENABLE_MLAPO with value False."
+        )
+        mock_info_once.assert_any_call(
+            "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2."
+        )
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.info_once")
+    @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
+    def test_migrated_config_overrides_envs(self, mock_fix_incompatible_config, mock_info_once):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "enable_context_parallel": False,
+            "enable_matmul_allreduce": False,
+            "enable_fused_mc2": 0,
+            "enable_mlapo": True,
+            "enable_flashcomm1": False,
+            "enable_flashcomm2_parallel_size": 0,
+            "msmonitor_use_daemon": False,
+            "enable_transpose_kv_cache_by_block": True,
+            "weight_nz_mode": 1,
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": "1",
+                "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
+                "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
+                "VLLM_ASCEND_ENABLE_MLAPO": "0",
+                "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
+                "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE": "2",
+                "MSMONITOR_USE_DAEMON": "1",
+                "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": "0",
+                "VLLM_ASCEND_ENABLE_NZ": "2",
+            },
+        ):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertFalse(ascend_config.enable_context_parallel)
+        self.assertFalse(ascend_config.enable_matmul_allreduce)
+        self.assertEqual(ascend_config.enable_fused_mc2, 0)
+        self.assertTrue(ascend_config.enable_mlapo)
+        self.assertFalse(ascend_config.enable_flashcomm1)
+        self.assertEqual(ascend_config.enable_flashcomm2_parallel_size, 0)
+        self.assertFalse(ascend_config.msmonitor_use_daemon)
+        self.assertTrue(ascend_config.enable_transpose_kv_cache_by_block)
+        self.assertEqual(ascend_config.weight_nz_mode, 1)
+        mock_info_once.assert_any_call("AscendConfig.enable_mlapo is set from additional_config with value True.")
+        mock_info_once.assert_any_call("AscendConfig.weight_nz_mode is set from additional_config with value 1.")
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")
+    def test_enable_flashcomm1_config_overrides_disabled_env(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"enable_flashcomm1": True}
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "0"}):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertTrue(ascend_config.enable_flashcomm1)
+        self.assertTrue(enable_sp(test_vllm_config))
+
+    @_clean_up_ascend_config
+    def test_enable_sp_falls_back_to_env_without_current_config(self):
+        clear_enable_sp()
+        with (
+            patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"}),
+            patch("vllm.config.get_current_vllm_config", side_effect=AssertionError),
+        ):
+            self.assertTrue(enable_sp())
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.utils.logger.warning_once")
+    def test_flashcomm2_warning_uses_enable_flashcomm1_config(self, mock_warning_once):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.parallel_config.tensor_parallel_size = 4
+        test_vllm_config.kv_transfer_config = None
+        ascend_config = type(
+            "MockAscendConfig",
+            (),
+            {
+                "enable_flashcomm2_parallel_size": 2,
+                "layer_sharding": None,
+                "enable_flashcomm1": True,
+                "finegrained_tp_config": type("MockFinegrainedTPConfig", (), {"oproj_tensor_parallel_size": 0})(),
+            },
+        )()
+
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "0"}):
+            self.assertEqual(get_flashcomm2_config_and_validate(ascend_config, test_vllm_config), 2)
+
+        flashcomm1_warning = (
+            "It is recommended to enable FLASHCOMM1 simultaneously when starting FLASHCOMM2 for optimal performance."
+        )
+        self.assertNotIn(flashcomm1_warning, [call.args[0] for call in mock_warning_once.call_args_list])
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform._fix_incompatible_config")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -123,11 +123,13 @@ class TestAscendConfig(TestBase):
         self.assertEqual(ascend_config.weight_nz_mode, 2)
         mock_info_once.assert_any_call(
             "AscendConfig.enable_mlapo falls back to environment variable VLLM_ASCEND_ENABLE_MLAPO with value False. "
-            "Please use additional_config.enable_mlapo instead, because VLLM_ASCEND_ENABLE_MLAPO will be removed in the next release."
+            "Please use additional_config.enable_mlapo instead, because VLLM_ASCEND_ENABLE_MLAPO will be "
+            "removed in the next release."
         )
         mock_info_once.assert_any_call(
             "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2. "
-            "Please use additional_config.weight_nz_mode instead, because VLLM_ASCEND_ENABLE_NZ will be removed in the next release."
+            "Please use additional_config.weight_nz_mode instead, because VLLM_ASCEND_ENABLE_NZ will be removed "
+            "in the next release."
         )
 
     @_clean_up_ascend_config

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -535,6 +535,7 @@ class TestNPUPlatform(TestBase):
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = False
+        mock_ascend_config.enable_balance_scheduling = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -551,8 +552,7 @@ class TestNPUPlatform(TestBase):
         self.platform = platform.NPUPlatform()
 
         with (
-            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
-            pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"),
+            pytest.raises(ValueError, match=r"enable_balance_scheduling.*PD-mixed.*PD-disaggregated"),
             patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
             patch.object(platform, "check_kv_extra_config"),
         ):
@@ -567,6 +567,7 @@ class TestNPUPlatform(TestBase):
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = False
+        mock_ascend_config.enable_balance_scheduling = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -583,8 +584,7 @@ class TestNPUPlatform(TestBase):
         self.platform = platform.NPUPlatform()
 
         with (
-            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
-            pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"),
+            pytest.raises(ValueError, match=r"enable_balance_scheduling.*PD-mixed.*PD-disaggregated"),
             patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
             patch.object(platform, "check_kv_extra_config"),
         ):

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -324,8 +324,10 @@ class TestUtils(TestBase):
             self.assertEqual(kwargs, {})
 
         # Test case 1: non-310P, NZ is disabled
+        mock_config = mock.MagicMock()
+        mock_config.weight_nz_mode = 0
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
@@ -335,8 +337,9 @@ class TestUtils(TestBase):
 
         # Test case 2: 310P always converts non-fp32 weights, even when NZ=0
         mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 0
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=True),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
@@ -346,8 +349,9 @@ class TestUtils(TestBase):
 
         # Test case 3: fp32 never converts, including on 310P
         mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 1
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=True),
         ):
             weight = torch.randn(32, 64, dtype=torch.float32)
@@ -357,8 +361,9 @@ class TestUtils(TestBase):
 
         # Test case 4: non-310P fp16 converts only when NZ=2
         mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 1
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
@@ -368,8 +373,9 @@ class TestUtils(TestBase):
 
         # Test case 5: non-310P fp16 converts when NZ=2
         mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
@@ -379,8 +385,9 @@ class TestUtils(TestBase):
 
         # Test case 6: non-310P bf16 converts when NZ=2
         mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 2
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
             weight = torch.randn(32, 64, dtype=torch.bfloat16)
@@ -390,8 +397,9 @@ class TestUtils(TestBase):
 
         # Test case 7: non-310P quantized weights still convert by default
         mock_npu_format_cast.reset_mock()
+        mock_config.weight_nz_mode = 1
         with (
-            mock.patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"}),
+            mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
             mock.patch("vllm_ascend.utils.is_310p", return_value=False),
         ):
             weight = torch.zeros(32, 64, dtype=torch.int8)

--- a/tests/ut/worker/test_model_runner_v1_with_device.py
+++ b/tests/ut/worker/test_model_runner_v1_with_device.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 from vllm.config import (
@@ -26,6 +28,7 @@ from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 BLOCK_SIZE = 128
 NUM_BLOCKS = 10
 DEVICE_TYPE = current_platform.device_type
+FAKE_WEIGHT_PATH = os.path.join(os.path.dirname(__file__), "..", "fake_weight")
 
 
 def initialize_kv_cache(runner: NPUModelRunner):
@@ -62,9 +65,10 @@ def initialize_kv_cache(runner: NPUModelRunner):
 
 def get_vllm_config():
     model_config = ModelConfig(
-        model="facebook/opt-125m",
+        model=FAKE_WEIGHT_PATH,
         dtype="float16",
         seed=42,
+        skip_tokenizer_init=True,
     )
     scheduler_config = SchedulerConfig(
         max_num_seqs=10,

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -203,8 +203,11 @@ class TestNPUWorker(TestBase):
             self.assertEqual(worker.cache_config.num_cpu_blocks, 50)
 
     @patch("vllm_ascend.worker.worker.CaMemAllocator")
-    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
-    def test_wake_up_mode_enabled(self, mock_allocator_class):
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_wake_up_mode_enabled(self, mock_get_config, mock_allocator_class):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 0
+        mock_get_config.return_value = mock_config
         """Test wake_up method when sleep mode is enabled"""
         from vllm_ascend.worker.worker import NPUWorker
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -74,9 +74,21 @@ class AscendConfig:
 
         from vllm_ascend import envs as ascend_envs
 
-        if self.profiling_chunk_config.enabled and ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING:
+        self.enable_balance_scheduling = self._get_config_value(
+            additional_config,
+            "enable_balance_scheduling",
+            "VLLM_ASCEND_BALANCE_SCHEDULING",
+            ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING,
+        )
+        self.enable_flashcomm1 = self._get_config_value(
+            additional_config,
+            "enable_flashcomm1",
+            "VLLM_ASCEND_ENABLE_FLASHCOMM1",
+            ascend_envs.VLLM_ASCEND_ENABLE_FLASHCOMM1,
+        )
+        if self.profiling_chunk_config.enabled and self.enable_balance_scheduling:
             raise ValueError(
-                "profiling_chunk_config and balance scheduling (VLLM_ASCEND_BALANCE_SCHEDULING) "
+                "profiling_chunk_config and balance scheduling (enable_balance_scheduling) "
                 "cannot be enabled at the same time. Please disable one of them."
             )
 
@@ -123,6 +135,49 @@ class AscendConfig:
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
         self.multistream_dsa_preprocess = additional_config.get("multistream_dsa_preprocess", False)
 
+        self.enable_context_parallel = self._get_config_value(
+            additional_config,
+            "enable_context_parallel",
+            "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL",
+            ascend_envs.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL,
+        )
+        self.enable_matmul_allreduce = self._get_config_value(
+            additional_config,
+            "enable_matmul_allreduce",
+            "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE",
+            ascend_envs.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE,
+        )
+        self.enable_fused_mc2 = self._get_config_value(
+            additional_config,
+            "enable_fused_mc2",
+            "VLLM_ASCEND_ENABLE_FUSED_MC2",
+            ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
+        )
+        self.enable_mlapo = self._get_config_value(
+            additional_config,
+            "enable_mlapo",
+            "VLLM_ASCEND_ENABLE_MLAPO",
+            ascend_envs.VLLM_ASCEND_ENABLE_MLAPO,
+        )
+        self.enable_flashcomm2_parallel_size = self._get_config_value(
+            additional_config,
+            "enable_flashcomm2_parallel_size",
+            "VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE",
+            ascend_envs.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE,
+        )
+        self.msmonitor_use_daemon = self._get_config_value(
+            additional_config,
+            "msmonitor_use_daemon",
+            "MSMONITOR_USE_DAEMON",
+            ascend_envs.MSMONITOR_USE_DAEMON,
+        )
+        self.enable_transpose_kv_cache_by_block = self._get_config_value(
+            additional_config,
+            "enable_transpose_kv_cache_by_block",
+            "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK",
+            ascend_envs.VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK,
+        )
+
         self.pd_tp_ratio = 1
         self.pd_head_ratio = 1
         self.num_head_replica = 1
@@ -156,6 +211,14 @@ class AscendConfig:
         # _npu_paged_attention in this cases. This should be removed once
         # npu_fused_infer_attention_score performs better on all scenarios.
         self.pa_shape_list = additional_config.get("pa_shape_list", [])
+        # Weight NZ mode configuration.
+        # 0: disabled, 1: only quant case enable nz (default), 2: BF16/FP16 also enable nz
+        self.weight_nz_mode = self._get_config_value(
+            additional_config,
+            "weight_nz_mode",
+            "VLLM_ASCEND_ENABLE_NZ",
+            ascend_envs.VLLM_ASCEND_ENABLE_NZ,
+        )
 
         # when enable_async_exponential is True, AscendSampler will be different from vllm Sampler,
         # which make batch_invariant mode not working.
@@ -210,6 +273,17 @@ class AscendConfig:
         self.enable_hamming_sparse = self.hamming_sparse["enabled"]
         self.sparse_json = self.hamming_sparse["sparse_json_location"]
         self._check_enable_hamming_sparse()
+
+    @staticmethod
+    def _get_config_value(additional_config: dict[str, Any], config_key: str, env_key: str, env_value: Any) -> Any:
+        if config_key in additional_config:
+            value = additional_config[config_key]
+            logger.info_once(f"AscendConfig.{config_key} is set from additional_config with value {value}.")
+            return value
+        logger.info_once(
+            f"AscendConfig.{config_key} falls back to environment variable {env_key} with value {env_value}."
+        )
+        return env_value
 
     def _check_mix_placement(self):
         if self.mix_placement:
@@ -640,6 +714,9 @@ def init_ascend_config(vllm_config):
 def clear_ascend_config():
     global _ASCEND_CONFIG
     _ASCEND_CONFIG = None
+    from vllm_ascend.utils import clear_enable_sp
+
+    clear_enable_sp()
 
 
 def get_ascend_config():

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -280,9 +280,11 @@ class AscendConfig:
             value = additional_config[config_key]
             logger.info_once(f"AscendConfig.{config_key} is set from additional_config with value {value}.")
             return value
-        logger.info_once(
-            f"AscendConfig.{config_key} falls back to environment variable {env_key} with value {env_value}."
-        )
+        if env_key in os.environ:
+            logger.info_once(
+                f"AscendConfig.{config_key} falls back to environment variable {env_key} with value {env_value}. "
+                f"Please use additional_config.{config_key} instead, because {env_key} will be removed in the next release."
+            )
         return env_value
 
     def _check_mix_placement(self):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -283,7 +283,8 @@ class AscendConfig:
         if env_key in os.environ:
             logger.info_once(
                 f"AscendConfig.{config_key} falls back to environment variable {env_key} with value {env_value}. "
-                f"Please use additional_config.{config_key} instead, because {env_key} will be removed in the next release."
+                f"Please use additional_config.{config_key} instead, because {env_key} will be removed in the "
+                "next release."
             )
         return env_value
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -10,7 +10,7 @@ from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed import get_dp_group, get_ep_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import BatchDescriptor, get_forward_context, set_forward_context
 
-import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_sp,
@@ -279,13 +279,13 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
     elif soc_version in {AscendDeviceType.A3}:
         # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
         # TODO: drop speculative method guard when dispatch_gmm_combine_decode supports w16a16
-        fused_mc2_enable = envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2
-        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
+        fused_mc2_enable = get_ascend_config().enable_fused_mc2
+        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32 and (not is_draft_model)
         if num_tokens <= mc2_tokens_capacity:
             fused_decode_enable = fused_mc2_enable
-            if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+            if fused_mc2_enable == 1:
                 fused_decode_enable = fused_mc2_enable and dispatch_ffn_combine_enable
-            elif envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 2:
+            elif fused_mc2_enable == 2:
                 fused_decode_enable = (
                     fused_mc2_enable
                     and speculative_enable_dispatch_gmm_combine_decode(vllm_config)
@@ -294,9 +294,9 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
             moe_comm_type = MoECommType.FUSED_MC2 if fused_decode_enable else MoECommType.MC2
         else:
             fused_prefill_enable = fused_mc2_enable
-            if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+            if fused_mc2_enable == 1:
                 fused_prefill_enable = fused_mc2_enable and dispatch_ffn_combine_enable
-            elif envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 2:
+            elif fused_mc2_enable == 2:
                 fused_prefill_enable = False
             moe_comm_type = MoECommType.FUSED_MC2 if fused_prefill_enable else MoECommType.ALLTOALL
     elif soc_version in {AscendDeviceType._310P}:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -19,7 +19,6 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-from vllm_ascend import envs
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
@@ -425,7 +424,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # The MLAPO operator fuses the pre-processing steps on Q/K/V in MLA into a single operator
         # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
-        self.enable_mlapo = envs.VLLM_ASCEND_ENABLE_MLAPO
+        self.enable_mlapo = get_ascend_config().enable_mlapo
 
         assert self.indexer is not None, "Indexer is required for DSA."
 

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -9,7 +9,6 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend import envs
 from vllm_ascend.utils import AscendDeviceType, get_ascend_config, get_ascend_device_type
 from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 
@@ -375,12 +374,13 @@ def transdata(nd_mat, block_size: tuple = (16, 16)):
 
 
 def enabling_mlapo(vllm_config: VllmConfig) -> bool:
+    config_val = get_ascend_config().enable_mlapo
     if get_ascend_device_type() == AscendDeviceType.A5:
-        return bool(envs.VLLM_ASCEND_ENABLE_MLAPO)
+        return bool(config_val)
 
     is_decode_instance = (
         vllm_config.kv_transfer_config is not None
         and vllm_config.kv_transfer_config.is_kv_consumer
         and not vllm_config.kv_transfer_config.is_kv_producer
     )
-    return bool(envs.VLLM_ASCEND_ENABLE_MLAPO and is_decode_instance)
+    return bool(config_val and is_decode_instance)

--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -74,13 +74,12 @@ def reduce_sum(x: torch.Tensor, dim: int | None = None, keepdim: bool = False) -
 
 
 def override_envs_for_invariance():
-    # enabling NZ mode introduces NZ format input to the triton operator,
-    # resulting in accuracy anomalies.
-    os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
-    # fused operator can't ensure batch invariant, so we disable it.
-    os.environ["VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE"] = "0"
+    from vllm_ascend.ascend_config import get_ascend_config
 
-    # communication determinism settings
+    ascend_config = get_ascend_config()
+    ascend_config.weight_nz_mode = 0
+    ascend_config.enable_matmul_allreduce = False
+
     os.environ["HCCL_DETERMINISTIC"] = "strict"
     os.environ["LCCL_DETERMINISTIC"] = "1"
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -47,7 +47,6 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import RequestStatus
 
-from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value
@@ -617,7 +616,7 @@ class KVCacheRecvingThread(threading.Thread):
         is_kv_transfer_end = global_offset == tp_num_need_pulls * self._prefill_pp_size - 1
         need_cat_cache = tp_num_need_pulls > 1 and is_kv_transfer_end
         need_nz_cache = get_ascend_config().enable_kv_nz and is_kv_transfer_end
-        use_fused_op = ascend_envs.VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK
+        use_fused_op = get_ascend_config().enable_transpose_kv_cache_by_block
         if need_nz_cache or need_cat_cache:
             # use fused op to reformat kv cache, we keep original implementation to provide ability to disable it.
             if use_fused_op and enable_custom_op():

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE", "0"))),
     # Whether to enable FlashComm optimization when tensor parallel is enabled.
     # This feature will get better performance when concurrency is large.
+    # DEPRECATED: use additional_config.enable_flashcomm1 instead.
     "VLLM_ASCEND_ENABLE_FLASHCOMM1": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0"))),
     # Whether to enable FLASHCOMM2. Setting it to 0 disables the feature, while setting it to 1 or above enables it.
     # The specific value set will be used as the O-matrix TP group size for flashcomm2.
@@ -101,9 +102,8 @@ env_variables: dict[str, Callable[[], Any]] = {
     # `dispatch_gmm_combine_decode` can be used only for **decode node** moe layer
     # with W8A8. And MTP layer must be W8A8.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
-    # Whether to enable balance scheduling in the v1 scheduler.
-    # Platform validation: only PD-mixed mode (`kv_role='kv_both'` or no kv_transfer_config).
-    # Not supported in PD-disaggregated mode (`kv_producer` / `kv_consumer` only).
+    # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.
+    # Use --additional-config '{"enable_balance_scheduling": true}' instead.
     "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),
     # use fused op transpose_kv_cache_by_block, default is True
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -79,7 +79,7 @@ class VllmEplbAdaptor:
                     self.expert_weight_names.append("fused_w1_scale_list")
                     self.expert_weight_names.append("fused_w2_scale_list")
             elif quant_type == QuantType.W4A8:
-                if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 != 1:
+                if get_ascend_config().enable_fused_mc2 != 1:
                     raise ValueError("EPLB not support W4A8 with fused MC2 disabled")
                 self.expert_weight_names = [
                     "w13_weight_list",

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed as dist
 from vllm.logger import logger
 
-import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.quantization.methods.base import QuantType
 
 
@@ -75,7 +75,7 @@ class VllmEplbAdaptor:
                     "w13_weight_scale_fp32_list",
                     "w2_weight_scale_list",
                 ]
-                if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+                if get_ascend_config().enable_fused_mc2 == 1:
                     self.expert_weight_names.append("fused_w1_scale_list")
                     self.expert_weight_names.append("fused_w2_scale_list")
             elif quant_type == QuantType.W4A8:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -30,7 +30,6 @@ from vllm.model_executor.layers.fused_moe.layer import FusedMoE, UnquantizedFuse
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner  # type: ignore
 
-import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
@@ -120,7 +119,7 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # ND format (or other formats), remove this specific 'if' check and the forced
         # npu_format_cast. At that point, the operator should be able to handle weights
         # in their native format without explicit casting here.
-        if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2:
+        if get_ascend_config().enable_fused_mc2:
             layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
             layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
         else:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 import torch
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
-import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
@@ -268,7 +268,7 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
-        if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+        if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
             self.expert_token_nums = None
@@ -304,7 +304,7 @@ class FusedMC2CommImpl(MoECommMethod):
             topk_ids = fused_experts_input.routing.log2phy[topk_ids]
 
         expert_tokens = None
-        if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+        if get_ascend_config().enable_fused_mc2 == 1:
             out = torch.empty_like(fused_experts_input.hidden_states)
             torch.ops._C_ascend.dispatch_ffn_combine(  # type: ignore
                 x=fused_experts_input.hidden_states,
@@ -323,7 +323,7 @@ class FusedMC2CommImpl(MoECommMethod):
                 expert_token_nums=self.expert_token_nums,
             )
             expert_tokens = self.expert_token_nums
-        elif envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 2:
+        elif get_ascend_config().enable_fused_mc2 == 2:
             assert fused_experts_input.routing.expert_map is not None, "expert_map cannot be None."
             out, expert_tokens = torch.ops._C_ascend.dispatch_gmm_combine_decode(  # type: ignore
                 x=fused_experts_input.hidden_states,
@@ -341,7 +341,7 @@ class FusedMC2CommImpl(MoECommMethod):
                 global_bs=self.token_dispatcher.global_bs,
             )
         else:
-            raise ValueError(f"Wrong value of {envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2=}")
+            raise ValueError(f"Wrong value of {get_ascend_config().enable_fused_mc2=}")
         return FusedExpertsResult(
             routed_out=out, expert_tokens=expert_tokens, swiglu_limit=fused_experts_input.swiglu_limit
         )

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -76,7 +76,8 @@
 #       requests simultaneously in a single scheduling session. This can impact the overall system throughput
 #       and performance in some scenarios.
 #    How：
-#       Set environmental variables VLLM_ASCEND_BALANCE_SCHEDULING=1 in startup script.
+#       Set --additional-config '{"enable_balance_scheduling": true}' or
+#       set environmental variable VLLM_ASCEND_BALANCE_SCHEDULING=1 (deprecated).
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/29721
 #    Future Plan:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,6 +16,7 @@
 
 import os
 
+from vllm_ascend import envs
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -20,7 +20,6 @@ import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
-from vllm_ascend import envs
 from vllm_ascend.utils import is_310p
 
 if not is_310p():
@@ -37,8 +36,7 @@ import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
-if envs.VLLM_ASCEND_BALANCE_SCHEDULING:
-    import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
+import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,11 +16,11 @@
 
 import os
 
-from vllm_ascend import envs
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
+from vllm_ascend import envs
 from vllm_ascend.utils import is_310p
 
 if not is_310p():

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -24,6 +24,14 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
+_ORIGINAL_RUN_ENGINE_CORE = EngineCoreProc.run_engine_core
+_ORIGINAL_SCHEDULER = Scheduler
+
+
+def _balance_scheduling_enabled(vllm_config) -> bool:
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    return bool(additional_config.get("enable_balance_scheduling", False))
+
 
 class BalanceScheduler(Scheduler):
     def __init__(
@@ -47,17 +55,22 @@ class BalanceScheduler(Scheduler):
             include_finished_set,
             log_stats,
         )
-        # Balance scheduling.
-        self.balance_queue = [
-            torch.tensor([0], dtype=torch.int, device="cpu")
-            for _ in range(self.vllm_config.parallel_config.data_parallel_size)
-        ]
+        self._balance_enabled = _balance_scheduling_enabled(vllm_config)
+        if self._balance_enabled:
+            self.balance_queue = [
+                torch.tensor([0], dtype=torch.int, device="cpu")
+                for _ in range(self.vllm_config.parallel_config.data_parallel_size)
+            ]
 
     def balance_gather(self, dp_group):
+        if not self._balance_enabled:
+            return
         running_tensor = torch.tensor([len(self.running)], dtype=torch.int, device="cpu")
         dist.all_gather(self.balance_queue, running_tensor, group=dp_group)
 
     def schedule(self) -> SchedulerOutput:
+        if not self._balance_enabled:
+            return super().schedule()
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
         # Each request just has the num_computed_tokens and
@@ -654,6 +667,9 @@ class BalanceDPEngineCoreProc(DPEngineCoreProc):
 
 def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
     """Launch EngineCore busy loop in background process."""
+    vllm_config = kwargs.get("vllm_config")
+    if not _balance_scheduling_enabled(vllm_config):
+        return _ORIGINAL_RUN_ENGINE_CORE(*args, dp_rank=dp_rank, local_dp_rank=local_dp_rank, **kwargs)
 
     # Signal handler used for graceful termination.
     # SystemExit exception is only raised once to allow this and worker

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -33,8 +33,7 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-import vllm_ascend.envs as envs_ascend
-from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
 # isort: off
 from vllm_ascend.utils import (
@@ -487,12 +486,12 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
-        if envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING:
+        if ascend_config.enable_balance_scheduling:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is not None and kv_role != "kv_both":
                 raise ValueError(
-                    "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) only supports PD-mixed mode "
+                    "enable_balance_scheduling only supports PD-mixed mode "
                     "(kv_role='kv_both' or no kv_transfer_config), and is not supported in "
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
@@ -581,7 +580,7 @@ class NPUPlatform(Platform):
             os.environ["PYTORCH_NPU_ALLOC_CONF"] = npu_alloc_configs
             logger.info("Set PYTORCH_NPU_ALLOC_CONF=%s", npu_alloc_configs)
 
-        if ascend_config.enable_mc2_hierarchy_comm and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2:
+        if ascend_config.enable_mc2_hierarchy_comm and get_ascend_config().enable_fused_mc2:
             raise ValueError(
                 "fused mc2 op cannot be used with hierarchy communication."
                 "Please disable VLLM_ASCEND_ENABLE_FUSED_MC2 by setting it to 0."

--- a/vllm_ascend/profiler/torch_npu_profiler.py
+++ b/vllm_ascend/profiler/torch_npu_profiler.py
@@ -16,6 +16,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from contextlib import suppress
 from typing import Any
 
 import torch_npu
@@ -23,6 +24,7 @@ from vllm.config import ProfilerConfig
 from vllm.profiler.wrapper import WorkerProfiler
 
 import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_config import get_ascend_config
 
 
 class TorchNPUProfilerWrapper(WorkerProfiler):
@@ -38,7 +40,10 @@ class TorchNPUProfilerWrapper(WorkerProfiler):
             raise RuntimeError(f"Unrecognized profiler: {profiler_config.profiler}")
         if not profiler_config.torch_profiler_dir:
             raise RuntimeError("torch_profiler_dir cannot be empty.")
-        if envs_ascend.MSMONITOR_USE_DAEMON:
+        msmonitor_use_daemon = envs_ascend.MSMONITOR_USE_DAEMON
+        with suppress(RuntimeError):
+            msmonitor_use_daemon = get_ascend_config().msmonitor_use_daemon
+        if msmonitor_use_daemon:
             raise RuntimeError("MSMONITOR_USE_DAEMON and torch profiler cannot be both enabled at the same time.")
 
         experimental_config = torch_npu.profiler._ExperimentalConfig(

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -23,7 +23,6 @@ import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.distributed import get_ep_group
 
-import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
@@ -251,7 +250,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (
-            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2 and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1
+            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2 and get_ascend_config().enable_fused_mc2 == 1
         )
         if self.dynamic_eplb:
             w1 = layer.w13_weight_list
@@ -307,7 +306,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.view(layer.w2_weight_scale.data.shape[0], -1)
         layer.w2_weight_offset.data = layer.w2_weight_offset.data.view(layer.w2_weight_offset.data.shape[0], -1)
 
-        if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+        if get_ascend_config().enable_fused_mc2 == 1:
             layer.fused_w1_scale = scale_from_float_to_int64(layer.w13_weight_scale.data)
             layer.fused_w2_scale = scale_from_float_to_int64(layer.w2_weight_scale.data)
 
@@ -318,7 +317,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 weight.clone() for weight in layer.w13_weight_scale_fp32.data.unbind(dim=0)
             ]
             layer.w2_weight_scale_list = [weight.clone() for weight in layer.w2_weight_scale.data.unbind(dim=0)]
-            if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+            if get_ascend_config().enable_fused_mc2 == 1:
                 layer.fused_w1_scale_list = [
                     weight.clone()
                     for weight in layer.fused_w1_scale.view(len(layer.w13_weight_list), -1).data.unbind(dim=0)
@@ -332,7 +331,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             del layer.w13_weight_scale
             del layer.w13_weight_scale_fp32
             del layer.w2_weight_scale
-            if envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2 == 1:
+            if get_ascend_config().enable_fused_mc2 == 1:
                 del layer.fused_w1_scale
                 del layer.fused_w2_scale
             torch.npu.empty_cache()

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -108,6 +108,15 @@ def get_dsv4_compress_ratio(config: Any, layer_idx: int) -> int:
     return compress_ratios[layer_idx]
 
 
+def clear_enable_sp():
+    global _ENABLE_SP
+    _ENABLE_SP = None
+    enable_dsa_cp.cache_clear()
+    enable_dsa_cp_with_layer_shard.cache_clear()
+    enable_dsa_cp_with_o_proj_tp.cache_clear()
+    _libc_getenv.cache_clear()
+
+
 def is_310p():
     return get_ascend_device_type() == AscendDeviceType._310P
 
@@ -200,13 +209,17 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if is_310p():
         return True
 
-    # NZ is disabled on non-310P.
-    if not envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+    # Get config value instead of env
+    config = get_ascend_config()
+    nz_mode = config.weight_nz_mode
+
+    # NZ is disabled when mode is 0.
+    if not nz_mode:
         return False
 
-    # BF16/FP16 convert only when enable_nz == 2.
+    # BF16/FP16 convert only when nz_mode == 2.
     if weight.dtype in {torch.bfloat16, torch.float16}:
-        return envs_ascend.VLLM_ASCEND_ENABLE_NZ == 2
+        return nz_mode == 2
 
     # Quantized or other supported dtypes convert by default.
     return True
@@ -871,7 +884,7 @@ def mlp_tp_enable() -> bool:
 
 
 def matmul_allreduce_enable() -> bool:
-    return envs_ascend.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE
+    return get_ascend_config().enable_matmul_allreduce
 
 
 def enable_sp_by_pass():
@@ -880,23 +893,31 @@ def enable_sp_by_pass():
 
 def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
     global _ENABLE_SP
-    if _ENABLE_SP is None:
-        if vllm_config is None:
+    if vllm_config is None:
+        try:
             from vllm.config import get_current_vllm_config
 
             vllm_config = get_current_vllm_config()
-        _ENABLE_SP = (
-            envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
-            # Flash comm 1 should be enabled by env VLLM_ASCEND_ENABLE_FLASHCOMM1
-            # We retain the env VLLM_ASCEND_ENABLE_FLASHCOMM here for backward compatibility.
-            or bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM", "0")))
-        )
+        except AssertionError:
+            vllm_config = None
+
+    additional_config = getattr(vllm_config, "additional_config", None) if vllm_config is not None else None
+    refresh = additional_config.get("refresh", False) if additional_config else False
+
+    if _ENABLE_SP is None or refresh:
+        if additional_config is not None and "enable_flashcomm1" in additional_config:
+            _ENABLE_SP = bool(additional_config["enable_flashcomm1"])
+        else:
+            try:
+                _ENABLE_SP = get_ascend_config().enable_flashcomm1
+            except RuntimeError:
+                _ENABLE_SP = envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
 
         if not _ENABLE_SP and enable_shared_expert_dp:
             _ENABLE_SP = True
             logger.info("shared_expert_dp requires enable_sp = True. has set enable_sp to True")
 
-    return _ENABLE_SP
+    return bool(_ENABLE_SP)
 
 
 # TODO remove it after vllm has this func
@@ -905,7 +926,7 @@ def shared_expert_dp_enabled() -> bool:
 
 
 def prefill_context_parallel_enable() -> bool:
-    return envs_ascend.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL
+    return get_ascend_config().enable_context_parallel
 
 
 def is_moe_model(vllm_config: VllmConfig):
@@ -1189,7 +1210,8 @@ def has_layer_idx(model_instance: torch.nn.Module) -> bool:
 
 
 def flashcomm2_enable() -> bool:
-    return envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE > 0
+    config_val = get_ascend_config().enable_flashcomm2_parallel_size
+    return config_val > 0
 
 
 def o_shard_enable() -> bool:
@@ -1200,10 +1222,10 @@ def o_shard_enable() -> bool:
 
 
 def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
-    flashcomm2_oproj_tp_size = envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE
+    flashcomm2_oproj_tp_size = ascend_config.enable_flashcomm2_parallel_size
     global_tp_size = vllm_config.parallel_config.tensor_parallel_size
 
-    if not flashcomm2_enable():
+    if ascend_config.enable_flashcomm2_parallel_size <= 0:
         return 0
 
     logger.info("Enable FLASHCOMM2 with flashcomm2_oproj_tensor_parallel_size = %s", flashcomm2_oproj_tp_size)
@@ -1217,7 +1239,7 @@ def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
                 "FLASHCOMM2 only supports 'o_proj' as the sole layer sharding configuration! "
                 f"Found invalid layer_sharding: {layer_sharding}"
             )
-    if not envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1:
+    if not ascend_config.enable_flashcomm1:
         logger.warning_once(
             "It is recommended to enable FLASHCOMM1 simultaneously when starting FLASHCOMM2 for optimal performance."
         )

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -212,10 +212,11 @@ class NPUWorker(WorkerBase):
         )
 
     def wake_up(self, tags: list[str] | None = None) -> None:
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+        nz_mode = get_ascend_config().weight_nz_mode
+        if nz_mode:
             raise ValueError(
                 "FRACTAL_NZ mode is enabled. This may cause model parameter precision issues "
-                "in the RL scenarios. Please set VLLM_ASCEND_ENABLE_NZ=0."
+                "in the RL scenarios. Please set weight_nz_mode=0 via --additional-config."
             )
         allocator = CaMemAllocator.get_instance()
         allocator.wake_up(tags=tags)
@@ -401,7 +402,7 @@ class NPUWorker(WorkerBase):
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
         # enable msMonitor to monitor the performance of vllm-ascend
-        if envs_ascend.MSMONITOR_USE_DAEMON:
+        if get_ascend_config().msmonitor_use_daemon:
             dp.step()
 
         if self._pp_send_work:

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -33,7 +33,6 @@ from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 from xlite._C import AttnMeta, AttnMHA, Model, ModelConfig, Runtime, ScoringFuncSigmoid, ScoringFuncSoftmax
 
-import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState, AscendMetadata
 from vllm_ascend.xlite.utils import _get_nested_attr
@@ -199,7 +198,7 @@ class LlamaXliteModel(XliteModel):
         xlite_config.moe_tp_size = 1
 
         xlite_config.attn_type = AttnMHA
-        xlite_config.weight_nz = envs_ascend.VLLM_ASCEND_ENABLE_NZ == 2
+        xlite_config.weight_nz = get_ascend_config().weight_nz_mode == 2
         scheduler_config = vllm_config.scheduler_config
         max_batch_size = scheduler_config.max_num_seqs
         max_seq_len = vllm_config.model_config.max_model_len


### PR DESCRIPTION
### What this PR does / why we need it?
Migrate selected vllm-ascend environment variables from direct env access to the
  `AscendConfig` / `additional_config` configuration path, enabling users to
  configure these options through `--additional-config` while keeping the existing
  environment variables as backward-compatible fallbacks during the transition
  period.

  The migration follows this precedence:

  `additional_config` explicit value > deprecated environment variable fallback >
  default value

  Migrated environment variables:

  - `VLLM_ASCEND_BALANCE_SCHEDULING` → `enable_balance_scheduling` (default:
  `False`)
  - `VLLM_ASCEND_ENABLE_FLASHCOMM1` → `enable_flashcomm1` (default: `False`)
  - `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE` → `enable_matmul_allreduce` (default:
  `False`)
  - `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE` → `enable_flashcomm2_parallel_size`
  (default: `0`)
  - `MSMONITOR_USE_DAEMON` → `msmonitor_use_daemon` (default: `False`)
  - `VLLM_ASCEND_ENABLE_MLAPO` → `enable_mlapo` (default: `True`)
  - `VLLM_ASCEND_ENABLE_NZ` → `weight_nz_mode` (default: `1`)
  - `VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL` → `enable_context_parallel` (default:
  `False`)
  - `VLLM_ASCEND_ENABLE_FUSED_MC2` → `enable_fused_mc2` (default: `0`)
  - `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` →
  `enable_transpose_kv_cache_by_block` (default: `True`)


  The original environment variables remain functional for now and are marked as
  deprecated where applicable, so existing deployments continue to work while users
   migrate to `--additional-config`.

### Does this PR introduce _any_ user-facing change?
Yes. Users can now use --additional-config '{"enable_mlapo": true, "enable_flashcomm2_parallel_size": 2}' instead of setting environment variables. Original environment variables are still supported for backward compatibility.

### How was this patch tested?

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
