### PR TITLE
[Performance] Reuse prebuilt chunk host metadata for Ascend chunk ops and earse synconize for qwen3.5 model

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -346,6 +346,7 @@
   optional: false
   source_file_dependencies:
     - vllm_ascend/ops/gdn.py
+    - vllm_ascend/ops/gdn_attn_builder.py
     - vllm_ascend/ops/triton/gdn_chunk_meta.py
   tests:
     - tests/ut/ops

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -82,6 +82,32 @@ class TestAscendAttentionMetadataBuilder(TestBase):
 
         self.assertFalse(result)
 
+    def test_unpadded_preserves_internal_seq_lens_cpu(self):
+        internal_seq_lens_cpu = torch.tensor([4, 5, 6], dtype=torch.int32)
+        common_attn_metadata = AscendCommonAttentionMetadata(
+            query_start_loc=torch.tensor([0, 2, 5, 9]),
+            query_start_loc_cpu=torch.tensor([0, 2, 5, 9]),
+            seq_lens=torch.tensor([4, 5, 6], dtype=torch.int32),
+            _seq_lens_cpu=internal_seq_lens_cpu,
+            seq_lens_cpu=None,
+            num_computed_tokens_cpu=None,
+            num_reqs=3,
+            num_actual_tokens=9,
+            max_query_len=4,
+            block_table_tensor=torch.zeros((3, 1), dtype=torch.int32),
+            slot_mapping=torch.arange(9, dtype=torch.int32),
+            causal=True,
+            actual_seq_lengths_q=[2, 3, 4],
+            positions=torch.arange(9),
+            attn_state=AscendAttentionState.ChunkedPrefill,
+            max_seq_len=6,
+        )
+
+        unpadded_metadata = common_attn_metadata.unpadded(num_actual_tokens=5, num_actual_reqs=2)
+
+        self.assertTrue(torch.equal(unpadded_metadata._seq_lens_cpu, internal_seq_lens_cpu[:2]))
+        self.assertIsNone(unpadded_metadata.seq_lens_cpu)
+
     @patch("vllm_ascend.attention.attention_v1.AscendMetadata")
     def test_build(self, mock_ascend_metadata):
         common_attn_metadata = AscendCommonAttentionMetadata(

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -257,6 +257,84 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
     assert pcp_calls == [("o_update", chunk_offsets)]
 
 
+def test_chunk_gated_delta_rule_fwd_uses_prebuilt_host_meta_without_runtime_tolist(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prebuilt_meta = type(
+        "PrebuiltMeta",
+        (),
+        {
+            "block_indices_cumsum": None,
+            "cu_seqlens_host": (0, 4, 7),
+            "chunk_indices_chunk64_host": (0, 0, 1, 0),
+            "chunk_indices_chunk64": torch.tensor([[0, 0], [1, 0]], dtype=torch.int32),
+            "chunk_offsets_chunk64": torch.tensor([0, 1, 2], dtype=torch.int32),
+            "update_chunk_offsets_chunk64": torch.tensor([0, 2, 4], dtype=torch.int32),
+            "final_chunk_indices_chunk64": torch.tensor([1, 3], dtype=torch.int32),
+            "chunk_indices_large_block": None,
+        },
+    )()
+
+    q = _DummyTensor("q")
+    k = _DummyTensor("k")
+    v = _DummyTensor("v")
+    g = _DummyTensor("g")
+    beta = _DummyTensor("beta")
+    initial_state = _DummyTensor("initial_state")
+
+    captured: dict[str, tuple[int, ...] | None] = {}
+
+    monkeypatch.setattr(chunk, "get_forward_context", lambda: type("Ctx", (), {"attn_metadata": None})())
+    monkeypatch.setattr(
+        chunk,
+        "get_pcp_group",
+        lambda: type("Group", (), {"world_size": 1, "rank_in_group": 0})(),
+    )
+    monkeypatch.setattr(chunk, "chunk_local_cumsum", lambda *args, **kwargs: _DummyTensor("g_cumsum"))
+    monkeypatch.setattr(chunk, "chunk_scaled_dot_kkt_fwd", lambda *args, **kwargs: _DummyTensor("A"))
+    monkeypatch.setattr(chunk, "solve_tril", lambda *args, **kwargs: _DummyTensor("A_solved"))
+    monkeypatch.setattr(chunk, "recompute_w_u_fwd", lambda *args, **kwargs: (_DummyTensor("w"), _DummyTensor("u")))
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "chunk_gated_delta_rule_fwd_h",
+        lambda *args, **kwargs: (
+            captured.update(
+                {
+                    "cu_seqlens": kwargs["cu_seqlens"],
+                    "chunk_indices": kwargs["chunk_indices"],
+                }
+            )
+            or (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state"))
+        ),
+    )
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        "chunk_fwd_o",
+        lambda *args, **kwargs: _DummyTensor("o_ascend"),
+    )
+    monkeypatch.setattr(
+        torch.Tensor,
+        "tolist",
+        lambda self: pytest.fail("runtime should not convert device tensors to host tuples"),
+    )
+
+    chunk.chunk_gated_delta_rule_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=1.0,
+        initial_state=initial_state,
+        output_final_state=False,
+        cu_seqlens=torch.tensor([0, 4, 7], dtype=torch.int32),
+        prebuilt_meta=prebuilt_meta,
+    )
+
+    assert captured["cu_seqlens"] == prebuilt_meta.cu_seqlens_host
+    assert captured["chunk_indices"] == prebuilt_meta.chunk_indices_chunk64_host
+
+
 def test_build_chunk_meta_device_rejects_non_npu_input():
     cu_seqlens = torch.tensor([0, 4, 4, 12], dtype=torch.int32)
 

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -157,6 +157,8 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
         (),
         {
             "block_indices_cumsum": None,
+            "cu_seqlens_host": (0, 4, 7),
+            "chunk_indices_chunk64_host": (0, 0, 1, 0),
             "chunk_indices_chunk64": None,
             "chunk_offsets_chunk64": chunk_offsets,
             "update_chunk_offsets_chunk64": update_chunk_offsets,
@@ -306,11 +308,13 @@ def test_chunk_gated_delta_rule_fwd_uses_prebuilt_host_meta_without_runtime_toli
             )
             or (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state"))
         ),
+        raising=False,
     )
     monkeypatch.setattr(
         torch.ops._C_ascend,
         "chunk_fwd_o",
         lambda *args, **kwargs: _DummyTensor("o_ascend"),
+        raising=False,
     )
     monkeypatch.setattr(
         torch.Tensor,

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -372,30 +372,37 @@ def test_build_non_spec_causal_conv1d_host_meta_requires_has_initial_state():
         )
 
 
-def test_get_non_spec_causal_conv1d_host_args_requires_prefill_fallback_meta():
+def test_get_non_spec_causal_conv1d_host_args_falls_back_to_runtime_metadata():
     attn_metadata = SimpleNamespace(
         non_spec_prefill_fallback_meta=None,
-        non_spec_causal_conv1d_meta=SimpleNamespace(
-            query_start_loc_opt=(0, 4, 12),
-            cache_indices_opt=(3, 9),
-            initial_state_mode_opt=(1, 0),
-        ),
+        non_spec_query_start_loc=torch.tensor([0, 4, 12], dtype=torch.int32),
+        non_spec_state_indices_tensor=torch.tensor([3, 9], dtype=torch.int32),
+        has_initial_state=torch.tensor([True, False]),
     )
 
-    with pytest.raises(RuntimeError, match="non_spec_prefill_fallback_meta\\.causal_conv1d"):
-        get_non_spec_causal_conv1d_host_args(
-            attn_metadata,
-        )
+    assert get_non_spec_causal_conv1d_host_args(attn_metadata) == (
+        (0, 4, 12),
+        (3, 9),
+        (1, 0),
+    )
 
 
-def test_get_non_spec_chunked_prefill_meta_requires_prefill_fallback_meta():
+def test_get_non_spec_causal_conv1d_host_args_requires_runtime_metadata():
     attn_metadata = SimpleNamespace(
         non_spec_prefill_fallback_meta=None,
-        non_spec_chunked_prefill_meta=SimpleNamespace(chunk_offsets_chunk64=torch.tensor([0, 1])),
+        non_spec_query_start_loc=torch.tensor([0, 4, 12], dtype=torch.int32),
+        non_spec_state_indices_tensor=torch.tensor([3, 9], dtype=torch.int32),
+        has_initial_state=None,
     )
 
