### PR TITLE
[CI] update weekly cases: Deepseekv3.2-w8a8 ; Glm-5.1-w8a8 ; Qwen3.5-397B-w8a8

### DIFF
--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -183,19 +183,6 @@ jobs:
           - name: Qwen3.5-122B-A10B-W8A8-A3
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
-          #### weekly cases
-          - name: Qwen3-397B-A17B-w8a8-A3-weekly
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: DeepSeek-V3.2-W8A8-weekly
-            os: linux-aarch64-a3-16
-            config_file_path: DeepSeek-V3.2-W8A8_A3_weekly.yaml
-
-          - name: GLM-5_1-w8a8-A3-weekly
-            os: linux-aarch64-a3-16
-            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
-
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -184,47 +184,7 @@ jobs:
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
           #### weekly cases
-          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs80
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs144
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs36
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs48
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs16
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs160
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs32
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs8
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs32_in65536
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs136
-            os: linux-aarch64-a3-16
-            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
-
-          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs16_in65536
+          - name: Qwen3-397B-A17B-w8a8-A3-weekly
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
 
@@ -232,19 +192,7 @@ jobs:
             os: linux-aarch64-a3-16
             config_file_path: DeepSeek-V3.2-W8A8_A3_weekly.yaml
 
-          - name: GLM-5_1-w8a8-High—Throughput-bs20
-            os: linux-aarch64-a3-16
-            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
-
-          - name: GLM-5_1-w8a8-High—Throughput-bs8
-            os: linux-aarch64-a3-16
-            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
-
-          - name: GLM-5_1-w8a8-High—Throughput-bs32
-            os: linux-aarch64-a3-16
-            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
-
-          - name: GLM-5_1-w8a8-High—Throughput-bs10
+          - name: GLM-5_1-w8a8-A3-weekly
             os: linux-aarch64-a3-16
             config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
 

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -180,6 +180,71 @@ jobs:
           - name: Qwen3.5-122B-A10B-W8A8-A3
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
+          #### weekly cases
+          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs80
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs144
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs36
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs48
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs16
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs160
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs32
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs8
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs32_in65536
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs136
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs16_in65536
+            os: linux-aarch64-a3-16
+            config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+
+          - name: DeepSeek-V3.2-W8A8-weekly
+            os: linux-aarch64-a3-16
+            config_file_path: DeepSeek-V3.2-W8A8_A3_weekly.yaml
+
+          - name: GLM-5_1-w8a8-High—Throughput-bs20
+            os: linux-aarch64-a3-16
+            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
+
+          - name: GLM-5_1-w8a8-High—Throughput-bs8
+            os: linux-aarch64-a3-16
+            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
+
+          - name: GLM-5_1-w8a8-High—Throughput-bs32
+            os: linux-aarch64-a3-16
+            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
+
+          - name: GLM-5_1-w8a8-High—Throughput-bs10
+            os: linux-aarch64-a3-16
+            config_file_path: GLM-5_1-W8A8_A3_weekly.yaml
+
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -126,6 +126,9 @@ jobs:
           - name: multi-node-GLM-5.1-w8a8-A3
             config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
             size: 2
+          - name: DeepSeek-V3_2-W8A8-EP_weekly
+            config_file_path: DeepSeek-V3_2-W8A8-EP_weekly.yaml
+            size: 2
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a3

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -126,9 +126,6 @@ jobs:
           - name: multi-node-GLM-5.1-w8a8-A3
             config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
             size: 2
-          - name: DeepSeek-V3_2-W8A8-EP_weekly
-            config_file_path: DeepSeek-V3_2-W8A8-EP_weekly.yaml
-            size: 2
     uses: ./.github/workflows/_e2e_nightly_multi_node.yaml
     with:
       soc_version: a3

--- a/tests/e2e/weekly/multi_node/configs/DeepSeek-V3_2-W8A8-EP_weekly.yaml
+++ b/tests/e2e/weekly/multi_node/configs/DeepSeek-V3_2-W8A8-EP_weekly.yaml
@@ -3,7 +3,6 @@ model: "vllm-ascend/DeepSeek-V3.2-W8A8"
 num_nodes: 2
 npu_per_node: 16
 env_common:
-
   OMP_PROC_BIND: false
   OMP_NUM_THREADS: 10
   HCCL_OP_EXPANSION_MODE: "AIV"

