### PR TITLE
[Feature] Add A5 MLA C8 feature

### DIFF
--- a/tests/ut/quantization/test_utils.py
+++ b/tests/ut/quantization/test_utils.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+from vllm.config import KVTransferConfig
+
 from tests.ut.base import TestBase
 from tests.ut.quantization.conftest_quantization import FAKQUANT_CONFIG, W8A8_CONFIG
 from vllm_ascend.quantization import AscendCompressedTensorsConfig
@@ -181,7 +183,7 @@ class TestEnableFaQuant(TestBase):
     def test_fa3_quantization_scenario(self):
         vllm_config = MagicMock()
         vllm_config.quant_config = AscendModelSlimConfig(FAKQUANT_CONFIG)
-        vllm_config.kv_transfer_config = None
+        vllm_config.kv_transfer_config = KVTransferConfig(kv_connector="MultiConnector", kv_role="kv_consumer")
         result = enable_fa_quant(vllm_config)
         self.assertTrue(result)
         result = enable_fa_quant(vllm_config, layer_name="test_layer")

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -759,7 +759,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         )
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
-        self.dtype = torch.int8 if self.fa_quant_layer else self.vllm_config.model_config.dtype
+        if self.fa_quant_layer:
+            self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+        else:
+            self.dtype = self.vllm_config.model_config.dtype
         self.layer_sharding_kwargs = []
         for layer_name in get_ascend_config().layer_sharding or []:
             if layer_name in kwargs:
@@ -981,30 +984,28 @@ class AscendMLAImpl(MLAAttentionImpl):
                 post_process_after_loading_for_shard_weight_series(layer)
 
     def _process_weights_for_fused_fa_quant(self):
-        self.gamma1 = self.q_a_layernorm.weight.data  # type: ignore[union-attr]
-        self.gamma2 = self.kv_a_layernorm.weight.data  # type: ignore[union-attr]
-
-        wu_q = self.q_proj.weight.data
-
-        self.wu_q = wu_q
-
-        q_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()  # type: ignore[union-attr]
-
-        self.wd_q = q_a_proj_fa3
-
-        kv_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-
-        self.wd_kv = kv_a_proj_fa3
-
-        self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
-        q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
-        self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
-        kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-        self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
-
-        layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
-        self.quant_kscale = layer.quant_kscale
-        self.fak_descale_float = layer.fak_descale_float
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
+            self.fak_descale_float = layer.fak_descale_float
+            self.quant_kscale = layer.quant_kscale
+            self.fak_descale_reciprocal = layer.fak_descale_reciprocal
+        else:
+            self.gamma1 = self.q_a_layernorm.weight.data  # type: ignore[union-attr]
+            self.gamma2 = self.kv_a_layernorm.weight.data  # type: ignore[union-attr]
+            wu_q = self.q_proj.weight.data
+            self.wu_q = wu_q
+            q_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()  # type: ignore[union-attr]
+            self.wd_q = q_a_proj_fa3
+            kv_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
+            self.wd_kv = kv_a_proj_fa3
+            self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
+            q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
+            self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
+            kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
+            self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
+            layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
+            self.quant_kscale = layer.quant_kscale
+            self.fak_descale_float = layer.fak_descale_float
 
     def _process_weights_for_fused_mlapo(self, act_dtype: torch.dtype):
         assert self.fused_qkv_a_proj is not None
@@ -1099,6 +1100,11 @@ class AscendMLAImpl(MLAAttentionImpl):
         weight_scale = weight_scale.reshape(-1, weight_scale.shape[1] * weight_scale.shape[2])
         self.weight_dq_scale = weight_scale[: self.q_lora_rank, ...]
         self.weight_dkv_kr_scale = weight_scale[self.q_lora_rank :, ...]
