### PR TITLE
[Misc] main2main 0519

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
+ARG VLLM_COMMIT=1ac10f159a09897baada01b14b6a0dd6442aefd6
 RUN git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD

--- a/.github/workflows/pr_test_full.yaml
+++ b/.github/workflows/pr_test_full.yaml
@@ -80,7 +80,7 @@ jobs:
     name: e2e-full
     strategy:
       matrix:
-        vllm_version: [0d4d334eaa583b9c09aa4eb7538c22db99fd84b3, v0.20.2]
+        vllm_version: [1ac10f159a09897baada01b14b6a0dd6442aefd6, v0.20.2]
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e_tracker == 'true' || needs.changes.outputs.e2e_tracker == true }}
     uses: ./.github/workflows/_e2e_test.yaml

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -41,7 +41,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_pre_commit.yml
     with:
-      vllm: 0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
+      vllm: 1ac10f159a09897baada01b14b6a0dd6442aefd6
   changes:
     runs-on: linux-aarch64-a2b3-0
     container:
@@ -157,7 +157,7 @@ jobs:
     if: ${{ needs.lint.result == 'success' && needs.changes.outputs.has_tests == 'true' }}
     strategy:
       matrix:
-        vllm_version: [0d4d334eaa583b9c09aa4eb7538c22db99fd84b3, v0.20.2]
+        vllm_version: [1ac10f159a09897baada01b14b6a0dd6442aefd6, v0.20.2]
     uses: ./.github/workflows/_optional_smart_e2e.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -167,7 +167,7 @@ jobs:
     name: e2e-light
     strategy:
       matrix:
-        vllm_version: [0d4d334eaa583b9c09aa4eb7538c22db99fd84b3, v0.20.2]
+        vllm_version: [1ac10f159a09897baada01b14b6a0dd6442aefd6, v0.20.2]
     # Note (yikun): If CI resource are limited we can split job into two chain jobs
     needs: [lint, changes]
     # only trigger e2e test after lint passed and the change is e2e related with pull request.

--- a/csrc/moe/chunk_fwd_o/tiling_base/error_log.h
+++ b/csrc/moe/chunk_fwd_o/tiling_base/error_log.h
@@ -1,26 +1,33 @@
 #ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
 #define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
 
+#include <cstdio>
 #include <string>
 #include "toolchain/slog.h"
 
 #define OP_LOGI(opname, ...)
 #define OP_LOGW(opname, ...)             \
     do {                                 \
-        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
-        printf("\n");                    \
+        (void)(opname);                  \
+        std::printf("[WARN] ");          \
+        std::printf(__VA_ARGS__);        \
+        std::printf("\n");              \
     } while (0)
 
 #define OP_LOGE_WITHOUT_REPORT(opname, ...) \
     do {                                    \
-        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
-        printf("\n");                       \
+        (void)(opname);                     \
+        std::printf("[ERRORx] ");           \
+        std::printf(__VA_ARGS__);           \
+        std::printf("\n");                 \
     } while (0)
 
 #define OP_LOGE(opname, ...)              \
     do {                                  \
-        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
-        printf("\n");                     \
+        (void)(opname);                   \
+        std::printf("[ERROR] ");          \
+        std::printf(__VA_ARGS__);         \
+        std::printf("\n");               \
     } while (0)
 
 #define OP_LOGD(opname, ...)

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/error_log.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/error_log.h
@@ -1,26 +1,33 @@
 #ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
 #define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
 
