### PR TITLE
[Performance][Bailing] Avoid prefill sync in linear attention

### DIFF
--- a/vllm_ascend/ops/bailing_moe_linear_attn.py
+++ b/vllm_ascend/ops/bailing_moe_linear_attn.py
@@ -27,16 +27,73 @@ import torch
 import torch.nn.functional as F
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.layernorm_guard import layernorm_fn
-from vllm.model_executor.layers.mamba.linear_attn import (
-    clear_linear_attention_cache_for_new_sequences,
-    linear_attention_decode,
-    linear_attention_prefill_and_mix,
-)
+from vllm.model_executor.layers.mamba.linear_attn import linear_attention_decode
 from vllm.model_executor.models.bailing_moe_linear import BailingMoELinearAttention
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.linear_attn import LinearAttentionMetadata
 
-from vllm_ascend.ops.triton.mamba.lightning_attn import AscendLightningAttentionKernel
+from vllm_ascend.ops.triton.mamba.lightning_attn import (
+    AscendLightningAttentionKernel,
+    clear_linear_attention_cache_for_prefill_npu,
+    pack_qkv_for_prefill,
+)
+
+
+def ascend_linear_attention_prefill_and_mix(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kv_cache: torch.Tensor,
+    state_indices_tensor: torch.Tensor,
+    attn_metadata: LinearAttentionMetadata,
+    slope_rate: torch.Tensor,
+    block_size: int,
+    decode_fn,
+    prefix_fn,
+    layer_idx: int | None = None,
+) -> torch.Tensor:
+    hidden = []
+    query_start_loc = getattr(attn_metadata, "query_start_loc_cpu", None)
+    if query_start_loc is None:
+        query_start_loc = attn_metadata.query_start_loc
+    state_indices = getattr(attn_metadata, "state_indices_cpu", None)
+    if state_indices is None:
+        state_indices = state_indices_tensor
+    offset = attn_metadata.num_decode_tokens
+    for prefill_idx in range(getattr(attn_metadata, "num_prefills", 0)):
+        if offset + prefill_idx + 1 >= len(query_start_loc):
+            break
+        if offset + prefill_idx >= len(state_indices):
+            break
+        start = int(query_start_loc[offset + prefill_idx])
+        end = int(query_start_loc[offset + prefill_idx + 1])
+        slot_id = state_indices[offset + prefill_idx]
+        if getattr(slot_id, "device", None) is not None and slot_id.device.type == "cpu":
+            slot_id = int(slot_id)
+
+        qs, ks, vs = pack_qkv_for_prefill(q, k, v, start, end)
+        slice_layer_cache = kv_cache[slot_id, ...]
+        out_slice = prefix_fn(
+            qs,
+            ks,
+            vs,
+            slice_layer_cache,
+            slope_rate,
+            block_size,
+            layer_idx=layer_idx,
+        )
+        hidden.append(out_slice)
+
+    if attn_metadata.num_decode_tokens > 0:
+        hidden_decode = decode_fn(q, k, v, kv_cache, state_indices_tensor, attn_metadata)
+        hidden.insert(0, hidden_decode)
+
+    if not hidden:
+        return torch.empty((0, q.shape[1] * q.shape[2]), device=q.device, dtype=q.dtype)
+
+    if len(hidden) == 1:
+        return hidden[0]
+    return torch.concat(hidden, dim=0).contiguous()
 
 
 class AscendBailingMoELinearAttention(BailingMoELinearAttention):
