### PR TITLE
[BugFix][Ops] Support mixed precision rotary mul

### DIFF
--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_def.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_def.cpp
@@ -9,7 +9,7 @@
  */
 
 /*!
- * \file rotary_position_embedding.cpp
+ * \file inplace_partial_rotary_mul_def.cpp
  * \brief
  */
 #include "register/op_def_registry.h"
@@ -44,17 +44,41 @@ public:
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Attr("mode").AttrType(OPTIONAL).Int(0);
         this->Attr("partial_slice").AttrType(OPTIONAL).ListInt({0, 0});
-        OpAICoreConfig regbaseCfg;
-        regbaseCfg.DynamicCompileStaticFlag(true)
+
+        this->AICore().AddConfig("ascend910b");
+        this->AICore().AddConfig("ascend910_93");
+
+        OpAICoreConfig config950;
+        config950.Input("x")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        config950.Input("cos")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        config950.Input("sin")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        config950.Output("x")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        config950.DynamicCompileStaticFlag(true)
             .DynamicRankSupportFlag(true)
             .DynamicShapeSupportFlag(true)
             .ExtendCfgInfo("opFile.value", "inplace_partial_rotary_mul");
-        this->AICore().AddConfig("ascend950", regbaseCfg);
-        this->AICore().AddConfig("ascend910b", regbaseCfg);
-        this->AICore().AddConfig("ascend910_93", regbaseCfg);
-
+        this->AICore().AddConfig("ascend950", config950);
     }
 };
 
 OP_ADD(InplacePartialRotaryMul);
-} // namespace ops
+}  // namespace ops

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_proto.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_proto.cpp
@@ -51,10 +51,10 @@ namespace ge {
  * (1, S, 1, D) or (B, 1, 1, D).
  */
 REG_OP(InplacePartialRotaryMul)
-    .INPUT(x, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16}))
-    .INPUT(cos, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16}))
-    .INPUT(sin, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16}))
-    .OUTPUT(x, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16}))
+    .INPUT(x, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16, DT_FLOAT16, DT_BFLOAT16}))
+    .INPUT(cos, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16, DT_FLOAT, DT_FLOAT}))
+    .INPUT(sin, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16, DT_FLOAT, DT_FLOAT}))
+    .OUTPUT(x, TensorType({DT_FLOAT16, DT_FLOAT, DT_BFLOAT16, DT_FLOAT16, DT_BFLOAT16}))
     .ATTR(mode, Int, 0)
     .ATTR(partial_slice, ListInt, {0, 0})
     .OP_END_FACTORY_REG(InplacePartialRotaryMul)

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_a_and_b.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_a_and_b.cpp
@@ -20,18 +20,21 @@ namespace optiling {
 constexpr uint64_t ROPE_A_AND_B_TILING_PRIORITY = 40000;
 constexpr int64_t DOUBLE_BUFFER = 2;
 constexpr int64_t UB_FACTOR = 4;
+constexpr int64_t UB_X_FACTOR = 4;
+constexpr int64_t UB_COS_SIN_FACTOR = 2;
 constexpr int64_t MAX_COPY_BLOCK_COUNT = 4095;
 constexpr int32_t WORKSPACE_SIZE = 16 * 1024 * 1024;
 constexpr uint64_t TILING_KEY_A = 20040;
 constexpr uint64_t TILING_KEY_B = 20041;
-constexpr int64_t HALF_INTERLEAVE_COEF = 2;
-constexpr int64_t QUARTER_MODE_COEF = 4;
+constexpr uint64_t TILING_KEY_A_BF16_FP32 = 20140;
+constexpr uint64_t TILING_KEY_A_FP16_FP32 = 20240;
+constexpr uint64_t TILING_KEY_B_BF16_FP32 = 20141;
+constexpr uint64_t TILING_KEY_B_FP16_FP32 = 20241;
 
 bool RopeRegBaseTilingClassAAndB::IsCapable()
 {
     // 处理全boardcast和不boardcast的情况
-    return (IsRegbaseSocVersion()) &&
-           (layout_ == RopeLayout::NO_BROADCAST || layout_ == RopeLayout::BROADCAST_BSN);
+    return (IsRegbaseSocVersion()) && (layout_ == RopeLayout::NO_BROADCAST || layout_ == RopeLayout::BROADCAST_BSN);
 }
 
 ge::graphStatus RopeRegBaseTilingClassAAndB::MergeDim()
@@ -58,22 +61,65 @@ ge::graphStatus RopeRegBaseTilingClassAAndB::SplitCore()
 ge::graphStatus RopeRegBaseTilingClassAAndB::ComputeUbFactor()
 {
     ubFactorB_ = 1;
-    // UB占用大小：
-    // 111d：2 * (2b + 1) * dAlign
-    // b1sd：2 * 4 * b * dAlign
-    int64_t dSize = CeilAlign(sliceLength_ * GetSizeByDataType(dtype_) / dSplitCoef_, this->blockSize_) * dSplitCoef_;
-    int64_t numOfDAvailable = FloorDiv(static_cast<int64_t>(aicoreParams_.ubSize), DOUBLE_BUFFER * dSize);
-    OPS_ERR_IF(numOfDAvailable < UB_FACTOR,
-                OPS_LOG_E(context_, "D is too big to load in ub, ubSize is %ld bytes, loading requires %ld bytes.",
-                        static_cast<int64_t>(aicoreParams_.ubSize), UB_FACTOR * dSize * (ubFactorB_ + 1)),
-                return ge::GRAPH_FAILED);
+
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    bool isMixedPrecision = (dtype_ == ge::DT_BF16 || dtype_ == ge::DT_FLOAT16) && cosDtype == ge::DT_FLOAT;
+
+    int64_t dSizeX = CeilAlign(sliceLength_ * GetSizeByDataType(dtype_) / dSplitCoef_, this->blockSize_) * dSplitCoef_;
+    int64_t dSizeCosSin =
+        CeilAlign(sliceLength_ * GetSizeByDataType(cosDtype) / dSplitCoef_, this->blockSize_) * dSplitCoef_;
+
     if (layout_ == RopeLayout::NO_BROADCAST) {
-        numOfDAvailable /= UB_FACTOR;
+        int64_t totalPerBUnit;
+        if (isMixedPrecision) {
+            // UB: 4 queues x double-buffer = 8 total buffers
+            // 4 * ubFactorB * dSizeX + 4 * ubFactorB * dSizeCosSin
+            // Per-B unit: 4 * dSizeX + 4 * dSizeCosSin
+            totalPerBUnit = (dSizeX + dSizeCosSin) * UB_FACTOR;
+        } else {
+            // UB: 4 queues x double-buffer = 8 * ubFactorB * dSizeX
+            // Per-B unit: 8 * dSizeX
+            totalPerBUnit = dSizeX * UB_FACTOR * DOUBLE_BUFFER;
+        }
+        int64_t numOfDAvailable = FloorDiv(static_cast<int64_t>(aicoreParams_.ubSize), totalPerBUnit);
+        OPS_ERR_IF(numOfDAvailable < 1,
+            OPS_LOG_E(context_,
+                "D is too big to load in ub, ubSize is %ld bytes, loading requires %ld bytes.",
+                static_cast<int64_t>(aicoreParams_.ubSize),
+                totalPerBUnit),
+            return ge::GRAPH_FAILED);
         ubFactorB_ = std::min(blockFactorB_, numOfDAvailable);
     } else {
-        numOfDAvailable -= 1;
-        numOfDAvailable /= DOUBLE_BUFFER;
-        ubFactorB_ = std::min(blockFactorB_, numOfDAvailable);
+        if (isMixedPrecision) {
+            // UB: UB_X_FACTOR * ubFactorB * dSizeX + UB_COS_SIN_FACTOR * dSizeCosSin
+            int64_t availableForX = static_cast<int64_t>(aicoreParams_.ubSize) - UB_COS_SIN_FACTOR * dSizeCosSin;
+            if (availableForX <= 0) {
+                OPS_LOG_E(context_,
+                    "D is too big to load in ub, ubSize is %ld bytes, cos/sin requires %ld bytes.",
+                    static_cast<int64_t>(aicoreParams_.ubSize),
+                    UB_COS_SIN_FACTOR * dSizeCosSin);
+                return ge::GRAPH_FAILED;
+            }
+            int64_t numOfDAvailable = FloorDiv(availableForX, UB_X_FACTOR * dSizeX);
+            OPS_ERR_IF(numOfDAvailable < 1,
+                OPS_LOG_E(context_,
+                    "D is too big to load in ub, ubSize is %ld bytes, loading requires %ld bytes.",
+                    static_cast<int64_t>(aicoreParams_.ubSize),
+                    UB_X_FACTOR * dSizeX + UB_COS_SIN_FACTOR * dSizeCosSin),
+                return ge::GRAPH_FAILED);
+            ubFactorB_ = std::min(blockFactorB_, numOfDAvailable);
+        } else {
+            int64_t numOfDAvailable = FloorDiv(static_cast<int64_t>(aicoreParams_.ubSize), DOUBLE_BUFFER * dSizeX);
+            OPS_ERR_IF(numOfDAvailable < UB_FACTOR,
+                OPS_LOG_E(context_,
+                    "D is too big to load in ub, ubSize is %ld bytes, loading requires %ld bytes.",
+                    static_cast<int64_t>(aicoreParams_.ubSize),
+                    UB_FACTOR * dSizeX * (ubFactorB_ + 1)),
+                return ge::GRAPH_FAILED);
+            numOfDAvailable -= 1;
+            numOfDAvailable /= DOUBLE_BUFFER;
+            ubFactorB_ = std::min(blockFactorB_, numOfDAvailable);
+        }
     }
 
     ubFactorB_ = std::min(ubFactorB_, MAX_COPY_BLOCK_COUNT / dSplitCoef_);
@@ -107,28 +153,48 @@ void RopeRegBaseTilingClassAAndB::SetTilingData()
     tilingData_.set_sliceLength(static_cast<int64_t>(sliceLength_));
 
     OPS_LOG_I(context_->GetNodeName(),
-              "RopeRegBaseTilingClassAAndB tilingData: "
-              "B is %ld, CosB is %ld, S is %ld, D is %ld, N is %ld, blockNumB %ld,"
-              "blockFactorB_ is %ld, blockNumS %ld, blockFactorS is %ld, ubLoopNumS is %ld,"
-              "ubFactorS is %ld, ubTailFactorS %ld, ubLoopNumB is %ld, ubFactorB is %ld,"
-              "ubTailFactorB is %ld, ubLoopNumN is %ld, ubFactorN is %ld, ubTailFactorN is %ld,"
-              "rotaryMode is %ld, tilingKey is %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
-              tilingData_.get_B(), tilingData_.get_CosB(), tilingData_.get_S(), tilingData_.get_D(), tilingData_.get_N(),
-              tilingData_.get_blockNumB(), tilingData_.get_blockFactorB(), tilingData_.get_blockNumS(),
-              tilingData_.get_blockFactorS(), tilingData_.get_ubLoopNumS(), tilingData_.get_ubFactorS(),
-              tilingData_.get_ubTailFactorS(), tilingData_.get_ubLoopNumB(), tilingData_.get_ubFactorB(),
-              tilingData_.get_ubTailFactorB(), tilingData_.get_ubLoopNumN(), tilingData_.get_ubFactorN(),
-              tilingData_.get_ubTailFactorN(), tilingData_.get_rotaryMode(), GetTilingKey(), tilingData_.get_sliceStart(), tilingData_.get_sliceEnd(), tilingData_.get_sliceLength());
+        "RopeRegBaseTilingClassAAndB tilingData: "
+        "B is %ld, CosB is %ld, S is %ld, D is %ld, N is %ld, blockNumB %ld,"
+        "blockFactorB_ is %ld, blockNumS %ld, blockFactorS is %ld, ubLoopNumS is %ld,"
+        "ubFactorS is %ld, ubTailFactorS %ld, ubLoopNumB is %ld, ubFactorB is %ld,"
+        "ubTailFactorB is %ld, ubLoopNumN is %ld, ubFactorN is %ld, ubTailFactorN is %ld,"
+        "rotaryMode is %ld, tilingKey is %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
+        tilingData_.get_B(),
+        tilingData_.get_CosB(),
+        tilingData_.get_S(),
+        tilingData_.get_D(),
+        tilingData_.get_N(),
+        tilingData_.get_blockNumB(),
+        tilingData_.get_blockFactorB(),
+        tilingData_.get_blockNumS(),
+        tilingData_.get_blockFactorS(),
+        tilingData_.get_ubLoopNumS(),
+        tilingData_.get_ubFactorS(),
+        tilingData_.get_ubTailFactorS(),
+        tilingData_.get_ubLoopNumB(),
+        tilingData_.get_ubFactorB(),
+        tilingData_.get_ubTailFactorB(),
+        tilingData_.get_ubLoopNumN(),
+        tilingData_.get_ubFactorN(),
+        tilingData_.get_ubTailFactorN(),
+        tilingData_.get_rotaryMode(),
+        GetTilingKey(),
+        tilingData_.get_sliceStart(),
+        tilingData_.get_sliceEnd(),
+        tilingData_.get_sliceLength());
 }
 
 ge::graphStatus RopeRegBaseTilingClassAAndB::DoOpTiling()
 {
-    OPS_ERR_IF(MergeDim() != ge::GRAPH_SUCCESS, OPS_LOG_E(context_->GetNodeName(), "failed to merge dim."),
-                return ge::GRAPH_FAILED);
-    OPS_ERR_IF(SplitCore() != ge::GRAPH_SUCCESS, OPS_LOG_E(context_->GetNodeName(), "failed to split core."),
-                return ge::GRAPH_FAILED);
+    OPS_ERR_IF(MergeDim() != ge::GRAPH_SUCCESS,
+        OPS_LOG_E(context_->GetNodeName(), "failed to merge dim."),
+        return ge::GRAPH_FAILED);
+    OPS_ERR_IF(SplitCore() != ge::GRAPH_SUCCESS,
+        OPS_LOG_E(context_->GetNodeName(), "failed to split core."),
+        return ge::GRAPH_FAILED);
     OPS_ERR_IF(ComputeUbFactor() != ge::GRAPH_SUCCESS,
-                OPS_LOG_E(context_->GetNodeName(), "failed to compute ub factor."), return ge::GRAPH_FAILED);
+        OPS_LOG_E(context_->GetNodeName(), "failed to compute ub factor."),
+        return ge::GRAPH_FAILED);
     return ge::GRAPH_SUCCESS;
 }
 
@@ -139,7 +205,18 @@ ge::graphStatus RopeRegBaseTilingClassAAndB::DoLibApiTiling()
 
 uint64_t RopeRegBaseTilingClassAAndB::GetTilingKey() const
 {
-    return layout_ == RopeLayout::NO_BROADCAST ? TILING_KEY_A : TILING_KEY_B;
+    auto xDtype = context_->GetInputDesc(0)->GetDataType();
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+
+    bool isNoBroadcast = (layout_ == RopeLayout::NO_BROADCAST);
+
+    if (xDtype == ge::DT_BF16 && cosDtype == ge::DT_FLOAT) {
+        return isNoBroadcast ? TILING_KEY_A_BF16_FP32 : TILING_KEY_B_BF16_FP32;
+    } else if (xDtype == ge::DT_FLOAT16 && cosDtype == ge::DT_FLOAT) {
+        return isNoBroadcast ? TILING_KEY_A_FP16_FP32 : TILING_KEY_B_FP16_FP32;
+    }
+
+    return isNoBroadcast ? TILING_KEY_A : TILING_KEY_B;
 }
 
 ge::graphStatus RopeRegBaseTilingClassAAndB::GetWorkspaceSize()
@@ -163,4 +240,4 @@ ge::graphStatus RopeRegBaseTilingClassAAndB::PostTiling()
 }
 
 // REGISTER_OPS_TILING_TEMPLATE(InplacePartialRotaryMul, RopeRegBaseTilingClassAAndB, ROPE_A_AND_B_TILING_PRIORITY);
-} // namespace optiling
+}  // namespace optiling

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_ab.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_ab.cpp
@@ -23,6 +23,8 @@ constexpr int64_t CONST_TWO = 2;
 constexpr int64_t CONST_FOUR = 4;
 constexpr int64_t DB_FLAG = 2;
 constexpr int64_t TILING_KEY_AB = 20030;
+constexpr int64_t TILING_KEY_AB_BF16_FP32 = 20130;
+constexpr int64_t TILING_KEY_AB_FP16_FP32 = 20230;
 
 ge::graphStatus RopeRegBaseTilingClassAB::DoOpTiling()
 {
@@ -37,6 +39,15 @@ ge::graphStatus RopeRegBaseTilingClassAB::DoOpTiling()
         return ge::GRAPH_FAILED;
     }
     dAlign_ = CeilAlign(sliceLength_ / dSplitCoef_, blockSize_ / typeSize) * dSplitCoef_;
+
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    bool isMixedPrecision = (dtype_ == ge::DT_BF16 || dtype_ == ge::DT_FLOAT16) && cosDtype == ge::DT_FLOAT;
+    int64_t cosTypeSize = ge::GetSizeByDataType(cosDtype);
+    if (cosTypeSize == 0) {
+        OPS_LOG_I("RopeRegBaseTilingClassAB DoOpTiling error, cosTypeSize == 0");
+        return ge::GRAPH_FAILED;
+    }
+    int64_t dAlignCosSin = CeilAlign(sliceLength_ / dSplitCoef_, blockSize_ / cosTypeSize) * dSplitCoef_;
 
     blockFactorBS_ = CeilDiv(bs, int64_t(aicoreParams_.blockDim));
     blockNumBS_ = CeilDiv(bs, blockFactorBS_);
@@ -57,17 +68,41 @@ ge::graphStatus RopeRegBaseTilingClassAB::DoOpTiling()
         blockTailN_ = n_;
     }
 
