### PR TITLE
[KV-Cache][Feature] Enable prefix caching with PCP/DCP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -540,6 +540,7 @@ setup(
     entry_points={
         "vllm.platform_plugins": ["ascend = vllm_ascend:register"],
         "vllm.general_plugins": [
+            "ascend_patch_general = vllm_ascend:register_patch_general",
             "ascend_kv_connector = vllm_ascend:register_connector",
             "ascend_model_loader = vllm_ascend:register_model_loader",
             "ascend_service_profiling = vllm_ascend:register_service_profiling",

--- a/tests/ut/patch/general/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/general/test_prefix_cache_cp_patches.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+from vllm_ascend.patch.general import patch_get_request_block_hasher as hasher_patch
+from vllm_ascend.patch.general.patch_hybrid_kv_cache_coordinator import (
+    AscendHybridKVCacheCoordinator,
+)
+from vllm_ascend.patch.general.patch_mamba_manager import AscendMambaManager
+from vllm_ascend.patch.worker import patch_mamba_utils
+from vllm_ascend.worker.pcp_utils import PCPManager
+
+
+def _set_hash_config_snapshot(
+    *,
+    cache_block_size: int,
+    pcp_size: int = 1,
+    dcp_size: int = 1,
+) -> None:
+    hasher_patch._VLLM_CONFIG_SNAPSHOT.clear()
+    hasher_patch._VLLM_CONFIG_SNAPSHOT.update(
+        {
+            "decode_context_parallel_size": dcp_size,
+            "prefill_context_parallel_size": pcp_size,
+            "block_size": cache_block_size,
+        }
+    )
+
+
+def _make_coordinator(dcp_world_size: int, pcp_world_size: int) -> AscendHybridKVCacheCoordinator:
+    coord = object.__new__(AscendHybridKVCacheCoordinator)
+    coord.dcp_world_size = dcp_world_size
+    coord.pcp_world_size = pcp_world_size
+    return coord
+
+
+def _make_mamba_spec(block_size: int = 16) -> MambaSpec:
+    return MambaSpec(
+        block_size=block_size,
+        shapes=((1,), (1,)),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+
+
+def _make_full_attention_spec(block_size: int = 16) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        head_size_v=1,
+        dtype=torch.float32,
+    )
+
+
+@pytest.mark.parametrize(
+    ("pcp_size", "dcp_size", "input_block_size", "expected"),
+    [
+        (1, 1, 16, 16),
+        (2, 1, 32, 32),
+        (1, 2, 32, 16),
+        (2, 2, 64, 32),
+        (2, 2, 16, 16),
+    ],
+)
+def test_get_hash_size_normalizes_virtual_block_size(
+    pcp_size: int,
+    dcp_size: int,
+    input_block_size: int,
+    expected: int,
+) -> None:
+    cache_block_size = 16
+    _set_hash_config_snapshot(
+        cache_block_size=cache_block_size,
+        pcp_size=pcp_size,
+        dcp_size=dcp_size,
+    )
+    assert hasher_patch.get_hash_size(input_block_size) == expected
+
+
+@pytest.mark.parametrize(
+    ("pcp_size", "dcp_size", "spec_factory", "expected"),
+    [
+        (1, 1, _make_full_attention_spec, 16),
+        (2, 2, _make_full_attention_spec, 64),
+        (2, 2, _make_mamba_spec, 32),
+        (2, 1, _make_mamba_spec, 32),
+        (1, 2, _make_mamba_spec, 16),
+    ],
+)
+def test_ascend_hybrid_coordinator_effective_block_size(
+    pcp_size: int,
+    dcp_size: int,
+    spec_factory,
+    expected: int,
+) -> None:
+    coord = _make_coordinator(dcp_world_size=dcp_size, pcp_world_size=pcp_size)
+    assert coord._get_effective_block_size(spec_factory()) == expected
+
+
+def test_ascend_mamba_manager_divides_block_size_for_dcp() -> None:
+    spec = _make_mamba_spec()
+    block_pool = MagicMock()
+
+    def _fake_mamba_init(self, kv_cache_spec, block_pool, **kwargs):
+        self.block_size = kv_cache_spec.block_size * 4
+        self.dcp_world_size = kwargs.get("dcp_world_size", 1)
+        self.pcp_world_size = kwargs.get("pcp_world_size", 1)
+
+    with patch(
+        "vllm_ascend.patch.general.patch_mamba_manager.MambaManager.__init__",
+        _fake_mamba_init,
+    ):
+        mgr = AscendMambaManager(
+            spec,
+            block_pool,
+            dcp_world_size=2,
+            pcp_world_size=2,
+        )
+
+    assert mgr.block_size == 32
+
+
+@pytest.mark.parametrize(
+    ("pcp_world_size", "expected"),
+    [(1, 16), (2, 32), (4, 64)],
+)
+def test_mamba_utils_effective_block_size_scales_with_pcp_only(
+    pcp_world_size: int,
+    expected: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        patch_mamba_utils,
+        "get_pcp_group",
+        lambda: SimpleNamespace(world_size=pcp_world_size),
+    )
+    assert patch_mamba_utils._get_effective_block_size(16) == expected
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected"),
+    [
+        ("qwen3_next", True),
+        ("qwen3_5_moe", True),
+        ("qwen2", False),
+    ],
+)
+def test_pcp_manager_hybrid_attn_model_types(
+    model_type: str,
+    expected: bool,
+) -> None:
+    vllm_config = MagicMock()
+    vllm_config.model_config.hf_config.model_type = model_type
+    vllm_config.parallel_config.cp_kv_cache_interleave_size = 64
+    vllm_config.speculative_config.num_speculative_tokens = 0
+
+    pcp_manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        dcp_world_size=1,
+        dcp_rank=0,
+        max_buffer_num_tokens=128,
+        max_num_reqs=8,
+        device="cpu",
+        vllm_config=vllm_config,
+        use_async_scheduling=False,
+        pin_memory=False,
+    )
+    assert pcp_manager.pcp_use_hybrid_attn is expected

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -41,6 +41,12 @@ def register():
     return "vllm_ascend.platform.NPUPlatform"
 
 
+def register_patch_general():
+    import importlib
+
+    importlib.import_module("vllm_ascend.patch.general")
+
+
 def register_connector():
     _ensure_global_patch()
 

--- a/vllm_ascend/patch/general/__init__.py
+++ b/vllm_ascend/patch/general/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import vllm_ascend.patch.general.patch_hybrid_kv_cache_coordinator  # noqa
+import vllm_ascend.patch.general.patch_mamba_manager  # noqa
+import vllm_ascend.patch.general.patch_get_request_block_hasher  # noqa

--- a/vllm_ascend/patch/general/patch_get_request_block_hasher.py
+++ b/vllm_ascend/patch/general/patch_get_request_block_hasher.py
@@ -1,0 +1,78 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific governing permissions and
+# limitations under the License.
+
+"""Scale ``get_request_block_hasher`` block size by CP world size when needed.
+
+``EngineCore`` passes ``hash_block_size`` from ``resolve_kv_cache_block_sizes``,
+which is already ``cache_config.block_size * pcp * dcp`` in the common case.
+If anything still passes the physical cache block size while CP is enabled,
+multiply once by ``pcp * dcp`` so hashing aligns with the scheduler virtual block.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import vllm.v1.engine.core as engine_core_module
+from vllm.v1.core import kv_cache_utils
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.core.sched.scheduler import Scheduler
+
+_ORIG_SCHEDULER_INIT = Scheduler.__init__
+_ORIG_GET_REQUEST_BLOCK_HASHER = kv_cache_utils.get_request_block_hasher
+_VLLM_CONFIG_SNAPSHOT: dict[str, Any] = {}
+
+
+def _set_vllm_config_snapshot(vllm_config: Any) -> None:
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    cache_config = getattr(vllm_config, "cache_config", None)
+    _VLLM_CONFIG_SNAPSHOT.clear()
+    _VLLM_CONFIG_SNAPSHOT.update(
+        {
+            "decode_context_parallel_size": getattr(parallel_config, "decode_context_parallel_size", None),
+            "prefill_context_parallel_size": getattr(parallel_config, "prefill_context_parallel_size", None),
+            "block_size": getattr(cache_config, "block_size", None),
+        }
+    )
+
+
+def _patched_scheduler_init(self, vllm_config, *args, **kwargs):
+    _set_vllm_config_snapshot(vllm_config)
+    return _ORIG_SCHEDULER_INIT(self, vllm_config, *args, **kwargs)
+
+
+def get_hash_size(block_size: int) -> int:
+    dcp_size: int = int(_VLLM_CONFIG_SNAPSHOT.get("decode_context_parallel_size", 1) or 1)
+    pcp_size: int = int(_VLLM_CONFIG_SNAPSHOT.get("prefill_context_parallel_size", 1) or 1)
+    cache_block_size: int = int(_VLLM_CONFIG_SNAPSHOT.get("block_size", 1) or 1)
+
+    if block_size == cache_block_size * pcp_size * dcp_size:
+        block_size //= dcp_size
+    return block_size
+
+
+def ascend_get_request_block_hasher(
+    block_size: int,
+    caching_hash_fn: Callable[[Any], bytes],
+) -> Callable[[Any], list[BlockHash]]:
+    hash_block_size = get_hash_size(block_size)
+    return _ORIG_GET_REQUEST_BLOCK_HASHER(hash_block_size, caching_hash_fn)
+
+
+kv_cache_utils.get_request_block_hasher = ascend_get_request_block_hasher
+engine_core_module.get_request_block_hasher = ascend_get_request_block_hasher
+Scheduler.__init__ = _patched_scheduler_init

--- a/vllm_ascend/patch/general/patch_hybrid_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/general/patch_hybrid_kv_cache_coordinator.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+from math import lcm
+
+import vllm.v1.core.kv_cache_coordinator as kv_cache_coordinator
+from vllm.v1.core.kv_cache_coordinator import (
+    BlockHash,
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    FullAttentionSpec,
+    HybridKVCacheCoordinator,
+    KVCacheBlock,
+    KVCacheConfig,
+    KVCacheCoordinator,
+    KVCacheMetricsCollector,
+    KVCacheSpec,
+    SingleTypeKVCacheManager,
+)
+from vllm.v1.kv_cache_interface import MambaSpec
+
+
+class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
+    """CP-aware hybrid KV cache coordinator for Ascend.
+    Upstream `HybridKVCacheCoordinator` assumes the logical block size used by
+    prefix caching is always the raw `kv_cache_spec.block_size`. Under PCP/DCP,
+    however, vllm-ascend hashes and allocates KV blocks using the virtual block
+    size, i.e. `block_size * dcp_world_size * pcp_world_size`. This subclass
+    keeps the upstream fixed-point lookup algorithm but makes all block-size
+    calculations CP-aware.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        use_eagle: bool,
+        enable_caching: bool,
+        enable_kv_cache_events: bool,
+        dcp_world_size: int,
+        pcp_world_size: int,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+    ):
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        self.hash_block_size = hash_block_size
+        for g in kv_cache_config.kv_cache_groups:
+            if isinstance(g.kv_cache_spec, MambaSpec):
+                self.hash_block_size = self._get_effective_block_size(g.kv_cache_spec)
+                break
+
+        KVCacheCoordinator.__init__(
+            self,
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=self.hash_block_size,
+            metrics_collector=metrics_collector,
+        )
+        assert all(
+            self._get_effective_block_size(g.kv_cache_spec) % self.hash_block_size == 0
+            for g in kv_cache_config.kv_cache_groups
+        ), "block_size must be divisible by hash_block_size"
+        self.verify_and_split_kv_cache_groups()
+
+    def _get_effective_block_size(self, kv_cache_spec: KVCacheSpec) -> int:
+        block_size = kv_cache_spec.block_size
+        if self.dcp_world_size * self.pcp_world_size > 1:
+            block_size *= self.dcp_world_size * self.pcp_world_size
+        if isinstance(kv_cache_spec, MambaSpec):
+            block_size = block_size // self.dcp_world_size
+        return block_size
+
+    def verify_and_split_kv_cache_groups(self) -> None:
+        attention_groups: list[tuple[KVCacheSpec, list[int], type[SingleTypeKVCacheManager]]] = []
+        for i, g in enumerate(self.kv_cache_config.kv_cache_groups):
+            manager_cls = self.single_type_managers[i].__class__
+            spec = g.kv_cache_spec
+            for existing_spec, group_ids, existing_cls in attention_groups:
+                if existing_spec == spec:
+                    assert manager_cls is existing_cls, "Expected same manager class for identical KV cache specs."
+                    group_ids.append(i)
+                    break
+            else:
+                attention_groups.append((spec, [i], manager_cls))
+        assert len(attention_groups) > 1, "HybridKVCacheCoordinator requires at least two attention groups."
+        self.attention_groups = sorted(
+            attention_groups,
+            key=lambda x: not isinstance(x[0], FullAttentionSpec),
+        )
+        block_sizes = [self._get_effective_block_size(spec) for spec, _, _ in attention_groups]
+        self.lcm_block_size = lcm(*block_sizes)
+
+        # Attention-group indices (into ``self.attention_groups``) that
+        # contain at least one EAGLE/MTP KV cache group.
+        self.eagle_attn_group_indices: set[int] = {
+            i
+            for i, (_, group_ids, _) in enumerate(self.attention_groups)
+            if any(gid in self.eagle_group_ids for gid in group_ids)
+        }
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+            effective_block_size = self._get_effective_block_size(kv_cache_spec)
+            if effective_block_size == self.hash_block_size:
+                return block_hashes
+            return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, effective_block_size)
+
+        num_groups = len(self.kv_cache_config.kv_cache_groups)
+        hit_length = max_cache_hit_length
+        hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * num_groups
+        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
+            self.attention_groups[0][0], FullAttentionSpec
+        )
+        eagle_verified: set[int] = set()
+        while True:
+            curr_hit_length = hit_length
+            for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
+                effective_block_size = self._get_effective_block_size(spec)
+                cached_blocks = hit_blocks_by_group[group_ids[0]]
+                if isinstance(spec, FullAttentionSpec) and cached_blocks is not None:
+                    num_blocks = curr_hit_length // effective_block_size
+                    curr_hit_length = num_blocks * effective_block_size
+                    continue
+                use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
+                _max_length = curr_hit_length
+                if use_eagle:
+                    # Eagle needs to match one more block and then pop the last.
+                    _max_length = min(curr_hit_length + effective_block_size, max_cache_hit_length)
+                hit_blocks = manager_cls.find_longest_cache_hit(
+                    block_hashes=_get_block_hashes(spec),
+                    max_length=curr_hit_length,
+                    kv_cache_group_ids=group_ids,
+                    block_pool=self.block_pool,
+                    kv_cache_spec=spec,
+                    use_eagle=use_eagle,
+                    alignment_tokens=self.lcm_block_size,
+                    dcp_world_size=self.dcp_world_size,
+                    pcp_world_size=self.pcp_world_size,
+                )
+                _new_hit_length = len(hit_blocks[0]) * effective_block_size
+                if use_eagle:
+                    eagle_verified.add(idx)
+                elif _new_hit_length < curr_hit_length:
+                    # length shrunk; invalidate previous eagle verifications
+                    eagle_verified.clear()
+                curr_hit_length = _new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks):
+                    hit_blocks_by_group[group_id] = blocks
+
+            if curr_hit_length >= hit_length:
+                break
+            hit_length = curr_hit_length
+            if is_simple_hybrid:
+                break
+        spec, group_ids, _ = self.attention_groups[0]
+        if isinstance(spec, FullAttentionSpec):
+            num_blocks = hit_length // self._get_effective_block_size(spec)
+            for group_id in group_ids:
+                if (blks := hit_blocks_by_group[group_id]) is not None:
+                    del blks[num_blocks:]
+        return tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group), hit_length
+
+
+kv_cache_coordinator.HybridKVCacheCoordinator = AscendHybridKVCacheCoordinator

