### PR TITLE
[Doc] Pin Read the Docs build to Python 3.11 to match support matrix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
### What this PR does / why we need it?

`.readthedocs.yaml` was pinning the docs build to Python 3.12, while the
project-wide support matrix (`README.md`, `README.zh.md`,
`docs/source/installation.md`, `docs/source/conf.py`, `CMakeLists.txt`,
`setup.py`) requires `Python >= 3.10, < 3.12` because of the `torch-npu`
and CANN wheel matrix. This PR aligns the Read the Docs build with the
documented support matrix and with `Dockerfile`'s `py3.11` base image.

Fixes #9289

### Does this PR introduce _any_ user-facing change?

No runtime change. Documentation build now runs on Python 3.11, which is
the highest version the project actually supports.

### How was this patch tested?

- Read the Docs preview build on the PR branch (3.11) succeeds.
- Grep confirms no other location in the repo references Python 3.12.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
