### PR TITLE
[Performance] Force pad draft tokens of all sequences to fixed length with zero-padding in ngram speculative decoding

### DIFF
--- a/vllm_ascend/spec_decode/ngram_proposer.py
+++ b/vllm_ascend/spec_decode/ngram_proposer.py
@@ -61,4 +61,10 @@ class AscendNgramProposer(NgramProposer):
             self.runner.input_batch.token_ids_cpu,
         )
 
+        target_len = self.k
+        for i in range(len(draft_token_ids)):
+            cur_len = len(draft_token_ids[i])
+            if cur_len < target_len:
+                draft_token_ids[i].extend([0] * (target_len - cur_len))
+
         return draft_token_ids


### PR DESCRIPTION
### What this PR does / why we need it?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8

Pad draft tokens to fixed length with zero-padding in ngram speculative decoding; achieves 24% performance improvement on AIME dataset for Qwen3-30B-A3B, and no accuracy loss has been verified on both AIME and GSM8K datasets.