-    int64_t baseBufferSize = dAlign_ * typeSize;
-    int64_t baseBlockInUb =
-        FloorAlign(static_cast<int64_t>(aicoreParams_.ubSize / CONST_TWO / DB_FLAG), blockSize_) / baseBufferSize;
-    OPS_ERR_IF(baseBlockInUb < 1, OPS_LOG_I(context_->GetNodeName(), "ubSize can't load 8 d size, d = %ld.", d_),
-                return ge::GRAPH_FAILED);
+    int64_t dSizeX = dAlign_ * typeSize;
+    int64_t dSizeCosSin = dAlignCosSin * cosTypeSize;
+    int64_t baseBlockInUb;
 
-    ubFactorN_ = std::min(blockFactorN_, baseBlockInUb - 1);
-    ubFactorN_ = std::min(ubFactorN_, MAX_COPY_BLOCK_COUNT / dSplitCoef_);
+    if (isMixedPrecision) {
+        baseBlockInUb =
+            FloorAlign(static_cast<int64_t>(aicoreParams_.ubSize / CONST_TWO / DB_FLAG), blockSize_) / dSizeX;
+        // UB: 4 * ubFactorBS * (dSizeX * ubFactorN + dSizeCosSin) <= ubSize
+        // => ubFactorBS * (ubFactorN + dSizeCosSin/dSizeX) <= ubSize/(4*dSizeX)
+        int64_t effectiveCosSinOverhead = CeilDiv(dSizeCosSin, dSizeX);
+        OPS_ERR_IF(baseBlockInUb < effectiveCosSinOverhead + 1,
+            OPS_LOG_I(context_->GetNodeName(), "ubSize can't load mixed precision, d = %ld.", d_),
+            return ge::GRAPH_FAILED);
 
-    ubFactorBS_ = std::min(FloorDiv(baseBlockInUb, ubFactorN_ + 1), blockFactorBS_);
-    ubFactorBS_ = (ubFactorBS_ == 0) ? 1 : ubFactorBS_;
+        ubFactorN_ = std::min(blockFactorN_, baseBlockInUb - effectiveCosSinOverhead);
+        ubFactorN_ = std::min(ubFactorN_, MAX_COPY_BLOCK_COUNT / dSplitCoef_);
+        if (ubFactorN_ <= 0) {
+            ubFactorN_ = 1;
+        }
+        ubFactorBS_ = std::min(FloorDiv(baseBlockInUb, ubFactorN_ + effectiveCosSinOverhead), blockFactorBS_);
+        ubFactorBS_ = (ubFactorBS_ == 0) ? 1 : ubFactorBS_;
+    } else {
+        int64_t baseBufferSize = dSizeX;
+        baseBlockInUb =
+            FloorAlign(static_cast<int64_t>(aicoreParams_.ubSize / CONST_TWO / DB_FLAG), blockSize_) / baseBufferSize;
+        OPS_ERR_IF(baseBlockInUb < 1,
+            OPS_LOG_I(context_->GetNodeName(), "ubSize can't load 8 d size, d = %ld.", d_),
+            return ge::GRAPH_FAILED);
+
+        ubFactorN_ = std::min(blockFactorN_, baseBlockInUb - 1);
+        ubFactorN_ = std::min(ubFactorN_, MAX_COPY_BLOCK_COUNT / dSplitCoef_);
+
+        ubFactorBS_ = std::min(FloorDiv(baseBlockInUb, ubFactorN_ + 1), blockFactorBS_);
+        ubFactorBS_ = (ubFactorBS_ == 0) ? 1 : ubFactorBS_;
+    }
 
     return ge::GRAPH_SUCCESS;
 }
@@ -102,20 +137,44 @@ ge::graphStatus RopeRegBaseTilingClassAB::PostTiling()
     context_->GetRawTilingData()->SetDataSize(tilingData_.GetDataSize());
 
     OPS_LOG_I(context_->GetNodeName(),
-            "RopeRegBaseTilingClassAB tilingData is B: %ld, CosB: %ld, S: %ld, D: %ld, N: %ld, kAlign: %ld, "
-            "dSplitCoef: %ld, BlockNumBS: %ld, BlockFactorBS: %ld, BlockTailBS: %ld, BlockNumN: %ld, "
-            "BlockFactorN: %ld, BlockTailN: %ld, UBFactorBS: %ld, UBFactorN: %ld, RotaryMode: %ld, TilingKey: %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
-            tilingData_.get_B(), tilingData_.get_CosB(), tilingData_.get_S(), tilingData_.get_D(), tilingData_.get_N(),
-            tilingData_.get_dAlign(), tilingData_.get_dSplitCoef(), tilingData_.get_blockNumBS(),
-            tilingData_.get_blockFactorBS(), tilingData_.get_blockTailBS(), tilingData_.get_blockNumN(),
-            tilingData_.get_blockFactorN(), tilingData_.get_blockTailN(), tilingData_.get_ubFactorBS(),
-            tilingData_.get_ubFactorN(), tilingData_.get_rotaryMode(), GetTilingKey(), tilingData_.get_sliceStart(), tilingData_.get_sliceEnd(), tilingData_.get_sliceLength());
+        "RopeRegBaseTilingClassAB tilingData is B: %ld, CosB: %ld, S: %ld, D: %ld, N: %ld, kAlign: %ld, "
+        "dSplitCoef: %ld, BlockNumBS: %ld, BlockFactorBS: %ld, BlockTailBS: %ld, BlockNumN: %ld, "
+        "BlockFactorN: %ld, BlockTailN: %ld, UBFactorBS: %ld, UBFactorN: %ld, RotaryMode: %ld, TilingKey: %ld, "
+        "sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
+        tilingData_.get_B(),
+        tilingData_.get_CosB(),
+        tilingData_.get_S(),
+        tilingData_.get_D(),
+        tilingData_.get_N(),
+        tilingData_.get_dAlign(),
+        tilingData_.get_dSplitCoef(),
+        tilingData_.get_blockNumBS(),
+        tilingData_.get_blockFactorBS(),
+        tilingData_.get_blockTailBS(),
+        tilingData_.get_blockNumN(),
+        tilingData_.get_blockFactorN(),
+        tilingData_.get_blockTailN(),
+        tilingData_.get_ubFactorBS(),
+        tilingData_.get_ubFactorN(),
+        tilingData_.get_rotaryMode(),
+        GetTilingKey(),
+        tilingData_.get_sliceStart(),
+        tilingData_.get_sliceEnd(),
+        tilingData_.get_sliceLength());
 
     return ge::GRAPH_SUCCESS;
 }
 
 uint64_t RopeRegBaseTilingClassAB::GetTilingKey() const
 {
+    auto xDtype = context_->GetInputDesc(0)->GetDataType();
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    if (xDtype == ge::DT_BF16 && cosDtype == ge::DT_FLOAT) {
+        return TILING_KEY_AB_BF16_FP32;
+    } else if (xDtype == ge::DT_FLOAT16 && cosDtype == ge::DT_FLOAT) {
+        return TILING_KEY_AB_FP16_FP32;
+    }
+
     return TILING_KEY_AB;
 }
 
@@ -132,4 +191,4 @@ bool RopeRegBaseTilingClassAB::IsCapable()
 
 // REGISTER_OPS_TILING_TEMPLATE(InplacePartialRotaryMul, RopeRegBaseTilingClassAB, 25000);
 
-} // namespace optiling
+}  // namespace optiling

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_aba_and_ba.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_aba_and_ba.cpp
@@ -18,10 +18,15 @@ using namespace AscendC;
 
 namespace optiling {
 
-constexpr uint64_t ROPE_ABA_AND_BA_TILING_PRIORITY = 10000;
 constexpr uint64_t TILING_KEY_ABA = 20010;
 constexpr uint64_t TILING_KEY_BA = 20011;
+constexpr uint64_t TILING_KEY_ABA_BF16_FP32 = 20110;
+constexpr uint64_t TILING_KEY_ABA_FP16_FP32 = 20210;
+constexpr uint64_t TILING_KEY_BA_BF16_FP32 = 20111;
+constexpr uint64_t TILING_KEY_BA_FP16_FP32 = 20211;
 constexpr int64_t UB_FACTOR = 4;
+constexpr int64_t MIXED_PRECISION_X_FACTOR = 4;
+constexpr int64_t MIXED_PRECISION_COS_SIN_FACTOR = 4;
 constexpr int64_t MAX_COPY_BLOCK_COUNT = 4095;
 constexpr int32_t WORKSPACE_SIZE = 16 * 1024 * 1024;
 
@@ -93,15 +98,28 @@ ge::graphStatus RopeRegBaseTilingClassABAAndBA::ComputeUbFactor()
     ubFactorS_ = 1;
     ubFactorB_ = 1;
     ubFactorN_ = 1;
-    // UB占用大小：
-    // 11sd：4 * (bn + 1) * s * dAlign
-    // b1sd：4 * b * (n + 1) * s * dAlign
-    int64_t dSize = CeilAlign(sliceLength_ * GetSizeByDataType(dtype_) / dSplitCoef_, this->blockSize_) * dSplitCoef_;
-    int64_t numOfDAvailable = FloorDiv(static_cast<int64_t>(aicoreParams_.ubSize), UB_FACTOR * dSize);
+
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    bool isMixedPrecision = (dtype_ == ge::DT_BF16 || dtype_ == ge::DT_FLOAT16) && cosDtype == ge::DT_FLOAT;
+
+    int64_t dSizeX = CeilAlign(sliceLength_ * GetSizeByDataType(dtype_) / dSplitCoef_, this->blockSize_) * dSplitCoef_;
+    int64_t dSizeCosSin =
+        CeilAlign(sliceLength_ * GetSizeByDataType(cosDtype) / dSplitCoef_, this->blockSize_) * dSplitCoef_;
+
+    int64_t totalDSize;
+    if (isMixedPrecision) {
+        totalDSize = dSizeX * MIXED_PRECISION_X_FACTOR + dSizeCosSin * MIXED_PRECISION_COS_SIN_FACTOR;
+    } else {
+        totalDSize = dSizeX * UB_FACTOR;
+    }
+
+    int64_t numOfDAvailable = FloorDiv(static_cast<int64_t>(aicoreParams_.ubSize), totalDSize);
     OPS_ERR_IF(numOfDAvailable < ubFactorB_ + 1,
-                OPS_LOG_E(context_, "D is too big to load in ub, ubSize is %ld bytes, loading requires %ld bytes.",
-                        static_cast<int64_t>(aicoreParams_.ubSize), UB_FACTOR * dSize * (ubFactorB_ + 1)),
-                return ge::GRAPH_FAILED);
+        OPS_LOG_E(context_,
+            "D is too big to load in ub, ubSize is %ld bytes, loading requires %ld bytes.",
+            static_cast<int64_t>(aicoreParams_.ubSize),
+            totalDSize * (ubFactorB_ + 1)),
+        return ge::GRAPH_FAILED);
 
     ubFactorS_ = std::min(blockFactorS_, FloorDiv(numOfDAvailable, ubFactorB_ + 1));
     ubFactorS_ = std::min(ubFactorS_, MAX_COPY_BLOCK_COUNT / dSplitCoef_);
@@ -161,26 +179,45 @@ void RopeRegBaseTilingClassABAAndBA::SetTilingData()
     tilingData_.set_sliceLength(static_cast<int64_t>(sliceLength_));
 
     OPS_LOG_I(context_->GetNodeName(),
-            "RopeRegBaseTilingClassABAAndBA tilingData: "
-            "B is %ld, CosB is %ld, S is %ld, D is %ld, N is %ld, blockNumB %ld,"
-            "blockFactorB_ is %ld, blockNumS %ld, blockFactorS is %ld, ubLoopNumS is %ld,"
-            "ubFactorS is %ld, ubTailFactorS %ld, ubLoopNumB is %ld, ubFactorB is %ld,"
-            "ubTailFactorB is %ld, ubLoopNumN is %ld, ubFactorN is %ld, ubTailFactorN is %ld,"
-            "rotaryMode is %ld, tilingKey is %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
-            tilingData_.get_B(), tilingData_.get_CosB(), tilingData_.get_S(), tilingData_.get_D(), tilingData_.get_N(),
-            tilingData_.get_blockNumB(), tilingData_.get_blockFactorB(), tilingData_.get_blockNumS(),
-            tilingData_.get_blockFactorS(), tilingData_.get_ubLoopNumS(), tilingData_.get_ubFactorS(),
-            tilingData_.get_ubTailFactorS(), tilingData_.get_ubLoopNumB(), tilingData_.get_ubFactorB(),
-            tilingData_.get_ubTailFactorB(), tilingData_.get_ubLoopNumN(), tilingData_.get_ubFactorN(),
-            tilingData_.get_ubTailFactorN(), tilingData_.get_rotaryMode(), GetTilingKey(), tilingData_.get_sliceStart(), tilingData_.get_sliceEnd(), tilingData_.get_sliceLength());
+        "RopeRegBaseTilingClassABAAndBA tilingData: "
+        "B is %ld, CosB is %ld, S is %ld, D is %ld, N is %ld, blockNumB %ld,"
+        "blockFactorB_ is %ld, blockNumS %ld, blockFactorS is %ld, ubLoopNumS is %ld,"
+        "ubFactorS is %ld, ubTailFactorS %ld, ubLoopNumB is %ld, ubFactorB is %ld,"
+        "ubTailFactorB is %ld, ubLoopNumN is %ld, ubFactorN is %ld, ubTailFactorN is %ld,"
+        "rotaryMode is %ld, tilingKey is %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
+        tilingData_.get_B(),
+        tilingData_.get_CosB(),
+        tilingData_.get_S(),
+        tilingData_.get_D(),
+        tilingData_.get_N(),
+        tilingData_.get_blockNumB(),
+        tilingData_.get_blockFactorB(),
+        tilingData_.get_blockNumS(),
+        tilingData_.get_blockFactorS(),
+        tilingData_.get_ubLoopNumS(),
+        tilingData_.get_ubFactorS(),
+        tilingData_.get_ubTailFactorS(),
+        tilingData_.get_ubLoopNumB(),
+        tilingData_.get_ubFactorB(),
+        tilingData_.get_ubTailFactorB(),
+        tilingData_.get_ubLoopNumN(),
+        tilingData_.get_ubFactorN(),
+        tilingData_.get_ubTailFactorN(),
+        tilingData_.get_rotaryMode(),
+        GetTilingKey(),
+        tilingData_.get_sliceStart(),
+        tilingData_.get_sliceEnd(),
+        tilingData_.get_sliceLength());
 }
 
 ge::graphStatus RopeRegBaseTilingClassABAAndBA::DoOpTiling()
 {
-    OPS_ERR_IF(SplitCore() != ge::GRAPH_SUCCESS, OPS_LOG_E(context_->GetNodeName(), "failed to split core."),
-                return ge::GRAPH_FAILED);
+    OPS_ERR_IF(SplitCore() != ge::GRAPH_SUCCESS,
+        OPS_LOG_E(context_->GetNodeName(), "failed to split core."),
+        return ge::GRAPH_FAILED);
     OPS_ERR_IF(ComputeUbFactor() != ge::GRAPH_SUCCESS,
-                OPS_LOG_E(context_->GetNodeName(), "failed to compute ub factor."), return ge::GRAPH_FAILED);
+        OPS_LOG_E(context_->GetNodeName(), "failed to compute ub factor."),
+        return ge::GRAPH_FAILED);
     return ge::GRAPH_SUCCESS;
 }
 
@@ -191,7 +228,15 @@ ge::graphStatus RopeRegBaseTilingClassABAAndBA::DoLibApiTiling()
 
 uint64_t RopeRegBaseTilingClassABAAndBA::GetTilingKey() const
 {
-    return cosb_ == 1 ? TILING_KEY_BA : TILING_KEY_ABA;
+    auto xDtype = context_->GetInputDesc(0)->GetDataType();
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    if (xDtype == ge::DT_BF16 && cosDtype == ge::DT_FLOAT) {
+        return (cosb_ == 1) ? TILING_KEY_BA_BF16_FP32 : TILING_KEY_ABA_BF16_FP32;
+    } else if (xDtype == ge::DT_FLOAT16 && cosDtype == ge::DT_FLOAT) {
+        return (cosb_ == 1) ? TILING_KEY_BA_FP16_FP32 : TILING_KEY_ABA_FP16_FP32;
+    }
+
+    return (cosb_ == 1) ? TILING_KEY_BA : TILING_KEY_ABA;
 }
 
 ge::graphStatus RopeRegBaseTilingClassABAAndBA::GetWorkspaceSize()
@@ -214,5 +259,6 @@ ge::graphStatus RopeRegBaseTilingClassABAAndBA::PostTiling()
     return ge::GRAPH_SUCCESS;
 }
 
