### PR TITLE
[EPLB][Feature] update log2phy by asynchronus copy

### DIFF
--- a/tests/ut/eplb/core/test_eplb_device_transfer_loader.py
+++ b/tests/ut/eplb/core/test_eplb_device_transfer_loader.py
@@ -77,14 +77,6 @@ def test_asyn_transfer_and_update(mock_adaptor):
     assert loader_obj.recv_expert_list == []
 
 
-def test_set_log2phy_map(mock_adaptor):
-    with patch("vllm_ascend.eplb.core.eplb_device_transfer_loader.get_dynamic_eplb_group", return_value=None):
-        loader_obj = loader.D2DExpertWeightLoader()
-    loader_obj.set_adator(mock_adaptor)
-    loader_obj.set_log2phy_map({"a": 1})
-    assert loader_obj.updated_log2phy_map == {"a": 1}
-
-
 def test_invalid_state_asyn_update(mock_adaptor):
     with patch("vllm_ascend.eplb.core.eplb_device_transfer_loader.get_dynamic_eplb_group", return_value=None):
         loader_obj = loader.D2DExpertWeightLoader()

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -157,7 +157,7 @@ class VllmEplbAdaptor:
 
     def do_update_log2phy_map(self, layer_id, updated_log2phy_map):
         if self.log2phy_map_per_layer[layer_id] is not None:
-            self.log2phy_map_per_layer[layer_id].copy_(updated_log2phy_map)
+            self.log2phy_map_per_layer[layer_id].copy_(updated_log2phy_map, non_blocking=True)
 
     def get_global_expert_map(self):
         all_layer_global_expert_map = []

--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -73,7 +73,7 @@ class D2DExpertWeightLoader:
         self.state = ExpertWeightUpdateState.READY
 
     def set_log2phy_map(self, log2phy_map):
-        self.updated_log2phy_map = log2phy_map
+        self.updated_log2phy_map = log2phy_map.pin_memory()
 
     def asyn_expert_weight_transfer(self, reqs):
         # Only when send/recv tasks are parsed into self.comm_op_list, d2d send/recv tasks can be launched

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -108,7 +108,7 @@ class EplbUpdator:
                 (expert_send_info, expert_recv_info, updated_expert_map, log2phy_map, layer_id) = (
                     self.update_info_all.pop(0)
                 )
-                log2phy_map_this_rank = torch.from_numpy(numpy.array(log2phy_map))
+                log2phy_map_this_rank = torch.from_numpy(numpy.array(log2phy_map, dtype=numpy.int32))
                 self.eplb_loader.set_log2phy_map(log2phy_map_this_rank)
                 updated_expert_map_this_rank = torch.from_numpy(numpy.array(updated_expert_map))
                 self.eplb_loader.generate_expert_d2d_transfer_task(


### PR DESCRIPTION
### What this PR does / why we need it?
1. Change the copy of log2phy （H2D）  to asynchronous.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
<img width="996" height="256" alt="1F4FC853-DBF8-4B15-8AC0-CE04E329F54F" src="https://github.com/user-attachments/assets/c99ef9c0-f7fd-4a86-84d1-5827883c07ff" />

aime2025 w/o eplb
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2025 | 4835d7 | accuracy | gen | 40.00 |

aime with eplb
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2025 | 4835d7 | accuracy | gen | 50.00 |

gpqa w/o eplb
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| GPQA_diamond | b1ed2c | accuracy | gen | 75.76 |

gpqa with eplb
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| GPQA_diamond | b1ed2c | accuracy | gen | 70.20 |

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
