### PR TITLE
[Feature][Model] Enable W4A8 per-channel GMM Swiglu quant

### DIFF
--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -49,6 +49,19 @@ class TestCumsumGroupList(unittest.TestCase):
                 self.assertIn("This feature is under development.", str(excinfo.exception))
 
 
+class TestW4A8RuntimeFlags(unittest.TestCase):
+    def test_w4a8_per_channel_gmm_swiglu_flag(self):
+        self.assertTrue(
+            MoEQuantParams(quant_type=QuantType.W4A8, is_per_channel_weight=True).use_w4a8_per_channel_gmm_swiglu
+        )
+        self.assertFalse(
+            MoEQuantParams(quant_type=QuantType.W4A8, is_per_channel_weight=False).use_w4a8_per_channel_gmm_swiglu
+        )
+        self.assertFalse(
+            MoEQuantParams(quant_type=QuantType.W8A8, is_per_channel_weight=True).use_w4a8_per_channel_gmm_swiglu
+        )
+
+
 class TestUnifiedApplyMlpRequest(unittest.TestCase):
     def test_request_unquant_path(self):
         hidden_states = torch.randn(2, 8)
@@ -134,6 +147,39 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                 self.assertEqual(quant_kwargs["weight_quant_type"], mxfp_dtype)
                 self.assertFalse(quant_kwargs["use_bf16"])
                 mock_unquant.assert_not_called()