--- a/vllm_ascend/patch/general/patch_mamba_manager.py
+++ b/vllm_ascend/patch/general/patch_mamba_manager.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+import vllm.v1.core.single_type_kv_cache_manager as single_type_kv_cache_manager
+from vllm.v1.core.single_type_kv_cache_manager import (
+    BlockHashList,
+    BlockPool,
+    KVCacheBlock,
+    KVCacheSpec,
+    MambaManager,
+    MambaSpec,
+)
+
+
+class AscendMambaManager(MambaManager):
+    """CP-aware Mamba manager for Ascend."""
+
+    def __init__(self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs) -> None:
+        super().__init__(kv_cache_spec, block_pool, **kwargs)
+        if self.dcp_world_size > 1:
+            self.block_size = int(self.block_size // self.dcp_world_size)  # type: ignore[has-type]
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, MambaSpec), "MambaManager can only be used for mamba groups"
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
+        block_size = kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(block_hashes[i], kv_cache_group_ids):
+                if block_size != alignment_tokens and (i + 1) * block_size % alignment_tokens != 0:
+                    continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.extend([block_pool.null_block] * i)
+                    computed.append(cached)
+                break
+        return computed_blocks
+
+
+single_type_kv_cache_manager.MambaManager = AscendMambaManager
+single_type_kv_cache_manager.spec_manager_map[MambaSpec] = AscendMambaManager

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -1,9 +1,119 @@
 # mypy: ignore-errors
 
