### PR TITLE
[Ops][BugFix] Fix stale custom ops build cache

### DIFF
--- a/csrc/build.sh
+++ b/csrc/build.sh
@@ -386,6 +386,34 @@ function clean_third_party()
     fi
 }
 
+function refresh_cmake_cache()
+{
+    local current_cann_path
+    local cached_cann_path
+    local cached_generator
+    local current_generator
+    current_cann_path=$(realpath -m "${ASCEND_CANN_PACKAGE_PATH}")
+    current_generator="${CMAKE_GENERATOR:-Unix Makefiles}"
+    if [ "${#CMAKE_GENERATOR_ARGS[@]}" -ge 2 ]; then
+        current_generator="${CMAKE_GENERATOR_ARGS[1]}"
+    fi
+
+    if [[ -f "${BUILD_DIR}/CMakeCache.txt" ]]; then
+        cached_cann_path=$(sed -n 's/^CUSTOM_ASCEND_CANN_PACKAGE_PATH:.*=//p' "${BUILD_DIR}/CMakeCache.txt")
+        if [[ -n "${cached_cann_path}" && "$(realpath -m "${cached_cann_path}")" != "${current_cann_path}" ]]; then
+            log "Info: CANN package path changed, refresh CMake cache."
+            rm -rf "${BUILD_DIR}"
+            return
+        fi
+
+        cached_generator=$(sed -n 's/^CMAKE_GENERATOR:INTERNAL=//p' "${BUILD_DIR}/CMakeCache.txt")
+        if [[ -n "${cached_generator}" && "${cached_generator}" != "${current_generator}" ]]; then
+            log "Info: CMake generator changed, refresh CMake cache."
+            rm -rf "${BUILD_DIR}"
+        fi
+    fi
+}
+
 function cmake_config()
 {
     local extra_option="$1"
@@ -1416,6 +1444,7 @@ else
     log "Info: ninja is not found; use default CMake generator"
 fi
 
+refresh_cmake_cache
 clean_build_out
 clean_output
 

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -3,6 +3,7 @@
 ROOT_DIR=$1
 SOC_VERSION=$2
 : "${ROOT_DIR:?ROOT_DIR is not set}"
+ROOT_DIR=$(cd "${ROOT_DIR}" && pwd -P) || exit 1
 
 log() {
     echo "[build_aclnn] $*"
@@ -269,12 +270,18 @@ log_selected_ops
   : "${SOC_VERSION:?SOC_VERSION is not set}"
   : "${SOC_ARG:?SOC_ARG is not set}"
 
+  custom_ops_install_dir="${ROOT_DIR}/vllm_ascend/_cann_ops_custom"
+
+  rm -f ./build/cann-ops-transformer*.run
   log "build command: bash build.sh --pkg --ops=\"${CUSTOM_OPS}\" --soc=\"${SOC_ARG}\""
   log "building custom ops ${CUSTOM_OPS} for ${SOC_VERSION}"
   bash build.sh --pkg --ops="${CUSTOM_OPS}" --soc="${SOC_ARG}"
   log "build.sh finished"
 
-  custom_ops_install_dir="${ROOT_DIR}/vllm_ascend/_cann_ops_custom"
+  shopt -s nullglob
+  installer_candidates=(./build/cann-ops-transformer*.run)
+  shopt -u nullglob
+
   log "custom_ops_install_dir=${custom_ops_install_dir}"
 
   mkdir -p -- "$custom_ops_install_dir"
@@ -283,10 +290,6 @@ log_selected_ops
   find "$custom_ops_install_dir" -mindepth 1 -maxdepth 1 \
     ! -name '.gitkeep' \
     -exec rm -rf -- {} +
-
-  shopt -s nullglob
-  installer_candidates=(./build/cann-ops-transformer*.run)
-  shopt -u nullglob
 
   log "installer candidate count=${#installer_candidates[@]}"
   for installer_file in "${installer_candidates[@]}"; do

--- a/csrc/cmake/func.cmake
+++ b/csrc/cmake/func.cmake
@@ -401,11 +401,14 @@ function(add_ops_src_copy)
     endif()
 
     if(NOT BUILD_OPS_RTY_KERNEL AND BELONG_MC2_OPS)
-        file(GLOB SRC_FILES ${SRC_COPY_SRC}/* ${SRC_COPY_SRC}/op_kernel/*)
+        file(GLOB SRC_FILES CONFIGURE_DEPENDS ${SRC_COPY_SRC}/* ${SRC_COPY_SRC}/op_kernel/*)
     else()
-        file(GLOB SRC_FILES ${SRC_COPY_SRC}/*)
+        file(GLOB SRC_FILES CONFIGURE_DEPENDS ${SRC_COPY_SRC}/*)
     endif()
     list(FILTER SRC_FILES EXCLUDE REGEX "op_host")
+    file(GLOB_RECURSE SRC_FILE_DEPS CONFIGURE_DEPENDS ${SRC_COPY_SRC}/*)
+    list(FILTER SRC_FILE_DEPS EXCLUDE REGEX "/op_host/")
+    list(SORT SRC_FILE_DEPS)
 
     get_filename_component(PARENT_PTH "${SRC_COPY_SRC}" DIRECTORY)
     get_filename_component(CUR_NAME "${SRC_COPY_SRC}" NAME)
@@ -420,16 +423,20 @@ function(add_ops_src_copy)
         set(_BUILD_FLAG ${SRC_COPY_DST}/${DOING_TARGET_NAME}.done)
         if (NOT BUILD_OPS_RTY_KERNEL AND BELONG_MC2_OPS)
             add_custom_command(OUTPUT ${_BUILD_FLAG}
+                    COMMAND rm -rf ${SRC_COPY_DST}
                     COMMAND mkdir -p ${SRC_COPY_DST}
                     COMMAND cp -rf ${SRC_FILES} ${SRC_COPY_DST}
                     COMMAND rm -rf ${SRC_COPY_DST}/op_kernel/
                     COMMAND touch ${_BUILD_FLAG}
+                    DEPENDS ${SRC_FILE_DEPS}
             )
         else()
             add_custom_command(OUTPUT ${_BUILD_FLAG}
+                    COMMAND rm -rf ${SRC_COPY_DST}
                     COMMAND mkdir -p ${SRC_COPY_DST}
                     COMMAND cp -rf ${SRC_FILES} ${SRC_COPY_DST}
                     COMMAND touch ${_BUILD_FLAG}
+                    DEPENDS ${SRC_FILE_DEPS}
             )
         endif()
 
@@ -445,6 +452,8 @@ function(add_ops_src_copy)
     if (DEFINED SRC_COPY_BE_RELIED)
         add_dependencies(${SRC_COPY_BE_RELIED} ${DOING_TARGET_NAME})
     endif ()
+
+    set(${SRC_COPY_TARGET_NAME}_STAMP ${_BUILD_FLAG} PARENT_SCOPE)
 
 endfunction()
 
@@ -470,6 +479,7 @@ function(add_bin_compile_target)
     endforeach()
 
     set(_ops_target_list)
+    set(_ops_config_deps)
     set(compile_scripts)
     file(GLOB scripts_list ${GEN_OUT_DIR}/*.sh)
     list(APPEND compile_scripts ${scripts_list})
@@ -511,6 +521,7 @@ function(add_bin_compile_target)
                     COMPUTE_UNIT
                     ${BINARY_COMPUTE_UNIT}
             )
+            set(OP_SRC_COPY_STAMPS ${${OP_TARGET_NAME}_src_copy_STAMP})
 
             if (DEFINED ${op_file}_depends)
                 foreach(depend_info ${${op_file}_depends})
@@ -528,13 +539,15 @@ function(add_bin_compile_target)
                             BE_RELIED
                             ${OP_TARGET_NAME}_src_copy
                     )
+                    list(APPEND OP_SRC_COPY_STAMPS ${${_depend_op_target}_STAMP})
                 endforeach()
             endif ()
 
             set(DYNAMIC_PY_FILE ${OP_SRC_OUT_DIR}/${op_type}.py)
             add_custom_command(OUTPUT ${DYNAMIC_PY_FILE}
-                    COMMAND cp -rf ${ASCEND_IMPL_OUT_DIR}/dynamic/${op_file}.py ${DYNAMIC_PY_FILE}
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ASCEND_IMPL_OUT_DIR}/dynamic/${op_file}.py ${DYNAMIC_PY_FILE}
                     # COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/cmake/scripts/update_get_kernel_source.sh ${DYNAMIC_PY_FILE}
+                    DEPENDS ${ASCEND_IMPL_OUT_DIR}/dynamic/${op_file}.py ${OP_SRC_COPY_STAMPS}
             )
 
             add_custom_target(${OP_TARGET_NAME}_py_copy
@@ -622,17 +635,22 @@ function(add_bin_compile_target)
             add_custom_command(OUTPUT ${_BUILD_FLAG}
                     COMMAND ${_BUILD_COMMAND}
                     COMMAND touch ${_BUILD_FLAG}
+                    DEPENDS
+                    ${bin_script}
+                    ${DYNAMIC_PY_FILE}
+                    ${OP_SRC_COPY_STAMPS}
                     WORKING_DIRECTORY ${GEN_OUT_DIR}
             )
 
             add_custom_target(${OP_TARGET_NAME}_${op_index}
                 DEPENDS ${_BUILD_FLAG}
             )
+            list(APPEND _ops_config_deps ${_BUILD_FLAG})
 
             if (ENABLE_OPS_HOST OR ENABLE_HOST_TILING)
                 add_dependencies(${OP_TARGET_NAME}_${op_index} optiling_compat generate_ops_info)
             endif ()
-            add_dependencies(${OP_TARGET_NAME}_${op_index} ${OP_TARGET_NAME}_src_copy ${OP_TARGET_NAME}_py_copy ${OP_TARGET_NAME}_mkdir)
+            add_dependencies(${OP_TARGET_NAME}_${op_index} generate_transformer_adapt_py ${OP_TARGET_NAME}_mkdir)
             add_dependencies(${OP_TARGET_NAME} ${OP_TARGET_NAME}_${op_index})
         endif ()
     endforeach()
@@ -644,6 +662,7 @@ function(add_bin_compile_target)
 
         add_custom_command(OUTPUT ${BINARY_INFO_CONFIG_FILE}
                 COMMAND ${HI_PYTHON} ${ASCENDC_CMAKE_UTIL_DIR}/ascendc_ops_config.py -p ${BIN_OUT_DIR} -s ${BINARY_COMPUTE_UNIT}
+                DEPENDS ${_ops_config_deps}
         )
 
         add_custom_target(${OPS_CONFIG_TARGET}

--- a/csrc/cmake/scripts/util/ascendc_bin_param_build.py
+++ b/csrc/cmake/scripts/util/ascendc_bin_param_build.py
@@ -25,6 +25,15 @@ import regex as re
 PYF_PATH = os.path.dirname(os.path.realpath(__file__))
 
 
+def write_if_different(path: str, content: str):
+    if os.path.exists(path):
+        with open(path) as fd:
+            if fd.read() == content:
+                return
+    with os.fdopen(os.open(path, const_var.WFLAGS, const_var.WMODES), "w") as fd:
+        fd.write(content)
+
+
 class ParamInfo(NamedTuple):
     dtype_list: list
     format_list: list
@@ -331,8 +340,7 @@ class BinParamBuilder(opdesc_parser.OpDesc):
                 self._write_build_cmd(param_file, bin_file, index_value, auto_gen_path, True)
 
     def _write_build_json(self: any, param_file: str, param):
-        with os.fdopen(os.open(param_file, const_var.WFLAGS, const_var.WMODES), "w") as fd:
-            json.dump(param, fd, indent="  ")
+        write_if_different(param_file, json.dumps(param, indent="  "))
 
     def _generate_check_result(self: any, enable_tiling_keys: bool, bin_file: str):
         check_result = ""
@@ -367,7 +375,11 @@ grep -q "None of the given tiling keys are in the supported list"; then\n'
         bin_cmd_str = "res=$(opc $1 --main_func={fun} --input_param={param} --soc_version={soc} \
                 --output=$2 --impl_mode={impl} --simplified_key_mode=0 --op_mode=dynamic "
 
+        with open(param_file, "rb") as fd:
+            param_hash = hashlib.md5(fd.read()).hexdigest()
+
         build_cmd_var = "#!/bin/bash\n"
+        build_cmd_var += f"# param_hash={param_hash}\n"
         build_cmd_var += f'echo "[{self.soc}] Generating {bin_file} ..."\n'
         plog_level = os.environ.get("ASCEND_GLOBAL_LOG_LEVEL")
         plog_stdout = os.environ.get("ASCEND_SLOG_PRINT_TO_STDOUT")
@@ -403,8 +415,7 @@ grep -q "None of the given tiling keys are in the supported list"; then\n'
         build_cmd_var += check_result
         build_cmd_var += f'echo "[{self.soc}] Generating {bin_file} Done"\n'
 
-        with os.fdopen(os.open(compile_file, const_var.WFLAGS, const_var.WMODES), "w") as fd:
-            fd.write(build_cmd_var)
+        write_if_different(compile_file, build_cmd_var)
 
 
 def get_tiling_keys(tiling_keys: str) -> set:

--- a/csrc/cmake/scripts/util/ascendc_impl_build.py
+++ b/csrc/cmake/scripts/util/ascendc_impl_build.py
@@ -12,6 +12,7 @@
 import argparse
 import datetime
 import glob
+import io
 import json
 import os
 import sys
@@ -21,6 +22,16 @@ import opdesc_parser
 import regex as re
 
 PYF_PATH = os.path.dirname(os.path.realpath(__file__))
+
+
+def write_if_different(path: str, content: str):
+    if os.path.exists(path):
+        with open(path) as fd:
+            if fd.read() == content:
+                return
+    with os.fdopen(os.open(path, const_var.WFLAGS, const_var.WMODES), "w") as fd:
+        fd.write(content)
+
 
 IMPL_HEAD = '''#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
@@ -376,19 +387,20 @@ class AdpBuilder(opdesc_parser.OpDesc):
             os.makedirs(out_path, exist_ok=True)
         adpfile = os.path.join(out_path, self.op_file + ".py")
         self._gen_op_compile_option(op_compile_option_all)
-        with os.fdopen(os.open(adpfile, const_var.WFLAGS, const_var.WMODES), "w") as fd:
-            self._write_head(fd)
-            self._write_argparse(fd)
-            self._get_impl_mode()
-            self._write_impl(fd, impl_path)
-            if self.op_chk_support:
-                self._write_cap("check_supported", fd)
-                self._write_cap("get_op_support_info", fd)
-            if self.op_fmt_sel:
-                self._write_cap("op_select_format", fd)
-                self._write_cap("get_op_specific_info", fd)
-            if self.op_range_limit == "limited" or self.op_range_limit == "dynamic":
-                self._write_glz(fd)
+        fd = io.StringIO()
+        self._write_head(fd)
+        self._write_argparse(fd)
+        self._get_impl_mode()
+        self._write_impl(fd, impl_path)
+        if self.op_chk_support:
+            self._write_cap("check_supported", fd)
+            self._write_cap("get_op_support_info", fd)
+        if self.op_fmt_sel:
+            self._write_cap("op_select_format", fd)
+            self._write_cap("get_op_specific_info", fd)
+        if self.op_range_limit == "limited" or self.op_range_limit == "dynamic":
+            self._write_glz(fd)
+        write_if_different(adpfile, fd.getvalue())
 
     def _gen_op_compile_option(self: any, op_compile_option_all: list = None):
         if op_compile_option_all is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes stale-cache correctness issues in the custom-ops incremental build path after #9890 introduced Ninja and preserved `csrc/build` across editable installs.

#9890 is the main performance improvement: it enables Ninja and lets CI restore/reuse `csrc/build`. This PR is a follow-up hardening patch for the cases where reusing that build directory can become incorrect or incomplete.

What #9890 does not fully cover:

- **Existing build directories created by another CMake generator.** After #9890, Ninja is selected by default when available. If a developer already has a `csrc/build` configured with `Unix Makefiles`, reusing it with `-G Ninja` fails with CMake's generator-mismatch error. This PR detects that mismatch and refreshes `csrc/build` automatically.
- **Generated custom-op dependency tracking.** Ninja can only rebuild what CMake declares in the build graph. Several generated custom-op artifacts are driven by copied sources, generated dynamic Python files, compile scripts, and `.done` stamps. This PR wires those inputs into the CMake dependencies so changed custom-op inputs rebuild the affected generated artifacts instead of reusing stale outputs.
- **Stale installer packages in a preserved build directory.** Once `csrc/build` is kept, old `cann-ops-transformer*.run` files can remain beside the newly generated installer. This PR removes stale installers before rebuilding so the install step still sees exactly one candidate.

This PR also refreshes `csrc/build` when the cached CANN package path differs from the current one. In CI, a CANN upgrade normally means a new image and therefore a different cache key, so this is not the primary CI scenario. It is still a useful low-cost guard for local editable installs and non-standard environments where `ASCEND_HOME_PATH`, `ASCEND_OPP_PATH`, or a `latest` symlink can change while the same `csrc/build` directory is reused.

This patch keeps the change focused:

- Refresh `csrc/build` when the cached CMake generator no longer matches the selected generator.
- Refresh `csrc/build` when the cached CANN package path no longer matches the current CANN package path.
- Track source-copy, generated dynamic Python, compile-script, and kernel stamp dependencies so changed custom-op inputs rebuild the affected generated artifacts.
- Keep generated parameter and adapter files content-stable, avoiding unnecessary downstream rebuilds when generated content does not change.
- Remove stale `cann-ops-transformer*.run` installers before rebuilding so installer selection remains unambiguous.
- Canonicalize `ROOT_DIR` before passing the install path to the generated CANN installer.

Fixes #9360.

### Does this PR introduce _any_ user-facing change?

Yes. Re-running `pip install -e .` continues to use the incremental custom-ops build path from #9890, but stale CMake caches are now discarded automatically when the CANN package path or CMake generator changes. Changed generated custom-op inputs are also tracked more accurately by CMake/Ninja.

### How was this patch tested?

No unit tests were added because this changes custom-ops build scripts and generated build dependencies rather than Python runtime logic.

Manual checks:

```bash
git diff --check upstream/main...HEAD
bash -n csrc/build.sh csrc/build_aclnn.sh
python3 -m py_compile \
  csrc/cmake/scripts/util/ascendc_bin_param_build.py \
  csrc/cmake/scripts/util/ascendc_impl_build.py
ruff check \
  csrc/cmake/scripts/util/ascendc_bin_param_build.py \
  csrc/cmake/scripts/util/ascendc_impl_build.py
```

Manual build validation on 310P custom ops:

```bash
SOC_VERSION=ascend310p1 MAX_JOBS=8 bash csrc/build_aclnn.sh . ascend310p1
```

This completed successfully, generated exactly one `cann-ops-transformer*.run` installer, and installed it under `vllm_ascend/_cann_ops_custom`.

The validation started from an existing `csrc/build/CMakeCache.txt` using `CMAKE_GENERATOR=Unix Makefiles` while Ninja was available. The build printed `Info: CMake generator changed, refresh CMake cache.`, reconfigured with Ninja, and completed successfully. The local build environment emitted many clock-skew warnings, but the command completed successfully.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
