### PR TITLE
[BugFix][Build] Keep custom op uninstall script removable

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -289,6 +289,11 @@ log_selected_ops
   chmod +x -- "${installer_candidates[0]}" || true
   log "running installer: ${installer_candidates[0]}"
   "${installer_candidates[0]}" --install-path="${custom_ops_install_dir}"
+  # CANN leaves generated vendor script dirs owner-read-only; keep repo-local
+  # editable-build artifacts removable by the non-root user who built them.
+  if [[ -d "${custom_ops_install_dir}/vendors/custom_transformer/scripts" ]]; then
+    chmod u+w "${custom_ops_install_dir}/vendors/custom_transformer/scripts"
+  fi
   log "installer finished"
   log "installed files under ${custom_ops_install_dir} (maxdepth=4, first 120 entries):"
   { find "${custom_ops_install_dir}" -mindepth 1 -maxdepth 4 -print | sort | head -n 120 | sed 's#^#[build_aclnn] install: #'; } || true


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes vllm-project/vllm-ascend#9314.

When vllm-ascend builds custom ops, it runs the generated CANN custom-op installer with an explicit repo-local install path under `vllm_ascend/_cann_ops_custom`. On CANN 8.5.1, that installer copies `uninstall.sh` into `vendors/custom_transformer/scripts` and applies mode `550` to the scripts directory.

For a source/editable build, this leaves the generated `uninstall.sh` in the checkout but prevents the same non-root user from deleting it during cleanup or rebuild.

This PR keeps the fix local and minimal: after the installer finishes, vllm-ascend restores owner write permission on the generated `vendors/custom_transformer/scripts` directory. The script file modes set by the installer are otherwise preserved.

### Does this PR introduce _any_ user-facing change?

Yes. Non-root source/editable builds can delete the generated `_cann_ops_custom/vendors/custom_transformer/scripts/uninstall.sh` without sudo or manual chmod.

### How was this patch tested?

No unit test was added because this is installation-script behavior.

Manual smoke test:

1. Copied CANN 8.5.1 `fwk_modules/scripts/install.sh` and `uninstall.sh` into a temporary package layout.
2. Rewrote `vendor_name=customize` to `vendor_name=custom_transformer`, matching the vllm-ascend packaging flow.
3. Ran the installer with `--install-path=<tmp>/install`.
4. Applied the same direct `chmod u+w <tmp>/install/vendors/custom_transformer/scripts` used by this PR.
5. Verified `vendors/custom_transformer/scripts` was mode `750`, `uninstall.sh` remained mode `550`, and `rm .../scripts/uninstall.sh` succeeded.

Also ran:

```bash
bash -n csrc/build_aclnn.sh
```
