### PR TITLE
[Feature] IndexCache: reuse topk_indices across decode steps for DSA models (DeepSeek V4)

### DIFF
--- a/tests/e2e/multicard/4-cards/test_deepseek_v4.py
+++ b/tests/e2e/multicard/4-cards/test_deepseek_v4.py
@@ -64,3 +64,52 @@ def test_deepseek_v4_w4a8_tp4_basic_greedy():
         for output_ids, output_str in outputs:
             assert len(output_str) > 0
             assert len(output_ids) > 0
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_ASCEND_APPLY_DSV4_PATCH": "1",
+        "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
+    },
+)
+@wait_until_npu_memory_free()
+def test_deepseek_v4_w4a8_tp4_index_cache_freq4():
+    """IndexCache freq=4 must produce non-empty greedy outputs identical in
+    shape to the baseline test, verifying skip_topk/topk_indices_buffer
+    plumbing (DSAModules → AscendDSAImpl) is wired correctly across both
+    serial and dual-stream paths.
+    """
+    example_prompts = [
+        "Hello, my name is",
+        "The capital of France is",
+        "What is the meaning of life?",
+    ]
+    max_tokens = 5
+
+    with VllmRunner(
+        "gdydems/DeepSeek-V4-Flash-w4a8-mtp",
+        max_model_len=8192,
+        max_num_seqs=16,
+        max_num_batched_tokens=4096,
+        dtype="auto",
+        tensor_parallel_size=4,
+        enable_expert_parallel=True,
+        gpu_memory_utilization=0.9,
+        quantization="ascend",
+        tokenizer_mode="deepseek_v4",
+        block_size=128,
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+        },
+        hf_overrides={
+            "use_index_cache": True,
+            "index_topk_freq": 4,
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
+
+        assert len(outputs) == len(example_prompts)
+        for output_ids, output_str in outputs:
+            assert len(output_str) > 0
+            assert len(output_ids) > 0

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1426,6 +1426,37 @@ class AscendDSAImpl(DSAAttentionImpl):
             self.compressor_norm = self.compressor.norm
             self.compressor_norm_eps = self.compressor.norm_eps
 
+        # IndexCache: skip_topk indicates this layer reuses topk from a previous
+        # indexer-bearing layer; use_index_cache marks whether the buffer must
+        # be kept fresh on non-skip layers so downstream skip layers can read.
+        self.skip_topk = kwargs.get("skip_topk", False)
+        self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
+        self.use_index_cache = self.skip_topk or getattr(
+            self.vllm_config.model_config.hf_config,
+            "use_index_cache",
+            False,
+        )
+
+    def _get_indexcache_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
+        if self.topk_indices_buffer is None:
+            raise RuntimeError("IndexCache requires topk_indices_buffer when skip_topk is enabled.")
+        topk_indices = self.topk_indices_buffer[offset : offset + num_tokens]
+        if topk_indices.dim() == 2:
+            topk_indices = topk_indices.unsqueeze(1)
+        return topk_indices
+
+    def _update_indexcache_topk_indices(self, topk_indices: torch.Tensor, offset: int = 0) -> None:
+        if self.topk_indices_buffer is None:
+            return
+        num_tokens = topk_indices.shape[0]
+        topk_tokens = topk_indices.shape[-1]
+        topk_indices_to_cache = topk_indices
+        topk_indices_buffer = self.topk_indices_buffer[offset : offset + num_tokens, :topk_tokens]
+        if topk_indices_to_cache.dim() == 3 and topk_indices_buffer.dim() == 2:
+            assert topk_indices_to_cache.shape[1] == 1
+            topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
+        topk_indices_buffer.copy_(topk_indices_to_cache)
+
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
 
@@ -1705,34 +1736,44 @@ class AscendDSAImpl(DSAAttentionImpl):
             compress_topk_idxs = None
             # Only call indexer_select_qli when compress_ratio == 4 (requires 5 elements in attn_metadata)
             if self.compress_ratio == 4:
-                if self.multistream_dsv4_dsa_overlap:
-                    compress_topk_idxs = self.cv_indexer_select_qli(  # multistream version
-                        x=hidden_states,
-                        qr=qr,
-                        kv_cache=kv_cache,
-                        attn_metadata=attn_metadata,
-                        cos=cos,
-                        sin=sin,
-                        compressed_cos=compress_cos,
-                        compressed_sin=compress_sin,
-                        actual_seq_lengths_query=actual_seq_lengths_query,
-                        actual_seq_lengths_key=actual_seq_lengths_key,
-                        with_prefill=True,
-                    )
+                # IndexCache: prefill segment lives at buffer[num_decode_tokens:]
+                # because dsa_v1 forward splits hidden_states as
+                # [decode | prefill]. See AscendDSAImpl.forward.
+                prefill_offset = attn_metadata[0].num_decode_tokens
+                prefill_num_tokens = hidden_states.shape[0]
+                if self.skip_topk:
+                    compress_topk_idxs = self._get_indexcache_topk_indices(prefill_num_tokens, offset=prefill_offset)
                 else:
-                    compress_topk_idxs = self.indexer_select_qli(  # original version
-                        x=hidden_states,
-                        qr=qr,
-                        kv_cache=kv_cache,
-                        attn_metadata=attn_metadata,
-                        cos=cos,
-                        sin=sin,
-                        compressed_cos=compress_cos,
-                        compressed_sin=compress_sin,
-                        actual_seq_lengths_query=actual_seq_lengths_query,
-                        actual_seq_lengths_key=actual_seq_lengths_key,
-                        with_prefill=True,
-                    )
+                    if self.multistream_dsv4_dsa_overlap:
+                        compress_topk_idxs = self.cv_indexer_select_qli(  # multistream version
+                            x=hidden_states,
+                            qr=qr,
+                            kv_cache=kv_cache,
+                            attn_metadata=attn_metadata,
+                            cos=cos,
+                            sin=sin,
+                            compressed_cos=compress_cos,
+                            compressed_sin=compress_sin,
+                            actual_seq_lengths_query=actual_seq_lengths_query,
+                            actual_seq_lengths_key=actual_seq_lengths_key,
+                            with_prefill=True,
+                        )
+                    else:
+                        compress_topk_idxs = self.indexer_select_qli(  # original version
+                            x=hidden_states,
+                            qr=qr,
+                            kv_cache=kv_cache,
+                            attn_metadata=attn_metadata,
+                            cos=cos,
+                            sin=sin,
+                            compressed_cos=compress_cos,
+                            compressed_sin=compress_sin,
+                            actual_seq_lengths_query=actual_seq_lengths_query,
+                            actual_seq_lengths_key=actual_seq_lengths_key,
+                            with_prefill=True,
+                        )
+                    if self.use_index_cache:
+                        self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
 
             coff = 2 if self.compressor_overlap else 1
 
@@ -1938,37 +1979,43 @@ class AscendDSAImpl(DSAAttentionImpl):
             compress_sin = common_decode_metadata.compress_sin[layer_name]
             compress_topk_idxs = None
             if self.compress_ratio == 4:
-                # use multistream.
-                if self.multistream_dsv4_dsa_overlap:
-                    compress_topk_idxs = self.cv_indexer_select_qli(  # multistream version
-                        x=hidden_states,
-                        qr=qr,
-                        kv_cache=kv_cache,
-                        attn_metadata=attn_metadata,
-                        cos=cos,
-                        sin=sin,
-                        compressed_cos=compress_cos,
-                        compressed_sin=compress_sin,
-                        actual_seq_lengths_query=actual_seq_lengths_query,
-                        actual_seq_lengths_key=actual_seq_lengths_key,
-                        with_prefill=False,
-                        qr_pertoken_scale=qr_pertoken_scale,
-                    )
+                # IndexCache: decode segment occupies buffer[:num_decode_tokens]
+                decode_num_tokens = hidden_states.shape[0]
+                if self.skip_topk:
+                    compress_topk_idxs = self._get_indexcache_topk_indices(decode_num_tokens, offset=0)
                 else:
-                    compress_topk_idxs = self.indexer_select_qli(  # original version
-                        x=hidden_states,
-                        qr=qr,
-                        kv_cache=kv_cache,
-                        attn_metadata=attn_metadata,
-                        cos=cos,
-                        sin=sin,
-                        compressed_cos=compress_cos,
-                        compressed_sin=compress_sin,
-                        actual_seq_lengths_query=actual_seq_lengths_query,
-                        actual_seq_lengths_key=actual_seq_lengths_key,
-                        with_prefill=False,
-                        qr_pertoken_scale=qr_pertoken_scale,
-                    )
+                    if self.multistream_dsv4_dsa_overlap:
+                        compress_topk_idxs = self.cv_indexer_select_qli(  # multistream version
+                            x=hidden_states,
+                            qr=qr,
+                            kv_cache=kv_cache,
+                            attn_metadata=attn_metadata,
+                            cos=cos,
+                            sin=sin,
+                            compressed_cos=compress_cos,
+                            compressed_sin=compress_sin,
+                            actual_seq_lengths_query=actual_seq_lengths_query,
+                            actual_seq_lengths_key=actual_seq_lengths_key,
+                            with_prefill=False,
+                            qr_pertoken_scale=qr_pertoken_scale,
+                        )
+                    else:
+                        compress_topk_idxs = self.indexer_select_qli(  # original version
+                            x=hidden_states,
+                            qr=qr,
+                            kv_cache=kv_cache,
+                            attn_metadata=attn_metadata,
+                            cos=cos,
+                            sin=sin,
+                            compressed_cos=compress_cos,
+                            compressed_sin=compress_sin,
+                            actual_seq_lengths_query=actual_seq_lengths_query,
+                            actual_seq_lengths_key=actual_seq_lengths_key,
+                            with_prefill=False,
+                            qr_pertoken_scale=qr_pertoken_scale,
+                        )
+                    if self.use_index_cache:
+                        self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
             coff = 2 if self.compressor_overlap else 1
 
@@ -2178,28 +2225,33 @@ class AscendDSAImpl(DSAAttentionImpl):
             actual_seq_lengths_query = common_decode_metadata.query_start_loc
             actual_seq_lengths_key = common_decode_metadata.seq_lens
 
-            # QLI
-            decode_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
-                query=decode_q_quant,
-                key=ik,
-                weights=decode_weights.to(torch.float16),
-                query_dequant_scale=decode_q_scale,
-                key_dequant_scale=isc.squeeze(-2),
-                actual_seq_lengths_query=indexer_decode_metadata.query_start_loc[1:],
-                actual_seq_lengths_key=indexer_decode_metadata.seq_lens,
-                block_table=indexer_decode_metadata.block_table,
-                metadata=indexer_decode_metadata.qli_metadata,
-                query_quant_mode=0,
-                key_quant_mode=0,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.index_topk,
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
-                cmp_ratio=4,
-                return_value=False,
-            )
+            # QLI (IndexCache: decode segment at buffer[:num_decode_tokens])
+            if self.skip_topk:
+                decode_topk_idxs = self._get_indexcache_topk_indices(num_decode_tokens, offset=0)
+            else:
+                decode_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
+                    query=decode_q_quant,
+                    key=ik,
+                    weights=decode_weights.to(torch.float16),
+                    query_dequant_scale=decode_q_scale,
+                    key_dequant_scale=isc.squeeze(-2),
+                    actual_seq_lengths_query=indexer_decode_metadata.query_start_loc[1:],
+                    actual_seq_lengths_key=indexer_decode_metadata.seq_lens,
+                    block_table=indexer_decode_metadata.block_table,
+                    metadata=indexer_decode_metadata.qli_metadata,
+                    query_quant_mode=0,
+                    key_quant_mode=0,
+                    layout_query="TND",
+                    layout_key="PA_BSND",
+                    sparse_count=self.index_topk,
+                    sparse_mode=3,
+                    pre_tokens=(1 << 63) - 1,
+                    next_tokens=(1 << 63) - 1,
+                    cmp_ratio=4,
+                    return_value=False,
+                )
+                if self.use_index_cache:
+                    self._update_indexcache_topk_indices(decode_topk_idxs, offset=0)
 
             # Sparse attention (decode)
             decode_attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