+        if self.fa_quant_layer:
+            layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
+            self.quant_kscale = layer.quant_kscale
+            self.fak_descale_float = layer.fak_descale_float
+            self.fak_descale_reciprocal = layer.fak_descale_reciprocal
 
     def get_context_seq_len_npu(self, index: int, attn_metadata: AscendMLAMetadata):
         prefill_metadata = attn_metadata.prefill
@@ -1159,8 +1165,14 @@ class AscendMLAImpl(MLAAttentionImpl):
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
             context_seq_len_npu = self.get_context_seq_len_npu(i, attn_metadata)
-            kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=q_nope.dtype, device=q_nope.device)
-            k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_nope.dtype, device=q_nope.device)
+            if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+                kv_c_normed = torch.empty(
+                    toks, num_heads, latent_kv_dim, dtype=cache_kv_c.dtype, device=cache_kv_c.device
+                )
+                k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
+            else:
+                kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=q_nope.dtype, device=q_nope.device)
+                k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_nope.dtype, device=q_nope.device)
 
             DeviceOperator.kv_cache_load(
                 cache_kv_c,
@@ -1179,6 +1191,10 @@ class AscendMLAImpl(MLAAttentionImpl):
                 toks=toks,
             )
             kv_c_normed = kv_c_normed.squeeze()
+            if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+                kv_c_normed = torch.mul(kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float).to(
+                    torch.bfloat16
+                )
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(-1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
             k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
             k_pe = k_pe.expand((*k_nope.shape[:-1], -1))
@@ -1291,6 +1307,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
+        c_kv_scale = None
+        if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+            c_kv_scale = self.fak_descale_reciprocal
         k_pe, k_nope, _, _ = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
             self.kv_a_layernorm.weight,  # type: ignore[union-attr]
@@ -1299,6 +1318,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             slots.to(torch.int64),
             kv_cache[1],
             kv_cache[0],
+            c_kv_scale=c_kv_scale,
             epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
             cache_mode=cache_mode,
         )
@@ -1319,6 +1339,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA"
+        c_kv_scale = None
+        if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+            c_kv_scale = self.fak_descale_reciprocal
         _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
             self.kv_a_layernorm.weight,  # type: ignore[union-attr]
@@ -1327,6 +1350,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             slots.to(torch.int64),
             kv_cache[1],
             kv_cache[0],
+            c_kv_scale=c_kv_scale,
             epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
             cache_mode=cache_mode,
             is_output_kv=True,
@@ -1361,7 +1385,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
         actual_seq_lengths = None
-        if self.fa_quant_layer:
+        if self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
             nz_fmt_last_dim = 16
             k_nope = k_nope.view(
                 -1, self.num_kv_heads, self.kv_lora_rank // (nz_fmt_last_dim * 2), block_size, nz_fmt_last_dim * 2
@@ -1407,7 +1431,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
             if self.fa_quant_layer:
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)
-        elif self.fa_quant_layer:
+        elif self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
             attn_mask = None
             input_layout = "BSND_NBSD"
             q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
@@ -1416,6 +1440,15 @@ class AscendMLAImpl(MLAAttentionImpl):
             sparse_mode = 0
             actual_seq_lengths = None
             attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
+        elif self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+            q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
+            q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
+            dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
+            attn_mask = None
+            input_layout = "BNSD"
+            sparse_mode = 0
+            actual_seq_lengths = None
+            attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1556,10 +1589,18 @@ class AscendMLAImpl(MLAAttentionImpl):
         sin = attn_metadata.decode.sin
         decode_ql_nope, decode_q_pe = self._q_proj_and_k_up_proj(decode_q_c)
         decode_q_pe = self.rope_single(decode_q_pe, cos, sin)
