### PR TITLE
[Feature][Attention][Kernel] Support Gemma4 inference on Ascend

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import torch
+from vllm.v1.attention.backend import AttentionCGSupport
 
 from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import (
@@ -81,6 +82,22 @@ class TestAscendAttentionMetadataBuilder(TestBase):
         result = self.builder.reorder_batch(mock_input_batch, mock_scheduler_output)
 
         self.assertFalse(result)
+
+    def test_get_cudagraph_support_for_supported_head_size(self):
+        mock_kv_cache_spec = MagicMock()
+        mock_kv_cache_spec.head_size = 128
+
+        result = AscendAttentionMetadataBuilder.get_cudagraph_support(self.mock_vllm_config, mock_kv_cache_spec)
+
+        self.assertEqual(result, AttentionCGSupport.ALWAYS)
+
+    def test_get_cudagraph_support_for_large_head_size(self):
+        mock_kv_cache_spec = MagicMock()
+        mock_kv_cache_spec.head_size = 512
+
+        result = AscendAttentionMetadataBuilder.get_cudagraph_support(self.mock_vllm_config, mock_kv_cache_spec)
+
+        self.assertEqual(result, AttentionCGSupport.ALWAYS)
 
     @patch("vllm_ascend.attention.attention_v1.AscendMetadata")
     def test_build(self, mock_ascend_metadata):
@@ -203,6 +220,33 @@ class TestAscendAttentionBackendImpl(TestBase):
             kv_sharing_target_layer_name=None,
             sinks=torch.tensor([-3.4062], dtype=torch.bfloat16),
         )
+
+    def test_gather_paged_kv_to_dense(self):
+        block_size = 2
+        key_cache = torch.arange(4 * block_size * 8 * 64).reshape(4, block_size, 8, 64)
+        value_cache = key_cache + 10000
+        block_table = torch.tensor([[1, 3], [0, 2]])
+        seq_lens = [3, 4]
+
+        dense_key, dense_value = self.impl._gather_paged_kv_to_dense(
+            key_cache,
+            value_cache,
+            block_table,
+            seq_lens,
+        )
+
+        expected_key = torch.cat(
+            (
+                key_cache[1],
+                key_cache[3, :1],
+                key_cache[0],
+                key_cache[2],
+            ),
+            dim=0,
+        )
+        expected_value = expected_key + 10000
+        torch.testing.assert_close(dense_key, expected_key)
+        torch.testing.assert_close(dense_value, expected_value)
 
     def test_forward_no_attn_metadata(self):
         """Test forward pass when attn_metadata is None"""

--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -9,9 +9,28 @@ from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackendImpl,
     AscendAttentionMetadataBuilder,
     AscendAttentionState,
+    AttentionGraphParam,
+    _normalize_graph_param,
 )
 from vllm_ascend.attention.kvcomp_attn.attention_utils import get_kvcomp_decode_params, reshape_and_cache_kvcomp
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+
+
+class TestAttentionGraphParam(TestBase):
+    def test_normalize_graph_param_uses_explicit_wrapper(self):
+        raw_param = (object(),)
+        kind, param, layer_name = _normalize_graph_param(
+            AttentionGraphParam("paged_attention", raw_param, "real_layer"),
+            "fallback_layer",
+        )
+
+        self.assertEqual(kind, "paged_attention")
+        self.assertIs(param, raw_param)
+        self.assertEqual(layer_name, "real_layer")
+
+    def test_normalize_graph_param_rejects_raw_tuple(self):
+        with self.assertRaisesRegex(TypeError, "Expected AttentionGraphParam"):
+            _normalize_graph_param(tuple(range(9)), "fallback_layer")
 
 
 class TestAscendAttentionBackend(TestBase):
@@ -221,6 +240,32 @@ class TestAscendAttentionBackendImpl(TestBase):
             sinks=torch.tensor([-3.4062], dtype=torch.bfloat16),
         )
 
+        self.impl_large_head = AscendAttentionBackendImpl(
+            num_heads=8,
+            head_size=512,
+            scale=1.0,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="float16",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name=None,
+        )
+
+        self.impl_kv_share = AscendAttentionBackendImpl(
+            num_heads=8,
+            head_size=512,
+            scale=1.0,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="float16",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name="producer_layer",
+        )
+
     def test_gather_paged_kv_to_dense(self):
         block_size = 2
         key_cache = torch.arange(4 * block_size * 8 * 64).reshape(4, block_size, 8, 64)
@@ -427,6 +472,116 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_fused_infer_attention_score.assert_called_once()
 
         assert output.shape == (10, 8, 64)
