### PR TITLE
[Doc] Add Qwen3.6-27B and Qwen3.6-35B-A3B deployment guides and supported-m…

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.po
@@ -19,15 +19,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:1
-msgid "Qwen3.5-27B"
-msgstr "Qwen3.5-27B"
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:1
+msgid "Qwen3.5-27B / Qwen3.6-27B"
+msgstr "Qwen3.5-27B / Qwen3.6-27B"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:3
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:3
 msgid "Introduction"
 msgstr "简介"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:5
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:5
 msgid ""
 "Qwen3.5 represents a significant leap forward, integrating breakthroughs "
 "in multimodal learning, architectural efficiency, reinforcement learning "
@@ -35,7 +35,7 @@ msgid ""
 "with unprecedented capability and efficiency."
 msgstr "Qwen3.5 代表了一次重大飞跃，它整合了多模态学习、架构效率、强化学习规模和全球可访问性方面的突破，为开发者和企业提供了前所未有的能力和效率。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:7
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:7
 msgid ""
 "This document will show the main verification steps of the model, "
 "including supported features, feature configuration, environment "
@@ -43,148 +43,148 @@ msgid ""
 "performance evaluation."
 msgstr "本文档将展示该模型的主要验证步骤，包括支持的特性、特性配置、环境准备、单节点和多节点部署、精度和性能评估。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:9
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:9
 msgid "The `Qwen3.5-27B` model is first supported in `vllm-ascend:v0.17.0rc1`."
 msgstr "`Qwen3.5-27B` 模型首次在 `vllm-ascend:v0.17.0rc1` 版本中得到支持。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:11
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:11
 msgid "Supported Features"
 msgstr "支持的特性"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:13
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:13
 msgid ""
 "Refer to [supported "
 "features](../../user_guide/support_matrix/supported_models.md) to get the"
 " model's supported feature matrix."
 msgstr "请参考[支持的特性](../../user_guide/support_matrix/supported_models.md)以获取模型支持的特性矩阵。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:15
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:15
 msgid ""
 "Refer to [feature guide](../../user_guide/feature_guide/index.md) to get "
 "the feature's configuration."
 msgstr "请参考[特性指南](../../user_guide/feature_guide/index.md)以获取特性的配置信息。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:17
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:17
 msgid "Environment Preparation"
 msgstr "环境准备"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:19
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:19
 msgid "Model Weight"
 msgstr "模型权重"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:21
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:21
 msgid ""
 "`Qwen3.5-27B`(BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1"
 " Atlas 800 A2 (64G × 8) node. [Download model "
 "weight](https://modelscope.cn/models/Qwen/Qwen3.5-27B)"
 msgstr "`Qwen3.5-27B` (BF16 版本)：需要 1 个 Atlas 800 A3 (64G × 16) 节点或 1 个 Atlas 800 A2 (64G × 8) 节点。[下载模型权重](https://modelscope.cn/models/Qwen/Qwen3.5-27B)"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:22
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:22
 msgid ""
 "`Qwen3.5-27B-w8a8`(Quantized version): requires 1 Atlas 800 A3 (64G × 16)"
 " node or 1 Atlas 800 A2 (64G × 8) node. [Download model "
 "weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)"
 msgstr "`Qwen3.5-27B-w8a8` (量化版本)：需要 1 个 Atlas 800 A3 (64G × 16) 节点或 1 个 Atlas 800 A2 (64G × 8) 节点。[下载模型权重](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:24
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:24
 msgid ""
 "It is recommended to download the model weight to the shared directory of"
 " multiple nodes, such as `/root/.cache/`."
 msgstr "建议将模型权重下载到多个节点的共享目录中，例如 `/root/.cache/`。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:26
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:26
 msgid "Verify Multi-node Communication(Optional)"
 msgstr "验证多节点通信（可选）"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:28
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:28
 msgid ""
 "If you want to deploy multi-node environment, you need to verify multi-"
 "node communication according to [verify multi-node communication "
 "environment](../../installation.md#verify-multi-node-communication)."
 msgstr "如果您想部署多节点环境，需要根据[验证多节点通信环境](../../installation.md#verify-multi-node-communication)来验证多节点通信。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:30
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:30
 msgid "Installation"
 msgstr "安装"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
 msgid "Use docker image"
 msgstr "使用 Docker 镜像"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:36
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:36
 msgid ""
 "For example, using images `quay.io/ascend/vllm-ascend:v0.17.0rc1`(for "
 "Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.17.0rc1-a3`(for Atlas "
 "800 A3)."
 msgstr "例如，使用镜像 `quay.io/ascend/vllm-ascend:v0.17.0rc1`（适用于 Atlas 800 A2）和 `quay.io/ascend/vllm-ascend:v0.17.0rc1-a3`（适用于 Atlas 800 A3）。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:38
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:38
 msgid ""
 "Select an image based on your machine type and start the docker image on "
 "your node, refer to [using docker](../../installation.md#set-up-using-"
 "docker)."
 msgstr "根据您的机器类型选择镜像，并在您的节点上启动 Docker 镜像，请参考[使用 Docker](../../installation.md#set-up-using-docker)。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
 msgid "Build from source"
 msgstr "从源码构建"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:78
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:78
 msgid "You can build all from source."
 msgstr "您可以从源码构建所有组件。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:80
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:80
 msgid ""
 "Install `vllm-ascend`, refer to [set up using "
 "python](../../installation.md#set-up-using-python)."
 msgstr "安装 `vllm-ascend`，请参考[使用 Python 设置](../../installation.md#set-up-using-python)。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:84
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:84
 msgid ""
 "If you want to deploy multi-node environment, you need to set up "
 "environment on each node."
 msgstr "如果您想部署多节点环境，需要在每个节点上设置环境。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:86
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:86
 msgid "Deployment"
 msgstr "部署"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:88
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:88
 msgid "Single-node Deployment"
 msgstr "单节点部署"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:90
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:90
 msgid ""
 "`Qwen3.5-27B` and `Qwen3.5-27B-w8a8` can both be deployed on 1 Atlas 800 "
 "A3(64G × 16), 1 Atlas 800 A2(64G × 8). Quantized version needs to start "
 "with parameter --quantization ascend."
 msgstr "`Qwen3.5-27B` 和 `Qwen3.5-27B-w8a8` 都可以部署在 1 个 Atlas 800 A3 (64G × 16) 或 1 个 Atlas 800 A2 (64G × 8) 节点上。量化版本需要使用参数 `--quantization ascend` 启动。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:92
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:92
 msgid "Run the following script to execute online 128k inference."
 msgstr "运行以下脚本来执行在线 128k 推理。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:125
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:125
 msgid "**Notice:**"
 msgstr "**注意：**"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:127
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:127
 msgid "The parameters are explained as follows:"
 msgstr "参数解释如下："
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:129
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:129
 msgid ""
 "`--data-parallel-size` 1 and `--tensor-parallel-size` 2 are common "
 "settings for data parallelism (DP) and tensor parallelism (TP) sizes."
 msgstr "`--data-parallel-size` 1 和 `--tensor-parallel-size` 2 是数据并行 (DP) 和张量并行 (TP) 大小的常见设置。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:130
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:130
 msgid ""
 "`--max-model-len` represents the context length, which is the maximum "
 "value of the input plus output for a single request."
 msgstr "`--max-model-len` 表示上下文长度，即单个请求的输入加输出的最大值。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:131
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:131
 msgid ""
 "`--max-num-seqs` indicates the maximum number of requests that each DP "
 "group is allowed to process. If the number of requests sent to the "