+import itertools
 
+from vllm.distributed.parallel_state import get_pcp_group
 from vllm.v1.worker import mamba_utils
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
+
+
+def _get_effective_block_size(block_size: int) -> int:
+    pcp_world_size = get_pcp_group().world_size
+    if pcp_world_size > 1:
+        block_size *= pcp_world_size
+    return block_size
+
+
+def preprocess_mamba(
+    scheduler_output,
+    kv_cache_config,
+    cache_config,
+    mamba_state_idx,
+    input_batch,
+    requests,
+    forward_context,
+    mamba_state_copy_funcs,
+    copy_bufs,
+):
+    """Copy mamba state using CP-aware block indexing."""
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    num_speculative_blocks = mamba_spec.num_speculative_blocks
+    if not cache_config.enable_prefix_caching:
+        return
+    block_size = _get_effective_block_size(mamba_spec.block_size)
+    finished_req_ids = scheduler_output.finished_req_ids
+    preempted_req_ids = scheduler_output.preempted_req_ids or set()
+    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
+    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
+        mamba_state_idx.pop(req_id, None)
+
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        prev_state_idx = mamba_state_idx.get(req_id)
+        if prev_state_idx is None:
+            prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
+
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+        num_blocks = (
+            mamba_utils.cdiv(req_state.num_computed_tokens + num_scheduled_tokens, block_size) + num_speculative_blocks
+        )
+
+        curr_state_idx = num_blocks - 1 - num_speculative_blocks
+        mamba_state_idx[req_id] = curr_state_idx
+        if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
+            mamba_utils.collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                prev_state_idx,
+                curr_state_idx,
+                input_batch.num_accepted_tokens_cpu[i] - 1,
+                req_state,
+                forward_context,
+            )
+            input_batch.num_accepted_tokens_cpu[i] = 1
+    mamba_utils.do_mamba_copy_block(copy_bufs)
+
+
+def postprocess_mamba(
+    scheduler_output,
+    kv_cache_config,
+    input_batch,
+    requests,
+    mamba_state_idx,
+    forward_context,
+    mamba_state_copy_funcs,
+    copy_bufs,
+):
+    """Finalize mamba state copies using CP-aware block indexing."""
+    num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
+    scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
+    num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    block_size = _get_effective_block_size(mamba_spec.block_size)
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        num_computed_tokens = req_state.num_computed_tokens
+        num_draft_tokens = len(scheduled_spec_decode_tokens_dict.get(req_id, []))
+        num_scheduled_tokens = num_scheduled_tokens_dict[req_id]
+        num_accepted_tokens = num_accepted_tokens_cpu[i]
+        num_tokens_running_state = num_computed_tokens + num_scheduled_tokens - num_draft_tokens
+        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens - 1
+        aligned_new_computed_tokens = new_num_computed_tokens // block_size * block_size
+        if aligned_new_computed_tokens >= num_tokens_running_state:
+            accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
+            src_block_idx = mamba_state_idx[req_id]
+            dest_block_idx = aligned_new_computed_tokens // block_size - 1
+            mamba_utils.collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                src_block_idx,
+                dest_block_idx,
+                accept_token_bias,
+                req_state,
+                forward_context,
+            )
+            if src_block_idx == dest_block_idx:
+                num_accepted_tokens_cpu[i] = 1
+    mamba_utils.do_mamba_copy_block(copy_bufs)
 
 
 def batch_memcpy(src_ptrs, dst_ptrs, sizes):
