### PR TITLE
[Main][Feature] Broadcast reset_prefix_cache to all PD nodes in layerwise proxy

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -566,6 +566,34 @@ async def handle_chat_completions(request: Request):
     return await _handle_completions("/chat/completions", request)
 
 
+@app.post("/reset_prefix_cache")
+async def reset_prefix_cache(request: Request):
+    params = dict(request.query_params)
+    all_servers = [
+        (s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders
+    ]
+    results = await asyncio.gather(
+        *[
+            client.post("/reset_prefix_cache", params=params)
+            for client, _ in all_servers
+        ],
+        return_exceptions=True,
+    )
+    failures = []
+    for (_, base_url), result in zip(all_servers, results):
+        if isinstance(result, Exception):
+            logger.error("reset_prefix_cache failed for %s: %s", base_url, result)
+            failures.append(base_url)
+        elif result.status_code != 200:
+            logger.error("reset_prefix_cache failed for %s: status %s", base_url, result.status_code)
+            failures.append(base_url)
+    if failures:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(status_code=500, content={"failed": failures})
+    from fastapi.responses import Response as FastAPIResponse
+    return FastAPIResponse(status_code=200)
+
+
 @app.get("/healthcheck")
 async def healthcheck():
     return {

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -566,31 +566,6 @@ async def handle_chat_completions(request: Request):
     return await _handle_completions("/chat/completions", request)
 
 
-@app.post("/reset_prefix_cache")
-async def reset_prefix_cache(request: Request):
-    params = dict(request.query_params)
-    all_servers = [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]
-    results = await asyncio.gather(
-        *[client.post("/reset_prefix_cache", params=params) for client, _ in all_servers],
-        return_exceptions=True,
-    )
-    failures = []
-    for (_, base_url), result in zip(all_servers, results):
-        if isinstance(result, Exception):
-            logger.error("reset_prefix_cache failed for %s: %s", base_url, result)
-            failures.append(base_url)
-        elif result.status_code != 200:
-            logger.error("reset_prefix_cache failed for %s: status %s", base_url, result.status_code)
-            failures.append(base_url)
-    if failures:
-        from fastapi.responses import JSONResponse
-
-        return JSONResponse(status_code=500, content={"failed": failures})
-    from fastapi.responses import Response as FastAPIResponse
-
-    return FastAPIResponse(status_code=200)
-
-
 @app.get("/healthcheck")
 async def healthcheck():
     return {

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -579,7 +579,9 @@ async def healthcheck():
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)
     failures = []
-    for client, base_url in [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]:
+    for client, base_url in [
+        (s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders
+    ]:
         try:
             resp = await client.post(f"{base_url}/reset_prefix_cache", params=params)
             resp.raise_for_status()

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -578,18 +578,13 @@ async def healthcheck():
 @app.post("/reset_prefix_cache")
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)
-    all_servers = [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]
-    results = await asyncio.gather(
-        *[client.post(f"{base_url}/reset_prefix_cache", params=params) for client, base_url in all_servers],
-        return_exceptions=True,
-    )
     failures = []
-    for (_, base_url), result in zip(all_servers, results):
-        if isinstance(result, Exception):
-            logger.error("reset_prefix_cache failed for %s: %s", base_url, result)
-            failures.append(base_url)
-        elif result.status_code != 200:
-            logger.error("reset_prefix_cache failed for %s: status %s", base_url, result.status_code)
+    for client, base_url in [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]:
+        try:
+            resp = await client.post(f"{base_url}/reset_prefix_cache", params=params)
+            resp.raise_for_status()
+        except Exception as e:
+            logger.error("reset_prefix_cache failed for %s: %s", base_url, e)
             failures.append(base_url)
     if failures:
         from fastapi.responses import JSONResponse

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -569,14 +569,9 @@ async def handle_chat_completions(request: Request):
 @app.post("/reset_prefix_cache")
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)
-    all_servers = [
-        (s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders
-    ]
+    all_servers = [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]
     results = await asyncio.gather(
-        *[
-            client.post("/reset_prefix_cache", params=params)
-            for client, _ in all_servers
-        ],
+        *[client.post("/reset_prefix_cache", params=params) for client, _ in all_servers],
         return_exceptions=True,
     )
     failures = []
@@ -589,8 +584,10 @@ async def reset_prefix_cache(request: Request):
             failures.append(base_url)
     if failures:
         from fastapi.responses import JSONResponse
+
         return JSONResponse(status_code=500, content={"failed": failures})
     from fastapi.responses import Response as FastAPIResponse
+
     return FastAPIResponse(status_code=200)
 
 
@@ -601,6 +598,31 @@ async def healthcheck():
         "prefill_instances": len(proxy_state.prefillers),
         "decode_instances": len(proxy_state.decoders),
     }
+
+
+@app.post("/reset_prefix_cache")
+async def reset_prefix_cache(request: Request):
+    params = dict(request.query_params)
+    all_servers = [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]
+    results = await asyncio.gather(
+        *[client.post(f"{base_url}/reset_prefix_cache", params=params) for client, base_url in all_servers],
+        return_exceptions=True,
+    )
+    failures = []
+    for (_, base_url), result in zip(all_servers, results):
+        if isinstance(result, Exception):
+            logger.error("reset_prefix_cache failed for %s: %s", base_url, result)
+            failures.append(base_url)
+        elif result.status_code != 200:
+            logger.error("reset_prefix_cache failed for %s: status %s", base_url, result.status_code)
+            failures.append(base_url)
+    if failures:
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(status_code=500, content={"failed": failures})
+    from fastapi.responses import Response as FastAPIResponse
+
+    return FastAPIResponse(status_code=200)
 
 
 @app.post("/v1/metaserver")

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -904,18 +904,13 @@ async def handle_chat_completions(request: Request):
 @app.post("/reset_prefix_cache")
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)
-    all_servers = [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]
-    results = await asyncio.gather(
-        *[client.post(f"{base_url}/reset_prefix_cache", params=params) for client, base_url in all_servers],
-        return_exceptions=True,
-    )
     failures = []
