### PR TITLE
[BugFix] Clamp MTP seq_lens at block table boundary

### DIFF
--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1351,6 +1351,105 @@ class TestEagleProposerPropose:
             assert torch.equal(self.proposer.token_indices_to_sample[:3], torch.tensor([3, 16, 29]))
             assert self.proposer.token_indices_to_sample.shape == torch.Size([1024])
 
+    def test_attn_update_masks_seq_lens_past_block_table_capacity(self):
+        self.proposer.method = "mtp"
+        self.proposer.max_model_len = 131072
+        self.proposer.kernel_block_size = 128
+
+        common_attn_metadata = create_common_attn_metadata(
+            BatchSpec(seq_lens=[80000], query_lens=[1]),
+            block_size=self.proposer.kernel_block_size,
+            device=self.device,
+            arange_block_indices=True,
+        )
+
+        mock_attn_group = MagicMock()
+        mock_builder = MagicMock()
+        mock_builder.build_for_drafting.return_value = MagicMock()
+        mock_attn_group.get_metadata_builder.return_value = mock_builder
+
+        common_attn_metadata, _ = self.proposer.attn_update_stack_num_spec_norm(
+            draft_step=1,
+            old_attn_metadata=None,
+            old_common_metadata=common_attn_metadata,
+            batch_size=1,
+            input_batch_size=1,
+            used_update_positions=torch.tensor([79999], dtype=torch.int64),
+            aclgraph_runtime_mode=CUDAGraphMode.NONE,
+            attn_group=mock_attn_group,
+        )
+
+        assert common_attn_metadata.seq_lens[0].item() == 1
+        assert common_attn_metadata.seq_lens_cpu[0].item() == 1
+        assert common_attn_metadata.positions[0].item() == 0
+        assert common_attn_metadata.slot_mapping[0].item() == -1
+
+    def test_attn_update_masks_cpu_seq_lens_at_max_model_len(self):
+        self.proposer.method = "mtp"
+        self.proposer.max_model_len = 10
+        self.proposer.kernel_block_size = 128
+
+        common_attn_metadata = create_common_attn_metadata(
+            BatchSpec(seq_lens=[9], query_lens=[1]),
+            block_size=self.proposer.kernel_block_size,
+            device=self.device,
+            arange_block_indices=True,
+        )
+
+        mock_attn_group = MagicMock()
+        mock_builder = MagicMock()
+        mock_builder.build_for_drafting.return_value = MagicMock()
+        mock_attn_group.get_metadata_builder.return_value = mock_builder
+
+        common_attn_metadata, _ = self.proposer.attn_update_stack_num_spec_norm(
+            draft_step=1,
+            old_attn_metadata=None,
+            old_common_metadata=common_attn_metadata,
+            batch_size=1,
+            input_batch_size=1,
+            used_update_positions=torch.tensor([9], dtype=torch.int64),
+            aclgraph_runtime_mode=CUDAGraphMode.NONE,
+            attn_group=mock_attn_group,
+        )
+
+        assert common_attn_metadata.seq_lens[0].item() == 1
+        assert common_attn_metadata.seq_lens_cpu[0].item() == 1
+        assert common_attn_metadata.positions[0].item() == 0
+        assert common_attn_metadata.slot_mapping[0].item() == -1
+
+    def test_attn_update_keeps_seq_lens_at_valid_max_model_len(self):
+        self.proposer.method = "mtp"
+        self.proposer.max_model_len = 10
+        self.proposer.kernel_block_size = 128
+
+        common_attn_metadata = create_common_attn_metadata(
+            BatchSpec(seq_lens=[9], query_lens=[1]),
+            block_size=self.proposer.kernel_block_size,
+            device=self.device,
+            arange_block_indices=True,
+        )
+
+        mock_attn_group = MagicMock()
+        mock_builder = MagicMock()
+        mock_builder.build_for_drafting.return_value = MagicMock()
+        mock_attn_group.get_metadata_builder.return_value = mock_builder
+
+        common_attn_metadata, _ = self.proposer.attn_update_stack_num_spec_norm(
+            draft_step=1,
+            old_attn_metadata=None,
+            old_common_metadata=common_attn_metadata,
+            batch_size=1,
+            input_batch_size=1,
+            used_update_positions=torch.tensor([8], dtype=torch.int64),
+            aclgraph_runtime_mode=CUDAGraphMode.NONE,
+            attn_group=mock_attn_group,
+        )
+
+        assert common_attn_metadata.seq_lens[0].item() == 10
+        assert common_attn_metadata.seq_lens_cpu[0].item() == 10
+        assert common_attn_metadata.positions[0].item() == 9
+        assert common_attn_metadata.slot_mapping[0].item() == 9
+
     # prefill or decode
     def is_decode(self, flag_prefill_decode):
         if flag_prefill_decode == "decode":

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -1357,6 +1357,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.num_computed_tokens_cpu = common_attn_metadata.num_computed_tokens_cpu.clone()
         common_attn_metadata.positions = common_attn_metadata.positions.clone()
 
