### PR TITLE
[CI] mock for torch event

### DIFF
--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -788,7 +788,7 @@ class TestPCPDCPGraphParams(TestBase):
             self.graph_params = get_graph_params()
         else:
             self.graph_params = graph_params
-        mock_event = torch.npu.ExternalEvent()
+        mock_event = MagicMock()
         mock_event.record = MagicMock()
         self.graph_params.events[4] = []
         self.graph_params.handles[4] = []


### PR DESCRIPTION
### What this PR does / why we need it?
Smart ut on cpu will get stack, see https://github.com/vllm-project/vllm-ascend/actions/runs/25894848029/job/76106027519?pr=9176, we should mock for `torch.npu.ExternalEvent()` in a non-NPU environment
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
