### PR TITLE
[Feature] Add weight transfer lifecycle methods to NPUWorker

### DIFF
--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -1269,8 +1269,8 @@ class TestNPUWorkerWeightUpdate(TestBase):
 
         engine.receive_weights.side_effect = fake_receive
         worker = self._make_worker(engine=engine)
-        fake_param = MagicMock()
-        worker.model_runner.model.get_parameter.return_value = fake_param
+        param = torch.nn.Parameter(torch.ones(2), requires_grad=True)
+        worker.model_runner.model.get_parameter.return_value = param
 
         if vllm_version_is("0.20.2"):
             typed = MagicMock()
@@ -1284,7 +1284,8 @@ class TestNPUWorkerWeightUpdate(TestBase):
         worker.update_weights({"foo": "bar"})
 
         worker.model_runner.model.get_parameter.assert_called_once_with("layer.weight")
-        fake_param.copy_.assert_called_once()
+        torch.testing.assert_close(param.detach(), torch.zeros(2))
+        self.assertTrue(param.requires_grad)
 
     @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
     def test_update_weights_rejects_nz(self):

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -5,6 +5,7 @@ import torch
 from vllm.config import CacheConfig, ModelConfig, ParallelConfig, ProfilerConfig, VllmConfig
 
 from tests.ut.base import TestBase
+from vllm_ascend.utils import vllm_version_is
 
 init_cached_hf_modules_path = "vllm.utils.import_utils.init_cached_hf_modules"
 
@@ -38,6 +39,7 @@ class TestNPUWorker(TestBase):
         self.vllm_config_mock.scheduler_config = None
         self.vllm_config_mock.device_config = None
         self.vllm_config_mock.compilation_config = None
+        self.vllm_config_mock.weight_transfer_config = None
 
         self.local_rank = 0
         self.rank = 0
@@ -1134,3 +1136,221 @@ class TestNPUWorker(TestBase):
 
             # When both flags are False, return EMPTY_MODEL_RUNNER_OUTPUT directly.
             self.assertEqual(result, mock_empty_output)