@@ -19,3 +129,5 @@ def batch_memcpy(src_ptrs, dst_ptrs, sizes):
 
 mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel
 mamba_utils.batch_memcpy = batch_memcpy
+mamba_utils.preprocess_mamba = preprocess_mamba
+mamba_utils.postprocess_mamba = postprocess_mamba

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -127,7 +127,7 @@ class PCPManager:
         self.pcp_enter_fa_restore_idx = torch.zeros(
             self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
         )
-        self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type == "qwen3_next"
+        self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type in ("qwen3_next", "qwen3_5_moe")
 
         self.pcp_pads_logits_hybrid_attn = torch.ones(self.max_num_reqs, dtype=torch.int32) * (self.pcp_world_size - 1)
         self.pcp_padded_tokens_fla = 0


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream prefix caching assumes logical KV block size equals kv_cache_spec.block_size. With PCP/DCP enabled, vllm-ascend hashes and allocates full-attention KV using virtual block size (block_size * pcp_world_size * dcp_world_size), which breaks prefix cache hit/miss unless scheduler, hasher, and worker paths agree on the same effective size.

This change registers the ascend_patch_general vLLM general plugin and adds CP-aware patches so prefix caching works under context parallel:

- Hybrid KV cache coordinator: AscendHybridKVCacheCoordinator scales effective block size by pcp * dcp for full-attention cache lookup and passes CP world sizes into find_longest_cache_hit.
- Request block hasher: normalize hash_block_size when EngineCore already passes the scheduler virtual block size (block_size * pcp * dcp).
- Mamba manager / worker utils: CP-aware block indexing for mamba state copy when prefix caching is enabled.
- PCP hybrid attention: treat qwen3_5_moe like qwen3_next.

