### PR TITLE
[BugFix][Feature] Fix ACLGraph attn metadata key resolution and add dflash speculative decoding support

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -487,6 +487,15 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 return
             if _EXTRA_CTX.is_draft_model:
                 attn_keys = attn_keys * (len(graph_params.attn_params[num_tokens]) // num_layers)
+            def _resolve_attn_key(metadata: dict, captured_key, fallback_key):
+                if captured_key in metadata:
+                    return captured_key
+                if captured_key is not None:
+                    for candidate in metadata:
+                        if candidate.endswith(captured_key) or captured_key.endswith(candidate):
+                            return candidate
+                return fallback_key
+
             attn_count = 0
             with torch.npu.stream(update_stream):
                 for key, param, handle, event in zip(
@@ -516,19 +525,23 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         c8_k_aq_offset,
                         c8_v_aq_scale,
                         c8_v_aq_offset,
+                        *captured_layer_name,
                     ) = param
+                    captured_key = captured_layer_name[0] if captured_layer_name else None
 
                     if _EXTRA_CTX.is_draft_model:
                         draft_step = attn_count // num_layers
-                        seq_lens = attn_metadata[draft_step][key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
-                        block_tables = attn_metadata[draft_step][key].block_tables
+                        metadata_key = _resolve_attn_key(attn_metadata[draft_step], captured_key, key)
+                        seq_lens = attn_metadata[draft_step][metadata_key].seq_lens_list
+                        actual_seq_lengths_q = attn_metadata[draft_step][metadata_key].actual_seq_lengths_q
+                        block_tables = attn_metadata[draft_step][metadata_key].block_tables
                         attn_count = attn_count + 1
-                        if not attn_metadata[draft_step][key].causal:
+                        if not attn_metadata[draft_step][metadata_key].causal:
                             sparse_mode = 0
                     else:
-                        seq_lens = attn_metadata[key].seq_lens_list
-                        actual_seq_lengths_q = attn_metadata[key].actual_seq_lengths_q
+                        metadata_key = _resolve_attn_key(attn_metadata, captured_key, key)
+                        seq_lens = attn_metadata[metadata_key].seq_lens_list
+                        actual_seq_lengths_q = attn_metadata[metadata_key].actual_seq_lengths_q
                         # NOTE:
                         # For models with sliding-window attention on the FIA full-graph replay path,
                         # rebinding `block_tables` to the latest metadata tensor causes corrupted /
@@ -538,8 +551,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         # Non-SWA models preserve the original behavior and continue to refresh
                         # block_tables from attn_metadata.
                         if not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
-                            block_tables = attn_metadata[key].block_tables
-
+                            block_tables = attn_metadata[metadata_key].block_tables
                     torch.npu.graph_task_update_begin(update_stream, handle)
                     input_layout = "TND"
                     extra_args = {}
@@ -687,6 +699,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             pre_tokens,
             next_tokens,
         )
+        layer_name = getattr(layer, "layer_name", None)
         if self.enable_c8_quant:
             attn_params = attn_params + (
                 weak_ref_tensors(layer._c8_k_aq_scale),
@@ -696,6 +709,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             )  # type: ignore
         else:
             attn_params = attn_params + (None, None, None, None)  # type: ignore
+        attn_params = attn_params + (layer_name,)  # type: ignore
         graph_params.attn_params[num_tokens].append(attn_params)
 
         torch.npu.graph_task_group_begin(stream)
@@ -857,12 +871,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
         kv_cache=None,
+        layer: AttentionLayer | None = None,
     ):
         # we inherit ForwardContext in model runner v2, when enable model
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
         if _EXTRA_CTX.capturing:
-            attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output)
+            attn_output, num_tokens = self.full_graph_fia(query, key, value, attn_metadata, output, layer)
             output[:num_tokens] = attn_output[:num_tokens]
             return output
 
@@ -1066,6 +1081,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         kv_cache: tuple[torch.Tensor],
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        layer: AttentionLayer | None = None,
     ):
         num_tokens = query.shape[0]
         if (
@@ -1075,7 +1091,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         ):
             output = self.forward_paged_attention(query, attn_metadata, output)
         else:
-            output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, kv_cache)
+            output = self.forward_fused_infer_attention(query, key, value, attn_metadata, output, kv_cache, layer)
 
         return output
 
@@ -1139,9 +1155,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             output[:num_tokens] = attn_output[:num_tokens]
             return output
         if output_padded is not None:
