### PR TITLE
[Ops][BugFix] Update Yuanrong backend handling for KV Pool

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -1107,6 +1107,11 @@ python -m vllm.entrypoints.openai.api_server \
 pip install openyuanrong-datasystem
 ```
 
+If the prebuilt package does not match the CANN or Ascend driver version in
+your environment, build Yuanrong Datasystem from source in the vLLM Ascend
+image. Follow the official Yuanrong Datasystem build instructions:
+<https://atomgit.com/openeuler/yuanrong-datasystem>
+
 ### Start etcd
 
 Yuanrong Datasystem uses etcd for service discovery. The following example
@@ -1149,7 +1154,8 @@ Start a Datasystem worker on each node by using `dscli`:
 dscli start -w \
   --worker_address "${WORKER_IP}:31501" \
   --etcd_address "${ETCD_IP}:2379" \
-  --shared_memory_size_mb 20480
+  --shared_memory_size_mb 40960 \
+  --enable_worker_worker_batch_get=true
 ```
 
 The `--worker_address` value is consumed later by `DS_WORKER_ADDR`, so keep
@@ -1174,7 +1180,7 @@ Set the following environment variables on each node before starting vLLM:
 | `PYTHONHASHSEED` | Yes | `0` | Must be consistent across all nodes to guarantee uniform hash generation. |
 | `DS_WORKER_ADDR` | Yes | N/A | Datasystem worker address in `<host>:<port>` format. This must match the local `dscli start --worker_address` value. |
 | `DS_ENABLE_EXCLUSIVE_CONNECTION` | No | `0` | Passed to Yuanrong `HeteroClient.enable_exclusive_connection`. Use `1` to enable the exclusive connection mode when required by your deployment. |
-| `DS_ENABLE_REMOTE_H2D` | No | `0` | Passed to Yuanrong `HeteroClient.enable_remote_h2d`. Use `1` only when remote host-to-device transfer is enabled in your Datasystem deployment. |
+| `DS_ENABLE_REMOTE_H2D` | No | `0` | Passed to Yuanrong `HeteroClient.enable_remote_h2d`. Use `1` only after the Remote H2D requirements below are met. |
 
 ```bash
 export PYTHONHASHSEED=0
@@ -1182,6 +1188,66 @@ export DS_WORKER_ADDR="${WORKER_IP}:31501"
 export DS_ENABLE_EXCLUSIVE_CONNECTION=0
 export DS_ENABLE_REMOTE_H2D=0
 ```
+
+#### Remote H2D Requirements
+
+Set `DS_ENABLE_REMOTE_H2D=1` only when Remote Host-to-Device transfer is
+enabled and verified in the Yuanrong Datasystem deployment:
+
+* Reserve enough 2 MiB HugeTLB pages before starting the worker. For 40 GiB
+  shared memory, reserve at least 20480 2 MiB huge pages.
+* Start each Datasystem worker with Remote H2D enabled. The worker start
+  command must include `--remote_h2d_device_ids`, `--enable_huge_tlb true`,
+  `--arena_per_tenant 1`, and `--enable_fallocate false`. Using multiple
+  available NPU device IDs is recommended, for example `"0,1,2,3,4,5,6,7"` on
+  an 8-NPU node.
+
+```bash
+dscli start -w \
+  --worker_address "${WORKER_IP}:31501" \
+  --etcd_address "${ETCD_IP}:2379" \
+  --shared_memory_size_mb 40960 \
+  --arena_per_tenant 1 \
+  --enable_huge_tlb true \
+  --enable_fallocate false \
+  --remote_h2d_device_ids "0,1,2,3,4,5,6,7" \
+  --enable_worker_worker_batch_get=true
+```
+
+* Make sure the NPU driver, firmware, and CANN toolkit required by Yuanrong
+  Remote H2D are installed and visible to the worker process. In containers,
+  mount the Ascend driver path, `npu-smi`, `hccn_tool`, `/etc/hccn.conf`,
+  `/etc/ascend_install.info`, and the required `/dev/davinci*` devices.
+* Verify the NPU and RoCE environment before enabling the client flag:
+
+```bash
+# Check the current 2 MiB HugeTLB page size, total count, and free count.
+grep -E "HugePages_Total|HugePages_Free|Hugepagesize" /proc/meminfo
+
+# Optional: check 2 MiB HugeTLB pages on each NUMA node.
+for node in /sys/devices/system/node/node*/hugepages/hugepages-2048kB; do
+  echo "$node total=$(cat "$node/nr_hugepages") free=$(cat "$node/free_hugepages")"
+done
+
+# Check that NPU devices and the driver are visible to the worker environment.
+npu-smi info
+
+# Check that the NPU topology is visible.
+npu-smi info -t topo
+
+# Check optical module detection on the selected local NPU.
+hccn_tool -i <local_npu_id> -optical -g
+
+# Check RoCE physical link status. The expected link status is UP.
+for i in {0..7}; do hccn_tool -i $i -link -g; done
+
+# Check the selected NPU IP address and reachability to the remote NPU.
+hccn_tool -i <local_npu_id> -ip -g
+hccn_tool -i <local_npu_id> -ping -g address <remote_npu_ip>
+```
+
+If these checks fail, keep `DS_ENABLE_REMOTE_H2D=0` and use the default
+Datasystem transfer path.
 
 ### Run AscendStoreConnector with Yuanrong backend
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -166,8 +166,8 @@ class YuanrongBackend(Backend):
                             keys[start:end], blob_lists[start:end], 0
                         )
                     )