-    for (_, base_url), result in zip(all_servers, results):
-        if isinstance(result, Exception):
-            logger.error("reset_prefix_cache failed for %s: %s", base_url, result)
-            failures.append(base_url)
-        elif result.status_code != 200:
-            logger.error("reset_prefix_cache failed for %s: status %s", base_url, result.status_code)
+    for client, base_url in [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]:
+        try:
+            resp = await client.post(f"{base_url}/reset_prefix_cache", params=params)
+            resp.raise_for_status()
+        except Exception as e:
+            logger.error("reset_prefix_cache failed for %s: %s", base_url, e)
             failures.append(base_url)
     if failures:
         from fastapi.responses import JSONResponse

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -905,7 +905,9 @@ async def handle_chat_completions(request: Request):
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)
     failures = []
-    for client, base_url in [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]:
+    for client, base_url in [
+        (s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders
+    ]:
         try:
             resp = await client.post(f"{base_url}/reset_prefix_cache", params=params)
             resp.raise_for_status()

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -901,6 +901,31 @@ async def handle_chat_completions(request: Request):
     return await _handle_completions("/chat/completions", request)
 
 
+@app.post("/reset_prefix_cache")
+async def reset_prefix_cache(request: Request):
+    params = dict(request.query_params)
+    all_servers = [(s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders]
+    results = await asyncio.gather(
+        *[client.post(f"{base_url}/reset_prefix_cache", params=params) for client, base_url in all_servers],
+        return_exceptions=True,
+    )
+    failures = []
+    for (_, base_url), result in zip(all_servers, results):
+        if isinstance(result, Exception):
+            logger.error("reset_prefix_cache failed for %s: %s", base_url, result)
+            failures.append(base_url)
+        elif result.status_code != 200:
+            logger.error("reset_prefix_cache failed for %s: status %s", base_url, result.status_code)
+            failures.append(base_url)
+    if failures:
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(status_code=500, content={"failed": failures})
+    from fastapi.responses import Response as FastAPIResponse
+
+    return FastAPIResponse(status_code=200)
+
+
 @app.get("/healthcheck")
 async def healthcheck():
     return {


### PR DESCRIPTION
### What this PR does / why we need it?

Adds a `/reset_prefix_cache` endpoint to the disaggregated prefill proxy (`load_balance_proxy_layerwise_server_example.py`  and `load_balance_proxy_server_example.py`). When called, the proxy fans out the request concurrently to all prefiller and decoder nodes, collects failures, and returns 500 with the list of failed nodes if any backend call fails.

This mirrors the existing `/reset_prefix_cache` API on individual vLLM servers and makes it usable in a PD-disaggregated deployment where clients only talk to the proxy.

### Does this PR introduce _any_ user-facing change?

Yes — adds a new POST `/reset_prefix_cache` endpoint on the proxy. Query parameters (e.g. `reset_running_requests`, `reset_external`) are forwarded as-is to each backend.

### How was this patch tested?

Manually verified the endpoint structure and fan-out logic.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
