### PR TITLE
[BugFix] Fix Ascend MM encoder attention backend selection

### DIFF
--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -15,7 +15,9 @@
 
 from unittest import mock
 
+import pytest
 import torch
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend import utils
 from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
@@ -43,6 +45,7 @@ def test_mm_encoder_attention_310_forward_oot_with_padding():
     layer.head_size = 80
     layer.enable_pad = True
     layer.scale_value = layer.head_size**-0.5
+    layer.attn_backend = AttentionBackendEnum.FLASH_ATTN
 
     bsz, q_len, kv_len = 2, 3, 3
     query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size)
@@ -78,3 +81,51 @@ def test_mm_encoder_attention_310_forward_oot_with_padding():
 
     assert out.shape == query.shape
     torch.testing.assert_close(out, query + 1.0)
+
+
+def test_mm_encoder_attention_310_forward_oot_respects_torch_sdpa_backend():
+    layer = AscendMMEncoderAttention310.__new__(AscendMMEncoderAttention310)
+    layer.attn_backend = AttentionBackendEnum.TORCH_SDPA
+
+    query = torch.randn(2, 3, 4, 80)
+    key = torch.randn(2, 3, 2, 80)
+    value = torch.randn(2, 3, 2, 80)
+    expected = torch.randn_like(query)
+
+    with (
+        mock.patch.object(
+            AscendMMEncoderAttention310,
+            "_forward_sdpa",
+            autospec=True,
+            return_value=expected,
+        ) as mock_sdpa,
+        mock.patch(
+            "vllm_ascend._310p.ops.mm_encoder_attention.torch_npu._npu_flash_attention_unpad",
+            create=True,
+        ) as mock_npu_flash_attention,
+    ):
+        output = layer.forward_oot(query, key, value)
+
+    assert output is expected
+    mock_sdpa.assert_called_once_with(layer, query, key, value, None)
+    mock_npu_flash_attention.assert_not_called()
+
+
+def test_mm_encoder_attention_310_forward_oot_rejects_unsupported_backend():
+    layer = AscendMMEncoderAttention310.__new__(AscendMMEncoderAttention310)
+    layer.attn_backend = AttentionBackendEnum.TRITON_ATTN
+
+    query = torch.randn(2, 3, 4, 80)
+    key = torch.randn(2, 3, 2, 80)
+    value = torch.randn(2, 3, 2, 80)
+
+    with (
+        mock.patch(
+            "vllm_ascend._310p.ops.mm_encoder_attention.torch_npu._npu_flash_attention_unpad",
+            create=True,
+        ) as mock_npu_flash_attention,
+        pytest.raises(ValueError, match="Unsupported multi-modal encoder attention backend"),
+    ):
+        layer.forward_oot(query, key, value)
+
+    mock_npu_flash_attention.assert_not_called()

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+import torch
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+from vllm_ascend.ops.mm_encoder_attention import AscendMMEncoderAttention
+
+
+def _make_layer(attn_backend: AttentionBackendEnum) -> AscendMMEncoderAttention:
+    layer = AscendMMEncoderAttention.__new__(AscendMMEncoderAttention)
+    layer.num_heads = 4
+    layer.num_kv_heads = 2
+    layer.head_size = 80
+    layer.enable_pad = True
+    layer.scale_value = layer.head_size**-0.5
+    layer.attn_backend = attn_backend
+    return layer
+
+
+def test_mm_encoder_attention_forward_oot_respects_torch_sdpa_backend():
+    layer = _make_layer(AttentionBackendEnum.TORCH_SDPA)
+    query = torch.randn(2, 3, layer.num_heads, layer.head_size)
+    key = torch.randn(2, 3, layer.num_kv_heads, layer.head_size)
+    value = torch.randn(2, 3, layer.num_kv_heads, layer.head_size)
+    expected = torch.randn_like(query)
+
+    with (
+        mock.patch.object(
+            AscendMMEncoderAttention,
+            "_forward_sdpa",
+            autospec=True,
+            return_value=expected,
+        ) as mock_sdpa,
+        mock.patch(
+            "vllm_ascend.ops.mm_encoder_attention.DeviceOperator.npu_flash_attention"
+        ) as mock_npu_flash_attention,
+    ):
+        output = layer.forward_oot(query, key, value)
+
+    assert output is expected
+    mock_sdpa.assert_called_once_with(layer, query, key, value, None)
+    mock_npu_flash_attention.assert_not_called()
+
+
+def test_mm_encoder_attention_forward_oot_uses_npu_flash_attention_for_flash_backend():
+    layer = _make_layer(AttentionBackendEnum.FLASH_ATTN)
+    bsz, q_len, kv_len = 2, 3, 3
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size)
+    key = torch.randn(bsz, kv_len, layer.num_kv_heads, layer.head_size)
+    value = torch.randn(bsz, kv_len, layer.num_kv_heads, layer.head_size)
+    capture = {}
+
+    def fake_npu_flash_attention(*, query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
+        capture["query_shape"] = query.shape
+        capture["key_shape"] = key.shape
+        capture["value_shape"] = value.shape
+        capture["seq_lens_cpu"] = seq_lens_cpu
+        capture["head_num"] = head_num
+        capture["scale_value"] = scale_value
+        capture["num_kv_heads"] = num_kv_heads
+        return query + 1.0
+
+    with mock.patch(
+        "vllm_ascend.ops.mm_encoder_attention.DeviceOperator.npu_flash_attention",
+        side_effect=fake_npu_flash_attention,
+    ):
+        output = layer.forward_oot(query, key, value)
+
+    assert capture["query_shape"] == (bsz * q_len, layer.num_heads, 128)
+    assert capture["key_shape"] == (bsz * kv_len, layer.num_heads, 128)
+    assert capture["value_shape"] == (bsz * kv_len, layer.num_heads, 128)
+    torch.testing.assert_close(
+        capture["seq_lens_cpu"],
+        torch.tensor([q_len, q_len], dtype=torch.int32),
+    )
+    assert capture["head_num"] == layer.num_heads
+    assert capture["scale_value"] == layer.scale_value
+    assert capture["num_kv_heads"] == layer.num_kv_heads
+    torch.testing.assert_close(output, query + 1.0)
+
+
+def test_mm_encoder_attention_forward_oot_rejects_unsupported_backend():
+    layer = _make_layer(AttentionBackendEnum.TRITON_ATTN)
+    query = torch.randn(2, 3, layer.num_heads, layer.head_size)
+    key = torch.randn(2, 3, layer.num_kv_heads, layer.head_size)
+    value = torch.randn(2, 3, layer.num_kv_heads, layer.head_size)
+
+    with (
+        mock.patch(
+            "vllm_ascend.ops.mm_encoder_attention.DeviceOperator.npu_flash_attention"
+        ) as mock_npu_flash_attention,
+        pytest.raises(ValueError, match="Unsupported multi-modal encoder attention backend"),
+    ):
+        layer.forward_oot(query, key, value)
+
+    mock_npu_flash_attention.assert_not_called()

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1,10 +1,12 @@
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.platforms import PlatformEnum
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
@@ -723,6 +725,62 @@ class TestNPUPlatform(TestBase):
         )
         result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
         self.assertEqual(result, "vllm_ascend.attention.attention_v1.AscendAttentionBackend")