+
+
+class TestNPUWorkerWeightUpdate(TestBase):
+    def _make_worker(self, engine=None):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+        worker.weight_transfer_engine = engine
+        worker._weight_update_active = False
+        worker._is_checkpoint_format = True
+        worker.device = torch.device("cpu")
+        worker.model_runner = MagicMock()
+        worker.model_runner.model = MagicMock()
+        worker.model_config = MagicMock()
+        return worker
+
+    def test_check_engine_raises_when_unconfigured(self):
+        worker = self._make_worker(engine=None)
+        with self.assertRaises(RuntimeError):
+            worker.init_weight_transfer_engine({})
+        with self.assertRaises(RuntimeError):
+            worker.start_weight_update()
+        with self.assertRaises(RuntimeError):
+            worker.update_weights({})
+        with self.assertRaises(RuntimeError):
+            worker.finish_weight_update()
+
+    def test_init_weight_transfer_engine_dispatches_to_engine(self):
+        engine = MagicMock()
+        engine.parse_init_info.return_value = "typed_init"
+        worker = self._make_worker(engine=engine)
+
+        init_info = {"master_address": "127.0.0.1", "master_port": 12345}
+        worker.init_weight_transfer_engine(init_info)
+
+        engine.parse_init_info.assert_called_once_with(init_info)
+        engine.init_transfer_engine.assert_called_once_with("typed_init")
+
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_checkpoint_format(self, mock_init_reload):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        worker.start_weight_update(is_checkpoint_format=True)
+
+        mock_init_reload.assert_called_once_with(worker.model_runner.model)
+        self.assertTrue(worker._weight_update_active)
+        self.assertTrue(worker._is_checkpoint_format)
+
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_kernel_format(self, mock_init_reload):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        worker.start_weight_update(is_checkpoint_format=False)
+
+        mock_init_reload.assert_not_called()
+        self.assertTrue(worker._weight_update_active)
+        self.assertFalse(worker._is_checkpoint_format)
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_rejects_reentry(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+
+        with self.assertRaises(RuntimeError):
+            worker.start_weight_update()
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    def test_start_weight_update_rejects_nz(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        with self.assertRaises(ValueError):
+            worker.start_weight_update()
+
+    def test_update_weights_requires_start(self):
+        if vllm_version_is("0.20.2"):
+            return  # v0.20.2 update_weights is self-contained; no start_weight_update guard
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        with self.assertRaises(RuntimeError):
+            worker.update_weights({"names": [], "dtype_names": [], "shapes": []})
+
+    @patch("torch.npu.synchronize", create=True)
+    @patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload")
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_update_weights_checkpoint_format(self, mock_init_reload, mock_finalize_reload, mock_sync):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        if vllm_version_is("0.20.2"):
+            typed = MagicMock()
+            typed.is_checkpoint_format = True
+            engine.parse_update_info.return_value = typed
+            # no start_weight_update phase: _weight_update_active stays False
+        else:
+            engine.parse_update_info.return_value = "typed_update"
+            worker._weight_update_active = True
+            worker._is_checkpoint_format = True
+
+        worker.update_weights({"foo": "bar"})
+
+        engine.parse_update_info.assert_called_once_with({"foo": "bar"})
+        engine.receive_weights.assert_called_once()
+        _, kwargs = engine.receive_weights.call_args
+        self.assertIs(kwargs["load_weights"], worker.model_runner.model.load_weights)
+        mock_sync.assert_called_once()
+
+        if vllm_version_is("0.20.2"):
+            # self-contained: reload lifecycle is managed inside update_weights
+            mock_init_reload.assert_called_once_with(worker.model_runner.model)
+            mock_finalize_reload.assert_called_once_with(worker.model_runner.model, worker.model_config)
+        else:
+            # main: reload lifecycle is split across start_weight_update / finish_weight_update
+            mock_init_reload.assert_not_called()
+            mock_finalize_reload.assert_not_called()
+
+    @patch("torch.npu.synchronize", create=True)
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_update_weights_kernel_format(self, mock_sync):
+        engine = MagicMock()
+
+        def fake_receive(update_info, load_weights):
+            load_weights([("layer.weight", torch.zeros(2))])
+
+        engine.receive_weights.side_effect = fake_receive
+        worker = self._make_worker(engine=engine)
+        fake_param = MagicMock()
+        worker.model_runner.model.get_parameter.return_value = fake_param
+
+        if vllm_version_is("0.20.2"):
+            typed = MagicMock()
+            typed.is_checkpoint_format = False
+            engine.parse_update_info.return_value = typed
+        else:
+            engine.parse_update_info.return_value = "typed_update"
+            worker._weight_update_active = True
+            worker._is_checkpoint_format = False
+
+        worker.update_weights({"foo": "bar"})
+
+        worker.model_runner.model.get_parameter.assert_called_once_with("layer.weight")
+        fake_param.copy_.assert_called_once()
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    def test_update_weights_rejects_nz(self):
+        # On main, NZ is caught in start_weight_update (see test_start_weight_update_rejects_nz).
+        # On v0.20.2, there is no start phase, so update_weights itself enforces the check.
+        if not vllm_version_is("0.20.2"):
+            return
+        engine = MagicMock()
+        typed = MagicMock()
+        typed.is_checkpoint_format = True
+        engine.parse_update_info.return_value = typed
+        worker = self._make_worker(engine=engine)
+        with self.assertRaises(ValueError):
+            worker.update_weights({"foo": "bar"})
+
+    @patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload")
+    def test_finish_weight_update_resets_state(self, mock_finalize_reload):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+        worker._is_checkpoint_format = True
+
+        worker.finish_weight_update()
+
+        mock_finalize_reload.assert_called_once_with(worker.model_runner.model, worker.model_config)
+        self.assertFalse(worker._weight_update_active)
+        self.assertTrue(worker._is_checkpoint_format)
+
+    def test_finish_without_start_raises(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        with self.assertRaises(RuntimeError):
+            worker.finish_weight_update()
+
+    def test_double_finish_raises(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+        worker._is_checkpoint_format = False
+
+        worker.finish_weight_update()
+
+        with self.assertRaises(RuntimeError):
+            worker.finish_weight_update()
+
+    @patch("torch.npu.synchronize", create=True)
+    def test_update_after_finish_requires_restart(self, _mock_sync):
+        if vllm_version_is("0.20.2"):
+            return  # v0.20.2 has no start/finish state machine
+        engine = MagicMock()
+        engine.parse_update_info.return_value = "typed"
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+        worker._is_checkpoint_format = False
+        worker.finish_weight_update()
+
+        with self.assertRaises(RuntimeError):
+            worker.update_weights({"names": [], "dtype_names": [], "shapes": []})
+
+    @patch("vllm.distributed.kv_transfer.ensure_kv_transfer_shutdown", create=True)
+    def test_shutdown_releases_engine(self, _mock_kv_shutdown):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker.profiler = None
+
+        worker.shutdown()
+
+        engine.shutdown.assert_called_once()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -32,6 +32,7 @@ from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
 from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
 from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized, get_kv_transfer_group, has_kv_transfer_group
+from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
@@ -130,6 +131,26 @@ class NPUWorker(WorkerBase):
         if vllm_config.model_config and vllm_config.model_config.enable_sleep_mode:
             # Buffers saved before sleep
             self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
+
+        # Weight transfer engine (initialized on-demand)
+        # Ensure HCCL engine is registered before creating it.
+        # register_engine() is not idempotent, so guard against double-registration
+        # which can happen if the plugin connector already registered it.
+        from vllm_ascend.distributed.weight_transfer import register_engine
+        try:
+            register_engine()
+        except ValueError:
+            pass  # already registered
+        self.weight_transfer_engine = (
+            WeightTransferEngineFactory.create_engine(
+                self.vllm_config.weight_transfer_config,
+                self.vllm_config.parallel_config,
+            )
+            if self.vllm_config.weight_transfer_config is not None
+            else None
+        )
+        self._weight_update_active = False
+        self._is_checkpoint_format = True
 
         # FixMe: this is a patch to fix the issue cause by https://github.com/vllm-project/vllm/commit/de94289a98d7ec52a5ef02719e01a1db8b505170
         from vllm.model_executor.layers.linear import WEIGHT_LOADER_V2_SUPPORTED
@@ -574,6 +595,142 @@ class NPUWorker(WorkerBase):
         weight = torch.rand((2, 4), dtype=torch.float16).npu()
         c = torch.rand((4, 4), dtype=torch.float32).npu()
         torch_npu._npu_matmul_add_fp32(x, weight, c)
+
+    def _check_weight_transfer_engine(self) -> None:
+        if self.weight_transfer_engine is None:
+            raise RuntimeError(
+                "Weight transfer not configured. "
+                "Please set weight_transfer_config to enable weight transfer."
+            )
+
+    def init_weight_transfer_engine(self, init_info: dict) -> None:
+        """Initialize weight transfer mechanism for HCCL backend.
+
+        This creates a stateless process group with the trainer process
+        for HCCL weight broadcasting.
+
+        Args:
+            init_info: Dictionary containing backend-specific initialization info
+                (master_address, master_port, rank_offset, world_size)
+        """
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
+        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+    def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
+        """Start a new weight update.
+
+        Prepares the model for receiving weights. For checkpoint format,
+        this initializes state for layerwise processing. For kernel format,
+        this is a no-op but must still be called for consistency.
+
+        Args:
+            is_checkpoint_format: Whether incoming weights are in checkpoint
+                format (need layerwise processing) or kernel format (direct
+                copy). Stored as state for finish_weight_update.
+        """
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is not supported for weight update. "
+                "Please set VLLM_ASCEND_ENABLE_NZ=0."
+            )
+        self._check_weight_transfer_engine()
+
+        if self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update called while a weight update is "
+                "already active. Call finish_weight_update first."
+            )
+
+        if is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import (
+                initialize_layerwise_reload,
+            )
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                initialize_layerwise_reload(model)
+
+        self._is_checkpoint_format = is_checkpoint_format
+        self._weight_update_active = True
+
+    def update_weights(self, update_info: dict) -> None:
+        """Receive weights from the trainer (one or more chunks).
+
+        start_weight_update must be called before update_weights and
+        finish_weight_update must be called after.
+
+        Args:
+            update_info: Dictionary containing backend-specific update info
+                (names, dtype_names, shapes, packed, etc.)
+        """
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update must be called before update_weights."
+            )
+
+        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
+
+        model = self.model_runner.model
+
+        with torch.device(self.device):
+            if self._is_checkpoint_format:
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=model.load_weights,
+                )
+            else:
+                def load_weights_direct(
+                    weights: list[tuple[str, torch.Tensor]],
+                ) -> None:
+                    for name, weight in weights:
+                        param = model.get_parameter(name)
+                        param.copy_(weight)
+
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=load_weights_direct,
+                )
+
+        # HCCL broadcast/packed path are asynchronous.
+        # Sync here so the next step uses the new weights.
+        torch.npu.synchronize()
+
+    def finish_weight_update(self) -> None:
+        """Finish the current weight update.
+
+        For checkpoint format, this runs layerwise postprocessing.
+        Uses the is_checkpoint_format state stored by start_weight_update.
+        """
+        self._check_weight_transfer_engine()
+
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update must be called before finish_weight_update."
+            )
+
+        is_checkpoint_format = self._is_checkpoint_format
+
+        if is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+            )
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                finalize_layerwise_reload(model, self.model_config)
+
+        # Reset state
+        self._weight_update_active = False
+        self._is_checkpoint_format = True
+
+    def shutdown(self) -> None:
+        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
+            weight_transfer_engine.shutdown()
 
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -279,8 +279,20 @@ class NPUWorker(WorkerBase):
         typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
