### PR TITLE
Fix FIA query padding for non-uniform ngram decode

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -544,11 +544,12 @@ class NPUModelRunner(GPUModelRunner):
         else:
             num_reqs_padded = batch_desc_num_reqs if batch_desc_num_reqs is not None else num_reqs
 
-        if num_tokens_padded == num_reqs_padded * self.uniform_decode_query_len:
+        last_loc = self.query_start_loc.np[num_reqs]
+        if (num_tokens_padded == num_reqs_padded * self.uniform_decode_query_len
+                and last_loc == num_reqs * self.uniform_decode_query_len):
             # Uniform-batch case: num_reqs must be no greater than num_reqs_padded
             assert num_reqs <= num_reqs_padded
 
-            last_loc = self.query_start_loc.np[num_reqs]
             self.query_start_loc.np[num_reqs + 1 : num_reqs_padded + 1] = (
                 self.arange_np[1 : num_reqs_padded + 1 - num_reqs] * self.uniform_decode_query_len + last_loc
             )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR tightens the uniform-batch check in `_pad_query_start_loc_for_fia()`.

With ngram speculative decoding, `uniform_decode_query_len` can be greater than 1. In FULL cudagraph mode, a non-uniform batch such as `[4, 4, 4, 1]` can be padded to 16 tokens and incorrectly satisfy the old condition:

```python
num_tokens_padded == num_reqs_padded * self.uniform_decode_query_len
```

However, the real `query_start_loc[num_reqs]` is still 13, so FIA with TND layout can fail because `actual_seq_lengths_q[-1] != queryT`.

This PR also checks that the real requests are uniformly sized before using the uniform path. Non-uniform ngram decode batches now fall through to the mixed-batch path, which appends the dummy request boundary at `num_tokens_padded`.

### Does this PR introduce _any_ user-facing change?

No API or interface change.

This fixes a runtime failure for ngram speculative decoding with FULL cudagraph and TND layout.

### How was this patch tested?

Tested with ngram speculative decoding and FULL cudagraph enabled in the affected environment.

Before this patch, the service failed during generation with the FIA TND layout error:

```text
When layout is TND, queryT(16) must be equal to the last element of actualSequenceLengthQ(13)
```

After applying this patch, the same ngram speculative decoding setup no longer reproduced the failure.

Also ran static syntax validation:

```bash
python -m py_compile vllm_ascend/worker/model_runner_v1.py
```
