### PR TITLE
[Doc] Add comments for Functional Verification curl commands

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-R1.md
+++ b/docs/source/tutorials/models/DeepSeek-R1.md
@@ -238,6 +238,8 @@ This solution has been tested and demonstrates excellent performance.
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -655,6 +655,8 @@ To run the vllm-ascend `Prefill-Decode Disaggregation` service, you need to depl
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -867,6 +867,8 @@ python load_balance_proxy_layerwise_server_example.py \
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/DeepSeekOCR2.md
+++ b/docs/source/tutorials/models/DeepSeekOCR2.md
@@ -135,6 +135,8 @@ INFO:     Application startup complete.
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/GLM4.x.md
+++ b/docs/source/tutorials/models/GLM4.x.md
@@ -711,19 +711,21 @@ python load_balance_proxy_server_example.py \
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl -H "Accept: application/json" \
     -H "Content-type: application/json" \
     -X POST \
     -d '{
-        "model": "glm", 
-        "messages": [{ 
-            "role": "user", 
-            "content": "The future of AI is" 
-        }], 
-        "stream": false, 
-        "ignore_eos": false, 
-        "temperature": 0, 
-        "max_tokens": 200 
+        "model": "glm",
+        "messages": [{
+            "role": "user",
+            "content": "The future of AI is"
+        }],
+        "stream": false,
+        "ignore_eos": false,
+        "temperature": 0,
+        "max_tokens": 200
     }' http://<node0_ip>:<port>/v1/chat/completions
 ```
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -1338,6 +1338,8 @@ Please refer to the following python file for further explanation and restrictio
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -728,6 +728,8 @@ bash proxy.sh
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/Qwen3-235B-A22B.md
+++ b/docs/source/tutorials/models/Qwen3-235B-A22B.md
@@ -264,6 +264,8 @@ INFO:     Application startup complete.
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
@@ -219,7 +219,9 @@ INFO:     Application startup complete.
 
 Once your server is started, you can query the model with input prompts:
 
-```shell  
+```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -552,6 +552,8 @@ bash proxy.sh
 Once your server is started, you can query the model with input prompts:
 
 ```shell
+# Replace <node0_ip> with your primary node IP (e.g., localhost for single-node deployment)
+# Replace <port> with the port used when starting the server (default: 8000)
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{


### PR DESCRIPTION
Add clarifying comments to Functional Verification sections across multiple model documentation files to explain:
- `<node0_ip>` should be replaced with primary node IP (localhost for single-node)
- `<port>` should match the port used when starting the server (default: 8000)

Fixes: #8963
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
