### PR TITLE
[Doc] Fix CANN 9.0.0 release-notes URL in README.md / README.zh.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ By using vLLM Ascend plugin, popular open-source models, including Transformer-l
 - OS: Linux
 - Software:
     - Python >= 3.10, < 3.12
-    - CANN == 9.0.0 (Ascend HDK version refers to [here](https://www.hiascend.com/document/detail/zh/canncommercial/83RC2/releasenote/releasenote_0000.html))
+    - CANN == 9.0.0 (Ascend HDK version refers to [here](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html))
     - PyTorch == 2.10.0, torch-npu == 2.10.0
     - vLLM (the same version as vllm-ascend)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -48,7 +48,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 - 操作系统：Linux
 - 软件：
     - Python >= 3.10, < 3.12
-    - CANN == 9.0.0 (Ascend HDK 版本参考[这里](https://www.hiascend.com/document/detail/zh/canncommercial/83RC2/releasenote/releasenote_0000.html))
+    - CANN == 9.0.0 (Ascend HDK 版本参考[这里](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html))
     - PyTorch == 2.10.0, torch-npu == 2.10.0
     - vLLM (与vllm-ascend版本一致)
 


### PR DESCRIPTION
### What this PR does / why we need it?

`README.md` (L57) and `README.zh.md` (L51) state `CANN == 9.0.0` but
link to the CANN 8.3 RC2 release-notes page
(`canncommercial/83RC2/...`). In practice the vendor site silently
302-redirects that URL to `…/canncommercial/900/index/index.html`,
which renders as a blank page — so users following the README link
land on no content at all. `docs/source/installation.md` already
uses the correct path (`canncommercial/900/releasenote/...`), which
returns HTTP 200 and shows the real CANN 9.0.0 release notes. This
PR aligns the two README files with `installation.md` so the link
actually works.

Fixes #9296

### Does this PR introduce _any_ user-facing change?

Documentation link only.

### How was this patch tested?

- Manual visual diff.
- Old URL (`…/canncommercial/83RC2/releasenote/releasenote_0000.html`)
  reproduced: it redirects to `…/canncommercial/900/index/index.html`
  which renders blank.
- New URL (`…/canncommercial/900/releasenote/releasenote_0000.html`)
  returns HTTP 200 and shows the "CANN 9.0.0版本说明" page.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
