### PR TITLE
[CI]Main2main 0515

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -27,7 +27,7 @@ on:
       continue_on_error:
         required: false
         type: boolean
-        default: true
+        default: false
       # The following inputs are used by comment-triggered E2E tests (/e2e <tests>).
       # They carry space-separated pytest paths, categorized by runner type.
       # Leave empty (default) when running label-triggered full/light suites.

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -27,7 +27,7 @@ on:
       continue_on_error:
         required: false
         type: boolean
-        default: false
+        default: true
       # The following inputs are used by comment-triggered E2E tests (/e2e <tests>).
       # They carry space-separated pytest paths, categorized by runner type.
       # Leave empty (default) when running label-triggered full/light suites.

--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
+ARG VLLM_COMMIT=0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -80,7 +80,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [ce29c26b31d432b1b4bc028c46bb2c3b07a667d8, v0.20.2]
+        vllm_version: [0d4d334eaa583b9c09aa4eb7538c22db99fd84b3, v0.20.2]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
+      vllm: 0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
   changes:
     runs-on: linux-aarch64-a2b3-0
     container:
@@ -155,7 +155,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && needs.changes.outputs.has_tests == 'true' }}
     strategy:
       matrix:
-        vllm_version: [ce29c26b31d432b1b4bc028c46bb2c3b07a667d8, v0.20.2]
+        vllm_version: [0d4d334eaa583b9c09aa4eb7538c22db99fd84b3, v0.20.2]
     uses: ./.github/workflows/_optional_smart_e2e.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -165,7 +165,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [ce29c26b31d432b1b4bc028c46bb2c3b07a667d8, v0.20.2]
