### PR TITLE
[Ops][BugFix] Add mutual exclusion check for BalanceScheduler and RecomputeScheduler

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -786,3 +786,68 @@ class TestNPUPlatform(TestBase):
             self.platform.get_static_graph_wrapper_cls(),
             "vllm_ascend.compilation.acl_graph.ACLGraphWrapper",
         )
+
+    def test_balance_scheduler_and_recompute_scheduler_mutex_check(self):
+        """Test that BalanceScheduler and RecomputeScheduler cannot be enabled simultaneously."""
+        from vllm_ascend.ascend_config import init_ascend_config
+
+        # Mock vllm_config with both schedulers enabled
+        mock_vllm_config = self.mock_vllm_config()
+        mock_vllm_config.additional_config = {
+            "enable_balance_scheduling": True,
+            "recompute_scheduler_enable": True,
+        }
+
+        # Should raise ValueError when both are enabled
+        with self.assertRaises(ValueError) as context:
+            with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
+                mock_ascend_config = self.mock_vllm_ascend_config()
+                mock_ascend_config.enable_balance_scheduling = True
+                mock_ascend_config.recompute_scheduler_enable = True
+                mock_init.return_value = mock_ascend_config
+
+                self.platform.check_and_update_config(mock_vllm_config)
+
+        self.assertIn("cannot be enabled simultaneously", str(context.exception))
+
+    def test_balance_scheduler_alone_works(self):
+        """Test that BalanceScheduler alone works fine."""
+        mock_vllm_config = self.mock_vllm_config()
+        mock_vllm_config.additional_config = {
+            "enable_balance_scheduling": True,
+        }
+
+        with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
+            mock_ascend_config = self.mock_vllm_ascend_config()
+            mock_ascend_config.enable_balance_scheduling = True
+            mock_ascend_config.recompute_scheduler_enable = False
+            mock_init.return_value = mock_ascend_config
+
+            # Should not raise any error
+            try:
+                self.platform.check_and_update_config(mock_vllm_config)
+            except ValueError as e:
+                # Only fail if it's the mutex check error
+                if "cannot be enabled simultaneously" in str(e):
+                    self.fail("BalanceScheduler alone should not raise mutex error")
+
+    def test_recompute_scheduler_alone_works(self):
+        """Test that RecomputeScheduler alone works fine."""
+        mock_vllm_config = self.mock_vllm_config()
+        mock_vllm_config.additional_config = {
+            "recompute_scheduler_enable": True,
+        }
+
+        with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
+            mock_ascend_config = self.mock_vllm_ascend_config()
+            mock_ascend_config.enable_balance_scheduling = False
+            mock_ascend_config.recompute_scheduler_enable = True
+            mock_init.return_value = mock_ascend_config
+
+            # Should not raise any error
+            try:
+                self.platform.check_and_update_config(mock_vllm_config)
+            except ValueError as e:
+                # Only fail if it's the mutex check error
+                if "cannot be enabled simultaneously" in str(e):
+                    self.fail("RecomputeScheduler alone should not raise mutex error")

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -816,6 +816,8 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.additional_config = {
             "enable_balance_scheduling": True,
         }
+        # Configure valid kv_role for balance scheduling (kv_both or None)
+        mock_vllm_config.kv_transfer_config = None
 
         with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
             mock_ascend_config = self.mock_vllm_ascend_config()
@@ -824,12 +826,7 @@ class TestNPUPlatform(TestBase):
             mock_init.return_value = mock_ascend_config
 
             # Should not raise any error
-            try:
-                self.platform.check_and_update_config(mock_vllm_config)
-            except ValueError as e:
-                # Only fail if it's the mutex check error
-                if "cannot be enabled simultaneously" in str(e):
-                    self.fail("BalanceScheduler alone should not raise mutex error")
+            self.platform.check_and_update_config(mock_vllm_config)
 
     def test_recompute_scheduler_alone_works(self):
         """Test that RecomputeScheduler alone works fine."""
@@ -837,6 +834,9 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.additional_config = {
             "recompute_scheduler_enable": True,
         }
+        # Configure valid kv_role for recompute scheduler (kv_producer or kv_consumer)
+        mock_vllm_config.kv_transfer_config = MagicMock()
+        mock_vllm_config.kv_transfer_config.kv_role = "kv_producer"
 
         with patch("vllm_ascend.platform.init_ascend_config") as mock_init:
             mock_ascend_config = self.mock_vllm_ascend_config()
@@ -845,9 +845,4 @@ class TestNPUPlatform(TestBase):
             mock_init.return_value = mock_ascend_config
 
             # Should not raise any error
-            try:
-                self.platform.check_and_update_config(mock_vllm_config)
-            except ValueError as e:
-                # Only fail if it's the mutex check error
-                if "cannot be enabled simultaneously" in str(e):
-                    self.fail("RecomputeScheduler alone should not raise mutex error")
+            self.platform.check_and_update_config(mock_vllm_config)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -486,6 +486,18 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
+        # NOTE: BalanceScheduler and RecomputeScheduler must not be enabled simultaneously.
+        # In PD disaggregation mode with multi-DP MoE, enabling both schedulers can cause
+        # MoE communication type mismatch across DP ranks (some perform All2AllV, others MC2),
+        # leading to AlltoAll deadlock. See https://github.com/vllm-project/vllm-ascend/issues/8975
+        if ascend_config.enable_balance_scheduling and ascend_config.recompute_scheduler_enable:
+            raise ValueError(
+                "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) and recompute_scheduler_enable "
+                "cannot be enabled simultaneously. This combination causes MoE communication type "
+                "mismatch across DP ranks in PD disaggregation mode, leading to AlltoAll deadlock. "
+                "Please disable one of them."
+            )
+
         if ascend_config.enable_balance_scheduling:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)


### PR DESCRIPTION
## Summary

- Add mutex check to prevent deadlock when both schedulers are enabled
- BalanceScheduler and RecomputeScheduler must not be enabled simultaneously
- In PD disaggregation mode with multi-DP MoE, enabling both schedulers can cause MoE communication type mismatch across DP ranks (some perform All2AllV, others MC2), leading to AlltoAll deadlock

## Changes

1. Add mutual exclusion check in `platform.py`
2. Add unit tests for the check

## Test Plan

- Unit tests added in `tests/ut/test_platform.py`
- All tests pass locally

Fixes #8975
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
