### PR TITLE
[Ops][BugFix] Add mutual exclusion check for BalanceScheduler and RecomputeScheduler

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -535,6 +535,7 @@ class TestNPUPlatform(TestBase):
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = False
+        mock_ascend_config.enable_balance_scheduling = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -551,8 +552,7 @@ class TestNPUPlatform(TestBase):
         self.platform = platform.NPUPlatform()
 
         with (
-            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
-            pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"),
+            pytest.raises(ValueError, match=r"enable_balance_scheduling.*PD-mixed.*PD-disaggregated"),
             patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
             patch.object(platform, "check_kv_extra_config"),
         ):
@@ -567,6 +567,7 @@ class TestNPUPlatform(TestBase):
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
         mock_ascend_config.recompute_scheduler_enable = False
+        mock_ascend_config.enable_balance_scheduling = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -583,8 +584,7 @@ class TestNPUPlatform(TestBase):
         self.platform = platform.NPUPlatform()
 
         with (
-            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
-            pytest.raises(ValueError, match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*PD-mixed.*PD-disaggregated"),
+            pytest.raises(ValueError, match=r"enable_balance_scheduling.*PD-mixed.*PD-disaggregated"),
             patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
             patch.object(platform, "check_kv_extra_config"),
         ):
@@ -786,3 +786,68 @@ class TestNPUPlatform(TestBase):
             self.platform.get_static_graph_wrapper_cls(),
             "vllm_ascend.compilation.acl_graph.ACLGraphWrapper",
         )