@@ -195,34 +195,34 @@ msgid ""
 "`--data-parallel-size` >= the actual total concurrency."
 msgstr "`--max-num-seqs` 表示每个 DP 组允许处理的最大请求数。如果发送到服务的请求数超过此限制，超出的请求将保持在等待状态，不会被调度。请注意，在等待状态所花费的时间也会计入 TTFT 和 TPOT 等指标。因此，在测试性能时，通常建议 `--max-num-seqs` * `--data-parallel-size` >= 实际总并发数。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:132
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:132
 msgid ""
 "`--max-num-batched-tokens` represents the maximum number of tokens that "
 "the model can process in a single step. Currently, vLLM v1 scheduling "
 "enables ChunkPrefill/SplitFuse by default, which means:"
 msgstr "`--max-num-batched-tokens` 表示模型在单步中可以处理的最大 token 数。目前，vLLM v1 调度默认启用 ChunkPrefill/SplitFuse，这意味着："
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:133
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:133
 msgid ""
 "(1) If the input length of a request is greater than `--max-num-batched-"
 "tokens`, it will be divided into multiple rounds of computation according"
 " to `--max-num-batched-tokens`;"
 msgstr "(1) 如果一个请求的输入长度大于 `--max-num-batched-tokens`，它将根据 `--max-num-batched-tokens` 被分成多轮计算；"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:134
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:134
 msgid ""
 "(2) Decode requests are prioritized for scheduling, and prefill requests "
 "are scheduled only if there is available capacity."
 msgstr "(2) 解码请求优先调度，只有在有可用容量时才会调度预填充请求。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:135
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:135
 msgid ""
 "Generally, if `--max-num-batched-tokens` is set to a larger value, the "
 "overall latency will be lower, but the pressure on GPU memory (activation"
 " value usage) will be greater."
 msgstr "通常，如果将 `--max-num-batched-tokens` 设置为较大的值，整体延迟会更低，但 GPU 内存（激活值使用）的压力会更大。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:136
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:136
 msgid ""
 "`--gpu-memory-utilization` represents the proportion of HBM that vLLM "
 "will use for actual inference. Its essential function is to calculate the"
