### PR TITLE
[Feature] Support the merged graph for dflash

### DIFF
--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -54,6 +54,10 @@ class AscendDflashProposer(AscendEagleProposer):
 
         self.arange_dflash = torch.arange(self.max_positions + 1, device=device, dtype=torch.int32)
 
+        self._dflash_hidden_states = torch.zeros(
+            (self.max_num_tokens, self.hidden_size), dtype=self.dtype, device=self.device
+        )
+
         self.parallel_drafting_hidden_state_tensor = None
 
     def set_inputs_first_pass(
@@ -78,7 +82,7 @@ class AscendDflashProposer(AscendEagleProposer):
         num_query_total = batch_size * num_query_per_req
 
         self._dflash_num_context = num_context
-        self._dflash_hidden_states = target_hidden_states
+        self._dflash_hidden_states[:num_context] = target_hidden_states
 
         token_indices_to_sample = torch.empty(
             batch_size * self.num_speculative_tokens,
@@ -215,13 +219,25 @@ class AscendDflashProposer(AscendEagleProposer):
             is_draft_model=True,
             draft_attn_metadatas=multi_steps_attn_metadata,
         ):
-            self.model.precompute_and_store_context_kv(context_states, context_positions)
+            if is_profile:
+                self.model.precompute_and_store_context_kv(context_states, context_positions)
+                self.model(
+                    input_ids=self.input_ids[:num_query_total],
+                    positions=self._get_positions(num_query_total),
+                    inputs_embeds=None,
+                )
 
-            self.model(
-                input_ids=self.input_ids[:num_query_total],
-                positions=self._get_positions(num_query_total),
-                inputs_embeds=None,
-            )
+            else:
+                self._dflash_num_context = num_input_tokens
+                self._runnable(
+                    num_input_tokens=num_input_tokens,
+                    batch_size=num_reqs,
+                    token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
+                    target_positions=self._get_positions(num_input_tokens),
+                    inputs_embeds=None,
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
+                    num_tokens=num_input_tokens,
+                )
 
             forward_context = get_forward_context()
             if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
@@ -234,7 +250,7 @@ class AscendDflashProposer(AscendEagleProposer):
         num_context = self._dflash_num_context
 
         self.model.precompute_and_store_context_kv(
-            self._dflash_hidden_states,
+            self._dflash_hidden_states[:num_context],
             self._context_positions_buffer[:num_context],
             self._context_slot_mapping_buffer[:num_context],
         )

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -340,22 +340,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() and self.use_cuda_graph:
             self.update_stream = torch.npu.Stream()
-            if self.method == "dflash":
-                self.model = ACLGraphWrapper(
-                    self.model,
-                    self.vllm_config,
-                    runtime_mode=CUDAGraphMode.FULL,
-                    use_eagle=self.use_eagle,
-                    enable_enpu=self.enable_enpu,
-                )
-            else:
-                self._runnable = ACLGraphWrapper(
-                    self._run_merged_draft,
-                    self.vllm_config,
-                    runtime_mode=CUDAGraphMode.FULL,
-                    use_eagle=self.use_eagle,
-                    enable_enpu=self.enable_enpu,
-                )
+            self._runnable = ACLGraphWrapper(
+                self._run_merged_draft,
+                self.vllm_config,
+                runtime_mode=CUDAGraphMode.FULL,
+                use_eagle=self.use_eagle,
+                enable_enpu=self.enable_enpu,
+            )
 
     def get_model(self) -> nn.Module:
         # get raw model out of the aclgraph wrapper.


### PR DESCRIPTION
### What this PR does / why we need it?
This PR expands the CUDA graph coverage for dflash speculative decoding by including the _run_merged_draft method in the graph, rather than just the basic model forward pass.

  Key changes:
  - Removed the special-case handling where dflash mode wrapped only the model with ACLGraphWrapper
  - Now both dflash and other methods consistently use _run_merged_draft for CUDA graph capture
  - Modified dflash proposer to properly handle hidden states buffer management for graph execution

performance test:
Qwen3-8B, DP1/TP1, constructing gsm8k dataset to repeat the input length to 1870, output length 1000, data num 100, temperature 0, graph mode FULL_DECODE_ONLY, spec_num  7

before

| concurrency| mean ttft | mean tpot |
| --- | --- | --- |
| 1 | 147.78 | 4.15 | 
| 2 | 166.41 | 4.53 | 
| 4 | 189.05 | 5.32 | 
| 8 | 269.48 | 6.21 | 
| 16 | 499.97 | 7.91 |

after

| concurrency| mean ttft | mean tpot |
| --- | --- | --- |
| 1 | 146.10 | 3.95 | 
| 2 | 163.97 | 4.32 | 
| 4 | 185.50 | 5.07 | 
| 8 | 258.38 | 6.09 | 
| 16 | 498.94 | 7.58 |


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.19.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d886c26d4d4fef7d079696beb4ece1cfb4b008a8
