### PR TITLE
[BugFix]:Fix UB overflow caused by compatibility issues after NPUIR upgrade

### DIFF
--- a/vllm_ascend/worker/v2/sample/logprob.py
+++ b/vllm_ascend/worker/v2/sample/logprob.py
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
 # This file is a part of the vllm-ascend project.
 
 import torch

--- a/vllm_ascend/worker/v2/sample/logprob.py
+++ b/vllm_ascend/worker/v2/sample/logprob.py
@@ -43,7 +43,7 @@ def _topk_log_softmax_kernel(
     for i in range(0, vocab_size, BLOCK_SIZE):
         block = i + tl.arange(0, BLOCK_SIZE)
         logits = tl.load(row_ptr + block, mask=block < vocab_size, other=float("-inf"))
-        max_val = tl.max(tl.maximum(logits, max_val))
+        max_val = tl.max(tl.maximum(logits, max_val, propagate_nan=tl.PropagateNan.ALL))
     max_val = max_val.to(tl.float32)  # type: ignore
 
     se = 0.0

--- a/vllm_ascend/worker/v2/sample/logprob.py
+++ b/vllm_ascend/worker/v2/sample/logprob.py
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# 
 # This file is a part of the vllm-ascend project.
 
 import torch


### PR DESCRIPTION
### What this PR does / why we need it?

After the NPU-IR update, the NaN handling logic of tl.maximum in Triton has changed. This consumes more UB space, causing UB overflow during execution of the original operator. A temporary workaround is required with no performance impact.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
The test method for the operator remains the same as before the modification. Run the pytest script directly:
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_token_logprobs.py
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