+
+    def test_request_quant_path_passes_w4a8_per_channel_flag(self):
+        hidden_states = torch.randn(2, 8)
+        expected = torch.randn(2, 8)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=hidden_states,
+            group_list=torch.tensor([2, 2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=torch.randn(2, 1),
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=torch.randn(1, 16, 8),
+                w2=torch.randn(1, 8, 8),
+                w1_scale=[torch.randn(1, 16)],
+                w2_scale=[torch.randn(1, 8)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W4A8, is_per_channel_weight=True),
+            fusion=False,
+            activation="silu",
+            need_trans=False,
+            dynamic_eplb=False,
+        )
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertTrue(output is expected)
+        quant_kwargs = mock_quant.call_args.kwargs
+        self.assertTrue(quant_kwargs["use_w4a8_per_channel_gmm_swiglu"])
+        mock_unquant.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/ut/ops/test_token_dispatcher.py
+++ b/tests/ut/ops/test_token_dispatcher.py
@@ -33,6 +33,8 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import (
 
 from vllm_ascend.ops.fused_moe.token_dispatcher import (  # isort: skip
     AscendDeviceType,
+    EXPERT_TOKEN_NUMS_TYPE_COUNT,
+    EXPERT_TOKEN_NUMS_TYPE_CUMSUM,
     TokenDispatcherWithAll2AllV,
     TokenDispatcherWithAllGather,
     TokenDispatcherWithMC2,
@@ -55,6 +57,7 @@ def build_token_dispatch_input_fixture(
     quant_type: QuantType = QuantType.NONE,
     comm_quant_mode: int | None = None,
     act_quant_type: torch.dtype | None = None,
+    is_per_channel_weight: bool = False,
 ) -> MoETokenDispatchInput:
     mxfp_spec = None
     if quant_type in (QuantType.MXFP8, QuantType.MXFP4):
@@ -74,6 +77,7 @@ def build_token_dispatch_input_fixture(
             quant_type=quant_type,
             comm_quant_mode=comm_quant_mode,
             mxfp=mxfp_spec,
+            is_per_channel_weight=is_per_channel_weight,
         ),
     )
 
@@ -173,6 +177,48 @@ class TestTokenDispatcherWithMC2(TestBase):
             mock_dispatch.assert_called_once()
             self.assertEqual(output.group_list_type, 0)  # group_list_type == 0
             self.assertIsInstance(output.combine_metadata, MoEMC2CombineMetadata)
+
+    def test_w4a8_per_channel_dispatch_uses_count_group_list(self):
+        hidden_states = torch.randn(10, 128)
+        topk_weights = torch.randn(10, 1)
+        topk_ids = torch.randint(0, 8, (10, 1))
+        expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        self.dispatcher.enable_dispatch_v2 = True
+
+        token_dispatch_input = build_token_dispatch_input_fixture(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+            quant_type=QuantType.W4A8,
+            is_per_channel_weight=True,
+        )
+        with patch(
+            "torch_npu.npu_moe_distribute_dispatch_v2", return_value=(torch.randn(10, 128),) * 5 + (None, None)
+        ) as mock_dispatch:
+            output = self.dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+        mock_dispatch.assert_called_once()
+        self.assertEqual(mock_dispatch.call_args.kwargs["expert_token_nums_type"], EXPERT_TOKEN_NUMS_TYPE_COUNT)
+        self.assertEqual(output.group_list_type, EXPERT_TOKEN_NUMS_TYPE_COUNT)
+
+    def test_w4a8_group_dispatch_keeps_prefix_sum_group_list(self):
+        hidden_states = torch.randn(10, 128)
+        topk_weights = torch.randn(10, 1)
+        topk_ids = torch.randint(0, 8, (10, 1))
+        expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+
+        token_dispatch_input = build_token_dispatch_input_fixture(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+            quant_type=QuantType.W4A8,
+            is_per_channel_weight=False,
+        )
+        kwargs = self.dispatcher.get_dispatch_mc2_kwargs(token_dispatch_input)
+
+        self.assertEqual(kwargs["expert_token_nums_type"], EXPERT_TOKEN_NUMS_TYPE_CUMSUM)
 
     def test_get_combine_mc_kwargs_with_quant(self):
         hidden_states = torch.randn(10, 128)

--- a/tests/ut/quantization/methods/test_w4a8.py
+++ b/tests/ut/quantization/methods/test_w4a8.py
@@ -261,9 +261,8 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
 
     @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
-    @patch("torch.Tensor.npu")
-    def test_process_weights_after_loading(self, mock_npu, mock_npu_quantize, mock_npu_format_cast):
-        mock_npu.return_value = torch.Tensor()
+    @patch("torch.Tensor.npu", new=lambda self: self)
+    def test_process_weights_after_loading(self, mock_npu_quantize, mock_npu_format_cast):
         mock_npu_quantize.return_value = torch.Tensor()
         mock_npu_format_cast.side_effect = identity
         # old quant version weight
@@ -287,6 +286,7 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         per_channel_layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
         self.quant_method.process_weights_after_loading(per_channel_layer)
         self.assertEqual(new_layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(per_channel_layer.w13_weight_scale.data.shape, (self.experts, 2 * self.input_size))
 
     def test_get_weight_compressed_tensors(self):
         self.quant_method.quant_method = COMPRESSED_TENSORS_METHOD
@@ -327,6 +327,7 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         top_k = 2
 
         layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
+        self.quant_method.is_per_channel_weight = True
         layer.swiglu_limit = 1000000
         x = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
         router_logits = torch.randn(tokens, num_experts, dtype=torch.float32)
@@ -384,6 +385,7 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         build_kwargs = mock_build_input.call_args.kwargs
         self.assertTrue(torch.equal(build_kwargs["hidden_states"], x))
         self.assertEqual(build_kwargs["quant_type"], self.quant_method.quant_type)
+        self.assertTrue(build_kwargs["is_per_channel_weight"])
         self.assertEqual(build_kwargs["activation"], "silu")
         self.assertEqual(build_kwargs["apply_router_weight_on_input"], False)
 

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -102,6 +102,7 @@ def quant_apply_mlp(
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
     swiglu_limit: int = 0,
+    use_w4a8_per_channel_gmm_swiglu: bool = False,
 ) -> torch.Tensor:
     input_hidden_dtype = hidden_states.dtype
     use_gmm_swiglu_quant_fusion = use_mxfp_quant or (fusion and not dynamic_eplb)
@@ -250,7 +251,19 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if _custom_gmm_swiglu_enabled(fusion, dynamic_eplb) and not use_mxfp_quant:
+        if use_w4a8_per_channel_gmm_swiglu and enable_custom_op():
+            hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
+                x=hidden_states,
+                weight=w1,
+                weight_scale=w1_scale if isinstance(w1_scale, list) else [w1_scale],
+                x_scale=pertoken_scale,
+                group_list=group_list,
+                weight_assist_matrix=bias1,
+                dequant_mode=0,
+                group_list_type=group_list_type,
+                swiglu_limit=swiglu_limit,
+            )
+        elif _custom_gmm_swiglu_enabled(fusion, dynamic_eplb) and not use_mxfp_quant:
             # gmm1: gate_up_proj & act_fn: swiglu
             hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
                 x=hidden_states,
@@ -450,4 +463,5 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         per_token_scale_type=per_token_scale_type,
         use_bf16=use_bf16,
         swiglu_limit=swiglu_limit,
+        use_w4a8_per_channel_gmm_swiglu=mlp_compute_input.quant.use_w4a8_per_channel_gmm_swiglu,
     )

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -138,6 +138,7 @@ def build_fused_experts_input(
     mxfp_scale_dtype: torch.dtype | None = None,
     mxfp_per_token_scale_dtype: torch.dtype | None = None,
     mxfp_use_bf16: bool | None = None,
+    is_per_channel_weight: bool = False,
     w1_scale: list[torch.Tensor] | torch.Tensor | None = None,
     w2_scale: list[torch.Tensor] | torch.Tensor | None = None,
     w1_scale_bias: list[torch.Tensor] | torch.Tensor | None = None,
@@ -184,6 +185,7 @@ def build_fused_experts_input(
                 mxfp_per_token_scale_dtype=mxfp_per_token_scale_dtype,
                 mxfp_use_bf16=mxfp_use_bf16,
             ),
+            is_per_channel_weight=is_per_channel_weight,
         ),
         swiglu_limit=swiglu_limit,
     )

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -61,6 +61,7 @@ class MoEQuantParams:
     quant_type: QuantType = QuantType.NONE
     comm_quant_mode: int | None = None
     mxfp: MoEMxfpParams | None = None