@@ -238,7 +238,7 @@ msgid ""
 "during actual inference. The default value is `0.9`."
 msgstr "`--gpu-memory-utilization` 表示 vLLM 将用于实际推理的 HBM 比例。其核心功能是计算可用的 kv_cache 大小。在预热阶段（在 vLLM 中称为 profile run），vLLM 会记录输入大小为 `--max-num-batched-tokens` 的推理过程中的峰值 GPU 内存使用量。然后，可用的 kv_cache 大小计算为：`--gpu-memory-utilization` * HBM 大小 - 峰值 GPU 内存使用量。因此，`--gpu-memory-utilization` 的值越大，可以使用的 kv_cache 就越多。然而，由于预热阶段的 GPU 内存使用量可能与实际推理期间不同（例如，由于 EP 负载不均衡），将 `--gpu-memory-utilization` 设置得过高可能会导致实际推理期间出现 OOM（内存不足）问题。默认值为 `0.9`。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:137
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:137
 msgid ""
 "`--no-enable-prefix-caching` indicates that prefix caching is disabled. "
 "To enable it, for mamba-like models Qwen3.5, set `--enable-prefix-"
@@ -248,13 +248,13 @@ msgid ""
 "which means that any prefix shorter than 2048 will never be cached."
 msgstr "`--no-enable-prefix-caching` 表示前缀缓存被禁用。要启用它，对于类似 Mamba 的模型 Qwen3.5，请设置 `--enable-prefix-caching` 和 `--mamba-cache-mode align`。请注意，当前混合 kv cache 的实现可能在调度时导致非常大的 block_size。例如，block_size 可能被调整为 2048，这意味着任何短于 2048 的前缀将永远不会被缓存。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:138
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:138
 msgid ""
 "`--quantization` \"ascend\" indicates that quantization is used. To "
 "disable quantization, remove this option."
 msgstr "`--quantization` \"ascend\" 表示使用量化。要禁用量化，请移除此选项。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:139
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:139
 msgid ""
 "`--compilation-config` contains configurations related to the aclgraph "
 "graph mode. The most significant configurations are \"cudagraph_mode\" "
@@ -265,7 +265,7 @@ msgid ""
 "\"FULL_DECODE_ONLY\" is recommended."
 msgstr "`--compilation-config` 包含与 aclgraph 图模式相关的配置。最重要的配置是 \"cudagraph_mode\" 和 \"cudagraph_capture_sizes\"，其含义如下：\"cudagraph_mode\"：表示特定的图模式。目前支持 \"PIECEWISE\" 和 \"FULL_DECODE_ONLY\"。图模式主要用于降低算子调度的开销。目前推荐使用 \"FULL_DECODE_ONLY\"。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:141
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:141
 msgid ""
 "\"cudagraph_capture_sizes\": represents different levels of graph modes. "
 "The default value is [1, 2, 4, 8, 16, 24, 32, 40,..., `--max-num-seqs`]. "
@@ -275,127 +275,127 @@ msgid ""
 "it necessary to set this separately to achieve optimal performance."
 msgstr "\"cudagraph_capture_sizes\"：表示不同级别的图模式。默认值为 [1, 2, 4, 8, 16, 24, 32, 40,..., `--max-num-seqs`]。在图模式下，不同级别图的输入是固定的，级别之间的输入会自动填充到下一级别。目前推荐使用默认设置。只有在某些场景下，才需要单独设置此参数以达到最佳性能。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:143
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:143
 msgid "Functional Verification"
 msgstr "功能验证"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:145
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:145
 msgid "Once your server is started, you can query the model with input prompts:"
 msgstr "一旦您的服务器启动，您就可以使用输入提示词查询模型："
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:158
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:158
 msgid "Accuracy Evaluation"
 msgstr "精度评估"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:160
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:160
 msgid "Here are two accuracy evaluation methods."
 msgstr "以下是两种精度评估方法。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:162