-            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded)
+            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded, layer)
         else:
-            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output)
+            attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output, layer)
         output[:num_tokens] = attn_output[:num_tokens]
         return output
 
@@ -1220,9 +1236,9 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                     output[:num_tokens] = attn_output[:num_tokens]
                     return output
                 if output_padded is not None:
-                    attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded)
+                    attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output_padded, layer)
                 else:
-                    attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output)
+                    attn_output = self.forward_impl(query, key, value, kv_cache, attn_metadata, output, layer)
                 output[:num_tokens] = attn_output[:num_tokens]
                 return output
             elif not self.is_kv_producer:

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -209,15 +209,19 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
+            num_spec_decodes = attn_metadata.num_spec_decodes
+            spec_state_indices_actual = spec_state_indices_tensor[:num_spec_decodes]
+            num_accepted_tokens_actual = num_accepted_tokens[:num_spec_decodes]
+            spec_query_start_loc_actual = spec_query_start_loc[: num_spec_decodes + 1]
             mixed_qkv_spec = causal_conv1d_update_npu(
                 mixed_qkv_spec,
                 conv_state,
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=spec_state_indices_tensor[:, 0][: attn_metadata.num_spec_decodes],
-                num_accepted_tokens=num_accepted_tokens,
-                query_start_loc=spec_query_start_loc,
+                conv_state_indices=spec_state_indices_actual[:, 0],
+                num_accepted_tokens=num_accepted_tokens_actual,
+                query_start_loc=spec_query_start_loc_actual,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
             )
@@ -282,7 +286,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            cu_seqlens = spec_query_start_loc[: attn_metadata.num_spec_decodes + 1]
+            cu_seqlens = spec_query_start_loc_actual
             actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
             query_spec = l2norm_fwd(query_spec)
             key_spec = l2norm_fwd(key_spec)
@@ -299,8 +303,8 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 state=ssm_state,
                 scale=key_spec.shape[-1] ** -0.5,
                 actual_seq_lengths=actual_seq_lengths,
-                ssm_state_indices=spec_state_indices_tensor.flatten(),
-                num_accepted_tokens=num_accepted_tokens.to(torch.int32),
+                ssm_state_indices=spec_state_indices_actual.flatten(),
+                num_accepted_tokens=num_accepted_tokens_actual.to(torch.int32),
             ).unsqueeze(0)
         else:
             core_attn_out_spec, last_recurrent_state = None, None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -528,7 +528,10 @@ class NPUModelRunner(GPUModelRunner):
                 elif self.speculative_config.method == "extract_hidden_states":
                     assert isinstance(self.drafter, AscendExtractHiddenStatesProposer)
                     self.use_aux_hidden_state_outputs = True
-                self.rejection_sampler = RejectionSampler(self.sampler)
+                elif self.speculative_config.method == "dflash":
+                    assert isinstance(self.drafter, AscendDflashProposer)
+                    self.use_aux_hidden_state_outputs = True
+                self.rejection_sampler = RejectionSampler(self.sampler, self.speculative_config, self.device)
         self.discard_request_indices = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
         self.num_discarded_requests = 0
 
@@ -1476,14 +1479,22 @@ class NPUModelRunner(GPUModelRunner):
                     target_positions = self._get_positions(num_scheduled_tokens)
                     target_hidden_states = hidden_states
                     if self.use_aux_hidden_state_outputs:
-                        target_hidden_states = torch.cat([h for h in aux_hidden_states], dim=-1)
+                        target_hidden_states = (
+                            aux_hidden_states
+                            if isinstance(aux_hidden_states, torch.Tensor)
+                            else torch.cat([h for h in aux_hidden_states], dim=-1)
+                        )
                 else:
                     token_indices_to_sample = None
                     # input_ids can be None for multimodal models.
                     target_token_ids = self.input_ids.gpu[:num_scheduled_tokens]
                     target_positions = self._get_positions(num_scheduled_tokens)
                     if self.use_aux_hidden_state_outputs:
-                        target_hidden_states = torch.cat([h[:num_scheduled_tokens] for h in aux_hidden_states], dim=-1)
+                        target_hidden_states = (
+                            aux_hidden_states[:num_scheduled_tokens]
+                            if isinstance(aux_hidden_states, torch.Tensor)
+                            else torch.cat([h[:num_scheduled_tokens] for h in aux_hidden_states], dim=-1)
+                        )
                     else:
                         target_hidden_states = hidden_states[:num_scheduled_tokens]
             else:
