### PR TITLE
[Misc] requirements: fix `pyporject` typo and drop duplicated arctic-inference pin in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,5 @@ scipy
 soundfile
 pytest_mock
 mindstudio-probe>=8.3.0
-arctic-inference==0.1.1
 xlite==0.1.0rc7
 uc-manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple
-# Should be mirrored in pyporject.toml
+# Should be mirrored in pyproject.toml
 cmake>=3.26
 decorator
 einops


### PR DESCRIPTION
### What this PR does / why we need it?

Two trivial cleanups (see #9318). No runtime change.

```diff
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple
-# Should be mirrored in pyporject.toml
+# Should be mirrored in pyproject.toml
 cmake>=3.26
```

```diff
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
-arctic-inference==0.1.1
```

`arctic-inference==0.1.1` is still installed via the transitive `-r requirements.txt`.

Fixes #9318.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `grep -n arctic-inference requirements.txt requirements-dev.txt` → 1 match (only in `requirements.txt`).
- `pip install --dry-run -r requirements-dev.txt` still resolves `arctic-inference==0.1.1`.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