+        block_table_max_seq_len = common_attn_metadata.block_table_tensor.shape[1] * self.kernel_block_size
+        max_attend_len = min(self.max_model_len, block_table_max_seq_len)
+        next_seq_lens = common_attn_metadata.seq_lens[:batch_size] + 1
+        exceeds_block_table_len = next_seq_lens > block_table_max_seq_len
+
         # NOTE(woosuk): We should handle the case where the draft model
         # generates tokens beyond the max model length. Since it is complex
         # to remove such requests from the batch, we keep them in the batch
@@ -1364,32 +1369,36 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # out-of-range access during the model execution. The draft tokens
         # generated with this adjustment should be ignored.
         if self.uses_mrope:
-            exceeds_max_model_len = used_update_positions[0] >= self.max_model_len
+            exceeds_max_model_len = (used_update_positions[0] >= self.max_model_len) | exceeds_block_table_len
             # Mask out the position ids that exceed the max model length.
             # Otherwise, we may get out-of-range error in RoPE.
             clamped_positions = torch.where(
                 exceeds_max_model_len.unsqueeze(0), torch.zeros_like(used_update_positions), used_update_positions
             )
         else:
-            exceeds_max_model_len = used_update_positions >= self.max_model_len
+            exceeds_max_model_len = (used_update_positions >= self.max_model_len) | exceeds_block_table_len
             clamped_positions = torch.where(exceeds_max_model_len, 0, used_update_positions)
 
         # For data integrity when async scheduling, we shouldn't use in place
         # operations in case they are modified in next step's `prepare_input`
         # of main model.
-        # Increment the sequence lengths.
-        common_attn_metadata.seq_lens[:batch_size] += 1
         # For the requests that exceed the max model length, we set the
         # sequence length to 1 to minimize their overheads in attention.
-        common_attn_metadata.seq_lens[:batch_size].masked_fill_(exceeds_max_model_len, 1)
+        common_attn_metadata.seq_lens[:batch_size] = torch.where(
+            exceeds_max_model_len, torch.ones_like(next_seq_lens), next_seq_lens
+        )
         if common_attn_metadata.seq_lens_cpu is not None:
-            common_attn_metadata.seq_lens_cpu[:batch_size] = common_attn_metadata.seq_lens_cpu[:batch_size] + 1
-            exceeds_mask = common_attn_metadata.seq_lens_cpu[:batch_size] >= self.max_model_len
-            common_attn_metadata.seq_lens_cpu[:batch_size].masked_fill_(exceeds_mask, 1)
+            next_seq_lens_cpu = common_attn_metadata.seq_lens_cpu[:batch_size] + 1
+            exceeds_mask = next_seq_lens_cpu > max_attend_len
+            common_attn_metadata.seq_lens_cpu[:batch_size] = torch.where(
+                exceeds_mask, torch.ones_like(next_seq_lens_cpu), next_seq_lens_cpu
+            )
         if common_attn_metadata._seq_lens_cpu is not None:
