### PR TITLE
[Feature][Model] Switch DeepSeekV4 hc_pre to fused op

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1479,6 +1479,14 @@ at::Tensor npu_hc_post_npu(
     return out;
 }
 
+constexpr int64_t HC_PRE_HC_LIMIT = 4;
+constexpr int64_t HC_PRE_D_LIMIT = 4096;
+constexpr int64_t HC_PRE_D_LIMIT_EXTEND = 7168;
+constexpr int64_t HC_PRE_MIX_HC_LIMIT = 24;
+constexpr int64_t HC_PRE_FUSION_BASE_BS = 8192;
+constexpr int64_t HC_PRE_FUSION_SPLIT_K_MAX_BS = 512;
+constexpr const char* ASCEND_950_PREFIX = "Ascend950";
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor> construct_hc_pre_output_tensor(const at::Tensor& x, int64_t hc_mult)
 {
     auto xDims = x.dim();
@@ -1541,20 +1549,21 @@ void check_hc_pre_shape_and_dtype(
 
     auto hc = x_dims == 4 ? x.size(2) : x.size(1);
     auto d = x_dims == 4 ? x.size(3) : x.size(2);
-    TORCH_CHECK(hc == hc_mult, "The hc of x should be equal to hc_mult, actual hc is ", hc,
-                ", hc_mult is ", hc_mult, ".");
-    auto hc_mix = (2 + hc_mult) * hc_mult;
+    TORCH_CHECK(hc_mult == HC_PRE_HC_LIMIT, "hc_mult only supports ", HC_PRE_HC_LIMIT, ", actual ", hc_mult, ".");
+    TORCH_CHECK(hc == HC_PRE_HC_LIMIT, "The hc of x only supports ", HC_PRE_HC_LIMIT, ", actual ", hc, ".");
+    TORCH_CHECK(d == HC_PRE_D_LIMIT || d == HC_PRE_D_LIMIT_EXTEND, "The d of x only supports ", HC_PRE_D_LIMIT,
+                " or ", HC_PRE_D_LIMIT_EXTEND, ", actual ", d, ".");
     TORCH_CHECK(hc_fn.dim() == 2, "Input tensor hc_fn's dim num should be 2, actual ", hc_fn.dim(), ".");
-    TORCH_CHECK(hc_fn.size(0) == hc_mix, "The hc_fn.shape[0] should be (2 + hc_mult) * hc_mult, actual ",
-                hc_fn.size(0), ", expected ", hc_mix, ".");
+    TORCH_CHECK(hc_fn.size(0) == HC_PRE_MIX_HC_LIMIT, "The hc_fn.shape[0] only supports ",
+                HC_PRE_MIX_HC_LIMIT, ", actual ", hc_fn.size(0), ".");
     TORCH_CHECK(hc_fn.size(1) == hc * d, "The hc_fn.shape[1] should be hc * d, actual hc_fn.shape[1] is ",
                 hc_fn.size(1), ", hc is ", hc, ", d is ", d, ".");
     TORCH_CHECK(hc_scale.dim() == 1, "Input tensor hc_scale's dim num should be 1, actual ", hc_scale.dim(), ".");
     TORCH_CHECK(hc_scale.size(0) == HC_SCALE_SIZE, "Input tensor hc_scale's shape should be [", HC_SCALE_SIZE,
                 "], actual [", hc_scale.size(0), "].");
     TORCH_CHECK(hc_base.dim() == 1, "Input tensor hc_base's dim num should be 1, actual ", hc_base.dim(), ".");
-    TORCH_CHECK(hc_base.size(0) == hc_mix, "The hc_base.shape[0] should be (2 + hc_mult) * hc_mult, actual ",
-                hc_base.size(0), ", expected ", hc_mix, ".");
+    TORCH_CHECK(hc_base.size(0) == HC_PRE_MIX_HC_LIMIT, "The hc_base.shape[0] only supports ",
+                HC_PRE_MIX_HC_LIMIT, ", actual ", hc_base.size(0), ".");
 
     TORCH_CHECK(x.dtype() == at::kBFloat16, "x's dtype should be BFLOAT16.");
     TORCH_CHECK(hc_fn.dtype() == at::kFloat, "hc_fn's dtype should be FLOAT32.");
@@ -1562,12 +1571,33 @@ void check_hc_pre_shape_and_dtype(
     TORCH_CHECK(hc_base.dtype() == at::kFloat, "hc_base's dtype should be FLOAT32.");
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_npu(
+int64_t get_hc_pre_batch_size(const at::Tensor& x)
+{
+    if (x.dim() == 4) {
+        return x.size(0) * x.size(1);
+    }
+    return x.size(0);
+}
+
+bool is_ascend950()
+{
+    static const char* soc_name = aclrtGetSocName();
+    return soc_name != nullptr && std::string(soc_name).find(ASCEND_950_PREFIX) == 0;
+}
+
+bool should_use_hc_pre_fusion(const at::Tensor& x)
+{
+    if (!is_ascend950()) {
+        return true;
+    }
+    auto bs = get_hc_pre_batch_size(x);
+    return bs <= HC_PRE_FUSION_SPLIT_K_MAX_BS || bs % HC_PRE_FUSION_BASE_BS == 0;
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> run_hc_pre_composite(
     const at::Tensor& x, const at::Tensor& hc_fn, const at::Tensor& hc_scale, const at::Tensor& hc_base,
     int64_t hc_mult, int64_t hc_sinkhorn_iters, double norm_eps, double hc_eps)
 {
-    check_hc_pre_shape_and_dtype(x, hc_fn, hc_scale, hc_base, hc_mult);
-
     auto xDims = x.dim();
     auto rsqrt = construct_hc_pre_rsqrt_output_tensor(x, norm_eps);
     EXEC_NPU_CMD(aclnnHcPreInvRms, x, norm_eps, rsqrt);
@@ -1591,12 +1621,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_npu(
     return std::tuple<at::Tensor, at::Tensor, at::Tensor>(y, post, comb_frag);
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_v2_npu(
+std::tuple<at::Tensor, at::Tensor, at::Tensor> run_hc_pre_fusion(
     const at::Tensor& x, const at::Tensor& hc_fn, const at::Tensor& hc_scale, const at::Tensor& hc_base,
     int64_t hc_mult, int64_t hc_sinkhorn_iters, double norm_eps, double hc_eps)
 {
-    check_hc_pre_shape_and_dtype(x, hc_fn, hc_scale, hc_base, hc_mult);
-
     auto output_tensors = construct_hc_pre_output_tensor(x, hc_mult);
     at::Tensor y = std::get<0>(output_tensors);
     at::Tensor post = std::get<1>(output_tensors);
@@ -1605,6 +1633,25 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_v2_npu(
                  y, post, comb_frag);
 
     return std::tuple<at::Tensor, at::Tensor, at::Tensor>(y, post, comb_frag);
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_npu(
+    const at::Tensor& x, const at::Tensor& hc_fn, const at::Tensor& hc_scale, const at::Tensor& hc_base,
+    int64_t hc_mult, int64_t hc_sinkhorn_iters, double norm_eps, double hc_eps)
+{
+    check_hc_pre_shape_and_dtype(x, hc_fn, hc_scale, hc_base, hc_mult);
+    return run_hc_pre_composite(x, hc_fn, hc_scale, hc_base, hc_mult, hc_sinkhorn_iters, norm_eps, hc_eps);
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_hc_pre_v2_npu(
+    const at::Tensor& x, const at::Tensor& hc_fn, const at::Tensor& hc_scale, const at::Tensor& hc_base,
+    int64_t hc_mult, int64_t hc_sinkhorn_iters, double norm_eps, double hc_eps)
+{
+    check_hc_pre_shape_and_dtype(x, hc_fn, hc_scale, hc_base, hc_mult);
+    if (!should_use_hc_pre_fusion(x)) {
+        return run_hc_pre_composite(x, hc_fn, hc_scale, hc_base, hc_mult, hc_sinkhorn_iters, norm_eps, hc_eps);
+    }
+    return run_hc_pre_fusion(x, hc_fn, hc_scale, hc_base, hc_mult, hc_sinkhorn_iters, norm_eps, hc_eps);
 }
 
 at::Tensor construct_hc_pre_inv_rms_output_tensor(const at::Tensor& x, float epsilon=1e-20)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py
@@ -1,0 +1,65 @@
+import gc
+
+import torch
+import torch_npu
+
+from vllm_ascend.utils import enable_custom_op
+
+torch_npu.npu.config.allow_internal_format = True
+enable_custom_op()
+
+HC_MULT = 4
+HIDDEN_SIZE = 4096
+MIX_HC = 24
+HC_SINKHORN_ITERS = 20
+NORM_EPS = 1e-6
+HC_EPS = 1e-6
+
+
+def _make_hc_pre_inputs(shape: tuple[int, ...]):
+    torch.manual_seed(1024)
+    x = torch.randn(shape, dtype=torch.bfloat16, device="npu")
+    hc_fn = (
+        torch.randn(
+            MIX_HC,
+            HC_MULT * HIDDEN_SIZE,
+            dtype=torch.float32,
+            device="npu",
+        )
+        * 0.01
+    )
+    hc_scale = torch.randn(3, dtype=torch.float32, device="npu") * 0.01
+    hc_base = torch.randn(MIX_HC, dtype=torch.float32, device="npu") * 0.01
+    return x, hc_fn, hc_scale, hc_base
+
+
+def _compare_hc_pre_outputs(shape: tuple[int, ...]):
+    x, hc_fn, hc_scale, hc_base = _make_hc_pre_inputs(shape)
+    expected = torch.ops._C_ascend.npu_hc_pre(x, hc_fn, hc_scale, hc_base, HC_MULT, HC_SINKHORN_ITERS, NORM_EPS, HC_EPS)
+    actual = torch.ops._C_ascend.npu_hc_pre_v2(
+        x, hc_fn, hc_scale, hc_base, HC_MULT, HC_SINKHORN_ITERS, NORM_EPS, HC_EPS
+    )
+
+    for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            actual_tensor.cpu(),
+            expected_tensor.cpu(),
+            atol=5e-2,
+            rtol=5e-2,
+        )
+
+
+@torch.inference_mode()
+def test_npu_hc_pre_v1_v2_bf16_3d_input():
+    _compare_hc_pre_outputs((2, HC_MULT, HIDDEN_SIZE))
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@torch.inference_mode()
+def test_npu_hc_pre_v1_v2_bf16_4d_input():
+    _compare_hc_pre_outputs((1, 2, HC_MULT, HIDDEN_SIZE))
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -786,7 +786,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
 
     def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_pre(
+        y = torch.ops._C_ascend.npu_hc_pre_v2(
             x, hc_fn, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.norm_eps, self.hc_eps
         )
         return y


### PR DESCRIPTION
### What this PR does / why we need it?

This PR switches DeepSeekV4 `hc_pre` from the composite small-op path to the `aclnnHcPre`-backed `npu_hc_pre_v2` interface.

It also aligns the runtime `hc_pre` torch binding contract with the CANN recipe binding while leaving the Meta implementation as shape inference only, so torch compile does not trip over runtime-only checks:

- `x` must be 3D or 4D BF16
- `hc_mult` / `hc` must be 4
- `d` must be 4096 or 7168
- `hc_fn` must be `[24, hc * d]`
- `hc_scale` must be `[3]`
- `hc_base` must be `[24]`
- non-`x` tensors must be FP32

For Ascend950, `npu_hc_pre_v2` follows the CANN recipe's batch filter and falls back to the composite path when `bs > 512` and `bs` is not aligned to 8192. Other SoCs continue to use the fused path.

Reference: https://gitcode.com/cann/cann-recipes-infer/blob/master/ops/ascendc/torch_ops_extension/custom_ops/csrc/npu_hc_pre.cpp

### Does this PR introduce _any_ user-facing change?

No public API change. DeepSeekV4 internally uses the fused `hc_pre` interface when supported, with the existing composite implementation kept as fallback.

### How was this patch tested?

- `PATH="$HOME/Library/Python/3.9/bin:$PATH" bash format.sh ci`
- `python3 -m py_compile vllm_ascend/models/deepseek_v4.py tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py`
- `bash -n csrc/build_aclnn.sh`
- `git diff --check`

Added `tests/e2e/nightly/single_node/ops/singlecard_ops/test_npu_hc_pre.py` to compare `npu_hc_pre` and `npu_hc_pre_v2` on 3D and 4D BF16 inputs. Local NPU runtime execution was not run from this macOS workspace.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