DCP handling for MambaSpec only (linear / hybrid attention state):

Full-attention KV blocks follow PCP and DCP virtual sizing, but linear attention (Mamba) state is not DCP-sharded on the worker—each rank keeps a full mamba state block. Prefix-cache logic must therefore undo the DCP factor for MambaSpec only:

- AscendHybridKVCacheCoordinator._get_effective_block_size: for MambaSpec, use (block_size * pcp * dcp) // dcp_world_size instead of the full virtual size used for FullAttentionSpec.
- AscendMambaManager: when dcp_world_size > 1, divide internal block_size by dcp_world_size so longest-cache-hit and block walks match per-rank mamba state granularity.

### Does this PR introduce any user-facing change?

Yes. Users can enable --enable-prefix-caching together with PCP and/or DCP; prefix cache hits and Mamba state copies use consistent virtual block sizing instead of silently missing or mis-aligning blocks.

### How was this patch tested?

- Unit tests: tests/ut/patch/general/test_prefix_cache_cp_patches.py (get_hash_size, effective block size for FullAttentionSpec vs MambaSpec, AscendMambaManager DCP scaling, mamba_utils PCP block size, PCPManager hybrid model types).
- Manual NPU testing with PCP/DCP and --enable-prefix-caching is still recommended for end-to-end validation.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