--- a/tests/e2e/weekly/multi_node/configs/DeepSeek-V3_2-W8A8-EP_weekly.yaml
+++ b/tests/e2e/weekly/multi_node/configs/DeepSeek-V3_2-W8A8-EP_weekly.yaml
@@ -1,0 +1,202 @@
+test_name: "weekly test DeepSeek-V3.2-W8A8-EP disaggregated_prefill"
+model: "vllm-ascend/DeepSeek-V3.2-W8A8"
+num_nodes: 2
+npu_per_node: 16
+env_common:
+
+  OMP_PROC_BIND: false
+  OMP_NUM_THREADS: 10
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  VLLM_USE_V1: "1"
+  HCCL_BUFFSIZE: "360"
+  ASCEND_AGGREGATE_ENABLE: "1"
+  ASCEND_TRANSPORT_PRINT: "1"
+  VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "300000"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+  VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: 8080
+
+disaggregated_prefill:
+  enabled: true
+  prefiller_host_index: [0, 1]
+  decoder_host_index: [2, 3]
+
+deployment:
+  -
+    envs:
+      VLLM_ASCEND_ENABLE_FLASHCOMM1: 1
+    server_cmd: >
+      vllm serve vllm-ascend/DeepSeek-V3.2-W8A8
+          --host 0.0.0.0
+          --port $SERVER_PORT
+          --data-parallel-size 2
+          --data-parallel-start-rank 0
+          --data-parallel-size-local 1
+          --data-parallel-address $LOCAL_IP
+          --tensor-parallel-size 16
+          --enable-expert-parallel
+          --seed 1024
+          --max-model-len 133000
+          --max-num-batched-tokens 8192
+          --trust-remote-code
+          --max-num-seqs 16
+          --gpu-memory-utilization 0.95
+          --quantization ascend
+          --enforce-eager
+          --no-enable-prefix-caching
+          --tokenizer-mode deepseek_v32 
+          --reasoning-parser deepseek_v3
+          --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' 
+          --additional-config '{"layer_sharding": ["q_b_proj", "o_proj"]}'
+          --kv-transfer-config
+          '{"kv_connector": "MooncakeConnectorV1",
+          "kv_role": "kv_producer",
+          "kv_port": "30000",
+          "engine_id": "0",
+          "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 16
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
+              }
+          }'
+
+  -
+    envs:
+      OMP_PROC_BIND: false
+      OMP_NUM_THREADS: 10
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      VLLM_USE_V1: "1"
+      HCCL_BUFFSIZE: "1100"
+      ASCEND_AGGREGATE_ENABLE: "1"
+      ASCEND_TRANSPORT_PRINT: "1"
+      ACL_OP_INIT_MODE: "1"
+      ASCEND_A3_ENABLE: "1"
+      VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "300000"
+      TASK_QUEUE_ENABLE: "1"
+      VLLM_ASCEND_ENABLE_MLAPO: "1"
+      VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+      DYNAMIC_EPLB: "true"
+    server_cmd: >
+      vllm serve vllm-ascend/DeepSeek-V3.2-W8A8
+          --host 0.0.0.0
+          --port $SERVER_PORT
+          --data-parallel-size 2
+          --data-parallel-size-local 1
+          --data-parallel-start-rank 1
+          --data-parallel-address $LOCAL_IP
+          --data-parallel-rpc-port 13389
+          --tensor-parallel-size 16
+          --enable-expert-parallel
+          --seed 1024
+          --max-model-len 133000 
+          --max-num-batched-tokens 100
+          --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}'
+          --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[3,6,9,12,15,18,21,24,27,30,33,36,39,42]"}'
+          --additional-config '{"recompute_scheduler_enable": true,"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2000,"algorithm_execution_interval":50, "eplb_policy_type":3, "num_redundant_experts":0}}'
+          --trust-remote-code
+          --max-num-seqs 14
+          --gpu-memory-utilization 0.92
+          --no-enable-prefix-caching
+          --async-scheduling
+          --quantization ascend
+          --tokenizer-mode deepseek_v32
+          --reasoning-parser deepseek_v3
+          --kv-transfer-config
+          '{"kv_connector": "MooncakeConnectorV1",
+          "kv_role": "kv_consumer",
+          "kv_port": "30200",
+          "engine_id": "2",
+          "kv_connector_module_path": "vllm_ascend.distributed.mooncake_connector",
+          "kv_connector_extra_config": {
+                      "prefill": {
+                              "dp_size": 2,
+                              "tp_size": 16
+                      },
+                      "decode": {
+                              "dp_size": 8,
+                              "tp_size": 4
+                      }
+              }
+          }'
+
+
+benchmarks:
+  perf_16384_1024_num64:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1200_deepseek
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 64
+    max_out_len: 1024
+    batch_size: 16
+    request_rate: 1
+    baseline: 1
+    threshold: 0.97
+
+  perf_16384_1024_num256:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1200_deepseek
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 256
+    max_out_len: 1024
+    batch_size: 64
+    request_rate: 1
+    baseline: 1
+    threshold: 0.97
+
+  perf_32768_512_num32:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs1000_deepseek
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 32
+    max_out_len: 512
+    batch_size: 8
+    request_rate: 1
+    baseline: 1
+    threshold: 0.97
+
+  perf_32768_512_num128:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs1000_deepseek
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 128
+    max_out_len: 512
+    batch_size: 32
+    request_rate: 0.7
+    baseline: 1
+    threshold: 0.97
+
+  perf_65536_1024_num4:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in65536_bs400_deepseek
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1024
+    batch_size: 1
+    request_rate: 0.1
+    baseline: 1
+    threshold: 0.97
+
+  perf_65536_1024_num16:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in65536_bs400_deepseek
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 16
+    max_out_len: 1024
+    batch_size: 4
+    request_rate: 1
+    baseline: 1
+    threshold: 0.97

