### PR TITLE
[Ops][Misc] Remove redundant float32 cast in DeepSeek V4 router logits

### DIFF
--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -2,13 +2,20 @@
 
 Get the latest info here: https://github.com/vllm-project/vllm-ascend/issues/1608
 
+**Legend Description**:
+
+- ✅ = Supported model/feature
+- 🔵 = Experimental supported model/feature
+- ❌ = Not supported model/feature
+- 🟡 = Not tested or verified
+
 ## Text-Only Language Models
 
 ### Generative Models
 
 | Model                         | Support   | Note                                                                 | BF16 | Supported Hardware | W8A8 | Chunked Prefill | Automatic Prefix Cache | LoRA | Speculative Decoding | Async Scheduling | Tensor Parallel | Pipeline Parallel | Expert Parallel | Data Parallel | Prefill-decode Disaggregation | Piecewise AclGraph | Fullgraph AclGraph | max-model-len | MLP Weight Prefetch | Doc |
 |-------------------------------|-----------|----------------------------------------------------------------------|------|--------------------|------|-----------------|------------------------|------|----------------------|------------------|-----------------|-------------------|-----------------|---------------|-------------------------------|--------------------|--------------------|---------------|---------------------|-----|
-| DeepSeek V4               | ✅        |                                                                      | ✅ | A2/A3 | ✅ | ✅ ||| ✅ |✅| ✅ || ✅ | ✅ | ✅ || ✅ | 1M || [DeepSeek-V4](../../tutorials/DeepSeek-V4.md) |
+| DeepSeek V4               | 🔵        |                                                                      | ✅ | A2/A3 | ✅ | ✅ ||| ✅ |✅| ✅ || ✅ | ✅ | ✅ || ✅ | 1M || [DeepSeek-V4](../../tutorials/DeepSeek-V4.md) |
 | DeepSeek V3/3.1               | ✅        |                                                                      | ✅ | A2/A3 | ✅ | ✅ | ✅ || ✅ || ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 240k || [DeepSeek-V3.1](../../tutorials/DeepSeek-V3.1.md) |
 | DeepSeek V3.2                 | 🔵        | Experimental                                                         | ✅ | A2/A3 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 160k | ✅ | [DeepSeek-V3.2](../../tutorials/DeepSeek-V3.2.md) |
 | DeepSeek R1                   | ✅        |                                                                      | ✅ | A2/A3 | ✅ | ✅ | ✅ || ✅ || ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 128k || [DeepSeek-R1](../../tutorials/DeepSeek-R1.md) |

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -351,7 +351,7 @@ class DeepseekV4MoE(nn.Module):
                                          router_logits=hidden_states)
         else:
             # router_logits: (num_tokens, n_experts)
-            router_logits = F.linear(hidden_states.float(), self.gate.weight)
+            router_logits = F.linear(hidden_states, self.gate.weight)
             fused_moe_out = self.experts(hidden_states=hidden_states,
                                          router_logits=router_logits)
 


### PR DESCRIPTION
The custom NPU kernels (moe_gating_top_k / moe_gating_top_k_hash) already handle bfloat16 input and internally cast to float32 for softmax/top-k compute. The Python-level .float() cast wasted memory bandwidth and forced the linear projection to run in float32 instead of bfloat16

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?

This PR removes a redundant `.float()` cast on `hidden_states` before the linear projection for router logits in the `DeepseekV4MoE` layer. Since the custom NPU kernels (`moe_gating_top_k` / `moe_gating_top_k_hash`) handle the cast to `float32` internally for softmax and top-k computations, performing the cast in Python was unnecessary. Removing it allows the linear projection to execute using `bfloat16` , reducing memory bandwidth usage and significantly improving performance.

- Fixes #


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Benchmark results on 8x910B3 with DeepSeek-V4-Flash-w8a8-mtp:
- QPS=1 mean TTFT: 936ms -> 653ms (-30%)
- QPS=1 p99 TTFT: 5286ms -> 1408ms (-73%)
- QPS=16 throughput: +3.6%
- QPS=inf throughput: +2.1%

