### PR TITLE
[Bugfix] ascend_config: use truthy check for enforce_eager instead of `is True`

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -354,7 +354,7 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config.enforce_eager is True:
+            if vllm_config.model_config.enforce_eager:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(


### PR DESCRIPTION
### What this PR does / why we need it?

Replaces the identity comparison `if vllm_config.model_config.enforce_eager is True:` in `vllm_ascend/ascend_config.py` (line 357) with the conventional truthy check `if vllm_config.model_config.enforce_eager:`. See #9311 for the full rationale.

This brings the site in line with:
- the rest of the same file, which always uses bare truthy checks for boolean config flags;
- upstream `vllm/config.py`, where `enforce_eager` is declared as `Optional[bool]` and consumed via truthy checks;
- [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations), which explicitly calls `if greeting is True:` *worse* than `if greeting == True:` and recommends the bare truthy form.

Fixes #9311.

### Does this PR introduce _any_ user-facing change?

No — for any value where `x is True` was already true, `bool(x)` is also true; the change only **broadens** the acceptance to truthy non-singleton values (e.g. `1`, `numpy.True_`), which is the behaviour every other call site already exhibits.

### How was this patch tested?

- The change is a 1-token modification (`is True` → empty), there is no new branch / new code path.
- Existing CI (`_pre_commit`, `_e2e_*`) covers the call site.
- Local `python -c "import vllm_ascend.ascend_config"` still imports cleanly.
- Note: this pattern is not flagged by the linters used in `vllm-ascend`, so there is no automated lint signal to monitor; this PR is verified via review and behavioural equivalence (any value that was previously `is True` is also truthy).
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
