### PR TITLE
[Feature][EPLB] Optimize log2phy mapping for TP

### DIFF
--- a/tests/ut/eplb/core/a2/test_eplb_utils.py
+++ b/tests/ut/eplb/core/a2/test_eplb_utils.py
@@ -8,7 +8,7 @@ from vllm.config import VllmConfig
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig, FusedMoEParallelConfig
 
 from vllm_ascend.ascend_config import init_ascend_config
-from vllm_ascend.eplb.core.eplb_utils import init_eplb_config
+from vllm_ascend.eplb.core.eplb_utils import generate_log2phy_map, init_eplb_config
 # isort: on
 
 
@@ -68,6 +68,26 @@ class TestAscendConfig(unittest.TestCase):
         self.assertTrue(torch.equal(expert_map, gt_expert_map))
         self.assertTrue(torch.equal(log2phy, gt_log2phy))
         self.assertEqual(redundant_experts, 2)
+
+    def test_generate_log2phy_map_rotates_tail_tp_rank_with_tp_size(self):
+        global_expert_map = [
+            torch.tensor([0, -1], dtype=torch.int32),
+            torch.tensor([0, -1], dtype=torch.int32),
+            torch.tensor([0, -1], dtype=torch.int32),
+            torch.tensor([0, -1], dtype=torch.int32),
+            torch.tensor([-1, 0], dtype=torch.int32),
+            torch.tensor([-1, 0], dtype=torch.int32),
+            torch.tensor([-1, 0], dtype=torch.int32),
+            torch.tensor([-1, 0], dtype=torch.int32),
+        ]
+
+        fallback_tail_dp1 = generate_log2phy_map(global_expert_map, ep_rank=7)
+        rotated_tail_dp0 = generate_log2phy_map(global_expert_map, ep_rank=3, tp_size=4)
+        rotated_tail_dp1 = generate_log2phy_map(global_expert_map, ep_rank=7, tp_size=4)
+
+        self.assertTrue(torch.equal(fallback_tail_dp1, torch.tensor([3, 7], dtype=torch.int32)))
+        self.assertTrue(torch.equal(rotated_tail_dp0, torch.tensor([3, 4], dtype=torch.int32)))
+        self.assertTrue(torch.equal(rotated_tail_dp1, torch.tensor([0, 5], dtype=torch.int32)))
 
     def test_init_eplb_config_without_eplb(self):
         self.vllm_config.additional_config = {"refresh": True}

--- a/vllm_ascend/eplb/core/eplb_utils.py
+++ b/vllm_ascend/eplb/core/eplb_utils.py
@@ -61,7 +61,7 @@ def generate_global_placement(n_expert, ep_size, n_redundant, num_shared_experts
     return torch.tensor(groups, dtype=torch.int32)
 
 
-def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num_shared_experts=1):
+def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num_shared_experts=1, tp_size=None):
     expert_map_path = eplb_config.expert_map_path
     n_experts = moe_config.num_experts
     ep_size = moe_config.ep_size
@@ -94,12 +94,20 @@ def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num
         global_expert_map.append(expert_map)
         if rankid == moe_config.ep_rank:
             local_expert_map = expert_map
-    log2phy = generate_log2phy_map(global_expert_map, moe_config.ep_rank).npu() if eplb_enable else None
+    log2phy = (
+        generate_log2phy_map(
+            global_expert_map,
+            moe_config.ep_rank,
+            tp_size=int(tp_size) if tp_size is not None else None,
+        ).npu()
+        if eplb_enable
+        else None
+    )
 
     return torch.stack(global_expert_map), local_expert_map, log2phy, n_redundant
 
 
-def generate_log2phy_map(global_expert_map, ep_rank):
+def generate_log2phy_map(global_expert_map, ep_rank, tp_size: int | None = None):
     log2phy_map = defaultdict(list)
     valid_count = torch.sum(global_expert_map[0] != -1)
     for rankid, map_per_rank in enumerate(global_expert_map):
@@ -110,7 +118,13 @@ def generate_log2phy_map(global_expert_map, ep_rank):
 
     for key in log2phy_map:
         num_of_duplications = len(log2phy_map[key])
