### PR TITLE
 [BugFix][Model] Fix moe_gating_topk_hash UB out of bounds in dummy load for DeepSeek V4

### DIFF
--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -282,13 +282,12 @@ class DeepseekV4MoE(nn.Module):
 
         self.hash = layer_idx < config.num_hash_layers and not is_draft_layer
         if self.hash:
-            # Use randint instead of empty to avoid garbage values causing
+            # Use zeros instead of empty to avoid garbage values causing
             # invalid memory access in dummy mode (--load-format="dummy")
             self.gate.tid2eid = nn.Parameter(
-                torch.randint(
-                    0,
-                    config.n_routed_experts,
-                    (config.vocab_size, config.num_experts_per_tok),
+                torch.zeros(
+                    config.vocab_size,
+                    config.num_experts_per_tok,
                     dtype=torch.int32,
                 ),
                 requires_grad=False,

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -290,7 +290,8 @@ class DeepseekV4MoE(nn.Module):
                     config.n_routed_experts,
                     (config.vocab_size, config.num_experts_per_tok),
                     dtype=torch.int32,
-                )
+                ),
+                requires_grad=False,
             )
             self.gate.e_score_correction_bias = None
         else:

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -282,8 +282,15 @@ class DeepseekV4MoE(nn.Module):
 
         self.hash = layer_idx < config.num_hash_layers and not is_draft_layer
         if self.hash:
+            # Use randint instead of empty to avoid garbage values causing
+            # invalid memory access in dummy mode (--load-format="dummy")
             self.gate.tid2eid = nn.Parameter(
-                torch.empty(config.vocab_size, config.num_experts_per_tok, dtype=torch.int32), requires_grad=False
+                torch.randint(
+                    0,
+                    config.n_routed_experts,
+                    (config.vocab_size, config.num_experts_per_tok),
+                    dtype=torch.int32,
+                )
             )
             self.gate.e_score_correction_bias = None
         else:


### PR DESCRIPTION
### What this PR does / why we need it?
In DeepseekV4MoE, when self.hash is enabled (i.e., the layer is a hash layer),self.gate.tid2eid was initialized with torch.empty(...), which leaves the tensor filled with uninitialized (garbage) values.

When running with --load-format="dummy" (dummy load mode), the model weights are never actually loaded from disk, so these garbage values remain in tid2eid. During forward pass, these invalid indices are used to look up expert assignments, causing out-of-bounds memory access in MoeGatingTopKHash kernel, which can lead to crashes.

<img width="2486" height="1308" alt="image" src="https://github.com/user-attachments/assets/a4b2e47d-e13e-4ee4-b6c0-3c7feeda4fd3" />

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
