### PR TITLE
[Refactor] Clarify GDN operator metadata and chunk head docs

### DIFF
--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -258,8 +258,16 @@ def test_build_chunk_offsets_falls_back_without_triton_kernel(monkeypatch: pytes
     chunk_offsets = torch.empty(4, dtype=torch.int32)
     update_chunk_offsets = torch.empty(4, dtype=torch.int32)
 
-    gdn_chunk_meta._build_chunk_offsets(chunk_counts, chunk_offsets, add_one=0)
-    gdn_chunk_meta._build_chunk_offsets(chunk_counts, update_chunk_offsets, add_one=1)
+    gdn_chunk_meta._build_chunk_offsets(
+        chunk_counts,
+        chunk_offsets,
+        extra_chunks_per_seq=0,
+    )
+    gdn_chunk_meta._build_chunk_offsets(
+        chunk_counts,
+        update_chunk_offsets,
+        extra_chunks_per_seq=1,
+    )
 
     assert torch.equal(chunk_offsets, torch.tensor([0, 2, 2, 5], dtype=torch.int32))
     assert torch.equal(update_chunk_offsets, torch.tensor([0, 3, 4, 8], dtype=torch.int32))
@@ -276,8 +284,16 @@ def test_build_chunk_offsets_does_not_launch_triton_prefix_sum_kernel(monkeypatc
     chunk_offsets = torch.empty(4, dtype=torch.int32)
     update_chunk_offsets = torch.empty(4, dtype=torch.int32)
 
-    gdn_chunk_meta._build_chunk_offsets(chunk_counts, chunk_offsets, add_one=0)
-    gdn_chunk_meta._build_chunk_offsets(chunk_counts, update_chunk_offsets, add_one=1)
+    gdn_chunk_meta._build_chunk_offsets(
+        chunk_counts,
+        chunk_offsets,
+        extra_chunks_per_seq=0,
+    )
+    gdn_chunk_meta._build_chunk_offsets(
+        chunk_counts,
+        update_chunk_offsets,
+        extra_chunks_per_seq=1,
+    )
 
     assert torch.equal(chunk_offsets, torch.tensor([0, 2, 2, 5], dtype=torch.int32))
     assert torch.equal(update_chunk_offsets, torch.tensor([0, 3, 4, 8], dtype=torch.int32))

--- a/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
@@ -15,7 +15,6 @@ from vllm.v1.kv_cache_interface import MambaSpec
 import vllm_ascend.patch.worker.patch_gdn_attn as patch_gdn_attn
 from vllm_ascend.ops.gdn import (
     get_non_spec_causal_conv1d_host_args,
-    get_non_spec_chunked_prefill_meta,
     to_int64_tuple,
 )
 from vllm_ascend.ops.triton.fla import utils as fla_utils
@@ -278,7 +277,7 @@ def _expected_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[in
     ],
     ids=lambda case: case.name if isinstance(case, BatchSpec) else None,
 )
-def test_non_spec_prefill_fallback_meta_matches_original_inputs_and_runtime_helpers(
+def test_non_spec_prefill_operator_meta_matches_original_inputs_and_runtime_helpers(
     batch_spec: BatchSpec,
     num_speculative_tokens: int,
     num_decode_draft_tokens_cpu: torch.Tensor | None,
@@ -291,16 +290,16 @@ def test_non_spec_prefill_fallback_meta_matches_original_inputs_and_runtime_help
         num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
     )
 
-    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
-    assert fallback_meta is not None
-    assert fallback_meta.causal_conv1d is not None
-    assert fallback_meta.chunk is not None
+    operator_meta = getattr(attn_metadata, "non_spec_prefill_operator_meta", None)
+    assert operator_meta is not None
+    assert operator_meta.causal_conv1d is not None
+    assert operator_meta.chunk is not None
 
     assert get_non_spec_causal_conv1d_host_args(attn_metadata) == _expected_conv1d_host_args(attn_metadata)
 
     _assert_chunk_meta_matches_runtime(
         builder,
-        fallback_meta.chunk,
+        operator_meta.chunk,
         attn_metadata.non_spec_query_start_loc,
     )
 
@@ -328,47 +327,6 @@ def test_build_non_spec_causal_conv1d_host_meta_avoids_seq_lens_cpu_fallback():
         host_meta.has_initial_state_cpu,
         torch.tensor([True, False]),
     )
-
-
-def test_build_non_spec_causal_conv1d_host_meta_requires_has_initial_state():
-    builder = SimpleNamespace(use_spec_decode=False)
-    attn_metadata = SimpleNamespace(
-        num_prefills=2,
-        non_spec_state_indices_tensor=torch.tensor([3, 9], dtype=torch.int32),
-        has_initial_state=None,
-    )
-    with pytest.raises(RuntimeError, match="has_initial_state"):
-        patch_gdn_attn._build_non_spec_causal_conv1d_host_meta(
-            builder,
-            attn_metadata,
-            non_spec_query_start_loc_cpu=torch.tensor([0, 4, 12], dtype=torch.int32),
-        )
-
-
-def test_get_non_spec_causal_conv1d_host_args_requires_prefill_fallback_meta():
-    attn_metadata = SimpleNamespace(
-        non_spec_prefill_fallback_meta=None,
-        non_spec_causal_conv1d_meta=SimpleNamespace(
-            query_start_loc_opt=(0, 4, 12),
-            cache_indices_opt=(3, 9),
-            initial_state_mode_opt=(1, 0),
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="non_spec_prefill_fallback_meta\\.causal_conv1d"):
-        get_non_spec_causal_conv1d_host_args(
-            attn_metadata,
-        )
-
-
-def test_get_non_spec_chunked_prefill_meta_requires_prefill_fallback_meta():
-    attn_metadata = SimpleNamespace(
-        non_spec_prefill_fallback_meta=None,
-        non_spec_chunked_prefill_meta=SimpleNamespace(chunk_offsets_chunk64=torch.tensor([0, 1])),
-    )
-
-    with pytest.raises(RuntimeError, match="non_spec_prefill_fallback_meta\\.chunk"):
-        get_non_spec_chunked_prefill_meta(attn_metadata)
 
 
 def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeypatch):
@@ -507,4 +465,4 @@ def test_builder_skips_prebuilt_meta_without_non_spec_prefill(batch_spec: BatchS
         num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
     )
 
-    assert getattr(attn_metadata, "non_spec_prefill_fallback_meta", None) is None
+    assert getattr(attn_metadata, "non_spec_prefill_operator_meta", None) is None

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -41,18 +41,9 @@ def to_int64_tuple(tensor: torch.Tensor) -> tuple[int, ...]:
     return tuple(tensor.tolist())
 
 
-def _require_non_spec_prefill_fallback_meta(attn_metadata, field_name: str):
-    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
-    if fallback_meta is None:
-        raise RuntimeError(
-            f"Expected attn_metadata.non_spec_prefill_fallback_meta.{field_name} for patched GDN non-spec prefill path."
-        )
-    return fallback_meta
-
-
 def get_non_spec_causal_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-    fallback_meta = _require_non_spec_prefill_fallback_meta(attn_metadata, "causal_conv1d")
-    causal_conv1d_meta = fallback_meta.causal_conv1d
+    operator_meta = attn_metadata.non_spec_prefill_operator_meta
+    causal_conv1d_meta = operator_meta.causal_conv1d
     return (
         to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu),
         to_int64_tuple(causal_conv1d_meta.cache_indices_cpu),
@@ -61,8 +52,7 @@ def get_non_spec_causal_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...]
 
 
 def get_non_spec_chunked_prefill_meta(attn_metadata):
-    fallback_meta = _require_non_spec_prefill_fallback_meta(attn_metadata, "chunk")
-    return fallback_meta.chunk
+    return attn_metadata.non_spec_prefill_operator_meta.chunk
 
 
 class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -8,7 +8,6 @@
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 # ruff: noqa: E501
 # mypy: ignore-errors
-import warnings
 
 import torch
 from einops import rearrange