-    with pytest.raises(RuntimeError, match="non_spec_prefill_fallback_meta\\.chunk"):
-        get_non_spec_chunked_prefill_meta(attn_metadata)
+    with pytest.raises(RuntimeError, match="has_initial_state"):
+        get_non_spec_causal_conv1d_host_args(attn_metadata)
+
+
+def test_get_non_spec_chunked_prefill_meta_allows_missing_prefill_fallback_meta():
+    attn_metadata = SimpleNamespace(non_spec_prefill_fallback_meta=None)
+
+    assert get_non_spec_chunked_prefill_meta(attn_metadata) is None
 
 
 def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeypatch):

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -9,14 +9,18 @@ import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.fla.ops import index as _fla_index
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import MambaSpec
 
-import vllm_ascend.patch.worker.patch_gdn_attn as patch_gdn_attn
+from vllm_ascend.ops import gdn_attn_builder as ascend_gdn_attn_builder
 from vllm_ascend.ops.gdn import (
+    AscendGatedDeltaNetAttention,
     get_non_spec_causal_conv1d_host_args,
     get_non_spec_chunked_prefill_meta,
     to_int64_tuple,
+)
+from vllm_ascend.ops.gdn_attn_builder import (
+    AscendGDNAttentionBackend,
+    AscendGDNAttentionMetadataBuilder,
 )
 from vllm_ascend.ops.triton.fla import utils as fla_utils
 from vllm_ascend.ops.triton.fla.utils import (
@@ -151,7 +155,7 @@ def _make_builder(*, device: torch.device, num_heads: int, num_speculative_token
         dtypes=(torch.float32,),
         mamba_cache_mode="none",
     )
-    return GDNAttentionMetadataBuilder(spec, ["layer0"], vllm_config, device)
+    return AscendGDNAttentionMetadataBuilder(spec, ["layer0"], vllm_config, device)
 
 
 def _build_attn_metadata(
@@ -191,31 +195,31 @@ def _build_attn_metadata(
 def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Tensor) -> None:
     assert torch.equal(
         chunk_meta.chunk_indices_chunk64,
-        runtime_prepare_chunk_indices(cu_seqlens, patch_gdn_attn._GDN_CHUNK_SIZE),
+        runtime_prepare_chunk_indices(cu_seqlens, ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
     )
     assert torch.equal(
         chunk_meta.chunk_offsets_chunk64,
-        runtime_prepare_chunk_offsets(cu_seqlens, patch_gdn_attn._GDN_CHUNK_SIZE),
+        runtime_prepare_chunk_offsets(cu_seqlens, ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
     )
     assert torch.equal(
         chunk_meta.update_chunk_offsets_chunk64,
         runtime_prepare_update_chunk_offsets(
             cu_seqlens,
-            patch_gdn_attn._GDN_CHUNK_SIZE,
+            ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
         ),
     )
     assert torch.equal(
         chunk_meta.final_chunk_indices_chunk64,
         runtime_prepare_final_chunk_indices(
             cu_seqlens,
-            patch_gdn_attn._GDN_CHUNK_SIZE,
+            ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
         ),
     )
     assert torch.equal(
         chunk_meta.chunk_indices_large_block,
         runtime_prepare_chunk_indices(
             cu_seqlens,
-            patch_gdn_attn._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE,
+            ascend_gdn_attn_builder._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE,
         ),
     )
     assert torch.equal(
@@ -236,6 +240,28 @@ def _patch_missing_runtime_cdiv(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda x, y: (x + y - 1) // y,
         raising=False,
     )
+
+
+def test_ascend_gdn_attention_uses_ascend_backend():
+    assert AscendGatedDeltaNetAttention.get_attn_backend(object()) is AscendGDNAttentionBackend
+    assert AscendGDNAttentionBackend.get_builder_cls() is AscendGDNAttentionMetadataBuilder
+
+
+def test_sequence_index_buffers_cover_spec_decode_when_cudagraph_disabled():
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+    )
+    assert builder.spec_sequence_indices_cpu.numel() >= builder.vllm_config.scheduler_config.max_num_seqs
+
+    spec_indices, non_spec_indices = builder._copy_sequence_indices_to_device(
+        torch.tensor([True], dtype=torch.bool),
+        num_spec_decodes=1,
+    )
+
+    assert torch.equal(spec_indices.cpu(), torch.tensor([0]))
+    assert non_spec_indices.numel() == 0
 
 
 def _expected_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
@@ -318,7 +344,7 @@ def test_build_non_spec_causal_conv1d_host_meta_avoids_seq_lens_cpu_fallback():
         has_initial_state=torch.tensor([True, False]),
     )
 
-    host_meta = patch_gdn_attn._build_non_spec_causal_conv1d_host_meta(
+    host_meta = ascend_gdn_attn_builder._build_non_spec_causal_conv1d_host_meta(
         builder,
         attn_metadata,
         non_spec_query_start_loc_cpu=torch.tensor([0, 4, 12], dtype=torch.int32),
@@ -339,7 +365,7 @@ def test_build_non_spec_causal_conv1d_host_meta_requires_has_initial_state():
         has_initial_state=None,
     )
     with pytest.raises(RuntimeError, match="has_initial_state"):
-        patch_gdn_attn._build_non_spec_causal_conv1d_host_meta(
+        ascend_gdn_attn_builder._build_non_spec_causal_conv1d_host_meta(
             builder,
             attn_metadata,
             non_spec_query_start_loc_cpu=torch.tensor([0, 4, 12], dtype=torch.int32),
@@ -387,8 +413,8 @@ def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeyp
 
     builder._ascend_gdn_chunk_meta_initialized = True
     builder._ascend_gdn_chunk_meta_device = SimpleNamespace(type="npu")
-    builder._ascend_gdn_chunk_size = patch_gdn_attn._GDN_CHUNK_SIZE
-    builder._ascend_gdn_large_block_size = patch_gdn_attn._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE
+    builder._ascend_gdn_chunk_size = ascend_gdn_attn_builder._GDN_CHUNK_SIZE
+    builder._ascend_gdn_large_block_size = ascend_gdn_attn_builder._GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE
     builder._ascend_gdn_cumsum_block_size = 256
     builder._ascend_gdn_chunked_prefill_pool_idx = -1
     builder._ascend_gdn_chunked_prefill_pool = [
@@ -411,15 +437,10 @@ def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeyp
         helper_calls[kwargs["chunk_size"]] = kwargs
 
     monkeypatch.setattr(
-        patch_gdn_attn,
+        ascend_gdn_attn_builder,
         "build_chunk_meta_device",
         fake_build_chunk_meta_device,
         raising=False,
-    )
-    monkeypatch.setattr(
-        patch_gdn_attn,
-        "_prepare_chunk_counts_cpu",
-        lambda *args, **kwargs: pytest.fail("_prepare_chunk_counts_cpu should not be used on the device path"),
     )
 
     attn_metadata = builder.build(
@@ -431,22 +452,22 @@ def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeyp
 
     expected_chunk_indices = runtime_prepare_chunk_indices(
         attn_metadata.non_spec_query_start_loc,
-        patch_gdn_attn._GDN_CHUNK_SIZE,
+        ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
     )
     expected_chunk_offsets = runtime_prepare_chunk_offsets(
         attn_metadata.non_spec_query_start_loc,
-        patch_gdn_attn._GDN_CHUNK_SIZE,
+        ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
     )
     expected_update_chunk_offsets = runtime_prepare_update_chunk_offsets(
         attn_metadata.non_spec_query_start_loc,
-        patch_gdn_attn._GDN_CHUNK_SIZE,
+        ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
     )
     expected_final_chunk_indices = runtime_prepare_final_chunk_indices(
         attn_metadata.non_spec_query_start_loc,
-        patch_gdn_attn._GDN_CHUNK_SIZE,
+        ascend_gdn_attn_builder._GDN_CHUNK_SIZE,
     )
 
-    chunk64_call = helper_calls[patch_gdn_attn._GDN_CHUNK_SIZE]
+    chunk64_call = helper_calls[ascend_gdn_attn_builder._GDN_CHUNK_SIZE]
     out_chunk_indices = cast(torch.Tensor, chunk64_call["out_chunk_indices"])
     out_chunk_offsets = cast(torch.Tensor, chunk64_call["out_chunk_offsets"])
     out_update_chunk_offsets = cast(
@@ -457,6 +478,7 @@ def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeyp
         torch.Tensor,
         chunk64_call["out_final_chunk_indices"],
     )
+    fallback_meta = get_non_spec_chunked_prefill_meta(attn_metadata)
     assert chunk64_call["cu_seqlens"] is attn_metadata.non_spec_query_start_loc
     assert out_chunk_indices.shape == expected_chunk_indices.shape
     assert out_chunk_indices.dtype == expected_chunk_indices.dtype
@@ -466,6 +488,10 @@ def test_builder_uses_device_chunk_builder_with_non_spec_query_start_loc(monkeyp
     assert out_update_chunk_offsets.dtype == torch.int32
     assert out_final_chunk_indices.shape == expected_final_chunk_indices.shape
     assert out_final_chunk_indices.dtype == torch.int32
+    assert fallback_meta.cu_seqlens_host == tuple(attn_metadata.non_spec_query_start_loc.to(torch.int64).tolist())
+    assert fallback_meta.chunk_indices_chunk64_host == tuple(
+        expected_chunk_indices.to(torch.int64).reshape(-1).tolist()
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -177,7 +177,7 @@ def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
     spec_decode_metadata.cu_num_draft_tokens = torch.tensor([2, 3], dtype=torch.int32)
     valid_sampled_tokens_count = torch.tensor([3, 1], dtype=torch.int32)
 
-    with patch.object(eagle_proposer, "HAS_TRITON", False):
+    with patch.object(llm_base_proposer, "HAS_TRITON", False):
         spec_common_attn_metadata, *_ = proposer.prepare_inputs_padded(
             common_attn_metadata,
             spec_decode_metadata,

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -142,6 +142,48 @@ def assert_attr_equal(attr: str | tuple[str, Any, Any], expect: Any, actual: Any
         assert torch.equal(expect_value, actual_value), f"{attr_name} tensor mismatch"
     else:
         assert expect_value == actual_value, f"{attr_name} value mismatch"
+def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
+    proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+    proposer.pcp_size = 1
+    proposer.arange = torch.arange(16, dtype=torch.int32)
+    proposer.runner = MagicMock()
+    proposer.runner.actual_seq_lengths_q = [3, 3]
+    proposer.runner.attn_state = AscendAttentionState.SpecDecoding
+    proposer.runner.decode_token_per_req = 4
+
+    internal_seq_lens_cpu = torch.tensor([7, 9], dtype=torch.int32)
+    common_attn_metadata = AscendCommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 3, 6], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 3, 6], dtype=torch.int32),
+        seq_lens=torch.tensor([7, 9], dtype=torch.int32),
+        _seq_lens_cpu=internal_seq_lens_cpu,
+        seq_lens_cpu=None,
+        num_computed_tokens_cpu=None,
+        num_reqs=2,
+        num_actual_tokens=6,
+        num_input_tokens=6,
+        max_query_len=3,
+        actual_seq_lengths_q=[3, 3],
+        block_table_tensor=torch.zeros((2, 1), dtype=torch.int32),
+        slot_mapping=torch.arange(6, dtype=torch.int32),
+        positions=torch.arange(6),
+        attn_state=AscendAttentionState.SpecDecoding,
+        decode_token_per_req=4,
+        max_seq_len=9,
+    )
+    spec_decode_metadata = MagicMock()
+    spec_decode_metadata.cu_num_draft_tokens = torch.tensor([2, 3], dtype=torch.int32)
+    valid_sampled_tokens_count = torch.tensor([3, 1], dtype=torch.int32)
+
+    with patch.object(eagle_proposer, "HAS_TRITON", False):
+        spec_common_attn_metadata, *_ = proposer.prepare_inputs_padded(
+            common_attn_metadata,
+            spec_decode_metadata,
+            valid_sampled_tokens_count,
+        )
+
+    assert spec_common_attn_metadata._seq_lens_cpu is internal_seq_lens_cpu
+    assert spec_common_attn_metadata.seq_lens_cpu is None
 
 
 class TestEagleProposerInitialization(TestBase):

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -142,6 +142,8 @@ def assert_attr_equal(attr: str | tuple[str, Any, Any], expect: Any, actual: Any
         assert torch.equal(expect_value, actual_value), f"{attr_name} tensor mismatch"
     else:
         assert expect_value == actual_value, f"{attr_name} value mismatch"
+
+
 def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
     proposer = AscendEagleProposer.__new__(AscendEagleProposer)
     proposer.pcp_size = 1

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -33,7 +33,7 @@ else:
 
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
 from vllm.triton_utils import triton
-from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
+from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata  # type: ignore
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
@@ -44,6 +44,7 @@ from vllm_ascend.compilation.acl_graph import (
     get_graph_params,
 )
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
@@ -60,9 +61,7 @@ def to_int64_tuple(tensor: torch.Tensor) -> tuple[int, ...]:
 
 def _check_and_get_host_args(attn_metadata, field_name: str, sub_field_name: str):
     if (fallback_meta := getattr(attn_metadata, field_name, None)) is None:
-        raise RuntimeError(
-            f"Expected attn_metadata.{field_name}.{sub_field_name} for patched GDN non-spec prefill path."
-        )
+        raise RuntimeError(f"Expected attn_metadata.{field_name}.{sub_field_name} for Ascend GDN fallback path.")
     return fallback_meta
 
 
@@ -275,6 +274,9 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
     def _warmup_prefill_kernels_v0202(self, mixed_qkv: torch.Tensor) -> None:
         return
 
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return AscendGDNAttentionBackend
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -295,7 +297,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             if vllm_version_is("0.21.0"):
                 b, a = ba.chunk(2, dim=-1)
             else:
-                b, a = self.split_ba(ba)
+                b, a = self._split_ba_for_tp(ba)
             b = b.contiguous()
             a = a.contiguous()
         else:
@@ -310,7 +312,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 if vllm_version_is("0.21.0"):
                     b, a = ba.chunk(2, dim=-1)
                 else:
-                    b, a = self.split_ba(ba)
+                    b, a = self._split_ba_for_tp(ba)
 
                 b = b.contiguous()
                 a = a.contiguous()

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -65,8 +65,25 @@ def _check_and_get_host_args(attn_metadata, field_name: str, sub_field_name: str
     return fallback_meta
 
 
+def _check_and_get_runtime_prefill_args(attn_metadata, field_name: str):
+    value = getattr(attn_metadata, field_name, None)
+    if value is None:
+        raise RuntimeError(f"Expected attn_metadata.{field_name} for Ascend GDN prefill path.")
+    return value
+
+
 def get_non_spec_causal_conv1d_host_args(attn_metadata) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-    fallback_meta = _check_and_get_host_args(attn_metadata, "non_spec_prefill_fallback_meta", "causal_conv1d")
+    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
+    if fallback_meta is None:
+        query_start_loc = _check_and_get_runtime_prefill_args(attn_metadata, "non_spec_query_start_loc")
+        cache_indices = _check_and_get_runtime_prefill_args(attn_metadata, "non_spec_state_indices_tensor")
+        has_initial_state = _check_and_get_runtime_prefill_args(attn_metadata, "has_initial_state")
+        return (
+            to_int64_tuple(query_start_loc),
+            to_int64_tuple(cache_indices),
+            to_int64_tuple(has_initial_state),
+        )
+
     causal_conv1d_meta = fallback_meta.causal_conv1d
     return (
         to_int64_tuple(causal_conv1d_meta.query_start_loc_cpu),
@@ -245,7 +262,9 @@ def update_conv1d_graph_params(
 
 
 def get_non_spec_chunked_prefill_meta(attn_metadata):
-    fallback_meta = _check_and_get_host_args(attn_metadata, "non_spec_prefill_fallback_meta", "chunk")
+    fallback_meta = getattr(attn_metadata, "non_spec_prefill_fallback_meta", None)
+    if fallback_meta is None:
+        return None
     return fallback_meta.chunk
 
 

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -16,28 +16,44 @@
 from dataclasses import dataclass
 
 import torch
-import vllm.v1.attention.backends.gdn_attn as gdn_attn
-from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.config import VllmConfig
+from vllm.v1.attention.backend import AttentionCGSupport, CommonAttentionMetadata
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionBackend,
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.attention.backends.utils import (
+    NULL_BLOCK_ID,
+    compute_causal_conv1d_metadata,
+    mamba_get_block_table_tensor,
+    split_decodes_and_prefills,
+)
+from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.ops.triton.gdn_chunk_meta import (
     _build_seq_lens,
     _validate_cu_seqlens,
     build_chunk_meta_device,
 )
-from vllm_ascend.utils import is_310p
 
 _GDN_CHUNK_SIZE = 64
 # Keep this aligned with solve_tril.LARGE_BLOCK_T in ops/triton/fla/solve_tril.py.
 _GDN_SOLVE_TRIL_LARGE_BLOCK_SIZE = 608 * 2
 _GDN_CUMSUM_WORKING_SET = 2**18
 
-_IS_PATCHED = False
-_ORIGINAL_BUILD = gdn_attn.GDNAttentionMetadataBuilder.build
-_ORIGINAL_INIT_THRESHOLD = gdn_attn.GDNAttentionMetadataBuilder._init_reorder_batch_threshold
+
+def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype == torch.bool:
+        tensor = tensor.to(torch.int32)
+    return torch.argsort(tensor, stable=True)
 
 
 @dataclass
 class GDNChunkedPrefillMetadata:
+    cu_seqlens_cpu: torch.Tensor
+    cu_seqlens_host: tuple[int, ...]
+    chunk_indices_chunk64_host: tuple[int, ...]
     chunk_indices_chunk64: torch.Tensor
     chunk_offsets_chunk64: torch.Tensor
     update_chunk_offsets_chunk64: torch.Tensor
@@ -143,6 +159,14 @@ def _fill_chunk_indices_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> in
         cursor += num_chunks
         compact_seq_idx += 1
     return cursor
+
+
+def _build_chunk_indices_host(cu_seqlens_cpu: torch.Tensor, chunk_size: int) -> tuple[int, ...]:
+    chunk_counts = _prepare_chunk_counts_cpu(cu_seqlens_cpu, chunk_size)
+    num_chunk_indices = int(chunk_counts.sum().item())
+    chunk_indices = torch.empty((num_chunk_indices, 2), dtype=torch.int64)
+    _fill_chunk_indices_cpu(chunk_indices, chunk_counts)
+    return tuple(chunk_indices.reshape(-1).tolist())
 
 
 def _fill_chunk_offsets_cpu(out: torch.Tensor, chunk_counts: torch.Tensor) -> int:
@@ -341,9 +365,16 @@ def _build_chunked_prefill_metadata(
     builder,
     tensors: dict[str, torch.Tensor],
     *,
+    cu_seqlens_cpu: torch.Tensor,
     slot: _GDNChunkedPrefillBufferSlot | None = None,
 ) -> GDNChunkedPrefillMetadata:
     return GDNChunkedPrefillMetadata(
+        cu_seqlens_cpu=cu_seqlens_cpu,
+        cu_seqlens_host=tuple(cu_seqlens_cpu.to(torch.int64).tolist()),
+        chunk_indices_chunk64_host=_build_chunk_indices_host(
+            cu_seqlens_cpu,
+            builder._ascend_gdn_chunk_size,
+        ),
         chunk_indices_chunk64=tensors["chunk_indices_chunk64"],
         chunk_offsets_chunk64=tensors["chunk_offsets_chunk64"],
         update_chunk_offsets_chunk64=tensors["update_chunk_offsets_chunk64"],
@@ -429,9 +460,13 @@ def _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu: torch.T
 
 def _build_non_spec_query_start_loc_cpu(
     builder,
+    attn_metadata,
     common_attn_metadata,
     num_decode_draft_tokens_cpu: torch.Tensor | None,
 ) -> torch.Tensor | None:
+    if attn_metadata.num_prefills <= 0 and attn_metadata.num_decodes <= 0:
+        return None
+
     query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
     spec_sequence_masks_cpu = _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu)
     if spec_sequence_masks_cpu is None:
@@ -461,7 +496,6 @@ def _build_spec_query_start_loc_cpu(
     if spec_sequence_masks_cpu is None:
         return query_start_loc_cpu
 
-    # query_start_loc_cpu is type of cumsum
     query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
     spec_query_lens_cpu = query_lens_cpu[spec_sequence_masks_cpu]
     spec_query_start_loc_cpu = torch.zeros(
@@ -593,11 +627,9 @@ def _build_non_spec_causal_conv1d_host_meta(
 ) -> GDNCausalConv1dHostMetadata:
     assert attn_metadata.num_prefills > 0
     if attn_metadata.non_spec_state_indices_tensor is None:
-        raise RuntimeError(
-            "Expected attn_metadata.non_spec_state_indices_tensor for patched GDN non-spec prefill path."
-        )
+        raise RuntimeError("Expected attn_metadata.non_spec_state_indices_tensor for Ascend GDN non-spec prefill path.")
     if attn_metadata.has_initial_state is None:
-        raise RuntimeError("Expected attn_metadata.has_initial_state for patched GDN non-spec prefill path.")
+        raise RuntimeError("Expected attn_metadata.has_initial_state for Ascend GDN non-spec prefill path.")
 
     slot = None
     if (
@@ -629,7 +661,7 @@ def _build_non_spec_decode_causal_conv1d_host_meta(
     non_spec_query_start_loc_cpu: torch.Tensor,
 ) -> GDNCausalConv1dHostMetadata:
     if attn_metadata.non_spec_state_indices_tensor is None:
-        raise RuntimeError("Expected attn_metadata.non_spec_state_indices_tensor for patched GDN non-spec decode path.")
+        raise RuntimeError("Expected attn_metadata.non_spec_state_indices_tensor for Ascend GDN non-spec decode path.")
 
     slot = None
     if attn_metadata.non_spec_state_indices_tensor.device.type != "cpu":
@@ -655,7 +687,7 @@ def _build_spec_causal_conv1d_host_meta(
 ) -> GDNSpecCausalConv1dHostMetadata:
     assert attn_metadata.spec_sequence_masks is not None
     if attn_metadata.spec_state_indices_tensor is None:
-        raise RuntimeError("Expected attn_metadata.spec_state_indices_tensor for patched GDN speculative path.")
+        raise RuntimeError("Expected attn_metadata.spec_state_indices_tensor for Ascend GDN speculative path.")
 
     slot = None
     if attn_metadata.spec_state_indices_tensor.device.type != "cpu":
@@ -684,7 +716,7 @@ def _build_non_spec_chunked_prefill_meta_cpu(builder, cu_seqlens_cpu: torch.Tens
     shape_info = _build_chunk_meta_shape_info(builder, cu_seqlens_cpu)
     tensors = _allocate_chunk_meta_cpu_tensors(shape_info)
     _fill_chunk_meta_cpu_tensors(tensors, shape_info)
-    return _build_chunked_prefill_metadata(builder, tensors)
+    return _build_chunked_prefill_metadata(builder, tensors, cu_seqlens_cpu=cu_seqlens_cpu)
 
 
 def _build_non_spec_chunked_prefill_meta(
@@ -703,167 +735,526 @@ def _build_non_spec_chunked_prefill_meta(
     slot = builder._ascend_gdn_chunked_prefill_pool[builder._ascend_gdn_chunked_prefill_pool_idx]
     tensors = _slice_chunk_meta_slot_tensors(slot, shape_info)
     _fill_chunk_meta_device_tensors(builder, cu_seqlens, tensors)
-    return _build_chunked_prefill_metadata(builder, tensors, slot=slot)
+    return _build_chunked_prefill_metadata(builder, tensors, cu_seqlens_cpu=cu_seqlens_cpu, slot=slot)
 
 
-def _patched_build(
-    self,
-    common_prefix_len: int,
-    common_attn_metadata,
-    num_accepted_tokens: torch.Tensor | None = None,
-    num_decode_draft_tokens_cpu: torch.Tensor | None = None,
-    fast_build: bool = False,
-):
-    attn_metadata = _ORIGINAL_BUILD(
+class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
+    _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
         self,
-        common_prefix_len,
-        common_attn_metadata,
-        num_accepted_tokens=num_accepted_tokens,
-        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
-        fast_build=fast_build,
-    )
-    attn_metadata.non_spec_prefill_fallback_meta = None
-    attn_metadata.non_spec_decode_fallback_meta = None
-    attn_metadata.spec_decode_fallback_meta = None
-    if attn_metadata.spec_sequence_masks is not None:
-        _patched_build_spec(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
-
-    if attn_metadata.num_prefills > 0:
-        _patched_build_prefill(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
-
-    if attn_metadata.num_decodes > 0:
-        _patched_build_decode(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
-
-    if (
-        self.use_full_cuda_graph
-        and attn_metadata.num_prefills == 0
-        and attn_metadata.num_spec_decodes == 0
-        and attn_metadata.num_decodes <= self.decode_cudagraph_max_bs
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
     ):
-        self.non_spec_state_indices_tensor[attn_metadata.num_actual_tokens :].fill_(NULL_BLOCK_ID)
-    return attn_metadata
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        sequence_index_capacity = max(
+            self.vllm_config.scheduler_config.max_num_seqs,
+            self.decode_cudagraph_max_bs,
+        )
+        self.spec_sequence_masks_cpu: torch.Tensor = torch.empty(
+            (sequence_index_capacity,),
+            dtype=torch.bool,
+            device="cpu",
+            pin_memory=device.type != "cpu",
+        )
+        self.spec_sequence_indices_cpu: torch.Tensor = torch.empty(
+            (sequence_index_capacity,),
+            dtype=torch.int64,
+            device="cpu",
+            pin_memory=device.type != "cpu",
+        )
+        self.non_spec_sequence_indices_cpu: torch.Tensor = torch.empty(
+            (sequence_index_capacity,),
+            dtype=torch.int64,
+            device="cpu",
+            pin_memory=device.type != "cpu",
+        )
+        self.spec_sequence_indices: torch.Tensor = torch.empty(
+            (sequence_index_capacity,),
+            dtype=torch.int64,
+            device=device,
+        )
+        self.non_spec_sequence_indices: torch.Tensor = torch.empty(
+            (sequence_index_capacity,),
+            dtype=torch.int64,
+            device=device,
+        )
 
-
-def _patched_build_prefill(
-    self,
-    attn_metadata: gdn_attn.GDNAttentionMetadata,
-    common_attn_metadata,
-    num_decode_draft_tokens_cpu: torch.Tensor | None = None,
-):
-    assert attn_metadata.num_prefills > 0
-
-    _ensure_chunk_meta_state(self, common_attn_metadata.query_start_loc.device)
-    _ensure_causal_conv1d_host_meta_state(
+    def _init_reorder_batch_threshold(
         self,
-        common_attn_metadata.query_start_loc.device,
-    )
-    non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
+        reorder_batch_threshold: int | None = 1,
+        supports_spec_as_decode: bool = False,
+        supports_dcp_with_varlen: bool = False,
+    ) -> None:
+        super()._init_reorder_batch_threshold(
+            reorder_batch_threshold,
+            supports_spec_as_decode,
+            supports_dcp_with_varlen,
+        )
+        if self.reorder_batch_threshold != 1:  # type: ignore
+            speculative_config = self.vllm_config.speculative_config
+            if (
+                speculative_config is not None
+                and speculative_config.num_speculative_tokens is not None
+                and hasattr(speculative_config, "method")
+                and speculative_config.method == "dflash"
+            ):
+                self.reorder_batch_threshold = 1 + speculative_config.num_speculative_tokens
+
+    def _copy_sequence_indices_to_device(
         self,
-        common_attn_metadata,
-        num_decode_draft_tokens_cpu,
-    )
-    assert non_spec_query_start_loc_cpu is not None
-    if attn_metadata.non_spec_query_start_loc is None:
-        raise RuntimeError("Expected attn_metadata.non_spec_query_start_loc for patched GDN non-spec prefill path.")
-    attn_metadata.non_spec_prefill_fallback_meta = GDNPrefillFallbackMeta(
-        causal_conv1d=_build_non_spec_causal_conv1d_host_meta(
+        spec_sequence_masks_cpu: torch.Tensor,
+        num_spec_decodes: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_reqs = spec_sequence_masks_cpu.numel()
+        num_non_spec_decodes = num_reqs - num_spec_decodes
+
+        spec_indices_cpu = self.spec_sequence_indices_cpu[:num_spec_decodes]
+        spec_indices_cpu.copy_(
+            torch.nonzero(spec_sequence_masks_cpu, as_tuple=True)[0],
+        )
+        spec_indices = self.spec_sequence_indices[:num_spec_decodes]
+        spec_indices.copy_(spec_indices_cpu, non_blocking=True)
+
+        non_spec_indices_cpu = self.non_spec_sequence_indices_cpu[:num_non_spec_decodes]
+        non_spec_indices_cpu.copy_(
+            torch.nonzero(~spec_sequence_masks_cpu, as_tuple=True)[0],
+        )
+        non_spec_indices = self.non_spec_sequence_indices[:num_non_spec_decodes]
+        non_spec_indices.copy_(non_spec_indices_cpu, non_blocking=True)
+
+        return spec_indices, non_spec_indices
+
+    def _attach_non_spec_prefill_fallback_meta(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        non_spec_query_start_loc_cpu: torch.Tensor | None,
+    ) -> GDNAttentionMetadata:
+        attn_metadata.non_spec_prefill_fallback_meta = None
+        if attn_metadata.num_prefills <= 0:
+            return attn_metadata
+
+        _ensure_chunk_meta_state(self, common_attn_metadata.query_start_loc.device)
+        _ensure_causal_conv1d_host_meta_state(
+            self,
+            common_attn_metadata.query_start_loc.device,
+        )
+        if non_spec_query_start_loc_cpu is None:
+            raise RuntimeError("Expected non_spec_query_start_loc_cpu for Ascend GDN non-spec prefill path.")
+        if attn_metadata.non_spec_query_start_loc is None:
+            raise RuntimeError("Expected attn_metadata.non_spec_query_start_loc for Ascend GDN non-spec prefill path.")
+
+        attn_metadata.non_spec_prefill_fallback_meta = GDNPrefillFallbackMeta(
+            causal_conv1d=_build_non_spec_causal_conv1d_host_meta(
+                self,
+                attn_metadata,
+                non_spec_query_start_loc_cpu,
+            ),
+            chunk=_build_non_spec_chunked_prefill_meta(
+                self,
+                non_spec_query_start_loc_cpu,
+                attn_metadata.non_spec_query_start_loc,
+            ),
+        )
+        return attn_metadata
+
+    def _attach_spec_decode_fallback_meta(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decode_draft_tokens_cpu: torch.Tensor | None,
+    ) -> GDNAttentionMetadata:
+        attn_metadata.spec_decode_fallback_meta = None
+        if attn_metadata.spec_sequence_masks is None:
+            return attn_metadata
+
+        _ensure_spec_causal_conv1d_host_meta_state(
+            self,
+            common_attn_metadata.query_start_loc.device,
+        )
+        spec_query_start_loc_cpu = _build_spec_query_start_loc_cpu(
+            self,
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )
+        if spec_query_start_loc_cpu is None:
+            raise RuntimeError("Expected spec query_start_loc_cpu for Ascend GDN speculative path.")
+        if attn_metadata.spec_query_start_loc is None:
+            raise RuntimeError("Expected attn_metadata.spec_query_start_loc for Ascend GDN speculative path.")
+
+        attn_metadata.spec_decode_fallback_meta = GDNSpecDecodeFallbackMeta(
+            spec_causal_conv1d=_build_spec_causal_conv1d_host_meta(
+                self,
+                attn_metadata,
+                spec_query_start_loc_cpu,
+            ),
+        )
+        return attn_metadata
+
+    def _attach_non_spec_decode_fallback_meta(
+        self,
+        attn_metadata: GDNAttentionMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decode_draft_tokens_cpu: torch.Tensor | None,
+    ) -> GDNAttentionMetadata:
+        attn_metadata.non_spec_decode_fallback_meta = None
+        if attn_metadata.num_decodes <= 0:
+            return attn_metadata
+
+        _ensure_causal_conv1d_host_meta_state(
+            self,
+            common_attn_metadata.query_start_loc.device,
+        )
+        non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
             self,
             attn_metadata,
-            non_spec_query_start_loc_cpu,
-        ),
-        chunk=_build_non_spec_chunked_prefill_meta(
-            self,
-            non_spec_query_start_loc_cpu,
-            attn_metadata.non_spec_query_start_loc,
-        ),
-    )
-    return attn_metadata
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )
+        if non_spec_query_start_loc_cpu is None:
+            raise RuntimeError("Expected non-spec query_start_loc_cpu for Ascend GDN non-spec decode path.")
 
+        attn_metadata.non_spec_decode_fallback_meta = GDNDecodeFallbackMeta(
+            causal_conv1d=_build_non_spec_decode_causal_conv1d_host_meta(
+                self,
+                attn_metadata,
+                non_spec_query_start_loc_cpu,
+            ),
+        )
+        return attn_metadata
 
-def _init_reorder_batch_threshold(
-    self,
-    reorder_batch_threshold: int | None = 1,
-    supports_spec_as_decode: bool = False,
-    supports_dcp_with_varlen: bool = False,
-) -> None:
-    _ORIGINAL_INIT_THRESHOLD(
+    def build(  # type: ignore[override]
         self,
-        reorder_batch_threshold,
-        supports_spec_as_decode,
-        supports_dcp_with_varlen,
-    )
-    if self.reorder_batch_threshold != 1:
-        speculative_config = self.vllm_config.speculative_config
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_accepted_tokens: torch.Tensor | None = None,
+        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        fast_build: bool = False,
+    ) -> GDNAttentionMetadata:
+        m = common_attn_metadata
+
+        query_start_loc = m.query_start_loc
+        query_start_loc_cpu = m.query_start_loc_cpu
+        context_lens_tensor = m.compute_num_computed_tokens()
+        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+        block_table_tensor = mamba_get_block_table_tensor(
+            m.block_table_tensor,
+            m.seq_lens,
+            self.kv_cache_spec,
+            self.vllm_config.cache_config.mamba_cache_mode,
+        )
+
+        spec_sequence_masks_cpu: torch.Tensor | None = None
+        spec_sequence_indices: torch.Tensor | None = None
+        non_spec_sequence_indices: torch.Tensor | None = None
+        if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
+            spec_sequence_masks = None
+            num_spec_decodes = 0
+        else:
+            num_reqs = num_decode_draft_tokens_cpu.numel()
+            spec_sequence_masks_cpu = self.spec_sequence_masks_cpu[:num_reqs]
+            torch.ge(
+                num_decode_draft_tokens_cpu,
+                0,
+                out=spec_sequence_masks_cpu,
+            )
+            num_spec_decodes = spec_sequence_masks_cpu.sum().item()
+            if num_spec_decodes == 0:
+                spec_sequence_masks = None
+                spec_sequence_masks_cpu = None
+            else:
+                spec_sequence_masks = self.spec_sequence_masks[:num_reqs]
+                spec_sequence_masks.copy_(spec_sequence_masks_cpu, non_blocking=True)
+                spec_sequence_indices, non_spec_sequence_indices = self._copy_sequence_indices_to_device(
+                    spec_sequence_masks_cpu,
+                    num_spec_decodes,
+                )
+
+        if spec_sequence_masks is None:
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+                m,
+                decode_threshold=1,
+            )
+            num_spec_decode_tokens = 0
+            spec_token_indx = None
+            non_spec_token_indx = None
+            spec_state_indices_tensor = None
+            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            spec_query_start_loc = None
+            non_spec_query_start_loc = query_start_loc
+            non_spec_query_start_loc_cpu = query_start_loc_cpu
+            num_accepted_tokens = None
+        else:
+            query_lens = query_start_loc[1:] - query_start_loc[:-1]
+            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+            assert spec_sequence_masks_cpu is not None
+            assert spec_sequence_indices is not None
+            assert non_spec_sequence_indices is not None
+
+            non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
+            num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
+            num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
+            num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
+            num_decode_tokens = num_decodes
+            num_prefill_tokens = non_spec_query_lens_cpu.sum().item() - num_decode_tokens
+            num_spec_decode_tokens = query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
+
+            if num_decodes > 0 and num_spec_decodes > 0:
+                num_prefills += num_decodes
+                num_prefill_tokens += num_decode_tokens
+                num_decodes = 0
+                num_decode_tokens = 0
+
+            if num_prefills == 0 and num_decodes == 0:
+                spec_token_size = min(
+                    num_spec_decodes * (self.num_spec + 1),
+                    query_start_loc_cpu[-1].item(),
+                )
+                spec_token_indx = torch.arange(
+                    spec_token_size,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                non_spec_token_indx = torch.empty(
+                    0,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                spec_state_indices_tensor = torch.index_select(
+                    block_table_tensor[:, : self.num_spec + 1],
+                    0,
+                    spec_sequence_indices,
+                )
+                non_spec_state_indices_tensor = None
+                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+                non_spec_query_start_loc = None
+                non_spec_query_start_loc_cpu = None
+            else:
+                spec_token_masks = torch.repeat_interleave(
+                    spec_sequence_masks,
+                    query_lens,
+                    output_size=query_start_loc_cpu[-1].item(),
+                )
+                index = _stable_argsort_for_npu(spec_token_masks)
+                num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+                non_spec_token_indx = index[:num_non_spec_tokens]
+                spec_token_indx = index[num_non_spec_tokens:]
+
+                spec_state_indices_tensor = torch.index_select(
+                    block_table_tensor[:, : self.num_spec + 1],
+                    0,
+                    spec_sequence_indices,
+                )
+                non_spec_state_indices_tensor = torch.index_select(
+                    block_table_tensor[:, 0],
+                    0,
+                    non_spec_sequence_indices,
+                )
+                spec_query_lens = torch.index_select(
+                    query_lens,
+                    0,
+                    spec_sequence_indices,
+                )
+                non_spec_query_lens = torch.index_select(
+                    query_lens,
+                    0,
+                    non_spec_sequence_indices,
+                )
+
+                spec_query_start_loc = torch.zeros(
+                    num_spec_decodes + 1,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                torch.cumsum(
+                    spec_query_lens,
+                    dim=0,
+                    out=spec_query_start_loc[1:],
+                )
+                non_spec_query_start_loc = torch.zeros(
+                    query_lens.size(0) - num_spec_decodes + 1,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                torch.cumsum(
+                    non_spec_query_lens,
+                    dim=0,
+                    out=non_spec_query_start_loc[1:],
+                )
+                non_spec_query_start_loc_cpu = torch.zeros(
+                    query_lens_cpu.size(0) - num_spec_decodes + 1,
+                    dtype=torch.int32,
+                )
+                torch.cumsum(
+                    query_lens_cpu[~spec_sequence_masks_cpu],
+                    dim=0,
+                    out=non_spec_query_start_loc_cpu[1:],
+                )
+
+            assert num_accepted_tokens is not None
+            num_accepted_tokens = torch.index_select(
+                num_accepted_tokens,
+                0,
+                spec_sequence_indices,
+            )
+
+        chunk_indices: torch.Tensor | None = None
+        chunk_offsets: torch.Tensor | None = None
+        if num_prefills > 0:
+            from vllm.model_executor.layers.fla.ops.index import (
+                prepare_chunk_indices,
+                prepare_chunk_offsets,
+            )
+            from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
+
+            gpu_device = query_start_loc.device
+            chunk_indices = prepare_chunk_indices(
+                non_spec_query_start_loc_cpu,
+                FLA_CHUNK_SIZE,
+            ).to(device=gpu_device, non_blocking=True)
+            chunk_offsets = prepare_chunk_offsets(
+                non_spec_query_start_loc_cpu,
+                FLA_CHUNK_SIZE,
+            ).to(device=gpu_device, non_blocking=True)
+
+        if num_prefills > 0:
+            has_initial_state = context_lens_tensor > 0
+            if spec_sequence_masks_cpu is not None:
+                assert non_spec_sequence_indices is not None
+                has_initial_state = torch.index_select(
+                    has_initial_state,
+                    0,
+                    non_spec_sequence_indices,
+                )
+                assert non_spec_query_start_loc_cpu is not None
+            nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
+                non_spec_query_start_loc_cpu,
+                device=query_start_loc.device,
+            )
+        else:
+            has_initial_state = None
+
+        assert not (num_decodes > 0 and num_spec_decodes > 0), (
+            f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
+        )
+
+        batch_size = m.num_actual_tokens
+
         if (
-            speculative_config is not None
-            and speculative_config.num_speculative_tokens is not None
-            and hasattr(speculative_config, "method")
-            and speculative_config.method == "dflash"
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_decodes == 0
+            and num_spec_decodes <= self.decode_cudagraph_max_bs
+            and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
         ):
-            self.reorder_batch_threshold = 1 + speculative_config.num_speculative_tokens
+            assert spec_sequence_masks is not None
+            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor,
+                non_blocking=True,
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
 
+            self.spec_sequence_masks[:num_spec_decodes].copy_(
+                spec_sequence_masks[:num_spec_decodes],
+                non_blocking=True,
+            )
+            spec_sequence_masks = self.spec_sequence_masks[:batch_size]
+            spec_sequence_masks[num_spec_decodes:].fill_(False)
 
-def _patched_build_spec(
-    self,
-    attn_metadata: gdn_attn.GDNAttentionMetadata,
-    common_attn_metadata,
-    num_decode_draft_tokens_cpu: torch.Tensor | None = None,
-):
-    assert attn_metadata.spec_sequence_masks is not None
-    _ensure_spec_causal_conv1d_host_meta_state(
-        self,
-        common_attn_metadata.query_start_loc.device,
-    )
-    spec_query_start_loc_cpu = _build_spec_query_start_loc_cpu(
-        self,
-        common_attn_metadata,
-        num_decode_draft_tokens_cpu,
-    )
-    assert spec_query_start_loc_cpu is not None
-    if attn_metadata.spec_query_start_loc is None:
-        raise RuntimeError("Expected attn_metadata.spec_query_start_loc for patched GDN speculative path.")
-    attn_metadata.spec_decode_fallback_meta = GDNSpecDecodeFallbackMeta(
-        spec_causal_conv1d=_build_spec_causal_conv1d_host_meta(
-            self,
+            assert non_spec_token_indx is not None and spec_token_indx is not None
+            self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(
+                non_spec_token_indx,
+                non_blocking=True,
+            )
+            non_spec_token_indx = self.non_spec_token_indx[: non_spec_token_indx.size(0)]
+
+            self.spec_token_indx[: spec_token_indx.size(0)].copy_(
+                spec_token_indx,
+                non_blocking=True,
+            )
+            spec_token_indx = self.spec_token_indx[: spec_token_indx.size(0)]
+
+            self.spec_query_start_loc[: num_spec_decodes + 1].copy_(
+                spec_query_start_loc,
+                non_blocking=True,
+            )
+            spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore
+            spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
+            spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
+
+            self.num_accepted_tokens[:num_spec_decodes].copy_(
+                num_accepted_tokens,
+                non_blocking=True,
+            )
+            num_accepted_tokens = self.num_accepted_tokens[:batch_size]
+            num_accepted_tokens[num_spec_decodes:].fill_(1)
+
+        if (
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_spec_decodes == 0
+            and num_decodes <= self.decode_cudagraph_max_bs
+        ):
+            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+                non_spec_state_indices_tensor,
+                non_blocking=True,
+            )
+            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
+            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+
+            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+                non_spec_query_start_loc,
+                non_blocking=True,
+            )
+            non_spec_num_query_tokens = non_spec_query_start_loc[-1]
+            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
+            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+
+        attn_metadata = GDNAttentionMetadata(
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            num_actual_tokens=m.num_actual_tokens,
+            has_initial_state=has_initial_state,
+            chunk_indices=chunk_indices,
+            chunk_offsets=chunk_offsets,
+            spec_query_start_loc=spec_query_start_loc,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            spec_state_indices_tensor=spec_state_indices_tensor,
+            non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+            spec_sequence_masks=spec_sequence_masks,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+            num_accepted_tokens=num_accepted_tokens,
+            nums_dict=nums_dict,
+            batch_ptr=batch_ptr,
+            token_chunk_offset_ptr=token_chunk_offset_ptr,
+        )
+        attn_metadata = self._attach_non_spec_prefill_fallback_meta(
             attn_metadata,
-            spec_query_start_loc_cpu,
-        ),
-    )
-    return attn_metadata
-
-
-def _patched_build_decode(
-    self,
-    attn_metadata: gdn_attn.GDNAttentionMetadata,
-    common_attn_metadata,
-    num_decode_draft_tokens_cpu: torch.Tensor | None = None,
-):
-    assert attn_metadata.num_decodes > 0
-    _ensure_causal_conv1d_host_meta_state(
-        self,
-        common_attn_metadata.query_start_loc.device,
-    )
-    non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
-        self,
-        common_attn_metadata,
-        num_decode_draft_tokens_cpu,
-    )
-    if non_spec_query_start_loc_cpu is None:
-        raise RuntimeError("Expected non-spec query_start_loc_cpu for patched GDN non-spec decode path.")
-    attn_metadata.non_spec_decode_fallback_meta = GDNDecodeFallbackMeta(
-        causal_conv1d=_build_non_spec_decode_causal_conv1d_host_meta(
-            self,
-            attn_metadata,
+            common_attn_metadata,
             non_spec_query_start_loc_cpu,
-        ),
-    )
-    return attn_metadata
+        )
+        attn_metadata = self._attach_spec_decode_fallback_meta(
+            attn_metadata,
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )
+        return self._attach_non_spec_decode_fallback_meta(
+            attn_metadata,
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )
 
 
-if not _IS_PATCHED and not is_310p():
-    gdn_attn.GDNChunkedPrefillMetadata = GDNChunkedPrefillMetadata
-    gdn_attn.GDNCausalConv1dHostMetadata = GDNCausalConv1dHostMetadata
-    gdn_attn.GDNPrefillFallbackMeta = GDNPrefillFallbackMeta
-    gdn_attn.GDNAttentionMetadataBuilder.build = _patched_build
-    gdn_attn.GDNAttentionMetadataBuilder._init_reorder_batch_threshold = _init_reorder_batch_threshold
-    _IS_PATCHED = True
+class AscendGDNAttentionBackend(GDNAttentionBackend):
+    @staticmethod
+    def get_builder_cls() -> type[AscendGDNAttentionMetadataBuilder]:
+        return AscendGDNAttentionMetadataBuilder

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -48,7 +48,9 @@ def chunk_gated_delta_rule_fwd(
         num_decodes = attn_metadata.num_decodes
     chunk_size = 64
     block_indices_cumsum = None if prebuilt_meta is None else prebuilt_meta.block_indices_cumsum
+    cu_seqlens_host = None if prebuilt_meta is None else prebuilt_meta.cu_seqlens_host
     chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_chunk64
+    chunk_indices_chunk64_host = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_chunk64_host
     chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.chunk_offsets_chunk64
     update_chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.update_chunk_offsets_chunk64
     final_chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.final_chunk_indices_chunk64
@@ -91,8 +93,12 @@ def chunk_gated_delta_rule_fwd(
     g_ascendc = g.transpose(1, 2).contiguous()
     q_ascendc = q.to(torch.bfloat16).transpose(1, 2).contiguous()
 
-    cu_seqlens = cu_seqlens.to(torch.int64)
+    cu_seqlens = None if cu_seqlens is None else cu_seqlens.to(torch.int64)
     chunk_indices = None if chunk_indices_chunk64 is None else chunk_indices_chunk64.to(torch.int64)
+    if cu_seqlens_host is None and cu_seqlens is not None:
+        cu_seqlens_host = tuple(cu_seqlens.tolist())
+    if chunk_indices_chunk64_host is None and chunk_indices is not None:
+        chunk_indices_chunk64_host = tuple(chunk_indices.flatten().tolist())
     h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_ascendc,
         w_ascendc,
@@ -103,8 +109,8 @@ def chunk_gated_delta_rule_fwd(
         output_final_state=True,
         chunk_size=64,
         save_new_value=True,
-        cu_seqlens=cu_seqlens.tolist() if cu_seqlens is not None else None,
-        chunk_indices=chunk_indices.flatten().tolist() if chunk_indices is not None else None,
+        cu_seqlens=cu_seqlens_host,
+        chunk_indices=chunk_indices_chunk64_host,
         use_exp2=False,
         transpose_state_layout=False,
     )
@@ -169,8 +175,8 @@ def chunk_gated_delta_rule_fwd(
         scale,
         g=g_ascendc,
         g_gamma=None,
-        cu_seqlens=cu_seqlens.tolist() if cu_seqlens is not None else None,
-        chunk_indices=chunk_indices.flatten().tolist() if chunk_indices is not None else None,
+        cu_seqlens=cu_seqlens_host,
+        chunk_indices=chunk_indices_chunk64_host,
         chunk_size=64,
         transpose_state_layout=False,
     )

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -465,27 +465,28 @@
 #           to override them, then delete the patch file `worker/patch_rejection_sampler.py`.
 #       2. make these functions as costom op, then remove AscendRejectionSampler
 #
-# ** 7. File: worker/patch_gdn_attn.py**
+## ** 6. File: worker/patch_module.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.v1.attention.backends.gdn_attn.GDNAttentionMetadataBuilder.build`
+#   1. `vllm.v1.attention.backends.gdn_attn.torch.argsort`
 #    Why:
-#       Qwen3.5/Qwen3Next GDN prefill on NPU needs prebuilt varlen chunk metadata
-#       to avoid forward-time host round-trips that break async scheduling.
+#       1. 'torch.argsort' func of npu does not support bool.
+#       2. Without `stable=True`, the output will have a lot of redundant tokens.
 #    How：
-#       Monkey-patch the upstream builder in-place, keep upstream code untouched,
-#       and attach prebuilt device metadata bundle onto the returned attention
-#       metadata object for Ascend-specific consumers.
+#       Replace with a new torch.argsort that will cast the input to torch.int32
+#       and do stable sort.
+#    Related PR (if no, explain why):
+#       1. It depends on torch_npu.
+#       2. https://github.com/vllm-project/vllm/pull/30632
 #    Future Plan:
-#       Remove this patch when upstream exposes a backend hook for extending GDN
-#       metadata or when the optimization is accepted upstream directly.
-#   2. `vllm.v1.attention.backends.gdn_attn.GDNAttentionMetadataBuilde.build`
+#       Remove this patch when bool is supported in 'torch.argsort' func of npu.
+#       Make 'torch.argsort' in `vllm.v1.attention.backends.gdn_attn` be stable.
+#   2. `vllm_ascend.ops.gdn_attn_builder.AscendGDNAttentionMetadataBuilder.build`
 #    Why:
 #       Qwen3.5/Qwen3Next GDN Decode/Specific Decode on NPU needs prebuilt varlen chunk metadata
 #       to avoid forward-time host round-trips that break async scheduling.
 #    How：
-#       Monkey-patch the upstream builder in-place, keep upstream code untouched,
-#       and attach prebuilt device metadata bundle onto the returned attention
-#       metadata object for Ascend-specific consumers.
+#       Override the GDN attention metadata builder for Ascend backend and attach
+#       prebuilt device metadata bundle onto the returned attention metadata object.
 #    Future Plan:
 #       Remove this patch when upstream exposes a backend hook for extending GDN
 #       metadata or when the optimization is accepted upstream directly.

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -38,7 +38,6 @@ import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
 
 if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
-    import vllm_ascend.patch.worker.patch_gdn_attn  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -150,6 +150,7 @@ Qwen3_5DecoderLayer.forward = AscendQwen3_5DecoderLayer.forward
 Qwen3NextAttention.forward = AscendQwen3NextAttention.forward
 _GDN_PATCH_TARGET._split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_tp
 _GDN_PATCH_TARGET.get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
+_GDN_PATCH_TARGET.get_attn_backend = AscendGatedDeltaNetAttention.get_attn_backend
 
 if is_310p():
     from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -8,12 +8,5 @@ from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBasePropos
 
 
 class AscendEagleProposer(EagleProposer, AscendSpecDecodeBaseProposer):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        device: torch.device,
-        runner=None,
-    ):
-        AscendSpecDecodeBaseProposer.__init__(
-            self, vllm_config, device, pass_hidden_states_to_model=True, runner=runner
-        )
+    def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
+        AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, True, runner=runner)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1046,9 +1046,10 @@ class NPUModelRunner(GPUModelRunner):
         # CPU values are optimistic (all drafts accepted). The kernel
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
-        cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
-            device=self.device, non_blocking=True
-        )
+        if self.use_async_spec_decode:
+            cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
+                device=self.device, non_blocking=True
+            )
         if (
             self.use_async_spec_decode
             and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1047,7 +1047,7 @@ class NPUModelRunner(GPUModelRunner):
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
         if self.use_async_spec_decode:
-            cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
+            computed_token_tensor_cpu = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
                 device=self.device, non_blocking=True
             )
         if (
@@ -1063,7 +1063,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.prev_positions.gpu[:num_reqs],
                 self.valid_sampled_token_count_gpu, # type: ignore[has-type]
                 self.prev_num_draft_tokens.gpu,
-                cpu_values,
+                computed_token_tensor_cpu,
             )
         else:
             self.num_computed_tokens[:num_reqs].copy_(
@@ -1265,7 +1265,7 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
             drift = self.num_computed_tokens[req_indices_gpu].to(
                 torch.int64
-            ) - cpu_values[req_indices_gpu]
+            ) - computed_token_tensor_cpu[req_indices_gpu]
             target = self.mrope_positions if self.uses_mrope else self.xdrope_positions
             target.gpu[:, :total_num_scheduled_tokens] += drift
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1046,6 +1046,9 @@ class NPUModelRunner(GPUModelRunner):
         # CPU values are optimistic (all drafts accepted). The kernel
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
+        cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
+            device=self.device, non_blocking=True
+        )
         if (
             self.use_async_spec_decode
             and self.valid_sampled_token_count_gpu is not None # type: ignore[has-type]
@@ -1053,9 +1056,6 @@ class NPUModelRunner(GPUModelRunner):
         ):
             self.prev_positions.copy_to_gpu(num_reqs)
             self.prev_num_draft_tokens.copy_to_gpu()
-            cpu_values = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
-                device=self.device, non_blocking=True
-            )
             update_num_computed_tokens_for_batch_change(
                 self.num_computed_tokens,
                 self.num_accepted_tokens.gpu[:num_reqs],
@@ -1264,9 +1264,7 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
             drift = self.num_computed_tokens[req_indices_gpu].to(
                 torch.int64
-            ) - self.input_batch.num_computed_tokens_cpu_tensor[req_indices].to(
-                device=self.device, dtype=torch.int64, non_blocking=True
-            )
+            ) - cpu_values[req_indices_gpu]
             target = self.mrope_positions if self.uses_mrope else self.xdrope_positions
             target.gpu[:, :total_num_scheduled_tokens] += drift
 


### PR DESCRIPTION
### What this PR does / why we need it?
1.Erease the synconize before chunk o and chunk fwd h op.
2.decrease the time between 2 decode steps
3.refactor the gdn attention backend（delete the gdn attn builder patch）.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
1.performence:
1)chunk o and chunk fwd h:
2)decode time between 2 decode steps decrease from 6ms to 3ms
3)3.5K/1.5K@TPOT50ms on Qwen3.5-397B-A13B model on A3:
330 performence: 2400 tokens/s @TPOT43ms
main code with this pr:2700 tokens/s @TPOT32ms
2.Accuracy:
Test GPQA on Qwen3.6-35B-A3B:
0 day accuracy:83.23.
main code with this pr:83.33


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