-            for key in failed_keys:
-                logger.error("Failed to get key %s", key)
+            if failed_keys:
+                logger.error("Failed to get %d keys. First few: %s", len(failed_keys), failed_keys[:10])
         except Exception as exc:
             logger.error("Failed to get keys %s: %s", keys, exc)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -6,10 +6,17 @@ from typing import Any
 import regex as re
 import torch
 from vllm.config import ParallelConfig
+from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import split_host_port
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
+
+
+def _iter_slices(total: int, batch_size: int):
+    for start in range(0, total, batch_size):
+        end = min(start + batch_size, total)
+        yield start, end
 
 
 @dataclass
@@ -81,6 +88,8 @@ class YuanrongHelper:
 
 
 class YuanrongBackend(Backend):
+    _DS_MAX_BATCH_KEYS = 10000
+
     def __init__(self, parallel_config: ParallelConfig):
         try:
             from yr.datasystem.hetero_client import Blob, DeviceBlobList, HeteroClient  # type: ignore[import-not-found]
@@ -89,7 +98,6 @@ class YuanrongBackend(Backend):
         except ImportError as exc:
             raise ImportError("Please install openyuanrong-datasystem to use the yuanrong backend.") from exc
 
-        self.rank = parallel_config.rank
         self._helper = YuanrongHelper(Blob, DeviceBlobList)
         self._ds_set_param = SetParam()
         self._ds_set_param.write_mode = WriteMode.NONE_L2_CACHE_EVICT
@@ -112,7 +120,8 @@ class YuanrongBackend(Backend):
             self.set_device()
 
     def set_device(self):
-        device = torch.device(f"npu:{self.rank}")
+        local_rank = get_world_group().local_rank
+        device = torch.device(f"npu:{local_rank}")
         torch.npu.set_device(device)
         self._helper._device_id = int(torch.npu.current_device())
 
@@ -126,8 +135,14 @@ class YuanrongBackend(Backend):
             return []
         try:
             keys = self._helper.normalize_keys(keys)
-            exists = self._hetero_client.exist(keys)  # type: ignore[union-attr]
-            return [1 if value else 0 for value in exists]
+            if len(keys) <= self._DS_MAX_BATCH_KEYS:
+                exists = self._hetero_client.exist(keys)  # type: ignore[union-attr]
+                return [1 if value else 0 for value in exists]
+            results: list[int] = []
+            for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                exists = self._hetero_client.exist(keys[start:end])  # type: ignore[union-attr]
+                results.extend(1 if value else 0 for value in exists)
+            return results
         except Exception as exc:
             logger.error("Failed to check keys %s: %s", keys, exc)
             return [0] * len(keys)
@@ -139,9 +154,18 @@ class YuanrongBackend(Backend):
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
-            failed_keys = self._hetero_client.mget_h2d(  # type: ignore[union-attr]
-                keys, blob_lists, 0
-            )
+            failed_keys: list[str] = []
+            if len(keys) <= self._DS_MAX_BATCH_KEYS:
+                failed_keys = self._hetero_client.mget_h2d(  # type: ignore[union-attr]
+                    keys, blob_lists, 0
+                )
+            else:
+                for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    failed_keys.extend(
+                        self._hetero_client.mget_h2d(  # type: ignore[union-attr]
+                            keys[start:end], blob_lists[start:end], 0
+                        )
+                    )
             for key in failed_keys:
                 logger.error("Failed to get key %s", key)
         except Exception as exc:
@@ -154,8 +178,14 @@ class YuanrongBackend(Backend):
             self._ensure_device_ready()
             keys = self._helper.normalize_keys(keys)
             blob_lists = self._helper.make_blob_lists(addrs, sizes)
-            self._hetero_client.mset_d2h(  # type: ignore[union-attr]
-                keys, blob_lists, self._ds_set_param
-            )
+            if len(keys) <= self._DS_MAX_BATCH_KEYS:
+                self._hetero_client.mset_d2h(  # type: ignore[union-attr]
+                    keys, blob_lists, self._ds_set_param
+                )
+            else:
+                for start, end in _iter_slices(len(keys), self._DS_MAX_BATCH_KEYS):
+                    self._hetero_client.mset_d2h(  # type: ignore[union-attr]
+                        keys[start:end], blob_lists[start:end], self._ds_set_param
+                    )
         except Exception as exc:
             logger.error("Failed to put keys %s: %s", keys, exc)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the Yuanrong backend for KV Pool to improve reliability in distributed deployments and make Yuanrong setup guidance clearer.

- Use `get_world_group().local_rank` for Yuanrong NPU device selection instead of `parallel_config.rank`, matching the Mooncake backend behavior.
- Split large Yuanrong `exist`, `get`, and `put` requests into bounded batches before calling Datasystem APIs.
- Aggregate failed-key logging in the Yuanrong `get` path to avoid excessive logs for large batches.
- Update the Yuanrong KV Pool documentation with recommended Datasystem worker parameters, Remote H2D requirements, HugeTLB checks, and source-build guidance when the prebuilt package does not match the local CANN or Ascend driver version.

### Does this PR introduce _any_ user-facing change?

No API or configuration compatibility change. The Yuanrong backend behavior is fixed internally, and the documentation now provides clearer deployment guidance. The Yuanrong `load_kvc took` info log is no longer emitted.

### How was this patch tested?

- Ran syntax validation for the touched Python backend file:
  `python -m py_compile vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py`
- Ran diff whitespace validation:
  `git diff --check`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8