-#: ../../source/tutorials/models/Qwen3.5-27B.md:174
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:162
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:174
 msgid "Using AISBench"
 msgstr "使用 AISBench"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:164
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:164
 msgid ""
 "Refer to [Using "
 "AISBench](../../developer_guide/evaluation/using_ais_bench.md) for "
 "details."
 msgstr "详情请参考[使用 AISBench](../../developer_guide/evaluation/using_ais_bench.md)。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:166
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:166
 msgid ""
 "After execution, you can get the result, here is the result of `Qwen3.5"
 "-27B-w8a8` in `vllm-ascend:v0.17.0rc1` for reference only."
 msgstr "执行后，您可以获得结果，以下是 `Qwen3.5-27B-w8a8` 在 `vllm-ascend:v0.17.0rc1` 中的结果，仅供参考。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "dataset"
 msgstr "数据集"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "version"
 msgstr "版本"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "metric"
 msgstr "指标"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "mode"
 msgstr "模式"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "vllm-api-general-chat"
 msgstr "vllm-api-general-chat"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "gsm8k"
 msgstr "gsm8k"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "-"
 msgstr "-"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "accuracy"
 msgstr "准确率"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "gen"
 msgstr "生成"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:76
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:76
 msgid "96.74"
 msgstr "96.74"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:172
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:172
 msgid "Performance"
 msgstr "性能"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:176
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:176
 msgid ""
 "Refer to [Using AISBench for performance "
 "evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-"
 "performance-evaluation) for details."
 msgstr "详情请参阅[使用AISBench进行性能评估](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation)。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:178
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:178
 msgid "Using vLLM Benchmark"
 msgstr "使用vLLM基准测试"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:180
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:180
 msgid "Run performance evaluation of `Qwen3.5-27B-w8a8` as an example."
 msgstr "以运行 `Qwen3.5-27B-w8a8` 的性能评估为例。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:182
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:182
 msgid ""
 "Refer to [vllm "
 "benchmark](https://docs.vllm.ai/en/latest/contributing/benchmarks.html) "
 "for more details."
 msgstr "更多详情请参阅[vllm基准测试](https://docs.vllm.ai/en/latest/contributing/benchmarks.html)。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:184
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:184
 msgid "There are three `vllm bench` subcommands:"
 msgstr "`vllm bench` 包含三个子命令："
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:186
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:186
 msgid "`latency`: Benchmark the latency of a single batch of requests."
 msgstr "`latency`：对单批次请求的延迟进行基准测试。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:187
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:187
 msgid "`serve`: Benchmark the online serving throughput."
 msgstr "`serve`：对在线服务吞吐量进行基准测试。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:188
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:188
 msgid "`throughput`: Benchmark offline inference throughput."
 msgstr "`throughput`：对离线推理吞吐量进行基准测试。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:190
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:190
 msgid "Take the `serve` as an example. Run the code as follows."
 msgstr "以 `serve` 为例，运行以下代码。"
 
-#: ../../source/tutorials/models/Qwen3.5-27B.md:197
+#: ../../source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md:197
 msgid ""
 "After about several minutes, you can get the performance evaluation "
 "result."

--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/support_matrix/supported_models.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/support_matrix/supported_models.po
@@ -491,8 +491,28 @@ msgid "Qwen3.5-27B"
 msgstr "Qwen3.5-27B"
 
 #: ../../source/user_guide/support_matrix/supported_models.md
-msgid "[Qwen3.5-27B](../../tutorials/models/Qwen3.5-27B.md)"
-msgstr "[Qwen3.5-27B](../../tutorials/models/Qwen3.5-27B.md)"
+msgid "[Qwen3.5-27B / Qwen3.6-27B](../../tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md)"
+msgstr "[Qwen3.5-27B / Qwen3.6-27B](../../tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md)"
+
+#: ../../source/user_guide/support_matrix/supported_models.md
+msgid "Qwen3.5-35B-A3B"
+msgstr "Qwen3.5-35B-A3B"
+
+#: ../../source/user_guide/support_matrix/supported_models.md
+msgid "[Qwen3.6-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md)"
+msgstr "[Qwen3.6-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md)"
+
+#: ../../source/user_guide/support_matrix/supported_models.md
+msgid "262144"
+msgstr "262144"
+
+#: ../../source/user_guide/support_matrix/supported_models.md
+msgid "Qwen3.6-35B-A3B"
+msgstr "Qwen3.6-35B-A3B"
+
+#: ../../source/user_guide/support_matrix/supported_models.md
+msgid "Qwen3.6-27B"
+msgstr "Qwen3.6-27B"
 
 #: ../../source/user_guide/support_matrix/supported_models.md
 msgid "Qwen3-Omni-30B-A3B-Thinking"

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -1,12 +1,15 @@
-# Qwen3.5-27B
+# Qwen3.5-27B/Qwen3.6-27B
 
 ## Introduction
 