+    is_per_channel_weight: bool = False
 
     @property
     def is_quant(self) -> bool:
@@ -73,6 +74,10 @@ class MoEQuantParams:
     @property
     def is_int_quant(self) -> bool:
         return self.quant_type in (QuantType.W8A8, QuantType.W4A8)
+
+    @property
+    def use_w4a8_per_channel_gmm_swiglu(self) -> bool:
+        return self.quant_type == QuantType.W4A8 and self.is_per_channel_weight
 
     @property
     def dispatch_with_quant(self) -> bool:

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -47,6 +47,17 @@ from vllm_ascend.utils import (
     should_skip_allreduce_across_dp_group,
 )
 
+EXPERT_TOKEN_NUMS_TYPE_CUMSUM = 0
+EXPERT_TOKEN_NUMS_TYPE_COUNT = 1
+
+
+def _get_expert_token_nums_type(token_dispatch_input: MoETokenDispatchInput) -> int:
+    # grouped_matmul_swiglu_quant_v2 consumes per-expert counts; existing
+    # MC2 grouped-matmul paths consume prefix sums.
+    if token_dispatch_input.quant.use_w4a8_per_channel_gmm_swiglu:
+        return EXPERT_TOKEN_NUMS_TYPE_COUNT
+    return EXPERT_TOKEN_NUMS_TYPE_CUMSUM
+
 
 class MoETokenDispatcher(ABC, Generic[TMoECombineMetadata]):
     def __init__(self, **kwargs) -> None:
@@ -161,6 +172,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         else:
             quant_mode = 0
         self.moe_expert_num = len(expert_map) + global_redundant_expert_num