+    def _check_nz_disabled(self) -> None:
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is enabled. This may cause model parameter "
+                "precision issues in the RL scenarios. Please set "
+                "VLLM_ASCEND_ENABLE_NZ=0."
+            )
+
     def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
-        """Begin a new weight update; prepares the model for layerwise reload."""
+        """Begin a new weight update; prepares the model for layerwise reload.
+
+        Only invoked on vLLM main. v0.20.2 has no /start_weight_update endpoint
+        and folds init/finalize layerwise reload into update_weights itself.
+        """
         self._check_weight_transfer_engine()
 
         if self._weight_update_active:
@@ -288,12 +300,7 @@ class NPUWorker(WorkerBase):
                 "start_weight_update called while a weight update is already active. Call finish_weight_update first."
             )
 
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
-            raise ValueError(
-                "FRACTAL_NZ mode is enabled. This may cause model parameter "
-                "precision issues in the RL scenarios. Please set "
-                "VLLM_ASCEND_ENABLE_NZ=0."
-            )
+        self._check_nz_disabled()
 
         if is_checkpoint_format:
             from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
@@ -310,36 +317,73 @@ class NPUWorker(WorkerBase):
         self._check_weight_transfer_engine()
         assert self.weight_transfer_engine is not None
 
-        if not self._weight_update_active:
-            raise RuntimeError("start_weight_update must be called before update_weights.")
-
         typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
         model = self.model_runner.model
 
