### PR TITLE
[Feature] chunk_gated_delta_rule_fwd_h supports kvcache discontin…

### DIFF
--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
@@ -53,7 +53,7 @@ public:
             .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .AutoContiguous();
+            .IgnoreContiguous();
 
         this->Input("cu_seqlens")
             .ParamType(OPTIONAL)
@@ -91,6 +91,7 @@ public:
 
         this->Attr("output_final_state").AttrType(REQUIRED).Bool(false);
         this->Attr("chunk_size").AttrType(REQUIRED).Int(64);
+        this->Attr("inital_state_stride0").AttrType(REQUIRED).Int(0);
 
         OpAICoreConfig aicore_config;
         aicore_config.DynamicCompileStaticFlag(true)

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.cpp
@@ -28,6 +28,7 @@ static constexpr size_t INPUT_CHUNK_INDICES_IDX = 6;
 
 static constexpr size_t ATTR_STORE_FINAL_STATE_IDX = 0;
 static constexpr size_t ATTR_CHUNK_SIZE_IDX = 1;
+static constexpr size_t ATTR_INITIAL_STATE_STRIDE_IDX = 2;
 
 static constexpr size_t DIM_BATCH = 0;
 static constexpr size_t DIM_HEAD_NUM = 1;
@@ -106,6 +107,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
     auto attrPtr = context->GetAttrs();
     bool storeFinalState = *(attrPtr->GetAttrPointer<bool>(ATTR_STORE_FINAL_STATE_IDX));
     int64_t chunkSize = *(attrPtr->GetAttrPointer<int64_t>(ATTR_CHUNK_SIZE_IDX));
+    int64_t initalStateStride0 = *(attrPtr->GetAttrPointer<int64_t>(ATTR_INITIAL_STATE_STRIDE_IDX));
 
     auto dtype = context->GetInputTensor(0)->GetDataType();
     uint64_t dataType =  dtype == ge::DT_BF16 ? 1 : 0;
@@ -147,6 +149,7 @@ ge::graphStatus Tiling4ChunkGatedDeltaRuleFwdH(gert::TilingContext *context)
     tiling.set_kHeadDim(kHeadDim);
     tiling.set_vHeadDim(vHeadDim);
     tiling.set_chunkSize(chunkSize);
+    tiling.set_initalStateStride0(initalStateStride0);
     tiling.set_useInitialState(useInitialState);
     tiling.set_storeFinalState(storeFinalState);
     tiling.set_dataType(dataType);

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_tiling.h
@@ -28,6 +28,7 @@ TILING_DATA_FIELD_DEF(int64_t, vNumHead);
 TILING_DATA_FIELD_DEF(int64_t, kHeadDim);
 TILING_DATA_FIELD_DEF(int64_t, vHeadDim);
 TILING_DATA_FIELD_DEF(int64_t, chunkSize);
+TILING_DATA_FIELD_DEF(int64_t, initalStateStride0);
 TILING_DATA_FIELD_DEF(bool, useInitialState);
 TILING_DATA_FIELD_DEF(bool, storeFinalState);
 TILING_DATA_FIELD_DEF(int64_t, dataType);

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/aclnn_chunk_gated_delta_rule_fwd_h.cpp
@@ -11,6 +11,7 @@
 #include "chunk_gated_delta_rule_fwd_h.h"
 #include <dlfcn.h>
 #include <new>
+#include <iostream>
 
 #include "aclnn_kernels/transdata.h"
 #include "aclnn_kernels/contiguous.h"