@@ -1513,12 +1524,20 @@ class NPUModelRunner(GPUModelRunner):
                     target_positions = positions
                     target_hidden_states = hidden_states
                     if self.use_aux_hidden_state_outputs:
-                        target_hidden_states = torch.cat([h for h in aux_hidden_states], dim=-1)
+                        target_hidden_states = (
+                            aux_hidden_states
+                            if isinstance(aux_hidden_states, torch.Tensor)
+                            else torch.cat([h for h in aux_hidden_states], dim=-1)
+                        )
                 else:
                     target_token_ids = self.input_ids.gpu[token_indices]
                     target_positions = self._get_positions(token_indices)
                     if self.use_aux_hidden_state_outputs:
-                        target_hidden_states = torch.cat([h[token_indices] for h in aux_hidden_states], dim=-1)
+                        target_hidden_states = (
+                            aux_hidden_states[token_indices]
+                            if isinstance(aux_hidden_states, torch.Tensor)
+                            else torch.cat([h[token_indices] for h in aux_hidden_states], dim=-1)
+                        )
                     else:
                         target_hidden_states = hidden_states[token_indices]
             assert self.drafter is not None
@@ -2336,7 +2355,11 @@ class NPUModelRunner(GPUModelRunner):
         if isinstance(hidden_states, tuple):
             return (
                 NPUModelRunner._all_gather_hidden_states(hidden_states[0]),
-                NPUModelRunner._all_gather_hidden_states_list(hidden_states[1]),
+                (
+                    NPUModelRunner._all_gather_hidden_states(hidden_states[1])
+                    if isinstance(hidden_states[1], torch.Tensor)
+                    else NPUModelRunner._all_gather_hidden_states_list(hidden_states[1])
+                ),
             )
         return NPUModelRunner._all_gather_hidden_states(hidden_states)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR contains two bug fixes and one feature for speculative decoding on Ascend NPU:

#### 1. [BugFix] Fix attention metadata key resolution in ACLGraph FULL_DECODE_ONLY mode (`attention_v1.py`)

In `full_graph_fia`, the `layer_name` is now captured from the `AttentionLayer` object and stored as part of `attn_params`. During `update_graph_params`, a new helper `_resolve_attn_key` is used to look up the correct metadata key by matching against the captured layer name (exact match, suffix, or prefix fallback).

Without this fix, models whose attention layer name does not exactly match the positional key (e.g. Qwen3.5 variants) raise a `KeyError` when updating ACLGraph parameters in FULL_DECODE_ONLY mode.

**Root cause**: ACLGraph captures attention parameters by positional key at graph-capture time, but at update time the metadata dict is keyed by layer name. For architectures where these differ, the lookup fails silently or raises an error.

#### 2. [BugFix] Fix speculative tensor slicing in GDN forward pass (`ops/gdn.py`)

Pre-slice `spec_state_indices_tensor`, `num_accepted_tokens`, and `spec_query_start_loc` to `num_spec_decodes` length before passing into `causal_conv1d_update_npu` and `chunk_gated_delta_rule_npu`. Previously the full-length tensors were passed, causing shape mismatches when `num_spec_decodes < tensor.size(0)` in speculative decode steps.

#### 3. [Feature] Add `dflash` method support for speculative decoding (`worker/model_runner_v1.py`)

- Adds `elif method == "dflash"` branch in `_set_up_drafter`, asserting `AscendDflashProposer` and setting `use_aux_hidden_state_outputs = True`.
- Propagates `speculative_config` and `device` to `RejectionSampler` constructor.
- Handles `aux_hidden_states` being either a pre-concatenated `torch.Tensor` or a list of tensors, avoiding an unnecessary `torch.cat` when the drafter already returns a single tensor.

### Does this PR introduce _any_ user-facing change?

Yes: users can now enable DFlash speculative decoding via `--speculative-config '{"method": "dflash", ...}'` on Ascend NPU. Existing ACLGraph FULL_DECODE_ONLY workflows on Qwen3.5 are also fixed.

### How was this patch tested?

- Validated on Ascend 910B2, CANN 8.5.0
- Model: Qwen3-14B / Qwen3.5 series
- Speculative config: dflash method, FULL_DECODE_ONLY ACLGraph mode
- Confirmed no regression on standard (non-speculative) decode path
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