-        with torch.device(self.device):
-            if self._is_checkpoint_format:
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=model.load_weights,
-                )
-            else:
+        if vllm_version_is("0.20.2"):
+            # v0.20.2 lifecycle: update_weights is self-contained — it runs
+            # initialize_layerwise_reload before receive_weights and
+            # finalize_layerwise_reload after, reading is_checkpoint_format
+            # off the update_info payload (no start/finish endpoints).
+            self._check_nz_disabled()
+            is_checkpoint_format = typed_update_info.is_checkpoint_format
+            with torch.device(self.device):
+                if is_checkpoint_format:
+                    from vllm.model_executor.model_loader.reload import (
+                        finalize_layerwise_reload,
+                        initialize_layerwise_reload,
+                    )
 
-                def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
-                    for name, weight in weights:
-                        param = model.get_parameter(name)
-                        param.copy_(weight)
+                    initialize_layerwise_reload(model)
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=model.load_weights,
+                    )
+                    finalize_layerwise_reload(model, self.model_config)
+                else:
 
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=load_weights_direct,
-                )
+                    def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
+                        for name, weight in weights:
+                            param = model.get_parameter(name)
+                            param.copy_(weight)
+
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=load_weights_direct,
+                    )
+        else:
+            # main lifecycle: state machine driven by start/finish.
+            if not self._weight_update_active:
+                raise RuntimeError("start_weight_update must be called before update_weights.")
+
+            with torch.device(self.device):
+                if self._is_checkpoint_format:
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=model.load_weights,
+                    )
+                else:
+
+                    def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
+                        for name, weight in weights:
+                            param = model.get_parameter(name)
+                            param.copy_(weight)
+
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=load_weights_direct,
+                    )
 
         # HCCL broadcast / packed paths are asynchronous.
         # Sync so the next step uses the new weights.
         torch.npu.synchronize()
 
     def finish_weight_update(self) -> None:
-        """Finish the current weight update; runs layerwise postprocessing."""
+        """Finish the current weight update; runs layerwise postprocessing.
+
+        Only invoked on vLLM main. v0.20.2 has no /finish_weight_update endpoint
+        and folds layerwise finalization into update_weights itself.
+        """
         self._check_weight_transfer_engine()
 
         if not self._weight_update_active:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -343,9 +343,10 @@ class NPUWorker(WorkerBase):
                 else:
 
                     def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