@@ -211,26 +210,30 @@ def chunk_gated_delta_rule(
     use_qk_l2norm_in_kernel: bool = False,
 ):
     r"""
+    Dimension names follow the GDN operator convention: `Hk` is the query/key
+    head count, `Hv` is the value/state head count, and `Hg` is the gate/beta
+    head count. These counts can differ for Qwen3.5-style GDN models.
+
     Args:
         q (torch.Tensor):
-            queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+            queries of shape `[B, T, Hk, K]` if `head_first=False` else `[B, Hk, T, K]`.
         k (torch.Tensor):
-            keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+            keys of shape `[B, T, Hk, K]` if `head_first=False` else `[B, Hk, T, K]`.
         v (torch.Tensor):
-            values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+            values of shape `[B, T, Hv, V]` if `head_first=False` else `[B, Hv, T, V]`.
         g (torch.Tensor):
-            (forget) gating tensor (in log space!) of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+            (forget) gating tensor (in log space!) of shape `[B, T, Hg]` if `head_first=False` else `[B, Hg, T]`.
         beta (torch.Tensor):
-            betas of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+            betas of shape `[B, T, Hg]` if `head_first=False` else `[B, Hg, T]`.
         scale (Optional[int]):
             Scale factor for the RetNet attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            Initial state of shape `[N, Hv, K, V]` for `N` input sequences.
             For equal-length input sequences, `N` equals the batch size `B`.
             Default: `None`.
         output_final_state (Optional[bool]):
-            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+            Whether to output the final state of shape `[N, Hv, K, V]`. Default: `False`.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
@@ -240,9 +243,9 @@ def chunk_gated_delta_rule(
 
     Returns:
         o (torch.Tensor):
-            Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+            Outputs of shape `[B, T, Hv, V]` if `head_first=False` else `[B, Hv, T, V]`.
         final_state (torch.Tensor):
-            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+            Final state of shape `[N, Hv, K, V]` if `output_final_state=True` else `None`.
 
     Examples::
         >>> import torch
@@ -250,13 +253,13 @@ def chunk_gated_delta_rule(
         >>> from einops import rearrange
         >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
         # inputs with equal lengths
-        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
-        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
-        >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
-        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
-        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
-        >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
-        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> B, T, Hk, Hv, Hg, K, V = 4, 2048, 4, 8, 8, 512, 512
+        >>> q = torch.randn(B, T, Hk, K, dtype=torch.bfloat16, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, Hk, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, Hv, V, dtype=torch.bfloat16, device='cuda')
+        >>> beta = torch.rand(B, T, Hg, dtype=torch.bfloat16, device='cuda').sigmoid()
+        >>> g = F.logsigmoid(torch.rand(B, T, Hg, dtype=torch.bfloat16, device='cuda'))
+        >>> h0 = torch.randn(B, Hv, K, V, dtype=torch.bfloat16, device='cuda')
         >>> o, ht = chunk_gated_delta_rule(
             q, k, v, g, beta,
             initial_state=h0,
@@ -275,7 +278,7 @@ def chunk_gated_delta_rule(
     """
     assert q.dtype == k.dtype == v.dtype
     assert q.dtype != torch.float32, "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
-    assert len(beta.shape) == 3, "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+    assert len(beta.shape) == 3, "beta must be of shape [B, T, Hg] if head_first=False, or [B, Hg, T] otherwise."
 
     if head_first:
         raise DeprecationWarning(
@@ -284,14 +287,6 @@ def chunk_gated_delta_rule(
             stacklevel=2,
         )
         q, k, v, beta, g = map(lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g))