-        log2phy_map[key] = log2phy_map[key][ep_rank % num_of_duplications]
+        if tp_size is not None and tp_size > 1:
+            tp_rank = ep_rank % tp_size
+            dp_like_rank = ep_rank // tp_size
+            replica_index = (tp_rank + dp_like_rank + key) % num_of_duplications
+        else:
+            replica_index = ep_rank % num_of_duplications
+        log2phy_map[key] = log2phy_map[key][replica_index]
 
     log2phy_map = torch.scatter(
         torch.zeros(len(log2phy_map), dtype=torch.int32),

--- a/vllm_ascend/eplb/core/eplb_worker.py
+++ b/vllm_ascend/eplb/core/eplb_worker.py
@@ -27,12 +27,19 @@ from vllm_ascend.eplb.core.policy.policy_factory import PolicyFactory
 
 
 class EplbWorker:
-    def __init__(self, shared_dict, policy_type, enable_d2d: bool = True):
+    def __init__(
+        self,
+        shared_dict,
+        policy_type,
+        enable_d2d: bool = True,
+        tp_size: int | None = None,
+    ):
         self.policy_type = policy_type
         self.policy = PolicyFactory.generate_policy(policy_type)
         self.shared_dict = shared_dict
         self.old_expert_maps = None
         self.enable_d2d = enable_d2d
+        self.tp_size = tp_size
         self.rank_id = dist.get_rank()
         self.multi_stage = policy_type == 3
 
@@ -280,7 +287,11 @@ class EplbWorker:
 
             maps.append(new_expert_map[self.rank_id].numpy().tolist())
 
-            log2phy_map = generate_log2phy_map(new_expert_map, self.rank_id)
+            log2phy_map = generate_log2phy_map(
+                new_expert_map,
+                self.rank_id,
+                tp_size=self.tp_size,
+            )
             log2phy_all.append(log2phy_map.numpy().tolist())
 
             layer_ids.append(layer_id)
@@ -323,7 +334,13 @@ class EplbWorker:
 
 
 class EplbProcess:
-    def __init__(self, shared_dict, policy_type: int = 0, enable_d2d: bool = True):
+    def __init__(
+        self,
+        shared_dict,
+        policy_type: int = 0,
+        enable_d2d: bool = True,
+        tp_size: int | None = None,
+    ):
         """
         Args:
             shared_dict: Cross-process shared dict returned by Manager().dict()
@@ -337,7 +354,12 @@ class EplbProcess:
         self.block_update_q: Queue[Any] = Queue(maxsize=1)
 
         # Create EplbWorker instance
-        self.worker = EplbWorker(self.shared_dict, self.policy_type, self.enable_d2d)
+        self.worker = EplbWorker(
+            self.shared_dict,
+            self.policy_type,
+            self.enable_d2d,
+            tp_size=tp_size,
+        )
 
     def worker_process(self, planner_q, block_update_q):
         """

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -414,7 +414,12 @@ class AscendFusedMoE(FusedMoE):
         num_experts += num_shared_experts if self.mix_placement else 0
         self.moe_config.num_experts = num_experts
         self.global_expert_map, self._expert_map, self.log2phy, self.global_redundant_expert_num = init_eplb_config(
-            eplb_config, self.moe_instance_id, self.moe_config, self.mix_placement, num_shared_experts
+            eplb_config,
+            self.moe_instance_id,
+            self.moe_config,
+            self.mix_placement,
+            num_shared_experts,
+            tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
         )
         self.global_num_experts = num_experts + self.global_redundant_expert_num
         self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -495,7 +495,12 @@ class NPUModelRunner(GPUModelRunner):
             self.eplb_loader = D2DExpertWeightLoader()
             self.manager = Manager()
             self.shared_dict = self.manager.dict({"expert_map": None, "moe_load": None, "expert_maps": None})
-            self.eplb_process = EplbProcess(shared_dict=self.shared_dict, policy_type=self.policy_type, enable_d2d=True)
+            self.eplb_process = EplbProcess(
+                shared_dict=self.shared_dict,
+                policy_type=self.policy_type,
+                enable_d2d=True,
+                tp_size=self.parallel_config.tensor_parallel_size,
+            )
             self.process = self.eplb_process._launch_process()
             self.eplb_updator = EplbUpdator(eplb_config, self.eplb_loader, self.eplb_process, self.process)
             # In pd colocation scenarios, we find that prefill/decode requests result in different


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes EPLB `log2phy` map generation for tensor-parallel deployments.

Before this change, replicated experts were selected with the same rank-order pattern across DP groups. When TP was enabled, the extra replicas could concentrate on the same tail TP ranks, which made EPLB physical expert placement less balanced.

The patch passes `tp_size` into EPLB map generation and uses a TP-aware rotation when selecting replicated experts. This applies to both:

- initial fused MoE setup
- dynamic EPLB updates used by policy2 and policy3

The previous fallback behavior is preserved when `tp_size` is not provided.

### Does this PR introduce _any_ user-facing change?

No. This is an internal EPLB placement optimization.

There is no API, CLI, configuration, or documented behavior change.

### How was this patch tested?

- Added regression coverage in `tests/ut/eplb/core/a2/test_eplb_utils.py` for the previous tail-TP-rank replica concentration pattern.
- Kept coverage for the existing fallback behavior when `tp_size` is not provided.
- Manual NPU validation on four Ascend A3 servers with a 2P1D deployment and `tp=4`. With this PR, EPLB expert placement becomes more balanced and the expert-load peak-to-average ratio is effectively reduced.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/0decac0d96c42b49572498019f0a0e3600f50398