-                        for name, weight in weights:
-                            param = model.get_parameter(name)
-                            param.copy_(weight)
+                        with torch.no_grad():
+                            for name, weight in weights:
+                                param = model.get_parameter(name)
+                                param.copy_(weight)
 
                     self.weight_transfer_engine.receive_weights(
                         typed_update_info,
@@ -365,9 +366,10 @@ class NPUWorker(WorkerBase):
                 else:
 
                     def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
-                        for name, weight in weights:
-                            param = model.get_parameter(name)
-                            param.copy_(weight)
+                        with torch.no_grad():
+                            for name, weight in weights:
+                                param = model.get_parameter(name)
+                                param.copy_(weight)
 
                     self.weight_transfer_engine.receive_weights(
                         typed_update_info,

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -31,9 +31,14 @@ from torch_npu.profiler import dynamic_profile as dp
 from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
 from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
-from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized, get_kv_transfer_group, has_kv_transfer_group
-from vllm.distributed.weight_transfer import WeightTransferEngineFactory
+from vllm.distributed.kv_transfer import (
+    ensure_kv_transfer_initialized,
+    ensure_kv_transfer_shutdown,
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
 from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
+from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
 from vllm.sequence import IntermediateTensors
@@ -133,14 +138,6 @@ class NPUWorker(WorkerBase):
             self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
 
         # Weight transfer engine (initialized on-demand)
-        # Ensure HCCL engine is registered before creating it.
-        # register_engine() is not idempotent, so guard against double-registration
-        # which can happen if the plugin connector already registered it.
-        from vllm_ascend.distributed.weight_transfer import register_engine
-        try:
-            register_engine()
-        except ValueError:
-            pass  # already registered
         self.weight_transfer_engine = (
             WeightTransferEngineFactory.create_engine(
                 self.vllm_config.weight_transfer_config,
@@ -268,6 +265,110 @@ class NPUWorker(WorkerBase):
                 if name in self._sleep_saved_buffers:
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
+
+    def _check_weight_transfer_engine(self) -> None:
+        if self.weight_transfer_engine is None:
+            raise RuntimeError(
+                "Weight transfer not configured. Please set weight_transfer_config to enable weight transfer."
+            )
+
+    def init_weight_transfer_engine(self, init_info: dict) -> None:
+        """Initialize the HCCL weight transfer process group with the trainer."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
+        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+    def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
+        """Begin a new weight update; prepares the model for layerwise reload."""
+        self._check_weight_transfer_engine()
+
+        if self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update called while a weight update is already active. Call finish_weight_update first."
+            )
+
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is enabled. This may cause model parameter "
+                "precision issues in the RL scenarios. Please set "
+                "VLLM_ASCEND_ENABLE_NZ=0."
+            )
+
+        if is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                initialize_layerwise_reload(model)
+
+        self._is_checkpoint_format = is_checkpoint_format
+        self._weight_update_active = True
+
+    def update_weights(self, update_info: dict) -> None:
+        """Receive a chunk of weights from the trainer and load them in place."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if not self._weight_update_active:
+            raise RuntimeError("start_weight_update must be called before update_weights.")
+
+        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
+        model = self.model_runner.model
+
+        with torch.device(self.device):
+            if self._is_checkpoint_format:
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=model.load_weights,
+                )
+            else:
+
+                def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
+                    for name, weight in weights:
+                        param = model.get_parameter(name)
+                        param.copy_(weight)
+
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=load_weights_direct,
+                )
+
+        # HCCL broadcast / packed paths are asynchronous.
+        # Sync so the next step uses the new weights.
+        torch.npu.synchronize()
+
+    def finish_weight_update(self) -> None:
+        """Finish the current weight update; runs layerwise postprocessing."""
+        self._check_weight_transfer_engine()
+
+        if not self._weight_update_active:
+            raise RuntimeError("start_weight_update must be called before finish_weight_update.")
+
+        if self._is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import finalize_layerwise_reload
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                finalize_layerwise_reload(model, self.model_config)
+
+        self._weight_update_active = False
+        self._is_checkpoint_format = True
+
+    def shutdown(self) -> None:
+        if ensure_kv_transfer_shutdown is not None:
+            ensure_kv_transfer_shutdown()
+
+        if self.profiler is not None:
+            self.profiler.shutdown()
+
+        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
+            weight_transfer_engine.shutdown()
+
+        if model_runner := getattr(self, "model_runner", None):
+            shutdown_fn = getattr(model_runner, "shutdown", None)
+            if callable(shutdown_fn):
+                shutdown_fn()
 
     def initialize_cache(self, num_gpu_blocks: int, num_cpu_blocks: int) -> None:
         self.cache_config.num_gpu_blocks = num_gpu_blocks
@@ -595,142 +696,6 @@ class NPUWorker(WorkerBase):
         weight = torch.rand((2, 4), dtype=torch.float16).npu()
         c = torch.rand((4, 4), dtype=torch.float32).npu()
         torch_npu._npu_matmul_add_fp32(x, weight, c)
-
-    def _check_weight_transfer_engine(self) -> None:
-        if self.weight_transfer_engine is None:
-            raise RuntimeError(
-                "Weight transfer not configured. "
-                "Please set weight_transfer_config to enable weight transfer."
-            )
-
-    def init_weight_transfer_engine(self, init_info: dict) -> None:
-        """Initialize weight transfer mechanism for HCCL backend.
-
-        This creates a stateless process group with the trainer process
-        for HCCL weight broadcasting.
-
-        Args:
-            init_info: Dictionary containing backend-specific initialization info
-                (master_address, master_port, rank_offset, world_size)
-        """
-        self._check_weight_transfer_engine()
-        assert self.weight_transfer_engine is not None
-        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
-        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
-
-    def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
-        """Start a new weight update.
-
-        Prepares the model for receiving weights. For checkpoint format,
-        this initializes state for layerwise processing. For kernel format,
-        this is a no-op but must still be called for consistency.
-
-        Args:
-            is_checkpoint_format: Whether incoming weights are in checkpoint
-                format (need layerwise processing) or kernel format (direct
-                copy). Stored as state for finish_weight_update.
-        """
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
-            raise ValueError(
-                "FRACTAL_NZ mode is not supported for weight update. "
-                "Please set VLLM_ASCEND_ENABLE_NZ=0."
-            )
-        self._check_weight_transfer_engine()
-
-        if self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update called while a weight update is "
-                "already active. Call finish_weight_update first."
-            )
-
-        if is_checkpoint_format:
-            from vllm.model_executor.model_loader.reload import (
-                initialize_layerwise_reload,
-            )
-
-            model = self.model_runner.model
-            with torch.device(self.device):
-                initialize_layerwise_reload(model)
-
-        self._is_checkpoint_format = is_checkpoint_format
-        self._weight_update_active = True
-
-    def update_weights(self, update_info: dict) -> None:
-        """Receive weights from the trainer (one or more chunks).
-
-        start_weight_update must be called before update_weights and
-        finish_weight_update must be called after.
-
-        Args:
-            update_info: Dictionary containing backend-specific update info
-                (names, dtype_names, shapes, packed, etc.)
-        """
-        self._check_weight_transfer_engine()
-        assert self.weight_transfer_engine is not None
-
-        if not self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update must be called before update_weights."
-            )
-
-        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
-
-        model = self.model_runner.model
-
-        with torch.device(self.device):
-            if self._is_checkpoint_format:
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=model.load_weights,
-                )
-            else:
-                def load_weights_direct(
-                    weights: list[tuple[str, torch.Tensor]],
-                ) -> None:
-                    for name, weight in weights:
-                        param = model.get_parameter(name)
-                        param.copy_(weight)
-
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=load_weights_direct,
-                )
-
-        # HCCL broadcast/packed path are asynchronous.
-        # Sync here so the next step uses the new weights.
-        torch.npu.synchronize()
-
-    def finish_weight_update(self) -> None:
-        """Finish the current weight update.
-
-        For checkpoint format, this runs layerwise postprocessing.
-        Uses the is_checkpoint_format state stored by start_weight_update.
-        """
-        self._check_weight_transfer_engine()
-
-        if not self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update must be called before finish_weight_update."
-            )
-
-        is_checkpoint_format = self._is_checkpoint_format
-
-        if is_checkpoint_format:
-            from vllm.model_executor.model_loader.reload import (
-                finalize_layerwise_reload,
-            )
-
-            model = self.model_runner.model
-            with torch.device(self.device):
-                finalize_layerwise_reload(model, self.model_config)
-
-        # Reset state
-        self._weight_update_active = False
-        self._is_checkpoint_format = True
-
-    def shutdown(self) -> None:
-        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
-            weight_transfer_engine.shutdown()
 
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()


### PR DESCRIPTION
### What this PR does / why we need it?
Add the weight transfer lifecycle methods to `NPUWorker` — `init_weight_transfer_engine`, `start_weight_update`, `update_weights`, `finish_weight_update` — aligning with upstream `GPUWorker`. This is the worker-side control plane for the HCCL weight transfer backend from #9152.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
