### PR TITLE
[BugFix] Update the package name from 'flash_attn_v3' to 'flash_attn_npu_v3'

### DIFF
--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -53,7 +53,7 @@ FA3 requires the `flash_attn_npu` package, which provides the `flash_attn_npu_v3
 
 ### Installation
 
-Install the `flash_attn_npu` wheel package refer to: https://github.com/MinghuasLab/flash-attention-npu/blob/main/README.md#installation.
+Install the `flash_attn_npu` wheel package refer to: <https://github.com/MinghuasLab/flash-attention-npu/blob/main/README.md#installation>.
 
 ## Enabling Flash Attention 3
 

--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -1,7 +1,8 @@
 # Flash Attention 3
 
 ```{note}
-Flash Attention 3 on Ascend is currently in beta. The `flash_attn_npu` package required for FA3 has not yet been open-sourced and is expected to be released after May 20th.
+Flash Attention 3 on Ascend is currently in beta. The `flash_attn_npu` package required for FA3 has been open-sourced on GitHub.
+Please refer to the [flash-attention-npu repository](https://github.com/MinghuasLab/flash-attention-npu) for more details.
 ```
 
 This document shows how to enable Flash Attention 3 (FA3) in vLLM-Ascend. FA3 provides a training-inference consistent attention implementation for Ascend NPUs.
@@ -48,23 +49,11 @@ We will support other NPUs in the future.
 
 ## Software Requirements
 
-FA3 requires the `flash_attn_npu` package, which provides the `flash_attn_v3` module with the `flash_attn_with_kvcache` operator.
-
-```{warning}
-The `flash_attn_npu` package has not yet been open-sourced. It is expected to be released after May 20th. Until then, external users cannot directly use Flash Attention 3.
-```
+FA3 requires the `flash_attn_npu` package, which provides the `flash_attn_npu_v3` module with the `flash_attn_with_kvcache` operator.
 
 ### Installation
 
-Install the `flash_attn_npu` wheel package as follows:
-
-```bash
-pip3 install flash_attn_npu-x.x.x-cp3xx-cp3xx-linux_aarch64.whl
-```
-
-```{note}
-Replace `x.x.x` with the actual package version, and `cp3xx` with the actual Python version tag matching your environment (e.g., `cp310` for Python 3.10, `cp311` for Python 3.11).
-```
+Install the `flash_attn_npu` wheel package refer to: https://github.com/MinghuasLab/flash-attention-npu/blob/main/README.md#installation.
 
 ## Enabling Flash Attention 3
 

--- a/tests/e2e/singlecard/test_attention_fa3.py
+++ b/tests/e2e/singlecard/test_attention_fa3.py
@@ -33,9 +33,9 @@ LONG_PROMPT = "The quick brown fox jumps over the lazy dog. " * 50
 
 def _fa3_available() -> bool:
     try:
-        if util.find_spec("flash_attn_v3") is None:
+        if util.find_spec("flash_attn_npu_v3") is None:
             return False
-        mod = import_module("flash_attn_v3")
+        mod = import_module("flash_attn_npu_v3")
         return hasattr(mod, "flash_attn_with_kvcache")
     except ImportError:
         return False
@@ -76,7 +76,7 @@ def _assert_outputs_match(fia_outputs, fa3_outputs, label=""):
         )
 
 
-@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_v3 is not installed")
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
 def test_fa3_vs_fia_single_prompt():
     """Compare FA3 and FIA with a single prompt (minimal batch size).
 
@@ -90,7 +90,7 @@ def test_fa3_vs_fia_single_prompt():
     _assert_outputs_match(fia_outputs, fa3_outputs, label="[SinglePrompt] ")
 
 
-@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_v3 is not installed")
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
 def test_fa3_vs_fia_mixed_lengths():
     """Compare FA3 and FIA with mixed prompt lengths in the same batch.
 
@@ -109,7 +109,7 @@ def test_fa3_vs_fia_mixed_lengths():
     _assert_outputs_match(fia_outputs, fa3_outputs, label="[MixedLen] ")
 
 
-@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_v3 is not installed")
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
 def test_fa3_vs_fia_with_chunkprefill():
     """Compare FA3 and FIA with single token generation where chunkprefill is used."""
     fia_outputs = _generate_with_backend(SHORT_PROMPTS, max_tokens=2, max_num_seqs=2, max_num_batched_tokens=5)
@@ -119,7 +119,7 @@ def test_fa3_vs_fia_with_chunkprefill():
     _assert_outputs_match(fia_outputs, fa3_outputs, label="[Chunkprefill] ")
 
 
-@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_v3 is not installed")
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
 def test_fa3_vs_fia_logprobs():
     """Compare FA3 and FIA logprobs for fine-grained numerical verification."""
     fia_logprobs = _generate_logprobs_with_backend(SHORT_PROMPTS[:1])

--- a/tests/ut/attention/test_attention_fa3.py
+++ b/tests/ut/attention/test_attention_fa3.py
@@ -8,9 +8,9 @@ import torch_npu
 
 def _fa3_available() -> bool:
     try:
-        if util.find_spec("flash_attn_v3") is None:
+        if util.find_spec("flash_attn_npu_v3") is None:
             return False
-        mod = import_module("flash_attn_v3")
+        mod = import_module("flash_attn_npu_v3")
         return hasattr(mod, "flash_attn_with_kvcache")
     except ImportError:
         return False
@@ -75,7 +75,7 @@ test_cases = [
 ]
 
 
-@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_v3 is not installed")
+@pytest.mark.skipif(not _fa3_available(), reason="flash_attn_npu_v3 is not installed")
 @pytest.mark.parametrize(
     "data_type, batch_size, num_heads, kv_heads, q_seqlen, kv_seqlen, head_size, block_size, is_causal", test_cases
 )
@@ -140,7 +140,7 @@ def test_fa_custom_ops_tnd(
         new_q_seqlen_list.append(pre_seq_sum)
     new_q_seqlen_list = torch.tensor(new_q_seqlen_list, dtype=torch.int32).npu()
 
-    from flash_attn_v3 import flash_attn_with_kvcache  # type: ignore[import-not-found]
+    from flash_attn_npu_v3 import flash_attn_with_kvcache  # type: ignore[import-not-found]
 
     out_out = flash_attn_with_kvcache(
         query,

--- a/vllm_ascend/attention/fa3_v1.py
+++ b/vllm_ascend/attention/fa3_v1.py
@@ -1,6 +1,6 @@
 import torch
 import vllm.envs as envs_vllm
-from flash_attn_v3 import flash_attn_with_kvcache as _fa3_fn  # type: ignore[import-not-found]
+from flash_attn_npu_v3 import flash_attn_with_kvcache as _fa3_fn  # type: ignore[import-not-found]
 from vllm.v1.attention.backend import AttentionBackend  # type: ignore
 
 from vllm_ascend.attention.attention_v1 import (
@@ -81,7 +81,7 @@ class AscendFAImpl(AscendAttentionBackendImpl):
             key_fa_blk,
             value_fa_blk,
             cache_seqlens=seq_lens,  # kv sequence length for each individual request (NOT cumulative)
-            page_table=block_table,  #  must match the block table for the corresponding q
+            page_table=block_table,  # must match the block table for the corresponding q
             cu_seqlens_q=actual_seq_lengths,  # cumulative sequence length for q
             max_seqlen_q=max_seq_len,
             causal=is_causal,

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -561,12 +561,11 @@ class AscendApplyRotaryEmb(ApplyRotaryEmb):
         is_neox_style: bool = True,
         enable_fp32_compute: bool = False,
     ) -> None:
-        from vllm.model_executor.custom_op import CustomOp
-
-        CustomOp.__init__(self, enforce_enable=enforce_enable)
-        self.is_neox_style = is_neox_style
-        self.enable_fp32_compute = enable_fp32_compute
-        self.apply_rotary_emb_flash_attn = None
+        super().__init__(
+            enforce_enable=enforce_enable,
+            is_neox_style=is_neox_style,
+            enable_fp32_compute=enable_fp32_compute,
+        )
 
     def forward_oot(
         self,

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -627,16 +627,16 @@ class NPUPlatform(Platform):
             return False
         if key != (False, False):
             raise ValueError("FA3 backend does not support MLA and SFA.")
-        if util.find_spec("flash_attn_v3") is None:
+        if util.find_spec("flash_attn_npu_v3") is None:
             raise ValueError(
-                "flash_attn_v3 is not installed but FA3 backend is requested. "
-                "Please install flash_attn_v3 to enable FA3."
+                "flash_attn_npu_v3 is not installed but FA3 backend is requested. "
+                "Please install flash_attn_npu_v3 to enable FA3."
             )
-        mod = import_module("flash_attn_v3")
+        mod = import_module("flash_attn_npu_v3")
         if not hasattr(mod, "flash_attn_with_kvcache"):
             raise ValueError(
-                "flash_attn_v3 is installed but does not provide "
-                "flash_attn_with_kvcache. Please check flash_attn_v3 "
+                "flash_attn_npu_v3 is installed but does not provide "
+                "flash_attn_with_kvcache. Please check flash_attn_npu_v3 "
                 "whether it supports flash_attn_with_kvcache."
             )
         logger.info(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the package name from `flash_attn_v3` to `flash_attn_npu_v3` to align with the `flash_attn_npu` open-source repository. It also updates the documentation with the repository link and installation instructions.([issue 10072](https://github.com/vllm-project/vllm-ascend/issues/10072))

### Does this PR introduce _any_ user-facing change?

Yes, the required package name for Flash Attention 3 on Ascend has changed from `flash_attn_v3` to `flash_attn_npu_v3`. Build and installation instructions have been updated to point to the open-source repository.

### How was this patch tested?

The changes were verified by updating the end-to-end and unit tests, ensuring they correctly detect and use the new package name.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