@@ -183,7 +184,19 @@ aclnnStatus aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize(
     CHECK_RET(ret == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
     CHECK_COND(ParamsDataContiguous(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID,
                "ParamsDataContiguous failed.");
-    auto result = l0op::ChunkGatedDeltaRuleFwdH(params.k, params.w, params.u, params.gOptional, params.initalStateOptional, params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize, params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
+
+    // aclGetViewStrides obtains the strides and the number of strides corresponding to aclTensor
+    int64_t *initialStateStridesValuePtr = nullptr;
+    int64_t initialStateStridesValue = 0;
+    uint64_t initialStateStridesNum = 0;
+
+    if (initalStateOptional != nullptr) {
+        ret = aclGetViewStrides(initalStateOptional, &initialStateStridesValuePtr, &initialStateStridesNum);
+        CHECK_RET(ret == ACLNN_SUCCESS, ret);
+        initialStateStridesValue = initialStateStridesValuePtr[initialStateStridesNum - 2];
+    }
+
+    auto result = l0op::ChunkGatedDeltaRuleFwdH(params.k, params.w, params.u, params.gOptional, params.initalStateOptional, params.cuSeqlensOptional, params.chunkIndicesOptional, params.outputFinalState, params.chunkSize, initialStateStridesValue, params.hOut, params.vNewOut, params.finalStateOut, executorPtr);
     CHECK_RET(result[0] != nullptr, ACLNN_ERR_PARAM_NULLPTR);
 
     // If the output tensor is non-contiguous, convert the calculated contiguous tensor to non-contiguous.

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.cpp
@@ -28,12 +28,13 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     const aclIntArray *chunkIndicesOptional,
     bool outputFinalState,
     int64_t chunkSize,
+    int64_t initialStateStridesValue,
     const aclTensor *hOut,
     const aclTensor *vNewOut,
     const aclTensor *finalStateOut,
     aclOpExecutor *executor)
 {
-    L0_DFX(ChunkGatedDeltaRuleFwdH, k, w, u, g, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional, outputFinalState, chunkSize, hOut, vNewOut, finalStateOut);
+    L0_DFX(ChunkGatedDeltaRuleFwdH, k, w, u, g, initalStateOptional, cuSeqlensOptional, chunkIndicesOptional, outputFinalState, chunkSize, initialStateStridesValue, hOut, vNewOut, finalStateOut);
 
     const aclTensor *actualCuSeqlens = nullptr;
     if (cuSeqlensOptional) {
@@ -58,7 +59,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkGatedDeltaRuleFwdH,
         OP_INPUT(k, w, u, g, initalStateOptional, actualCuSeqlens, actualChunkIndices),
         OP_OUTPUT(hOut, vNewOut, finalStateOut),
-        OP_ATTR(outputFinalState, chunkSize));
+        OP_ATTR(outputFinalState, chunkSize, initialStateStridesValue));
     if (ret != ACLNN_SUCCESS) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ADD_TO_LAUNCHER_LIST_AICORE failed.");
         return {nullptr, nullptr, nullptr};

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/op_api/chunk_gated_delta_rule_fwd_h.h
@@ -23,6 +23,7 @@ const std::array<const aclTensor *, 3> ChunkGatedDeltaRuleFwdH(
     const aclIntArray *chunkIndicesOptional,
     bool outputFinalState,
     int64_t chunkSize,
+    int64_t initialStateStridesValue,
     const aclTensor *hOut,
     const aclTensor *vNewOut,
     const aclTensor *finalStateOut,

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -63,6 +63,7 @@ struct BlockSchedulerGdnFwdH {
     uint32_t kHeadDim;
     uint32_t vHeadDim;
     uint32_t chunkSize;
+    uint32_t initalStateStride0;
     uint32_t vBlockSize{128};
     uint32_t isVariedLen;
     uint32_t shapeBatch;
@@ -130,6 +131,7 @@ struct BlockSchedulerGdnFwdH {
         kHeadDim = gdnFwdHTilingData->kHeadDim;
         vHeadDim = gdnFwdHTilingData->vHeadDim;
         chunkSize = gdnFwdHTilingData->chunkSize;
+        initalStateStride0 = gdnFwdHTilingData->initalStateStride0;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
         shapeBatch = gdnFwdHTilingData->shapeBatch;
         tokenBatch = gdnFwdHTilingData->tokenBatch;
@@ -210,7 +212,7 @@ struct BlockSchedulerGdnFwdH {
         kHeadIdx = vHeadIdx / headGroups;
         offsets[currStage].isInitialState = chunkIdx == 0; 
         offsets[currStage].isFinalState = chunkIdx == (batchChunks - 1);
-        offsets[currStage].initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * vHeadDim; 
+        offsets[currStage].initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * initalStateStride0;
         offsets[currStage].finalStateOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * vHeadDim;  
         offsets[currStage].hSrcOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset + chunkIdx) * kHeadDim * vHeadDim;
         offsets[currStage].hDstOffset = offsets[currStage].hSrcOffset + kHeadDim * vHeadDim;

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -154,6 +154,7 @@ public:
     uint32_t kHeadDim;
     uint32_t vHeadDim;
     uint32_t chunkSize;
+    uint32_t initalStateStride0;
     bool useInitialState;
     bool storeFinalState;
     uint32_t isVariedLen;
@@ -201,6 +202,7 @@ public:
         kHeadDim = gdnFwdHTilingData->kHeadDim;
         vHeadDim = gdnFwdHTilingData->vHeadDim;
         chunkSize = gdnFwdHTilingData->chunkSize;
+        initalStateStride0 = gdnFwdHTilingData->initalStateStride0;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
@@ -320,19 +322,21 @@ public:
                 uint32_t pingpongFlag = 1;
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+                AscendC::DataCopyParams repeatParams = {static_cast<uint16_t>(kHeadDim), static_cast<uint16_t>(vHeadDim * sizeof(ElementInitialState) / 32), 
+                    static_cast<uint16_t>((initalStateStride0 - vHeadDim)* sizeof(ElementInitialState) / 32), static_cast<uint16_t>(0)};
                 for (uint32_t shapeBatchIdx = 0; shapeBatchIdx < shapeBatch; shapeBatchIdx++) {
                     for (uint32_t vHeadIdx = 0; vHeadIdx < vNumHead; vHeadIdx++) {
                         for (uint32_t tokenBatchIdx = 0; tokenBatchIdx < vecBlockScheduler.tokenBatch; tokenBatchIdx++) {
                             uint32_t batchIdx = isVariedLen ? tokenBatchIdx : shapeBatchIdx;
                             uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
-                            uint32_t initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * stateBlockSize;
+                            uint32_t initialStateSrcOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * initalStateStride0;
                             uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
                             AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
                             AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
                             auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
                             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
                             if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], repeatParams);
                                 AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
                                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
                                 AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
@@ -340,7 +344,7 @@ public:
                                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
                                 AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
                             } else {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], repeatParams);
                                 AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
                                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
                                 AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);


### PR DESCRIPTION
### What this PR does / why we need it?
for memory optimization: chunk_gated_delta_rule_fwd_h supports kvcache discontinuous
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
test gpqa on Qwen3.6-27B
modify before, average 85.048:
```
| GPQA_diamond | b1ed2c | accuracy | gen | 84.34 |
| GPQA_diamond | b1ed2c | accuracy | gen | 84.34 |
| GPQA_diamond | b1ed2c | accuracy | gen | 84.85 |
| GPQA_diamond | b1ed2c | accuracy | gen | 87.37 |
| GPQA_diamond | b1ed2c | accuracy | gen | 84.34 |
```
modify after, average 85.656:
```
| GPQA_diamond | b1ed2c | accuracy | gen | 87.37 |
| GPQA_diamond | b1ed2c | accuracy | gen | 85.86 |
| GPQA_diamond | b1ed2c | accuracy | gen | 85.86 |
| GPQA_diamond | b1ed2c | accuracy | gen | 84.85 |
| GPQA_diamond | b1ed2c | accuracy | gen | 84.34 |
```
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
