### PR TITLE
[DNM] Add custom triton kernel

### DIFF
--- a/vllm_ascend/patch/worker/patch_rejection_sampler.py
+++ b/vllm_ascend/patch/worker/patch_rejection_sampler.py
@@ -4,6 +4,7 @@ from vllm_ascend.sample.rejection_sampler import apply_sampling_constraints, exp
 
 # TODO: delete this patch after apply_sampling_constraints and rejection_sample
 #   are extracted to as class func of RejectionSampler
-rs.apply_sampling_constraints = apply_sampling_constraints
+# No need to patch now, using triton dispatcher instead.
+#rs.apply_sampling_constraints = apply_sampling_constraints
 rs.rejection_sample = rejection_sample
-rs.expand_batch_to_tokens = expand_batch_to_tokens
+#rs.expand_batch_to_tokens = expand_batch_to_tokens

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -152,6 +152,7 @@ class NPUPlatform(Platform):
         else:
             from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
 
+        from vllm_ascend import register_triton_kernels   # noqa: F401
         config_deprecated_logging()
 
     @classmethod

--- a/vllm_ascend/register_triton_kernels.py
+++ b/vllm_ascend/register_triton_kernels.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from vllm.model_executor.triton_dispatcher import register_kernel
+
+
+@register_kernel("vllm.v1.sample.rejection_sampler.expand_kernel")
+def expand_kernel_ascend(
+    output_ptr,
+    input_ptr,
+    cu_num_tokens_ptr,
+    replace_from,
+    replace_to,
+    MAX_NUM_TOKENS,
+    grid=None,
+):
+    """
+    Ascend implementation of expand_kernel.
+
+    This kernel expands a [batch_size] tensor to [num_tokens] tensor.
+    The Ascend implementation uses a different grid/block strategy for
+    better performance on NPU hardware.
+
+    Args:
+        output_ptr: Output tensor [num_tokens]
+        input_ptr: Input tensor [batch_size]
+        cu_num_tokens_ptr: Cumulative number of tokens [batch_size]
+        replace_from: Value to replace
+        replace_to: Replacement value
+        MAX_NUM_TOKENS: Maximum number of tokens (tl.constexpr)
+        grid: Grid configuration from dispatcher (batch_size)
+    """
+    from vllm_ascend.ops.triton.reject_sample import (
+        cal_grid_and_block_size,
+        expand_kernel,
+    )
+
+    batch_size = grid if isinstance(grid, int) else grid[0]
+    grid_size, block_size = cal_grid_and_block_size(batch_size)
+    vec_len = batch_size
+
+    expand_kernel[(grid_size,)](
+        output_ptr,
+        input_ptr,
+        cu_num_tokens_ptr,
+        replace_from,
+        replace_to,
+        vec_len,
+        MAX_NUM_TOKENS=MAX_NUM_TOKENS,
+        BLOCK_SIZE=block_size,
+    )


### PR DESCRIPTION
`expand_kernel` ascend implementation by triton register, instead of patch way. 

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