-Qwen3.5 represents a significant leap forward, integrating breakthroughs in multimodal learning, architectural efficiency, reinforcement learning scale, and global accessibility to empower developers and enterprises with unprecedented capability and efficiency.
+Qwen3.5 and Qwen3.6-27B are dense models (not MoE) that share the same hybrid attention design (GDN + full attention). Deployment on vLLM Ascend follows the same pattern for both; only model weights, context length defaults, and first-supported versions differ.
 
-This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
+Qwen3.5 represents a significant leap forward in multimodal learning, architectural efficiency, and global accessibility. Qwen3.6-27B builds on that architecture with stronger agentic coding, native multimodal support, and up to 262144 context length.
 
-The `Qwen3.5-27B` model is first supported in `vllm-ascend:v0.17.0rc1`.
+This document covers supported features, environment setup, single-node deployment, and accuracy/performance evaluation.
+
+- `Qwen3.5-27B` is first supported in `vllm-ascend:v0.17.0rc1`.
+- `Qwen3.6-27B` is first supported in `vllm-ascend:v0.18.0rc1`.
 
 ## Supported Features
 
@@ -18,8 +21,15 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### Model Weight
 
+**Qwen3.5-27B**
+
 - `Qwen3.5-27B`(BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.5-27B)
 - `Qwen3.5-27B-w8a8`(Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)