@@ -2238,28 +2290,34 @@ class AscendDSAImpl(DSAAttentionImpl):
             prefill_actual_seq_lengths_query = common_prefill_metadata.query_start_loc
             prefill_actual_seq_lengths_key = common_prefill_metadata.seq_lens
 
-            # QLI
-            prefill_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
-                query=prefill_q_quant,
-                key=ik,
-                weights=prefill_weights.to(torch.float16),
-                query_dequant_scale=prefill_q_scale,
-                key_dequant_scale=isc.squeeze(-2),
-                actual_seq_lengths_query=indexer_prefill_metadata.query_start_loc[1:],
-                actual_seq_lengths_key=indexer_prefill_metadata.seq_lens,
-                block_table=indexer_prefill_metadata.block_table,
-                metadata=indexer_prefill_metadata.qli_metadata,
-                query_quant_mode=0,
-                key_quant_mode=0,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.index_topk,
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
-                cmp_ratio=4,
-                return_value=False,
-            )
+            # QLI (IndexCache: prefill segment at buffer[num_decode_tokens:num_actual_tokens])
+            prefill_num_tokens = num_actual_tokens - num_decode_tokens
+            if self.skip_topk:
+                prefill_topk_idxs = self._get_indexcache_topk_indices(prefill_num_tokens, offset=num_decode_tokens)
+            else:
+                prefill_topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer(
+                    query=prefill_q_quant,
+                    key=ik,
+                    weights=prefill_weights.to(torch.float16),
+                    query_dequant_scale=prefill_q_scale,
+                    key_dequant_scale=isc.squeeze(-2),
+                    actual_seq_lengths_query=indexer_prefill_metadata.query_start_loc[1:],
+                    actual_seq_lengths_key=indexer_prefill_metadata.seq_lens,
+                    block_table=indexer_prefill_metadata.block_table,
+                    metadata=indexer_prefill_metadata.qli_metadata,
+                    query_quant_mode=0,
+                    key_quant_mode=0,
+                    layout_query="TND",
+                    layout_key="PA_BSND",
+                    sparse_count=self.index_topk,
+                    sparse_mode=3,
+                    pre_tokens=(1 << 63) - 1,
+                    next_tokens=(1 << 63) - 1,
+                    cmp_ratio=4,
+                    return_value=False,
+                )
+                if self.use_index_cache:
+                    self._update_indexcache_topk_indices(prefill_topk_idxs, offset=num_decode_tokens)
 
             # Sparse attention (prefill)
             prefill_attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -684,6 +684,25 @@ class DeepseekV4Attention(nn.Module):
                     prefix=f"{prefix}.indexer",
                 )
 
