### PR TITLE
[BugFix] Propagate upstream HTTP errors in disagg proxy

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -129,7 +129,7 @@ from typing import Any
 
 import httpx
 from fastapi import FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 
 try:
     from vllm.logger import init_logger
@@ -573,6 +573,18 @@ def with_cancellation(handler_func):
 app = FastAPI(lifespan=lifespan)
 
 
+def build_upstream_error_response(error: httpx.HTTPStatusError) -> Response:
+    headers = {}
+    content_type = error.response.headers.get("content-type")
+    if content_type:
+        headers["content-type"] = content_type
+    return Response(
+        content=error.response.content,
+        status_code=error.response.status_code,
+        headers=headers,
+    )
+
+
 async def send_request_to_service(
     client: httpx.AsyncClient,
     prefiller_id: int,
@@ -629,7 +641,11 @@ async def stream_service_response_with_retry(
     for attempt in range(1, max_retries + 1):
         try:
             async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError:
+                    await response.aread()
+                    raise
                 first_chunk_sent = False
                 async for chunk in response.aiter_bytes():
                     first_chunk_sent = True
@@ -708,6 +724,7 @@ class InstanceInfo:
 
 
 async def _handle_completions(api: str, request: Request):
+    generator_owns_request_lifecycle = False
     try:
         proxy_state.request_num += 1
         req_data = await request.json()
@@ -810,6 +827,17 @@ async def _handle_completions(api: str, request: Request):
                         yield chunk
             except asyncio.CancelledError:
                 raise
+            except httpx.HTTPStatusError as e:
+                logger.error(
+                    "Upstream decoder %s returned status %s for request %s",
+                    instance_info.decoder.url,
+                    e.response.status_code,
+                    instance_info.request_id,
+                )
+                proxy_state.abort_prefiller_request(instance_info.prefiller_idx, instance_info.request_id)
+                release_prefiller_kv_once()
+                if not stream_flag:
+                    raise
             except Exception as e:
                 logger.error(
                     "Error during streaming from decoder %s: %s the aborted request %s "
@@ -820,6 +848,8 @@ async def _handle_completions(api: str, request: Request):
                 )
                 proxy_state.abort_prefiller_request(instance_info.prefiller_idx, instance_info.request_id)
                 release_prefiller_kv_once()
+                if not stream_flag:
+                    raise
             finally:
                 # After streaming is done or cancelled, release tokens.
                 release_prefiller_kv_once()
@@ -828,7 +858,18 @@ async def _handle_completions(api: str, request: Request):
 
         # Determine the correct media type based on stream flag
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
-        return StreamingResponse(generate_stream(), media_type=media_type)
+        if stream_flag:
+            return StreamingResponse(generate_stream(), media_type=media_type)
+
+        generator_owns_request_lifecycle = True
+        response_body = bytearray()
+        async for chunk in generate_stream():
+            response_body.extend(chunk)
+        return Response(content=bytes(response_body), media_type=media_type)
+    except httpx.HTTPStatusError as e:
+        if not generator_owns_request_lifecycle:
+            proxy_state.request_num -= 1
+        return build_upstream_error_response(e)
     except Exception as e:
         import traceback
 
@@ -836,7 +877,8 @@ async def _handle_completions(api: str, request: Request):
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print(e)
         print("".join(traceback.format_exception(*exc_info)))
-        proxy_state.request_num -= 1
+        if not generator_owns_request_lifecycle:
+            proxy_state.request_num -= 1
         raise
 
 

--- a/tests/ut/test_load_balance_proxy_server_example.py
+++ b/tests/ut/test_load_balance_proxy_server_example.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import Request
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROXY_PATH = REPO_ROOT / "examples" / "disaggregated_prefill_v1" / "load_balance_proxy_server_example.py"
+MODULE_NAME = "vllm_ascend_examples_load_balance_proxy_server_example"
+
+
+def _load_proxy_module():
+    sys.modules.pop(MODULE_NAME, None)
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, PROXY_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_request(payload: dict) -> Request:
+    body = json.dumps(payload).encode("utf-8")
+    sent = False
+
+    async def receive():
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/completions",
+        "raw_path": b"/v1/completions",
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+    return Request(scope, receive)
+
+
+def test_handle_completions_returns_upstream_400_response(monkeypatch):
+    module = _load_proxy_module()
+    module.proxy_state = SimpleNamespace(request_num=0)
+
+    req = httpx.Request("POST", "http://prefiller.example/v1/completions")
+    upstream_response = httpx.Response(
+        400,
+        request=req,
+        json={"error": {"message": "context length exceeded"}},
+        headers={"content-type": "application/json"},
+    )
+    upstream_error = httpx.HTTPStatusError("Bad Request", request=req, response=upstream_response)
+
+    async def raise_upstream_error(*args, **kwargs):
+        raise upstream_error
+
+    monkeypatch.setattr(module, "_handle_select_instance", raise_upstream_error)
+
+    response = asyncio.run(module._handle_completions("/completions", _build_request({"prompt": "hello"})))
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {"error": {"message": "context length exceeded"}}
+    assert module.proxy_state.request_num == 0
+
+
+def test_stream_service_response_reads_http_error_body_before_response_closes():
+    module = _load_proxy_module()
+
+    class FakeStreamingResponse:
+        def __init__(self):
+            self.closed = False
+            self.read_closed_states = []
+            self.request = httpx.Request("POST", "http://decoder.example/v1/completions")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self.closed = True
+
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("Bad Gateway", request=self.request, response=self)
+
+        async def aread(self):
+            self.read_closed_states.append(self.closed)
+            if self.closed:
+                raise RuntimeError("response already closed")
+            return b'{"error":"bad gateway"}'
+
+    class FakeClient:
+        def __init__(self, response):
+            self.response = response
+
+        def stream(self, *args, **kwargs):
+            return self.response
+
+    response = FakeStreamingResponse()
+    client = FakeClient(response)
+
+    async def consume_stream():
+        async for _ in module.stream_service_response_with_retry(
+            client,
+            "/completions",
+            {"prompt": "hello"},
+            "request-id",
+            max_retries=1,
+        ):
+            pytest.fail("expected an HTTPStatusError before any chunks are streamed")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(consume_stream())
+
+    assert response.read_closed_states == [False]


### PR DESCRIPTION
### What this PR does / why we need it?
This PR makes the disaggregated prefill load-balance proxy propagate upstream HTTP error responses back to clients instead of masking them during proxy handling.

- Preserve upstream status code, response body, and content type for `httpx.HTTPStatusError`.
- Let non-streaming completion requests surface decoder-side HTTP failures through the proxy response.
- Add a regression unit test covering an upstream `400` error response.

### Does this PR introduce _any_ user-facing change?
Yes. For non-streaming requests sent through the disaggregated proxy example, upstream HTTP errors are now returned to the client with the original status code and payload.

### How was this patch tested?
Not run in this environment because the required test environment is currently unavailable.

Added regression coverage in:
- `tests/ut/test_load_balance_proxy_server_example.py`

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
