### PR TITLE
[Ascend950][BugFix] fix npu_add_rms_norm_dynamic_quant error in A5

### DIFF
--- a/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
@@ -308,7 +308,7 @@ class AddRMSNormDynamicQuantPattern(BasePattern):
             Replacement for the AddRMSNormQuant fusion.
             """
             output = torch.ops.npu.npu_add_rms_norm_dynamic_quant(
-                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, True]
+                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, False]
             )
             return (
                 output[0],
@@ -364,7 +364,7 @@ class AddRMSNormDynamicQuantPatternWithBias(BasePattern):
             Replacement for the AddRMSNormQuant fusion.
             """
             output = torch.ops.npu.npu_add_rms_norm_dynamic_quant(
-                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, True], beta=bias
+                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, False], beta=bias
             )
             return (
                 output[0],
@@ -408,7 +408,7 @@ class AddRMSNormDynamicQuantSPPattern(BasePattern):
             Replacement for the AddRMSNormQuant fusion.
             """
             output = torch.ops.npu.npu_add_rms_norm_dynamic_quant(
-                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, True]
+                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, False]
             )
             out3 = output[3]
             quantized_output = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(output[0], True)
@@ -464,7 +464,7 @@ class AddRMSNormDynamicQuantSPPatternWithBias(BasePattern):
             Replacement for the AddRMSNormQuant fusion.
             """
             output = torch.ops.npu.npu_add_rms_norm_dynamic_quant(
-                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, True], beta=bias
+                rms_norm_input, residual, rms_norm_weight, epsilon=self.eps, output_mask=[True, False], beta=bias
             )
             out3 = output[3]
             quantized_output = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(output[0], True)


### PR DESCRIPTION
### What this PR does / why we need it?
**Error information**
RuntimeError: npu_add rms norm_dynamic_quant:../third party/op-plugin/
AcINN_Parameter_Error(EZ1001): Input tensor's shape[[1]] should be same with output's shape[[39500, 5120]].
**Error Cause**
`output_mask` Input parameters do not meet operator requirements
**Solution**
[Operator Documentation](https://gitcode.com/cann/ops-nn/blob/master/norm/add_rms_norm_dynamic_quant/docs/aclnnAddRmsNormDynamicQuantV2.md)
Modify to `[True, False]`

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