+        # IndexCache: decide whether this layer reuses topk from a previous
+        # indexer-bearing layer. Refer: https://arxiv.org/abs/2603.12201
+        # Only meaningful when this layer actually owns an Indexer (c4) and
+        # IndexCache is enabled via hf-overrides. MTP layers are excluded
+        # because spec_decode shares topk_indices_buffer at the model level
+        # only, leaving impl-level references stale.
+        skip_topk = False
+        if self.compress_ratio == 4 and getattr(config, "use_index_cache", False) and ".mtp." not in prefix:
+            compress_ratios = getattr(config, "compress_ratios", None) or []
+            indexer_seq_idx = sum(1 for r in compress_ratios[:config_layer_idx] if r == 4)
+            pattern = getattr(config, "index_topk_pattern", None)
+            freq = getattr(config, "index_topk_freq", 1)
+            if pattern is None:
+                skip_topk = max(indexer_seq_idx - 1, 0) % freq != 0
+            else:
+                assert pattern[0] == "F", "index_topk_pattern must start with 'F'"
+                if 0 <= indexer_seq_idx < len(pattern):
+                    skip_topk = pattern[indexer_seq_idx] == "S"
+
         dsa_modules = DSAModules(
             wq_a=self.wq_a,
             q_norm=self.q_norm,
@@ -696,6 +715,7 @@ class DeepseekV4Attention(nn.Module):
             indexer=self.indexer,
             compressor=self.compressor,
             topk_indices_buffer=topk_indices_buffer,
+            skip_topk=skip_topk,
         )
 
         self.dsa_attn = AscendDeepseekSparseAttention(
@@ -846,6 +866,10 @@ class DeepseekV4Model(nn.Module):
             )
         else:
             topk_indices_buffer = None