+
+    def test_get_supported_vit_attn_backends(self):
+        self.assertEqual(
+            self.platform.get_supported_vit_attn_backends(),
+            [AttentionBackendEnum.FLASH_ATTN, AttentionBackendEnum.TORCH_SDPA],
+        )
+
+    def test_get_vit_attn_backend_uses_flash_for_npu_supported_dtype(self):
+        for dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                self.assertEqual(
+                    self.platform.get_vit_attn_backend(head_size=128, dtype=dtype),
+                    AttentionBackendEnum.FLASH_ATTN,
+                )
+
+    def test_get_vit_attn_backend_uses_sdpa_for_fp32(self):
+        self.assertEqual(
+            self.platform.get_vit_attn_backend(
+                head_size=128,
+                dtype=torch.float32,
+            ),
+            AttentionBackendEnum.TORCH_SDPA,
+        )
+
+    def test_get_vit_attn_backend_honors_override(self):
+        self.assertEqual(
+            self.platform.get_vit_attn_backend(
+                head_size=128,
+                dtype=torch.float16,
+                backend=AttentionBackendEnum.TORCH_SDPA,
+            ),
+            AttentionBackendEnum.TORCH_SDPA,
+        )
+
+    def test_fix_incompatible_config_preserves_mm_encoder_attn_backend(self):
+        multimodal_config = SimpleNamespace(mm_encoder_attn_backend=AttentionBackendEnum.TORCH_SDPA)
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                disable_cascade_attn=False,
+                multimodal_config=multimodal_config,
+            ),
+            cache_config=None,
+            observability_config=None,
+            scheduler_config=None,
+            speculative_config=None,
+            kv_transfer_config=None,
+            attention_config=None,
+            parallel_config=None,
+        )
+
+        self.platform._fix_incompatible_config(vllm_config)
+
+        self.assertEqual(
+            multimodal_config.mm_encoder_attn_backend,
+            AttentionBackendEnum.TORCH_SDPA,
+        )
 
     def test_get_punica_wrapper(self):
         result = self.platform.get_punica_wrapper()

