### PR TITLE
[Doc][Feature] Update installation guide for Deepseek-V4 support

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -280,15 +280,15 @@ The default workdir is `/workspace`, vLLM and vLLM Ascend code are placed in `/v
 
 ## Extra information
 
-### Deepseek-V4 Support
+### DeepSeek-V4 Support
 
-vLLM-Ascend supports Deepseek-V4 models with sparse attention architecture. Key features include:
+vLLM-Ascend supports DeepSeek-V4 models with sparse attention architecture. Key features include:
 
 - **Model Architecture**: Sparse attention mechanism optimized for long-context scenarios
 - **Supported Features**: W8A8 quantization, speculative decoding with MTP (Multi-Token Prediction), expert parallelism, PD disaggregation
 - **Hardware Requirements**: Atlas A2/A3 series
 
-For deployment guidance, refer to [DeepSeek-V3.2](tutorials/models/DeepSeek-V3.2.md) tutorial (Deepseek-V4 shares similar deployment patterns).
+For deployment guidance, refer to [DeepSeek-V3.2](tutorials/models/DeepSeek-V3.2.md) tutorial (DeepSeek-V4 shares similar deployment patterns).
 
 :::{note}
 `DeepseekV4Config` is provided by vLLM's internal compatibility layer (`vllm.transformers_utils.configs.deepseek_v4`), not by HuggingFace transformers directly.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -280,6 +280,20 @@ The default workdir is `/workspace`, vLLM and vLLM Ascend code are placed in `/v
 
 ## Extra information
 
+### Deepseek-V4 Support
+
+vLLM-Ascend supports Deepseek-V4 models with sparse attention architecture. Key features include:
+
+- **Model Architecture**: Sparse attention mechanism optimized for long-context scenarios
+- **Supported Features**: W8A8 quantization, speculative decoding with MTP (Multi-Token Prediction), expert parallelism, PD disaggregation
+- **Hardware Requirements**: Atlas A2/A3 series
+
+For deployment guidance, refer to [DeepSeek-V3.2](tutorials/models/DeepSeek-V3.2.md) tutorial (Deepseek-V4 shares similar deployment patterns).
+
+:::{note}
+`DeepseekV4Config` is provided by vLLM's internal compatibility layer (`vllm.transformers_utils.configs.deepseek_v4`), not by HuggingFace transformers directly.
+:::
+
 ### Verify installation
 
 Create and run a simple inference test. The `example.py` can be like:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds documentation for Deepseek-V4 model support in vLLM-Ascend. Following the merge of Deepseek-V4 model implementation (#9270), the installation guide lacked corresponding documentation for users.

The documentation includes:
- Model architecture overview (sparse attention for long-context scenarios)
- Supported features: W8A8 quantization, speculative decoding with MTP, expert parallelism, PD disaggregation
- Hardware requirements: Atlas A2/A3 series
- Clarification that `DeepseekV4Config` is provided by vLLM's internal compatibility layer, not HuggingFace transformers

### Does this PR introduce _any_ user-facing change?

Yes, this PR adds a new documentation section for Deepseek-V4 support in the installation guide.

### How was this patch tested?

- Verified documentation syntax consistency with Sphinx/MyST format
- Confirmed referenced link path `tutorials/models/DeepSeek-V3.2.md` exists
- Tested in CPU-only environment with `VLLM_TARGET_DEVICE=empty`
- CI will handle NPU hardware testing

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
