### PR TITLE
[Test] Add DeepSeek-V4-Flash nightly e2e accuracy test

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -17,6 +17,7 @@
       "gdydems/DeepSeek-V4-Flash-w4a8-mtp",
       "DevQuasar/deepseek-ai.DeepSeek-V3.2-BF16",
       "Eco-Tech/DeepSeek-V3.1-w8a8-mtp-QuaRot",
+      "Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp",
       "Eco-Tech/Qwen3-30B-A3B-w8a8",
       "Eco-Tech/Kimi-K2.5-W4A8",
       "Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot",

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -317,6 +317,9 @@ jobs:
           - name: Qwen3.5-122B-A10B-W8A8-A3
             os: linux-aarch64-a3-16
             config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
+          - name: DeepSeek-V4-Flash-w8a8
+            os: linux-aarch64-a3-16
+            config_file_path: DeepSeek-V4-Flash.yaml
           # pytest-driven tests
           - name: custom-multi-ops
             os: linux-aarch64-a3-16

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash.yaml
@@ -1,0 +1,61 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "DeepSeek-V4-Flash-TP8-DP1-Case"
+    model: "Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp"
+    envs:
+      HCCL_BUFFSIZE: "1024"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "10"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      VLLM_ASCEND_APPLY_DSV4_PATCH: "1"
+      SERVER_PORT: "DEFAULT_PORT"
+    server_cmd:
+      - "--max-model-len"
+      - "150000"
+      - "--max-num-batched-tokens"
+      - "4096"
+      - "--served-model-name"
+      - "dsv4"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--max-num-seqs"
+      - "32"
+      - "--data-parallel-size"
+      - "1"
+      - "--tensor-parallel-size"
+      - "8"
+      - "--enable-expert-parallel"
+      - "--tokenizer-mode"
+      - "deepseek_v4"
+      - "--tool-call-parser"
+      - "deepseek_v4"
+      - "--enable-auto-tool-choice"
+      - "--reasoning-parser"
+      - "deepseek_v4"
+      - "--safetensors-load-strategy"
+      - "prefetch"
+      - "--quantization"
+      - "ascend"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--api-server-count"
+      - "1"
+      - "--block-size"
+      - "128"
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--async-scheduling"
+    benchmarks:
+      acc:
+        case_type: accuracy
+        dataset_path: vllm-ascend/gsm8k-lite
+        request_conf: vllm_api_general_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+        max_out_len: 4096
+        batch_size: 32
+        baseline: 95
+        threshold: 5


### PR DESCRIPTION
 ### Summary:                                                                                                                                                                           
                                                                                         
  - Add DeepSeek-V4-Flash.yaml e2e config under tests/e2e/nightly/single_node/models/configs/                                                                                        
    - Model: Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp (W8A8 quantized, ascend quantization)   
    - TP=4, DP=4, EP enabled                                                                                                                                                         
    - max-model-len=150000, max-num-batched-tokens=4096, max-num-seqs=32                                                                                                             
    - Full graph decode mode (FULL_DECODE_ONLY), async scheduling                                                                                                                    
    - Tokenizer/tool/reasoning parser all set to deepseek_v4                                                                                                                         
    - Accuracy benchmark only: GSM8K-lite, 0-shot CoT, baseline 95/threshold 5                                                                                                       
  - Register the model in .github/workflows/misc/model_dataset_list.json                                                                                                             
  - Add DeepSeek-V4-Flash-w8a8 job to nightly CI pipeline (schedule_nightly_test_a3.yaml) on A3 16-card                                                                              
                                                                                                                                                                                     
  ### Test plan:                                                                                                                                                                         
  - CI nightly e2e accuracy test passes on A3 16-card
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