+
+**Qwen3.6-27B**
+
+- `Qwen3.6-27B`(BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-27B)
+- `Qwen3.6-27B-w8a8`(Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 
@@ -32,9 +42,9 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 :::::{tab-set}
 ::::{tab-item} Use docker image
 
-For example, using images `quay.io/ascend/vllm-ascend:v0.17.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.17.0rc1-a3`(for Atlas 800 A3).
+For example, using images `quay.io/ascend/vllm-ascend:v0.17.0rc1` / `v0.18.0rc1` (for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.17.0rc1-a3` / `v0.18.0rc1-a3` (for Atlas 800 A3).
 
-Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+Select an image based on your machine type and model version, then start the docker image on your node. Refer to [using docker](../../installation.md#set-up-using-docker).
 
 ```{code-block} bash
   :substitutions:
@@ -87,7 +97,9 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 ### Single-node Deployment
 
-`Qwen3.5-27B` and `Qwen3.5-27B-w8a8` can both be deployed on 1 Atlas 800 A3(64G × 16), 1 Atlas 800 A2(64G × 8). Quantized version needs to start with parameter --quantization ascend.
+`Qwen3.5-27B`, `Qwen3.5-27B-w8a8`, `Qwen3.6-27B`, and `Qwen3.6-27B-w8a8` can all be deployed on 1 Atlas 800 A3 (64G × 16) or 1 Atlas 800 A2 (64G × 8). Quantized versions need `--quantization ascend`.
+
+#### Qwen3.5-27B-w8a8
 
 Run the following script to execute online 128k inference.
 
@@ -122,6 +134,41 @@ vllm serve Eco-Tech/Qwen3.5-27B-w8a8-mtp \
 --async-scheduling
 ```
 
+#### Qwen3.6-27B-w8a8
+
+Run the following script to execute online inference with up to 262144 context length.
+
+```shell
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+# To reduce memory fragmentation and avoid out of memory
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_BUFFSIZE=512
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+export TASK_QUEUE_ENABLE=1
+
+vllm serve Eco-Tech/Qwen3.6-27B-w8a8 \
+--host 0.0.0.0 \
+--port 8000 \
+--data-parallel-size 1 \
+--tensor-parallel-size 2 \
+--seed 1024 \
+--quantization ascend \
+--served-model-name qwen3.6 \
+--max-num-seqs 32 \
+--max-model-len 262144 \
+--max-num-batched-tokens 8096 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--no-enable-prefix-caching \
+--speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
+--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+--additional-config '{"enable_cpu_binding":true}' \
+--async-scheduling
+```
+
 **Notice:**
 
 The parameters are explained as follows:
@@ -136,13 +183,14 @@ The parameters are explained as follows:
 - `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Its essential function is to calculate the available kv_cache size. During the warm-up phase (referred to as profile run in vLLM), vLLM records the peak GPU memory usage during an inference process with an input size of `--max-num-batched-tokens`. The available kv_cache size is then calculated as: `--gpu-memory-utilization` * HBM size - peak GPU memory usage. Therefore, the larger the value of `--gpu-memory-utilization`, the more kv_cache can be used. However, since the GPU memory usage during the warm-up phase may differ from that during actual inference (e.g., due to uneven EP load), setting `--gpu-memory-utilization` too high may lead to OOM (Out of Memory) issues during actual inference. The default value is `0.9`.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, for mamba-like models Qwen3.5, set `--enable-prefix-caching` and `--mamba-cache-mode align`. Notice the current implementation of hybrid kv cache might result in a very large block_size when scheduling. For example, the block_size may be adjusted to 2048, which means that any prefix shorter than 2048 will never be cached.
 - `--quantization` "ascend" indicates that quantization is used. To disable quantization, remove this option.
+- `--speculative_config` uses `qwen3_5_mtp` for both Qwen3.5 and Qwen3.6 because they share the same MTP head design.
 - `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are "cudagraph_mode" and "cudagraph_capture_sizes", which have the following meanings:
 "cudagraph_mode": represents the specific graph mode. Currently, "PIECEWISE" and "FULL_DECODE_ONLY" are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, "FULL_DECODE_ONLY" is recommended.
 - "cudagraph_capture_sizes": represents different levels of graph modes. The default value is [1, 2, 4, 8, 16, 24, 32, 40,..., `--max-num-seqs`]. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance.
 
 ## Functional Verification
 
-Once your server is started, you can query the model with input prompts:
+Once your server is started, you can query the model with input prompts. Use the `--served-model-name` you configured (`qwen3.5` or `qwen3.6`):
 
 ```shell
 curl http://localhost:8000/v1/completions \
@@ -163,7 +211,7 @@ Here are two accuracy evaluation methods.
 
 1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
 
-2. After execution, you can get the result, here is the result of `Qwen3.5-27B-w8a8` in `vllm-ascend:v0.17.0rc1` for reference only.
+2. After execution, you can get the result. Here is the result of `Qwen3.5-27B-w8a8` in `vllm-ascend:v0.17.0rc1` for reference only.
 
 | dataset | version | metric | mode | vllm-api-general-chat |
 |----- | ----- | ----- | ----- | -----|
@@ -177,7 +225,7 @@ Refer to [Using AISBench for performance evaluation](../../developer_guide/evalu
 
 ### Using vLLM Benchmark
 
-Run performance evaluation of `Qwen3.5-27B-w8a8` as an example.
+Run performance evaluation of `Qwen3.5-27B-w8a8` or `Qwen3.6-27B-w8a8` as an example.
 
 Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/benchmarks.html) for more details.
 
@@ -191,7 +239,10 @@ Take the `serve` as an example. Run the code as follows.
 
 ```shell
 export VLLM_USE_MODELSCOPE=True
+# For Qwen3.5-27B-w8a8:
 vllm bench serve --model Eco-Tech/Qwen3.5-27B-w8a8-mtp --dataset-name random --random-input 200 --num-prompts 200 --request-rate 1 --save-result --result-dir ./
+# For Qwen3.6-27B-w8a8:
+vllm bench serve --model Eco-Tech/Qwen3.6-27B-w8a8 --dataset-name random --random-input 200 --num-prompts 200 --request-rate 1 --save-result --result-dir ./
 ```
 
 After about several minutes, you can get the performance evaluation result.

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -1,0 +1,194 @@
+# Qwen3.6-35B-A3B
+
+## Introduction
+
+Qwen3.6-35B-A3B is a sparse MoE model in the Qwen3.6 family. It has 35B total parameters with about 3B activated per token, and uses the same hybrid attention architecture (GDN + full attention) as Qwen3.5. Deployment on vLLM Ascend follows the same pattern as other Qwen3.5-style MoE models.
+
+This document covers supported features, environment setup, single-node deployment, and accuracy/performance evaluation.
+
+The `Qwen3.6-35B-A3B` model is first supported in `vllm-ascend:v0.18.0rc1`.
+
+## Supported Features
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
+
+Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
+
+## Environment Preparation
+
+### Model Weight
+
+- `Qwen3.6-35B-A3B`(BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-35B-A3B)
+- `Qwen3.6-35B-A3B-w8a8`(Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-35B-A3B-w8a8)
+
+It is recommended to download the model weight to `/root/.cache/`.
+
+### Installation
+
+:::::{tab-set}
+::::{tab-item} Use docker image
+
+For example, using images `quay.io/ascend/vllm-ascend:v0.18.0rc1`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.18.0rc1-a3`(for Atlas 800 A3).
+
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+
+```{code-block} bash
+  :substitutions:
+  # Update --device according to your device (Atlas A2: /dev/davinci[0-7] Atlas A3:/dev/davinci[0-15]).
+  # Update the vllm-ascend image according to your environment.
+  # Note you should download the weight to /root/.cache in advance.
+  # Update the vllm-ascend image
+  export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+  export NAME=vllm-ascend
+
+  # Run the container using the defined variables
+  docker run --rm \
+  --name $NAME \
+  --net=host \
+  --shm-size=1g \
+  --device /dev/davinci0 \
+  --device /dev/davinci1 \
+  --device /dev/davinci2 \
+  --device /dev/davinci3 \
+  --device /dev/davinci4 \
+  --device /dev/davinci5 \
+  --device /dev/davinci6 \
+  --device /dev/davinci7 \
+  --device /dev/davinci_manager \
+  --device /dev/devmm_svm \
+  --device /dev/hisi_hdc \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+  -v /etc/ascend_install.info:/etc/ascend_install.info \
+  -it $IMAGE bash
+```
+
+::::
+::::{tab-item} Build from source
+
+You can build all from source.
+
+- Install `vllm-ascend`, refer to [set up using python](../../installation.md#set-up-using-python).
+
+::::
+:::::
+
+## Deployment
+
+### Single-node Deployment
+
+`Qwen3.6-35B-A3B-w8a8` can be deployed on 1 Atlas 800 A3 (64G × 16) or 1 Atlas 800 A2 (64G × 8). Start with `--quantization ascend` and `--enable-expert-parallel`.
+
+Run the following script to execute online inference with up to 262144 context length on 1 Atlas 800 A3 (64G × 16).
+
+```shell
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+# To reduce memory fragmentation and avoid out of memory
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_BUFFSIZE=1024
+export OMP_NUM_THREADS=1
+export TASK_QUEUE_ENABLE=1
+echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+sysctl -w vm.swappiness=0
+sysctl -w kernel.numa_balancing=0
+sysctl kernel.sched_migration_cost_ns=50000
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+vllm serve Eco-Tech/Qwen3.6-35B-A3B-w8a8 \
+--host 0.0.0.0 \
+--port 8000 \
+--data-parallel-size 1 \
+--tensor-parallel-size 2 \
+--enable-expert-parallel \
+--seed 1024 \
+--quantization ascend \
+--served-model-name qwen3.6 \
+--max-num-seqs 128 \
+--max-model-len 262144 \
+--max-num-batched-tokens 16384 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--enable-prefix-caching \
+--speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
+--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+--additional-config '{"enable_cpu_binding":true, "multistream_overlap_shared_expert": true}' \
+--async-scheduling
+```
+
+**Notice:**
+
+The parameters are explained as follows:
+
+- `--data-parallel-size` 1 and `--tensor-parallel-size` 2 are common settings for data parallelism (DP) and tensor parallelism (TP) sizes.
+- `--enable-expert-parallel` indicates that EP is enabled. Note that vLLM does not support a mixed approach of ETP and EP; that is, MoE can either use pure EP or pure TP.
+- `--max-model-len` represents the context length, which is the maximum value of the input plus output for a single request.
+- `--max-num-seqs` indicates the maximum number of requests that each DP group is allowed to process. If the number of requests sent to the service exceeds this limit, the excess requests will remain in a waiting state and will not be scheduled. Note that the time spent in the waiting state is also counted in metrics such as TTFT and TPOT. Therefore, when testing performance, it is generally recommended that `--max-num-seqs` * `--data-parallel-size` >= the actual total concurrency.
+- `--max-num-batched-tokens` represents the maximum number of tokens that the model can process in a single step. Currently, vLLM v1 scheduling enables ChunkPrefill/SplitFuse by default, which means:
+    - (1) If the input length of a request is greater than `--max-num-batched-tokens`, it will be divided into multiple rounds of computation according to `--max-num-batched-tokens`;
+    - (2) Decode requests are prioritized for scheduling, and prefill requests are scheduled only if there is available capacity.
+    - Generally, if `--max-num-batched-tokens` is set to a larger value, the overall latency will be lower, but the pressure on GPU memory (activation value usage) will be greater.
+- `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Its essential function is to calculate the available kv_cache size. During the warm-up phase (referred to as profile run in vLLM), vLLM records the peak GPU memory usage during an inference process with an input size of `--max-num-batched-tokens`. The available kv_cache size is then calculated as: `--gpu-memory-utilization` * HBM size - peak GPU memory usage. Therefore, the larger the value of `--gpu-memory-utilization`, the more kv_cache can be used. However, since the GPU memory usage during the warm-up phase may differ from that during actual inference (e.g., due to uneven EP load), setting `--gpu-memory-utilization` too high may lead to OOM (Out of Memory) issues during actual inference. The default value is `0.9`.
+- `--enable-prefix-caching` can be enabled for Qwen3.6 models. To disable it, use ``--no-enable-prefix-caching``. Note that for models with large context lengths, prefix caching may require significant memory.
+- `--quantization` "ascend" indicates that quantization is used. To disable quantization, remove this option.
+- `--speculative_config` uses `qwen3_5_mtp` because Qwen3.6 shares the same MTP head design as Qwen3.5.
+- `--additional-config` `"multistream_overlap_shared_expert": true` is recommended for MoE models to overlap shared-expert computation.
+- `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are "cudagraph_mode" and "cudagraph_capture_sizes", which have the following meanings:
+"cudagraph_mode": represents the specific graph mode. Currently, "PIECEWISE" and "FULL_DECODE_ONLY" are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, "FULL_DECODE_ONLY" is recommended.
+- "cudagraph_capture_sizes": represents different levels of graph modes. The default value is [1, 2, 4, 8, 16, 24, 32, 40,..., `--max-num-seqs`]. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance.
+
+## Functional Verification
+
+Once your server is started, you can query the model with input prompts:
+
+```shell
+curl http://localhost:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.6",
+        "prompt": "The future of AI is",
+        "max_completion_tokens": 50,
+        "temperature": 0
+    }'
+```
+
+## Accuracy Evaluation
+
+### Using AISBench
+
+1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
+
+2. After execution, you can get the accuracy result of `Qwen3.6-35B-A3B-w8a8` for reference.
+
+## Performance
+
+### Using AISBench
+
+Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
+
+### Using vLLM Benchmark
+
+Run performance evaluation of `Qwen3.6-35B-A3B-w8a8` as an example.
+
+Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/benchmarks.html) for more details.
+
+There are three `vllm bench` subcommands:
+
+- `latency`: Benchmark the latency of a single batch of requests.
+- `serve`: Benchmark the online serving throughput.
+- `throughput`: Benchmark offline inference throughput.
+
+Take the `serve` as an example. Run the code as follows.
+
+```shell
+export VLLM_USE_MODELSCOPE=True
+vllm bench serve --model Eco-Tech/Qwen3.6-35B-A3B-w8a8 --dataset-name random --random-input 200 --num-prompts 200 --request-rate 1 --save-result --result-dir ./
+```
+
+After about several minutes, you can get the performance evaluation result.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -22,7 +22,8 @@ Qwen3-8B-W4A8.md
 Qwen3-32B-W4A4.md
 Qwen3-Next.md
 Qwen3-Omni-30B-A3B-Thinking.md
-Qwen3.5-27B.md
+Qwen3.5-27B-Qwen3.6-27B.md
+Qwen3.6-35B-A3B.md
 Qwen3.5-397B-A17B.md
 DeepSeek-V3.1.md
 DeepSeek-V3.2.md

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -82,7 +82,10 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Qwen3-VL                       | ✅            |                                                                      ||A2/A3|||||||✅|||||✅|✅||| [Qwen-VL-Dense](../../tutorials/models/Qwen-VL-Dense.md) |
 | Qwen3-VL-MOE                   | ✅            |                                                                      | ✅ | A2/A3||✅|✅|||✅|✅|✅|✅|✅|✅|✅|✅|256k||[Qwen3-VL-MOE](../../tutorials/models/Qwen3-VL-235B-A22B-Instruct.md)|
 | Qwen3.5-397B-A17B              | ✅            |                                                                      |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|1010000|| [Qwen3.5-397B-A17B](../../tutorials/models/Qwen3.5-397B-A17B.md) |
-| Qwen3.5-27B                    | ✅            |                                                                      |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|1010000|| [Qwen3.5-27B](../../tutorials/models/Qwen3.5-27B.md) |
+| Qwen3.5-27B                    | ✅            |                        |✅| A2/A3 |✅|✅|✅||✅|✅|✅|||✅|✅|✅|✅|1010000|| [Qwen3.5-27B / Qwen3.6-27B](../../tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md) |
+| Qwen3.5-35B-A3B                | ✅            |                                                                      |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|262144|| |
+| Qwen3.6-27B                    | ✅            |                          |✅| A2/A3 |✅|✅|✅||✅|✅|✅|||✅|✅|✅|✅|262144|| [Qwen3.5-27B / Qwen3.6-27B](../../tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md) |
+| Qwen3.6-35B-A3B                | ✅            |                        |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|262144|| [Qwen3.6-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md) |
 | Qwen3-Omni-30B-A3B-Thinking    | 🔵            |                                                                      ||A2/A3|||||||✅||✅|||||||[Qwen3-Omni-30B-A3B-Thinking](../../tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md)|
 | Qwen2.5-Omni                   | 🔵            |                                                                      || A2/A3 |||||||||||||||| [Qwen2.5-Omni](../../tutorials/models/Qwen2.5-Omni.md) |
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds documentation and tutorials for the Qwen3.6-27B and Qwen3.6-35B-A3B models, providing deployment scripts and updating the support matrix.

### Does this PR introduce _any_ user-facing change?
Documentation-only updates are not considered user-facing changes.

### How was this patch tested?
Documentation was reviewed for technical accuracy. 