@@ -50,7 +107,7 @@ class AscendBailingMoELinearAttention(BailingMoELinearAttention):
     """
 
     def _prefill_and_mix_infer(self, q, k, v, kv_cache, state_indices_tensor, attn_metadata):
-        return linear_attention_prefill_and_mix(
+        return ascend_linear_attention_prefill_and_mix(
             q=q,
             k=k,
             v=v,
@@ -144,7 +201,8 @@ class AscendBailingMoELinearAttention(BailingMoELinearAttention):
         if attn_metadata is not None:
             kv_cache = self.kv_cache[0]
             state_indices_tensor = attn_metadata.state_indices_tensor
-            clear_linear_attention_cache_for_new_sequences(kv_cache, state_indices_tensor, attn_metadata)
+            if getattr(attn_metadata, "num_prefills", 0) > 0:
+                clear_linear_attention_cache_for_prefill_npu(kv_cache, state_indices_tensor, attn_metadata)
 
         # Compute attention
         decode_only = getattr(attn_metadata, "num_prefills", 0) == 0

--- a/vllm_ascend/ops/triton/mamba/lightning_attn.py
+++ b/vllm_ascend/ops/triton/mamba/lightning_attn.py
@@ -29,6 +29,178 @@ from vllm.triton_utils import tl, triton
 
 
 @triton.jit
+def _clear_linear_attention_cache_kernel(
+    KV_CACHE,
+    STATE_INDICES,
+    QUERY_START_LOC,
+    SEQ_LENS,
+    num_decode_tokens: tl.constexpr,
+    d: tl.constexpr,
+    e: tl.constexpr,
+    kv_stride_slot: tl.constexpr,
+    kv_stride_h: tl.constexpr,
+    kv_stride_d: tl.constexpr,
+    kv_stride_e: tl.constexpr,
+    BLOCK_KV: tl.constexpr,
+):
+    prefill_idx = tl.program_id(0)
+    head = tl.program_id(1)
+    kv_block = tl.program_id(2)
+
+    req_idx = num_decode_tokens + prefill_idx
+    q_start = tl.load(QUERY_START_LOC + req_idx)
+    q_end = tl.load(QUERY_START_LOC + req_idx + 1)
+    seq_len = tl.load(SEQ_LENS + req_idx)
+    slot_id = tl.load(STATE_INDICES + req_idx)
+
+    offsets = kv_block * BLOCK_KV + tl.arange(0, BLOCK_KV)
+    dim_d = offsets // e
+    dim_e = offsets - dim_d * e
+    should_clear = seq_len == q_end - q_start
+
+    ptrs = KV_CACHE + slot_id * kv_stride_slot + head * kv_stride_h + dim_d * kv_stride_d + dim_e * kv_stride_e
+    tl.store(ptrs, 0.0, mask=should_clear & (offsets < d * e))
+
+
+def clear_linear_attention_cache_for_prefill_npu(
+    kv_cache: torch.Tensor,
+    state_indices_tensor: torch.Tensor,
+    attn_metadata,
+) -> None:
+    num_prefills = getattr(attn_metadata, "num_prefills", 0)
+    if num_prefills <= 0:
+        return
+
+    num_decode_tokens = getattr(attn_metadata, "num_decode_tokens", 0)
+    _, h, d, e = kv_cache.shape
+    block_kv = 256
+    grid = (num_prefills, h, triton.cdiv(d * e, block_kv))
+    _clear_linear_attention_cache_kernel[grid](
+        kv_cache,
+        state_indices_tensor,
+        attn_metadata.query_start_loc,
+        attn_metadata.seq_lens,
+        num_decode_tokens,
+        d,
+        e,
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        BLOCK_KV=block_kv,
+    )
+
+
+@triton.jit
+def _pack_qkv_transpose_kernel(
+    Q,
+    K,
+    V,
+    QO,
+    KO,
+    VO,
+    q_start,
+    n,
+    h: tl.constexpr,
+    d: tl.constexpr,
+    q_stride_t: tl.constexpr,
+    q_stride_h: tl.constexpr,
+    q_stride_d: tl.constexpr,
+    k_stride_t: tl.constexpr,
+    k_stride_h: tl.constexpr,
+    k_stride_d: tl.constexpr,
+    v_stride_t: tl.constexpr,
+    v_stride_h: tl.constexpr,
+    v_stride_d: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    head = tl.program_id(0)
+    block_t = tl.program_id(1)
+
+    offs_t = block_t * BLOCK_T + tl.arange(0, BLOCK_T)
+    offs_d = tl.arange(0, BLOCK_D)
+    mask = (offs_t[:, None] < n) & (offs_d[None, :] < d)
+
+    token = q_start + offs_t[:, None]
+    dim = offs_d[None, :]
+
+    q = tl.load(
+        Q + token * q_stride_t + head * q_stride_h + dim * q_stride_d,
+        mask=mask,
+        other=0.0,
+    )
+    k = tl.load(
+        K + token * k_stride_t + head * k_stride_h + dim * k_stride_d,
+        mask=mask,
+        other=0.0,
+    )
+    v = tl.load(
+        V + token * v_stride_t + head * v_stride_h + dim * v_stride_d,
+        mask=mask,
+        other=0.0,
+    )
+
+    out = head * n * d + offs_t[:, None] * d + dim
+    tl.store(QO + out, q, mask=mask)
+    tl.store(KO + out, k, mask=mask)
+    tl.store(VO + out, v, mask=mask)
+
+
+def pack_qkv_for_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_start: int | torch.Tensor,
+    q_end: int | torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack [T, H, D] Q/K/V slices into [H, N, D] contiguous tensors."""
+    q_start = int(q_start)
+    q_end = int(q_end)
+    n = q_end - q_start
+    if n <= 0:
+        h, d = q.shape[1], q.shape[2]
+        empty = torch.empty((h, 0, d), dtype=q.dtype, device=q.device)
+        return empty, empty, empty
+
+    assert q.dim() == k.dim() == v.dim() == 3
+    assert q.shape == k.shape == v.shape
+
+    h, d = q.shape[1], q.shape[2]
+    qo = torch.empty((h, n, d), dtype=q.dtype, device=q.device)
+    ko = torch.empty_like(qo)
+    vo = torch.empty_like(qo)
+
+    block_t = 32
+    block_d = triton.next_power_of_2(d)
+    grid = (h, triton.cdiv(n, block_t))
+    _pack_qkv_transpose_kernel[grid](
+        q,
+        k,
+        v,
+        qo,
+        ko,
+        vo,
+        q_start,
+        n,
+        h,
+        d,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+    )
+    return qo, ko, vo
+
+
+@triton.jit
 def _fwd_diag_kernel(
     Q,
     K,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -52,6 +52,7 @@ from vllm.utils.mem_utils import DeviceMemoryProfiler
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.attention.backends.linear_attn import LinearAttentionMetadata
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.attention.selector import get_attn_backend  # type: ignore
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -2550,6 +2551,36 @@ class NPUModelRunner(GPUModelRunner):
             cm_base.num_logits_indices = logits_indices.size(0)
             cm_base.logits_indices_padded = self._prepare_kv_sharing_fast_prefill(logits_indices)
 
+        def _get_linear_attn_state_indices_cpu(
+            kv_cache_gid: int,
+            common_attn_metadata: CommonAttentionMetadata,
+        ) -> torch.Tensor | None:
+            # The prefill path loops over requests in Python. Keep the cache
+            # slot index on CPU there so kv_cache[slot] does not force a device
+            # scalar sync after the previous NPU kernel.
+            if self.use_cp or self.pcp_size > 1:
+                return None
+
+            kv_cache_spec = kv_cache_groups[kv_cache_gid].kv_cache_spec
+            if not isinstance(kv_cache_spec, MambaSpec):
+                return None
+
+            num_reqs = len(common_attn_metadata.query_start_loc_cpu) - 1
+            block_table_cpu = self.input_batch.block_table[kv_cache_gid].get_cpu_tensor()[:num_reqs]
+            mamba_cache_mode = self.vllm_config.cache_config.mamba_cache_mode
+            if mamba_cache_mode in ("all", "none"):
+                return block_table_cpu[:, 0]
+
+            seq_lens_cpu = common_attn_metadata._seq_lens_cpu
+            if seq_lens_cpu is None:
+                seq_lens_cpu = getattr(common_attn_metadata, "seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                return None
+
+            seq_lens_cpu = seq_lens_cpu[:num_reqs].to(torch.int64)
+            start_indices = torch.clamp((seq_lens_cpu - 1) // kv_cache_spec.block_size, min=0)
+            return torch.gather(block_table_cpu, 1, start_indices.unsqueeze(1)).squeeze(1)
+
         def _build_attn_group_metadata(
             kv_cache_gid: int,
             attn_gid: int,
@@ -2580,6 +2611,13 @@ class NPUModelRunner(GPUModelRunner):
                     common_attn_metadata=common_attn_metadata,
                     **extra_attn_metadata_args,
                 )
+                if isinstance(attn_metadata_i, LinearAttentionMetadata) and attn_metadata_i.num_prefills > 0:
+                    attn_metadata_i.query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+                    attn_metadata_i.seq_lens_cpu = common_attn_metadata._seq_lens_cpu
+                    attn_metadata_i.state_indices_cpu = _get_linear_attn_state_indices_cpu(
+                        kv_cache_gid,
+                        common_attn_metadata,
+                    )
                 # NOTE(zxr): Due to the Triton operator does not deal with -1 padding in FullGraph mode,
                 # the padding needs to be changed from -1 to 0 to avoid writing invalid mamba block.
                 if self.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs() \


### PR DESCRIPTION
### What this PR does / why we need it?
NPU runs asynchronously, but reading device-side scalars (slicing, indexing, Python `if` on device tensors) forces a device sync and stalls the kernel dispatch pipeline. The linear-attention prefill path had two such syncs right after RoPE:

- The per-request Python loop sliced QKV using device-side query_start_loc / state_indices, syncing once per prefill request.
- New-sequence cache clearing used `if context_len == 0` on a device scalar.

Fixes:
- Lower QKV packing/transpose and new-sequence cache clearing into Triton kernels (_pack_qkv_transpose_kernel, _clear_linear_attention_cache_kernel) so host no longer reads device values.
- Build CPU mirrors of query_start_loc / seq_lens / state_indices for the prefill Python loop, attached only when num_prefills > 0 so decode-only TPOT pays no extra state-index computation.

Result: no host<->NPU scalar syncs in the linear-attention prefill path; subsequent layers can be dispatched without stalls.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
<img width="1920" height="1017" alt="image" src="https://github.com/user-attachments/assets/baed7b93-ef92-4a70-9609-0e1c3a468fb1" />
<img width="779" height="354" alt="image" src="https://github.com/user-attachments/assets/4772a1b6-33e1-4049-aae8-0f7398e2f417" />


- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