+
+    @patch("torch_npu._npu_paged_attention")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_gemma4_swa_decode_uses_fia_operator(
+        self,
+        mock_get_forward_context,
+        mock_npu_reshape_and_cache,
+        mock_fused_infer_attention_score,
+        mock_paged_attention,
+    ):
+        query = torch.randn(2, 8 * 64)
+        key = torch.randn(2, 8 * 64)
+        value = torch.randn(2, 8 * 64)
+        kv_cache = torch.empty(2, 4, 128, 8, 64)
+        output = torch.empty(2, 8, 64)
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.DecodeOnly
+        metadata.seq_lens = torch.tensor([16, 16])
+        metadata.actual_seq_lengths_q = [1, 2]
+        metadata.block_tables = torch.zeros(2, 4, dtype=torch.long)
+        metadata.num_actual_tokens = 2
+        metadata.slot_mapping = torch.arange(2)
+        metadata.num_decodes = 2
+        metadata.num_prefills = 0
+        metadata.causal = True
+        metadata.model_runner_type = "generate"
+        layer = self.layer_no_quant
+
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        mock_fused_infer_attention_score.return_value = (torch.ones(2, 8, 64), 1)
+
+        output = self.impl_swa.forward(layer, query, key, value, kv_cache, metadata, output)
+
+        mock_paged_attention.assert_not_called()
+        mock_fused_infer_attention_score.assert_called_once()
+        assert output.shape == (2, 8, 64)
+
+    @patch("torch_npu.npu_fusion_attention")
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_gemma4_large_head_prefill_uses_fusion_attention(
+        self,
+        mock_get_forward_context,
+        mock_npu_reshape_and_cache,
+        mock_npu_fusion_attention,
+    ):
+        query = torch.randn(3, 8, 512)
+        key = torch.randn(3, 8, 512)
+        value = torch.randn(3, 8, 512)
+        kv_cache = torch.empty(2, 4, 128, 8, 512)
+        output = torch.empty_like(query)
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.actual_seq_lengths_q = [3]
+        metadata.seq_lens_list = [3]
+        metadata.attn_mask = None
+        metadata.causal = True
+        metadata.slot_mapping = torch.arange(3)
+        metadata.num_actual_tokens = 3
+        metadata.model_runner_type = "generate"
+        layer = self.layer_no_quant
+
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        mock_npu_fusion_attention.return_value = (torch.ones_like(query), None)
+
+        output = self.impl_large_head.forward(layer, query, key, value, kv_cache, metadata, output)
+
+        mock_npu_fusion_attention.assert_called_once()
+        assert mock_npu_fusion_attention.call_args.kwargs["head_num"] == 8
+        assert mock_npu_fusion_attention.call_args.kwargs["input_layout"] == "TND"
+        assert output.shape == (3, 8, 512)
+
+    @patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache")
+    def test_gemma4_kv_sharing_target_skips_cache_overwrite(self, mock_reshape_and_cache):
+        query = torch.randn(2, 8, 512)
+        key = torch.randn(2, 8, 512)
+        value = torch.randn(2, 8, 512)
+        kv_cache = torch.empty(2, 4, 128, 8, 512)
+        output = torch.empty_like(query)
+
+        metadata = self.attn_metadata
+        metadata.slot_mapping = torch.arange(2)
+        metadata.num_actual_tokens = 2
+
+        returned = self.impl_kv_share.reshape_and_cache(query, key, value, kv_cache, metadata, output)
+
+        mock_reshape_and_cache.assert_not_called()
+        self.assertIs(returned[0], query)
+        self.assertIs(returned[1], key)
+        self.assertIs(returned[2], value)
+        self.assertIs(returned[3], output)
+
+    def test_gemma4_kv_sharing_target_reads_current_token_cache(self):
+        key_cache = torch.arange(4 * 8 * 512, dtype=torch.float32).reshape(1, 4, 8, 512)
+        value_cache = key_cache + 10000
+        self.impl_kv_share.key_cache = key_cache
+        self.impl_kv_share.value_cache = value_cache
+
+        metadata = self.attn_metadata
+        metadata.actual_seq_lengths_q = [2]
+        metadata.slot_mapping = torch.tensor([1, 3], dtype=torch.long)
+
+        key, value = self.impl_kv_share._get_current_token_shared_kv(metadata)
+
+        torch.testing.assert_close(key, key_cache.reshape(-1, 8, 512)[[1, 3]])
+        torch.testing.assert_close(value, value_cache.reshape(-1, 8, 512)[[1, 3]])
 
     def test_get_kvcomp_params_early_exit(self):
         """

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -27,12 +27,14 @@ from pytest_mock import MockerFixture
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
+from vllm_ascend.ops.fused_moe.experts_selector import _custom_routing_accepts_num_experts
 from vllm_ascend.ops.fused_moe.fused_moe import (
     AscendFusedMoE,
     AscendMoERunner,
     AscendUnquantizedFusedMoEMethod,
 )
 from vllm_ascend.ops.fused_moe.moe_comm_method import FusedExpertsResult
+from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
     MoEPrepareOutput,
@@ -243,6 +245,87 @@ class MockQuantMethod(nn.Module):
             self.apply = MagicMock(return_value=(torch.randn(num_tokens, 32), torch.randn(num_tokens, 10)))
         else:
             self.apply = MagicMock(return_value=(torch.randn(num_tokens, 32)))
+
+
+class TestUnifiedApplyMLP:
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_swiglu")
+    def test_unified_apply_mlp_without_quantization_gelu(
+        self, mock_npu_swiglu, mock_npu_grouped_matmul, mock_soc_version
+    ):
+        mock_gate_up_out = torch.randn(10, 40, dtype=torch.float16)
+        mock_down_out = torch.randn(10, 20, dtype=torch.float16)
+        mock_npu_grouped_matmul.side_effect = [
+            [mock_gate_up_out],
+            [mock_down_out],
+        ]
+
+        hidden_states = torch.randn(10, 20, dtype=torch.float16)
+        w1 = torch.randn(5, 20, 40, dtype=torch.float16)
+        w2 = torch.randn(5, 40, 20, dtype=torch.float16)
+        group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
+
+        result = unified_apply_mlp(
+            mlp_compute_input=build_mlp_compute_input_fixture(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                group_list=group_list,
+                with_quant=False,
+                activation="gelu",
+            )
+        )
+
+        assert mock_npu_grouped_matmul.call_count == 2
+        mock_npu_swiglu.assert_not_called()
+        gate, up = mock_gate_up_out.chunk(2, dim=-1)
+        expected_mlp_input = torch.nn.functional.gelu(gate) * up
+        torch.testing.assert_close(
+            mock_npu_grouped_matmul.call_args_list[1].kwargs["x"][0],
+            expected_mlp_input,
+        )
+        if isinstance(result, tuple):
+            result = result[0]
+        torch.testing.assert_close(result, mock_down_out)
+
+
+class TestExpertsSelector:
+    def test_custom_routing_signature_without_num_experts(self):
+        def routing_function(hidden_states, gating_output, topk, renormalize):
+            pass
+
+        assert not _custom_routing_accepts_num_experts(routing_function)
+
+    def test_custom_routing_signature_with_num_experts(self):
+        def routing_function(hidden_states, gating_output, topk, renormalize, num_experts):
+            pass
+
+        assert _custom_routing_accepts_num_experts(routing_function)
+
+    def test_custom_routing_signature_with_kwargs(self):
+        def routing_function(**kwargs):
+            pass
+
+        assert _custom_routing_accepts_num_experts(routing_function)
+
+    def test_custom_routing_signature_uninspectable(self, mocker):
+        mocker.patch(
+            "vllm_ascend.ops.fused_moe.experts_selector.inspect.signature",
+            side_effect=ValueError,
+        )
+
+        assert not _custom_routing_accepts_num_experts(object())
+
+    def test_custom_routing_signature_unhashable_callable(self):
+        class RoutingFunction:
+            def __eq__(self, other):
+                return self is other
+
+            def __call__(self, hidden_states, gating_output, topk, renormalize, num_experts):
+                pass
+
+        assert _custom_routing_accepts_num_experts(RoutingFunction())
 
 
 def _drop_self(signature: inspect.Signature) -> list[inspect.Parameter]:

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -148,6 +148,38 @@ class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
         self.assertEqual(actual_output_token_ids[1], [4, 5, 7])
 
 
+class TestNPUModelRunnerModelForward(unittest.TestCase):
+    def test_model_forward_keeps_input_ids_for_multimodal_embeds(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.model = MagicMock(return_value=torch.randn(3, 4))
+        runner.supports_mm_inputs = True
+        runner.enable_enpu = False
+        runner.input_ids = SimpleNamespace(gpu=torch.arange(8))
+        runner._update_full_graph_params_if_needed = MagicMock()
+
+        forward_context = SimpleNamespace(flash_comm_v1_enabled=False)
+        positions = torch.arange(3)
+        inputs_embeds = torch.randn(3, 4)
+
+        with patch(
+            "vllm_ascend.worker.model_runner_v1.get_forward_context",
+            return_value=forward_context,
+        ):
+            runner._model_forward(
+                3,
+                input_ids=None,
+                positions=positions,
+                inputs_embeds=inputs_embeds,
+                mm_kwargs="kept",
+            )
+
+        call_kwargs = runner.model.call_args.kwargs
+        torch.testing.assert_close(call_kwargs["input_ids"], torch.arange(3))
+        self.assertIs(call_kwargs["positions"], positions)
+        self.assertIs(call_kwargs["inputs_embeds"], inputs_embeds)
+        self.assertEqual(call_kwargs["mm_kwargs"], "kept")
+
+
 class TestNPUModelRunnerDebugger(unittest.TestCase):
     def _build_runner(self, debugger=None):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -69,6 +69,43 @@ from vllm_ascend.worker.kvcomp_utils import KVCompMetaData
 SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
+# Ascend FIA TND currently supports these head dimensions on the vLLM-Ascend
+# path. Larger heterogeneous-head models need a prefill fallback to avoid
+# unsupported-kernel behavior.
+FIA_TND_SUPPORTED_HEAD_SIZES = {64, 128, 192}
+
+# Full graph attention params are currently stored as tuples. Keep the layout
+# lengths named here so capture/replay compatibility is explicit while avoiding
+# magic-number checks in the update path.
+PAGED_ATTENTION_GRAPH_PARAM_LEN = 9
+PAGED_ATTENTION_GRAPH_PARAM_WITH_LAYER_LEN = PAGED_ATTENTION_GRAPH_PARAM_LEN + 1
+FIA_GRAPH_PARAM_LEN = 20
+FIA_GRAPH_PARAM_WITH_LAYER_LEN = FIA_GRAPH_PARAM_LEN + 1
+
+
+def _is_paged_attention_graph_param(param: tuple) -> bool:
+    return len(param) in (
+        PAGED_ATTENTION_GRAPH_PARAM_LEN,
+        PAGED_ATTENTION_GRAPH_PARAM_WITH_LAYER_LEN,
+    )
+
+
+def _graph_param_has_layer_name(param: tuple) -> bool:
+    return len(param) in (
+        PAGED_ATTENTION_GRAPH_PARAM_WITH_LAYER_LEN,
+        FIA_GRAPH_PARAM_WITH_LAYER_LEN,
+    )
+
+
+def _split_graph_param_layer_name(param: tuple, fallback_layer_name: str) -> tuple[tuple, str]:
+    if _graph_param_has_layer_name(param):
+        return param[:-1], param[-1]
+    return param, fallback_layer_name
+
+
+def _uses_sliding_window_attention(vllm_config: VllmConfig) -> bool:
+    return getattr(vllm_config.model_config.hf_text_config, "sliding_window", None) is not None
+
 
 @register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
@@ -383,6 +420,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             alibi_slopes = torch.tensor(alibi_slopes, dtype=torch.float32, device="npu")
         self.alibi_slopes = alibi_slopes
         self.attn_type = attn_type
+        self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
@@ -397,6 +435,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self.sinks = sinks
         self.layerIndex = 0
         self.enable_hamming_sparse = is_enable_hamming_sparse()
+        self._layer_name: str | None = None
 
     @staticmethod
     def update_graph_params(
@@ -408,15 +447,20 @@ class AscendAttentionBackendImpl(AttentionImpl):
         num_dcp_pcp_tokens=None,
         draft_attn_metadatas=None,
     ):
-        if using_paged_attention(num_tokens, vllm_config):
-            # Paged Attention update logic
-            if _EXTRA_CTX.is_draft_model:
-                if _EXTRA_CTX.is_draft_model_prefill:
-                    graph_params = get_draft_graph_prefill_params()
-                else:
-                    graph_params = get_draft_graph_params()
+        if _EXTRA_CTX.is_draft_model:
+            if _EXTRA_CTX.is_draft_model_prefill:
+                graph_params = get_draft_graph_prefill_params()
             else:
-                graph_params = get_graph_params()
+                graph_params = get_draft_graph_params()
+        else:
+            graph_params = get_graph_params()
+        attn_params = graph_params.attn_params.get(num_tokens, [])
+        uses_paged_attention_params = len(attn_params) > 0 and all(
+            _is_paged_attention_graph_param(param) for param in attn_params
+        )
+
+        if uses_paged_attention_params or (using_paged_attention(num_tokens, vllm_config) and len(attn_params) == 0):
+            # Paged Attention update logic
             with torch.npu.stream(update_stream):
                 for key, param, handle, event in zip(
                     forward_context.attn_metadata,
@@ -424,6 +468,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
                 ):
+                    param, layer_name = _split_graph_param_layer_name(param, key)
                     (
                         query,
                         key_cache,
@@ -435,7 +480,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         seq_lens,
                         output,
                     ) = param
-                    seq_lens = forward_context.attn_metadata[key].seq_lens
+                    metadata_key = layer_name if layer_name in forward_context.attn_metadata else key
+                    current_attn_metadata = forward_context.attn_metadata[metadata_key]
+                    block_table = current_attn_metadata.block_tables
+                    seq_lens = current_attn_metadata.seq_lens
 
                     workspace = torch_npu._npu_paged_attention_get_workspace(
                         query=query,
@@ -552,7 +600,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_metadata = draft_attn_metadatas
                 attn_keys = list(attn_metadata[0].keys())
             else:
-                graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
                 attn_keys = list(attn_metadata.keys())
                 # In some speculative methods (such as DFlash), the order of attn_keys in the Target model
@@ -591,6 +638,58 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
                 ):
+                    if _is_paged_attention_graph_param(param):
+                        param, layer_name = _split_graph_param_layer_name(param, key)
+                        (
+                            query,
+                            key_cache,
+                            value_cache,
+                            num_kv_heads,
+                            num_heads,
+                            scale,
+                            block_table,
+                            seq_lens,
+                            output,
+                        ) = param
+                        if _EXTRA_CTX.is_draft_model:
+                            draft_step = attn_count // num_layers
+                            block_table = attn_metadata[draft_step][key].block_tables
+                            seq_lens = attn_metadata[draft_step][key].seq_lens
+                            attn_count = attn_count + 1
+                        else:
+                            metadata_key = layer_name if layer_name in attn_metadata else key
+                            block_table = attn_metadata[metadata_key].block_tables
+                            seq_lens = attn_metadata[metadata_key].seq_lens
+                        workspace = torch_npu._npu_paged_attention_get_workspace(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value_cache,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_table,
+                            context_lens=seq_lens,
+                            out=output,
+                        )
+                        torch.npu.graph_task_update_begin(update_stream, handle)
+                        torch_npu._npu_paged_attention(
+                            query=query,
+                            key_cache=key_cache,
+                            value_cache=value_cache,
+                            num_kv_heads=num_kv_heads,
+                            num_heads=num_heads,
+                            scale_value=scale,
+                            block_table=block_table,
+                            context_lens=seq_lens,
+                            out=output,
+                            workspace=workspace,
+                        )
+                        torch.npu.graph_task_update_end(update_stream)
+                        event.record(update_stream)
+                        continue
+
+                    param, layer_name = _split_graph_param_layer_name(param, key)
+
                     (
                         query,
                         key_cache,
@@ -623,18 +722,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         if not attn_metadata[draft_step][key].causal:
                             sparse_mode = 0
                     else:
-                        seq_lens = attn_metadata[key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
-                        # NOTE:
-                        # For models with sliding-window attention on the FIA full-graph replay path,
-                        # rebinding `block_tables` to the latest metadata tensor causes corrupted /
-                        # repeated outputs in our repro on Ascend NPU.
-                        #
-                        # Keep the captured block_tables tensor on this affected path.
-                        # Non-SWA models preserve the original behavior and continue to refresh
-                        # block_tables from attn_metadata.
-                        if not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
-                            block_tables = attn_metadata[key].block_tables
+                        metadata_key = layer_name if layer_name in attn_metadata else key
+                        seq_lens = attn_metadata[metadata_key].seq_lens_list
+                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
+                        # SWA full-graph replay keeps the captured block table
+                        # tensor. Rebinding it from per-step metadata has been
+                        # observed to corrupt SWA decode replay on NPU.
+                        # Non-SWA models preserve the previous behavior and
+                        # refresh block tables from current metadata.
+                        if not _uses_sliding_window_attention(vllm_config):
+                            block_tables = attn_metadata[metadata_key].block_tables
 
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
@@ -765,6 +862,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         event.wait(stream)
         event.reset(stream)
         graph_params.events[num_tokens].append(event)
+        # Record the owning layer so graph replay can refresh metadata by the
+        # real attention layer instead of relying on dict iteration order.
+        layer_name = layer.layer_name if layer is not None else self._layer_name
         attn_params = (
             weak_ref_tensors(query),
             weak_ref_tensors(key),
@@ -789,9 +889,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 weak_ref_tensors(layer._c8_k_aq_offset),
                 weak_ref_tensors(layer._c8_v_aq_scale),
                 weak_ref_tensors(layer._c8_v_aq_offset),
+                layer_name,
             )  # type: ignore
         else:
-            attn_params = attn_params + (None, None, None, None)  # type: ignore
+            attn_params = attn_params + (None, None, None, None, layer_name)  # type: ignore
         graph_params.attn_params[num_tokens].append(attn_params)
 
         torch.npu.graph_task_group_begin(stream)
@@ -959,6 +1060,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     attn_metadata.block_tables,
                     attn_metadata.seq_lens,
                     weak_ref_tensors(output),
+                    self._layer_name,
                 )
             )
 
@@ -1201,6 +1303,121 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_kvlen=attn_metadata.actual_seq_lengths_q,
         )[0]
 
+    def _forward_large_head_prefill_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        query = query[:num_tokens]
+        key, value, actual_seq_lengths_kv = self._get_large_head_prefill_kv(
+            key,
+            value,
+            attn_metadata,
+            num_tokens,
+        )
+        sparse_mode = 4 if self.sliding_window is not None else 3 if attn_metadata.causal else 0
+        pre_tokens = self.sliding_window if self.sliding_window is not None else SWA_INT_MAX
+        next_tokens = 0 if attn_metadata.causal or self.sliding_window is not None else SWA_INT_MAX
+        attn_mask = attn_metadata.attn_mask
+        if attn_mask is not None and attn_mask.dtype not in (torch.bool, torch.uint8):
+            attn_mask = attn_mask.bool()
+        attn_output = torch_npu.npu_fusion_attention(
+            query=query,
+            key=key,
+            value=value,
+            head_num=self.num_heads,
+            input_layout="TND",
+            atten_mask=attn_mask,
+            scale=self.scale,
+            pre_tockens=pre_tokens,
+            next_tockens=next_tokens,
+            actual_seq_qlen=attn_metadata.actual_seq_lengths_q,
+            actual_seq_kvlen=actual_seq_lengths_kv,
+            sparse_mode=sparse_mode,
+        )[0]
+        output[:num_tokens] = attn_output[:num_tokens]
+        return output
+
+    def _get_large_head_prefill_kv(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        if (
+            attn_metadata.attn_state == AscendAttentionState.PrefillNoCache
+            or self.key_cache is None
+            or self.value_cache is None
+        ):
+            return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+        seq_lens = attn_metadata.seq_lens_list
+        if not seq_lens:
+            return key[:num_tokens], value[:num_tokens], attn_metadata.actual_seq_lengths_q
+
+        # Chunked prefill can have historical KV already resident in the paged
+        # cache. The large-head fallback uses dense TND attention, so gather the
+        # paged KV blocks into sequence-major dense tensors first.
+        dense_key, dense_value = self._gather_paged_kv_to_dense(
+            self.key_cache,
+            self.value_cache,
+            attn_metadata.block_tables,
+            seq_lens,
+        )
+        actual_seq_lengths_kv = torch.tensor(seq_lens, dtype=torch.int32).cumsum(0).tolist()
+        return dense_key, dense_value, actual_seq_lengths_kv
+
+    def _gather_paged_kv_to_dense(
+        self,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        seq_lens: list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        block_size = key_cache.shape[1]
+        seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.long, device=key_cache.device)
+        max_seq_len = int(seq_lens_tensor.max().item())
+        num_blocks = cdiv(max_seq_len, block_size)
+        block_table = block_table[: len(seq_lens), :num_blocks].long()
+
+        flat_block_ids = block_table.reshape(-1)
+        max_tokens_padded = num_blocks * block_size
+        dense_shape = (
+            len(seq_lens),
+            max_tokens_padded,
+            self.num_kv_heads,
+            self.head_size,
+        )
+        gathered_key = key_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+        gathered_value = value_cache.index_select(0, flat_block_ids).reshape(dense_shape)
+
+        positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key_cache.device)
+        valid_mask = positions.unsqueeze(0) < seq_lens_tensor.unsqueeze(1)
+        return gathered_key[valid_mask].contiguous(), gathered_value[valid_mask].contiguous()
+
+    def _should_use_large_head_attention_fallback(self) -> bool:
+        unsupported_fia_tnd_head_size = self.head_size not in FIA_TND_SUPPORTED_HEAD_SIZES
+        return self.sinks is None and unsupported_fia_tnd_head_size
+
+    def _get_current_token_shared_kv(
+        self,
+        attn_metadata: AscendMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor] | tuple[None, None]:
+        if self.key_cache is None or self.value_cache is None:
+            return None, None
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        if attn_metadata.slot_mapping is None or attn_metadata.slot_mapping.numel() < num_tokens:
+            return None, None
+        slots = attn_metadata.slot_mapping[:num_tokens].long()
+        key = self.key_cache.reshape(-1, self.num_kv_heads, self.head_size).index_select(0, slots)
+        value = self.value_cache.reshape(-1, self.num_kv_heads, self.head_size).index_select(0, slots)
+        return key, value
+
     def do_kv_cache_update(
         self,
         layer: torch.nn.Module,
@@ -1237,6 +1454,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 attn_metadata.reshape_cache_event = torch.npu.Event()
             if self.key_cache is None:
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+            if self.kv_sharing_target_layer_name is not None:
+                # KV-sharing target layers consume the producer layer's cache.
+                # Re-caching here would overwrite the shared KV slots.
+                if self.is_kv_producer:
+                    attn_metadata.reshape_cache_event.record()
+                return query, key, value, output
             slots = attn_metadata.slot_mapping
             encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
             DeviceOperator.reshape_and_cache(
@@ -1263,11 +1486,40 @@ class AscendAttentionBackendImpl(AttentionImpl):
     ):
         num_tokens = query.shape[0]
         if (
+            self.kv_sharing_target_layer_name is not None
+            and key is not None
+            and value is not None
+            and query.shape[0] == key.shape[0]
+            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill)
+        ):
+            shared_key, shared_value = self._get_current_token_shared_kv(attn_metadata)
+            if shared_key is not None and shared_value is not None:
+                return self._forward_large_head_prefill_attention(
+                    query,
+                    shared_key,
+                    shared_value,
+                    attn_metadata,
+                    output,
+                )
+
+        if (
             attn_metadata.attn_state == AscendAttentionState.DecodeOnly
-            and using_paged_attention(num_tokens, self.vllm_config)
             and self.sliding_window is None
+            and (
+                using_paged_attention(num_tokens, self.vllm_config) or self._should_use_large_head_attention_fallback()
+            )
         ):
             output = self.forward_paged_attention(query, attn_metadata, output)
+        elif (
+            not _EXTRA_CTX.capturing
+            and self._should_use_large_head_attention_fallback()
+            and self.kv_sharing_target_layer_name is None
+            and key is not None
+            and value is not None
+            and query.shape[0] == key.shape[0]
+            and attn_metadata.attn_state in (AscendAttentionState.PrefillNoCache, AscendAttentionState.ChunkedPrefill)
+        ):
+            output = self._forward_large_head_prefill_attention(query, key, value, attn_metadata, output)
         else:
             output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, kv_cache)
 
@@ -1299,6 +1551,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         assert output is not None, "Output tensor must be provided."
         if self.enable_hamming_sparse:
             self.layerIndex = int(layer.layer_name.split(".")[2])
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendAttentionBackendImpl")

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -17,6 +17,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Literal, NamedTuple
 
 import torch
 import torch_npu
@@ -74,33 +75,31 @@ _ATTN_KEYS_BUFFER = None
 # unsupported-kernel behavior.
 FIA_TND_SUPPORTED_HEAD_SIZES = {64, 128, 192}
 
-# Full graph attention params are currently stored as tuples. Keep the layout
-# lengths named here so capture/replay compatibility is explicit while avoiding
-# magic-number checks in the update path.
-PAGED_ATTENTION_GRAPH_PARAM_LEN = 9
-PAGED_ATTENTION_GRAPH_PARAM_WITH_LAYER_LEN = PAGED_ATTENTION_GRAPH_PARAM_LEN + 1
-FIA_GRAPH_PARAM_LEN = 20
-FIA_GRAPH_PARAM_WITH_LAYER_LEN = FIA_GRAPH_PARAM_LEN + 1
+GraphParamKind = Literal["paged_attention", "fia"]
 
 
-def _is_paged_attention_graph_param(param: tuple) -> bool:
-    return len(param) in (
-        PAGED_ATTENTION_GRAPH_PARAM_LEN,
-        PAGED_ATTENTION_GRAPH_PARAM_WITH_LAYER_LEN,
-    )
+class AttentionGraphParam(NamedTuple):
+    """Captured attention graph metadata.
+
+    `kind` records which attention op was captured, and `layer_name` binds the
+    captured params back to the real attention layer during graph replay. This
+    avoids inferring op type from tuple length or relying on metadata dict order.
+    """
+
+    kind: GraphParamKind
+    params: tuple
+    layer_name: str | None
 
 
-def _graph_param_has_layer_name(param: tuple) -> bool:
-    return len(param) in (
-        PAGED_ATTENTION_GRAPH_PARAM_WITH_LAYER_LEN,
-        FIA_GRAPH_PARAM_WITH_LAYER_LEN,
-    )
+def _normalize_graph_param(param: AttentionGraphParam, fallback_layer_name: str) -> tuple[GraphParamKind, tuple, str]:
+    if not isinstance(param, AttentionGraphParam):
+        raise TypeError(f"Expected AttentionGraphParam, got {type(param).__name__}")
+    return param.kind, param.params, param.layer_name or fallback_layer_name
 
 
-def _split_graph_param_layer_name(param: tuple, fallback_layer_name: str) -> tuple[tuple, str]:
-    if _graph_param_has_layer_name(param):
-        return param[:-1], param[-1]
-    return param, fallback_layer_name
+def _get_graph_param_kind(param: AttentionGraphParam) -> GraphParamKind:
+    kind, _, _ = _normalize_graph_param(param, "")
+    return kind
 
 
 def _uses_sliding_window_attention(vllm_config: VllmConfig) -> bool:
@@ -456,7 +455,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             graph_params = get_graph_params()
         attn_params = graph_params.attn_params.get(num_tokens, [])
         uses_paged_attention_params = len(attn_params) > 0 and all(
-            _is_paged_attention_graph_param(param) for param in attn_params
+            _get_graph_param_kind(param) == "paged_attention" for param in attn_params
         )
 
         if uses_paged_attention_params or (using_paged_attention(num_tokens, vllm_config) and len(attn_params) == 0):
@@ -468,7 +467,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
                 ):
-                    param, layer_name = _split_graph_param_layer_name(param, key)
+                    _, param, layer_name = _normalize_graph_param(param, key)
                     (
                         query,
                         key_cache,
@@ -638,8 +637,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     graph_params.handles[num_tokens],
                     graph_params.events[num_tokens],
                 ):
-                    if _is_paged_attention_graph_param(param):
-                        param, layer_name = _split_graph_param_layer_name(param, key)
+                    param_kind, param, layer_name = _normalize_graph_param(param, key)
+                    if param_kind == "paged_attention":
                         (
                             query,
                             key_cache,
@@ -687,8 +686,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         torch.npu.graph_task_update_end(update_stream)
                         event.record(update_stream)
                         continue
-
-                    param, layer_name = _split_graph_param_layer_name(param, key)
 
                     (
                         query,
@@ -889,11 +886,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 weak_ref_tensors(layer._c8_k_aq_offset),
                 weak_ref_tensors(layer._c8_v_aq_scale),
                 weak_ref_tensors(layer._c8_v_aq_offset),
-                layer_name,
             )  # type: ignore
         else:
-            attn_params = attn_params + (None, None, None, None, layer_name)  # type: ignore
-        graph_params.attn_params[num_tokens].append(attn_params)
+            attn_params = attn_params + (None, None, None, None)  # type: ignore
+        graph_params.attn_params[num_tokens].append(AttentionGraphParam("fia", attn_params, layer_name))
 
         torch.npu.graph_task_group_begin(stream)
         torch_npu.npu_fused_infer_attention_score.out(
@@ -1050,16 +1046,19 @@ class AscendAttentionBackendImpl(AttentionImpl):
             event.reset(stream)
             graph_params.events[num_tokens].append(event)
             graph_params.attn_params[num_tokens].append(
-                (
-                    weak_ref_tensors(query),
-                    weak_ref_tensors(self.key_cache),
-                    weak_ref_tensors(self.value_cache),
-                    self.num_kv_heads,
-                    self.num_heads,
-                    self.scale,
-                    attn_metadata.block_tables,
-                    attn_metadata.seq_lens,
-                    weak_ref_tensors(output),
+                AttentionGraphParam(
+                    "paged_attention",
+                    (
+                        weak_ref_tensors(query),
+                        weak_ref_tensors(self.key_cache),
+                        weak_ref_tensors(self.value_cache),
+                        self.num_kv_heads,
+                        self.num_heads,
+                        self.scale,
+                        attn_metadata.block_tables,
+                        attn_metadata.seq_lens,
+                        weak_ref_tensors(output),
+                    ),
                     self._layer_name,
                 )
             )
@@ -1408,6 +1407,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self,
         attn_metadata: AscendMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor] | tuple[None, None]:
+        """Gather current-token KV from the producer layer's shared cache."""
+
         if self.key_cache is None or self.value_cache is None:
             return None, None
         num_tokens = attn_metadata.actual_seq_lengths_q[-1]