+        vllm_version: [0d4d334eaa583b9c09aa4eb7538c22db99fd84b3, v0.20.2]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ myst_substitutions = {
     # CANN image tag
     "cann_image_tag": "9.0.0-910b-ubuntu22.04-py3.11",
     # vLLM commit hash for main branch
-    "main_vllm_commit": "ce29c26b31d432b1b4bc028c46bb2c3b07a667d8",
+    "main_vllm_commit": "0d4d334eaa583b9c09aa4eb7538c22db99fd84b3",
     # vLLM tag for main branch
     "main_vllm_tag": "v0.20.2",
     # Python version for main branch

--- a/tests/e2e/multicard/2-cards/test_qwen3_moe_routing_replay.py
+++ b/tests/e2e/multicard/2-cards/test_qwen3_moe_routing_replay.py
@@ -19,7 +19,6 @@ def test_qwen3_moe_routing_replay():
         cudagraph_capture_sizes=[1, 2, 4, 8],
         distributed_executor_backend="mp",
         enable_return_routed_experts=True,
-        async_scheduling=False,
     ) as vllm_model:
         sampling_params = SamplingParams(
             max_tokens=5, temperature=0.8, top_p=0.95, output_kind=RequestOutputKind.FINAL_ONLY

--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -262,6 +262,7 @@ class TestProfilingChunkScheduler(TestBase):
         model_config.hf_config = mock_hf_config
         model_config.hf_text_config = MagicMock()
         model_config.hf_text_config.is_encoder_decoder = False
+        model_config.runner_type = "generate"
 
         scheduler_config = SchedulerConfig(
             max_num_seqs=MAX_NUM_SEQS,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -172,7 +172,11 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             num_experts=num_logical_experts,
         )
         if layer.vllm_config.model_config is not None and layer.vllm_config.model_config.enable_return_routed_experts:
-            capturer = RoutedExpertsCapturer.get_instance()
+            if vllm_version_is("0.20.2"):
+                # 0.20.2: capturer is a process-wide singleton.
+                capturer = RoutedExpertsCapturer.get_instance()
+            else:
+                capturer = getattr(layer, "_ascend_routed_experts_capturer", None)
             if capturer is not None:
                 capturer.capture(layer_id=layer.layer_id, topk_ids=topk_ids)
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -75,6 +75,11 @@ from vllm.v1.outputs import (
     SamplerOutput,
     make_empty_encoder_model_runner_output,
 )
+
+from vllm_ascend.utils import vllm_version_is
+
+if not vllm_version_is("0.20.2"):
+    from vllm.v1.outputs import RoutedExpertsLists
 from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import RejectionSampler
@@ -1576,9 +1581,12 @@ class NPUModelRunner(GPUModelRunner):
         intermediate_tensors: IntermediateTensors | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         if self.vllm_config.model_config.enable_return_routed_experts:
-            capturer = RoutedExpertsCapturer.get_instance()
-            if capturer is not None:
-                capturer.clear_buffer()
+            if vllm_version_is("0.20.2"):
+                capturer = RoutedExpertsCapturer.get_instance()
+                if capturer is not None:
+                    capturer.clear_buffer()
+            elif self.routed_experts_initialized:
+                self.routed_experts_capturer.clear_buffer()
 
         if self.ascend_config.profiling_chunk_config.need_timing:
             # Check if the scheduler signaled that calibration is complete.
@@ -2082,10 +2090,29 @@ class NPUModelRunner(GPUModelRunner):
             if self.speculative_config is not None:
                 self.finalize_kv_connector()
 
+        routed_experts_lists = None
         if self.model_config.enable_return_routed_experts:
-            capturer = RoutedExpertsCapturer.get_instance()
-            if capturer is not None:
-                capturer.save_captured_experts(indices=self.cpu_slot_mapping)
+            if vllm_version_is("0.20.2"):
+                capturer = RoutedExpertsCapturer.get_instance()
+                if capturer is not None:
+                    capturer.save_captured_experts(indices=self.cpu_slot_mapping)
+            elif self.routed_experts_initialized:
+                # NOTE: this is the sync-scheduling path. async-scheduling
+                # would build a RoutedExpertsTensors snapshot instead and
+                # let AsyncGPUModelRunnerOutput finalize it -- left as a
+                # follow-up.
+                buf = self.routed_experts_capturer.get_device_buffer()
+                total = scheduler_output.total_num_scheduled_tokens
+                self.routed_experts_cpu[:total].copy_(buf[:total], non_blocking=True)
+                self.routed_experts_slot_mapping_cpu[:total].copy_(
+                    self.routed_experts_slot_mapping_device[:total],
+                    non_blocking=True,
+                )
+                torch.npu.current_stream().synchronize()
+                routed_experts_lists = RoutedExpertsLists(
+                    routing_data=self.routed_experts_cpu[:total].numpy(),
+                    slot_mapping=self.routed_experts_slot_mapping_cpu[:total].numpy(),
+                )
 
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids_output_copy,
@@ -2097,6 +2124,9 @@ class NPUModelRunner(GPUModelRunner):
             pooler_output=[],
             ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
             cudagraph_stats=cudagraph_stats,
+            **(
+                {} if vllm_version_is("0.20.2") else {"routed_experts": routed_experts_lists}
+            ),
         )
         if self.ascend_config.profiling_chunk_config.need_timing and hasattr(self, '_execution_start_time'):
             self._sync_device()
@@ -2625,7 +2655,16 @@ class NPUModelRunner(GPUModelRunner):
                     kv_cache_gid,
                 )
             if self.model_config.enable_return_routed_experts and kv_cache_gid == 0:
-                self.cpu_slot_mapping = slot_mapping.cpu().numpy()
+                if vllm_version_is("0.20.2"):
+                    self.cpu_slot_mapping = slot_mapping.cpu().numpy()
+                elif self.routed_experts_initialized:
+                    # snapshot slot_mapping into a private device
+                    # buffer so the next ``_prepare_inputs`` does not
+                    # overwrite it while D2H is still pending.
+                    n = slot_mapping.shape[0]
+                    self.routed_experts_slot_mapping_device[:n].copy_(
+                        slot_mapping
+                    )
             return blk_table_tensor, slot_mapping
 
         block_table_gid_0, slot_mapping_gid_0 = _get_block_table_and_slot_mapping(0)