--- a/tests/e2e/weekly/single_node/configs/DeepSeek-V3.2-W8A8_A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/DeepSeek-V3.2-W8A8_A3_weekly.yaml
@@ -1,0 +1,128 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+_envs: &envs
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      VLLM_USE_V1: "1"
+      HCCL_BUFFSIZE: "256"
+      ASCEND_AGGREGATE_ENABLE: "1"
+      ASCEND_TRANSPORT_PRINT: "1"
+      ACL_OP_INIT_MODE: "1"
+      ASCEND_A3_ENABLE: "1"
+      VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "300000"
+      TASK_QUEUE_ENABLE: "1"
+      VLLM_ASCEND_ENABLE_MLAPO: "1"
+      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+      SERVER_PORT: "DEFAULT_PORT"
+
+_server_cmd: &server_cmd
+      - "--enable-expert-parallel"
+      - "--tensor-parallel-size"
+      - "8"
+      - "--data-parallel-size"
+      - "2"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--seed"
+      - "1024"
+      - "--max-model-len"
+      - "67000"
+      - "--max-num-batched-tokens"
+      - "4096"
+      - "--max-num-seqs"
+      - "8"
+      - "--trust-remote-code"
+      - "--quantization"
+      - "ascend"
+      - "--async-scheduling"
+      - "--gpu-memory-utilization"
+      - "0.95"
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,2,4,8,16,24,32,40,48], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--no-enable-prefix-caching"
+      - "--speculative-config"
+      - '{"num_speculative_tokens": 3, "method":"deepseek_mtp"}'
+      - "--reasoning-parser"
+      - "deepseek_v3"
+      - "--tokenizer_mode"
+      - "deepseek_v32"
+
+_benchmarks: &benchmarks
+      perf_16384_bs4:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1200_deepseek
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 4
+        max_out_len: 1024
+        batch_size: 1
+        request_rate: 0
+        baseline: 1
+        threshold: 0.97
+      perf_16384_bs16:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs1200_deepseek
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 16
+        max_out_len: 1024
+        batch_size: 4
+        request_rate: 0.5
+        baseline: 1
+        threshold: 0.97
+      perf_32768_bs4:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs1000_deepseek
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 4
+        max_out_len: 512
+        batch_size: 1
+        request_rate: 0
+        baseline: 1
+        threshold: 0.97
+      perf_32768_bs8:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs1000_deepseek
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 8
+        max_out_len: 512
+        batch_size: 2
+        request_rate: 0.2
+        baseline: 1
+        threshold: 0.97
+      perf_65536_bs4:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K_prefix0_in65536_bs400_deepseek
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 4
+        max_out_len: 1024
+        batch_size: 1
+        request_rate: 0
+        baseline: 1
+        threshold: 0.97
+      perf_65536_bs8:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K_prefix0_in65536_bs400_deepseek
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 8
+        max_out_len: 1024
+        batch_size: 2
+        request_rate: 1
+        baseline: 1
+        threshold: 0.97
+
+test_cases:
+  - name: "DeepSeek-V3.2-W8A8-weekly"
+    model: "vllm-ascend/DeepSeek-V3.2-W8A8"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    benchmarks:
+      <<: *benchmarks

--- a/tests/e2e/weekly/single_node/configs/DeepSeek-V3.2-W8A8_A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/DeepSeek-V3.2-W8A8_A3_weekly.yaml
@@ -47,7 +47,7 @@ _server_cmd: &server_cmd
       - '{"num_speculative_tokens": 3, "method":"deepseek_mtp"}'
       - "--reasoning-parser"
       - "deepseek_v3"
-      - "--tokenizer_mode"
+      - "--tokenizer-mode"
       - "deepseek_v32"
 
 _benchmarks: &benchmarks

