### PR TITLE
[Ops][BugFix] Fix arch32 detection in ARCH_DIRECTORY setup

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -59,7 +59,7 @@ foreach(SOC_VERSION ${ASCEND_COMPUTE_UNIT})
   endif()
 endforeach()
 
-list(FIND ARCH_DIRECTORY "arch32" INDXE)
+list(FIND ARCH_DIRECTORY "arch32" INDEX)
 if(NOT INDEX EQUAL -1)
     list(APPEND ARCH_DIRECTORY "arch22")
 endif()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a typo in the CMake logic for `arch32` detection. The result of `list(FIND)` was stored in `INDXE` but checked using `INDEX`, which could lead to incorrect build configurations if `INDEX` held a stale value from a previous lookup.

### Does this PR introduce _any_ user-facing change?

No. This is a build-system correctness fix.

### How was this patch tested?

CI passed with existing tests.


- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
