### PR TITLE
[CI] set `MAX_JOBS` for vllm-ascend install in workflows

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -407,6 +407,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "46"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -535,6 +537,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "46"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -720,6 +724,8 @@ jobs:
           pip show mooncake-transfer-engine-ascend || true
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "92"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -847,6 +853,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_a3 }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "92"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -974,6 +982,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_310p }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "23"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
@@ -1084,6 +1094,8 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-${{ inputs.image_310p }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend
+        env:
+          MAX_JOBS: "92"
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt

--- a/.github/workflows/_optional_smart_e2e.yaml
+++ b/.github/workflows/_optional_smart_e2e.yaml
@@ -121,10 +121,10 @@ jobs:
             vllm-ascend-build-v1-${{ runner.os }}-swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.group.image_tag }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
       - name: Install vllm-project/vllm-ascend with device
-        env:
-          MAX_JOBS: 23
         if: ${{ steps.check_npu.outputs.has_npu == 'true' }}
         run: |
+          export MAX_JOBS=$(( ${{ matrix.group.num_npus }} * 23 ))
+          
           pip install uc-manager
           uv pip install -r requirements-dev.txt
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1


### PR DESCRIPTION
### What this PR does / why we need it?

- Add `MAX_JOBS` to the step "Install vllm-project/vllm-ascend" in the workflow to control parallel compilation capacity and prevent OOM during compilation.

- Calculation rule for `MAX_JOBS`: Number of CPU cores × Number of NPU cards

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
