### PR TITLE
[Feature] support ffncombine swiglulimit

### DIFF
--- a/csrc/mc2/dispatch_ffn_combine/dispatch_ffn_combine_torch_adpt.h
+++ b/csrc/mc2/dispatch_ffn_combine/dispatch_ffn_combine_torch_adpt.h
@@ -31,7 +31,8 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine(
     int64_t max_output_size,
     at::Tensor& out,
     at::Tensor& expert_token_nums,
-    const c10::optional<at::Tensor>& x_active_mask
+    const c10::optional<at::Tensor>& x_active_mask,
+    double swiglu_limit
 ) {
     char *group_ep_ptr = const_cast<char *>(group.data());
     bool is_int8 = weight1[0].dtype() == at::kChar;
@@ -48,6 +49,7 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine(
                  x_active_mask.has_value() ? x_active_mask.value() : at::Tensor(),
                  group_ep_ptr,
                  max_output_size,
+                 swiglu_limit,
                  out,
                  expert_token_nums);
     } else if (is_int4){

--- a/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_def.cpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_def.cpp
@@ -77,6 +77,7 @@ class DispatchFFNCombine : public OpDef {
     this->Attr("M").AttrType(OPTIONAL).Int();
     this->Attr("transB").AttrType(OPTIONAL).Bool(false);
     this->Attr("weightNz").AttrType(OPTIONAL).Bool(false);
+    this->Attr("swigluLimit").AttrType(OPTIONAL).Float(0.0f);
 
     OpAICoreConfig aicore_config;
     aicore_config.DynamicCompileStaticFlag(true)

--- a/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/dispatch_ffn_combine_tiling.cpp
@@ -35,6 +35,7 @@ namespace {
     constexpr uint32_t ATTR_MAX_OUTPUT_SIZE_INDEX = 1;
     constexpr uint32_t ATTR_IS_TRANS_B = 2;
     constexpr uint32_t ATTR_WEIGHT_NZ = 3;
+    constexpr uint32_t ATTR_SWIGLU_LIMIT = 4;
     constexpr uint64_t INIT_TILINGKEY = 1000000;
     constexpr uint64_t TILINGKEY_TRANS_B = 1U;
     constexpr uint64_t TILINGKEY_WEIGHT_NZ = 10;
@@ -93,6 +94,7 @@ static ge::graphStatus DispatchFFNCombineCheckAttrAndSetTiling(gert::TilingConte
     auto maxOutputSizePtr = attrs->GetAttrPointer<int>(ATTR_MAX_OUTPUT_SIZE_INDEX);
     auto is_trans_b = attrs->GetAttrPointer<bool>(ATTR_IS_TRANS_B);
     auto weight_nz = attrs->GetAttrPointer<bool>(ATTR_WEIGHT_NZ);
+    auto swiglu_limit = attrs->GetAttrPointer<float>(ATTR_SWIGLU_LIMIT);
     OP_TILING_CHECK(groupPtr == nullptr || strlen(groupPtr) == 0,
     OP_LOGE(K_INNER_DEBUG, "group is invalid."), return GRAPH_FAILED);
 
@@ -104,6 +106,7 @@ static ge::graphStatus DispatchFFNCombineCheckAttrAndSetTiling(gert::TilingConte
     info.maxOutputSize = *maxOutputSizePtr;
     info.isTransposeB = *is_trans_b;
     info.isWeightNz = *weight_nz;
+    info.swigluLimit = swiglu_limit != nullptr ? *swiglu_limit : 0.0f;
 
     int64_t rankSize;
     (void)ge::HcomTopoInfo::Instance().GetGroupRankSize(groupPtr, rankSize);

--- a/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.cpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.cpp
@@ -45,7 +45,7 @@ extern aclnnStatus aclnnInnerDispatchFFNCombineGetWorkspaceSize(const aclTensor*
                                                          const aclTensor* expertId, const aclTensorList* scale1, const aclTensorList* scale2,
                                                          const aclTensor* probs, const aclTensor* xActiveMask,
                                                          const char* group, int64_t maxOutputSize,
-                                                         bool transB, bool weightNz,
+                                                         bool transB, bool weightNz, double swigluLimit,
                                                          const aclTensor* out, const aclTensor* expertTokenNums,
                                                          uint64_t* workspaceSize, aclOpExecutor** executor);
 extern aclnnStatus aclnnInnerDispatchFFNCombine(void *workspace, uint64_t workspaceSize,
@@ -57,7 +57,7 @@ extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, 
 aclnnStatus aclnnDispatchFFNCombineGetWorkspaceSize(const aclTensor* x, const aclTensorList* weight1, const aclTensorList* weight2,
                                                     const aclTensor* expertId, const aclTensorList* scale1, const aclTensorList* scale2,
                                                     const aclTensor* probs, const aclTensor* xActiveMask,
-                                                    const char* group, int64_t maxOutputSize,
+                                                    const char* group, int64_t maxOutputSize, double swigluLimit,
                                                     const aclTensor* out, const aclTensor* expertTokenNums,
                                                     uint64_t* workspaceSize, aclOpExecutor** executor)
 {
@@ -65,7 +65,7 @@ aclnnStatus aclnnDispatchFFNCombineGetWorkspaceSize(const aclTensor* x, const ac
     bool weightNz = true;
 
     aclnnStatus ret = aclnnInnerDispatchFFNCombineGetWorkspaceSize(x, weight1, weight2, expertId, scale1, scale2, probs, xActiveMask, group,
-                                                                    maxOutputSize, transB, weightNz,
+                                                                    maxOutputSize, transB, weightNz, swigluLimit,
                                                                     out, expertTokenNums, workspaceSize, executor);
     return ret;
 }

--- a/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/op_api/aclnn_dispatch_ffn_combine.h
@@ -42,7 +42,7 @@ extern "C" {
 __attribute__((visibility("default"))) aclnnStatus aclnnDispatchFFNCombineGetWorkspaceSize(const aclTensor* x, const aclTensorList* weight1, const aclTensorList* weight2,
                                                                                         const aclTensor* expertId, const aclTensorList* scale1, const aclTensorList* scale2,
                                                                                         const aclTensor* probs, const aclTensor* xActiveMask,
-                                                                                        const char* group, int64_t maxOutputSize,
+                                                                                        const char* group, int64_t maxOutputSize, double swigluLimit,
                                                                                         const aclTensor* out, const aclTensor* expertTokenNums,
                                                                                         uint64_t* workspaceSize, aclOpExecutor** executor);
 

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine.h
@@ -103,6 +103,7 @@ private:
     int32_t maxOutputSize;
     int32_t EP;
     int32_t listLen;
+    float swigluLimit;
 
     optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData;
     uint64_t initRoutingQuantTilingKey;
@@ -144,6 +145,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Init(GM_ADDR xGM,
     expertPerRank = tilingData.dispatchFFNCombineInfo.expertPerRank;
     maxOutputSize = tilingData.dispatchFFNCombineInfo.maxOutputSize;
     listLen = tilingData.dispatchFFNCombineInfo.listLen;
+    swigluLimit = tilingData.dispatchFFNCombineInfo.swigluLimit;
 
     m0 = tilingData.cocTiling.m0;
     k0 = tilingData.cocTiling.k0;
@@ -279,7 +281,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Process()
         outGM_, layoutD1, layoutD2,
         expertIdGM_, moeInitRoutingQuantV2Scale, moeInitRoutingQuantV2Offset,
         expertTokensBeforeCapacity, probs_,
-        workspaceGM_, gmExpertTokenNums_, ubMoveNum, xActiveMaskGM_, moeInitRoutingQuantV2TilingData};
+        workspaceGM_, gmExpertTokenNums_, ubMoveNum, xActiveMaskGM_, moeInitRoutingQuantV2TilingData, swigluLimit};
     //Call kernel
     MatmulKernel kernel(params);
     kernel(params);

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
@@ -139,6 +139,7 @@ public:
         uint32_t epilogueCoreNum;
         uint32_t epilogueGranularity;
         optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData;
+        float swigluLimit;
         //--------------
 
         // Methods
@@ -162,7 +163,8 @@ public:
             GM_ADDR expertTokensBeforeCapacity_, GM_ADDR probs_,
             GM_ADDR ptrWorkspace_, GM_ADDR gmExpertTokenNums_, int32_t ubMoveNum_,
             GM_ADDR ptrXActiveMask_,
-            optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData_
+            optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData_,
+            float swigluLimit_
         ) : problemShape(problemShape_),
             EP(EP_), listLen(listLen_), expertPerRank(expertPerRank_), maxOutputSize(maxOutputSize_),
             rank(rank_), rankSize(rankSize_), topK(topK_),
@@ -175,11 +177,12 @@ public:
             ptrScale2(ptrScale2_), layoutScale2(layoutScale2_),
             ptrOutput(reinterpret_cast<__gm__ ElementD2 *>(ptrOutput_)), layoutD1(layoutD1_), layoutD2(layoutD2_),
             expertIdx(expertIdx_), moeInitRoutingQuantV2Scale(moeInitRoutingQuantV2Scale_),
-            moeInitRoutingQuantV2Offset(moeInitRoutingQuantV2Offset_), 
+            moeInitRoutingQuantV2Offset(moeInitRoutingQuantV2Offset_),
             expertTokensBeforeCapacity(expertTokensBeforeCapacity_), probs(probs_),
             ptrWorkspace(ptrWorkspace_), ptrExpertTokenNums(gmExpertTokenNums_), ubMoveNum(ubMoveNum_),
             ptrXActiveMask(ptrXActiveMask_),
-            moeInitRoutingQuantV2TilingData(moeInitRoutingQuantV2TilingData_)
+            moeInitRoutingQuantV2TilingData(moeInitRoutingQuantV2TilingData_),
+            swigluLimit(swigluLimit_)
         {
         }
     };
@@ -924,7 +927,7 @@ private:
             LayoutC layoutC{dequantSum1, params.problemShape.n()};
             int64_t gmOffsetC = layoutC.GetOffset(offsetC);
             int64_t gmOffsetD = params.layoutD1.GetOffset(offsetC);
-            blockEpilogue1(gmC[gmOffsetC], shapeC, gmPerTokenScale1[rowStartThisCore], gmPermutedToken[gmOffsetD], gmPerTokenScale2[rowStartThisCore], params.epilogueCoreNum);
+            blockEpilogue1(gmC[gmOffsetC], shapeC, gmPerTokenScale1[rowStartThisCore], gmPermutedToken[gmOffsetD], gmPerTokenScale2[rowStartThisCore], params.epilogueCoreNum, params.swigluLimit);
         }
         AscendC::SyncAll<true>();
         // Synchronization signal: SwiGLU notifies GMM2 [1]
@@ -942,7 +945,7 @@ private:
                 LayoutC layoutC{dequantLen, params.problemShape.n()};
                 int64_t gmOffsetC = layoutC.GetOffset(offsetC);
                 int64_t gmOffsetD = params.layoutD1.GetOffset(offsetC);
-                blockEpilogue1(gmC[gmOffsetC], shapeC, gmPerTokenScale1[rowStartThisCore], gmPermutedToken[gmOffsetD], gmPerTokenScale2[rowStartThisCore], coreNum);
+                blockEpilogue1(gmC[gmOffsetC], shapeC, gmPerTokenScale1[rowStartThisCore], gmPermutedToken[gmOffsetD], gmPerTokenScale2[rowStartThisCore], coreNum, params.swigluLimit);
             }
             AscendC::SyncAll<true>();
             // Synchronization signal: SwiGLU notifies GMM2 [2]

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_tiling.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_tiling.h
@@ -31,6 +31,7 @@ struct DispatchFFNCombineInfo {
     uint32_t topK;
     uint32_t worldSize;
     uint32_t listLen;
+    float swigluLimit;
 };
 
 struct CoCTiling {

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/utils/block_epilogue_pertoken_swiglu.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/utils/block_epilogue_pertoken_swiglu.hpp
@@ -119,8 +119,9 @@ public:
             AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventUbCVMTE2List[i]);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(eventUbDMTE3VList[i]);  
         }
-
         ubPerTokenScaleOutput = resource.ubBuf.template GetBufferByByte<float>(ubOffset);
+        ubOffset += 32;
+        sharedTmpBuffer = resource.ubBuf.template GetBufferByByte<uint8_t>(ubOffset);
     }
     CATLASS_DEVICE
     void Finalize()
@@ -150,6 +151,7 @@ public:
         AscendC::GlobalTensor<ElementPerTokenScale> const &gmPerTokenScale2,
 
         uint32_t epilogueCoreNum = 40,
+        float swigluLimit = 0.0f,
         Callback &&callback = Callback{}
     )
     {
@@ -220,6 +222,15 @@ public:
             AscendC::Muls(ubCFp32, ubCFp32, perTokenScale, blockN);
             AscendC::PipeBarrier<PIPE_V>();
 
+            // swiglu limit clamp
+            if (swigluLimit > 0.0f) {
+                AscendC::ClampMax(ubCFp32, ubCFp32, sharedTmpBuffer, swigluLimit, blockN);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::ClampMin(ubCFp32[ChunkTileLen], ubCFp32[ChunkTileLen], sharedTmpBuffer, -1.0f * swigluLimit, ChunkTileLen);
+                //AscendC::ClampMin(ubCFp32, ubCFp32, sharedTmpBuffer, -1.0f * swigluLimit, ChunkTileLen);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            
             // Swiglu computation process
             AscendC::Muls(ubCFp32ChunkN, ubCFp32, -1.0f, ChunkTileLen);
             AscendC::PipeBarrier<PIPE_V>();
@@ -304,7 +315,7 @@ private:
     AscendC::LocalTensor<int32_t> ubQuantS32List[UB_STAGES];
     AscendC::LocalTensor<half> ubQuantF16List[UB_STAGES];
     AscendC::LocalTensor<float> ubPerTokenScaleOutput;
-
+    AscendC::LocalTensor<uint8_t> sharedTmpBuffer;
 
     CopyGmToUbC copyGmToUbC;
     CopyUbToGmD copyUbToGmD;

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2396,7 +2396,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     ops.def(
         "dispatch_ffn_combine(Tensor x, Tensor[] weight1, Tensor[] weight2, Tensor expert_idx,"
         "                     Tensor[] scale1, Tensor[] scale2, Tensor[]? bias1, Tensor[]? bias2, Tensor probs, str group,"
-        "                     int max_output_size, Tensor! out, Tensor! expert_token_nums, Tensor? x_active_mask=None) -> (Tensor out, Tensor expert_token_nums)"
+        "                     int max_output_size, Tensor! out, Tensor! expert_token_nums, Tensor? x_active_mask=None, float swiglu_limit=1000000.0) -> (Tensor out, Tensor expert_token_nums)"
     );
     ops.impl("dispatch_ffn_combine", torch::kPrivateUse1, &vllm_ascend::dispatch_ffn_combine);
 

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -235,7 +235,8 @@ std::tuple<at::Tensor&, at::Tensor&> dispatch_ffn_combine_meta(
     int64_t max_output_size,
     at::Tensor& out,
     at::Tensor& expert_token_nums,
-    const c10::optional<at::Tensor> &x_active_mask
+    const c10::optional<at::Tensor> &x_active_mask,
+    double swiglu_limit
 ) {
     return {out, expert_token_nums};
 }

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -318,6 +318,7 @@ class FusedMC2CommImpl(MoECommMethod):
                 probs=fused_experts_input.topk_weights.to(torch.float32),
                 group=self.token_dispatcher.moe_all_to_all_group_name,
                 max_output_size=65536,
+                swiglu_limit=fused_experts_input.swiglu_limit,
                 x_active_mask=fused_experts_input.routing.mc2_mask,
                 out=out,
                 expert_token_nums=self.expert_token_nums,


### PR DESCRIPTION
  ### Summary                                                                                
                                                                                                                                                                                     
  Add swiglu_limit parameter support to the W8A8 dispatch_ffn_combine fused MoE operator, mirroring the existing W4A8 support from #9259.                                            
                                                                                                                                                                                     
  Why this is needed                                                                                                                                                                 
                                                                                                                                                                                     
  The dispatch_ffn_combine W4A8 operator already supports a swiglu_limit parameter to clamp activations before the SwiGLU computation, preventing numerical overflow. This PR extends
   the same capability to the W8A8 path so both quantization paths have consistent overflow protection.                                                                              
                                                                                         
  ### What changed                                                                                                                                                                       
                                                                                         
  - C++ operator definition (dispatch_ffn_combine_def.cpp, dispatch_ffn_combine_tiling.h/cpp): Added swigluLimit as an optional float attribute (default 0.0, meaning no clamping),  
  read through tiling into DispatchFFNCombineInfo                                                                                                                                    
  - aclnn API (aclnn_dispatch_ffn_combine.h/cpp): Threaded swigluLimit through GetWorkspaceSize to the op executor                                                                   
  - Kernel class (dispatch_ffn_combine.h, dispatch_ffn_combine_kernel.hpp): Added swigluLimit to the kernel class member, Params struct, and both blockEpilogue1 call sites          
  - Block epilogue (block_epilogue_pertoken_swiglu.hpp): Added ClampMax/ClampMin after per-token scale multiply when swigluLimit > 0 — clamps the gate half to [-swigluLimit, 
  swigluLimit], with a dedicated uint8_t UB scratch buffer                                                                                                                           
  - Torch bindings (torch_binding.cpp, torch_binding_meta.cpp, dispatch_ffn_combine_torch_adpt.h): Exposed swiglu_limit=1000000.0 (effectively no-op by default) as the last optional
   parameter                                       
                                                                                                                                                                                     
  ### User-facing changes                                                                    
                                                                                                                                                                                     
  None — existing Python callers work without modification since the default swiglu_limit=1000000.0 preserves current behavior. Users can pass a smaller swiglu_limit value to enable
   clamping when needed.                                                                                                                                                             
                                                                                                                                                                                     
  ### Test plan                                                                                                                                                                          
                                                                                                                                                                                     
  - Verified compilation with existing CI                                                
  - Existing dispatch_ffn_combine callers in moe_comm_method.py continue to work with default value       
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