-    if not head_first and q.shape[1] < q.shape[2]:
-        warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
-            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-            "when head_first=False was specified. "
-            "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
-            stacklevel=2,
-        )
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(

--- a/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
+++ b/vllm_ascend/ops/triton/fla/chunk_scaled_dot_kkt.py
@@ -92,15 +92,16 @@ def chunk_scaled_dot_kkt_fwd(
     r"""
     Compute beta * K * K^T.
 
+    `Hk` is the key head count and `Hg` is the gate/beta head count. They can
+    differ, so the comments use separate names instead of a single `H`.
+
     Args:
         k (torch.Tensor):
-            The key tensor of shape `[B, T, H, K]`.
+            The key tensor of shape `[B, T, Hk, K]`.
         beta (torch.Tensor):
-            The beta tensor of shape `[B, T, H]`.
-        g (torch.Tensor):
-            The cumulative sum of the gate tensor of shape `[B, T, H]`. Default: `None`.
-        gk (torch.Tensor):
-            The cumulative sum of the gate tensor of shape `[B, T, H, K]` applied to the key tensor. Default: `None`.
+            The beta tensor of shape `[B, T, Hg]`.
+        g_cumsum (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, Hg]`. Default: `None`.
         cu_seqlens (torch.LongTensor):
             The cumulative sequence lengths of the input tensor.
             Default: None
@@ -110,7 +111,7 @@ def chunk_scaled_dot_kkt_fwd(
             The dtype of the output tensor. Default: `torch.float32`
 
     Returns:
-        beta * K * K^T of shape `[B, T, H, BT]` where `BT` is the chunk size.
+        beta * K * K^T of shape `[B, T, Hg, BT]` where `BT` is the chunk size.
     """
     B, T, Hg, K = k.shape
 

--- a/vllm_ascend/ops/triton/gdn_chunk_meta.py
+++ b/vllm_ascend/ops/triton/gdn_chunk_meta.py
@@ -13,17 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Build GDN FLA chunk metadata without round-tripping through CPU helpers.
+
+The GDN chunk kernels consume three kinds of operator metadata:
+
+- ``chunk_indices``: rows of ``[compact_sequence_index, chunk_index]`` used by
+  FLA kernels to locate each non-empty sequence chunk.
+- ``chunk_offsets``: prefix offsets into ``chunk_indices`` for each sequence.
+- ``update_chunk_offsets`` and ``final_chunk_indices``: update-path offsets and
+  the final update row per sequence, where the update path reserves one extra
+  row per sequence for recurrent state updates.
+"""
+
 import torch
 from vllm.triton_utils import tl, triton
 
 
 def _cdiv(x: int, y: int) -> int:
+    """Return ceil(x / y), using Triton's helper when the runtime provides it."""
     triton_cdiv = getattr(triton, "cdiv", None)
     if triton_cdiv is not None:
         return triton_cdiv(x, y)
     return (x + y - 1) // y
 
 
+# Input:
+# - cu_seqlens_ptr: cumulative sequence offsets, shape [num_seqs + 1].
+# - num_seqs: number of sequences represented by cu_seqlens_ptr.
+# - chunk_size: token count per chunk.
+# Output:
+# - chunk_counts_ptr: per-sequence ceil(seq_len / chunk_size), shape [num_seqs].
+# What it does:
+# - Converts cumulative offsets into sequence lengths, then stores how many FLA
+#   chunks each sequence needs for one chunk size.
 @triton.jit
 def _build_chunk_counts_kernel(
     cu_seqlens_ptr,
@@ -33,37 +55,56 @@ def _build_chunk_counts_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < num_seqs
+    seq_offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid_seqs = seq_offsets < num_seqs
 
-    bos = tl.load(cu_seqlens_ptr + offsets, mask=mask, other=0).to(tl.int32)
-    eos = tl.load(cu_seqlens_ptr + offsets + 1, mask=mask, other=0).to(tl.int32)
-    seq_lens = eos - bos
+    seq_start = tl.load(cu_seqlens_ptr + seq_offsets, mask=valid_seqs, other=0).to(tl.int32)
+    seq_end = tl.load(cu_seqlens_ptr + seq_offsets + 1, mask=valid_seqs, other=0).to(tl.int32)
+    seq_lens = seq_end - seq_start
     chunk_counts = (seq_lens + chunk_size - 1) // chunk_size
 
-    tl.store(chunk_counts_ptr + offsets, chunk_counts, mask=mask)
+    tl.store(chunk_counts_ptr + seq_offsets, chunk_counts, mask=valid_seqs)
 
 
+# Input:
+# - chunk_counts_ptr: per-sequence chunk counts, shape [num_seqs].
+# - num_seqs: number of sequences.
+# - EXTRA_CHUNKS_PER_SEQ: 0 for normal chunk offsets, 1 for update offsets.
+# Output:
+# - out_offsets_ptr: prefix offsets, shape [num_seqs + 1].
+# What it does:
+# - Builds an exclusive prefix sum over chunk counts. The update path passes
+#   EXTRA_CHUNKS_PER_SEQ=1 because it has one extra state-update row per
+#   sequence.
 @triton.jit
 def _build_chunk_offsets_kernel(
     chunk_counts_ptr,
     out_offsets_ptr,
     num_seqs,
-    ADD_ONE: tl.constexpr,
+    EXTRA_CHUNKS_PER_SEQ: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets <= num_seqs
-    prefix = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    prefix_offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid_offsets = prefix_offsets <= num_seqs
+    prefix_sums = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
 
     for seq_idx in range(0, num_seqs):
         chunk_count = tl.load(chunk_counts_ptr + seq_idx, mask=seq_idx < num_seqs, other=0).to(tl.int32)
-        prefix += tl.where(mask & (offsets > seq_idx), chunk_count + ADD_ONE, 0)
+        prefix_sums += tl.where(valid_offsets & (prefix_offsets > seq_idx), chunk_count + EXTRA_CHUNKS_PER_SEQ, 0)
 
-    tl.store(out_offsets_ptr + offsets, prefix.to(out_offsets_ptr.dtype.element_ty), mask=mask)
+    tl.store(out_offsets_ptr + prefix_offsets, prefix_sums.to(out_offsets_ptr.dtype.element_ty), mask=valid_offsets)
 
 
+# Input:
+# - update_chunk_offsets_ptr: update-path prefix offsets, shape [num_seqs + 1].
+# - num_seqs: number of sequences.
+# Output:
+# - out_final_chunk_indices_ptr: final update row index per sequence, shape
+#   [num_seqs].
+# What it does:
+# - Converts each sequence's exclusive end offset into the row index of its
+#   final update entry.
 @triton.jit
 def _build_final_chunk_indices_kernel(
     update_chunk_offsets_ptr,
@@ -72,13 +113,13 @@ def _build_final_chunk_indices_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < num_seqs
-    final_indices = tl.load(update_chunk_offsets_ptr + offsets + 1, mask=mask, other=0).to(tl.int32) - 1
+    seq_offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    valid_seqs = seq_offsets < num_seqs
+    final_indices = tl.load(update_chunk_offsets_ptr + seq_offsets + 1, mask=valid_seqs, other=0).to(tl.int32) - 1
     tl.store(
-        out_final_chunk_indices_ptr + offsets,
+        out_final_chunk_indices_ptr + seq_offsets,
         final_indices.to(out_final_chunk_indices_ptr.dtype.element_ty),
-        mask=mask,
+        mask=valid_seqs,
     )
 
 
@@ -89,6 +130,19 @@ def _validate_optional_output(
     expected_shape: tuple[int, ...] | None,
     expected_device: torch.device,
 ) -> None:
+    """Validate an optional output tensor before metadata is written.
+
+    Args:
+        name: Human-readable tensor name used in error messages.
+        tensor: Optional output tensor supplied by the caller.
+        expected_shape: Exact expected shape, or ``None`` when the caller-owned
+            leading dimension is validated separately.
+        expected_device: Device that must match the input sequence lengths.
+
+    Returns:
+        None. Raises ``ValueError`` when a supplied tensor cannot be written by
+        the metadata builder.
+    """
     if tensor is None:
         return
     if tensor.device != expected_device:
@@ -102,6 +156,15 @@ def _validate_optional_output(
 
 
 def _validate_cu_seqlens(cu_seqlens: torch.Tensor, chunk_size: int) -> None:
+    """Validate the public device metadata-builder inputs.
+
+    Args:
+        cu_seqlens: Cumulative sequence offsets on NPU, shape ``[num_seqs + 1]``.
+        chunk_size: Number of tokens per chunk for the metadata being built.
+
+    Returns:
+        None. Raises when the input cannot be consumed by the NPU metadata path.
+    """
     if not isinstance(cu_seqlens, torch.Tensor):
         raise TypeError("cu_seqlens must be a torch.Tensor")
     if cu_seqlens.device.type != "npu":
@@ -119,10 +182,28 @@ def _validate_cu_seqlens(cu_seqlens: torch.Tensor, chunk_size: int) -> None:
 
 
 def _build_seq_lens(cu_seqlens: torch.Tensor) -> torch.Tensor:
+    """Return per-sequence lengths from cumulative sequence offsets.
+
+    Args:
+        cu_seqlens: Cumulative sequence offsets, shape ``[num_seqs + 1]``.
+
+    Returns:
+        A tensor of shape ``[num_seqs]`` where each element is ``eos - bos``.
+    """
     return cu_seqlens[1:] - cu_seqlens[:-1]
 
 
 def _build_chunk_counts(seq_lens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    """Return ceil(seq_len / chunk_size) for each sequence.
+
+    Args:
+        seq_lens: Per-sequence token lengths, shape ``[num_seqs]``.
+        chunk_size: Number of tokens per chunk.
+
+    Returns:
+        A tensor of shape ``[num_seqs]`` with the number of chunks needed by
+        each sequence.
+    """
     chunk_counts = torch.empty(
         seq_lens.shape[0],
         dtype=seq_lens.dtype,
@@ -143,11 +224,23 @@ def _build_chunk_offsets(
     chunk_counts: torch.Tensor,
     out_offsets: torch.Tensor,
     *,
-    add_one: int,
+    extra_chunks_per_seq: int,
 ) -> None:
+    """Build prefix offsets from per-sequence chunk counts.
+
+    Args:
+        chunk_counts: Per-sequence chunk counts, shape ``[num_seqs]``.
+        out_offsets: Output prefix offsets, shape ``[num_seqs + 1]``.
+        extra_chunks_per_seq: Extra rows to reserve per sequence.
+
+    Returns:
+        None. ``out_offsets`` is filled in place. ``extra_chunks_per_seq`` is 1
+        for update offsets because the FLA update path reserves one extra
+        state-update row per sequence.
+    """
     out_offsets[0] = 0
     if chunk_counts.numel() > 0:
-        torch.cumsum(chunk_counts + add_one, dim=0, out=out_offsets[1:])
+        torch.cumsum(chunk_counts + extra_chunks_per_seq, dim=0, out=out_offsets[1:])
 
 
 def _build_final_chunk_indices(
@@ -155,6 +248,18 @@ def _build_final_chunk_indices(
     update_chunk_offsets: torch.Tensor,
     out_final_chunk_indices: torch.Tensor,
 ) -> None:
+    """Build the final update-row index for each sequence.
+
+    Args:
+        chunk_counts: Per-sequence chunk counts, shape ``[num_seqs]``.
+        update_chunk_offsets: Prefix offsets for the update path, shape
+            ``[num_seqs + 1]``. Each sequence reserves one extra update row.
+        out_final_chunk_indices: Output tensor, shape ``[num_seqs]``.
+
+    Returns:
+        None. ``out_final_chunk_indices`` is filled in place with
+        ``update_chunk_offsets[1:] - 1``.
+    """
     num_seqs = chunk_counts.shape[0]
     if hasattr(_build_final_chunk_indices_kernel, "__getitem__"):
         block_size = 256
@@ -180,6 +285,27 @@ def _build_chunk_meta_device_from_seq_lens(
     out_update_chunk_offsets: torch.Tensor | None = None,
     out_final_chunk_indices: torch.Tensor | None = None,
 ) -> None:
+    """Build GDN chunk operator metadata from per-sequence lengths.
+
+    Args:
+        seq_lens: Per-sequence token lengths on the target device, shape
+            ``[num_seqs]``.
+        chunk_size: Number of tokens per chunk.
+        out_chunk_indices: Optional output rows of
+            ``[compact_sequence_index, chunk_index]``. The row count must match
+            the sum of ``ceil(seq_len / chunk_size)`` over all sequences.
+        out_chunk_offsets: Optional prefix offsets into ``out_chunk_indices``,
+            shape ``[num_seqs + 1]``.
+        out_update_chunk_offsets: Optional update-path prefix offsets, shape
+            ``[num_seqs + 1]``. Each sequence reserves one extra update row.
+        out_final_chunk_indices: Optional final update-row index per sequence,
+            shape ``[num_seqs]``.
+
+    Returns:
+        None. Supplied output tensors are filled in place. Zero-length
+        sequences are compacted out of ``out_chunk_indices`` to match
+        ``prepare_chunk_indices``.
+    """
     if (
         out_chunk_indices is None
         and out_chunk_offsets is None
@@ -230,31 +356,39 @@ def _build_chunk_meta_device_from_seq_lens(
 
     chunk_counts = _build_chunk_counts(seq_lens, chunk_size)
 
-    chunk_offsets = out_chunk_offsets
-    if chunk_offsets is None and out_chunk_indices is not None:
-        chunk_offsets = torch.empty(
+    chunk_offsets_for_indices = out_chunk_offsets
+    if chunk_offsets_for_indices is None and out_chunk_indices is not None:
+        chunk_offsets_for_indices = torch.empty(
             expected_prefix_shape,
             dtype=seq_lens.dtype,
             device=seq_lens.device,
         )
-    update_chunk_offsets = out_update_chunk_offsets
-    if update_chunk_offsets is None and out_final_chunk_indices is not None:
-        update_chunk_offsets = torch.empty(
+    update_offsets_for_final_indices = out_update_chunk_offsets
+    if update_offsets_for_final_indices is None and out_final_chunk_indices is not None:
+        update_offsets_for_final_indices = torch.empty(
             expected_prefix_shape,
             dtype=seq_lens.dtype,
             device=seq_lens.device,
         )
 
-    if chunk_offsets is not None:
-        _build_chunk_offsets(chunk_counts, chunk_offsets, add_one=0)
+    if chunk_offsets_for_indices is not None:
+        _build_chunk_offsets(
+            chunk_counts,
+            chunk_offsets_for_indices,
+            extra_chunks_per_seq=0,
+        )
 
-    if update_chunk_offsets is not None:
-        _build_chunk_offsets(chunk_counts, update_chunk_offsets, add_one=1)
+    if update_offsets_for_final_indices is not None:
+        _build_chunk_offsets(
+            chunk_counts,
+            update_offsets_for_final_indices,
+            extra_chunks_per_seq=1,
+        )
 
     if out_final_chunk_indices is not None:
         _build_final_chunk_indices(
             chunk_counts,
-            update_chunk_offsets,
+            update_offsets_for_final_indices,
             out_final_chunk_indices,
         )
 
@@ -262,12 +396,22 @@ def _build_chunk_meta_device_from_seq_lens(
         total_chunks = out_chunk_indices.shape[0]
         if total_chunks == 0:
             return
-        rows = torch.arange(total_chunks, device=seq_lens.device, dtype=chunk_offsets.dtype)
-        compact_chunk_offsets = torch.unique_consecutive(chunk_offsets)
-        seq_indices = torch.bucketize(rows, compact_chunk_offsets[1:], right=True)
-        chunk_starts = compact_chunk_offsets.index_select(0, seq_indices)
-        out_chunk_indices[:, 0].copy_(seq_indices.to(dtype=out_chunk_indices.dtype))
-        out_chunk_indices[:, 1].copy_((rows - chunk_starts).to(dtype=out_chunk_indices.dtype))
+        # Runtime prepare_chunk_indices compacts away zero-length sequences.
+        # Repeated prefix offsets identify those empty sequences on device.
+        chunk_rows = torch.arange(
+            total_chunks,
+            device=seq_lens.device,
+            dtype=chunk_offsets_for_indices.dtype,
+        )
+        compact_chunk_offsets = torch.unique_consecutive(chunk_offsets_for_indices)
+        compact_seq_indices = torch.bucketize(
+            chunk_rows,
+            compact_chunk_offsets[1:],
+            right=True,
+        )
+        chunk_starts = compact_chunk_offsets.index_select(0, compact_seq_indices)
+        out_chunk_indices[:, 0].copy_(compact_seq_indices.to(dtype=out_chunk_indices.dtype))
+        out_chunk_indices[:, 1].copy_((chunk_rows - chunk_starts).to(dtype=out_chunk_indices.dtype))
 
 
 def build_chunk_meta_device(
@@ -281,6 +425,27 @@ def build_chunk_meta_device(
     seq_lens: torch.Tensor | None = None,
     validate_inputs: bool = True,
 ) -> None:
+    """Build GDN chunk operator metadata on device.
+
+    Args:
+        cu_seqlens: Cumulative sequence offsets, shape ``[num_seqs + 1]``.
+            The public path expects this tensor on NPU.
+        chunk_size: Number of tokens per chunk for this metadata set.
+        out_chunk_indices: Optional output rows of
+            ``[compact_sequence_index, chunk_index]``.
+        out_chunk_offsets: Optional prefix offsets into ``out_chunk_indices``.
+        out_update_chunk_offsets: Optional update-path prefix offsets.
+        out_final_chunk_indices: Optional final update-row indices.
+        seq_lens: Optional precomputed sequence lengths. Passing this lets the
+            caller validate ``cu_seqlens`` once and reuse the derived lengths
+            across several chunk sizes.
+        validate_inputs: Whether to run public input validation. Internal
+            callers set this to ``False`` after validating shared inputs once.
+
+    Returns:
+        None. The provided output tensors are mutated in place and then passed
+        to the GDN FLA operators.
+    """
     if validate_inputs:
         _validate_cu_seqlens(cu_seqlens, chunk_size)
     elif chunk_size <= 0:

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -37,6 +37,8 @@ _ORIGINAL_INIT_THRESHOLD = gdn_attn.GDNAttentionMetadataBuilder._init_reorder_ba
 
 @dataclass
 class GDNChunkedPrefillMetadata:
+    """Operator arguments consumed by the GDN chunked-prefill FLA kernels."""
+
     chunk_indices_chunk64: torch.Tensor
     chunk_offsets_chunk64: torch.Tensor
     update_chunk_offsets_chunk64: torch.Tensor
@@ -48,6 +50,8 @@ class GDNChunkedPrefillMetadata:
 
 @dataclass
 class GDNCausalConv1dHostMetadata:
+    """CPU-side operator arguments consumed by the GDN causal-conv1d path."""
+
     query_start_loc_cpu: torch.Tensor
     cache_indices_cpu: torch.Tensor
     has_initial_state_cpu: torch.Tensor
@@ -55,13 +59,17 @@ class GDNCausalConv1dHostMetadata:
 
 
 @dataclass
-class GDNPrefillFallbackMeta:
+class GDNNonSpecPrefillOperatorMetadata:
+    """Prebuilt metadata consumed by GDN non-spec prefill operators."""
+
     causal_conv1d: GDNCausalConv1dHostMetadata
     chunk: GDNChunkedPrefillMetadata
 
 
 @dataclass
 class _GDNChunkedPrefillBufferSlot:
+    """Reusable device buffers sized for the scheduler maximums."""
+
     chunk_indices_chunk64: torch.Tensor
     chunk_offsets_chunk64: torch.Tensor
     update_chunk_offsets_chunk64: torch.Tensor
@@ -72,12 +80,16 @@ class _GDNChunkedPrefillBufferSlot:
 
 @dataclass
 class _GDNCausalConv1dHostBufferSlot:
+    """Reusable pinned CPU buffers for async device-to-host metadata copies."""
+
     cache_indices_cpu: torch.Tensor
     has_initial_state_cpu: torch.Tensor
 
 
 @dataclass
-class _GDNChunkMetaSizeInfo:
+class _GDNChunkOperatorArgSizes:
+    """Row counts needed by each chunk metadata tensor for one batch."""
+
     num_seqs: int
     num_chunk_indices_chunk64: int
     num_chunk_indices_large_block: int
@@ -85,7 +97,9 @@ class _GDNChunkMetaSizeInfo:
 
 
 @dataclass
-class _GDNChunkMetaShapeInfo(_GDNChunkMetaSizeInfo):
+class _GDNChunkOperatorArgCpuCounts(_GDNChunkOperatorArgSizes):
+    """CPU chunk counts plus the derived operator-argument tensor sizes."""
+
     chunk_counts_chunk64: torch.Tensor
     chunk_counts_large_block: torch.Tensor
     chunk_counts_cumsum: torch.Tensor
@@ -98,54 +112,119 @@ def _next_power_of_2(value: int) -> int:
 
 
 def _prepare_chunk_counts_cpu(cu_seqlens_cpu: torch.Tensor, chunk_size: int) -> torch.Tensor:
-    lens = cu_seqlens_cpu[1:] - cu_seqlens_cpu[:-1]
-    return torch.div(lens + chunk_size - 1, chunk_size, rounding_mode="floor")
+    """Return per-sequence chunk counts from CPU cumulative sequence offsets.
+
+    Args:
+        cu_seqlens_cpu: CPU cumulative sequence offsets, shape
+            ``[num_seqs + 1]``.
+        chunk_size: Number of tokens per chunk.
+
+    Returns:
+        A CPU tensor of shape ``[num_seqs]`` containing
+        ``ceil(seq_len / chunk_size)`` for each sequence.
+    """
+    seq_lens_cpu = cu_seqlens_cpu[1:] - cu_seqlens_cpu[:-1]
+    return torch.div(seq_lens_cpu + chunk_size - 1, chunk_size, rounding_mode="floor")
 
 
-def _fill_chunk_indices_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> int:
-    cursor = 0
-    compact_seq_idx = 0
+def _fill_chunk_indices_cpu(chunk_indices: torch.Tensor, chunk_counts: torch.Tensor) -> int:
+    """Fill CPU chunk-index rows for one chunk size.
+
+    Args:
+        chunk_indices: Output tensor of shape ``[num_chunks, 2]``.
+        chunk_counts: Per-sequence chunk counts, shape ``[num_seqs]``.
+
+    Returns:
+        Number of rows written. Each row is
+        ``[compact_sequence_index, chunk_index]`` and zero-length sequences are
+        skipped to match the runtime FLA helper.
+    """
+    write_offset = 0
+    compact_sequence_index = 0
     for num_chunks in chunk_counts.tolist():
         if num_chunks <= 0:
             continue
         # `prepare_chunk_indices` compacts away zero-length sequences, so the
         # sequence index here must follow the same compact numbering.
-        out[cursor : cursor + num_chunks, 0].fill_(compact_seq_idx)
-        out[cursor : cursor + num_chunks, 1] = torch.arange(
+        chunk_indices[write_offset : write_offset + num_chunks, 0].fill_(compact_sequence_index)
+        chunk_indices[write_offset : write_offset + num_chunks, 1] = torch.arange(
             num_chunks,
-            dtype=out.dtype,
+            dtype=chunk_indices.dtype,
         )
-        cursor += num_chunks
-        compact_seq_idx += 1
-    return cursor
+        write_offset += num_chunks
+        compact_sequence_index += 1
+    return write_offset
 
 
-def _fill_chunk_offsets_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> int:
-    out[0] = 0
+def _fill_chunk_offsets_cpu(chunk_offsets: torch.Tensor, chunk_counts: torch.Tensor) -> int:
+    """Fill CPU prefix offsets into chunk-index rows.
+
+    Args:
+        chunk_offsets: Output prefix tensor, shape ``[num_seqs + 1]``.
+        chunk_counts: Per-sequence chunk counts, shape ``[num_seqs]``.
+
+    Returns:
+        Number of prefix entries written.
+    """
+    chunk_offsets[0] = 0
     if chunk_counts.numel() > 0:
-        torch.cumsum(chunk_counts, dim=0, out=out[1 : chunk_counts.numel() + 1])
+        torch.cumsum(chunk_counts, dim=0, out=chunk_offsets[1 : chunk_counts.numel() + 1])
     return chunk_counts.numel() + 1
 
 
-def _fill_update_chunk_offsets_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> int:
-    out[0] = 0
+def _fill_update_chunk_offsets_cpu(update_chunk_offsets: torch.Tensor, chunk_counts: torch.Tensor) -> int:
+    """Fill CPU update-path prefix offsets.
+
+    Args:
+        update_chunk_offsets: Output prefix tensor, shape ``[num_seqs + 1]``.
+        chunk_counts: Per-sequence chunk counts, shape ``[num_seqs]``.
+
+    Returns:
+        Number of prefix entries written. Each sequence contributes its normal
+        chunk count plus one extra recurrent state-update row.
+    """
+    update_chunk_offsets[0] = 0
     if chunk_counts.numel() > 0:
         torch.cumsum(
             chunk_counts + 1,
             dim=0,
-            out=out[1 : chunk_counts.numel() + 1],
+            out=update_chunk_offsets[1 : chunk_counts.numel() + 1],
         )
     return chunk_counts.numel() + 1
 
 
-def _fill_final_chunk_indices_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> int:
+def _fill_final_chunk_indices_cpu(final_chunk_indices: torch.Tensor, chunk_counts: torch.Tensor) -> int:
+    """Fill CPU final update-row indices.
+
+    Args:
+        final_chunk_indices: Output tensor, shape ``[num_seqs]``.
+        chunk_counts: Per-sequence chunk counts, shape ``[num_seqs]``.
+
+    Returns:
+        Number of entries written. Entry ``i`` is the last update row reserved
+        for sequence ``i``.
+    """
     if chunk_counts.numel() > 0:
-        torch.cumsum(chunk_counts + 1, dim=0, out=out[: chunk_counts.numel()])
-        out[: chunk_counts.numel()].sub_(1)
+        torch.cumsum(
+            chunk_counts + 1,
+            dim=0,
+            out=final_chunk_indices[: chunk_counts.numel()],
+        )
+        final_chunk_indices[: chunk_counts.numel()].sub_(1)
     return chunk_counts.numel()
 
 
-def _build_chunk_meta_shape_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNChunkMetaShapeInfo:
+def _build_chunk_operator_arg_cpu_counts(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNChunkOperatorArgCpuCounts:
+    """Build CPU chunk counts and derived tensor sizes for all GDN chunk args.
+
+    Args:
+        builder: Patched GDN metadata builder carrying the three chunk sizes.
+        cu_seqlens_cpu: CPU cumulative offsets for non-spec prefill requests.
+
+    Returns:
+        Per-chunk-size counts plus the output row counts needed to allocate and
+        fill chunk64, large-block, and cumsum operator arguments on CPU.
+    """
     chunk_counts_chunk64 = _prepare_chunk_counts_cpu(
         cu_seqlens_cpu,
         builder._ascend_gdn_chunk_size,
@@ -158,7 +237,7 @@ def _build_chunk_meta_shape_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNC
         cu_seqlens_cpu,
         builder._ascend_gdn_cumsum_block_size,
     )
-    return _GDNChunkMetaShapeInfo(
+    return _GDNChunkOperatorArgCpuCounts(
         num_seqs=chunk_counts_chunk64.numel(),
         num_chunk_indices_chunk64=int(chunk_counts_chunk64.sum().item()),
         num_chunk_indices_large_block=int(chunk_counts_large_block.sum().item()),
@@ -170,6 +249,15 @@ def _build_chunk_meta_shape_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNC
 
 
 def _count_chunk_indices_cpu(seq_lens_cpu: torch.Tensor, chunk_size: int) -> int:
+    """Return the number of rows needed by prepare_chunk_indices.
+
+    Args:
+        seq_lens_cpu: CPU sequence lengths, shape ``[num_seqs]``.
+        chunk_size: Number of tokens per chunk.
+
+    Returns:
+        Total number of chunk-index rows for this chunk size.
+    """
     return int(
         torch.div(
             seq_lens_cpu + chunk_size - 1,
@@ -181,9 +269,19 @@ def _count_chunk_indices_cpu(seq_lens_cpu: torch.Tensor, chunk_size: int) -> int
     )
 
 
-def _build_chunk_meta_size_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNChunkMetaSizeInfo:
+def _build_chunk_operator_arg_sizes(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNChunkOperatorArgSizes:
+    """Build only the tensor sizes needed by device-side metadata filling.
+
+    Args:
+        builder: Patched GDN metadata builder carrying the three chunk sizes.
+        cu_seqlens_cpu: CPU cumulative offsets for non-spec prefill requests.
+
+    Returns:
+        Row counts used to slice reusable device slots before Triton/Torch fills
+        the actual metadata values on NPU.
+    """
     seq_lens_cpu = cu_seqlens_cpu[1:] - cu_seqlens_cpu[:-1]
-    return _GDNChunkMetaSizeInfo(
+    return _GDNChunkOperatorArgSizes(
         num_seqs=seq_lens_cpu.numel(),
         num_chunk_indices_chunk64=_count_chunk_indices_cpu(
             seq_lens_cpu,
@@ -200,30 +298,39 @@ def _build_chunk_meta_size_info(builder, cu_seqlens_cpu: torch.Tensor) -> _GDNCh
     )
 
 
-def _allocate_chunk_meta_cpu_tensors(shape_info: _GDNChunkMetaSizeInfo) -> dict[str, torch.Tensor]:
+def _allocate_chunk_meta_cpu_tensors(arg_sizes: _GDNChunkOperatorArgSizes) -> dict[str, torch.Tensor]:
+    """Allocate CPU tensors for all GDN chunked-prefill operator arguments.
+
+    Args:
+        arg_sizes: Exact row counts for the current non-spec prefill batch.
+
+    Returns:
+        A dictionary keyed by metadata field name. The tensors are empty and
+        must be filled before being wrapped in ``GDNChunkedPrefillMetadata``.
+    """
     return {
         "chunk_indices_chunk64": torch.empty(
-            (shape_info.num_chunk_indices_chunk64, 2),
+            (arg_sizes.num_chunk_indices_chunk64, 2),
             dtype=torch.int32,
         ),
         "chunk_offsets_chunk64": torch.empty(
-            (shape_info.num_seqs + 1,),
+            (arg_sizes.num_seqs + 1,),
             dtype=torch.int32,
         ),
         "update_chunk_offsets_chunk64": torch.empty(
-            (shape_info.num_seqs + 1,),
+            (arg_sizes.num_seqs + 1,),
             dtype=torch.int32,
         ),
         "final_chunk_indices_chunk64": torch.empty(
-            (shape_info.num_seqs,),
+            (arg_sizes.num_seqs,),
             dtype=torch.int32,
         ),
         "chunk_indices_large_block": torch.empty(
-            (shape_info.num_chunk_indices_large_block, 2),
+            (arg_sizes.num_chunk_indices_large_block, 2),
             dtype=torch.int32,
         ),
         "block_indices_cumsum": torch.empty(
-            (shape_info.num_block_indices_cumsum, 2),
+            (arg_sizes.num_block_indices_cumsum, 2),
             dtype=torch.int32,
         ),
     }
@@ -231,45 +338,65 @@ def _allocate_chunk_meta_cpu_tensors(shape_info: _GDNChunkMetaSizeInfo) -> dict[
 
 def _slice_chunk_meta_slot_tensors(
     slot: _GDNChunkedPrefillBufferSlot,
-    shape_info: _GDNChunkMetaSizeInfo,
+    arg_sizes: _GDNChunkOperatorArgSizes,
 ) -> dict[str, torch.Tensor]:
+    """Take current-batch views from reusable device metadata buffers.
+
+    Args:
+        slot: One reusable buffer slot allocated to scheduler maximum sizes.
+        arg_sizes: Exact row counts for the current non-spec prefill batch.
+
+    Returns:
+        A dictionary of device tensor views sized to the current batch. The
+        views keep ``slot`` storage and are filled in place by the device path.
+    """
     return {
-        "chunk_indices_chunk64": slot.chunk_indices_chunk64[: shape_info.num_chunk_indices_chunk64],
-        "chunk_offsets_chunk64": slot.chunk_offsets_chunk64[: shape_info.num_seqs + 1],
-        "update_chunk_offsets_chunk64": slot.update_chunk_offsets_chunk64[: shape_info.num_seqs + 1],
-        "final_chunk_indices_chunk64": slot.final_chunk_indices_chunk64[: shape_info.num_seqs],
-        "chunk_indices_large_block": slot.chunk_indices_large_block[: shape_info.num_chunk_indices_large_block],
-        "block_indices_cumsum": slot.block_indices_cumsum[: shape_info.num_block_indices_cumsum],
+        "chunk_indices_chunk64": slot.chunk_indices_chunk64[: arg_sizes.num_chunk_indices_chunk64],
+        "chunk_offsets_chunk64": slot.chunk_offsets_chunk64[: arg_sizes.num_seqs + 1],
+        "update_chunk_offsets_chunk64": slot.update_chunk_offsets_chunk64[: arg_sizes.num_seqs + 1],
+        "final_chunk_indices_chunk64": slot.final_chunk_indices_chunk64[: arg_sizes.num_seqs],
+        "chunk_indices_large_block": slot.chunk_indices_large_block[: arg_sizes.num_chunk_indices_large_block],
+        "block_indices_cumsum": slot.block_indices_cumsum[: arg_sizes.num_block_indices_cumsum],
     }
 
 
 def _fill_chunk_meta_cpu_tensors(
     tensors: dict[str, torch.Tensor],
-    shape_info: _GDNChunkMetaShapeInfo,
+    cpu_counts: _GDNChunkOperatorArgCpuCounts,
 ) -> None:
+    """Fill all CPU GDN chunked-prefill metadata tensors.
+
+    Args:
+        tensors: CPU tensors allocated by ``_allocate_chunk_meta_cpu_tensors``.
+        cpu_counts: Per-chunk-size counts and derived row counts.
+
+    Returns:
+        None. The tensors are mutated in place and then passed to the GDN FLA
+        operators through ``GDNChunkedPrefillMetadata``.
+    """
     _fill_chunk_indices_cpu(
         tensors["chunk_indices_chunk64"],
-        shape_info.chunk_counts_chunk64,
+        cpu_counts.chunk_counts_chunk64,
     )
     _fill_chunk_offsets_cpu(
         tensors["chunk_offsets_chunk64"],
-        shape_info.chunk_counts_chunk64,
+        cpu_counts.chunk_counts_chunk64,
     )
     _fill_update_chunk_offsets_cpu(
         tensors["update_chunk_offsets_chunk64"],
-        shape_info.chunk_counts_chunk64,
+        cpu_counts.chunk_counts_chunk64,
     )
     _fill_final_chunk_indices_cpu(
         tensors["final_chunk_indices_chunk64"],
-        shape_info.chunk_counts_chunk64,
+        cpu_counts.chunk_counts_chunk64,
     )
     _fill_chunk_indices_cpu(
         tensors["chunk_indices_large_block"],
-        shape_info.chunk_counts_large_block,
+        cpu_counts.chunk_counts_large_block,
     )
     _fill_chunk_indices_cpu(
         tensors["block_indices_cumsum"],
-        shape_info.chunk_counts_cumsum,
+        cpu_counts.chunk_counts_cumsum,
     )
 
 
@@ -278,13 +405,27 @@ def _fill_chunk_meta_device_tensors(
     cu_seqlens: torch.Tensor,
     tensors: dict[str, torch.Tensor],
 ) -> None:
-    seq_lens = None
+    """Fill all device GDN chunked-prefill metadata tensors.
+
+    Args:
+        builder: Patched GDN metadata builder carrying chunk sizes.
+        cu_seqlens: NPU cumulative offsets for non-spec prefill requests.
+        tensors: Device tensor views from ``_slice_chunk_meta_slot_tensors``.
+
+    Returns:
+        None. The tensors are filled in place by ``build_chunk_meta_device``.
+        ``cu_seqlens`` is validated once, and the derived sequence lengths are
+        reused for all three chunk sizes.
+    """
+    device_seq_lens = None
     validate_inputs = True
     if cu_seqlens.device.type == "npu":
+        # Validate the shared cu_seqlens once, then reuse its derived sequence
+        # lengths for all chunk sizes to avoid redundant device slicing.
         _validate_cu_seqlens(cu_seqlens, builder._ascend_gdn_chunk_size)
         assert builder._ascend_gdn_large_block_size > 0
         assert builder._ascend_gdn_cumsum_block_size > 0
-        seq_lens = _build_seq_lens(cu_seqlens)
+        device_seq_lens = _build_seq_lens(cu_seqlens)
         validate_inputs = False
     build_chunk_meta_device(
         cu_seqlens=cu_seqlens,
@@ -293,31 +434,40 @@ def _fill_chunk_meta_device_tensors(
         out_chunk_offsets=tensors["chunk_offsets_chunk64"],
         out_update_chunk_offsets=tensors["update_chunk_offsets_chunk64"],
         out_final_chunk_indices=tensors["final_chunk_indices_chunk64"],
-        seq_lens=seq_lens,
+        seq_lens=device_seq_lens,
         validate_inputs=validate_inputs,
     )
     build_chunk_meta_device(
         cu_seqlens=cu_seqlens,
         chunk_size=builder._ascend_gdn_large_block_size,
         out_chunk_indices=tensors["chunk_indices_large_block"],
-        seq_lens=seq_lens,
+        seq_lens=device_seq_lens,
         validate_inputs=validate_inputs,
     )
     build_chunk_meta_device(
         cu_seqlens=cu_seqlens,
         chunk_size=builder._ascend_gdn_cumsum_block_size,
         out_chunk_indices=tensors["block_indices_cumsum"],
-        seq_lens=seq_lens,
+        seq_lens=device_seq_lens,
         validate_inputs=validate_inputs,
     )
 
 
 def _build_chunked_prefill_metadata(
-    builder,
     tensors: dict[str, torch.Tensor],
     *,
     slot: _GDNChunkedPrefillBufferSlot | None = None,
 ) -> GDNChunkedPrefillMetadata:
+    """Wrap filled tensors in the metadata object consumed by GDN operators.
+
+    Args:
+        tensors: Filled chunk metadata tensors keyed by field name.
+        slot: Optional owner of reusable device storage. Keeping this reference
+            prevents the backing buffers from being reused too early.
+
+    Returns:
+        A ``GDNChunkedPrefillMetadata`` instance ready for operator calls.
+    """
     return GDNChunkedPrefillMetadata(
         chunk_indices_chunk64=tensors["chunk_indices_chunk64"],
         chunk_offsets_chunk64=tensors["chunk_offsets_chunk64"],
@@ -336,7 +486,16 @@ def _get_gdn_num_heads(builder) -> int:
     return builder.vllm_config.model_config.get_num_attention_heads(builder.vllm_config.parallel_config)
 
 
-def _allocate_chunked_prefill_slot(builder, device: torch.device):
+def _allocate_chunked_prefill_slot(builder, device: torch.device) -> _GDNChunkedPrefillBufferSlot:
+    """Allocate one reusable device slot for GDN chunked-prefill metadata.
+
+    Args:
+        builder: GDN metadata builder with scheduler maximum batch sizes.
+        device: Target device for the operator metadata tensors.
+
+    Returns:
+        A slot sized to ``max_num_batched_tokens`` and ``max_num_seqs``.
+    """
     max_num_batched_tokens = builder.vllm_config.scheduler_config.max_num_batched_tokens
     max_num_seqs = builder.vllm_config.scheduler_config.max_num_seqs
     return _GDNChunkedPrefillBufferSlot(
@@ -374,15 +533,30 @@ def _allocate_chunked_prefill_slot(builder, device: torch.device):
 
 
 def _ensure_chunk_meta_state(builder, device: torch.device) -> None:
+    """Initialize chunk metadata state on the patched builder.
+
+    Args:
+        builder: GDN metadata builder being patched.
+        device: Device where chunk metadata should be produced.
+
+    Returns:
+        None. The builder receives chunk-size constants and, for non-CPU
+        devices, a small pool of reusable metadata buffer slots.
+    """
     if getattr(builder, "_ascend_gdn_chunk_meta_initialized", False):
         return
     builder._ascend_gdn_chunk_meta_initialized = True
     builder._ascend_gdn_chunk_meta_device = device
     builder._ascend_gdn_chunk_size = _GDN_CHUNK_SIZE
     builder._ascend_gdn_large_block_size = _GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE
-    gdn_num_heads = _get_gdn_num_heads(builder)
-    cumsum_chunks = max(1, _GDN_CUMSUM_WORKING_SET // (gdn_num_heads * builder._ascend_gdn_chunk_size))
-    builder._ascend_gdn_cumsum_block_size = _next_power_of_2(cumsum_chunks)
+    num_gdn_value_heads = _get_gdn_num_heads(builder)
+    # The cumsum chunk size is chosen so the per-head working set stays under
+    # the tuned solve-tril budget, rounded up for Triton-friendly tiling.
+    cumsum_chunk_size = max(
+        1,
+        _GDN_CUMSUM_WORKING_SET // (num_gdn_value_heads * builder._ascend_gdn_chunk_size),
+    )
+    builder._ascend_gdn_cumsum_block_size = _next_power_of_2(cumsum_chunk_size)
     builder._ascend_gdn_chunked_prefill_pool_idx = -1
     builder._ascend_gdn_chunked_prefill_pool = []
     if device.type != "cpu":
@@ -392,11 +566,17 @@ def _ensure_chunk_meta_state(builder, device: torch.device) -> None:
         ]
 
 
+def _has_spec_decode_drafts(num_decode_draft_tokens_cpu: torch.Tensor) -> bool:
+    # The upstream builder only enters the spec path when at least one request
+    # has a positive draft-token count; all-zero draft counts are no-op spec.
+    return bool(torch.gt(num_decode_draft_tokens_cpu, 0).any().item())
+
+
 def _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu: torch.Tensor | None) -> torch.Tensor | None:
     if (
         not getattr(builder, "use_spec_decode", False)
         or num_decode_draft_tokens_cpu is None
-        or num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0].sum().item() == 0
+        or not _has_spec_decode_drafts(num_decode_draft_tokens_cpu)
     ):
         return None
     return num_decode_draft_tokens_cpu >= 0
@@ -478,12 +658,13 @@ def _copy_to_pinned_cpu(
         return tensor
 
     assert pinned_buffer is not None
-    cpu_tensor = pinned_buffer[: tensor.numel()]
-    cpu_tensor.copy_(
+    # The returned view is kept alive through the metadata object's buffer slot.
+    cpu_view = pinned_buffer[: tensor.numel()]
+    cpu_view.copy_(
         tensor.reshape(-1),
         non_blocking=True,
     )
-    return cpu_tensor
+    return cpu_view
 
 
 def _build_non_spec_causal_conv1d_host_meta(
@@ -492,61 +673,80 @@ def _build_non_spec_causal_conv1d_host_meta(
     non_spec_query_start_loc_cpu: torch.Tensor,
 ) -> GDNCausalConv1dHostMetadata:
     assert attn_metadata.num_prefills > 0
-    if attn_metadata.non_spec_state_indices_tensor is None:
-        raise RuntimeError(
-            "Expected attn_metadata.non_spec_state_indices_tensor for patched GDN non-spec prefill path."
-        )
-    if attn_metadata.has_initial_state is None:
-        raise RuntimeError("Expected attn_metadata.has_initial_state for patched GDN non-spec prefill path.")
+    non_spec_state_indices = attn_metadata.non_spec_state_indices_tensor
+    has_initial_state = attn_metadata.has_initial_state
 
-    slot = None
-    if (
-        attn_metadata.non_spec_state_indices_tensor.device.type != "cpu"
-        or attn_metadata.has_initial_state.device.type != "cpu"
-    ):
-        slot = _acquire_causal_conv1d_host_slot(builder)
+    host_slot = None
+    if non_spec_state_indices.device.type != "cpu" or has_initial_state.device.type != "cpu":
+        host_slot = _acquire_causal_conv1d_host_slot(builder)
 
     cache_indices_cpu = _copy_to_pinned_cpu(
-        attn_metadata.non_spec_state_indices_tensor,
-        None if slot is None else slot.cache_indices_cpu,
+        non_spec_state_indices,
+        None if host_slot is None else host_slot.cache_indices_cpu,
     )
     has_initial_state_cpu = _copy_to_pinned_cpu(
-        attn_metadata.has_initial_state,
-        None if slot is None else slot.has_initial_state_cpu,
+        has_initial_state,
+        None if host_slot is None else host_slot.has_initial_state_cpu,
     )
 
     return GDNCausalConv1dHostMetadata(
         query_start_loc_cpu=non_spec_query_start_loc_cpu,
         cache_indices_cpu=cache_indices_cpu,
         has_initial_state_cpu=has_initial_state_cpu,
-        _buffer_slot=slot,
+        _buffer_slot=host_slot,
     )
 
 
-def _build_non_spec_chunked_prefill_meta_cpu(builder, cu_seqlens_cpu: torch.Tensor) -> GDNChunkedPrefillMetadata:
-    shape_info = _build_chunk_meta_shape_info(builder, cu_seqlens_cpu)
-    tensors = _allocate_chunk_meta_cpu_tensors(shape_info)
-    _fill_chunk_meta_cpu_tensors(tensors, shape_info)
-    return _build_chunked_prefill_metadata(builder, tensors)
+def _build_non_spec_chunked_prefill_meta_cpu(
+    builder,
+    non_spec_query_start_loc_cpu: torch.Tensor,
+) -> GDNChunkedPrefillMetadata:
+    """Build GDN chunked-prefill operator metadata entirely on CPU.
+
+    Args:
+        builder: Patched GDN metadata builder carrying chunk sizes.
+        non_spec_query_start_loc_cpu: CPU cumulative offsets for non-spec
+            prefill requests.
+
+    Returns:
+        Filled chunked-prefill metadata whose tensors live on CPU.
+    """
+    cpu_counts = _build_chunk_operator_arg_cpu_counts(builder, non_spec_query_start_loc_cpu)
+    tensors = _allocate_chunk_meta_cpu_tensors(cpu_counts)
+    _fill_chunk_meta_cpu_tensors(tensors, cpu_counts)
+    return _build_chunked_prefill_metadata(tensors)
 
 
 def _build_non_spec_chunked_prefill_meta(
     builder,
-    cu_seqlens_cpu: torch.Tensor,
-    cu_seqlens: torch.Tensor,
+    non_spec_query_start_loc_cpu: torch.Tensor,
+    non_spec_query_start_loc: torch.Tensor,
 ) -> GDNChunkedPrefillMetadata:
+    """Build GDN chunked-prefill operator metadata for non-spec prefill.
+
+    Args:
+        builder: Patched GDN metadata builder carrying state and chunk sizes.
+        non_spec_query_start_loc_cpu: CPU cumulative offsets used to calculate
+            exact tensor row counts.
+        non_spec_query_start_loc: Runtime cumulative offsets on the target
+            device, used to fill metadata values on device.
+
+    Returns:
+        ``GDNChunkedPrefillMetadata`` containing chunk64, large-block, and
+        cumsum metadata tensors for the GDN operators.
+    """
     device = builder._ascend_gdn_chunk_meta_device
     if device.type == "cpu":
-        return _build_non_spec_chunked_prefill_meta_cpu(builder, cu_seqlens_cpu)
+        return _build_non_spec_chunked_prefill_meta_cpu(builder, non_spec_query_start_loc_cpu)
 
-    shape_info = _build_chunk_meta_size_info(builder, cu_seqlens_cpu)
+    arg_sizes = _build_chunk_operator_arg_sizes(builder, non_spec_query_start_loc_cpu)
     builder._ascend_gdn_chunked_prefill_pool_idx = (builder._ascend_gdn_chunked_prefill_pool_idx + 1) % len(
         builder._ascend_gdn_chunked_prefill_pool
     )
     slot = builder._ascend_gdn_chunked_prefill_pool[builder._ascend_gdn_chunked_prefill_pool_idx]
-    tensors = _slice_chunk_meta_slot_tensors(slot, shape_info)
-    _fill_chunk_meta_device_tensors(builder, cu_seqlens, tensors)
-    return _build_chunked_prefill_metadata(builder, tensors, slot=slot)
+    tensors = _slice_chunk_meta_slot_tensors(slot, arg_sizes)
+    _fill_chunk_meta_device_tensors(builder, non_spec_query_start_loc, tensors)
+    return _build_chunked_prefill_metadata(tensors, slot=slot)
 
 
 def _patched_build(
@@ -565,7 +765,7 @@ def _patched_build(
         num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
         fast_build=fast_build,
     )
-    attn_metadata.non_spec_prefill_fallback_meta = None
+    attn_metadata.non_spec_prefill_operator_meta = None
     if attn_metadata.num_prefills <= 0:
         return attn_metadata
 
@@ -580,10 +780,7 @@ def _patched_build(
         common_attn_metadata,
         num_decode_draft_tokens_cpu,
     )
-    assert non_spec_query_start_loc_cpu is not None
-    if attn_metadata.non_spec_query_start_loc is None:
-        raise RuntimeError("Expected attn_metadata.non_spec_query_start_loc for patched GDN non-spec prefill path.")
-    attn_metadata.non_spec_prefill_fallback_meta = GDNPrefillFallbackMeta(
+    attn_metadata.non_spec_prefill_operator_meta = GDNNonSpecPrefillOperatorMetadata(
         causal_conv1d=_build_non_spec_causal_conv1d_host_meta(
             self,
             attn_metadata,
@@ -624,7 +821,7 @@ def _init_reorder_batch_threshold(
 if not _IS_PATCHED and not is_310p():
     gdn_attn.GDNChunkedPrefillMetadata = GDNChunkedPrefillMetadata
     gdn_attn.GDNCausalConv1dHostMetadata = GDNCausalConv1dHostMetadata
-    gdn_attn.GDNPrefillFallbackMeta = GDNPrefillFallbackMeta
+    gdn_attn.GDNNonSpecPrefillOperatorMetadata = GDNNonSpecPrefillOperatorMetadata
     gdn_attn.GDNAttentionMetadataBuilder.build = _patched_build
     gdn_attn.GDNAttentionMetadataBuilder._init_reorder_batch_threshold = _init_reorder_batch_threshold
     _IS_PATCHED = True


### PR DESCRIPTION
## Summary

- Rename the GDN non-spec prefill metadata container from fallback/runtime wording to operator metadata.
- Rename chunk metadata sizing helpers around the operator arguments they allocate or fill, using `arg_sizes` and CPU chunk-count names instead of abstract layout/plan/output-size wording.
- Document the GDN chunk metadata Triton kernels and helper functions with their inputs, in-place outputs, and responsibilities.
- Clarify chunk metadata helper comments around zero-length sequence compaction, update offsets, and pinned CPU buffer lifetime.
- Update chunk operator documentation to distinguish Hk, Hv, and Hg dimensions, addressing #8267.
- Remove defensive wrapper checks around GDN non-spec prefill operator metadata consumption and remove the heuristic head/sequence format warning.

Fixes #8267.

## Motivation

The previous fallback metadata name was ambiguous because the object is not an error fallback. It is a prebuilt metadata bundle consumed by the GDN non-spec prefill operators. The updated naming makes the consumer and execution path explicit.

The chunk metadata helpers build tensors that are passed as GDN operator arguments, so their names now describe those operator-argument sizes/counts directly instead of calling them a layout, plan, or output size. The metadata builder now also documents what each Triton kernel and wrapper helper receives, which tensors it mutates, and how those tensors map to the chunked-prefill operators.

Issue #8267 also points out that chunk operator comments used a single H for query/key, value, and gate/beta heads, even though Qwen3.5-style GDN models can use different head counts. The comments now use Hk, Hv, and Hg so the operator shapes are easier to read and debug.

## Validation

- `python -m py_compile vllm_ascend/ops/triton/gdn_chunk_meta.py vllm_ascend/patch/worker/patch_gdn_attn.py`
- `uvx ruff format --check vllm_ascend/ops/triton/gdn_chunk_meta.py vllm_ascend/patch/worker/patch_gdn_attn.py`
- `uvx ruff check vllm_ascend/ops/triton/gdn_chunk_meta.py vllm_ascend/patch/worker/patch_gdn_attn.py`
- `git diff --check`

Local pytest was not run because this path depends on torch/torch_npu and the workspace instructions route such tests to the remote container.