@@ -1455,8 +1456,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             if self.key_cache is None:
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
             if self.kv_sharing_target_layer_name is not None:
-                # KV-sharing target layers consume the producer layer's cache.
-                # Re-caching here would overwrite the shared KV slots.
+                # KV-sharing target layers, used by Gemma4 local/global layer
+                # pairs, consume the producer layer's cache. Re-caching here
+                # would overwrite the shared KV slots before attention reads it.
                 if self.is_kv_producer:
                     attn_metadata.reshape_cache_event.record()
                 return query, key, value, output

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 from collections.abc import Callable
 
 import torch
@@ -25,6 +26,21 @@ from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import split_tensor_along_first_dim
 from vllm_ascend.utils import get_weight_prefetch_method
+
+
+def _inspect_custom_routing_accepts_num_experts(custom_routing_function: Callable) -> bool:
+    try:
+        signature = inspect.signature(custom_routing_function)
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "num_experts"
+        for parameter in signature.parameters.values()
+    )
+
+
+def _custom_routing_accepts_num_experts(custom_routing_function: Callable) -> bool:
+    return _inspect_custom_routing_accepts_num_experts(custom_routing_function)
 
 
 def select_experts(
@@ -379,13 +395,15 @@ def _native_select_experts(
         topk_weights = topk_weights + e_score_correction_bias
 
     if custom_routing_function is not None:
-        topk_weights, topk_ids = custom_routing_function(
-            hidden_states=hidden_states,
-            gating_output=router_logits,
-            topk=top_k,
-            renormalize=renormalize,
-            num_experts=num_experts,
-        )
+        routing_kwargs = {
+            "hidden_states": hidden_states,
+            "gating_output": router_logits,
+            "topk": top_k,
+            "renormalize": renormalize,
+        }
+        if _custom_routing_accepts_num_experts(custom_routing_function):
+            routing_kwargs["num_experts"] = num_experts
+        topk_weights, topk_ids = custom_routing_function(**routing_kwargs)
         # Required by npu_moe_init_routing
         topk_ids = topk_ids.to(torch.int32)
         return topk_weights, topk_ids

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -372,6 +372,9 @@ def unquant_apply_mlp(
     if act_name == "swigluoai":
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
+    elif act_name == "gelu":
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        gate_up_out = torch.nn.functional.gelu(gate) * up
     else:
         gate_up_out = torch_npu.npu_swiglu(gate_up_out)
 

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -270,11 +270,13 @@ def rope_forward_triton(
 
     num_tokens, n_q_head, head_dim = q.shape
     n_kv_head = k.shape[1]
-    # TODO: use a more robust method to get BLOCK_SIZE_HEAD
+    # Keep the tile no larger than the local head count. Some TP-sharded
+    # models have very few heads per rank, and the previous fixed 64-head
+    # tile could exceed Ascend UB capacity even though most lanes were masked.
     if is_neox_style:
-        BLOCK_SIZE_HEAD = 64
+        BLOCK_SIZE_HEAD = min(64, triton.next_power_of_2(max(n_q_head, n_kv_head)))
     else:
-        BLOCK_SIZE_HEAD = 32
+        BLOCK_SIZE_HEAD = min(32, triton.next_power_of_2(max(n_q_head, n_kv_head)))
     num_vectorcore = get_vectorcore_num()
     n_row = min(num_tokens, num_vectorcore)
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2495,6 +2495,15 @@ class NPUModelRunner(GPUModelRunner):
             "inputs_embeds": inputs_embeds,
             **model_kwargs,
         }
+        if (
+            self.supports_mm_inputs
+            and model_inputs["input_ids"] is None
+            and inputs_embeds is not None
+        ):
+            # NPU graph compilation may still inspect input_ids shape even when
+            # the multimodal model consumes inputs_embeds. Keep a real tensor to
+            # avoid tracing None through the compiled language-model boundary.
+            model_inputs["input_ids"] = self.input_ids.gpu[:num_tokens_padded]
         run_model = partial(self.model, **model_inputs)
 
         if self.enable_enpu:
@@ -3177,7 +3186,14 @@ class NPUModelRunner(GPUModelRunner):
         ):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens
-            if self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
+            model_kwargs = self._init_model_kwargs()
+            if self.supports_mm_inputs and not self.model_config.is_encoder_decoder:
+                input_ids, inputs_embeds = self._prepare_mm_inputs(num_tokens_padded)
+                model_kwargs = {
+                    **model_kwargs,
+                    **self._dummy_mm_kwargs(num_reqs),
+                }
+            elif self.enable_prompt_embeds:
                 input_ids = None
                 inputs_embeds = self.inputs_embeds.gpu[:num_tokens_padded]
             else:
@@ -3244,7 +3260,12 @@ class NPUModelRunner(GPUModelRunner):
                 input_ids=input_ids,
             ):
                 outputs = self._model_forward(
-                    num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
+                    num_tokens_padded,
+                    input_ids,
+                    positions,
+                    intermediate_tensors,
+                    inputs_embeds,
+                    **model_kwargs,
                 )
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs


### PR DESCRIPTION
# [Feature][Attention][Kernel] Support Gemma4 large-head and KV-sharing inference on Ascend

## What This PR Does

This PR fixes Gemma4 inference failures on vLLM-Ascend without changing vLLM core.

Main changes:

- Add Ascend attention fallback for FIA TND unsupported head sizes.
- Fix KV-sharing layers so they do not overwrite shared KV cache and use shared K/V during prefill.
- Fix FULL_DECODE_ONLY graph replay when captured params are paged-attention params.
- Make MoE custom routing compatible with functions that do not accept `num_experts`.
- Adjust Triton RoPE head tile size for TP-sharded small local head counts.

Related issue: vllm-project/vllm-ascend#8986

## Validation

Real-weight Gemma4 validation:

| Model | TP | Validation |
|---|---:|---|
| `/mnt/weight/gemma-4-E2B-it` | 1 | text / image / audio / FULL_DECODE_ONLY |
| `/mnt/weight/gemma-4-E4B-it` | 1 | text / image / audio / FULL_DECODE_ONLY |
| `/mnt/weight/gemma-4-31B-it` | 4 | text / image / FULL_DECODE_ONLY |
| `/mnt/weight/gemma-4-26B-A4B-it` | 2 | text / image / EP / FULL_DECODE_ONLY |

Cross-model regression:

| Model | Purpose | Result |
|---|---|---|
| `/mnt/weight/Qwen3-0.6B` | normal head_dim=128 FIA/RoPE path | PASS |
| `/mnt/weight/Qwen3.5-4B` | non-Gemma large-head head_dim=256 path | PASS |
| `/mnt/weight/Qwen3-30B-A3B-Instruct-2507-w8a8` | MoE expert selector path | PASS |

Local checks:

- `python -m py_compile` on changed Python files: PASS
- direct custom-routing helper checks: PASS
- `git diff --check` on changed files: PASS

Could not run full `bash format.sh` in the nightly image because `pre-commit` is not installed and the configured proxy cannot reach the package index.

## Notes

No changes are made under `/vllm-workspace/vllm`.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
