### PR TITLE
[Feature] A5 npu_gather_pa_kv_cache operator adaptation for pcp

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1526,7 +1526,7 @@ class TestAscendMLAImpl(TestBase):
         prefill_metadata.block_table = torch.randint(0, 100, (2, 4))
         attn_metadata.prefill = prefill_metadata
 
-        mock_device_operator.mla_cache_load = MagicMock()
+        mock_device_operator.kv_cache_load = MagicMock()
 
         mock_fia.return_value = (
             torch.randn(batch_size, self.impl.num_heads, self.impl.v_head_dim),

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -740,13 +740,13 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
         key = torch.empty(total_toks, num_heads, head_size, dtype=query.dtype, device=query.device)
         value = torch.empty(total_toks, num_heads, head_size, dtype=query.dtype, device=query.device)
         if total_toks > 0:
-            torch_npu.atb.npu_paged_cache_load(
+            DeviceOperator.kv_cache_load(
                 cache_key,
                 cache_value,
                 attn_metadata.prefill.block_tables,
                 local_chunked_kv_lens_rank,
                 # slot offsets of current chunk in current iteration
-                seq_starts=attn_metadata.prefill.chunked_context.starts,
+                attn_metadata.prefill.chunked_context.starts,
                 key=key,
                 value=value,
             )

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1163,7 +1163,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=q_nope.dtype, device=q_nope.device)
             k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_nope.dtype, device=q_nope.device)
 
-            DeviceOperator.mla_cache_load(
+            DeviceOperator.kv_cache_load(
                 cache_kv_c,
                 cache_k_pe,
                 prefill_metadata.block_table,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -190,7 +190,7 @@ class BaseDeviceAdaptor:
         )[0]
 
     @staticmethod
-    def mla_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_starts, key, value):
+    def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_starts, key, value):
         torch_npu.atb.npu_paged_cache_load(
             cache_kv_c,
             cache_k_pe,
@@ -553,12 +553,12 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )[0]
 
     @staticmethod
-    def mla_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_offset, key, value):
+    def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_offset, key, value):
         torch_npu.npu_gather_pa_kv_cache(
             cache_kv_c,
             cache_k_pe,
             block_table,
-            context_seq_len_npu,
+            context_seq_len_npu.contiguous(),
             seq_offset=seq_offset,
             key=key,
             value=value,


### PR DESCRIPTION
### What this PR does / why we need it?
A5 npu_gather_pa_kv_cache operator adaptation for pcp.

1. Replaces the direct `torch_npu.atb.npu_paged_cache_load` call in `_load_kv_for_chunk` with `DeviceOperator.kv_cache_load,` so the `_load_kv_for_chunk` path can go through the device operator abstraction.

1. The name of the `mla_cache_load` function is changed to `kv_cache_load.` This function is used to efficiently obtain the key-value data of a specified sequence from the KV cache.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