--- a/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
@@ -1,0 +1,165 @@
+# ==========================================
+# Shared Configurations
+# ==========================================
+
+_envs: &envs
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "1"
+  HCCL_BUFFSIZE: "200"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  VLLM_ASCEND_BALANCE_SCHEDULING: "1"
+  VLLM_ASCEND_ENABLE_MLAPO: "1"
+  SERVER_PORT: "DEFAULT_PORT"
+
+_server_cmd: &server_cmd
+  - "--enable-expert-parallel"
+  - "--tensor-parallel-size"
+  - "16"
+  - "--data-parallel-size"
+  - "1"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--seed"
+  - "1024"
+  - "--max-num-batched-tokens"
+  - "4096"
+  - "--trust-remote-code"
+  - "--quantization"
+  - "ascend"
+  - "--enable-chunked-prefill"
+  - "--async-scheduling"
+  - "--additional-config"
+  - '{"enable_npugraph_ex": true,"fuse_muls_add":true,"multistream_overlap_shared_expert":true}'
+  - "--compilation-config"
+  - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+  - "--speculative-config"
+  - '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
+
+_special_dependencies: &special_dependencies
+  transformers: "5.2.0"
+
+_benchmarks: &benchmarks
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs100_glm5
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 20
+    max_out_len: 1024
+    batch_size: 5
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+
+_benchmarks_bs8: &benchmarks_bs8
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs100_glm5
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 8
+    max_out_len: 512
+    batch_size: 2
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+
+_benchmarks_bs32: &benchmarks_bs32
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix90_in32768_bs100_glm5
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 32
+    max_out_len: 512
+    batch_size: 8
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+
+_benchmarks_bs10: &benchmarks_bs10
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix90_in65536_bs100_glm5
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 10
+    max_out_len: 1024
+    batch_size: 5
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+#  16384 1024  0%  20
+  - name: "GLM-5_1-w8a8-High—Throughput-bs20"
+    model: "Eco-Tech/GLM-5.1-w8a8"
+    special_dependencies: *special_dependencies
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--max-model-len"
+      - "20480"
+      - "--max-num-seqs"
+      - "48"
+      - "--gpu-memory-utilization"
+      - "0.95"
+    benchmarks:
+      <<: *benchmarks
+#32768 512 0%  8
+  - name: "GLM-5_1-w8a8-High—Throughput-bs8"
+    model: "Eco-Tech/GLM-5.1-w8a8"
+    special_dependencies: *special_dependencies
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--max-model-len"
+      - "33792"
+      - "--max-num-seqs"
+      - "48"
+      - "--gpu-memory-utilization"
+      - "0.95"
+    benchmarks:
+      <<: *benchmarks_bs8
+
+#32768  512 90% 32
+  - name: "GLM-5_1-w8a8-High—Throughput-bs32"
+    model: "Eco-Tech/GLM-5.1-w8a8"
+    special_dependencies: *special_dependencies
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--max-model-len"
+      - "33792"
+      - "--max-num-seqs"
+      - "48"
+      - "--gpu-memory-utilization"
+      - "0.95"
+    benchmarks:
+      <<: *benchmarks_bs32
+#65536  1024  90% 10
+  - name: "GLM-5_1-w8a8-High—Throughput-bs10"
+    model: "Eco-Tech/GLM-5.1-w8a8"
+    special_dependencies: *special_dependencies
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--max-model-len"
+      - "66600"
+      - "--max-num-seqs"
+      - "8"
+      - "--gpu-memory-utilization"
+      - "0.97"
+      - "--enable-prefix-caching"
+    benchmarks:
+      <<: *benchmarks_bs10

--- a/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
@@ -36,8 +36,6 @@ _server_cmd: &server_cmd
   - "--speculative-config"
   - '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 
