### PR TITLE
[Misc] Remove useless argsort patch

### DIFF
--- a/vllm_ascend/patch/worker/patch_module.py
+++ b/vllm_ascend/patch/worker/patch_module.py
@@ -1,36 +1,3 @@
-import torch
-
-
-# torch_npu.argsort does not sipport bool now, it will support it in the future.
-# TODO When the operator of argsort is ready, this patch must be removed.
-def _argsort(tensor, *args, **kwargs):
-    if tensor.dtype == torch.bool:
-        # If it is not stable, it will have redundant outputs.
-        kwargs["stable"] = True
-        return torch.argsort(tensor.to(torch.int32), *args, **kwargs)
-    else:
-        return torch.argsort(tensor, *args, **kwargs)
-
-
-class _TorchWrapper:
-    def __init__(self):
-        self._raw_torch = torch
-
-    def __getattr__(self, name):
-        if name == "argsort":
-            return _argsort
-        else:
-            return getattr(self._raw_torch, name)
-
-
-_is_patched = False
-
-
-# patch argsort only for torch in gdn_attn
-def patch_torch_npu_argsort():
-    global _is_patched
-    if not _is_patched:
-        import vllm.v1.attention.backends.gdn_attn as gdn_attn
-
-        gdn_attn.torch = _TorchWrapper()
-        _is_patched = True
+# This file previously contained argsort patching for torch_npu.
+# Removed because torch_npu 2.10.0 fixed the bool argsort support.
+# See: https://github.com/vllm-project/vllm-ascend/issues/9241

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -119,7 +119,6 @@ from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.eplb.utils import model_register
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
-from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
@@ -2723,7 +2722,6 @@ class NPUModelRunner(GPUModelRunner):
             extra_attn_metadata_args = {}
             if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
                 assert ubid is None, "UBatching not supported with GDN yet"
-                patch_torch_npu_argsort()
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
                     num_decode_draft_tokens_cpu=self.num_decode_draft_tokens.cpu[:num_reqs_padded],


### PR DESCRIPTION
torch_npu 2.10.0 has fixed the bool support in torch.argsort, so the patch_torch_npu_argsort() workaround is no longer needed.

Fixes: #9241
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