+
+    def test_balance_scheduler_and_recompute_scheduler_mutex_check(self):
+        """Test that BalanceScheduler and RecomputeScheduler cannot be enabled simultaneously."""
+        from vllm_ascend.ascend_config import init_ascend_config
+
+        # Mock vllm_config with both schedulers enabled
+        mock_vllm_config = self.mock_vllm_config()
+        mock_vllm_config.additional_config = {
+            "enable_balance_scheduling": True,
+            "recompute_scheduler_enable": True,
+        }
+
+        # Should raise ValueError when both are enabled
+        with self.assertRaises(ValueError) as context:
+            with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
+                mock_ascend_config = self.mock_vllm_ascend_config()
+                mock_ascend_config.enable_balance_scheduling = True
+                mock_ascend_config.recompute_scheduler_enable = True
+                mock_init.return_value = mock_ascend_config
+
+                self.platform.check_and_update_config(mock_vllm_config)
+
+        self.assertIn("cannot be enabled simultaneously", str(context.exception))
+
+    def test_balance_scheduler_alone_works(self):
+        """Test that BalanceScheduler alone works fine."""
+        mock_vllm_config = self.mock_vllm_config()
+        mock_vllm_config.additional_config = {
+            "enable_balance_scheduling": True,
+        }
+
+        with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
+            mock_ascend_config = self.mock_vllm_ascend_config()
+            mock_ascend_config.enable_balance_scheduling = True
+            mock_ascend_config.recompute_scheduler_enable = False
+            mock_init.return_value = mock_ascend_config
+
+            # Should not raise any error
+            try:
+                self.platform.check_and_update_config(mock_vllm_config)
+            except ValueError as e:
+                # Only fail if it's the mutex check error
+                if "cannot be enabled simultaneously" in str(e):
+                    self.fail("BalanceScheduler alone should not raise mutex error")
+
+    def test_recompute_scheduler_alone_works(self):
+        """Test that RecomputeScheduler alone works fine."""
+        mock_vllm_config = self.mock_vllm_config()
+        mock_vllm_config.additional_config = {
+            "recompute_scheduler_enable": True,
+        }
+
+        with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
+            mock_ascend_config = self.mock_vllm_ascend_config()
+            mock_ascend_config.enable_balance_scheduling = False
+            mock_ascend_config.recompute_scheduler_enable = True
+            mock_init.return_value = mock_ascend_config
+
+            # Should not raise any error
+            try:
+                self.platform.check_and_update_config(mock_vllm_config)
+            except ValueError as e:
+                # Only fail if it's the mutex check error
+                if "cannot be enabled simultaneously" in str(e):
+                    self.fail("RecomputeScheduler alone should not raise mutex error")

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import os
+from importlib import import_module, util
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -30,8 +31,9 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
-import vllm_ascend.envs as envs_ascend
-from vllm_ascend.ascend_config import init_ascend_config
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
 # isort: off
 from vllm_ascend.utils import (
@@ -377,11 +379,24 @@ class NPUPlatform(Platform):
         if compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
             compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
-        # encoder-decoder models currently only support piecewise mode
-        if model_config and model_config.is_encoder_decoder is True:
-            if compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY:
-                logger.warning("encoder-decoder model doesn't support FULL_DECODE_ONLY, fallback to PIECEWISE ")
-            compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+        # Encoder-decoder models currently only support PIECEWISE mode
+        # TODO(Jian Li): Confirm this behavior and explain why
+        if (
+            model_config
+            and model_config.is_encoder_decoder
+            and compilation_config.cudagraph_mode not in (CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE)
+        ):
+            cudagraph_mode = (
+                CUDAGraphMode.PIECEWISE
+                if compilation_config.mode == CompilationMode.VLLM_COMPILE
+                else CUDAGraphMode.NONE
+            )
+            logger.info_once(
+                "Encoder-decoder models don't support %s, fallback to %s.",
+                compilation_config.cudagraph_mode,
+                cudagraph_mode,
+            )
+            compilation_config.cudagraph_mode = cudagraph_mode
 
         # get custom compile backend for graph fusion
         compilation_config.oot_compiler = cls.get_compile_backend()
@@ -471,12 +486,24 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
-        if envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING:
+        # NOTE: BalanceScheduler and RecomputeScheduler must not be enabled simultaneously.
+        # In PD disaggregation mode with multi-DP MoE, enabling both schedulers can cause
+        # MoE communication type mismatch across DP ranks (some perform All2AllV, others MC2),
+        # leading to AlltoAll deadlock. See https://github.com/vllm-project/vllm-ascend/issues/8975
+        if ascend_config.enable_balance_scheduling and ascend_config.recompute_scheduler_enable:
+            raise ValueError(
+                "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) and recompute_scheduler_enable "
+                "cannot be enabled simultaneously. This combination causes MoE communication type "
+                "mismatch across DP ranks in PD disaggregation mode, leading to AlltoAll deadlock. "
+                "Please disable one of them."
+            )
+
+        if ascend_config.enable_balance_scheduling:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is not None and kv_role != "kv_both":
                 raise ValueError(
-                    "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) only supports PD-mixed mode "
+                    "enable_balance_scheduling only supports PD-mixed mode "
                     "(kv_role='kv_both' or no kv_transfer_config), and is not supported in "
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
@@ -565,7 +592,7 @@ class NPUPlatform(Platform):
             os.environ["PYTORCH_NPU_ALLOC_CONF"] = npu_alloc_configs
             logger.info("Set PYTORCH_NPU_ALLOC_CONF=%s", npu_alloc_configs)
 
-        if ascend_config.enable_mc2_hierarchy_comm and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2:
+        if ascend_config.enable_mc2_hierarchy_comm and get_ascend_config().enable_fused_mc2:
             raise ValueError(
                 "fused mc2 op cannot be used with hierarchy communication."
                 "Please disable VLLM_ASCEND_ENABLE_FUSED_MC2 by setting it to 0."
@@ -589,12 +616,17 @@ class NPUPlatform(Platform):
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, attn_selector_config, num_heads: int | None = None):
+        use_compress = getattr(attn_selector_config, "use_compress", False)
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
 
+        if selected_backend == AttentionBackendEnum.FLASH_ATTN and cls._validate_fa3_backend(key, attn_selector_config):
+            return "vllm_ascend.attention.fa3_v1.AscendFABackend"
+
         backend_map = {
-            (True, False): "vllm_ascend.attention.mla_v1.AscendMLABackend",
-            (False, False): "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
-            (True, True): "vllm_ascend.attention.sfa_v1.AscendSFABackend",
+            (True, False, False): "vllm_ascend.attention.mla_v1.AscendMLABackend",
+            (False, False, False): "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
+            (True, True, False): "vllm_ascend.attention.sfa_v1.AscendSFABackend",
+            (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSABackend",
         }
         backend_map_310 = {
             (
@@ -609,7 +641,34 @@ class NPUPlatform(Platform):
         if is_310p():
             return backend_map_310.get(key, backend_map_310[(False, False)])
 
-        return backend_map[key]
+        return backend_map[(attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)]
+
+    @classmethod
+    def _validate_fa3_backend(cls, key, attn_selector_config):
+        if not attn_selector_config.use_batch_invariant:
+            logger.info(
+                "FA3 will not be enabled when not in training-inference consistency scenario. "
+                "Note that Ascend NPU will use its registered plugin backend instead."
+            )
+            return False
+        if key != (False, False):
+            raise ValueError("FA3 backend does not support MLA and SFA.")
+        if util.find_spec("flash_attn_npu_v3") is None:
+            raise ValueError(
+                "flash_attn_npu_v3 is not installed but FA3 backend is requested. "
+                "Please install flash_attn_npu_v3 to enable FA3."
+            )
+        mod = import_module("flash_attn_npu_v3")
+        if not hasattr(mod, "flash_attn_with_kvcache"):
+            raise ValueError(
+                "flash_attn_npu_v3 is installed but does not provide "
+                "flash_attn_with_kvcache. Please check flash_attn_npu_v3 "
+                "whether it supports flash_attn_with_kvcache."
+            )
+        logger.info(
+            "In training-inference consistency scenario, FA3 will be enabled, which may cause performance degradation."
+        )
+        return True
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
@@ -900,8 +959,13 @@ class NPUPlatform(Platform):
                 )
                 att_config.flash_attn_version = None
 
-            # Notify user that the backend will be managed by Ascend plugins
-            if getattr(att_config, "backend", None) is not None:
+            # Notify user that the backend will be managed by Ascend plugins,
+            # and for training-inference consistency, when att_config.backend
+            # == AttentionBackendEnum.FLASH_ATTN,it is NOT reset to None
+            if (
+                getattr(att_config, "backend", None) is not None
+                and att_config.backend != AttentionBackendEnum.FLASH_ATTN
+            ):
                 logger.info(
                     "User specified attention backend '%s'. Note that Ascend NPU "
                     "will use its registered plugin backend instead. Resetting to None.",


### PR DESCRIPTION
## Summary

- Add mutex check to prevent deadlock when both schedulers are enabled
- BalanceScheduler and RecomputeScheduler must not be enabled simultaneously
- In PD disaggregation mode with multi-DP MoE, enabling both schedulers can cause MoE communication type mismatch across DP ranks (some perform All2AllV, others MC2), leading to AlltoAll deadlock

## Changes

1. Add mutual exclusion check in `platform.py`
2. Add unit tests for the check

## Test Plan

- Unit tests added in `tests/ut/test_platform.py`
- All tests pass locally

Fixes #8975
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