@@ -3215,6 +3254,21 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def _bind_routed_experts_capturer(self, capturer) -> None:
+        # Upstream binds via ``module.router.set_capture_fn(...)`` on
+        # FusedMoE layers whose router is a ``BaseRouter``. Ascend's
+        # ``select_experts`` does not go through ``BaseRouter``, so the
+        # upstream hook never fires. Instead, stash the capturer as a
+        # plain attribute on every FusedMoE layer; ``apply()`` reads it
+        # back on the hot path. Only used on vLLM main (PR #39568+);
+        # the 0.20.2 path uses the ``RoutedExpertsCapturer.get_instance``
+        # singleton and never calls this method.
+        from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+        for module in self.compilation_config.static_forward_context.values():
+            if isinstance(module, FusedMoE):
+                module._ascend_routed_experts_capturer = capturer
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2097,10 +2097,6 @@ class NPUModelRunner(GPUModelRunner):
                 if capturer is not None:
                     capturer.save_captured_experts(indices=self.cpu_slot_mapping)
             elif self.routed_experts_initialized:
-                # NOTE: this is the sync-scheduling path. async-scheduling
-                # would build a RoutedExpertsTensors snapshot instead and
-                # let AsyncGPUModelRunnerOutput finalize it -- left as a
-                # follow-up.
                 buf = self.routed_experts_capturer.get_device_buffer()
                 total = scheduler_output.total_num_scheduled_tokens
                 self.routed_experts_cpu[:total].copy_(buf[:total], non_blocking=True)


### PR DESCRIPTION
### What this PR does / why we need it?
Upstream PR [vllm-project/vllm#39568](https://github.com/vllm-project/vllm/pull/39568) is a complete rewrite of the routed-experts capture/transport pipeline. It supersedes both:

- The original 0.20.2 design — `RoutedExpertsCapturer.get_instance()` singleton, `save_captured_experts(indices=...)`, shared-memory + `fcntl.flock` cross-process transport.
- The intermediate PR #39917 design — module-level `get_global_experts_capturer()`, `init_routed_experts_capturer_with_shared_cache()`, `issue_routing_d2h_copy()`, `extract_routed_experts_for_current_batch()`. This API existed in main for only a few days and was never in a stable release; it has been **fully removed**.

After the upgrade to vLLM 0515, vllm-ascend faces two API surfaces that are incompatible at the source level:

| Aspect | 0.20.2 | main |
|---|---|---|
| Capturer access | `RoutedExpertsCapturer.get_instance()` (singleton) | `runner.routed_experts_capturer` (per-runner instance, no global) |
| Per-step `clear_buffer` | via singleton | via runner attribute |
| Per-step D2H + ship | `capturer.save_captured_experts(indices=cpu_slot_mapping)` (sync, shm write) | runner-managed pinned `routed_experts_cpu` D2H + `RoutedExpertsLists` on `ModelRunnerOutput.routed_experts` |
| Output channel | shm/flock to scheduler | `ModelRunnerOutput.routed_experts: RoutedExpertsLists` (NamedTuple, msgpack + zmq IPC) |
| `slot_mapping` source | `slot_mapping.cpu().numpy()` saved to `self.cpu_slot_mapping` | private device snapshot `routed_experts_slot_mapping_device`, then pinned `routed_experts_slot_mapping_cpu` |
| Layer hook injection | `select_experts` calls singleton from inside `apply()` | `module.router.set_capture_fn(...)` from `_bind_routed_experts_capturer` |

## Strategy Overview

1. **Keep the 0.20.2 path intact.** It already works end-to-end. All 0.20.2-specific call sites stay byte-identical.
2. **Add a parallel main path** gated by `vllm_version_is("0.20.2") == False`. Reuse upstream `GPUModelRunner.init_routed_experts_capturer()` (inherited) for buffer allocation; override only `_bind_routed_experts_capturer` because Ascend's `select_experts` does not go through upstream `BaseRouter`.
3. **Async scheduling: piggyback on upstream `AsyncGPUModelRunnerOutput`.** vllm-ascend already constructs that wrapper directly, so adding the `routed_experts=` kwarg is enough — the wrapper handles `to_cpu_nonblocking()` on its copy stream and `tolists()` finalization in `get_output()` for free.
4. **No new compat module, no monkey patches.** Branching is inline at each call site; total surface is one new method (`_bind_routed_experts_capturer`) plus three branched call sites in `model_runner_v1.py` and one in `fused_moe.py`.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
