### PR TITLE
[BugFix]Fix MTP tokens out-of-range error in speculative decoding

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2088,7 +2088,6 @@ class NPUModelRunner(GPUModelRunner):
                         assert spec_decode_common_attn_metadata is not None
                         if self.drafter is not None: # Fix mypy type check for drafter None check
                             next_token_ids, valid_sampled_tokens_count = self.drafter.prepare_next_token_ids_padded(
-                                    spec_decode_common_attn_metadata,
                                     sampled_token_ids,
                                     self.requests,
                                     self.input_batch,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2064,7 +2064,7 @@ class NPUModelRunner(GPUModelRunner):
 
         with record_function_or_nullcontext("draft_token"):
             if self.speculative_config:
-                input_fits_in_drafter =(
+                input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
                     spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
                     <= self.effective_drafter_max_model_len
                 )
@@ -2081,26 +2081,27 @@ class NPUModelRunner(GPUModelRunner):
                 if use_padded_batch:
                     # EAGLE speculative decoding can use the GPU sampled tokens
                     # as inputs, and does not need to wait for bookkeeping to finish.
+                    sampled_token_ids = sampler_output.sampled_token_ids
                     if input_fits_in_drafter:
                         propose_draft_token_ids(sampler_output.sampled_token_ids)
                     elif self.valid_sampled_token_count_event is not None:
-                        common_attn_metadata = spec_decode_common_attn_metadata
-                        sampled_token_ids = sampler_output.sampled_token_ids
-                        next_token_ids, valid_sampled_tokens_count = self.drafter.prepare_next_token_ids_padded(
-                                common_attn_metadata,
-                                sampled_token_ids,
-                                self.requests,
-                                self.input_batch,
-                                self.discard_request_indices.gpu,
-                                self.num_discarded_requests,
+                        assert spec_decode_common_attn_metadata is not None
+                        if self.drafter is not None: # Fix mypy type check for drafter None check
+                            next_token_ids, valid_sampled_tokens_count = self.drafter.prepare_next_token_ids_padded(
+                                    spec_decode_common_attn_metadata,
+                                    sampled_token_ids,
+                                    self.requests,
+                                    self.input_batch,
+                                    self.discard_request_indices.gpu,
+                                    self.num_discarded_requests,
+                                )
+                            self._copy_valid_sampled_token_count(
+                                next_token_ids, valid_sampled_tokens_count
                             )
-                        self._copy_valid_sampled_token_count(
-                            next_token_ids, valid_sampled_tokens_count
-                        )
-                        self._draft_token_ids = torch.zeros(
-                            1, device=self.device, dtype=torch.int32
-                        ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
-                        self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
+                            self._draft_token_ids = torch.zeros(
+                                1, device=self.device, dtype=torch.int32
+                            ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
+                            self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
                 if self.speculative_config and not use_padded_batch and input_fits_in_drafter:
                     # ngram and other speculative decoding methods use the sampled
                     # tokens on the CPU, so they are run after bookkeeping.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2064,6 +2064,10 @@ class NPUModelRunner(GPUModelRunner):
 
         with record_function_or_nullcontext("draft_token"):
             if self.speculative_config:
+                input_fits_in_drafter =(
+                    spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
+                    <= self.effective_drafter_max_model_len
+                )
                 use_padded_batch = (
                     self.speculative_config
                     and (
@@ -2077,8 +2081,27 @@ class NPUModelRunner(GPUModelRunner):
                 if use_padded_batch:
                     # EAGLE speculative decoding can use the GPU sampled tokens
                     # as inputs, and does not need to wait for bookkeeping to finish.
-                    propose_draft_token_ids(sampler_output.sampled_token_ids)
-                if self.speculative_config and not use_padded_batch:
+                    if input_fits_in_drafter:
+                        propose_draft_token_ids(sampler_output.sampled_token_ids)
+                    elif self.valid_sampled_token_count_event is not None:
+                        common_attn_metadata = spec_decode_common_attn_metadata
+                        sampled_token_ids = sampler_output.sampled_token_ids
+                        next_token_ids, valid_sampled_tokens_count = self.drafter.prepare_next_token_ids_padded(
+                                common_attn_metadata,
+                                sampled_token_ids,
+                                self.requests,
+                                self.input_batch,
+                                self.discard_request_indices.gpu,
+                                self.num_discarded_requests,
+                            )
+                        self._copy_valid_sampled_token_count(
+                            next_token_ids, valid_sampled_tokens_count
+                        )
+                        self._draft_token_ids = torch.zeros(
+                            1, device=self.device, dtype=torch.int32
+                        ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
+                        self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
+                if self.speculative_config and not use_padded_batch and input_fits_in_drafter:
                     # ngram and other speculative decoding methods use the sampled
                     # tokens on the CPU, so they are run after bookkeeping.
                     propose_draft_token_ids(valid_sampled_token_ids)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes a bug in the speculative decoding workflow where MTP (Multi-Token Prediction) tokens could exceed the drafter's maximum sequence length, causing runtime errors.

Changes:

- Added input validation for the drafter to verify if the input sequence length fits within the drafter's maximum model length before processing draft tokens
- Implemented a fallback mechanism in the padded batch processing logic to handle cases where input tokens exceed the drafter's capacity
- Ensures proper token count management and clears draft token buffers when necessary
Why needed: When using speculative decoding with MTP, the system could encounter out-of-range errors when the input sequence plus spec tokens exceeded the drafter's maximum length. This fix prevents potential runtime errors by safely handling oversized inputs through capacity checks and robust fallback mechanisms.
### Does this PR introduce _any_ user-facing change?
No. This is a bug fix that improves the robustness of speculative decoding with MTP. It does not introduce any API changes or alter the expected behavior for valid inputs. Users will experience improved stability when using speculative decoding with models that have sequence length constraints.
### How was this patch tested?
The fix was tested with speculative decoding scenarios involving MTP where input sequences approach or exceed the drafter's maximum length. The implementation ensures that:

- Valid inputs within drafter capacity continue to work correctly
- Out-of-range scenarios are handled gracefully with proper fallback
- Token count management remains accurate in all cases
- Draft buffers are properly cleared when fallback is triggered
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/ce29c26b31d432b1b4bc028c46bb2c3b07a667d8
