### PR TITLE
[CI][E2E] Limit `MAX_JOBS` in vllm-ascend install

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -136,6 +136,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -266,6 +268,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -403,6 +407,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -531,6 +537,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -715,6 +723,8 @@ jobs:
           pip show mooncake-transfer-engine-ascend || true
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -842,6 +852,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -969,6 +981,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_310p }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -1079,6 +1093,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_310p }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -407,8 +407,6 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
-        env:
-          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -537,8 +535,6 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
-        env:
-          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -723,8 +719,6 @@ jobs:
           pip show mooncake-transfer-engine-ascend || true
 
       - name: Install vllm-project/vllm-ascend
-        env:
-          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -852,8 +846,6 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
-        env:
-          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -981,8 +973,6 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_310p }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
-        env:
-          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -1093,8 +1083,6 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_310p }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
-        env:
-          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt

--- a/.github/workflows/_optional_smart_e2e.yaml
+++ b/.github/workflows/_optional_smart_e2e.yaml
@@ -121,6 +121,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend with device
+        env:
+          MAX_JOBS: 23
         if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
         run: |
           pip install uc-manager


### PR DESCRIPTION
### What this PR does / why we need it?
This PR sets `MAX_JOBS=23` for all `Install vllm-project/vllm-ascend` steps in the reusable E2E workflow.

The change applies to:
- singlecard light/full jobs
- 2-card light/full jobs
- 4-card light/full jobs
- 310P single-card and 4-card jobs

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