+        dequant_scale_q_nope = None
+        if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+            decode_ql_nope, dequant_scale_q_nope = torch_npu.npu_dynamic_quant(
+                decode_ql_nope, dst_type=torch.float8_e4m3fn
+            )
+            decode_q_pe = (decode_q_pe / dequant_scale_q_nope.unsqueeze(-1) / self.fak_descale_float).to(torch.bfloat16)
         decode_slots = attn_metadata.slot_mapping[:num_decode_tokens:1]
         decode_kv_no_split = kv_no_split[:num_decode_tokens]
         decode_k_pe, decode_k_nope = self.exec_kv_decode(decode_kv_no_split, cos, sin, kv_cache, decode_slots)
-        return DecodeMLAPreprocessResult(decode_ql_nope, decode_q_pe, decode_k_nope, decode_k_pe)
+        return DecodeMLAPreprocessResult(
+            decode_ql_nope, decode_q_pe, decode_k_nope, decode_k_pe, dequant_scale_q_nope=dequant_scale_q_nope
+        )
 
     def _mla_preprocess(self, layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv):
         # MLA Preprocess:
@@ -1670,10 +1711,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
         # MLA Preprocess
-        if self.fa_quant_layer or (
-            self.enable_mlapo
-            and attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
-            and attn_metadata.num_prefills == 0
+        if (self.fa_quant_layer or self.enable_mlapo) and (
+            attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS and attn_metadata.num_prefills == 0
         ):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                 hidden_states.contiguous(), need_gather_q_kv

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1165,14 +1165,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
             context_seq_len_npu = self.get_context_seq_len_npu(i, attn_metadata)
-            if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
-                kv_c_normed = torch.empty(
-                    toks, num_heads, latent_kv_dim, dtype=cache_kv_c.dtype, device=cache_kv_c.device
-                )
-                k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
-            else:
-                kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=q_nope.dtype, device=q_nope.device)
-                k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_nope.dtype, device=q_nope.device)
+            kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=cache_kv_c.dtype, device=cache_kv_c.device)
+            k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
 
             DeviceOperator.kv_cache_load(
                 cache_kv_c,
@@ -1433,22 +1427,20 @@ class AscendMLAImpl(MLAAttentionImpl):
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)
         elif self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
             attn_mask = None
-            input_layout = "BSND_NBSD"
-            q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
-            q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
-            dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
             sparse_mode = 0
             actual_seq_lengths = None
-            attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
-        elif self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
-            q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
-            q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-            dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-            attn_mask = None
-            input_layout = "BNSD"
-            sparse_mode = 0
-            actual_seq_lengths = None
-            attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
+            if get_ascend_device_type() == AscendDeviceType.A5:
+                input_layout = "BNSD"
+                q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
+                q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
+                dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
+                attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
+            else:
+                input_layout = "BSND_NBSD"
+                q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
+                q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
+                dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
+                attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1425,7 +1425,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
             if self.fa_quant_layer:
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)
-        elif self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
+        elif self.fa_quant_layer:
             attn_mask = None
             sparse_mode = 0
             actual_seq_lengths = None

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -578,10 +578,8 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         cos_shape = attn_metadata.decode.cos.shape
         cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
         sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
-
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
-
-        decode_q_nope, decode_q_pe, _, _, _ = torch_npu.npu_mla_prolog_v3(
+        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
             token_x=hidden_states,
             weight_dq=atten_obj.weight_dq,
             weight_uq_qr=atten_obj.weight_uq_qr,
@@ -599,17 +597,20 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             dequant_scale_w_uq_qr=atten_obj.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
             dequant_scale_w_dkv_kr=atten_obj.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
             cache_mode="PA_BSND",
-            query_quant_mode=0,
+            query_quant_mode=1 if atten_obj.fa_quant_layer else 0,
             weight_quant_mode=3,
+            kv_cache_quant_mode=1 if atten_obj.fa_quant_layer else 0,
+            quant_scale_ckv=atten_obj.fak_descale_reciprocal if atten_obj.fa_quant_layer else None,
         )