+
+        # Expose at model level so spec_decode/llm_base_proposer can share
+        # this buffer with the MTP draft via attribute replacement.
+        self.topk_indices_buffer = topk_indices_buffer
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -57,6 +57,7 @@ class DSAModules:
     compressor: torch.nn.Module | None
     topk_indices_buffer: torch.Tensor | None
     indexer_rotary_emb: torch.nn.Module | None = None
+    skip_topk: bool = False
 
 
 class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
@@ -109,6 +110,7 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
         self.compressor = dsa_modules.compressor
         self.topk_indices_buffer = dsa_modules.topk_indices_buffer
         self.indexer_rotary_emb = dsa_modules.indexer_rotary_emb
+        self.skip_topk = dsa_modules.skip_topk
         self.prefix = prefix
 
         ascend_device_type = get_ascend_device_type()
@@ -151,6 +153,8 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
             attn_sink=self.attn_sink,
             eps=self.eps,
             swa_cache_layer=self.swa_cache_layer,
+            skip_topk=self.skip_topk,
+            topk_indices_buffer=self.topk_indices_buffer,
         )
 
         compilation_config = get_current_vllm_config().compilation_config


### PR DESCRIPTION
## What this PR does

Implements **IndexCache** for DSA-based models (DeepSeek V4 / V4-Flash), which reuses `topk_indices` computed by `npu_quant_lightning_indexer` across decode steps instead of recomputing every step.

