### PR TITLE
[Doc][BugFix] Fix parameter mismatch in DeepSeek-V3.2.md

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -542,7 +542,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name dsv3 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 32560 \
             --trust-remote-code \
@@ -617,7 +617,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name dsv3 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 32560 \
             --trust-remote-code \
@@ -694,7 +694,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name dsv3 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 12 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
@@ -771,7 +771,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name dsv3 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 12 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY",  "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
@@ -866,8 +866,12 @@ python load_balance_proxy_layerwise_server_example.py \
 
 Once your server is started, you can query the model with input prompts:
 
+**Note**: 
+- `<node0_ip>`: The IP address of the node where the server is running. Use `localhost` if running locally.
+- `<port>`: The port number specified in the server startup command (e.g., `7000`).
+
 ```shell
-curl http://<node0_ip>:<port>/v1/completions \
+curl http://localhost:7000/v1/completions \
     -H "Content-Type: application/json" \
     -d '{
         "model": "deepseek_v3.2",

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -542,7 +542,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3.2 \
+            --served-model-name deepseek_v3_2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 32560 \
             --trust-remote-code \
@@ -617,7 +617,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3.2 \
+            --served-model-name deepseek_v3_2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 32560 \
             --trust-remote-code \
@@ -694,7 +694,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3.2 \
+            --served-model-name deepseek_v3_2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 12 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
@@ -771,7 +771,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3.2 \
+            --served-model-name deepseek_v3_2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 12 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY",  "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
@@ -867,14 +867,14 @@ python load_balance_proxy_layerwise_server_example.py \
 Once your server is started, you can query the model with input prompts:
 
 **Note**: 
-- `<node0_ip>`: The IP address of the node where the server is running. Use `localhost` if running locally.
-- `<port>`: The port number specified in the server startup command (e.g., `7000`).
+- `<node0_ip>`: The IP address of the node where the server is running (e.g., localhost).
+- `<port>`: The port number specified in the server startup command (e.g., 8000).
 
 ```shell
-curl http://localhost:7000/v1/completions \
+curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "deepseek_v3.2",
+        "model": "deepseek_v3_2",
         "prompt": "The future of AI is",
         "max_completion_tokens": 50,
         "temperature": 0

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -542,7 +542,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3_2 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 32560 \
             --trust-remote-code \
@@ -617,7 +617,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3_2 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 32560 \
             --trust-remote-code \
@@ -694,7 +694,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3_2 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 12 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
@@ -771,7 +771,7 @@ Before you start, please
             "torch_profiler_dir": "./vllm_profile",
             "torch_profiler_with_stack": false}' \
             --seed 1024 \
-            --served-model-name deepseek_v3_2 \
+            --served-model-name deepseek_v3.2 \
             --max-model-len 68000 \
             --max-num-batched-tokens 12 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY",  "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
@@ -874,7 +874,7 @@ Once your server is started, you can query the model with input prompts:
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "deepseek_v3_2",
+        "model": "deepseek_v3.2",
         "prompt": "The future of AI is",
         "max_completion_tokens": 50,
         "temperature": 0


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects the `served-model-name` in the DeepSeek-V3.2 tutorial to ensure consistency with the model parameter used in the example query. It also adds explanatory notes for server parameters and updates the `curl` command with a concrete example.

Fixes #9358

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation update, verified by inspection.