-
         decode_q_nope = decode_q_nope.view(bsz, atten_obj.num_heads, atten_obj.kv_lora_rank)
         decode_q_pe = decode_q_pe.view(bsz, atten_obj.num_heads, -1)
 
         decode_q_nope, decode_q_pe = atten_obj.reorg_decode_q(decode_q_nope, decode_q_pe)
         from vllm_ascend.attention.mla_v1 import DecodeMLAPreprocessResult
 
-        decode_preprocess_res = DecodeMLAPreprocessResult(decode_q_nope, decode_q_pe, decode_k_nope, decode_k_pe)
+        decode_preprocess_res = DecodeMLAPreprocessResult(
+            decode_q_nope, decode_q_pe, decode_k_nope, decode_k_pe, dequant_scale_q_nope=dequant_scale_q_nope
+        )
         return decode_preprocess_res, None
 
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1256,7 +1256,7 @@ class MooncakeConnectorWorker:
             for i in range(len(first_kv_cache_tuple)):
                 block_shape = first_kv_cache_tuple[i].shape[-block_rank:]
                 logger.info("block_shape: %s", block_shape)
-                self.block_len.append(first_kv_cache[i].element_size() * math.prod(block_shape))
+                self.block_len.append(first_kv_cache_tuple[i].element_size() * math.prod(block_shape))
         else:
             # eager:[num_block, block_size, num_head, hidden_dim]
             block_rank = (

--- a/vllm_ascend/quantization/methods/kv_c8.py
+++ b/vllm_ascend/quantization/methods/kv_c8.py
@@ -2,6 +2,8 @@ import torch
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
 from .base import AscendAttentionScheme
 from .registry import register_scheme
 
@@ -55,7 +57,10 @@ class AscendFAQuantAttentionMethod:
         fa_k_scale = torch.squeeze(layer.fa_k.scale).unsqueeze(0)
         layer.fak_descale_float = torch.nn.Parameter(fa_k_scale.to(torch.float), requires_grad=False)
         layer.fak_descale = torch.nn.Parameter(fa_k_scale, requires_grad=False)
-        layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale, requires_grad=False)
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale.to(torch.float), requires_grad=False)
+        else:
+            layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale, requires_grad=False)
         fa_k_offset = torch.squeeze(layer.fa_k.offset).unsqueeze(0)
         layer.fak_offset = torch.nn.Parameter(fa_k_offset.to(layer.fak_descale.dtype), requires_grad=False)
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -41,7 +41,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.layers.vocab_parallel_embedding import UnquantizedEmbeddingMethod, VocabParallelEmbedding
 from vllm.model_executor.models.utils import WeightsMapper
 
-from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, calc_split_factor
+from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, AscendDeviceType, calc_split_factor, get_ascend_device_type
 
 from .methods import get_scheme_class
 
@@ -600,7 +600,10 @@ class AscendModelSlimConfig(QuantizationConfig):
             and vllm_config.kv_transfer_config.is_kv_consumer
             and not vllm_config.kv_transfer_config.is_kv_producer
         )
-        return bool(is_decode_instance and self.is_fa_quant_layer(layer_name))
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            return self.is_fa_quant_layer(layer_name)
+        else:
+            return bool(is_decode_instance and self.is_fa_quant_layer(layer_name))
 
     def is_indexer_quant_layer(self, prefix):
         if self.enable_indexer_quant:
@@ -612,7 +615,7 @@ class AscendModelSlimConfig(QuantizationConfig):
     def get_kv_quant_dtype(self, layer_name, cache_dtype, model_config):
         if self.enable_fa_quant and self.is_fa_quant_layer(layer_name):
             ori_dtype = model_config.dtype
-            quant_dtype = torch.int8
+            quant_dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
             # For MLA models like deepseek, we only quantify K cache to ensure accuracy
             if model_config.use_mla:
                 return quant_dtype, ori_dtype

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -21,7 +21,12 @@ from pathlib import Path
 from vllm import envs
 from vllm.logger import logger
 
