### PR TITLE
[CI] Reduce auto doc translation frequency to every 3 days

### DIFF
--- a/.github/workflows/schedule_doc_translate.yaml
+++ b/.github/workflows/schedule_doc_translate.yaml
@@ -19,7 +19,7 @@ name: Auto Doc Translate
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */3 * *'
   workflow_dispatch:
     inputs:
       target_branch:


### PR DESCRIPTION
### What this PR does / why we need it?

Change the cron schedule for the auto doc translation workflow from daily to every 3 days to reduce unnecessary CI resource consumption and API usage.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