+        expert_token_nums_type = _get_expert_token_nums_type(token_dispatch_input)
         kwargs_mc2 = {
             "x": hidden_states,
             "expert_ids": topk_ids,
@@ -168,7 +180,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             "shared_expert_rank_num": 0,
             "moe_expert_num": self.moe_expert_num,
             "global_bs": self.global_bs,
-            "expert_token_nums_type": 0,
+            "expert_token_nums_type": expert_token_nums_type,
         }
         if self.global_bs == 0:
             kwargs_mc2["x_active_mask"] = token_dispatch_input.routing.mc2_mask
@@ -240,7 +252,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         if not token_dispatch_input.quant.dispatch_with_quant:
             dynamic_scale = None
 
-        group_list_type = 0
+        group_list_type = kwargs_mc2["expert_token_nums_type"]
         return MoETokenDispatchOutput(
             hidden_states=expand_x,
             dynamic_scale=dynamic_scale,

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -424,6 +424,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w2_scale=w2_scale,
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
+                is_per_channel_weight=self.is_per_channel_weight,
                 swiglu_limit=layer.swiglu_limit,
             )
         )
@@ -481,6 +482,12 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 weight.to(torch.float32), torch.tensor([1.0]).npu(), None, torch.quint4x2, -1, False
             )
 
+    @staticmethod
+    def maybe_squeeze_per_channel_weight_scale(scale: torch.Tensor) -> torch.Tensor:
+        if scale.dim() > 1 and scale.shape[1] == 1:
+            return scale.squeeze(1)
+        return scale
+
     def process_weights_after_loading(self, layer):
         if self.quant_method == COMPRESSED_TENSORS_METHOD:
             self.process_weights_after_loading_compressed_tensors(layer)
@@ -496,6 +503,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             scale_np = scale.cpu().numpy()
             scale_np.dtype = np.uint32
             scale_uint64_tensor = torch.from_numpy(scale_np.astype(np.int64)).npu()
+            if self.is_per_channel_weight:
+                return self.maybe_squeeze_per_channel_weight_scale(scale_uint64_tensor)
             return scale_uint64_tensor
 
         def update_bias_compressed_tensors(weight: torch.Tensor, scale: torch.Tensor, strategy: str):
@@ -559,6 +568,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
 
         self.update_bias(layer, w13_bias, w2_bias)
 
+        if self.is_per_channel_weight:
+            layer.w13_weight_scale.data = self.maybe_squeeze_per_channel_weight_scale(layer.w13_weight_scale.data)
         layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
         layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables the custom `grouped_matmul_swiglu_quant_v2` path for the W4A8 per-channel MoE scenario.

- Carries `is_per_channel_weight` through the fused MoE runtime metadata.
- Uses `grouped_matmul_swiglu_quant_v2` only when the path is W4A8 + per-channel weight + custom ops enabled.
- Keeps grouped W4A8 and W8A8 on the existing grouped-matmul paths.
- Uses count-style MC2 `expert_token_nums` only for the W4A8 per-channel GMM path.
- Adjusts W4A8 per-channel `w13_weight_scale` to the `[E, N]` / `[N]` shape expected by the op.

This intentionally does not include the storage-shape helper torch bindings from the source commit.

### Does this PR introduce _any_ user-facing change?

No. This adds an internal W4A8 MoE execution path and does not expose a user-facing API or interface change.

### How was this patch tested?

- `python -m py_compile vllm_ascend/ops/fused_moe/moe_stage_params.py vllm_ascend/ops/fused_moe/moe_runtime_args.py vllm_ascend/ops/fused_moe/token_dispatcher.py vllm_ascend/ops/fused_moe/moe_mlp.py vllm_ascend/quantization/methods/w4a8.py tests/ut/ops/test_moe_mlp.py tests/ut/ops/test_token_dispatcher.py tests/ut/quantization/methods/test_w4a8.py`
- `uvx ruff check ...`
- `uvx ruff format --check ...`

`pytest` was not runnable in this local worktree because the Python environment is missing project runtime dependencies such as `numpy`, `torch`, `torch_npu`, and `vllm`.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3