-            common_attn_metadata._seq_lens_cpu[:batch_size] = common_attn_metadata._seq_lens_cpu[:batch_size] + 1
-            exceeds_mask_internal = common_attn_metadata._seq_lens_cpu[:batch_size] >= self.max_model_len
-            common_attn_metadata._seq_lens_cpu[:batch_size].masked_fill_(exceeds_mask_internal, 1)
+            next_seq_lens_cpu = common_attn_metadata._seq_lens_cpu[:batch_size] + 1
+            exceeds_mask_internal = next_seq_lens_cpu > max_attend_len
+            common_attn_metadata._seq_lens_cpu[:batch_size] = torch.where(
+                exceeds_mask_internal, torch.ones_like(next_seq_lens_cpu), next_seq_lens_cpu
+            )
         if common_attn_metadata.num_computed_tokens_cpu is not None:
             common_attn_metadata.num_computed_tokens_cpu[:batch_size] += 1
         if self.uses_mrope:


### PR DESCRIPTION
### What this PR does

Fixes an MTP speculative decoding boundary case where vllm-ascend can pass a `seq_lens` / `actual_seq_lengths_key` value to SFA that requires one more KV block than the active request's `block_table` contains.

At full-context boundary, the request may have exactly filled its current block table row, for example:

```text
block_table_shape=(1, 625)
block_size=128
max key length addressable by this row = 80000
```

The current draft metadata update can advance `seq_lens` to `80001` while `position < max_model_len`, so the existing `position >= max_model_len` guard does not fire. SFA then forwards `actual_seq_lengths_key=80001` to `torch_npu.npu_lightning_indexer`, which requires block index `625` while valid columns are `[0, 624]`.

### Why this is in the proposer

The scheduler already clamps the target-model scheduled tokens at the context boundary. In the repro it schedules the final valid verification step:

```text
num_computed_tokens=[79995]
num_scheduled_tokens=4
scheduled_spec_decode_tokens=[-1, -1, -1]
new_block_ids=[None]
num_common_prefix_blocks=[625]
```

The invalid value is introduced while vllm-ascend builds per-draft-step attention metadata for MTP. This is analogous to upstream EAGLE handling over-boundary draft work in the proposer by clamping positions / slot mappings and keeping the invalid draft tokens as padding work.

The additional Ascend/SFA invariant is:

```text
seq_lens <= block_table.shape[1] * kernel_block_size
```

Otherwise `seq_lens` becomes `actual_seq_lengths_key` for `torch_npu.npu_lightning_indexer`, and the PA block-table lookup can read beyond the active row.

### Fix

In `AscendSpecDecodeBaseProposer.attn_update_stack_num_spec_norm`, compute the maximum key length covered by the current block table:

```text
max_attend_len = min(max_model_len, block_table.shape[1] * kernel_block_size)
```

Then mask draft requests when `next_seq_lens > max_attend_len`, reusing the existing padding behavior:

- set `seq_lens` / CPU mirrors to `1`
- clamp `positions` to `0`
- keep slot mapping masked to `PADDING_SLOT_ID`

This keeps over-boundary draft tokens in the batch as ignored padding work instead of passing an invalid key length into attention.

### Test

Added unit coverage for:

- the reproduced 80k boundary shape: `seq_lens=80000`, `block_table.shape[1]=625`, `kernel_block_size=128`, `next_seq_lens=80001`
- the `max_model_len` boundary where the next draft position is already beyond the model length
- the valid boundary where `seq_lens == max_model_len` must remain valid and keep CPU/GPU mirrors consistent

### Related issue

Fixes #9098.

### Verification

```text
python -m ruff check vllm_ascend/spec_decode/eagle_proposer.py tests/ut/spec_decode/test_eagle_proposer.py
# All checks passed

python -m py_compile vllm_ascend/spec_decode/eagle_proposer.py tests/ut/spec_decode/test_eagle_proposer.py
# passed
```

Targeted pytest could not run in this local checkout because the active vLLM import root is incompatible with this vllm-ascend tree before test collection:

```text
ImportError: cannot import name 'probabilistic_rejection_sampler_utils' from 'vllm.v1.worker.gpu.spec_decode'
```

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