Key idea: in DSA (DeepSeek Sparse Attention), `npu_quant_lightning_indexer` selects the top-K KV blocks to attend to. For many layers, the selected indices are stable across consecutive decode steps — so we can skip the expensive indexer call and read a cached result instead.

Reference: arxiv 2603.12201 (IndexCache), Section 3.1.2

---

## Changes

### `vllm_ascend/attention/dsa_v1.py`
- `AscendDSAImpl.__init__`: accept `skip_topk` (bool) and `topk_indices_buffer` (Tensor) kwargs
- `_decode_forward`: add `skip_topk` branch — S-layers read cached indices, F-layers run indexer + write buffer
- `_prefill_forward`: prefill always recomputes; write result to buffer for subsequent reuse
- Add helpers: `_get_indexcache_topk_indices`, `_update_indexcache_topk_indices`

### `vllm_ascend/models/deepseek_v4.py`
- `DeepseekV2DecoderLayer.__init__`: compute per-layer `_skip_topk` from `use_index_cache` + `index_topk_freq` / `index_topk_pattern` in HF config
- `DeepseekV4Attention.__init__`: accept and forward `skip_topk` param

### `vllm_ascend/ops/dsa.py`
- `AscendDeepseekSparseAttention.__init__`: accept and store `skip_topk`, forward to `AscendDSAImpl` via kwargs

---

## Config

Enable via `hf_overrides` in `vllm serve`:

```bash
# freq-based: recompute every 4 layers, reuse the other 3
--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'

# pattern-based: explicit per-layer F/S string
--hf-overrides '{"use_index_cache": true, "index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSF"}'
```

---

## Performance (DeepSeek V4-Flash, Ascend 910B4, input 32K / output 1K)

| Concurrency | Throughput (tok/s) | TTFT (ms) | TPOT (ms) |
|---|---|---|---|
| Baseline (no IndexCache) | 1,423 | 6,182 | 186.4 |
| IndexCache (`index_topk_freq=4`) | **1,554 (+9.18%)** | 5,813 | 171.8 |

Accuracy (GPQA-diamond): −0.51 pt (within acceptable range)

---

## Test plan

- [x] Single-card smoke test: output matches baseline token-for-token with `use_index_cache=false`
- [x] Pattern `FFSFSSSFSS...` (hand-tuned): GPQA-diamond −0.51pt, throughput +9.18%
- [ ] Greedy pattern search (LM loss) on business calibration set — further accuracy/perf improvement expected

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3



---

Co-authored-by: wangzhao-11a <2638825065@qq.com>
Co-authored-by: yuefeng Wu <33725817+ChefWu551@users.noreply.github.com>