--- a/vllm_ascend/_310p/ops/mm_encoder_attention.py
+++ b/vllm_ascend/_310p/ops/mm_encoder_attention.py
@@ -20,9 +20,11 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 MIN_PAD_SIZE: int = 64  # min_size to pad weight
 MAX_PAD_SIZE: int = 128  # max_size to pad weight
+NPU_FLASH_ATTN_BACKENDS = {AttentionBackendEnum.FLASH_ATTN}
 
 # Use seq_lens CPU cache to avoid frequent d2h copy.
 # AscendMMEncoderAttention310 will copy the cu_seqlens from NPU to CPU in every
@@ -89,15 +91,13 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
 
         return query, key, value
 
-    def forward_oot(
+    def _forward_npu_flash_attention(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
-        sequence_lengths: torch.Tensor | None = None,
-    ):
+    ) -> torch.Tensor:
         bsz, q_len = query.size()[:2]
         kv_len = key.size(1)
         is_reshaped = query.dim() == 4
@@ -140,3 +140,20 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
         else:
             context_layer = einops.rearrange(context_layer, "(b s) h d -> b s (h d)", b=bsz).contiguous()
         return context_layer
+
+    def forward_oot(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            return self._forward_sdpa(query, key, value, cu_seqlens)
+
+        if self.attn_backend in NPU_FLASH_ATTN_BACKENDS:
+            return self._forward_npu_flash_attention(query, key, value, cu_seqlens)
+
+        raise ValueError(f"Unsupported multi-modal encoder attention backend for Ascend: {self.attn_backend}.")

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -26,6 +26,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 
 MIN_PAD_SIZE: int = 64  # min_size to pad weight
 MAX_PAD_SIZE: int = 128  # max_size to pad weight
+NPU_FLASH_ATTN_BACKENDS = {AttentionBackendEnum.FLASH_ATTN}
 
 # Use seq_lens CPU cache to avoid frequent d2h copy.
 # AscendMMEncoderAttention will copy the cu_seqlens from NPU to CPU in every
@@ -122,15 +123,14 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
         return cu_seqlens
 
-    def forward_oot(
+    def _forward_npu_flash_attention(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
         sequence_lengths: torch.Tensor | None = None,
-    ):
+    ) -> torch.Tensor:
         bsz, q_len = query.size()[:2]
         kv_len = key.size(1)
         is_reshaped = query.dim() == 4
@@ -175,3 +175,20 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         else:
             context_layer = einops.rearrange(context_layer, "(b s) h d -> b s (h d)", b=bsz).contiguous()
         return context_layer
+
+    def forward_oot(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            return self._forward_sdpa(query, key, value, cu_seqlens)
+
+        if self.attn_backend in NPU_FLASH_ATTN_BACKENDS:
+            return self._forward_npu_flash_attention(query, key, value, cu_seqlens, sequence_lengths)
+
+        raise ValueError(f"Unsupported multi-modal encoder attention backend for Ascend: {self.attn_backend}.")

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -63,6 +63,7 @@ else:
     FlexibleArgumentParser = None
 
 _CUSTOM_OP_REGISTERED = False
+MAX_VIT_FLASH_ATTN_HEAD_SIZE = 128
 
 
 def config_deprecated_logging():
@@ -618,6 +619,36 @@ class NPUPlatform(Platform):
         return backend_map[key]
 
     @classmethod
+    def get_supported_vit_attn_backends(cls) -> list[AttentionBackendEnum]:
+        return [
+            AttentionBackendEnum.FLASH_ATTN,
+            AttentionBackendEnum.TORCH_SDPA,
+        ]
+
+    @classmethod
+    def get_vit_attn_backend(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        backend: AttentionBackendEnum | None = None,
+    ) -> AttentionBackendEnum:
+        if backend is not None:
+            assert backend in cls.get_supported_vit_attn_backends(), (
+                f"Backend {backend} is not supported for vit attention. "
+                f"Supported backends are: {cls.get_supported_vit_attn_backends()}"
+            )
+            logger.info_once(f"Using backend {backend} for vit attention")
+            return backend
+
+        # The Ascend MM encoder flash-attention path pads head sizes up to 128.
+        if dtype in (torch.float16, torch.bfloat16) and head_size <= MAX_VIT_FLASH_ATTN_HEAD_SIZE:
+            logger.info_once("Using backend FLASH_ATTN for vit attention")
+            return AttentionBackendEnum.FLASH_ATTN
+
+        logger.info_once("Using backend TORCH_SDPA for vit attention")
+        return AttentionBackendEnum.TORCH_SDPA
+
+    @classmethod
     def _validate_fa3_backend(cls, key, attn_selector_config):
         if not attn_selector_config.use_batch_invariant:
             logger.info(
@@ -844,18 +875,7 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.cache_config.cpu_kvcache_space_bytes = None
 
-        # ==================== 3. MultiModal Config ====================
-        multimodal_config = getattr(model_config, "multimodal_config", None) if model_config else None
-        if multimodal_config:
-            # Ascend uses a different mechanism for Multi-Modal attention
-            if getattr(multimodal_config, "mm_encoder_attn_backend", None) is not None:
-                logger.warning(
-                    "Parameter '--mm-encoder-attn-backend' is set but Ascend uses "
-                    "a plugin mechanism for multi-modal attention. Resetting to None."
-                )
-                multimodal_config.mm_encoder_attn_backend = None
-
-        # ==================== 4. Observability Config ====================
+        # ==================== 3. Observability Config ====================
         if vllm_config.observability_config:
             # NVTX tracing is NVIDIA specific
             if getattr(vllm_config.observability_config, "enable_layerwise_nvtx_tracing", False):
@@ -865,7 +885,7 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.observability_config.enable_layerwise_nvtx_tracing = False
 
-        # ==================== 5. Scheduler Config ====================
+        # ==================== 4. Scheduler Config ====================
         if vllm_config.scheduler_config:
             # Partial prefills are specific to ROCm optimization
             if getattr(vllm_config.scheduler_config, "max_num_partial_prefills", 1) != 1:
@@ -874,7 +894,7 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.scheduler_config.max_num_partial_prefills = 1
 
-        # ==================== 6. Speculative Config ====================
+        # ==================== 5. Speculative Config ====================
         if vllm_config.speculative_config:
             # Ascend automatically inherits main model quantization
             if getattr(vllm_config.speculative_config, "quantization", None) is not None:
@@ -884,7 +904,7 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.speculative_config.quantization = None
 
-        # ==================== 7. KV Transfer Config ====================
+        # ==================== 6. KV Transfer Config ====================
         if vllm_config.kv_transfer_config:
             # Buffer size is primarily tied to NCCL (GPU) backends
             current_buffer_size = getattr(vllm_config.kv_transfer_config, "kv_buffer_size", 1e9)
@@ -904,7 +924,7 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.kv_transfer_config.enable_permute_local_kv = False
 
-        # ==================== 8. Attention Config ====================
+        # ==================== 7. Attention Config ====================
         if vllm_config.attention_config:
             att_config = vllm_config.attention_config
 
@@ -955,7 +975,7 @@ class NPUPlatform(Platform):
                 )
                 att_config.flash_attn_max_num_splits_for_cuda_graph = 32
 
-        # ==================== 9. Parallel Config ====================
+        # ==================== 8. Parallel Config ====================
         if vllm_config.parallel_config:
             # ray_workers_use_nsight requires NVIDIA Nsight which is not
             # available on Ascend NPU


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes Ascend MM encoder attention backend selection and dispatch.

Root cause:
- vLLM selects the MM/VIT encoder attention backend through `get_vit_attn_backend()`.
- Ascend did not override this platform selector, so the base platform defaulted MM/VIT attention to `TORCH_SDPA`.
- The Ascend OOT `MMEncoderAttention` implementation then ignored `self.attn_backend` and always forced NPU flash attention.
- This broke fp32 SigLIP pooling cases that should stay on torch SDPA.
- After making the execution path respect `TORCH_SDPA`, large fp16 Qwen3-VL/310P vision attention exposed the opposite issue: it still defaulted to torch SDPA and OOMed because SDPA can allocate quadratic `B * H * Q * K` intermediates.

Fix:
- Add Ascend platform-level VIT/MM encoder backend selection.
- Select `FLASH_ATTN` by default for Ascend-supported fp16/bf16 MM encoder attention with `head_size <= 128`.
- Fall back to `TORCH_SDPA` for unsupported cases such as fp32.
- Preserve explicit `mm_encoder_attn_backend` overrides instead of clearing them in Ascend config normalization.
- Make Ascend `MMEncoderAttention.forward_oot()` dispatch only according to the selected backend:
  - `FLASH_ATTN` -> Ascend NPU flash attention
  - `TORCH_SDPA` -> upstream `_forward_sdpa(...)`

This keeps backend policy in the platform selector and keeps the execution layer from silently overriding upstream/user backend decisions.

### Does this PR introduce _any_ user-facing change?

No, bug-fix behavior only.

Ascend MM encoder attention now respects explicit `mm_encoder_attn_backend` configuration and uses Ascend platform capability rules to choose the default backend.

### How was this patch tested?
vLLM UT
- `tests/models/multimodal/pooling/test_siglip.py` passed on Ascend: 9 passed

And vLLM-Ascend CI passed (tests/e2e/310p/singlecard/test_vl_model_singlecard.py::test_qwen3_vl_8b_tp1_fp16)