### PR TITLE
[Ascend950][BugFix] Fix w8a8_mxfp8 weight_scale group count: use cdiv for non-divisible input_size

### DIFF
--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from vllm.utils.math_utils import cdiv
 from collections.abc import Callable
 from typing import Any
 
@@ -24,6 +23,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.distributed import get_ep_group
+from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import math
+from vllm.utils.math_utils import cdiv
 from collections.abc import Callable
 from typing import Any
 

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import math
 from collections.abc import Callable
 from typing import Any
 
@@ -62,7 +63,10 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        params_dict["weight_scale"] = torch.empty(output_size, input_size // self.group_size, dtype=torch.uint8)
+        num_groups = input_size // self.group_size
+        if input_size % self.group_size != 0:
+            num_groups = math.ceil(input_size / self.group_size)
+        params_dict["weight_scale"] = torch.empty(output_size, num_groups, dtype=torch.uint8)
         return params_dict
 
     def apply(

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -65,7 +65,7 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         params_dict = {}
         num_groups = input_size // self.group_size
         if input_size % self.group_size != 0:
-            num_groups = math.ceil(input_size / self.group_size)
+            num_groups = cdiv(input_size, self.group_size)
         params_dict["weight_scale"] = torch.empty(output_size, num_groups, dtype=torch.uint8)
         return params_dict
 

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -63,7 +63,9 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        num_groups = input_size // self.group_size if input_size % self.group_size == 0 else cdiv(input_size, self.group_size)
+        num_groups = (
+            input_size // self.group_size if input_size % self.group_size == 0 else cdiv(input_size, self.group_size)
+        )
         params_dict["weight_scale"] = torch.empty(output_size, num_groups, dtype=torch.uint8)
         return params_dict
 

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -63,9 +63,7 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        num_groups = input_size // self.group_size
-        if input_size % self.group_size != 0:
-            num_groups = cdiv(input_size, self.group_size)
+        num_groups = input_size // self.group_size if input_size % self.group_size == 0 else cdiv(input_size, self.group_size)
         params_dict["weight_scale"] = torch.empty(output_size, num_groups, dtype=torch.uint8)
         return params_dict
 

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -63,10 +63,7 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        num_groups = (
-            input_size // self.group_size if input_size % self.group_size == 0 else cdiv(input_size, self.group_size)
-        )
-        params_dict["weight_scale"] = torch.empty(output_size, num_groups, dtype=torch.uint8)
+        params_dict["weight_scale"] = torch.empty(output_size, cdiv(input_size, self.group_size), dtype=torch.uint8)
         return params_dict
 
     def apply(


### PR DESCRIPTION

### What this PR does / why we need it?
In `AscendW8A8MXFP8DynamicLinearMethod.apply_weights`, the group count of `weight_scale` is computed via integer floor division as `input_size // self.group_size`. If `input_size` is not divisible by `group_size` (e.g. Kimi-K2.5 with `k_dim=4304` and `group_size=32`, resulting in `4304 // 32 = 134`), one group will be missing in calculation. This causes partial shape truncation of the `weight_scale` tensor and further leads to errors during model inference.
To fix this issue, update the calculation method to `vllm.utils.math_utils.cdiv(input_size, self.group_size)` 
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.20.1
- vLLM main: https://github.com/vllm-project/vllm/commit/c7aa186d67b6f051680831418e957c67f34ba7a2