-// REGISTER_OPS_TILING_TEMPLATE(InplacePartialRotaryMul, RopeRegBaseTilingClassABAAndBA, ROPE_ABA_AND_BA_TILING_PRIORITY);
-} // namespace optiling
+// REGISTER_OPS_TILING_TEMPLATE(InplacePartialRotaryMul, RopeRegBaseTilingClassABAAndBA,
+// ROPE_ABA_AND_BA_TILING_PRIORITY);
+}  // namespace optiling

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_bab.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_bab.cpp
@@ -17,11 +17,13 @@
 
 namespace optiling {
 constexpr uint64_t ROPE_BAB_TILING_PRIORITY = 20000;
-constexpr uint32_t MIN_UB_LOAD_D_NUM = 4; // x, y或in, cos输入开doubleBuffer
+constexpr uint32_t MIN_UB_LOAD_D_NUM = 4;  // x, y或in, cos输入开doubleBuffer
 constexpr uint32_t DOUBLE_BUFFER = 2;
 constexpr int64_t MIN_COPY_BLOCK_COUNT = 4095;
 constexpr size_t WORK_SPACE_SIZE = static_cast<size_t>(16) * 1024 * 1024;
 constexpr int64_t TILING_KEY_BAB = 20020;
+constexpr int64_t TILING_KEY_BAB_BF16_FP32 = 20120;
+constexpr int64_t TILING_KEY_BAB_FP16_FP32 = 20220;
 
 ge::graphStatus RopeRegBaseTilingClassBAB::DoOpTiling()
 {
@@ -38,8 +40,8 @@ ge::graphStatus RopeRegBaseTilingClassBAB::DoOpTiling()
         return ge::GRAPH_FAILED;
     }
     if (blockNumB_ * blockNumS_ > coreNum_) {
-        OPS_LOG_E(context_->GetNodeName(), "split coreNum [%ld] large than coreNum[%ld]", blockNumB_ * blockNumS_,
-                coreNum_);
+        OPS_LOG_E(
+            context_->GetNodeName(), "split coreNum [%ld] large than coreNum[%ld]", blockNumB_ * blockNumS_, coreNum_);
         return ge::GRAPH_FAILED;
     }
     return ge::GRAPH_SUCCESS;
@@ -94,15 +96,26 @@ ge::graphStatus RopeRegBaseTilingClassBAB::SplitCore()
 ge::graphStatus RopeRegBaseTilingClassBAB::SplitUb()
 {
     uint32_t typeSize = ge::GetSizeByDataType(dtype_);
-    int64_t dAlign = CeilAlign(sliceLength_ * typeSize / dSplitCoef_, blockSize_) * dSplitCoef_;
-    // interleave模式需要补pad, D对齐
-    int64_t canLoadDNum = FloorDiv(ubSize_, dAlign);
-    if (canLoadDNum < MIN_UB_LOAD_D_NUM + MIN_UB_LOAD_D_NUM) {
-        OPS_LOG_E(context_->GetNodeName(), "ubSize_ can't load 10 d_, d_ = %ld.", d_);
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    uint32_t cosTypeSize = ge::GetSizeByDataType(cosDtype);
+
+    // For mixed precision (x is BF16/FP16, cos/sin is FP32):
+    // UB needs to store: x(dtype_), cos(float32), sin(float32), output(dtype_)
+    // In mixed precision case, cos/sin use 4 bytes, x uses 2 bytes
+    int64_t dAlignX = CeilAlign(sliceLength_ * typeSize / dSplitCoef_, blockSize_) * dSplitCoef_;
+    int64_t dAlignCosSin = CeilAlign(sliceLength_ * cosTypeSize / dSplitCoef_, blockSize_) * dSplitCoef_;
+
+    // Total buffer needed per element: x buffer + cos buffer + sin buffer + output buffer
+    // For double buffer mode, need to multiply by DOUBLE_BUFFER
+    int64_t totalDAlign = dAlignX * 2 + dAlignCosSin * 2;  // x/y queue double buffer + cos/sin queue double buffer
+
+    int64_t canLoadDNum = FloorDiv(ubSize_, totalDAlign);
+    if (canLoadDNum < MIN_UB_LOAD_D_NUM) {
+        OPS_LOG_E(context_->GetNodeName(), "ubSize_ can't load enough d_, d_ = %ld.", d_);
         return ge::GRAPH_FAILED;
     }
     canLoadDNum = canLoadDNum / MIN_UB_LOAD_D_NUM;
-    int64_t ubLoopNum = CeilDiv(n_, (canLoadDNum - 1)); // 这里减去sin, cos 开doubleBuffer
+    int64_t ubLoopNum = CeilDiv(n_, (canLoadDNum - 1));
     ubFactorN_ = std::min(CeilDiv(n_, ubLoopNum), MIN_COPY_BLOCK_COUNT / dSplitCoef_);
     ubLoopNumN_ = CeilDiv(n_, ubFactorN_);
     if (ubFactorN_ == 0) {
@@ -118,18 +131,36 @@ ge::graphStatus RopeRegBaseTilingClassBAB::SplitUb()
 void RopeRegBaseTilingClassBAB::PrintTilingData()
 {
     OPS_LOG_I(context_->GetNodeName(),
-            "RopeRegBaseTilingClassBAB tilingData: useCoreNum is %ld,"
-            "B is %ld, CosB is %ld, S is %ld, D is %ld, N is %ld, blockNumB %ld,"
-            "blockFactorB_ is %ld, blockNumS %ld, blockFactorS is %ld, ubLoopNumS is %ld,"
-            "ubFactorS is %ld, ubTailFactorS %ld, ubLoopNumB is %ld, ubFactorB is %ld,"
-            "ubTailFactorB is %ld, ubLoopNumN is %ld, ubFactorN is %ld, ubTailFactorN is %ld,"
-            "rotaryMode is %ld, tilingKey is %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
-            usedCoreNum_, tilingData_.get_B(), tilingData_.get_CosB(), tilingData_.get_S(), tilingData_.get_D(),
-            tilingData_.get_N(), tilingData_.get_blockNumB(), tilingData_.get_blockFactorB(),
-            tilingData_.get_blockNumS(), tilingData_.get_blockFactorS(), tilingData_.get_ubLoopNumS(),
-            tilingData_.get_ubFactorS(), tilingData_.get_ubTailFactorS(), tilingData_.get_ubLoopNumB(),
-            tilingData_.get_ubFactorB(), tilingData_.get_ubTailFactorB(), tilingData_.get_ubLoopNumN(),
-            tilingData_.get_ubFactorN(), tilingData_.get_ubTailFactorN(), tilingData_.get_rotaryMode(), tilingKey_, tilingData_.get_sliceStart(), tilingData_.get_sliceEnd(), tilingData_.get_sliceLength());
+        "RopeRegBaseTilingClassBAB tilingData: useCoreNum is %ld,"
+        "B is %ld, CosB is %ld, S is %ld, D is %ld, N is %ld, blockNumB %ld,"
+        "blockFactorB_ is %ld, blockNumS %ld, blockFactorS is %ld, ubLoopNumS is %ld,"
+        "ubFactorS is %ld, ubTailFactorS %ld, ubLoopNumB is %ld, ubFactorB is %ld,"
+        "ubTailFactorB is %ld, ubLoopNumN is %ld, ubFactorN is %ld, ubTailFactorN is %ld,"
+        "rotaryMode is %ld, tilingKey is %ld, sliceStart is %ld, sliceEnd is %ld, sliceLength is %ld",
+        usedCoreNum_,
+        tilingData_.get_B(),
+        tilingData_.get_CosB(),
+        tilingData_.get_S(),
+        tilingData_.get_D(),
+        tilingData_.get_N(),
+        tilingData_.get_blockNumB(),
+        tilingData_.get_blockFactorB(),
+        tilingData_.get_blockNumS(),
+        tilingData_.get_blockFactorS(),
+        tilingData_.get_ubLoopNumS(),
+        tilingData_.get_ubFactorS(),
+        tilingData_.get_ubTailFactorS(),
+        tilingData_.get_ubLoopNumB(),
+        tilingData_.get_ubFactorB(),
+        tilingData_.get_ubTailFactorB(),
+        tilingData_.get_ubLoopNumN(),
+        tilingData_.get_ubFactorN(),
+        tilingData_.get_ubTailFactorN(),
+        tilingData_.get_rotaryMode(),
+        tilingKey_,
+        tilingData_.get_sliceStart(),
+        tilingData_.get_sliceEnd(),
+        tilingData_.get_sliceLength());
     return;
 }
 
@@ -169,8 +200,16 @@ ge::graphStatus RopeRegBaseTilingClassBAB::PostTiling()
 
 uint64_t RopeRegBaseTilingClassBAB::GetTilingKey() const
 {
+    auto xDtype = context_->GetInputDesc(0)->GetDataType();
+    auto cosDtype = context_->GetInputDesc(1)->GetDataType();
+    if (xDtype == ge::DT_BF16 && cosDtype == ge::DT_FLOAT) {
+        return TILING_KEY_BAB_BF16_FP32;
+    } else if (xDtype == ge::DT_FLOAT16 && cosDtype == ge::DT_FLOAT) {
+        return TILING_KEY_BAB_FP16_FP32;
+    }
+
     return TILING_KEY_BAB;
 }
 
 // REGISTER_OPS_TILING_TEMPLATE(InplacePartialRotaryMul, RopeRegBaseTilingClassBAB, ROPE_BAB_TILING_PRIORITY);
-} // namespace optiling
+}  // namespace optiling

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_base.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/rope_regbase_tiling_base.cpp
@@ -190,17 +190,35 @@ ge::graphStatus RopeRegBaseTilingClass::CheckDtypeAndAttr()
 {
     dtype_ = context_->GetInputDesc(X_INDEX)->GetDataType();
     OPS_ERR_IF(std::find(SUPPORT_DTYPE.begin(), SUPPORT_DTYPE.end(), dtype_) == SUPPORT_DTYPE.end(),
-                OPS_LOG_E(context_->GetNodeName(), "Only support F32, BF16, F16 datetype, actual %s.",
+                OPS_LOG_E(context_->GetNodeName(), "Only support F32, BF16, F16 datetype for x, actual %s.",
                         ge::TypeUtils::DataTypeToSerialString(dtype_).c_str()),
                 return ge::GRAPH_FAILED);
-    for (int64_t i = X_INDEX; i <= SIN_INDEX; i++) {
-        auto type = context_->GetInputDesc(i)->GetDataType();
-        OPS_ERR_IF(type != dtype_,
-                    OPS_LOG_E(context_, "input %ld datatype expect %s, actual %s.", i,
-                            ge::TypeUtils::DataTypeToSerialString(dtype_).c_str(),
-                            ge::TypeUtils::DataTypeToSerialString(type).c_str()),
-                    return ge::GRAPH_FAILED);
-    }
+
+    auto cosType = context_->GetInputDesc(COS_INDEX)->GetDataType();
+    auto sinType = context_->GetInputDesc(SIN_INDEX)->GetDataType();
+
+    // Check cos/sin dtype: same type, and must be F32, BF16, or F16
+    OPS_ERR_IF(cosType != sinType,
+                OPS_LOG_E(context_, "cos and sin datatype should be same, cos is %s, sin is %s.",
+                        ge::TypeUtils::DataTypeToSerialString(cosType).c_str(),
+                        ge::TypeUtils::DataTypeToSerialString(sinType).c_str()),
+                return ge::GRAPH_FAILED);
+    OPS_ERR_IF(std::find(SUPPORT_DTYPE.begin(), SUPPORT_DTYPE.end(), cosType) == SUPPORT_DTYPE.end(),
+                OPS_LOG_E(context_->GetNodeName(), "Only support F32, BF16, F16 datetype for cos/sin, actual %s.",
+                        ge::TypeUtils::DataTypeToSerialString(cosType).c_str()),
+                return ge::GRAPH_FAILED);
+
+    // Mixed precision: x is BF16/FP16, cos/sin are FP32
+    bool isMixedPrecision = (dtype_ == ge::DT_BF16 || dtype_ == ge::DT_FLOAT16) && cosType == ge::DT_FLOAT;
+    bool isSamePrecision = (dtype_ == cosType);
+
+    OPS_ERR_IF(!isSamePrecision && !isMixedPrecision,
+                OPS_LOG_E(context_, "Unsupported dtype combination: x=%s, cos=%s. "
+                        "Supported: same type, or x=BF16/FP16 with cos/sin=FP32.",
+                        ge::TypeUtils::DataTypeToSerialString(dtype_).c_str(),
+                        ge::TypeUtils::DataTypeToSerialString(cosType).c_str()),
+                return ge::GRAPH_FAILED);
+
     auto outputType = context_->GetOutputDesc(Y_INDEX)->GetDataType();
     OPS_ERR_IF(outputType != dtype_,
                 OPS_LOG_E(context_, "output datatype expect %s, actual %s.",

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/apply_rotary_pos_emb_common.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/apply_rotary_pos_emb_common.h
@@ -40,17 +40,11 @@ constexpr uint32_t HALF_INTERLEAVE_COEF = 2;
 constexpr uint32_t QUARTER_MODE_COEF = 4;
 constexpr uint32_t DOUBLE_BUFFER = 2;
 
-enum class ApplyRotaryPosEmbRotaryMode : int64_t {
-    HALF = 1,
-    INTERLEAVE = 2,
-    QUARTER = 3,
-};
-
-enum class RotaryPosEmbeddingMode : int64_t {
-    HALF = 0,
-    INTERLEAVE = 1,
-    QUARTER = 2,
-    DEEPSEEK_INTERLEAVE = 3
+struct RotaryPosEmbeddingMode {
+    static constexpr int64_t HALF = 0;
+    static constexpr int64_t INTERLEAVE = 1;
+    static constexpr int64_t QUARTER = 2;
+    static constexpr int64_t DEEPSEEK_INTERLEAVE = 3;
 };
 
 /*
@@ -58,21 +52,21 @@ enum class RotaryPosEmbeddingMode : int64_t {
     qOut[1] = q[1] * cos[1] + q[0] * sin[1]
 */
 template <typename T>
-__aicore__ inline void HalfAlignVF(
-    const LocalTensor<T>& sinTensor, const LocalTensor<T>& cosTensor, const LocalTensor<T>& inTensor,
-    const LocalTensor<T>& outTensor, uint32_t dLen, uint32_t dAlign, uint16_t currSNum, uint16_t currDNum)
+__aicore__ inline void HalfAlignVF(const LocalTensor<T> &sinTensor, const LocalTensor<T> &cosTensor,
+    const LocalTensor<T> &inTensor, const LocalTensor<T> &outTensor, uint32_t dLen, uint32_t dAlign, uint16_t currSNum,
+    uint16_t currDNum)
 {
-    __local_mem__ T* sinUb = (__local_mem__ T*)sinTensor.GetPhyAddr();
-    __local_mem__ T* cosUb = (__local_mem__ T*)cosTensor.GetPhyAddr();
-    __local_mem__ T* inUb = (__local_mem__ T*)inTensor.GetPhyAddr();
-    __local_mem__ T* outUb = (__local_mem__ T*)outTensor.GetPhyAddr();
+    __local_mem__ T *sinUb = (__local_mem__ T *)sinTensor.GetPhyAddr();
+    __local_mem__ T *cosUb = (__local_mem__ T *)cosTensor.GetPhyAddr();
+    __local_mem__ T *inUb = (__local_mem__ T *)inTensor.GetPhyAddr();
+    __local_mem__ T *outUb = (__local_mem__ T *)outTensor.GetPhyAddr();
     uint32_t halfD = dLen / HALF_INTERLEAVE_COEF;
     uint32_t halfDAlign = ops::CeilAlign(halfD, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(T)));
     uint16_t repeatTimes = ops::CeilDiv(halfD, VL_FLOAT32_SIZE);
-    __local_mem__ T* currInUb;
-    __local_mem__ T* currOutUb;
-    __local_mem__ T* currSinUb;
-    __local_mem__ T* currCosUb;
+    __local_mem__ T *currInUb;
+    __local_mem__ T *currOutUb;
+    __local_mem__ T *currSinUb;
+    __local_mem__ T *currCosUb;
 
     __VEC_SCOPE__
     {
@@ -125,21 +119,21 @@ __aicore__ inline void HalfAlignVF(
     qOut[3] = q[3] * cos[3] + q[2] * sin[3]
 */
 template <typename T>
-__aicore__ inline void QuarterAlignVF(
-    const LocalTensor<T>& sinTensor, const LocalTensor<T>& cosTensor, const LocalTensor<T>& inTensor,
-    const LocalTensor<T>& outTensor, uint32_t dLen, uint32_t dAlign, uint16_t currSNum, uint16_t currDNum)
+__aicore__ inline void QuarterAlignVF(const LocalTensor<T> &sinTensor, const LocalTensor<T> &cosTensor,
+    const LocalTensor<T> &inTensor, const LocalTensor<T> &outTensor, uint32_t dLen, uint32_t dAlign, uint16_t currSNum,
+    uint16_t currDNum)
 {
-    __local_mem__ T* sinUb = (__local_mem__ T*)sinTensor.GetPhyAddr();
-    __local_mem__ T* cosUb = (__local_mem__ T*)cosTensor.GetPhyAddr();
-    __local_mem__ T* inUb = (__local_mem__ T*)inTensor.GetPhyAddr();
-    __local_mem__ T* outUb = (__local_mem__ T*)outTensor.GetPhyAddr();
+    __local_mem__ T *sinUb = (__local_mem__ T *)sinTensor.GetPhyAddr();
+    __local_mem__ T *cosUb = (__local_mem__ T *)cosTensor.GetPhyAddr();
+    __local_mem__ T *inUb = (__local_mem__ T *)inTensor.GetPhyAddr();
+    __local_mem__ T *outUb = (__local_mem__ T *)outTensor.GetPhyAddr();
     uint32_t quarterD = dLen / QUARTER_MODE_COEF;
     uint32_t quarterDAlign = ops::CeilAlign(quarterD, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(T)));
     uint16_t repeatTimes = ops::CeilDiv(quarterD, VL_FLOAT32_SIZE);
-    __local_mem__ T* currInUb;
-    __local_mem__ T* currOutUb;
-    __local_mem__ T* currSinUb;
-    __local_mem__ T* currCosUb;
+    __local_mem__ T *currInUb;
+    __local_mem__ T *currOutUb;
+    __local_mem__ T *currSinUb;
+    __local_mem__ T *currCosUb;
 
     __VEC_SCOPE__
     {
@@ -209,14 +203,14 @@ __aicore__ inline void QuarterAlignVF(
 }
 
 template <typename T>
-__aicore__ inline void InterleaveModeVF(
-    const LocalTensor<T>& sinTensor, const LocalTensor<T>& cosTensor, const LocalTensor<T>& inTensor,
-    const LocalTensor<T>& outTensor, uint32_t dLen, uint16_t currSNum, uint16_t currDNum)
+__aicore__ inline void InterleaveModeVF(const LocalTensor<T> &sinTensor, const LocalTensor<T> &cosTensor,
+    const LocalTensor<T> &inTensor, const LocalTensor<T> &outTensor, uint32_t dLen, uint16_t currSNum,
+    uint16_t currDNum)
 {
-    __local_mem__ T* sinUb = (__local_mem__ T*)sinTensor.GetPhyAddr();
-    __local_mem__ T* cosUb = (__local_mem__ T*)cosTensor.GetPhyAddr();
-    __local_mem__ T* inUb = (__local_mem__ T*)inTensor.GetPhyAddr();
-    __local_mem__ T* outUb = (__local_mem__ T*)outTensor.GetPhyAddr();
+    __local_mem__ T *sinUb = (__local_mem__ T *)sinTensor.GetPhyAddr();
+    __local_mem__ T *cosUb = (__local_mem__ T *)cosTensor.GetPhyAddr();
+    __local_mem__ T *inUb = (__local_mem__ T *)inTensor.GetPhyAddr();
+    __local_mem__ T *outUb = (__local_mem__ T *)outTensor.GetPhyAddr();
     uint16_t repeatTimes = dLen / VL_FLOAT32_SIZE;
     uint32_t dAlignLen = ops::CeilAlign(dLen, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(T)));
     uint16_t loopNum = repeatTimes / 2;
@@ -224,12 +218,12 @@ __aicore__ inline void InterleaveModeVF(
     uint16_t tailTwoVL = tailNum / VL_FLOAT32_SIZE;
     uint16_t tailOneVL = (tailTwoVL == 1) ? 0 : 1;
     uint32_t tailLen = tailNum % VL_FLOAT32_SIZE;
-    __local_mem__ T* currInUb;
-    __local_mem__ T* currOutUb;
-    __local_mem__ T* currSinUb;
-    __local_mem__ T* currCosUb;
-    __local_mem__ T* tailSinUb;
-    __local_mem__ T* tailCosUb;
+    __local_mem__ T *currInUb;
+    __local_mem__ T *currOutUb;
+    __local_mem__ T *currSinUb;
+    __local_mem__ T *currCosUb;
+    __local_mem__ T *tailSinUb;
+    __local_mem__ T *tailCosUb;
 
     __VEC_SCOPE__
     {
@@ -323,14 +317,14 @@ __aicore__ inline void InterleaveModeVF(
 }
 
 template <typename T>
-__aicore__ inline void DeepSeekInterleaveModeVF(
-    const LocalTensor<T>& sinTensor, const LocalTensor<T>& cosTensor, const LocalTensor<T>& inTensor,
-    const LocalTensor<T>& outTensor, uint32_t dLen, uint16_t currSNum, uint16_t currDNum)
+__aicore__ inline void DeepSeekInterleaveModeVF(const LocalTensor<T> &sinTensor, const LocalTensor<T> &cosTensor,
+    const LocalTensor<T> &inTensor, const LocalTensor<T> &outTensor, uint32_t dLen, uint16_t currSNum,
+    uint16_t currDNum)
 {
-    __local_mem__ T* sinUb = (__local_mem__ T*)sinTensor.GetPhyAddr();
-    __local_mem__ T* cosUb = (__local_mem__ T*)cosTensor.GetPhyAddr();
-    __local_mem__ T* inUb = (__local_mem__ T*)inTensor.GetPhyAddr();
-    __local_mem__ T* outUb = (__local_mem__ T*)outTensor.GetPhyAddr();
+    __local_mem__ T *sinUb = (__local_mem__ T *)sinTensor.GetPhyAddr();
+    __local_mem__ T *cosUb = (__local_mem__ T *)cosTensor.GetPhyAddr();
+    __local_mem__ T *inUb = (__local_mem__ T *)inTensor.GetPhyAddr();
+    __local_mem__ T *outUb = (__local_mem__ T *)outTensor.GetPhyAddr();
     uint32_t dAlign = ops::CeilAlign(dLen, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(T)));
     uint32_t halfD = dLen / HALF_INTERLEAVE_COEF;
     uint32_t halfDAlign = ops::CeilAlign(halfD, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(T)));
@@ -340,10 +334,10 @@ __aicore__ inline void DeepSeekInterleaveModeVF(
     uint16_t tailOneVL = tailTwoNum > 0 ? (1 - tailTwoVL) : 0;
     uint32_t halfTailNum = tailTwoNum / HALF_INTERLEAVE_COEF;
     uint32_t tailNum = tailTwoNum - tailTwoVL * VL_FLOAT32_SIZE;
-    __local_mem__ T* currInUb;
-    __local_mem__ T* currOutUb;
-    __local_mem__ T* currSinUb;
-    __local_mem__ T* currCosUb;
+    __local_mem__ T *currInUb;
+    __local_mem__ T *currOutUb;
+    __local_mem__ T *currSinUb;
+    __local_mem__ T *currCosUb;
 
     __VEC_SCOPE__
     {
@@ -372,8 +366,13 @@ __aicore__ inline void DeepSeekInterleaveModeVF(
                     uint32_t offset = i * VL_FLOAT32_SIZE;
                     uint32_t halfOffset = offset + halfDAlign;
                     uint32_t inOffset = offset * HALF_INTERLEAVE_COEF;
-                    ops::LoadTwoTensorForDtypeT<T>(
-                        currInUb, currInUb, vregIn, vregHalfIn, pregFull, pregFull, inOffset,
+                    ops::LoadTwoTensorForDtypeT<T>(currInUb,
+                        currInUb,
+                        vregIn,
+                        vregHalfIn,
+                        pregFull,
+                        pregFull,
+                        inOffset,
                         inOffset + VL_FLOAT32_SIZE);
                     ops::LoadTwoTensorForDtypeT<T>(
                         currSinUb, currSinUb, vregSin, vregHalfSin, pregFull, pregFull, offset, halfOffset);
@@ -398,8 +397,13 @@ __aicore__ inline void DeepSeekInterleaveModeVF(
                     uint32_t offset = repeatTimes * VL_FLOAT32_SIZE;
                     uint32_t halfOffset = offset + halfDAlign;
                     uint32_t inOffset = offset * HALF_INTERLEAVE_COEF;
-                    ops::LoadTwoTensorForDtypeT<T>(
-                        currInUb, currInUb, vregIn, vregHalfIn, pregFull, pregTail, inOffset,
+                    ops::LoadTwoTensorForDtypeT<T>(currInUb,
+                        currInUb,
+                        vregIn,
+                        vregHalfIn,
+                        pregFull,
+                        pregTail,
+                        inOffset,
                         inOffset + VL_FLOAT32_SIZE);
                     ops::LoadTwoTensorForDtypeT<T>(
                         currSinUb, currSinUb, vregSin, vregHalfSin, pregHalfTail, pregHalfTail, offset, halfOffset);
@@ -447,9 +451,9 @@ __aicore__ inline void DeepSeekInterleaveModeVF(
 }
 
 template <typename T, bool IsBBoardcast>
-__aicore__ inline void BatchHalfAlignVF(
-    __local_mem__ T* in, __local_mem__ T* cos, __local_mem__ T* sin, __local_mem__ T* out, uint16_t sLength,
-    uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign, int64_t ubFactorS, int64_t ubFactorN)
+__aicore__ inline void BatchHalfAlignVF(__local_mem__ T *in, __local_mem__ T *cos, __local_mem__ T *sin,
+    __local_mem__ T *out, uint16_t sLength, uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign,
+    int64_t ubFactorS, int64_t ubFactorN)
 {
     uint32_t dHalfSize = d / HALF_INTERLEAVE_COEF;
     uint16_t dLoopCount = (dHalfSize + VL_FLOAT32_SIZE - 1) / VL_FLOAT32_SIZE;
@@ -514,9 +518,9 @@ __aicore__ inline void BatchHalfAlignVF(
 }
 
 template <typename T, bool IsBBoardcast>
-__aicore__ inline void BatchQuarterAlignVF(
-    __local_mem__ T* in, __local_mem__ T* cos, __local_mem__ T* sin, __local_mem__ T* out, uint16_t sLength,
-    uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign, int64_t ubFactorS, int64_t ubFactorN)
+__aicore__ inline void BatchQuarterAlignVF(__local_mem__ T *in, __local_mem__ T *cos, __local_mem__ T *sin,
+    __local_mem__ T *out, uint16_t sLength, uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign,
+    int64_t ubFactorS, int64_t ubFactorN)
 {
     uint32_t dQuarterSize = d / QUARTER_MODE_COEF;
     uint16_t dLoopCount = (dQuarterSize + VL_FLOAT32_SIZE - 1) / VL_FLOAT32_SIZE;
@@ -561,24 +565,54 @@ __aicore__ inline void BatchQuarterAlignVF(
                     for (uint16_t i = 0; i < dLoopCount; i++) {
                         pregLoop = MicroAPI::UpdateMask<float>(count);
                         // 拷贝到RegBase内
-                        ops::LoadTwoTensorForDtypeT<T>(
-                            currInUb, currInUb, inPart1Reg, inPart2Reg, pregLoop, pregLoop, i * VL_FLOAT32_SIZE,
+                        ops::LoadTwoTensorForDtypeT<T>(currInUb,
+                            currInUb,
+                            inPart1Reg,
+                            inPart2Reg,
+                            pregLoop,
+                            pregLoop,
+                            i * VL_FLOAT32_SIZE,
                             i * VL_FLOAT32_SIZE + dQuarterOffset);
-                        ops::LoadTwoTensorForDtypeT<T>(
-                            currInUb, currInUb, inPart3Reg, inPart4Reg, pregLoop, pregLoop,
-                            i * VL_FLOAT32_SIZE + dHalfOffset, i * VL_FLOAT32_SIZE + dThreeQuarterOffset);
-                        ops::LoadTwoTensorForDtypeT<T>(
-                            currCosUb, currCosUb, cosPart1Reg, cosPart2Reg, pregLoop, pregLoop, i * VL_FLOAT32_SIZE,
+                        ops::LoadTwoTensorForDtypeT<T>(currInUb,
+                            currInUb,
+                            inPart3Reg,
+                            inPart4Reg,
+                            pregLoop,
+                            pregLoop,
+                            i * VL_FLOAT32_SIZE + dHalfOffset,
+                            i * VL_FLOAT32_SIZE + dThreeQuarterOffset);
+                        ops::LoadTwoTensorForDtypeT<T>(currCosUb,
+                            currCosUb,
+                            cosPart1Reg,
+                            cosPart2Reg,
+                            pregLoop,
+                            pregLoop,
+                            i * VL_FLOAT32_SIZE,
                             i * VL_FLOAT32_SIZE + dQuarterOffset);
-                        ops::LoadTwoTensorForDtypeT<T>(
-                            currCosUb, currCosUb, cosPart3Reg, cosPart4Reg, pregLoop, pregLoop,
-                            i * VL_FLOAT32_SIZE + dHalfOffset, i * VL_FLOAT32_SIZE + dThreeQuarterOffset);
-                        ops::LoadTwoTensorForDtypeT<T>(
-                            currSinUb, currSinUb, sinPart1Reg, sinPart2Reg, pregLoop, pregLoop, i * VL_FLOAT32_SIZE,
+                        ops::LoadTwoTensorForDtypeT<T>(currCosUb,
+                            currCosUb,
+                            cosPart3Reg,
+                            cosPart4Reg,
+                            pregLoop,
+                            pregLoop,
+                            i * VL_FLOAT32_SIZE + dHalfOffset,
+                            i * VL_FLOAT32_SIZE + dThreeQuarterOffset);
+                        ops::LoadTwoTensorForDtypeT<T>(currSinUb,
+                            currSinUb,
+                            sinPart1Reg,
+                            sinPart2Reg,
+                            pregLoop,
+                            pregLoop,
+                            i * VL_FLOAT32_SIZE,
                             i * VL_FLOAT32_SIZE + dQuarterOffset);
-                        ops::LoadTwoTensorForDtypeT<T>(
-                            currSinUb, currSinUb, sinPart3Reg, sinPart4Reg, pregLoop, pregLoop,
-                            i * VL_FLOAT32_SIZE + dHalfOffset, i * VL_FLOAT32_SIZE + dThreeQuarterOffset);
+                        ops::LoadTwoTensorForDtypeT<T>(currSinUb,
+                            currSinUb,
+                            sinPart3Reg,
+                            sinPart4Reg,
+                            pregLoop,
+                            pregLoop,
+                            i * VL_FLOAT32_SIZE + dHalfOffset,
+                            i * VL_FLOAT32_SIZE + dThreeQuarterOffset);
                         // 计算
                         Mul(cosPart1Reg, inPart1Reg, cosPart1Reg, pregLoop);
                         Mul(sinPart1Reg, inPart2Reg, sinPart1Reg, pregLoop);
@@ -608,9 +642,9 @@ __aicore__ inline void BatchQuarterAlignVF(
 }
 
 template <typename T, bool IsBBoardcast>
-__aicore__ inline void BatchInterleaveModeVF(
-    __local_mem__ T* in, __local_mem__ T* cos, __local_mem__ T* sin, __local_mem__ T* out, uint16_t sLength,
-    uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign, int64_t ubFactorS, int64_t ubFactorN)
+__aicore__ inline void BatchInterleaveModeVF(__local_mem__ T *in, __local_mem__ T *cos, __local_mem__ T *sin,
+    __local_mem__ T *out, uint16_t sLength, uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign,
+    int64_t ubFactorS, int64_t ubFactorN)
 {
     uint32_t loopSize = 2 * VL_FLOAT32_SIZE;
     uint16_t dLoopCount = (d + loopSize - 1) / loopSize;
@@ -691,9 +725,9 @@ __aicore__ inline void BatchInterleaveModeVF(
 }
 
 template <typename T, bool IsBBoardcast>
-__aicore__ inline void BatchDeepSeekInterleaveModeVF(
-    __local_mem__ T* in, __local_mem__ T* cos, __local_mem__ T* sin, __local_mem__ T* out, uint16_t sLength,
-    uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign, int64_t ubFactorS, int64_t ubFactorN)
+__aicore__ inline void BatchDeepSeekInterleaveModeVF(__local_mem__ T *in, __local_mem__ T *cos, __local_mem__ T *sin,
+    __local_mem__ T *out, uint16_t sLength, uint16_t bLength, uint16_t nLength, int64_t d, int64_t dAlign,
+    int64_t ubFactorS, int64_t ubFactorN)
 {
     uint32_t loopSize = 2 * VL_FLOAT32_SIZE;
     uint16_t dLoopCount = (d + loopSize - 1) / loopSize;
@@ -773,4 +807,203 @@ __aicore__ inline void BatchDeepSeekInterleaveModeVF(
     }
 }
 
-#endif // APPLY_ROTARY_POS_EMB_COMMON_H
+// Mixed precision: TX is half/bfloat16 for input, cos/sin are float
+template <typename TX>
+__aicore__ inline void InterleaveModeVFMixed(const LocalTensor<TX> &inTensor, const LocalTensor<float> &cosTensor,
+    const LocalTensor<float> &sinTensor, const LocalTensor<TX> &outTensor, uint32_t dLen, uint16_t currSNum,
+    uint16_t currDNum)
+{
+    __local_mem__ TX *inUb = (__local_mem__ TX *)inTensor.GetPhyAddr();
+    __local_mem__ float *cosUb = (__local_mem__ float *)cosTensor.GetPhyAddr();
+    __local_mem__ float *sinUb = (__local_mem__ float *)sinTensor.GetPhyAddr();
+    __local_mem__ TX *outUb = (__local_mem__ TX *)outTensor.GetPhyAddr();
+    uint16_t repeatTimes = dLen / VL_FLOAT32_SIZE;
+    uint32_t dAlignLen = ops::CeilAlign(dLen, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(TX)));
+    uint32_t dAlignLenFloat = ops::CeilAlign(dLen, static_cast<uint32_t>(BLOCK_TYPE_SIZE / sizeof(float)));
+    uint16_t loopNum = repeatTimes / 2;
+    uint32_t tailNum = dLen - loopNum * 2 * VL_FLOAT32_SIZE;
+    uint16_t tailTwoVL = tailNum / VL_FLOAT32_SIZE;
+    uint16_t tailOneVL = (tailTwoVL == 1) ? 0 : 1;
+    uint32_t tailLen = tailNum % VL_FLOAT32_SIZE;
+    __local_mem__ TX *currInUb;
+    __local_mem__ TX *currOutUb;
+    __local_mem__ float *currSinUb;
+    __local_mem__ float *currCosUb;
+
+    __VEC_SCOPE__
+    {
+        MicroAPI::RegTensor<float> vregFormerCos;
+        MicroAPI::RegTensor<float> vregLatterCos;
+        MicroAPI::RegTensor<float> vregFormerSin;
+        MicroAPI::RegTensor<float> vregLatterSin;
+        MicroAPI::RegTensor<float> vregFormerIn;
+        MicroAPI::RegTensor<float> vregLatterIn;
+        MicroAPI::RegTensor<float> vregOdd;
+        MicroAPI::RegTensor<float> vregEven;
+        MicroAPI::MaskReg pregLoop;
+        MicroAPI::MaskReg pregTail;
+        for (uint16_t sIdx = 0; sIdx < currSNum; sIdx++) {
+            currSinUb = sinUb + sIdx * dAlignLenFloat;
+            currCosUb = cosUb + sIdx * dAlignLenFloat;
+            for (uint16_t idxD = 0; idxD < currDNum; idxD++) {
+                currInUb = inUb + (sIdx * currDNum + idxD) * dAlignLen;
+                currOutUb = outUb + (sIdx * currDNum + idxD) * dAlignLen;
+                pregLoop = MicroAPI::CreateMask<float, MicroAPI::MaskPattern::ALL>();
+                for (uint16_t i = 0; i < loopNum; i++) {
+                    uint32_t evenOffSet = (i * 2) * VL_FLOAT32_SIZE;
+                    uint32_t oddOffset = evenOffSet + VL_FLOAT32_SIZE;
+                    ops::LoadOneTensorForDtypeT<TX>(currInUb, vregFormerIn, pregLoop, evenOffSet);
+                    ops::LoadOneTensorForDtypeT<TX>(currInUb, vregLatterIn, pregLoop, oddOffset);
+                    DataCopy(vregFormerCos, currCosUb + evenOffSet);
+                    DataCopy(vregLatterCos, currCosUb + oddOffset);
+                    DataCopy(vregFormerSin, currSinUb + evenOffSet);
+                    DataCopy(vregLatterSin, currSinUb + oddOffset);
+                    Mul(vregFormerCos, vregFormerCos, vregFormerIn, pregLoop);
+                    Mul(vregLatterCos, vregLatterCos, vregLatterIn, pregLoop);
+                    MicroAPI::DeInterleave<float>(vregEven, vregOdd, vregFormerIn, vregLatterIn);
+                    Muls(vregOdd, vregOdd, float(-1.0), pregLoop);
+                    MicroAPI::Interleave<float>(vregFormerIn, vregLatterIn, vregOdd, vregEven);
+                    Mul(vregFormerSin, vregFormerSin, vregFormerIn, pregLoop);
+                    Add(vregFormerCos, vregFormerCos, vregFormerSin, pregLoop);
+                    Mul(vregLatterSin, vregLatterSin, vregLatterIn, pregLoop);
+                    Add(vregLatterCos, vregLatterCos, vregLatterSin, pregLoop);
+                    ops::StoreOneTensorForDtypeT<TX>(currOutUb, vregFormerCos, pregLoop, evenOffSet);
+                    ops::StoreOneTensorForDtypeT<TX>(currOutUb, vregLatterCos, pregLoop, oddOffset);
+                }
+
+                currInUb = inUb + (sIdx * currDNum + idxD) * dAlignLen + (loopNum * 2 * VL_FLOAT32_SIZE);
+                currOutUb = outUb + (sIdx * currDNum + idxD) * dAlignLen + (loopNum * 2 * VL_FLOAT32_SIZE);
+                __local_mem__ float *tailSinUb = currSinUb + loopNum * 2 * VL_FLOAT32_SIZE;
+                __local_mem__ float *tailCosUb = currCosUb + loopNum * 2 * VL_FLOAT32_SIZE;
+                for (uint16_t i = 0; i < tailTwoVL; i++) {
+                    uint32_t updateCnt = tailLen;
+                    pregTail = MicroAPI::UpdateMask<float>(updateCnt);
+                    ops::LoadOneTensorForDtypeT<TX>(currInUb, vregFormerIn, pregLoop, 0);
+                    ops::LoadOneTensorForDtypeT<TX>(currInUb, vregLatterIn, pregTail, VL_FLOAT32_SIZE);
+                    DataCopy(vregFormerCos, tailCosUb);
+                    DataCopy(vregLatterCos, tailCosUb + VL_FLOAT32_SIZE);
+                    DataCopy(vregFormerSin, tailSinUb);
+                    DataCopy(vregLatterSin, tailSinUb + VL_FLOAT32_SIZE);
+                    Mul(vregFormerCos, vregFormerCos, vregFormerIn, pregLoop);
+                    Mul(vregLatterCos, vregLatterCos, vregLatterIn, pregTail);
+                    MicroAPI::DeInterleave<float>(vregEven, vregOdd, vregFormerIn, vregLatterIn);
+                    Muls(vregOdd, vregOdd, float(-1.0), pregLoop);
+                    MicroAPI::Interleave<float>(vregFormerIn, vregLatterIn, vregOdd, vregEven);
+                    Mul(vregFormerSin, vregFormerSin, vregFormerIn, pregLoop);
+                    Add(vregFormerCos, vregFormerCos, vregFormerSin, pregLoop);
+                    Mul(vregLatterSin, vregLatterSin, vregLatterIn, pregTail);
+                    Add(vregLatterCos, vregLatterCos, vregLatterSin, pregTail);
+                    ops::StoreOneTensorForDtypeT<TX>(currOutUb, vregFormerCos, pregLoop, 0);
+                    ops::StoreOneTensorForDtypeT<TX>(currOutUb, vregLatterCos, pregTail, VL_FLOAT32_SIZE);
+                }
+
+                for (uint16_t i = 0; i < tailOneVL; i++) {
+                    uint32_t updateCnt = tailLen;
+                    pregTail = MicroAPI::UpdateMask<float>(updateCnt);
+                    ops::LoadOneTensorForDtypeT<TX>(currInUb, vregFormerIn, pregTail, 0);
+                    DataCopy(vregFormerCos, tailCosUb);
+                    DataCopy(vregFormerSin, tailSinUb);
+                    Mul(vregFormerCos, vregFormerCos, vregFormerIn, pregTail);
+                    MicroAPI::DeInterleave<float>(vregEven, vregOdd, vregFormerIn, vregLatterIn);
+                    Muls(vregOdd, vregOdd, float(-1.0), pregTail);
+                    MicroAPI::Interleave<float>(vregFormerIn, vregLatterIn, vregOdd, vregEven);
+                    Mul(vregFormerSin, vregFormerSin, vregFormerIn, pregTail);
+                    Add(vregFormerCos, vregFormerCos, vregFormerSin, pregTail);
+                    ops::StoreOneTensorForDtypeT<TX>(currOutUb, vregFormerCos, pregTail, 0);
+                }
+            }
+        }
+    }
+}
+
+// Mixed precision BatchInterleaveModeVF for ABA layout
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void BatchInterleaveModeVFMixed(__local_mem__ TX *in, __local_mem__ float *cos,
+    __local_mem__ float *sin, __local_mem__ TX *out, uint16_t sLength, uint16_t bLength, uint16_t nLength, int64_t d,
+    int64_t dAlign, int64_t dAlignFloat, int64_t ubFactorS, int64_t ubFactorN)
+{
+    uint32_t loopSize = 2 * VL_FLOAT32_SIZE;
+    uint32_t txLoopSize = loopSize * sizeof(float) / sizeof(TX);  // Convert to TX element units
+    uint16_t dLoopCount = (d + loopSize - 1) / loopSize;
+
+    uint32_t halfNum = d / 2;
+    uint32_t part1Num = (dLoopCount - 1) * VL_FLOAT32_SIZE;
+    uint32_t part2Num = part1Num;
+    uint32_t tailNum = d - part1Num - part2Num;
+    if (tailNum > VL_FLOAT32_SIZE) {
+        part1Num += VL_FLOAT32_SIZE;
+        part2Num += (tailNum - VL_FLOAT32_SIZE);
+    } else {
+        part1Num += tailNum;
+    }
+
+    int32_t bStepUb = ubFactorN * ubFactorS * dAlign;
+    int32_t nStepUb = ubFactorS * dAlign;
+    int32_t cosSinBStepUb = ubFactorS * dAlignFloat;
+    int32_t cosSinSStepUb = dAlignFloat;
+
+    __VEC_SCOPE__
+    {
+        MicroAPI::RegTensor<float> inPart1Reg;
+        MicroAPI::RegTensor<float> inPart2Reg;
+        MicroAPI::RegTensor<float> cosPart1Reg;
+        MicroAPI::RegTensor<float> cosPart2Reg;
+        MicroAPI::RegTensor<float> sinPart1Reg;
+        MicroAPI::RegTensor<float> sinPart2Reg;
+        MicroAPI::MaskReg pregLoop;
+        MicroAPI::MaskReg pregPart1;
+        MicroAPI::MaskReg pregPart2;
+        __local_mem__ TX *currInUb, *currOutUb;
+        __local_mem__ float *currSinUb, *currCosUb;
+        for (uint16_t bIdx = 0; bIdx < bLength; bIdx++) {
+            for (uint16_t nIdx = 0; nIdx < nLength; nIdx++) {
+                for (uint16_t sIdx = 0; sIdx < sLength; sIdx++) {
+                    uint32_t halfCnt = halfNum;
+                    uint32_t part1Cnt = part1Num;
+                    uint32_t part2Cnt = part2Num;
+                    currInUb = in + bIdx * bStepUb + nIdx * nStepUb + sIdx * dAlign;
+                    currOutUb = out + bIdx * bStepUb + nIdx * nStepUb + sIdx * dAlign;
+                    if constexpr (IsBBoardcast) {
+                        currCosUb = cos + sIdx * cosSinSStepUb;
+                        currSinUb = sin + sIdx * cosSinSStepUb;
+                    } else {
+                        currCosUb = cos + bIdx * cosSinBStepUb + sIdx * cosSinSStepUb;
+                        currSinUb = sin + bIdx * cosSinBStepUb + sIdx * cosSinSStepUb;
+                    }
+                    for (uint16_t i = 0; i < dLoopCount; i++) {
+                        pregLoop = MicroAPI::UpdateMask<float>(halfCnt);
+                        pregPart1 = MicroAPI::UpdateMask<float>(part1Cnt);
+                        pregPart2 = MicroAPI::UpdateMask<float>(part2Cnt);
+                        ops::LoadOneTensorForDtypeT<TX>(currInUb, inPart1Reg, pregPart1, i * txLoopSize);
+                        ops::LoadOneTensorForDtypeT<TX>(currInUb,
+                            inPart2Reg,
+                            pregPart2,
+                            i * txLoopSize + VL_FLOAT32_SIZE * sizeof(float) / sizeof(TX));
+                        ops::LoadOneTensorForDtypeT<float>(currCosUb, cosPart1Reg, pregPart1, i * loopSize);
+                        ops::LoadOneTensorForDtypeT<float>(
+                            currCosUb, cosPart2Reg, pregPart2, i * loopSize + VL_FLOAT32_SIZE);
+                        ops::LoadOneTensorForDtypeT<float>(currSinUb, sinPart1Reg, pregPart1, i * loopSize);
+                        ops::LoadOneTensorForDtypeT<float>(
+                            currSinUb, sinPart2Reg, pregPart2, i * loopSize + VL_FLOAT32_SIZE);
+                        Mul(cosPart1Reg, cosPart1Reg, inPart1Reg, pregPart1);
+                        Mul(cosPart2Reg, cosPart2Reg, inPart2Reg, pregPart2);
+                        MicroAPI::DeInterleave<float>(inPart1Reg, inPart2Reg, inPart1Reg, inPart2Reg);
+                        Muls(inPart2Reg, inPart2Reg, float(-1.0), pregLoop);
+                        MicroAPI::Interleave<float>(inPart1Reg, inPart2Reg, inPart2Reg, inPart1Reg);
+                        Mul(sinPart1Reg, sinPart1Reg, inPart1Reg, pregPart1);
+                        Add(cosPart1Reg, cosPart1Reg, sinPart1Reg, pregPart1);
+                        Mul(sinPart2Reg, sinPart2Reg, inPart2Reg, pregPart2);
+                        Add(cosPart2Reg, cosPart2Reg, sinPart2Reg, pregPart2);
+                        ops::StoreOneTensorForDtypeT<TX>(currOutUb, cosPart1Reg, pregPart1, i * txLoopSize);
+                        ops::StoreOneTensorForDtypeT<TX>(currOutUb,
+                            cosPart2Reg,
+                            pregPart2,
+                            i * txLoopSize + VL_FLOAT32_SIZE * sizeof(float) / sizeof(TX));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif  // APPLY_ROTARY_POS_EMB_COMMON_H

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.cpp
@@ -18,6 +18,10 @@
     #include "rotary_position_embedding_reg_ab.h"
     #include "rotary_position_embedding_reg_aba_and_ba.h"
     #include "rotary_position_embedding_reg_a_and_b.h"
+    #include "rotary_position_embedding_reg_bab_mixed.h"
+    #include "rotary_position_embedding_reg_aba_and_ba_mixed.h"
+    #include "rotary_position_embedding_reg_a_and_b_mixed.h"
+    #include "rotary_position_embedding_reg_ab_mixed.h"
 #else
     #include "kernel_operator.h"
     #include "kernel_tiling/kernel_tiling.h"
@@ -38,6 +42,20 @@
 #define TILING_KEY_AB 20030
 #define TILING_KEY_A 20040
 #define TILING_KEY_B 20041
+
+#define TILING_KEY_ABA_BF16_FP32_MIXED 20110
+#define TILING_KEY_ABA_FP16_FP32_MIXED 20210
+#define TILING_KEY_BA_BF16_FP32_MIXED 20111
+#define TILING_KEY_BA_FP16_FP32_MIXED 20211
+#define TILING_KEY_BAB_BF16_FP32_MIXED 20120
+#define TILING_KEY_BAB_FP16_FP32_MIXED 20220
+#define TILING_KEY_AB_BF16_FP32_MIXED 20130
+#define TILING_KEY_AB_FP16_FP32_MIXED 20230
+#define TILING_KEY_A_BF16_FP32_MIXED 20140
+#define TILING_KEY_A_FP16_FP32_MIXED 20240
+#define TILING_KEY_B_BF16_FP32_MIXED 20141
+#define TILING_KEY_B_FP16_FP32_MIXED 20241
+
 #define TILING_KEY1 1
 #define TILING_KEY2 2
 
@@ -94,6 +112,106 @@ extern "C" __global__ __aicore__ void inplace_partial_rotary_mul(GM_ADDR x, GM_A
             GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
             const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
             InplacePartialRotaryMul::RotaryPositionEmbeddingAAndB<DTYPE_X, true> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        // Mixed precision: x is half/bfloat16, cos/sin are float32
+        else if (TILING_KEY_IS(TILING_KEY_BAB_FP16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingBABMixed<half> op(&pipe, tilingData);
+            op.Init(x, cos, sin, y);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_BAB_BF16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingBABMixed<bfloat16_t> op(&pipe, tilingData);
+            op.Init(x, cos, sin, y);
+            op.Process();
+        }
+        // Mixed precision ABA/BA kernels
+        else if (TILING_KEY_IS(TILING_KEY_ABA_FP16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingABAAndBAMixed<half, false> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_ABA_BF16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingABAAndBAMixed<bfloat16_t, false> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_BA_FP16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingABAAndBAMixed<half, true> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_BA_BF16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingABAAndBAMixed<bfloat16_t, true> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        // Mixed precision AAndB kernels
+        else if (TILING_KEY_IS(TILING_KEY_A_FP16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingAAndBMixed<half, false> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_A_BF16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingAAndBMixed<bfloat16_t, false> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_B_FP16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingAAndBMixed<half, true> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_B_BF16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingAAndBMixed<bfloat16_t, true> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        // Mixed precision AB kernels
+        else if (TILING_KEY_IS(TILING_KEY_AB_FP16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingABMixed<half> op;
+            op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
+            op.Process();
+        }
+        else if (TILING_KEY_IS(TILING_KEY_AB_BF16_FP32_MIXED))
+        {
+            GET_TILING_DATA_WITH_STRUCT(RopeRegbaseTilingData, tiling_data_in, tiling);
+            const RopeRegbaseTilingData *__restrict tilingData = &tiling_data_in;
+            InplacePartialRotaryMul::RotaryPositionEmbeddingABMixed<bfloat16_t> op;
             op.Init(x, cos, sin, y, workspace, tilingData, &pipe);
             op.Process();
         }

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_a_and_b_mixed.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_a_and_b_mixed.h
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file rotary_position_embedding_reg_a_and_b_mixed.h
+ * \brief Mixed precision kernel for AAndB layout: x is half/bfloat16, cos/sin are float
+ */
+#ifndef ROTARY_POSITION_EMBEDDING_REG_A_AND_B_MIXED_H
+#define ROTARY_POSITION_EMBEDDING_REG_A_AND_B_MIXED_H
+
+#include "apply_rotary_pos_emb_common.h"
+
+namespace InplacePartialRotaryMul {
+using namespace AscendC;
+
+template <typename TX, bool IsBoardCast>
+class RotaryPositionEmbeddingAAndBMixed {
+public:
+    __aicore__ inline RotaryPositionEmbeddingAAndBMixed(){};
+
+    __aicore__ inline ~RotaryPositionEmbeddingAAndBMixed(){};
+
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR cos, GM_ADDR sin, GM_ADDR qOut, GM_ADDR workspace,
+        const RopeRegbaseTilingData *tilingData, TPipe *pipe);
+
+    __aicore__ inline void Process();
+
+private:
+    __aicore__ inline void InitAllGlobalBuffer(GM_ADDR q, GM_ADDR cos, GM_ADDR sin, GM_ADDR qOut);
+    __aicore__ inline void InitAllBuffer();
+    __aicore__ inline void InitLoopParams();
+    __aicore__ inline void ProcessInLoop(
+        LocalTensor<float> &cos, LocalTensor<float> &sin, int64_t bStart, int64_t bLength);
+    __aicore__ inline void CopyInCosAndSin(int64_t bStart, int64_t bLength);
+    __aicore__ inline void CopyInQ(GlobalTensor<TX> &source, int64_t bStart, int64_t bLength);
+    __aicore__ inline void CopyOutQ(GlobalTensor<TX> &target, int64_t bStart, int64_t bLength);
+
+    __aicore__ inline void Compute(LocalTensor<float> &cos, LocalTensor<float> &sin, int64_t bLength);
+
+private:
+    static constexpr uint32_t COS_DB_BUFFER = IsBoardCast ? 1 : DOUBLE_BUFFER;
+
+    TPipe *pipe_;
+
+    GlobalTensor<TX> qGm_;
+    GlobalTensor<float> cosGm_;
+    GlobalTensor<float> sinGm_;
+    GlobalTensor<TX> qOutGm_;
+
+    TQue<QuePosition::VECIN, DOUBLE_BUFFER> qInQueue_;
+    TQue<QuePosition::VECIN, COS_DB_BUFFER> cosInQueue_;
+    TQue<QuePosition::VECIN, COS_DB_BUFFER> sinInQueue_;
+    TQue<QuePosition::VECOUT, DOUBLE_BUFFER> qOutQueue_;
+
+    int64_t blockIdx_ = 0;
+    int64_t bBlockStart_ = 0;
+    int64_t bBlockLength_ = 0;
+
+    const RopeRegbaseTilingData *tilingData_;
+    int64_t ubFactorB_ = 0;
+    int64_t D_ = 0;
+    int64_t dAlign_ = 0;
+    int64_t dAlignFloat_ = 0;
+    uint8_t dSplitCoef_ = 1;
+    uint8_t copyInQSplitCoef_ = 1;
+    uint64_t ubCopyInStride = 0;
+};
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::Init(GM_ADDR q, GM_ADDR cos, GM_ADDR sin,
+    GM_ADDR qOut, GM_ADDR workspace, const RopeRegbaseTilingData *tilingData, TPipe *pipe)
+{
+    this->tilingData_ = tilingData;
+    this->pipe_ = pipe;
+    this->blockIdx_ = GetBlockIdx();
+    this->InitAllGlobalBuffer(q, cos, sin, qOut);
+    this->InitAllBuffer();
+    this->InitLoopParams();
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::InitAllGlobalBuffer(
+    GM_ADDR q, GM_ADDR cos, GM_ADDR sin, GM_ADDR qOut)
+{
+    this->qGm_.SetGlobalBuffer((__gm__ TX *)q);
+    this->cosGm_.SetGlobalBuffer((__gm__ float *)cos);
+    this->sinGm_.SetGlobalBuffer((__gm__ float *)sin);
+    this->qOutGm_.SetGlobalBuffer((__gm__ TX *)qOut);
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::InitAllBuffer()
+{
+    this->ubFactorB_ = this->tilingData_->ubFactorB;
+    this->D_ = this->tilingData_->D;
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::HALF) ||
+        tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+        this->dSplitCoef_ = HALF_INTERLEAVE_COEF;
+    } else if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::QUARTER)) {
+        this->dSplitCoef_ = QUARTER_MODE_COEF;
+    }
+    this->copyInQSplitCoef_ = dSplitCoef_;
+    this->dAlign_ =
+        ops::CeilAlign<int64_t>(tilingData_->sliceLength / dSplitCoef_, BLOCK_TYPE_SIZE / sizeof(TX)) * dSplitCoef_;
+    this->dAlignFloat_ =
+        ops::CeilAlign<int64_t>(tilingData_->sliceLength / dSplitCoef_, BLOCK_TYPE_SIZE / sizeof(float)) * dSplitCoef_;
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+        this->copyInQSplitCoef_ = 1;
+        if constexpr (!IsBoardCast) {
+            this->ubCopyInStride =
+                (this->dAlign_ * sizeof(TX) -
+                    ops::CeilAlign<int64_t>(tilingData_->sliceLength * sizeof(TX), BLOCK_TYPE_SIZE)) /
+                BLOCK_TYPE_SIZE;
+        }
+    }
+
+    this->pipe_->InitBuffer(this->qInQueue_, DOUBLE_BUFFER, ubFactorB_ * dAlign_ * sizeof(TX));
+    this->pipe_->InitBuffer(this->qOutQueue_, DOUBLE_BUFFER, ubFactorB_ * dAlign_ * sizeof(TX));
+    if constexpr (IsBoardCast) {
+        this->pipe_->InitBuffer(this->cosInQueue_, COS_DB_BUFFER, dAlignFloat_ * sizeof(float));
+        this->pipe_->InitBuffer(this->sinInQueue_, COS_DB_BUFFER, dAlignFloat_ * sizeof(float));
+    } else {
+        this->pipe_->InitBuffer(this->cosInQueue_, COS_DB_BUFFER, ubFactorB_ * dAlignFloat_ * sizeof(float));
+        this->pipe_->InitBuffer(this->sinInQueue_, COS_DB_BUFFER, ubFactorB_ * dAlignFloat_ * sizeof(float));
+    }
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::InitLoopParams()
+{
+    this->bBlockLength_ = tilingData_->blockFactorB;
+    if (blockIdx_ == tilingData_->blockNumB - 1 && tilingData_->B % tilingData_->blockFactorB != 0) {
+        this->bBlockLength_ = tilingData_->B % tilingData_->blockFactorB;
+    }
+    this->bBlockStart_ = blockIdx_ * tilingData_->blockFactorB;
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::Process()
+{
+    int64_t ubLoopCount = ops::CeilDiv(bBlockLength_, ubFactorB_);
+    if constexpr (IsBoardCast) {
+        this->CopyInCosAndSin(0, 1);
+        LocalTensor<float> cosUb = this->cosInQueue_.template DeQue<float>();
+        LocalTensor<float> sinUb = this->sinInQueue_.template DeQue<float>();
+        for (int64_t ubLoopIdx = 0; ubLoopIdx < ubLoopCount; ubLoopIdx++) {
+            this->ProcessInLoop(cosUb,
+                sinUb,
+                bBlockStart_ + ubLoopIdx * ubFactorB_,
+                ubLoopIdx != ubLoopCount - 1 ? ubFactorB_ : bBlockLength_ - ubLoopIdx * ubFactorB_);
+        }
+        this->cosInQueue_.FreeTensor(cosUb);
+        this->sinInQueue_.FreeTensor(sinUb);
+    } else {
+        for (int64_t ubLoopIdx = 0; ubLoopIdx < ubLoopCount; ubLoopIdx++) {
+            this->CopyInCosAndSin(bBlockStart_ + ubLoopIdx * ubFactorB_,
+                ubLoopIdx != ubLoopCount - 1 ? ubFactorB_ : bBlockLength_ - ubLoopIdx * ubFactorB_);
+            LocalTensor<float> cosUb = this->cosInQueue_.template DeQue<float>();
+            LocalTensor<float> sinUb = this->sinInQueue_.template DeQue<float>();
+            this->ProcessInLoop(cosUb,
+                sinUb,
+                bBlockStart_ + ubLoopIdx * ubFactorB_,
+                ubLoopIdx != ubLoopCount - 1 ? ubFactorB_ : bBlockLength_ - ubLoopIdx * ubFactorB_);
+            this->cosInQueue_.FreeTensor(cosUb);
+            this->sinInQueue_.FreeTensor(sinUb);
+        }
+    }
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::ProcessInLoop(
+    LocalTensor<float> &cos, LocalTensor<float> &sin, int64_t bUbStart, int64_t bUbLength)
+{
+    CopyInQ(qGm_, bUbStart, bUbLength);
+    Compute(cos, sin, bUbLength);
+    CopyOutQ(qOutGm_, bUbStart, bUbLength);
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::CopyInCosAndSin(
+    int64_t bStart, int64_t bLength)
+{
+    LocalTensor<float> cosUb = this->cosInQueue_.template AllocTensor<float>();
+    LocalTensor<float> sinUb = this->sinInQueue_.template AllocTensor<float>();
+    DataCopyPadExtParams<float> copyPadExtparams;
+    copyPadExtparams.isPad = false;
+    copyPadExtparams.leftPadding = 0;
+    copyPadExtparams.rightPadding = 0;
+    copyPadExtparams.paddingValue = 0;
+    DataCopyExtParams copyExtParams;
+    if constexpr (IsBoardCast) {
+        copyExtParams.blockCount = 1 * dSplitCoef_;
+    } else {
+        copyExtParams.blockCount = bLength * dSplitCoef_;
+    }
+    copyExtParams.blockLen = tilingData_->sliceLength * sizeof(float) / dSplitCoef_;
+    copyExtParams.srcStride = 0;
+    copyExtParams.dstStride = 0;
+    DataCopyPad(cosUb, this->cosGm_[bStart * tilingData_->sliceLength], copyExtParams, copyPadExtparams);
+    DataCopyPad(sinUb, this->sinGm_[bStart * tilingData_->sliceLength], copyExtParams, copyPadExtparams);
+    this->cosInQueue_.template EnQue(cosUb);
+    this->sinInQueue_.template EnQue(sinUb);
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::CopyInQ(
+    GlobalTensor<TX> &source, int64_t bStart, int64_t bLength)
+{
+    LocalTensor<TX> target = this->qInQueue_.template AllocTensor<TX>();
+    DataCopyExtParams copyExtParams;
+    copyExtParams.blockCount = bLength * copyInQSplitCoef_;
+    copyExtParams.blockLen = tilingData_->sliceLength * sizeof(TX) / copyInQSplitCoef_;
+    copyExtParams.srcStride = (tilingData_->D - tilingData_->sliceLength) * sizeof(TX);
+    copyExtParams.dstStride = ubCopyInStride;
+    DataCopyPadExtParams<TX> copyPadExtparams;
+    copyPadExtparams.isPad = false;
+    copyPadExtparams.leftPadding = 0;
+    copyPadExtparams.rightPadding = 0;
+    copyPadExtparams.paddingValue = 0;
+    DataCopyPad(target, source[bStart * D_ + tilingData_->sliceStart], copyExtParams, copyPadExtparams);
+    this->qInQueue_.template EnQue(target);
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::CopyOutQ(
+    GlobalTensor<TX> &target, int64_t bStart, int64_t bLength)
+{
+    LocalTensor<TX> source = this->qOutQueue_.template DeQue<TX>();
+    DataCopyExtParams copyExtParams;
+    copyExtParams.blockCount = bLength * dSplitCoef_;
+    copyExtParams.blockLen = tilingData_->sliceLength * sizeof(TX) / dSplitCoef_;
+    copyExtParams.srcStride = 0;
+    copyExtParams.dstStride = (tilingData_->D - tilingData_->sliceLength) * sizeof(TX);
+    DataCopyPad(target[bStart * D_ + tilingData_->sliceStart], source, copyExtParams);
+    this->qOutQueue_.FreeTensor(source);
+}
+
+template <typename TX, bool IsBoardCast>
+__aicore__ inline void RotaryPositionEmbeddingAAndBMixed<TX, IsBoardCast>::Compute(
+    LocalTensor<float> &cos, LocalTensor<float> &sin, int64_t bLength)
+{
+    LocalTensor<TX> inUb = this->qInQueue_.template DeQue<TX>();
+    LocalTensor<TX> outUb = this->qOutQueue_.template AllocTensor<TX>();
+    if constexpr (IsBoardCast) {
+        InterleaveModeVFMixed<TX>(inUb, cos, sin, outUb, tilingData_->sliceLength, 1, bLength);
+    } else {
+        BatchInterleaveModeVFMixed<TX, IsBoardCast>((__local_mem__ TX *)inUb.GetPhyAddr(),
+            (__local_mem__ float *)cos.GetPhyAddr(),
+            (__local_mem__ float *)sin.GetPhyAddr(),
+            (__local_mem__ TX *)outUb.GetPhyAddr(),
+            bLength,
+            1,
+            1,
+            tilingData_->sliceLength,
+            dAlign_,
+            dAlignFloat_,
+            ubFactorB_,
+            1);
+    }
+
+    this->qInQueue_.FreeTensor(inUb);
+    this->qOutQueue_.template EnQue(outUb);
+}
+}  // namespace InplacePartialRotaryMul
+
+#endif

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_ab_mixed.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_ab_mixed.h
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file rotary_position_embedding_reg_ab_mixed.h
+ * \brief Mixed precision kernel for AB layout: x is half/bfloat16, cos/sin are float
+ */
+#ifndef ROTARY_POSITION_EMBEDDING_REG_AB_MIXED_H
+#define ROTARY_POSITION_EMBEDDING_REG_AB_MIXED_H
+
+#include "apply_rotary_pos_emb_common.h"
+
+namespace InplacePartialRotaryMul {
+using namespace AscendC;
+
+template <typename TX>
+class RotaryPositionEmbeddingABMixed {
+public:
+    __aicore__ inline RotaryPositionEmbeddingABMixed(){};
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR cos, GM_ADDR sin, GM_ADDR y, GM_ADDR workspace,
+        const RopeRegbaseTilingData *tilingData, TPipe *pipe);
+    __aicore__ inline void Process();
+
+private:
+    __aicore__ inline void ProcessLoop(int64_t xGmOffset, LocalTensor<float> cosBuffer, LocalTensor<float> sinBuffer,
+        int64_t ubIdx, int64_t bsCount, int64_t nCount);
+
+private:
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, 1> xInQueue_;
+    TQue<QuePosition::VECIN, 1> cosInQueue_;
+    TQue<QuePosition::VECIN, 1> sinInQueue_;
+    TQue<QuePosition::VECOUT, 1> yOutQueue_;
+
+    GlobalTensor<TX> xGm_;
+    GlobalTensor<float> cosGm_;
+    GlobalTensor<float> sinGm_;
+    GlobalTensor<TX> yGm_;
+    const RopeRegbaseTilingData *tilingData_;
+    DataCopyPadExtParams<TX> padParams_ = {false, 0, 0, static_cast<TX>(0)};
+    DataCopyPadExtParams<float> padParamsFloat_ = {false, 0, 0, 0};
+    uint8_t DB_FLAG = 2;
+    uint32_t dSplitSizeTX_ = 0;
+    uint32_t dSplitSizeFloat_ = 0;
+    int64_t bsBlockCount_ = 0;
+    int64_t nBlockCount_ = 0;
+    int64_t sliceAlignTX_ = 0;
+    int64_t sliceAlignFloat_ = 0;
+};
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingABMixed<TX>::Init(GM_ADDR x, GM_ADDR cos, GM_ADDR sin, GM_ADDR y,
+    GM_ADDR workspace, const RopeRegbaseTilingData *tilingData, TPipe *pipe)
+{
+    pipe_ = pipe;
+    tilingData_ = tilingData;
+    dSplitSizeTX_ = tilingData_->sliceLength / tilingData_->dSplitCoef * sizeof(TX);
+    dSplitSizeFloat_ = tilingData_->sliceLength / tilingData_->dSplitCoef * sizeof(float);
+    int64_t blockDimBS = GetBlockIdx() / tilingData_->blockNumN;
+    int64_t blockDimN = GetBlockIdx() % tilingData_->blockNumN;
+    bsBlockCount_ = (blockDimBS == tilingData_->blockNumBS - 1) ? tilingData_->blockTailBS : tilingData_->blockFactorBS;
+    nBlockCount_ = (blockDimN == tilingData_->blockNumN - 1) ? tilingData_->blockTailN : tilingData_->blockFactorN;
+
+    int64_t cosOffset = blockDimBS * tilingData_->blockFactorBS * tilingData_->sliceLength;
+    int64_t offset = blockDimBS * tilingData_->blockFactorBS * tilingData_->D;
+    int64_t xOffset =
+        offset * tilingData_->N + blockDimN * tilingData_->blockFactorN * tilingData_->D + tilingData_->sliceStart;
+    this->cosGm_.SetGlobalBuffer((__gm__ float *)cos + cosOffset);
+    this->sinGm_.SetGlobalBuffer((__gm__ float *)sin + cosOffset);
+    this->xGm_.SetGlobalBuffer((__gm__ TX *)x + xOffset);
+    this->yGm_.SetGlobalBuffer((__gm__ TX *)y + xOffset);
+
+    sliceAlignTX_ =
+        ops::CeilDiv(tilingData_->sliceLength * sizeof(TX), GetUbBlockSize()) * GetUbBlockSize() / sizeof(TX);
+    sliceAlignFloat_ =
+        ops::CeilDiv(tilingData_->sliceLength * sizeof(float), GetUbBlockSize()) * GetUbBlockSize() / sizeof(float);
+    int64_t bufferSizeTX = sliceAlignTX_ * sizeof(TX) * tilingData_->ubFactorBS;
+    int64_t bufferSizeFloat = sliceAlignFloat_ * sizeof(float) * tilingData_->ubFactorBS;
+    pipe_->InitBuffer(xInQueue_, DB_FLAG, bufferSizeTX * tilingData_->ubFactorN);
+    pipe_->InitBuffer(yOutQueue_, DB_FLAG, bufferSizeTX * tilingData_->ubFactorN);
+    pipe_->InitBuffer(cosInQueue_, DB_FLAG, bufferSizeFloat);
+    pipe_->InitBuffer(sinInQueue_, DB_FLAG, bufferSizeFloat);
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingABMixed<TX>::Process()
+{
+    uint32_t bsLoopCnt = ops::CeilDiv(bsBlockCount_, tilingData_->ubFactorBS);
+    uint32_t nLoopCnt = ops::CeilDiv(nBlockCount_, tilingData_->ubFactorN);
+    for (uint32_t bsLoopIdx = 0; bsLoopIdx < bsLoopCnt; bsLoopIdx++) {
+        int64_t xGmOffset = bsLoopIdx * tilingData_->ubFactorBS * tilingData_->N * tilingData_->D;
+        uint32_t currBSNum = (bsLoopIdx != bsLoopCnt - 1) ? tilingData_->ubFactorBS
+                                                          : bsBlockCount_ - (bsLoopIdx * tilingData_->ubFactorBS);
+
+        DataCopyExtParams cosParams = {
+            static_cast<uint16_t>(currBSNum * tilingData_->dSplitCoef), dSplitSizeFloat_, 0, 0, 0};
+
+        LocalTensor<float> cosBuffer = cosInQueue_.AllocTensor<float>();
+        LocalTensor<float> sinBuffer = sinInQueue_.AllocTensor<float>();
+        DataCopyPad(cosBuffer,
+            cosGm_[bsLoopIdx * tilingData_->ubFactorBS * tilingData_->sliceLength],
+            cosParams,
+            padParamsFloat_);
+        cosInQueue_.EnQue(cosBuffer);
+        cosBuffer = cosInQueue_.DeQue<float>();
+        DataCopyPad(sinBuffer,
+            sinGm_[bsLoopIdx * tilingData_->ubFactorBS * tilingData_->sliceLength],
+            cosParams,
+            padParamsFloat_);
+        sinInQueue_.EnQue(sinBuffer);
+        sinBuffer = sinInQueue_.DeQue<float>();
+
+        for (int64_t nLoopIdx = 0; nLoopIdx < nLoopCnt; nLoopIdx++) {
+            int64_t currNNum = (nLoopIdx != nLoopCnt - 1) ? tilingData_->ubFactorN
+                                                          : nBlockCount_ - (nLoopIdx * tilingData_->ubFactorN);
+            ProcessLoop(xGmOffset, cosBuffer, sinBuffer, nLoopIdx, currBSNum, currNNum);
+        }
+
+        cosInQueue_.FreeTensor(cosBuffer);
+        sinInQueue_.FreeTensor(sinBuffer);
+    }
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingABMixed<TX>::ProcessLoop(int64_t xGmOffset, LocalTensor<float> cosBuffer,
+    LocalTensor<float> sinBuffer, int64_t ubIdx, int64_t bsCount, int64_t nCount)
+{
+    int64_t totalCount = bsCount * nCount;
+    DataCopyExtParams inParams = {static_cast<uint16_t>(totalCount * tilingData_->dSplitCoef),
+        dSplitSizeTX_,
+        static_cast<uint32_t>((tilingData_->D - tilingData_->sliceLength) * sizeof(TX)),
+        0,
+        0};
+    DataCopyExtParams outParams = {static_cast<uint16_t>(totalCount * tilingData_->dSplitCoef),
+        dSplitSizeTX_,
+        0,
+        static_cast<uint32_t>((tilingData_->D - tilingData_->sliceLength) * sizeof(TX)),
+        0};
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+        inParams = {static_cast<uint16_t>(totalCount),
+            tilingData_->D * sizeof(TX),
+            static_cast<uint32_t>((tilingData_->D - tilingData_->sliceLength) * sizeof(TX)),
+            0,
+            0};
+    }
+
+    LocalTensor<TX> inBuffer = xInQueue_.AllocTensor<TX>();
+    LocalTensor<TX> outBuffer = yOutQueue_.AllocTensor<TX>();
+
+    DataCopyPad(inBuffer, xGm_[xGmOffset + ubIdx * tilingData_->ubFactorN * tilingData_->D], inParams, padParams_);
+
+    xInQueue_.EnQue(inBuffer);
+    inBuffer = xInQueue_.DeQue<TX>();
+
+    InterleaveModeVFMixed<TX>(inBuffer, cosBuffer, sinBuffer, outBuffer, tilingData_->sliceLength, bsCount, nCount);
+
+    yOutQueue_.EnQue(outBuffer);
+    outBuffer = yOutQueue_.DeQue<TX>();
+    xInQueue_.FreeTensor(inBuffer);
+
+    DataCopyPad(yGm_[xGmOffset + ubIdx * tilingData_->ubFactorN * tilingData_->D], outBuffer, outParams);
+
+    yOutQueue_.FreeTensor(outBuffer);
+}
+
+}  // namespace InplacePartialRotaryMul
+
+#endif  // ROTARY_POSITION_EMBEDDING_REG_AB_MIXED_H

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_aba_and_ba_mixed.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_aba_and_ba_mixed.h
@@ -1,0 +1,364 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file rotary_position_embedding_reg_aba_and_ba_mixed.h
+ * \brief Mixed precision kernel for ABA/BA layout: x is half/bfloat16, cos/sin are float
+ */
+
+#ifndef ROTARY_POSITION_EMBEDDING_REG_ABA_AND_BA_MIXED_H
+#define ROTARY_POSITION_EMBEDDING_REG_ABA_AND_BA_MIXED_H
+
+#include "apply_rotary_pos_emb_common.h"
+
+namespace InplacePartialRotaryMul {
+using namespace AscendC;
+
+template <typename TX, bool IsBBoardcast>
+class RotaryPositionEmbeddingABAAndBAMixed {
+public:
+    __aicore__ inline RotaryPositionEmbeddingABAAndBAMixed(){};
+    __aicore__ inline ~RotaryPositionEmbeddingABAAndBAMixed(){};
+
+    __aicore__ inline void Init(GM_ADDR q, GM_ADDR cos, GM_ADDR sin, GM_ADDR qOut, GM_ADDR workspace,
+        const RopeRegbaseTilingData *tilingData, TPipe *pipe);
+    __aicore__ inline void Process();
+
+private:
+    __aicore__ inline void InitAllGlobalBuffer(GM_ADDR q, GM_ADDR cos, GM_ADDR sin, GM_ADDR qOut);
+    __aicore__ inline void InitAllBuffer();
+    __aicore__ inline void InitLoopParams();
+    __aicore__ inline void ProcessInSLoop(int64_t sUbStart, int64_t sUbLength);
+    __aicore__ inline void ProcessInSBLoop(int64_t sUbStart, int64_t sUbLength, int64_t bUbStart, int64_t bUbLength,
+        LocalTensor<TX> &cos, LocalTensor<TX> &sin);
+    __aicore__ inline void ProcessInSBNLoop(int64_t sUbStart, int64_t sUbLength, int64_t bUbStart, int64_t bUbLength,
+        int64_t nUbStart, int64_t nUbLength, int64_t nTotalSize, LocalTensor<float> &cosFloat,
+        LocalTensor<float> &sinFloat, GlobalTensor<TX> &in, GlobalTensor<TX> &out);
+    __aicore__ inline void CopyInCosAndSin(int64_t sStart, int64_t sLength, int64_t bStart, int64_t bLength);
+    __aicore__ inline void CopyInQ(GlobalTensor<TX> &source, int64_t sStart, int64_t sLength, int64_t bStart,
+        int64_t bLength, int64_t nStart, int64_t nLength, int64_t nTotalSize);
+    __aicore__ inline void CopyOutQ(GlobalTensor<TX> &target, int64_t sStart, int64_t sLength, int64_t bStart,
+        int64_t bLength, int64_t nStart, int64_t nLength, int64_t nTotalSize);
+    __aicore__ inline void Compute(
+        LocalTensor<float> &cos, LocalTensor<float> &sin, int64_t sLength, int64_t bLength, int64_t nLength);
+
+private:
+    TPipe *pipe_;
+
+    GlobalTensor<TX> qGm_;
+    GlobalTensor<float> cosGm_;
+    GlobalTensor<float> sinGm_;
+    GlobalTensor<TX> qOutGm_;
+
+    TQue<QuePosition::VECIN, DOUBLE_BUFFER> qInQueue_;
+    TQue<QuePosition::VECIN, DOUBLE_BUFFER> cosInQueue_;
+    TQue<QuePosition::VECIN, DOUBLE_BUFFER> sinInQueue_;
+    TQue<QuePosition::VECOUT, DOUBLE_BUFFER> qOutQueue_;
+
+    int64_t blockIdx_ = 0;
+    int64_t bBlockStart_ = 0;
+    int64_t bBlockLength_ = 0;
+    int64_t sBlockStart_ = 0;
+    int64_t sBlockLength_ = 0;
+
+    const RopeRegbaseTilingData *tilingData_;
+    int64_t ubFactorB_ = 0;
+    int64_t ubFactorS_ = 0;
+    int64_t ubFactorN_ = 0;
+    int64_t D_ = 0;
+    int64_t dAlign_ = 0;
+    int64_t dAlignFloat_ = 0;
+    uint8_t dSplitCoef_ = 1;
+    uint8_t copyInQSplitCoef_ = 1;
+    uint64_t ubCopyInStride = 0;
+};
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::Init(GM_ADDR q, GM_ADDR cos, GM_ADDR sin,
+    GM_ADDR qOut, GM_ADDR workspace, const RopeRegbaseTilingData *tilingData, TPipe *pipe)
+{
+    this->tilingData_ = tilingData;
+    this->blockIdx_ = GetBlockIdx();
+    this->pipe_ = pipe;
+    this->InitAllGlobalBuffer(q, cos, sin, qOut);
+    this->InitAllBuffer();
+    this->InitLoopParams();
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::InitAllGlobalBuffer(
+    GM_ADDR q, GM_ADDR cos, GM_ADDR sin, GM_ADDR qOut)
+{
+    this->qGm_.SetGlobalBuffer((__gm__ TX *)q);
+    this->cosGm_.SetGlobalBuffer((__gm__ float *)cos);
+    this->sinGm_.SetGlobalBuffer((__gm__ float *)sin);
+    this->qOutGm_.SetGlobalBuffer((__gm__ TX *)qOut);
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::InitAllBuffer()
+{
+    this->ubFactorB_ = this->tilingData_->ubFactorB;
+    this->ubFactorS_ = this->tilingData_->ubFactorS;
+    this->ubFactorN_ = this->tilingData_->ubFactorN;
+    this->D_ = this->tilingData_->D;
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::HALF) ||
+        tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+        this->dSplitCoef_ = HALF_INTERLEAVE_COEF;
+    } else if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::QUARTER)) {
+        this->dSplitCoef_ = QUARTER_MODE_COEF;
+    }
+    this->copyInQSplitCoef_ = dSplitCoef_;
+    this->dAlign_ =
+        ops::CeilAlign<int64_t>(tilingData_->sliceLength / dSplitCoef_, BLOCK_TYPE_SIZE / sizeof(TX)) * dSplitCoef_;
+    this->dAlignFloat_ =
+        ops::CeilAlign<int64_t>(tilingData_->sliceLength / dSplitCoef_, BLOCK_TYPE_SIZE / sizeof(float)) * dSplitCoef_;
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+        this->copyInQSplitCoef_ = 1;
+        this->ubCopyInStride = (this->dAlign_ * sizeof(TX) -
+                                   ops::CeilAlign<int64_t>(tilingData_->sliceLength * sizeof(TX), BLOCK_TYPE_SIZE)) /
+                               BLOCK_TYPE_SIZE;
+    }
+    this->pipe_->InitBuffer(
+        this->qInQueue_, DOUBLE_BUFFER, ubFactorB_ * ubFactorS_ * ubFactorN_ * dAlign_ * sizeof(TX));
+    this->pipe_->InitBuffer(
+        this->qOutQueue_, DOUBLE_BUFFER, ubFactorB_ * ubFactorS_ * ubFactorN_ * dAlign_ * sizeof(TX));
+    if constexpr (IsBBoardcast) {
+        this->pipe_->InitBuffer(this->cosInQueue_, DOUBLE_BUFFER, ubFactorS_ * dAlignFloat_ * sizeof(float));
+        this->pipe_->InitBuffer(this->sinInQueue_, DOUBLE_BUFFER, ubFactorS_ * dAlignFloat_ * sizeof(float));
+    } else {
+        this->pipe_->InitBuffer(
+            this->cosInQueue_, DOUBLE_BUFFER, ubFactorB_ * ubFactorS_ * dAlignFloat_ * sizeof(float));
+        this->pipe_->InitBuffer(
+            this->sinInQueue_, DOUBLE_BUFFER, ubFactorB_ * ubFactorS_ * dAlignFloat_ * sizeof(float));
+    }
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::InitLoopParams()
+{
+    int64_t bIdx = blockIdx_ % tilingData_->blockNumB;
+    int64_t sIdx = blockIdx_ / tilingData_->blockNumB;
+    this->bBlockLength_ = tilingData_->blockFactorB;
+    this->sBlockLength_ = tilingData_->blockFactorS;
+    if (bIdx == tilingData_->blockNumB - 1 && tilingData_->B % tilingData_->blockFactorB != 0) {
+        this->bBlockLength_ = tilingData_->B % tilingData_->blockFactorB;
+    }
+    if (sIdx == tilingData_->blockNumS - 1 && tilingData_->S % tilingData_->blockFactorS != 0) {
+        this->sBlockLength_ = tilingData_->S % tilingData_->blockFactorS;
+    }
+    this->bBlockStart_ = bIdx * tilingData_->blockFactorB;
+    this->sBlockStart_ = sIdx * tilingData_->blockFactorS;
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::Process()
+{
+    int64_t ubLoopCount = ops::CeilDiv(sBlockLength_, ubFactorS_);
+    for (int64_t ubLoopIdx = 0; ubLoopIdx < ubLoopCount; ubLoopIdx++) {
+        this->ProcessInSLoop(sBlockStart_ + ubLoopIdx * ubFactorS_,
+            ubLoopIdx != ubLoopCount - 1 ? ubFactorS_ : sBlockLength_ - ubLoopIdx * ubFactorS_);
+    }
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::ProcessInSLoop(
+    int64_t sUbStart, int64_t sUbLength)
+{
+    int64_t ubLoopCount = ops::CeilDiv(bBlockLength_, ubFactorB_);
+    if constexpr (IsBBoardcast) {
+        this->CopyInCosAndSin(sUbStart, sUbLength, 0, 1);
+        LocalTensor<float> cosUbFloat = this->cosInQueue_.template DeQue<float>();
+        LocalTensor<float> sinUbFloat = this->sinInQueue_.template DeQue<float>();
+        LocalTensor<TX> cosUb = cosUbFloat.template ReinterpretCast<TX>();
+        LocalTensor<TX> sinUb = sinUbFloat.template ReinterpretCast<TX>();
+        for (int64_t ubLoopIdx = 0; ubLoopIdx < ubLoopCount; ubLoopIdx++) {
+            this->ProcessInSBLoop(sUbStart,
+                sUbLength,
+                bBlockStart_ + ubLoopIdx * ubFactorB_,
+                ubLoopIdx != ubLoopCount - 1 ? ubFactorB_ : bBlockLength_ - ubLoopIdx * ubFactorB_,
+                cosUb,
+                sinUb);
+        }
+        this->sinInQueue_.FreeTensor(sinUbFloat);
+        this->cosInQueue_.FreeTensor(cosUbFloat);
+    } else {
+        for (int64_t ubLoopIdx = 0; ubLoopIdx < ubLoopCount; ubLoopIdx++) {
+            this->CopyInCosAndSin(sUbStart,
+                sUbLength,
+                bBlockStart_ + ubLoopIdx * ubFactorB_,
+                ubLoopIdx != ubLoopCount - 1 ? ubFactorB_ : bBlockLength_ - ubLoopIdx * ubFactorB_);
+            LocalTensor<float> cosUbFloat = this->cosInQueue_.template DeQue<float>();
+            LocalTensor<float> sinUbFloat = this->sinInQueue_.template DeQue<float>();
+            LocalTensor<TX> cosUb = cosUbFloat.template ReinterpretCast<TX>();
+            LocalTensor<TX> sinUb = sinUbFloat.template ReinterpretCast<TX>();
+            this->ProcessInSBLoop(sUbStart,
+                sUbLength,
+                bBlockStart_ + ubLoopIdx * ubFactorB_,
+                ubLoopIdx != ubLoopCount - 1 ? ubFactorB_ : bBlockLength_ - ubLoopIdx * ubFactorB_,
+                cosUb,
+                sinUb);
+            this->cosInQueue_.FreeTensor(cosUbFloat);
+            this->sinInQueue_.FreeTensor(sinUbFloat);
+        }
+    }
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::ProcessInSBLoop(int64_t sUbStart,
+    int64_t sUbLength, int64_t bUbStart, int64_t bUbLength, LocalTensor<TX> &cos, LocalTensor<TX> &sin)
+{
+    int64_t qUbLoopCount = ops::CeilDiv(tilingData_->N, ubFactorN_);
+    LocalTensor<float> cosFloat = cos.template ReinterpretCast<float>();
+    LocalTensor<float> sinFloat = sin.template ReinterpretCast<float>();
+    for (int64_t ubLoopIdx = 0; ubLoopIdx < qUbLoopCount; ubLoopIdx++) {
+        this->ProcessInSBNLoop(sUbStart,
+            sUbLength,
+            bUbStart,
+            bUbLength,
+            ubLoopIdx * ubFactorN_,
+            ubLoopIdx != qUbLoopCount - 1 ? ubFactorN_ : tilingData_->N - ubLoopIdx * ubFactorN_,
+            tilingData_->N,
+            cosFloat,
+            sinFloat,
+            qGm_,
+            qOutGm_);
+    }
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::ProcessInSBNLoop(int64_t sUbStart,
+    int64_t sUbLength, int64_t bUbStart, int64_t bUbLength, int64_t nUbStart, int64_t nUbLength, int64_t nTotalSize,
+    LocalTensor<float> &cosFloat, LocalTensor<float> &sinFloat, GlobalTensor<TX> &in, GlobalTensor<TX> &out)
+{
+    CopyInQ(in, sUbStart, sUbLength, bUbStart, bUbLength, nUbStart, nUbLength, nTotalSize);
+    Compute(cosFloat, sinFloat, sUbLength, bUbLength, nUbLength);
+    CopyOutQ(out, sUbStart, sUbLength, bUbStart, bUbLength, nUbStart, nUbLength, nTotalSize);
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::CopyInCosAndSin(
+    int64_t sStart, int64_t sLength, int64_t bStart, int64_t bLength)
+{
+    LocalTensor<float> cosUb = this->cosInQueue_.template AllocTensor<float>();
+    LocalTensor<float> sinUb = this->sinInQueue_.template AllocTensor<float>();
+    LoopModeParams loopParams;
+    loopParams.loop2Size = 1;
+    loopParams.loop1Size = bLength;
+    loopParams.loop2SrcStride = 0;
+    loopParams.loop2DstStride = 0;
+    loopParams.loop1SrcStride = tilingData_->S * tilingData_->sliceLength * sizeof(float);
+    loopParams.loop1DstStride = ubFactorS_ * dAlignFloat_ * sizeof(float);
+    SetLoopModePara(loopParams, DataCopyMVType::OUT_TO_UB);
+    DataCopyPadExtParams<float> copyPadExtparams;
+    copyPadExtparams.isPad = false;
+    copyPadExtparams.leftPadding = 0;
+    copyPadExtparams.rightPadding = 0;
+    copyPadExtparams.paddingValue = 0;
+    DataCopyExtParams copyExtParams;
+    copyExtParams.blockCount = sLength * dSplitCoef_;
+    copyExtParams.blockLen = tilingData_->sliceLength * sizeof(float) / dSplitCoef_;
+    copyExtParams.srcStride = 0;
+    copyExtParams.dstStride = 0;
+    DataCopyPad(cosUb,
+        this->cosGm_[bStart * tilingData_->S * tilingData_->sliceLength + sStart * tilingData_->sliceLength],
+        copyExtParams,
+        copyPadExtparams);
+    DataCopyPad(sinUb,
+        this->sinGm_[bStart * tilingData_->S * tilingData_->sliceLength + sStart * tilingData_->sliceLength],
+        copyExtParams,
+        copyPadExtparams);
+    ResetLoopModePara(DataCopyMVType::OUT_TO_UB);
+    this->cosInQueue_.template EnQue(cosUb);
+    this->sinInQueue_.template EnQue(sinUb);
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::CopyInQ(GlobalTensor<TX> &source,
+    int64_t sStart, int64_t sLength, int64_t bStart, int64_t bLength, int64_t nStart, int64_t nLength,
+    int64_t nTotalSize)
+{
+    LocalTensor<TX> target = this->qInQueue_.template AllocTensor<TX>();
+    LoopModeParams loopParams;
+    loopParams.loop2Size = bLength;
+    loopParams.loop1Size = nLength;
+    loopParams.loop2SrcStride = nTotalSize * tilingData_->S * D_ * sizeof(TX);
+    loopParams.loop2DstStride = ubFactorN_ * ubFactorS_ * dAlign_ * sizeof(TX);
+    loopParams.loop1SrcStride = tilingData_->S * D_ * sizeof(TX);
+    loopParams.loop1DstStride = ubFactorS_ * dAlign_ * sizeof(TX);
+    SetLoopModePara(loopParams, DataCopyMVType::OUT_TO_UB);
+    DataCopyExtParams copyExtParams;
+    copyExtParams.blockCount = sLength * copyInQSplitCoef_;
+    copyExtParams.blockLen = tilingData_->sliceLength * sizeof(TX) / copyInQSplitCoef_;
+    copyExtParams.srcStride = (tilingData_->D - tilingData_->sliceLength) * sizeof(TX);
+    copyExtParams.dstStride = ubCopyInStride;
+    DataCopyPadExtParams<TX> copyPadExtparams;
+    copyPadExtparams.isPad = false;
+    int64_t offset = bStart * nTotalSize * tilingData_->S * D_ + nStart * tilingData_->S * D_ + sStart * D_ +
+                     tilingData_->sliceStart;
+    DataCopyPad(target, source[offset], copyExtParams, copyPadExtparams);
+    ResetLoopModePara(DataCopyMVType::OUT_TO_UB);
+    this->qInQueue_.template EnQue(target);
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::CopyOutQ(GlobalTensor<TX> &target,
+    int64_t sStart, int64_t sLength, int64_t bStart, int64_t bLength, int64_t nStart, int64_t nLength,
+    int64_t nTotalSize)
+{
+    LocalTensor<TX> source = this->qOutQueue_.template DeQue<TX>();
+    LoopModeParams loopParams;
+    loopParams.loop2Size = bLength;
+    loopParams.loop1Size = nLength;
+    loopParams.loop2SrcStride = ubFactorN_ * ubFactorS_ * dAlign_ * sizeof(TX);
+    loopParams.loop2DstStride = nTotalSize * tilingData_->S * D_ * sizeof(TX);
+    loopParams.loop1SrcStride = ubFactorS_ * dAlign_ * sizeof(TX);
+    loopParams.loop1DstStride = tilingData_->S * D_ * sizeof(TX);
+    SetLoopModePara(loopParams, DataCopyMVType::UB_TO_OUT);
+    DataCopyExtParams copyExtParams;
+    copyExtParams.blockCount = sLength * dSplitCoef_;
+    copyExtParams.blockLen = tilingData_->sliceLength * sizeof(TX) / dSplitCoef_;
+    copyExtParams.srcStride = 0;
+    copyExtParams.dstStride = (tilingData_->D - tilingData_->sliceLength) * sizeof(TX);
+    int64_t offset = bStart * nTotalSize * tilingData_->S * D_ + nStart * tilingData_->S * D_ + sStart * D_ +
+                     tilingData_->sliceStart;
+    DataCopyPad(target[offset], source, copyExtParams);
+    ResetLoopModePara(DataCopyMVType::UB_TO_OUT);
+    this->qOutQueue_.FreeTensor(source);
+}
+
+template <typename TX, bool IsBBoardcast>
+__aicore__ inline void RotaryPositionEmbeddingABAAndBAMixed<TX, IsBBoardcast>::Compute(
+    LocalTensor<float> &cos, LocalTensor<float> &sin, int64_t sLength, int64_t bLength, int64_t nLength)
+{
+    LocalTensor<TX> inUb = this->qInQueue_.template DeQue<TX>();
+    LocalTensor<TX> outUb = this->qOutQueue_.template AllocTensor<TX>();
+    int64_t totalLength = sLength * bLength * nLength * tilingData_->sliceLength;
+
+    BatchInterleaveModeVFMixed<TX, IsBBoardcast>((__local_mem__ TX *)inUb.GetPhyAddr(),
+        (__local_mem__ float *)cos.GetPhyAddr(),
+        (__local_mem__ float *)sin.GetPhyAddr(),
+        (__local_mem__ TX *)outUb.GetPhyAddr(),
+        sLength,
+        bLength,
+        nLength,
+        tilingData_->sliceLength,
+        dAlign_,
+        dAlignFloat_,
+        ubFactorS_,
+        ubFactorN_);
+
+    this->qInQueue_.FreeTensor(inUb);
+    this->qOutQueue_.template EnQue(outUb);
+}
+
+}  // namespace InplacePartialRotaryMul
+
+#endif  // ROTARY_POSITION_EMBEDDING_REG_ABA_AND_BA_MIXED_H

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_bab_mixed.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/rotary_position_embedding_reg_bab_mixed.h
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file rotary_position_embedding_reg_bab_mixed.h
+ * \brief Mixed precision kernel: x is half/bfloat16, cos/sin are float
+ */
+
+#ifndef ROTARY_POSITION_EMBEDDING_REG_BAB_MIXED_H
+#define ROTARY_POSITION_EMBEDDING_REG_BAB_MIXED_H
+
+#include "apply_rotary_pos_emb_common.h"
+
+namespace InplacePartialRotaryMul {
+using namespace AscendC;
+
+template <typename TX>
+class RotaryPositionEmbeddingBABMixed {
+public:
+    __aicore__ inline RotaryPositionEmbeddingBABMixed(TPipe *pipe, const RopeRegbaseTilingData *tiling)
+        : pipe_(pipe), tilingData_(tiling){};
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR cos, GM_ADDR sin, GM_ADDR y);
+    __aicore__ inline void Process();
+
+private:
+    constexpr static int32_t bufferNum = 2;
+    const RopeRegbaseTilingData *tilingData_;
+    TPipe *pipe_;
+    int64_t blockIdx_ = 0;
+    int64_t dSplitCoef_ = 1;
+    uint32_t dSplitSize_ = 0;
+    int64_t dAlign_ = 0;
+    int64_t dAlignFloat_ = 0;
+    int64_t bIdx_ = 0;
+    int64_t sIdx_ = 0;
+    int64_t bNum_ = 0;
+    int64_t sNum_ = 0;
+    int64_t ubFactorS_ = 0;
+    int64_t ubFactorN_ = 0;
+    GlobalTensor<TX> xGm_;
+    GlobalTensor<float> cosGm_;
+    GlobalTensor<float> sinGm_;
+    GlobalTensor<TX> yOutGm_;
+
+    TQue<QuePosition::VECIN, bufferNum> xInQue_;
+    TQue<QuePosition::VECIN, bufferNum> cosInQue_;
+    TQue<QuePosition::VECIN, bufferNum> sinInQue_;
+    TQue<QuePosition::VECOUT, bufferNum> yOutQue_;
+
+private:
+    __aicore__ inline void PrePareParams();
+    __aicore__ inline void ProcessNLoop(const uint32_t bIdx, const uint32_t sIdx, const uint32_t currSNum);
+    __aicore__ inline void Compute(const LocalTensor<float> &sinTensor, const LocalTensor<float> &cosTensor,
+        const LocalTensor<TX> &inTensor, const LocalTensor<TX> &outTensor, const uint32_t currSNum,
+        const uint32_t currDNum);
+    __aicore__ inline void ProcessN(const LocalTensor<float> &sinTensor, const LocalTensor<float> &cosTensor,
+        const uint32_t bIdx, const uint32_t sIdx, const uint32_t currSNum);
+};
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingBABMixed<TX>::Init(GM_ADDR x, GM_ADDR cos, GM_ADDR sin, GM_ADDR y)
+{
+    this->blockIdx_ = GetBlockIdx();
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::HALF) ||
+        tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+        this->dSplitCoef_ = HALF_INTERLEAVE_COEF;
+    } else if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::QUARTER)) {
+        this->dSplitCoef_ = QUARTER_MODE_COEF;
+    }
+    this->dSplitSize_ = tilingData_->sliceLength / dSplitCoef_ * sizeof(TX);
+    this->dAlign_ =
+        ops::CeilAlign<int64_t>(tilingData_->sliceLength / dSplitCoef_, BLOCK_TYPE_SIZE / sizeof(TX)) * dSplitCoef_;
+    this->dAlignFloat_ =
+        ops::CeilAlign<int64_t>(tilingData_->sliceLength / dSplitCoef_, BLOCK_TYPE_SIZE / sizeof(float)) * dSplitCoef_;
+    ubFactorN_ = tilingData_->ubFactorN;
+    ubFactorS_ = tilingData_->ubFactorS;
+    this->xGm_.SetGlobalBuffer((__gm__ TX *)x);
+    this->cosGm_.SetGlobalBuffer((__gm__ float *)cos);
+    this->sinGm_.SetGlobalBuffer((__gm__ float *)sin);
+    this->yOutGm_.SetGlobalBuffer((__gm__ TX *)y);
+    this->pipe_->InitBuffer(xInQue_, bufferNum, ubFactorS_ * ubFactorN_ * dAlign_ * sizeof(TX));
+    this->pipe_->InitBuffer(cosInQue_, bufferNum, ubFactorS_ * dAlignFloat_ * sizeof(float));
+    this->pipe_->InitBuffer(sinInQue_, bufferNum, ubFactorS_ * dAlignFloat_ * sizeof(float));
+    this->pipe_->InitBuffer(yOutQue_, bufferNum, ubFactorS_ * ubFactorN_ * dAlign_ * sizeof(TX));
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingBABMixed<TX>::PrePareParams()
+{
+    bIdx_ = blockIdx_ % tilingData_->blockNumB;
+    sIdx_ = blockIdx_ / tilingData_->blockNumB;
+    bNum_ = tilingData_->blockFactorB;
+    sNum_ = tilingData_->blockFactorS;
+    if (bIdx_ == tilingData_->blockNumB - 1 && tilingData_->B % tilingData_->blockFactorB != 0) {
+        bNum_ = tilingData_->B % tilingData_->blockFactorB;
+    }
+    if (sIdx_ == tilingData_->blockNumS - 1 && tilingData_->S % tilingData_->blockFactorS != 0) {
+        sNum_ = tilingData_->S % tilingData_->blockFactorS;
+    }
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingBABMixed<TX>::Process()
+{
+    PrePareParams();
+    uint32_t bIdxStart = bIdx_ * tilingData_->blockFactorB;
+    for (uint32_t bIdx = bIdxStart; bIdx < bIdxStart + bNum_; bIdx++) {
+        uint32_t sIdxStart = sIdx_ * tilingData_->blockFactorS;
+        uint32_t sLoopCnt = ops::CeilDiv(sNum_, ubFactorS_);
+        for (uint32_t loopIdx = 0; loopIdx < sLoopCnt; loopIdx++) {
+            uint32_t currSNum = (loopIdx != sLoopCnt - 1) ? ubFactorS_ : sNum_ - loopIdx * ubFactorS_;
+            ProcessNLoop(bIdx, sIdxStart + loopIdx * ubFactorS_, currSNum);
+        }
+    }
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingBABMixed<TX>::ProcessNLoop(
+    const uint32_t bIdx, const uint32_t sIdx, const uint32_t currSNum)
+{
+    LocalTensor<float> sinTensor = sinInQue_.AllocTensor<float>();
+    LocalTensor<float> cosTensor = cosInQue_.AllocTensor<float>();
+    int64_t offset = sIdx * tilingData_->sliceLength;
+    uint32_t dSplitSizeFloat = tilingData_->sliceLength / dSplitCoef_ * sizeof(float);
+    DataCopyExtParams copyParams{static_cast<uint16_t>(currSNum * dSplitCoef_), dSplitSizeFloat, 0, 0, 0};
+    DataCopyPadExtParams<float> padParams{false, 0, 0, 0};
+    DataCopyPad(sinTensor, sinGm_[offset], copyParams, padParams);
+    DataCopyPad(cosTensor, cosGm_[offset], copyParams, padParams);
+    sinInQue_.EnQue(sinTensor);
+    cosInQue_.EnQue(cosTensor);
+    sinTensor = sinInQue_.DeQue<float>();
+    cosTensor = cosInQue_.DeQue<float>();
+    ProcessN(sinTensor, cosTensor, bIdx, sIdx, currSNum);
+    sinInQue_.FreeTensor(sinTensor);
+    cosInQue_.FreeTensor(cosTensor);
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingBABMixed<TX>::ProcessN(const LocalTensor<float> &sinTensor,
+    const LocalTensor<float> &cosTensor, const uint32_t bIdx, const uint32_t sIdx, const uint32_t currSNum)
+{
+    LocalTensor<TX> xTensor;
+    LocalTensor<TX> yTensor;
+    int64_t baseOffset = (bIdx * tilingData_->S + sIdx) * tilingData_->N * tilingData_->D + tilingData_->sliceStart;
+    for (uint32_t idxN = 0; idxN < tilingData_->ubLoopNumN; idxN++) {
+        int64_t currDNum = (idxN == tilingData_->ubLoopNumN - 1) ? tilingData_->ubTailFactorN : ubFactorN_;
+        int64_t offset = baseOffset + idxN * ubFactorN_ * tilingData_->D;
+        xTensor = xInQue_.AllocTensor<TX>();
+        DataCopyExtParams copyInParams{static_cast<uint16_t>(currSNum * currDNum * dSplitCoef_),
+            dSplitSize_,
+            static_cast<uint32_t>((tilingData_->D - tilingData_->sliceLength) * sizeof(TX)),
+            0,
+            0};
+        DataCopyExtParams copyOutParams{static_cast<uint16_t>(currSNum * currDNum * dSplitCoef_),
+            dSplitSize_,
+            0,
+            static_cast<uint32_t>((tilingData_->D - tilingData_->sliceLength) * sizeof(TX)),
+            0};
+        if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::DEEPSEEK_INTERLEAVE)) {
+            copyInParams = {static_cast<uint16_t>(currSNum * currDNum),
+                tilingData_->sliceLength * sizeof(TX),
+                static_cast<uint32_t>((tilingData_->D - tilingData_->sliceLength) * sizeof(TX)),
+                0,
+                0};
+        }
+        DataCopyPadExtParams<TX> padParams{false, 0, 0, 0};
+        DataCopyPad(xTensor, xGm_[offset], copyInParams, padParams);
+        xInQue_.EnQue(xTensor);
+        xTensor = xInQue_.DeQue<TX>();
+        yTensor = yOutQue_.AllocTensor<TX>();
+        Compute(sinTensor, cosTensor, xTensor, yTensor, currSNum, currDNum);
+        xInQue_.FreeTensor(xTensor);
+        yOutQue_.EnQue(yTensor);
+        yTensor = yOutQue_.DeQue<TX>();
+        DataCopyPad(yOutGm_[offset], yTensor, copyOutParams);
+        yOutQue_.FreeTensor(yTensor);
+    }
+}
+
+template <typename TX>
+__aicore__ inline void RotaryPositionEmbeddingBABMixed<TX>::Compute(const LocalTensor<float> &sinTensor,
+    const LocalTensor<float> &cosTensor, const LocalTensor<TX> &inTensor, const LocalTensor<TX> &outTensor,
+    const uint32_t currSNum, const uint32_t currDNum)
+{
+    if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::INTERLEAVE)) {
+        InterleaveModeVFMixed<TX>(
+            inTensor, cosTensor, sinTensor, outTensor, tilingData_->sliceLength, currSNum, currDNum);
+    } else if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::HALF)) {
+        // For HALF mode, need to implement HalfAlignVFMixed
+        InterleaveModeVFMixed<TX>(
+            inTensor, cosTensor, sinTensor, outTensor, tilingData_->sliceLength, currSNum, currDNum);
+    } else if (tilingData_->rotaryMode == static_cast<int64_t>(RotaryPosEmbeddingMode::QUARTER)) {
+        // For QUARTER mode, need to implement QuarterAlignVFMixed
+        InterleaveModeVFMixed<TX>(
+            inTensor, cosTensor, sinTensor, outTensor, tilingData_->sliceLength, currSNum, currDNum);
+    }
+}
+
+}  // namespace InplacePartialRotaryMul
+#endif  // ROTARY_POSITION_EMBEDDING_REG_BAB_MIXED_H


### PR DESCRIPTION
### What this PR does / why we need it?

Ports the mixed precision `inplace_partial_rotary_mul` changes from cann-recipes-infer PR 456 into the vLLM Ascend operator layout.

- Allows FP16/BF16 `x` with FP32 `cos`/`sin` in the custom op schema and tiling path.
- Adds mixed precision tiling keys and regbase kernels for the custom operator.

This PR intentionally keeps the scope to the operator implementation only. A dedicated E2E test can be added separately.

### Does this PR introduce _any_ user-facing change?

No public API change. This extends the supported dtype combination for the custom operator.

### How was this patch tested?

- `git diff upstream/main --check`
- Confirmed the PR diff only contains `csrc/attention/inplace_partial_rotary_mul` operator changes and no test file additions.

NPU hardware execution was not run locally.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