-_special_dependencies: &special_dependencies
-  transformers: "5.2.0"
 
 _benchmarks: &benchmarks
   perf:

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
@@ -1,0 +1,404 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+
+_envs: &envs
+      VLLM_USE_MODELSCOPE: "true"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      HCCL_BUFFSIZE: "1024"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      SERVER_PORT: "DEFAULT_PORT"
+      VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+      VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+      VLLM_RPC_TIMEOUT: "600"
+_server_cmd: &server_cmd
+      - "--tensor-parallel-size"
+      - "16"
+      - "--data-parallel-size"
+      - "1"
+      - "--enable-expert-parallel"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-num-seqs"
+      - "128"
+      - "--quantization"
+      - "ascend"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--trust-remote-code"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--additional-config"
+      - '{"enable_cpu_binding":true}'
+      - "--async-scheduling"
+      - "--allowed-local-media-path"
+      - "/"
+      - "--mm-processor-cache-gb"
+      - "0"
+      - "--safetensors-load-strategy"
+      - "lazy"
+_benchmarks: &benchmarks
+      perf:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K-in131072-bs100-qwen3
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 8
+        max_out_len: 1024
+        batch_size: 2
+        request_rate: 0
+        baseline: 1
+        threshold: 0.97
+
+
+_benchmarks_bs144: &benchmarks_bs144
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs200_qwen3
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 144
+      max_out_len: 1024
+      batch_size: 36
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs36: &benchmarks_bs36
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs100_qwen3_5
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 36
+      max_out_len: 1024
+      batch_size: 9
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs48: &benchmarks_bs48
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs100_qwen3
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 48
+      max_out_len: 512
+      batch_size: 12
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs16: &benchmarks_bs16
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix0_in32768_bs100_qwen3
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 16
+      max_out_len: 512
+      batch_size: 4
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+
+_benchmarks_bs160: &benchmarks_bs160
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix90_in32768_bs1000_qwen
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 160
+      max_out_len: 512
+      batch_size: 40
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs32: &benchmarks_bs32
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix90_in32768_bs1000_qwen
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 32
+      max_out_len: 512
+      batch_size: 8
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs8: &benchmarks_bs8
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix0_in65536_bs200_qwen3_5
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 8
+      max_out_len: 1024
+      batch_size: 2
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs32_in65536: &benchmarks_bs32_in65536
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix0_in65536_bs200_qwen3_5
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 32
+      max_out_len: 1024
+      batch_size: 8
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs136: &benchmarks_bs136
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix90_in65536_bs1000_qwen
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 136
+      max_out_len: 1024
+      batch_size: 34
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs16_in65536: &benchmarks_bs16_in65536
+    perf:
+      case_type: performance
+      dataset_path: vllm-ascend/GSM8K_prefix90_in65536_bs1000_qwen
+      request_conf: vllm_api_stream_chat
+      dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+      num_prompts: 16
+      max_out_len: 1024
+      batch_size: 4
+      request_rate: 0
+      baseline: 1
+      threshold: 0.97
+
+_benchmarks_bs80: &benchmarks_bs80
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in131072-bs100-qwen3
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 80
+    max_out_len: 1024
+    batch_size: 20
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+test_cases:
+
+#131072 1024  0.9 80
+  - name: "Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs80"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "133120"
+    benchmarks:
+      <<: *benchmarks_bs80
+
+  - name: "Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs2"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "133120"
+    benchmarks:
+      <<: *benchmarks
+
+  - name: "Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs144"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "18432"
+    benchmarks:
+      <<: *benchmarks_bs144
+
+  - name: "Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs36"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "18432"
+    benchmarks:
+      <<: *benchmarks_bs36
+
+  - name: "Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs48"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "34304"
+    benchmarks:
+      <<: *benchmarks_bs48
+
+
+  - name: "Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs16"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "34304"
+    benchmarks:
+      <<: *benchmarks_bs16
+
+  - name: "Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs160"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "34304"
+    benchmarks:
+      <<: *benchmarks_bs160
+
+#65536 1024  0 32
+  - name: "Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs32"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "34304"
+    benchmarks:
+      <<: *benchmarks_bs32
+
+#65536 1024  0 8
+  - name: "Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs8"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "67584"
+    benchmarks:
+      <<: *benchmarks_bs8
+
+#65536  1024  0 32
+  - name: "Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs32_in65536"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--no-enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "67584"
+    benchmarks:
+      <<: *benchmarks_bs32_in65536
+
+#67584  65536 1024  0.9 136
+  - name: "Qwen3-397B-A17B-w8a8-A3-High—Throughput-bs136"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,4,8,12,16,24,32,48,56,64,72,84,96,108,112,128,160,172,196,200,212,232,256,272,288,312,328,344,360,384,400,416,432,448,480,512], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "67584"
+    benchmarks:
+      <<: *benchmarks_bs136
+
+#67584  65536 1024  0.9 16
+  - name: "Qwen3-397B-A17B-w8a8-A3-Minimal-Delay-bs16_in65536"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--enable-prefix-caching"
+      - "--speculative_config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--max-model-len"
+      - "67584"
+    benchmarks:
+      <<: *benchmarks_bs16_in65536
+


### PR DESCRIPTION
### What this PR does / why we need it?
we add the new weekly A3 cases:  Deepseekv3.2-w8a8 ; Glm-5.1-w8a8 ; Qwen3.5-397B-w8a8 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
run the case

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
