### PR TITLE
[BugFix][310p] Fix torch-npu cannot import error

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -821,7 +821,7 @@ jobs:
           else
             pip install -e .
           fi
-          pip uninstall -y triton triton-ascend
+          pip uninstall -y triton-ascend triton
 
       - name: Uninstall triton-ascend (310p e2e-light)
         if: ${{ inputs.type == 'light' }}
@@ -931,7 +931,7 @@ jobs:
           else
             pip install -e .
           fi
-          pip uninstall -y triton triton-ascend
+          pip uninstall -y triton-ascend triton
 
       - name: Uninstall triton-ascend (310p e2e-light)
         if: ${{ inputs.type == 'light' }}

--- a/.github/workflows/pr_test_light.yaml
+++ b/.github/workflows/pr_test_light.yaml
@@ -80,6 +80,8 @@ jobs:
             ut_tracker:
               - 'tests/ut/**'
             _310_tracker:
+              - '.github/workflows/pr_test_light.yaml'
+              - '.github/workflows/_e2e_test.yaml'
               - 'vllm_ascend/_310p/**'
               - 'csrc/**'
               - 'tests/e2e/310p/**'

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -54,8 +54,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    python3 -m pip uninstall -y triton-ascend triton&& \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple && \
+    python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -51,8 +51,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
-    python3 -m pip uninstall -y triton-ascend triton&& \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple && \
+    python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc


### PR DESCRIPTION
### What this PR does / why we need it?

Fixed the recent CI failure on Ascend 310P where `torch_npu` could not be imported.

The root cause is related to the `torch-npu` 2.10.0 upgrade. After the upgrade, if a residual `triton` directory still exists in the environment, importing `torch_npu` may indirectly depend on `triton.language`. However, Triton is not supported on Ascend 310P and should be removed.

In the CI environment, `triton` had been uninstalled, but the cleanup was incomplete because of the uninstall order. We need to uninstall `triton-ascend` first and then uninstall `triton`; otherwise, some Triton-related files may remain.

The correct cleanup order is:

```bash
pip uninstall -y triton-ascend
pip uninstall -y triton
```
### Does this PR introduce _any_ user-facing change?

NA

### How was this patch tested?

CI 
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
