### PR TITLE
[Feature] Add support for multimodel inputs of dflash

### DIFF
--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -70,6 +70,7 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
     # Inputs
     next_token_ids_ptr,  # [num_reqs]
     target_positions_ptr,  # [num_context]
+    context_slot_mapping_ptr,  # [num_context]
     # Outputs
     out_input_ids_ptr,  # [num_query_total] (output)
     out_context_positions_ptr,  # [num_context] (output)
@@ -82,6 +83,7 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
     block_table_stride,  # stride of block_table dim 0 (in elements)
     # Metadata
     query_start_loc_ptr,  # [num_reqs + 1]
+    seq_lens_ptr,  # [num_reqs]
     num_rejected_tokens_ptr,  # [num_reqs] or null (0) when not padded
     # Scalars
     parallel_drafting_token_id,  # tl.int32
@@ -102,17 +104,18 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
             pos = tl.load(target_positions_ptr + ctx_pos_idx)
             tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
 
-            block_num = pos // block_size
-            block_id = tl.load(block_table_ptr + req_idx * block_table_stride + block_num).to(tl.int64)
-            slot = block_id * block_size + (pos % block_size)
+            slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
             tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
 
         if HAS_NUM_REJECTED:
             num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
             valid_ctx_end = ctx_end - num_rejected
         else:
+            num_rejected = 0
             valid_ctx_end = ctx_end
 
+        seq_len = tl.load(seq_lens_ptr + req_idx)
+        effective_seq_len = seq_len - num_rejected
         last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
 
         for q_idx in range(0, num_query_per_req):
@@ -121,9 +124,10 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
 
             tl.store(out_query_positions_ptr + query_out_idx, query_pos)
 
-            block_num_q = query_pos // block_size
+            query_cache_pos = effective_seq_len + q_idx
+            block_num_q = query_cache_pos // block_size
             block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
-            slot_q = block_id_q * block_size + (query_pos % block_size)
+            slot_q = block_id_q * block_size + (query_cache_pos % block_size)
             tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
 
             if q_idx == 0:

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -96,6 +96,7 @@ class AscendDflashProposer(AscendEagleProposer):
             # Inputs
             next_token_ids_ptr=next_token_ids,
             target_positions_ptr=target_positions,
+            context_slot_mapping_ptr=cad.slot_mapping,
             # Outputs
             out_input_ids_ptr=self.input_ids,
             out_context_positions_ptr=self._context_positions_buffer,
@@ -108,6 +109,7 @@ class AscendDflashProposer(AscendEagleProposer):
             block_table_stride=cad.block_table_tensor.stride(0),
             # Metadata
             query_start_loc_ptr=cad.query_start_loc,
+            seq_lens_ptr=cad.seq_lens,
             num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,


### PR DESCRIPTION
## What this PR does / why we need it?

DFlash builds its own context/query inputs before running the draft model. For text-only inputs, the kernel could reconstruct KV slots from:
_slot = block_table[position // block_size] * block_size + position % block_size_
For the **text-only inputs**, they are effectively a simple 1D sequence, as example:
_token index/position/slot offset::  0, 1, 2, 3, ..._ -- so for text-only decode, position and "logical KV slot offset" are almost the same thing.

For the **multimodal inputs** this assumption is wrong. MM inputs can use 2D/3D positional tensors, for example M-RoPE-style positions [3, num_tokens]. The rows encode different positional dimensions. Image / vision placeholder tokens can have repeated or non-contiguous position values. Therefore:
_position value != linear token index_ and _position value != KV slot offset_
Dflash Triton kernel receives only a raw pointer: _pos = tl.load(target_positions_ptr + ctx_pos_idx)_ so that means it effectively reads only the flattened first positional row for the first num_tokens elements. It ignores the fact that the tensor has multiple positional dimensions, so for MM input the kernel derives KV slots from M-RoPE values, not from the actual physical slot mapping assigned by vLLM. 
**That causes two issues:**
1. **Context KV slots are wrong.** Context hidden states are written into slots computed from multimodal position values instead of cad.slot_mapping.
2. **Slot collisions can happen.** Image-related positions can repeat, so multiple context tokens can map to the same slot. 

## What the patch changes?

1. Before calling the DFlash kernel, the patch saves: draft_block_table, original_context_slot_mapping and original_seq_lens, because ater DFlash mutates: cad.query_start_loc, cad.seq_lens and cad.slot_mapping. After that mutation, the original target metadata is lost. But for MM we need the pre-DFlash target slot mapping to correctly place context KV.
2. After the kernel runs, the patch overwrites the context slot mapping. KV slots must match the target model’s actual physical token slots, not slots reconstructed from multimodal position values. **This avoids slot collisions from repeated M-RoPE/image positions.** Also need new slots after the current effective sequence length _query_logical_pos_ then maps it to physical KV slots and **this avoids using m-RoPE positions as KV-cache offsets.**

## Does this PR introduce any user-facing change?

The patch fixes multimodal inference by preserving the original target metadata before DFlash mutates attention metadata and **works only in Dflash branch only with multimodal inputs.**

## How to reproduce the problem?

Inference script will be attached ...

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
