### PR TITLE
[Performance] Pad suffix decoding proposer draft tokens for fullgraph compatibility

### DIFF
--- a/vllm_ascend/spec_decode/suffix_proposer.py
+++ b/vllm_ascend/spec_decode/suffix_proposer.py
@@ -1,10 +1,12 @@
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
+from vllm.config import CUDAGraphMode
 
 
 class AscendSuffixDecodingProposer(SuffixDecodingProposer):
     def __init__(self, vllm_config, runner):
         super().__init__(vllm_config)
         self.runner = runner
+        self.vllm_config = vllm_config
 
     def dummy_run(
         self,
@@ -21,4 +23,11 @@ class AscendSuffixDecodingProposer(SuffixDecodingProposer):
         pass
 
     def propose(self, valid_sampled_token_ids):
-        return super().propose(self.runner.input_batch, valid_sampled_token_ids)
+        draft_token_ids = super().propose(self.runner.input_batch, valid_sampled_token_ids)
+        if self.vllm_config.compilation_config.cudagraph_mode.has_mode(CUDAGraphMode.FULL):
+            target_len = self.num_speculative_tokens
+            for i in range(len(draft_token_ids)):
+                cur_len = len(draft_token_ids[i])
+                if cur_len < target_len:
+                    draft_token_ids[i].extend([0] * (target_len - cur_len))
+        return draft_token_ids


### PR DESCRIPTION
### What this PR does / why we need it?

When suffix decoding is used with graph FULL decode mode, the variable-length draft token sequences returned by the suffix decoding proposer prevent graph from matching fixed tensor shapes, causing fallback to eager execution with severe performance degradation.

This PR pads draft token sequences to  length when graph FULL decode mode is active, enabling proper graph hits.

### Performance Results

Tested on Qwen3.5-35B-A3B, Ascend 910B x2, TP=2, suffix decoding with num_speculative_tokens=3:

| Configuration | Graph Mode | Patch | Throughput |
|---|---|---|---|
| Suffix speculation | FULL_DECODE_ONLY | No | 6.09 tok/s |
| Suffix speculation | PIECEWISE | No | 16.32 tok/s |
| Suffix speculation | FULL_DECODE_ONLY | **Yes** | **59.58 tok/s** |

**+878% throughput improvement** vs FULL_DECODE_ONLY without patch.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Benchmarked with vLLM serve on Ascend 910B NPU with Qwen3.5-35B-A3B model, comparing throughput with and without the patch under suffix decoding + graph FULL_DECODE_ONLY mode.

Signed-off-by: xshhanbaobao <xiaoshihan.xsh@gmail.com>, walterchenchn <walterchenchn@outlook.com>