-from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD
+from vllm_ascend.utils import (
+    ASCEND_QUANTIZATION_METHOD,
+    COMPRESSED_TENSORS_METHOD,
+    AscendDeviceType,
+    get_ascend_device_type,
+)
 
 
 def get_model_file(
@@ -200,6 +205,9 @@ def maybe_auto_detect_quantization(vllm_config) -> None:
 
 
 def enable_fa_quant(vllm_config, layer_name=None) -> bool:
+    is_kv_consumer = vllm_config.kv_transfer_config is not None and vllm_config.kv_transfer_config.is_kv_consumer
+    if not is_kv_consumer and get_ascend_device_type() != AscendDeviceType.A5:
+        return False
     if vllm_config.quant_config is not None and getattr(vllm_config.quant_config, "enable_fa_quant", False):
         if layer_name is not None:
             return vllm_config.quant_config.enabling_fa_quant(vllm_config, layer_name)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3646,7 +3646,7 @@ class NPUModelRunner(GPUModelRunner):
                             k_dim,
                             v_dim,
                         ]
-                        if self.is_kv_consumer and enable_fa_quant(self.vllm_config):
+                        if enable_fa_quant(self.vllm_config):
                             k_tensor_split_factor, v_tensor_split_factor = (
                                 self.vllm_config.quant_config.get_kv_quant_split_factor(layer_name, kv_head_dim_list)
                             )
@@ -3929,7 +3929,7 @@ class NPUModelRunner(GPUModelRunner):
                             v_dim,
                         )
                     k_cache_dtype = v_cache_dtype = current_kv_cache_spec.dtype
-                    if self.is_kv_consumer and enable_fa_quant(self.vllm_config):
+                    if enable_fa_quant(self.vllm_config):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -234,9 +234,6 @@ def _allocate_kv_cache(
             to their corresponding memory buffer for K cache and V cache
     """
     vllm_config = get_current_vllm_config()
-    is_kv_consumer = (
-        vllm_config.kv_transfer_config.is_kv_consumer if vllm_config.kv_transfer_config is not None else False
-    )
 
     # init kv cache tensors
     kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -260,7 +257,7 @@ def _allocate_kv_cache(
         k_dim, v_dim = _get_attention_kv_cache_dims(example_layer_name, example_kv_cache_spec)
         assert k_dim > 0 and v_dim > 0
         kv_head_dim_list = [k_dim, v_dim]
-        if is_kv_consumer and enable_fa_quant(vllm_config):
+        if enable_fa_quant(vllm_config):
             k_tensor_split_factor, v_tensor_split_factor = vllm_config.quant_config.get_kv_quant_split_factor(
                 example_layer_name, kv_head_dim_list
             )
@@ -307,9 +304,6 @@ def _reshape_kv_cache(
             to their corresponding memory buffer for KV cache
     """
     vllm_config = get_current_vllm_config()
-    is_kv_consumer = (
-        vllm_config.kv_transfer_config.is_kv_consumer if vllm_config.kv_transfer_config is not None else False
-    )
 
     kv_caches: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
     for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
@@ -358,7 +352,7 @@ def _reshape_kv_cache(
                     v_shape = (mla_num_blocks, mla_block_size, num_kv_heads, v_dim)
 
                 k_cache_dtype = v_cache_dtype = kv_cache_spec.dtype
-                if is_kv_consumer and enable_fa_quant(vllm_config):
+                if enable_fa_quant(vllm_config):
                     k_cache_dtype, v_cache_dtype = vllm_config.quant_config.get_kv_quant_dtype(
                         layer_name, kv_cache_spec.dtype, vllm_config.model_config
                     )


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces support for the A5 MLA C8 feature on Ascend devices. Key changes include:
- Support for `float8_e4m3fn` data type in MLA quantization for A5 hardware.
- Configuration updates in `modelslim_config.py` to handle A5-specific quantization requirements.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The PR does not specify testing details. It is recommended to verify the changes with MLA-based models on A5 hardware.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