+#include <cstdio>
 #include <string>
 #include "toolchain/slog.h"
 
 #define OP_LOGI(opname, ...)
 #define OP_LOGW(opname, ...)             \
     do {                                 \
-        printf("[WARN][%s] ", (opname), ##__VA_ARGS__); \
-        printf("\n");                    \
+        (void)(opname);                  \
+        std::printf("[WARN] ");          \
+        std::printf(__VA_ARGS__);        \
+        std::printf("\n");              \
     } while (0)
 
 #define OP_LOGE_WITHOUT_REPORT(opname, ...) \
     do {                                    \
-        printf("[ERRORx][%s] ", (opname), ##__VA_ARGS__);  \
-        printf("\n");                       \
+        (void)(opname);                     \
+        std::printf("[ERRORx] ");           \
+        std::printf(__VA_ARGS__);           \
+        std::printf("\n");                 \
     } while (0)
 
 #define OP_LOGE(opname, ...)              \
     do {                                  \
-        printf("[ERROR][%s] ", (opname), ##__VA_ARGS__);    \
-        printf("\n");                     \
+        (void)(opname);                   \
+        std::printf("[ERROR] ");          \
+        std::printf(__VA_ARGS__);         \
+        std::printf("\n");               \
     } while (0)
 
 #define OP_LOGD(opname, ...)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ myst_substitutions = {
     # CANN image tag
     "cann_image_tag": "9.0.0-910b-ubuntu22.04-py3.11",
     # vLLM commit hash for main branch
-    "main_vllm_commit": "0d4d334eaa583b9c09aa4eb7538c22db99fd84b3",
+    "main_vllm_commit": "1ac10f159a09897baada01b14b6a0dd6442aefd6",
     # vLLM tag for main branch
     "main_vllm_tag": "v0.20.2",
     # Python version for main branch

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -182,7 +182,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # RoPE need (max_num_tokens,)
             self.positions = torch.zeros(self.max_num_tokens, dtype=torch.int32, device=device)
 
-        self.token_arange_np = np.arange(self.max_num_tokens + 1)
+        self.token_arange_np = np.arange(self.max_num_tokens + 1, dtype=np.int32)
         self.enable_enpu = self.runner.enable_enpu
         self.use_eagle = self.runner.use_eagle
 

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -80,6 +80,9 @@ def _gumbel_sample_kernel(
     local_argmax_stride,
     local_max_ptr,
     local_max_stride,
+    processed_logits_ptr,
+    processed_logits_stride,
+    processed_logits_col_ptr,
     logits_ptr,
     logits_stride,
     idx_mapping_ptr,
@@ -104,6 +107,20 @@ def _gumbel_sample_kernel(
     logits = logits.to(tl.float32)
 
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    if temp != 0.0 and APPLY_TEMPERATURE:
+        logits = logits / temp
+
+    if processed_logits_ptr is not None:
+        if processed_logits_col_ptr is not None:
+            col = tl.load(processed_logits_col_ptr)
+        else:
+            col = 0
+        tl.store(
+            processed_logits_ptr + req_state_idx * processed_logits_stride + col * vocab_size + block,
+            logits,
+            mask=mask,
+        )
+
     if temp != 0.0:
         # Calculate the seed for gumbel noise.
         seed = tl.load(seeds_ptr + req_state_idx)
@@ -118,12 +135,6 @@ def _gumbel_sample_kernel(
         r = tl.rand(gumbel_seed, block).to(tl.float32)
         gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
         gumbel_noise = gumbel_noise.to(tl.float32)
-
-        # Apply temperature.
-        if APPLY_TEMPERATURE:
-            # NOTE(woosuk): Match the behavior of _temperature_kernel.
-            # E.g., if the kernel uses tl.div_rn, we should use tl.div_rn here too.
-            logits = logits / temp
 
         # Apply gumbel noise.
         logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
@@ -142,8 +153,12 @@ def gumbel_sample(
     seed: torch.Tensor,  # [num_reqs]
     pos: torch.Tensor,  # [num_reqs]
     apply_temperature: bool,
-    processed_logits_out: torch.Tensor | None = None,  # [num_reqs, vocab_size]
+    output_processed_logits: torch.Tensor | None = None,
+    output_processed_logits_col: torch.Tensor | None = None,
+    use_fp64: bool = False,
 ) -> torch.Tensor:
+    if use_fp64:
+        raise NotImplementedError("FP64 Gumbel sampling is not supported on NPU.")
     num_reqs, vocab_size = logits.shape
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(vocab_size, BLOCK_SIZE)
@@ -165,6 +180,9 @@ def gumbel_sample(
         local_argmax.stride(0),
         local_max,
         local_max.stride(0),
+        output_processed_logits,
+        output_processed_logits.stride(0) if output_processed_logits is not None else 0,
+        output_processed_logits_col,
         logits,
         logits.stride(0),
         idx_mapping,

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -336,11 +336,14 @@ def rejection_sample(
     num_speculative_steps: int,
     # [num_speculative_steps]
     synthetic_conditional_rates: torch.Tensor | None = None,
+    use_fp64: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if use_fp64:
+        raise NotImplementedError("FP64 rejection sampling is not supported on NPU.")
     if synthetic_conditional_rates is not None:
         # Synthetic rejection sampling needs tl_rand64, which NPU Triton does
         # not support. The greedy fallback below would silently use u=0.0 and
-        # produce wrong acceptance — refuse loudly instead.
+        # produce wrong acceptance; refuse loudly instead.
         raise NotImplementedError(
             "Synthetic rejection sampling is not supported on NPU yet; use rejection_sample_method='standard'."
         )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates vllm-ascend main2main validation to:

- vLLM version: `v0.20.2`
- vLLM main commit: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
- vLLM diff: https://github.com/vllm-project/vllm/compare/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3...1ac10f159a09897baada01b14b6a0dd6442aefd6

Main upstream changes and vllm-ascend adaptations:

1. vLLM PR: https://github.com/vllm-project/vllm/pull/41775  
   `[Model Runner V2] FP32 gumbel sampling`

   Upstream changes:
   - Adds `use_fp64_gumbel` config / argument.
   - Changes Gumbel sampling and rejection sampling paths to accept `use_fp64`.
   - Makes FP32 Gumbel the default path and keeps FP64 optional.

   vllm-ascend adaptation:
   - Update `vllm_ascend/worker/v2/sample/gumbel.py` to accept `use_fp64`.
   - Update `vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py` to accept `use_fp64`.
   - Raise `NotImplementedError` for `use_fp64=True` on NPU because the current NPU Triton path does not support FP64 Gumbel / rejection sampling.

2. vLLM PR: https://github.com/vllm-project/vllm/pull/41162  
   `[Model Runner V2] Rebuild attn metadata between draft decode steps`

   Upstream changes:
   - Adds `output_processed_logits` / `output_processed_logits_col` protocol for EAGLE draft sampling.
   - Uses `output_processed_logits_col` to select the current speculative draft step when writing draft logits.

   vllm-ascend adaptation:
   - Add `output_processed_logits` and `output_processed_logits_col` support in NPU `gumbel_sample`.
   - Store processed logits before adding Gumbel noise so rejection sampling can consume the draft logits.


3. vLLM PR: https://github.com/vllm-project/vllm/pull/42692  
   `[Bugfix] DFlash FP8 KV-Cache`

   Upstream changes:
   - Changes `SpecDecodeBaseProposer.token_arange_np` from default NumPy integer dtype to `np.int32`.

   vllm-ascend adaptation:
   - Update `vllm_ascend/spec_decode/eagle_proposer.py` to use `np.arange(..., dtype=np.int32)`.
   - Keep the Ascend-specific `max_num_tokens + 1` behavior for `query_start_loc_cpu[:batch_size + 1]`.

4. No direct upstream vLLM PR

   vllm-ascend adaptation:
   - Fix `OP_LOGE` / `OP_LOGW` format warnings in:
     - `csrc/moe/chunk_fwd_o/tiling_base/error_log.h`
     - `csrc/moe/chunk_gated_delta_rule_fwd_h/tiling_base/error_log.h`

   Reason:
   - The old macros passed `std::string` to `%s`, which fails when the current build treats format warnings as errors.


### Does this PR introduce _any_ user-facing change?

No.

This PR is for main2main compatibility validation and internal NPU sampling / speculative decoding adaptation.

One behavior to note: if users explicitly enable `--use-fp64-gumbel` on NPU, vllm-ascend will raise `NotImplementedError`.

### How was this patch tested?

- vLLM version: `v0.20.2`
- vLLM main commit: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
- vLLM diff: https://github.com/vllm-project/vllm/compare/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3...1ac10f159a09897baada01b14b6a0dd6442aefd6
- Validation focus:
  - NPU Gumbel sampling
  - EAGLE / MTP speculative decoding
  - rejection sampling
  - custom op build