### PR TITLE
[Feature] Add working version for 310P

### DIFF
--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_aclnn_ctypes.py
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_aclnn_ctypes.py
@@ -7,9 +7,14 @@ Usage:
   export LD_LIBRARY_PATH=/.../opp/vendors/custom_transformer/op_api/lib/:$LD_LIBRARY_PATH
   python test_aclnn_ctypes.py
 """
-import sys, os, ctypes, math
+
+import ctypes
+import os
+import sys
+
 import torch
 import torch_npu
+
 
 # ── Load CANN libs ──────────────────────────────────────────────
 def _find_lib(name):
@@ -22,6 +27,7 @@ def _find_lib(name):
         if os.path.isfile(p):
             return p
     return name  # let ctypes try default search
+
 
 _acl = ctypes.CDLL(_find_lib("libascendcl.so"))
 _nnop = ctypes.CDLL(_find_lib("libnnopbase.so"))
@@ -37,9 +43,15 @@ c_bool = ctypes.c_bool
 # aclCreateTensor is in libnnopbase, not libascendcl
 _nnop.aclCreateTensor.restype = c_void_p
 _nnop.aclCreateTensor.argtypes = [
-    ctypes.POINTER(c_int64), c_uint64, c_int,
-    ctypes.POINTER(c_int64), c_int64, c_int,
-    ctypes.POINTER(c_int64), c_uint64, c_void_p,
+    ctypes.POINTER(c_int64),
+    c_uint64,
+    c_int,
+    ctypes.POINTER(c_int64),
+    c_int64,
+    c_int,
+    ctypes.POINTER(c_int64),
+    c_uint64,
+    c_void_p,
 ]
 
 # aclDestroyTensor
@@ -66,13 +78,24 @@ if not _getws or not _exec:
 # GetWorkspaceSize(k,w,u, g,gk,init, outFS,chunkSz,saveNV, cuSeq,chunkIdx, exp2,transpose, h,vn,fs, wsSize,executor)
 _getws.restype = c_int
 _getws.argtypes = [
-    c_void_p, c_void_p, c_void_p,      # k, w, u
-    c_void_p, c_void_p, c_void_p,      # g, gk, initial_state
-    c_bool, c_int64, c_bool,            # output_final_state, chunk_size, save_new_value
-    c_void_p, c_void_p,                 # cu_seqlens, chunk_indices
-    c_bool, c_bool,                     # use_exp2, transpose_state_layout
-    c_void_p, c_void_p, c_void_p,      # h_out, v_new_out, final_state_out
-    ctypes.POINTER(c_uint64), ctypes.POINTER(c_void_p),  # ws_size, executor
+    c_void_p,
+    c_void_p,
+    c_void_p,  # k, w, u
+    c_void_p,
+    c_void_p,
+    c_void_p,  # g, gk, initial_state
+    c_bool,
+    c_int64,
+    c_bool,  # output_final_state, chunk_size, save_new_value
+    c_void_p,
+    c_void_p,  # cu_seqlens, chunk_indices
+    c_bool,
+    c_bool,  # use_exp2, transpose_state_layout
+    c_void_p,
+    c_void_p,
+    c_void_p,  # h_out, v_new_out, final_state_out
+    ctypes.POINTER(c_uint64),
+    ctypes.POINTER(c_void_p),  # ws_size, executor
 ]
 
 # Execute(workspace, ws_size, executor, stream)
@@ -81,11 +104,11 @@ _exec.argtypes = [c_void_p, c_uint64, c_void_p, c_void_p]
 
 # ── ACL dtype map ───────────────────────────────────────────────
 _DTYPE_MAP = {
-    torch.float16: 1,   # ACL_FLOAT16
-    torch.float32: 0,   # ACL_FLOAT
-    torch.int64: 9,     # ACL_INT64
-    torch.int32: 3,     # ACL_INT32
-    torch.bfloat16: 27, # ACL_BF16
+    torch.float16: 1,  # ACL_FLOAT16
+    torch.float32: 0,  # ACL_FLOAT
+    torch.int64: 9,  # ACL_INT64
+    torch.int32: 3,  # ACL_INT32
+    torch.bfloat16: 27,  # ACL_BF16
 }
 ACL_FORMAT_ND = 2
 ACL_MEM_MALLOC_HUGE_FIRST = 0
@@ -100,9 +123,15 @@ def _make_acl_tensor(t):
     storage_dim = c_int64(t.storage().nbytes() // t.element_size())
     storage_base = c_void_p(t.untyped_storage().data_ptr())
     return _nnop.aclCreateTensor(
-        shape, len(t.shape), _DTYPE_MAP[t.dtype],
-        strides, t.storage_offset(), ACL_FORMAT_ND,
-        ctypes.byref(storage_dim), 1, storage_base,
+        shape,
+        len(t.shape),
+        _DTYPE_MAP[t.dtype],
+        strides,
+        t.storage_offset(),
+        ACL_FORMAT_ND,
+        ctypes.byref(storage_dim),
+        1,
+        storage_base,
     )
 
 
@@ -129,8 +158,8 @@ def call_kernel(k, w, u, g, initial_state=None, chunk_size=64):
     buf = torch.empty(total, dtype=k.dtype, device=k.device)
 
     h_out = buf[:h_elems].view(B, HV, NT, K, V)
-    vn_out = buf[h_pad // k.element_size():][:vn_elems].view(B, HV, T, V)
-    fs_out = buf[h_pad // k.element_size() + vn_pad // k.element_size():][:1]
+    vn_out = buf[h_pad // k.element_size() :][:vn_elems].view(B, HV, T, V)
+    fs_out = buf[h_pad // k.element_size() + vn_pad // k.element_size() :][:1]
 
     # Create aclTensors
     acl_k = _make_acl_tensor(k)
@@ -149,12 +178,24 @@ def call_kernel(k, w, u, g, initial_state=None, chunk_size=64):
     ws_size = c_uint64(0)
     executor = c_void_p(None)
     ret = _getws(
-        acl_k, acl_w, acl_u,
-        acl_g, None, acl_init,
-        False, chunk_size, True,
-        None, None, False, False,
-        acl_h, acl_vn, acl_fs,
-        ctypes.byref(ws_size), ctypes.byref(executor),
+        acl_k,
+        acl_w,
+        acl_u,
+        acl_g,
+        None,
+        acl_init,
+        False,
+        chunk_size,
+        True,
+        None,
+        None,
+        False,
+        False,
+        acl_h,
+        acl_vn,
+        acl_fs,
+        ctypes.byref(ws_size),
+        ctypes.byref(executor),
     )
     assert ret == 0, f"GetWorkspaceSize failed: {ret}"
 
@@ -192,17 +233,17 @@ def cpu_reference(k, w, u, g, initial_state=None, chunk_size=64):
 
     for c in range(NT):
         t0 = c * chunk_size
-        W_chunk = w[:, :, t0:t0+chunk_size, :]
-        ws = torch.einsum('bhik,bhkv->bhiv', W_chunk, h)
-        g_chunk = g[:, :, t0:t0+chunk_size]
+        W_chunk = w[:, :, t0 : t0 + chunk_size, :]
+        ws = torch.einsum("bhik,bhkv->bhiv", W_chunk, h)
+        g_chunk = g[:, :, t0 : t0 + chunk_size]
         v_update = torch.zeros(B, HV, chunk_size, V)
         for i in range(chunk_size):
             gi_cum = g_chunk[:, :, -1] - g_chunk[:, :, i]
-            vn = u[:, :, t0+i, :] - ws[:, :, i, :]
-            v_new[:, :, t0+i, :] = vn
+            vn = u[:, :, t0 + i, :] - ws[:, :, i, :]
+            v_new[:, :, t0 + i, :] = vn
             v_update[:, :, i, :] = gi_cum.unsqueeze(-1).exp() * vn
-        K_chunk = k[:, :, t0:t0+chunk_size, :]
-        h_work = torch.einsum('bhik,bhiv->bhkv', K_chunk, v_update)
+        K_chunk = k[:, :, t0 : t0 + chunk_size, :]
+        h_work = torch.einsum("bhik,bhiv->bhkv", K_chunk, v_update)
         h = h * g_chunk[:, :, -1:].unsqueeze(-1).exp() + h_work
         h_chunks.append(h.clone())
     return h_chunks, v_new
@@ -236,8 +277,12 @@ def main():
 
     print("NPU kernel (aclnn via ctypes)...")
     h_out, vn_out = call_kernel(
-        k.npu(), w.npu(), u.npu(), g.npu(),
-        initial_state=init.npu(), chunk_size=CHUNK,
+        k.npu(),
+        w.npu(),
+        u.npu(),
+        g.npu(),
+        initial_state=init.npu(),
+        chunk_size=CHUNK,
     )
     torch.npu.synchronize()
     h_npu = h_out.cpu().float()
@@ -253,7 +298,7 @@ def main():
         npu = h_npu[0, :, c].flatten()
         c_val = cosine(npu, ref)
         mae = (npu - ref).abs().mean().item()
-        tag = "init" if c == 0 else f"after chunk {c-1}"
+        tag = "init" if c == 0 else f"after chunk {c - 1}"
         passed = c_val >= 0.999
         if not passed:
             ok = False

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_aclnn_ctypes.py
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_aclnn_ctypes.py
@@ -1,0 +1,279 @@
+"""
+Direct aclnn kernel test via ctypes — no C++ binding needed.
+Calls aclnnChunkGatedDeltaRuleFwdH through libcust_opapi.so.
+
+Usage:
+  source /usr/local/Ascend/ascend-toolkit/latest/bin/setenv.bash
+  export LD_LIBRARY_PATH=/.../opp/vendors/custom_transformer/op_api/lib/:$LD_LIBRARY_PATH
+  python test_aclnn_ctypes.py
+"""
+import sys, os, ctypes, math
+import torch
+import torch_npu
+
+# ── Load CANN libs ──────────────────────────────────────────────
+def _find_lib(name):
+    """Search LD_LIBRARY_PATH + common locations."""
+    for d in os.environ.get("LD_LIBRARY_PATH", "").split(":") + [
+        "/usr/local/Ascend/ascend-toolkit/latest/aarch64-linux/lib64",
+        "/usr/local/Ascend/ascend-toolkit/latest/x86_64-linux/lib64",
+    ]:
+        p = os.path.join(d, name)
+        if os.path.isfile(p):
+            return p
+    return name  # let ctypes try default search
+
+_acl = ctypes.CDLL(_find_lib("libascendcl.so"))
+_nnop = ctypes.CDLL(_find_lib("libnnopbase.so"))
+_opapi = ctypes.CDLL(_find_lib("libcust_opapi.so"))
+
+# ── ACL type aliases ────────────────────────────────────────────
+c_void_p = ctypes.c_void_p
+c_int64 = ctypes.c_int64
+c_uint64 = ctypes.c_uint64
+c_int = ctypes.c_int
+c_bool = ctypes.c_bool
+
+# aclCreateTensor is in libnnopbase, not libascendcl
+_nnop.aclCreateTensor.restype = c_void_p
+_nnop.aclCreateTensor.argtypes = [
+    ctypes.POINTER(c_int64), c_uint64, c_int,
+    ctypes.POINTER(c_int64), c_int64, c_int,
+    ctypes.POINTER(c_int64), c_uint64, c_void_p,
+]
+
+# aclDestroyTensor
+_nnop.aclDestroyTensor.restype = c_int
+_nnop.aclDestroyTensor.argtypes = [c_void_p]
+
+# aclrtSynchronizeStream
+_acl.aclrtSynchronizeStream.restype = c_int
+_acl.aclrtSynchronizeStream.argtypes = [c_void_p]
+
+# aclrtMalloc / aclrtFree for workspace
+_acl.aclrtMalloc.restype = c_int
+_acl.aclrtMalloc.argtypes = [ctypes.POINTER(c_void_p), c_uint64, c_int]
+_acl.aclrtFree.restype = c_int
+_acl.aclrtFree.argtypes = [c_void_p]
+
+# Our kernel
+_getws = getattr(_opapi, "aclnnChunkGatedDeltaRuleFwdHGetWorkspaceSize", None)
+_exec = getattr(_opapi, "aclnnChunkGatedDeltaRuleFwdH", None)
+if not _getws or not _exec:
+    print("ERROR: aclnn kernel symbols not found. Install the .run package first.", file=sys.stderr)
+    sys.exit(1)
+
+# GetWorkspaceSize(k,w,u, g,gk,init, outFS,chunkSz,saveNV, cuSeq,chunkIdx, exp2,transpose, h,vn,fs, wsSize,executor)
+_getws.restype = c_int
+_getws.argtypes = [
+    c_void_p, c_void_p, c_void_p,      # k, w, u
+    c_void_p, c_void_p, c_void_p,      # g, gk, initial_state
+    c_bool, c_int64, c_bool,            # output_final_state, chunk_size, save_new_value
+    c_void_p, c_void_p,                 # cu_seqlens, chunk_indices
+    c_bool, c_bool,                     # use_exp2, transpose_state_layout
+    c_void_p, c_void_p, c_void_p,      # h_out, v_new_out, final_state_out
+    ctypes.POINTER(c_uint64), ctypes.POINTER(c_void_p),  # ws_size, executor
+]
+
+# Execute(workspace, ws_size, executor, stream)
+_exec.restype = c_int
+_exec.argtypes = [c_void_p, c_uint64, c_void_p, c_void_p]
+
+# ── ACL dtype map ───────────────────────────────────────────────
+_DTYPE_MAP = {
+    torch.float16: 1,   # ACL_FLOAT16
+    torch.float32: 0,   # ACL_FLOAT
+    torch.int64: 9,     # ACL_INT64
+    torch.int32: 3,     # ACL_INT32
+    torch.bfloat16: 27, # ACL_BF16
+}
+ACL_FORMAT_ND = 2
+ACL_MEM_MALLOC_HUGE_FIRST = 0
+
+
+def _make_acl_tensor(t):
+    """Create an aclTensor* from a PyTorch NPU tensor."""
+    if t is None:
+        return None
+    shape = (c_int64 * len(t.shape))(*t.shape)
+    strides = (c_int64 * len(t.stride()))(*t.stride())
+    storage_dim = c_int64(t.storage().nbytes() // t.element_size())
+    storage_base = c_void_p(t.untyped_storage().data_ptr())
+    return _nnop.aclCreateTensor(
+        shape, len(t.shape), _DTYPE_MAP[t.dtype],
+        strides, t.storage_offset(), ACL_FORMAT_ND,
+        ctypes.byref(storage_dim), 1, storage_base,
+    )
+
+
+def _get_stream():
+    """Get the current NPU stream as a void*."""
+    return c_void_p(torch_npu.npu.current_stream().npu_stream)
+
+
+# ── Kernel wrapper ──────────────────────────────────────────────
+def call_kernel(k, w, u, g, initial_state=None, chunk_size=64):
+    """Call the aclnn kernel and return (h_out, v_new_out)."""
+    B, Hg, T, K = k.shape
+    HV, V = u.shape[1], u.shape[3]
+    NT = (T + chunk_size - 1) // chunk_size
+
+    # Contiguous output buffer (310P packs outputs contiguously)
+    h_elems = B * HV * NT * K * V
+    h_bytes = h_elems * k.element_size()
+    h_pad = ((h_bytes + 1023) // 512) * 512  # CANN 310P adds 512B gap between outputs
+    vn_elems = B * HV * T * V
+    vn_bytes = vn_elems * k.element_size()
+    vn_pad = ((vn_bytes + 1023) // 512) * 512
+    total = h_pad // k.element_size() + vn_pad // k.element_size() + 256
+    buf = torch.empty(total, dtype=k.dtype, device=k.device)
+
+    h_out = buf[:h_elems].view(B, HV, NT, K, V)
+    vn_out = buf[h_pad // k.element_size():][:vn_elems].view(B, HV, T, V)
+    fs_out = buf[h_pad // k.element_size() + vn_pad // k.element_size():][:1]
+
+    # Create aclTensors
+    acl_k = _make_acl_tensor(k)
+    acl_w = _make_acl_tensor(w)
+    acl_u = _make_acl_tensor(u)
+    acl_g = _make_acl_tensor(g)
+    acl_init = _make_acl_tensor(initial_state)
+    acl_h = _make_acl_tensor(h_out)
+    acl_vn = _make_acl_tensor(vn_out)
+    acl_fs = _make_acl_tensor(fs_out)
+
+    stream = _get_stream()
+    _acl.aclrtSynchronizeStream(stream)
+
+    # GetWorkspaceSize
+    ws_size = c_uint64(0)
+    executor = c_void_p(None)
+    ret = _getws(
+        acl_k, acl_w, acl_u,
+        acl_g, None, acl_init,
+        False, chunk_size, True,
+        None, None, False, False,
+        acl_h, acl_vn, acl_fs,
+        ctypes.byref(ws_size), ctypes.byref(executor),
+    )
+    assert ret == 0, f"GetWorkspaceSize failed: {ret}"
+
+    # Allocate workspace
+    ws_ptr = c_void_p(None)
+    if ws_size.value > 0:
+        ret = _acl.aclrtMalloc(ctypes.byref(ws_ptr), ws_size, ACL_MEM_MALLOC_HUGE_FIRST)
+        assert ret == 0, f"aclrtMalloc failed: {ret}"
+
+    # Execute
+    ret = _exec(ws_ptr, ws_size, executor, stream)
+    assert ret == 0, f"Execute failed: {ret}"
+    _acl.aclrtSynchronizeStream(stream)
+
+    # Cleanup
+    if ws_ptr.value:
+        _acl.aclrtFree(ws_ptr)
+    for t in [acl_k, acl_w, acl_u, acl_g, acl_init, acl_h, acl_vn, acl_fs]:
+        if t:
+            _nnop.aclDestroyTensor(t)
+
+    return h_out, vn_out
+
+
+# ── CPU reference (matches kernel semantics) ────────────────────
+def cpu_reference(k, w, u, g, initial_state=None, chunk_size=64):
+    """Kernel does: cube1=w@h, vec1=u-ws, cube2=k^T@v_update, vec2=h*exp(g)+h_work."""
+    k, w, u, g = k.float(), w.float(), u.float(), g.float()
+    B, Hg, T, K = k.shape
+    HV, V = u.shape[1], u.shape[3]
+    NT = T // chunk_size
+    h = initial_state.float().clone() if initial_state is not None else torch.zeros(B, HV, K, V)
+    h_chunks = [h.clone()]
+    v_new = torch.zeros_like(u)
+
+    for c in range(NT):
+        t0 = c * chunk_size
+        W_chunk = w[:, :, t0:t0+chunk_size, :]
+        ws = torch.einsum('bhik,bhkv->bhiv', W_chunk, h)
+        g_chunk = g[:, :, t0:t0+chunk_size]
+        v_update = torch.zeros(B, HV, chunk_size, V)
+        for i in range(chunk_size):
+            gi_cum = g_chunk[:, :, -1] - g_chunk[:, :, i]
+            vn = u[:, :, t0+i, :] - ws[:, :, i, :]
+            v_new[:, :, t0+i, :] = vn
+            v_update[:, :, i, :] = gi_cum.unsqueeze(-1).exp() * vn
+        K_chunk = k[:, :, t0:t0+chunk_size, :]
+        h_work = torch.einsum('bhik,bhiv->bhkv', K_chunk, v_update)
+        h = h * g_chunk[:, :, -1:].unsqueeze(-1).exp() + h_work
+        h_chunks.append(h.clone())
+    return h_chunks, v_new
+
+
+# ── Test ────────────────────────────────────────────────────────
+def cosine(a, b):
+    a, b = a.flatten().double(), b.flatten().double()
+    if a.norm() == 0 and b.norm() == 0:
+        return 1.0
+    if a.norm() == 0 or b.norm() == 0:
+        return 0.0
+    return torch.nn.functional.cosine_similarity(a.unsqueeze(0), b.unsqueeze(0)).item()
+
+
+def main():
+    torch.manual_seed(42)
+    torch_npu.npu.set_device(0)
+
+    B, T, Hg, HV, K, V, CHUNK = 1, 128, 1, 1, 128, 128, 64
+    DTYPE = torch.float16
+
+    k = torch.randn(B, Hg, T, K, dtype=DTYPE, device="cpu") * 0.1
+    w = torch.randn(B, Hg, T, K, dtype=DTYPE, device="cpu") * 0.1
+    u = torch.randn(B, HV, T, V, dtype=DTYPE, device="cpu") * 0.1
+    g = (-torch.rand(B, HV, T, device="cpu") * 0.1).float()
+    init = torch.randn(B, HV, K, V, dtype=DTYPE, device="cpu") * 0.01
+
+    print("CPU reference...")
+    h_ref, vn_ref = cpu_reference(k, w, u, g, init, CHUNK)
+
+    print("NPU kernel (aclnn via ctypes)...")
+    h_out, vn_out = call_kernel(
+        k.npu(), w.npu(), u.npu(), g.npu(),
+        initial_state=init.npu(), chunk_size=CHUNK,
+    )
+    torch.npu.synchronize()
+    h_npu = h_out.cpu().float()
+    vn_npu = vn_out.cpu().float()
+
+    NT = T // CHUNK
+    ok = True
+    print(f"\nB={B} T={T} K={K} V={V} chunk={CHUNK}")
+
+    print("\nh (state):")
+    for c in range(min(NT + 1, h_npu.shape[2])):
+        ref = h_ref[c].flatten()
+        npu = h_npu[0, :, c].flatten()
+        c_val = cosine(npu, ref)
+        mae = (npu - ref).abs().mean().item()
+        tag = "init" if c == 0 else f"after chunk {c-1}"
+        passed = c_val >= 0.999
+        if not passed:
+            ok = False
+        print(f"  h[{c}] ({tag}): cos={c_val:.6f} mae={mae:.6f} [{'OK' if passed else 'FAIL'}]")
+
+    print("\nv_new:")
+    for c in range(NT):
+        t0, t1 = c * CHUNK, (c + 1) * CHUNK
+        ref = vn_ref[:, :, t0:t1].flatten()
+        npu = vn_npu[:, :, t0:t1].flatten()
+        c_val = cosine(npu, ref)
+        mae = (npu - ref).abs().mean().item()
+        passed = c_val >= 0.999
+        if not passed:
+            ok = False
+        print(f"  chunk {c}: cos={c_val:.6f} mae={mae:.6f} [{'OK' if passed else 'FAIL'}]")
+
+    print(f"\n{'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_npu_chunk_gdr.py
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_npu_chunk_gdr.py
@@ -1,0 +1,77 @@
+"""
+Precision test: chunk_gated_delta_rule_fwd_h on Ascend 310P.
+Uses the vllm-ascend Python API (chunk_gated_delta_rule_pytorch).
+Compares NPU fp16 vs CPU fp32 reference.
+"""
+import sys
+import math
+import torch
+import torch_npu
+
+from vllm_ascend._310p.ops.fla.chunk_gated_delta_rule import chunk_gated_delta_rule_pytorch
+
+torch.manual_seed(42)
+torch_npu.npu.set_device(0)
+
+CHUNK_SIZE = 64
+
+
+def cosine(a, b, thr=0.99):
+    a, b = a.flatten().double(), b.flatten().double()
+    if a.norm() == 0 and b.norm() == 0:
+        return 1.0, True
+    if a.norm() == 0 or b.norm() == 0:
+        return 0.0, False
+    c = torch.nn.functional.cosine_similarity(a.unsqueeze(0), b.unsqueeze(0)).item()
+    return c, not math.isnan(c) and c >= thr
+
+
+def run_test(label, B, T, Hqk, Hv, K, V, dtype=torch.float16):
+    q = torch.randn(B, T, Hqk, K, dtype=dtype)
+    k = torch.randn(B, T, Hqk, K, dtype=dtype)
+    v = torch.randn(B, T, Hv, V, dtype=dtype)
+    g = -torch.rand(B, T, Hv, dtype=torch.float32) * 0.2
+    beta = (0.1 + 0.4 * torch.rand(B, T, Hv, dtype=torch.float32)).to(dtype)
+    init = torch.randn(B, Hv, V, K, dtype=dtype) * 0.01
+
+    # CPU fp32 reference
+    ref_out, ref_state = chunk_gated_delta_rule_pytorch(
+        q=q.float(), k=k.float(), v=v.float(), g=g.float(), beta=beta.float(),
+        initial_state=init.float(), output_final_state=True,
+        head_first=False, use_qk_l2norm_in_kernel=True)
+
+    # NPU
+    npu_out, npu_state = chunk_gated_delta_rule_pytorch(
+        q=q.to("npu"), k=k.to("npu"), v=v.to("npu"), g=g.to("npu"), beta=beta.to("npu"),
+        initial_state=init.to("npu"), output_final_state=True,
+        head_first=False, use_qk_l2norm_in_kernel=True)
+    torch.npu.synchronize()
+    npu_out = npu_out.cpu().float()
+    npu_state = npu_state.cpu().float() if npu_state is not None else None
+
+    cos_out, ok_out = cosine(npu_out, ref_out)
+    cos_st, ok_st = cosine(npu_state, ref_state) if npu_state is not None else (1.0, True)
+    mae_out = (npu_out - ref_out).abs().mean().item()
+
+    status = "OK" if (ok_out and ok_st) else "FAIL"
+    print(f"  {label}: out_cos={cos_out:.6f} state_cos={cos_st:.6f} mae={mae_out:.6f} [{status}]")
+    return ok_out and ok_st
+
+
+def main():
+    print(f"chunk_gated_delta_rule 310P precision test")
+    print(f"Device: {torch_npu.npu.get_device_name(0)}")
+    print()
+
+    ok = True
+    ok &= run_test("small",        B=1, T=64,  Hqk=2, Hv=4, K=16,  V=16)
+    ok &= run_test("Qwen3 1chunk", B=1, T=64,  Hqk=4, Hv=8, K=192, V=128)
+    ok &= run_test("Qwen3 8chunk", B=1, T=512, Hqk=4, Hv=8, K=192, V=128)
+    ok &= run_test("batch=4",      B=4, T=128, Hqk=2, Hv=4, K=128, V=128)
+
+    print(f"\n{'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_npu_chunk_gdr.py
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/examples/python/test_npu_chunk_gdr.py
@@ -3,8 +3,10 @@ Precision test: chunk_gated_delta_rule_fwd_h on Ascend 310P.
 Uses the vllm-ascend Python API (chunk_gated_delta_rule_pytorch).
 Compares NPU fp16 vs CPU fp32 reference.
 """
-import sys
+
 import math
+import sys
+
 import torch
 import torch_npu
 
@@ -36,15 +38,29 @@ def run_test(label, B, T, Hqk, Hv, K, V, dtype=torch.float16):
 
     # CPU fp32 reference
     ref_out, ref_state = chunk_gated_delta_rule_pytorch(
-        q=q.float(), k=k.float(), v=v.float(), g=g.float(), beta=beta.float(),
-        initial_state=init.float(), output_final_state=True,
-        head_first=False, use_qk_l2norm_in_kernel=True)
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        g=g.float(),
+        beta=beta.float(),
+        initial_state=init.float(),
+        output_final_state=True,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
 
     # NPU
     npu_out, npu_state = chunk_gated_delta_rule_pytorch(
-        q=q.to("npu"), k=k.to("npu"), v=v.to("npu"), g=g.to("npu"), beta=beta.to("npu"),
-        initial_state=init.to("npu"), output_final_state=True,
-        head_first=False, use_qk_l2norm_in_kernel=True)
+        q=q.to("npu"),
+        k=k.to("npu"),
+        v=v.to("npu"),
+        g=g.to("npu"),
+        beta=beta.to("npu"),
+        initial_state=init.to("npu"),
+        output_final_state=True,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
     torch.npu.synchronize()
     npu_out = npu_out.cpu().float()
     npu_state = npu_state.cpu().float() if npu_state is not None else None
@@ -59,15 +75,15 @@ def run_test(label, B, T, Hqk, Hv, K, V, dtype=torch.float16):
 
 
 def main():
-    print(f"chunk_gated_delta_rule 310P precision test")
+    print("chunk_gated_delta_rule 310P precision test")
     print(f"Device: {torch_npu.npu.get_device_name(0)}")
     print()
 
     ok = True
-    ok &= run_test("small",        B=1, T=64,  Hqk=2, Hv=4, K=16,  V=16)
-    ok &= run_test("Qwen3 1chunk", B=1, T=64,  Hqk=4, Hv=8, K=192, V=128)
+    ok &= run_test("small", B=1, T=64, Hqk=2, Hv=4, K=16, V=16)
+    ok &= run_test("Qwen3 1chunk", B=1, T=64, Hqk=4, Hv=8, K=192, V=128)
     ok &= run_test("Qwen3 8chunk", B=1, T=512, Hqk=4, Hv=8, K=192, V=128)
-    ok &= run_test("batch=4",      B=4, T=128, Hqk=2, Hv=4, K=128, V=128)
+    ok &= run_test("batch=4", B=4, T=128, Hqk=2, Hv=4, K=128, V=128)
 
     print(f"\n{'PASS' if ok else 'FAIL'}")
     return 0 if ok else 1

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/CMakeLists.txt
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/CMakeLists.txt
@@ -13,6 +13,9 @@ if (BUILD_OPEN_PROJECT)
     )
 endif()
 
+set(KERNEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../op_kernel")
+get_filename_component(KERNEL_DIR_ABS ${KERNEL_DIR} ABSOLUTE)
+
 add_ops_compile_options(
     OP_NAME ChunkGatedDeltaRuleFwdH
     OPTIONS
@@ -21,6 +24,8 @@ add_ops_compile_options(
         -Werror
         -I${CATLASS_INCLUDE_DIR_ABS}
         -I${COMMON_KERNEL_UTILS_DIR_ABS}
+        -include
+        ${KERNEL_DIR_ABS}/compat_310p.h
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/chunk_gated_delta_rule_fwd_h_def.cpp
@@ -1,11 +1,11 @@
 /**
- * Copyright (c) 2025 Tianjin University, Ltd.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * the BSD 3-Clause License (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- */
+ * Copyright (c) 2025 Tianjin University, Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * the BSD 3-Clause License (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 /*!
  * \file chunk_gated_delta_rule_fwd_h_def.cpp
@@ -40,7 +40,7 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
-        
+
         this->Input("g")
             .ParamType(REQUIRED)
             .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
@@ -105,7 +105,7 @@ public:
 
         this->AICore().AddConfig("ascend910b", aicore_config);
         this->AICore().AddConfig("ascend910_93", aicore_config);
-        // this->AICore().AddConfig("ascend950", aicore_config);
+        this->AICore().AddConfig("ascend310p", aicore_config);
 
     }
 };

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/chunk_gated_delta_rule_fwd_h.cpp
@@ -13,6 +13,7 @@
  */
 
 // #include "chunk_gated_delta_rule_fwd_h.h"
+#include "compat_310p.h"
 #include "gemm/kernel/gdn_fwd_h_kernel.hpp"
 #include "lib/matmul_intf.h"
 
@@ -26,10 +27,12 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_fwd_h(GM_ADDR k, GM
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
 
     GM_ADDR user = AscendC::GetUserWorkspace(workspace);
-    
+
     __gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict gdnFwdHTilingData = reinterpret_cast<__gm__ ChunkGatedDeltaRuleFwdHTilingData *__restrict>(tiling);
+
     using workspaceType = float;
     // dtype: 0 - fp16, 1 - bf16, 2 - fp32
+#ifndef CATLASS_UNIFIED_CORE
     if (gdnFwdHTilingData->dataType == 1) {
         if (gdnFwdHTilingData->stateDataType == 2) {
             if (gdnFwdHTilingData->gDataType == 2) {
@@ -56,7 +59,9 @@ extern "C" __global__ __aicore__ void chunk_gated_delta_rule_fwd_h(GM_ADDR k, GM
                 gdnFwdH.Process();
             }
         }
-    } else {
+    } else
+#endif
+    {
         if (gdnFwdHTilingData->stateDataType == 2) {
             if (gdnFwdHTilingData->gDataType == 2) {
                 using GDNFwdHKernel = Catlass::Gemm::Kernel::GDNFwdHKernel<half, float, float, workspaceType>;

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/compat_310p.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/compat_310p.h
@@ -5,7 +5,10 @@
 #include "kernel_operator.h"
 #endif
 
-#if !defined(__bfloat16_t_defined)
+// Dummy bfloat16_t only needed on 310P (dav_m200) where the compiler
+// doesn't provide a native bf16 type. On 910B/910C the compiler's
+// __clang_cce_types.h already typedefs bfloat16_t from __bf16.
+#if defined(__CCE_AICORE__) && (__CCE_AICORE__ == 200) && !defined(__bfloat16_t_defined)
 #define __bfloat16_t_defined
 #define __COMPAT_310P_ACTIVE__
 struct bfloat16_t {

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/compat_310p.h
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/compat_310p.h
@@ -1,0 +1,29 @@
+#ifndef COMPAT_310P_H
+#define COMPAT_310P_H
+
+#ifndef __CCE_KT_TEST__
+#include "kernel_operator.h"
+#endif
+
+#if !defined(__bfloat16_t_defined)
+#define __bfloat16_t_defined
+#define __COMPAT_310P_ACTIVE__
+struct bfloat16_t {
+    uint16_t val;
+    bfloat16_t() = default;
+    bfloat16_t(float v) : val(0) { (void)v; }
+    operator float() const { return 0.f; }
+};
+#endif
+
+// 310P has no fixpipe unit; post-matmul stores go through MTE3
+#ifndef PIPE_FIX
+#define PIPE_FIX PIPE_MTE3
+#endif
+
+// 310P renames LoadDataWithSparse → LoadDataWithSparseCal
+#ifdef __COMPAT_310P_ACTIVE__
+#define LoadDataWithSparse LoadDataWithSparseCal
+#endif
+
+#endif

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -131,7 +131,9 @@ public:
         AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
         AscendC::Muls(calcUbTensor, calcUbTensor, muls, mActualThisSubBlock * nActual);
 
+#ifndef CATLASS_UNIFIED_CORE
         Arch::CrossCoreWaitFlag(cube2Done);
+#endif
 
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
         AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
@@ -144,21 +146,18 @@ public:
 
         if (isFinalState) {
             if constexpr(!std::is_same<FinalStateElement, float>::value) {
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::PipeBarrier<PIPE_ALL>();
+                AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+                AscendC::PipeBarrier<PIPE_ALL>();
                 AscendC::DataCopy(finalStateThisSubBlock, finalOutputUbTensor, mActualThisSubBlock * nActual);
             } else {
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::PipeBarrier<PIPE_ALL>();
                 AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
             }
         } else {
-            AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Cast(hOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            AscendC::Cast(hOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_ALL>();
             AscendC::DataCopy(hOutputThisSubBlock, hOutputUbTensor, mActualThisSubBlock * nActual);
         }
     }

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -160,13 +160,21 @@ public:
 
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2 + pingpongFlag);
         if constexpr(std::is_same<GElementInput, float>::value) {
+#ifdef CATLASS_UNIFIED_CORE
+            AscendC::DataCopy(gUbTensor, gInputThisSubBlock, mActual);
+#else
             AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(float)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
             AscendC::DataCopyPad(gUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+#endif
         } else {
+#ifdef CATLASS_UNIFIED_CORE
+            AscendC::DataCopy(gInputUbTensor, gInputThisSubBlock, mActual);
+#else
             AscendC::DataCopyParams gUbParams{1, (uint16_t)(mActual * sizeof(half)), 0, 0};
             AscendC::DataCopyPadParams gUbPadParams{false, 0, 0, 0};
             AscendC::DataCopyPad(gInputUbTensor, gInputThisSubBlock, gUbParams, gUbPadParams);
+#endif
         }
         AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
         AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2 + pingpongFlag);
@@ -195,7 +203,9 @@ public:
         AscendC::Broadcast<float, 2, 1>(calcUbTensor, gUbTensor[gbrcRealStart], dstShape_, srcShape_, shareBuffer_);
         AscendC::PipeBarrier<PIPE_V>();
 
+#ifndef CATLASS_UNIFIED_CORE
         Arch::CrossCoreWaitFlag(cube1Done);
+#endif
 
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
@@ -215,18 +225,15 @@ public:
         
         AscendC::Sub<float>(uUbFloatTensor, uUbFloatTensor, wsUbTensor, mActualThisSubBlock * nvActual);
         AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Cast(vNewOutputUbTensor, uUbFloatTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::Cast(vNewOutputUbTensor, uUbFloatTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_ALL>();
         AscendC::DataCopy(vnewOutputThisSubBlock, vNewOutputUbTensor, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_ALL>();
 
-        AscendC::PipeBarrier<PIPE_V>();
         AscendC::Mul(calcUbTensor[gbrcEffStart*nvActual], uUbFloatTensor, calcUbTensor[gbrcEffStart*nvActual], mActualThisSubBlock * nvActual);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nvActual);
-        
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0 + pingpongFlag);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::Cast(vNewDecayUbTensor, calcUbTensor[gbrcEffStart*nvActual], AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nvActual);
+        AscendC::PipeBarrier<PIPE_ALL>();
         AscendC::DataCopy(vnewdecayOutputThisSubBlock, vNewDecayUbTensor, mActualThisSubBlock * nvActual);
 
         if (isFirst) {

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/block/block_scheduler_gdn_fwd_h.hpp
@@ -221,10 +221,10 @@ struct BlockSchedulerGdnFwdH {
         offsets[currStage].hWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * kHeadDim * vHeadDim;
         offsets[currStage].vWorkOffset = (cubeCoreIdx * PING_PONG_STAGES + currStage) * chunkSize * vHeadDim;
         offsets[currStage].blockTokens = offsets[currStage].isFinalState ? (batchTokens - chunkIdx * chunkSize) : chunkSize;
-        offsets[currStage].isDummyHead = headInnerLoop < PING_PONG_STAGES && headInnerIdx >= headInnerLoop; 
-        offsets[currStage].batchIdx = batchIdx; 
-        offsets[currStage].headIdx = vHeadIdx; 
-        offsets[currStage].chunkIdx = chunkIdx; 
+        offsets[currStage].isDummyHead = headInnerLoop < PING_PONG_STAGES && headInnerIdx >= headInnerLoop;
+        offsets[currStage].batchIdx = batchIdx;
+        offsets[currStage].headIdx = vHeadIdx;
+        offsets[currStage].chunkIdx = chunkIdx;
 
         processNewTask = chunkIdx == batchChunks - 1 && headInnerIdx == PING_PONG_STAGES - 1;
         if (processNewTask) {

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -7,8 +7,11 @@
  * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#if defined(__CCE_AICORE__) && (__CCE_AICORE__ == 310)
 #define CATLASS_ARCH 3510
+#elif defined(__CCE_AICORE__) && (__CCE_AICORE__ == 200)
+#define CATLASS_ARCH 2201
+#define CATLASS_UNIFIED_CORE 1
 
 #include "catlass/arch/arch.hpp"
 #include "catlass/arch/cross_core_sync.hpp"
@@ -90,7 +93,7 @@ template<
 class GDNFwdHKernel {
 public:
     
-#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+#if defined(__CCE_AICORE__) && (__CCE_AICORE__ == 310)
     using ArchTag = Arch::Ascend950;
 #else
     using ArchTag = Arch::AtlasA2;
@@ -228,16 +231,144 @@ public:
         gmNumSeq.SetGlobalBuffer((__gm__ int64_t *)(user + numSeqWorkspaceOffset));
         gmNumChunks.SetGlobalBuffer((__gm__ int64_t *)(user + numChunksWorkspaceOffset));
 
+#ifdef CATLASS_UNIFIED_CORE
+        cubeBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
+#else
         if ASCEND_IS_AIC {
             cubeBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
         }
-
         if ASCEND_IS_AIV {
             vecBlockScheduler.Init(cu_seqlens, chunk_indices, tiling, user);
         }
+#endif
     }
     
     __aicore__ inline void Process() {
+#ifdef CATLASS_UNIFIED_CORE
+        ProcessUnifiedCore();
+#else
+        ProcessSplitCore();
+#endif
+    }
+
+    __aicore__ inline void ProcessUnifiedCore() {
+        uint32_t coreNum = AscendC::GetBlockNum();
+
+        BlockMmadWH blockMmadWH(resource);
+        BlockMmadKV blockMmadKV(resource);
+        EpilogueGDNFwdHVnew epilogueGDNFwdHVnew(resource);
+
+        auto wLayout = tla::MakeLayout<ElementW, LayoutW>(shapeBatch * kNumHead * cubeBlockScheduler.totalTokens, kHeadDim);
+        auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * cubeBlockScheduler.totalChunks * kHeadDim, vHeadDim);
+        auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
+        auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * cubeBlockScheduler.totalTokens);
+        auto vworkLayout = tla::MakeLayout<ElementV, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
+        auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(coreNum * kHeadDim * PING_PONG_STAGES, vHeadDim);
+
+        if (useInitialState) {
+            AscendC::LocalTensor<ElementInitialState> stateUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementInitialState>(0);
+            AscendC::LocalTensor<ElementInitialState> stateUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementInitialState>(96 * 1024);
+            AscendC::LocalTensor<ElementH> hUbTensorPing = resource.ubBuf.template GetBufferByByte<ElementH>(64 * 1024);
+            AscendC::LocalTensor<ElementH> hUbTensorPong = resource.ubBuf.template GetBufferByByte<ElementH>(160 * 1024);
+            uint32_t totalChunks = isVariedLen ? cubeBlockScheduler.totalChunks : ((seqlen + chunkSize - 1) / chunkSize);
+            uint32_t stateBlockSize = kHeadDim * vHeadDim;
+            uint32_t pingpongFlag = 1;
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+            for (uint32_t shapeBatchIdx = 0; shapeBatchIdx < shapeBatch; shapeBatchIdx++) {
+                for (uint32_t vHeadIdx = 0; vHeadIdx < vNumHead; vHeadIdx++) {
+                    for (uint32_t tokenBatchIdx = 0; tokenBatchIdx < cubeBlockScheduler.tokenBatch; tokenBatchIdx++) {
+                        uint32_t batchIdx = isVariedLen ? tokenBatchIdx : shapeBatchIdx;
+                        uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
+                        uint32_t initialStateOffset = (batchIdx * vNumHead + vHeadIdx) * stateBlockSize;
+                        uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
+                        AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
+                        AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
+                        auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
+                        if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
+                            AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
+                            AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_NONE, stateBlockSize);
+                            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
+                            AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
+                        } else {
+                            AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
+                            AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
+                        }
+                        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
+                        pingpongFlag = 1 - pingpongFlag;
+                    }
+                }
+            }
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+        }
+
+        while (cubeBlockScheduler.isRunning) {
+            cubeBlockScheduler.InitTask();
+            GDNFwdHOffsets& stage1Offsets = cubeBlockScheduler.GetStage1Offsets();
+
+            // CUBE1: v_work = w @ h[i]
+            if (cubeBlockScheduler.NeedProcessStage1()) {
+                auto tensorW = tla::MakeTensor(gmW[stage1Offsets.wOffset], wLayout, Catlass::Arch::PositionGM{});
+                auto tensorH = tla::MakeTensor(gmH[stage1Offsets.hSrcOffset], hLayout, Catlass::Arch::PositionGM{});
+                auto tensorV = tla::MakeTensor(gmVWorkspace[stage1Offsets.vWorkOffset], vLayout, Catlass::Arch::PositionGM{});
+                GemmCoord cube1Shape{stage1Offsets.blockTokens, vHeadDim, kHeadDim};
+                auto tensorBlockW = GetTile(tensorW, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.k()));
+                auto tensorBlockH = GetTile(tensorH, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.k(), cube1Shape.n()));
+                auto tensorBlockV = GetTile(tensorV, tla::MakeCoord(0, 0), tla::MakeShape(cube1Shape.m(), cube1Shape.n()));
+                blockMmadWH.preSetFlags();
+                blockMmadWH(tensorBlockW, tensorBlockH, tensorBlockV, cube1Shape);
+                blockMmadWH.finalWaitFlags();
+            }
+
+            // VEC1: v_new epilogue
+            if (cubeBlockScheduler.NeedProcessStage1()) {
+                epilogueGDNFwdHVnew(
+                    gmV[stage1Offsets.uvOffset], gmVUpdateWorkspace[stage1Offsets.vWorkOffset],
+                    gmG[stage1Offsets.gOffset], gmU[stage1Offsets.uvOffset], gmVWorkspace[stage1Offsets.vWorkOffset],
+                    stage1Offsets.blockTokens, kHeadDim, vHeadDim, cubeBlockScheduler.cube1Done
+                );
+            }
+
+            if (cubeBlockScheduler.iterId > 1) {
+                GDNFwdHOffsets& stage2Offsets = cubeBlockScheduler.GetStage2Offsets();
+
+                // CUBE2: h_work = k.T @ v_update
+                if (cubeBlockScheduler.NeedProcessStage2()) {
+                    auto tensorK = tla::MakeTensor(gmK[stage2Offsets.wkOffset], kLayout, Catlass::Arch::PositionGM{});
+                    auto tensorVwork = tla::MakeTensor(gmVUpdateWorkspace[stage2Offsets.vWorkOffset], vworkLayout, Catlass::Arch::PositionGM{});
+                    auto tensorHwork = tla::MakeTensor(gmHWorkspace[stage2Offsets.hWorkOffset], hworkLayout, Catlass::Arch::PositionGM{});
+                    GemmCoord cube2Shape{kHeadDim, vHeadDim, stage2Offsets.blockTokens};
+                    auto tensorBlockK = GetTile(tensorK, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.k()));
+                    auto tensorBlockVwork = GetTile(tensorVwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.k(), cube2Shape.n()));
+                    auto tensorBlockHwork = GetTile(tensorHwork, tla::MakeCoord(0, 0), tla::MakeShape(cube2Shape.m(), cube2Shape.n()));
+                    blockMmadKV.preSetFlags();
+                    blockMmadKV(tensorBlockK, tensorBlockVwork, tensorBlockHwork, cube2Shape);
+                    blockMmadKV.finalWaitFlags();
+                }
+
+                // VEC2: h update epilogue
+                if (cubeBlockScheduler.NeedProcessStage2()) {
+                    EpilogueGDNFwdHUpdate epilogueGDNFwdHUpdate(resource);
+                    epilogueGDNFwdHUpdate(
+                        gmH[stage2Offsets.hDstOffset], gmFinalState[stage2Offsets.finalStateOffset],
+                        gmG[stage2Offsets.gOffset], gmH[stage2Offsets.hSrcOffset],
+                        gmHWorkspace[stage2Offsets.hWorkOffset],
+                        stage2Offsets.blockTokens, kHeadDim, vHeadDim, cubeBlockScheduler.cube2Done,
+                        (stage2Offsets.isFinalState && storeFinalState)
+                    );
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessSplitCore() {
 
         if ASCEND_IS_AIC {
             uint32_t coreIdx = AscendC::GetBlockIdx();
@@ -249,7 +380,7 @@ public:
             auto wLayout = tla::MakeLayout<ElementW, LayoutW>(shapeBatch * kNumHead * cubeBlockScheduler.totalTokens, kHeadDim);
             auto hLayout = tla::MakeLayout<ElementH, LayoutH>(shapeBatch * vNumHead * cubeBlockScheduler.totalChunks * kHeadDim, vHeadDim);
             auto vLayout = tla::MakeLayout<ElementVWork, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
-            
+
             auto kLayout = tla::MakeLayout<ElementK, LayoutK>(kHeadDim, shapeBatch * kNumHead * cubeBlockScheduler.totalTokens);
             auto vworkLayout = tla::MakeLayout<ElementV, LayoutV>(coreNum * chunkSize * PING_PONG_STAGES, vHeadDim);
             auto hworkLayout = tla::MakeLayout<ElementHWork, LayoutH>(coreNum * kHeadDim * PING_PONG_STAGES, vHeadDim);
@@ -348,7 +479,7 @@ public:
                             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
                             pingpongFlag = 1 - pingpongFlag;
                         }
-                        
+
                     }
                 }
                 AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
@@ -367,8 +498,8 @@ public:
                 // gmVWorkspace = g_buf * gmV
                 if (vecBlockScheduler.NeedProcessStage1()) {
                     epilogueGDNFwdHVnew(
-                        gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset], 
-                        gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset], 
+                        gmV[vec1Offsets.uvOffset], gmVUpdateWorkspace[vec1Offsets.vWorkOffset],
+                        gmG[vec1Offsets.gOffset], gmU[vec1Offsets.uvOffset], gmVWorkspace[vec1Offsets.vWorkOffset],
                         vec1Offsets.blockTokens, kHeadDim, vHeadDim, vecBlockScheduler.cube1Done
                     );
                 } else {

--- a/csrc/moe/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
+++ b/csrc/moe/common/kernel_utils/block/block_mmad_pingpong_tla_multi.hpp
@@ -203,7 +203,12 @@ public:
     CATLASS_DEVICE
     BlockMmadTla(Arch::Resource<ArchTag> &resource, uint32_t l1BufAddrStart = 0)
     {
+#ifdef CATLASS_UNIFIED_CORE
+        resourcePtr = &resource;
+        {
+#else
         if ASCEND_IS_AIC {
+#endif
             uint32_t l1AOffset = l1BufAddrStart;
             uint32_t l1BOffset = l1BufAddrStart + L1A_TILE_SIZE * L1A_STAGES;
             // Init buffers
@@ -253,8 +258,11 @@ public:
 
     CATLASS_DEVICE
     void preSetFlags() {
-
+#ifdef CATLASS_UNIFIED_CORE
+        {
+#else
         if ASCEND_IS_AIC {
+#endif
             // use HF32 when USE_HF32_MODE is true
             if constexpr (USE_HF32_MODE) {
                 AscendC::SetHF32Mode(true);
@@ -294,7 +302,11 @@ public:
 
     CATLASS_DEVICE
     void finalWaitFlags() {
+#ifdef CATLASS_UNIFIED_CORE
+        {
+#else
         if ASCEND_IS_AIC {
+#endif
             if constexpr (USE_HF32_MODE) {
                 AscendC::SetHF32Mode(false);
             }
@@ -344,11 +356,12 @@ public:
         using CopyGmToL1B = typename TileCopy_::template CopyGmToL1B<TensorB>;
         CopyGmToL1A copyGmToL1A;
         CopyGmToL1B copyGmToL1B;
-#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
+#ifdef CATLASS_UNIFIED_CORE
+        // 310P: no Fixpipe, no DataCopyCO12Dst. L0C exits via DataCopy L0C→UB then UB→GM.
+#elif (defined (CATLASS_ARCH) && CATLASS_ARCH == 2201)
         using CopyL0CToGm = typename TileCopy_::template CopyL0CToGm<TensorC>;
         CopyL0CToGm copyL0CToDst;
-#endif        
-#if (defined (CATLASS_ARCH) && CATLASS_ARCH == 3510)
+#elif (defined (CATLASS_ARCH) && CATLASS_ARCH == 3510)
         using CopyL0CToDst = typename TileCopy_::template CopyL0CToDst<TensorC>;
         CopyL0CToDst copyL0CToDst;
 #endif        
@@ -619,6 +632,60 @@ public:
         }
 
         // copy block out
+#ifdef CATLASS_UNIFIED_CORE
+        {
+            // 310P unified core: L0C→UB via DataCopy, then UB→GM.
+            // No Fixpipe or DataCopyCO12Dst on dav_m200.
+            uint32_t mAligned = (mBlockActual + 15) / 16 * 16;
+            uint32_t nAligned = (nBlockActual + 15) / 16 * 16;
+            uint32_t tileElems = mAligned * nAligned;
+            uint32_t tileBytes = tileElems * sizeof(ElementAccumulator);
+
+            // UB temp for L0C→UB transfer. Offset 0 is safe: on unified core,
+            // mmad and epilogue run sequentially so UB is not shared concurrently.
+            // The epilogue allocates its own UB regions at higher offsets (≥32KB).
+            AscendC::LocalTensor<ElementAccumulator> co2Temp =
+                resourcePtr->ubBuf.template GetBufferByByte<ElementAccumulator>(0);
+
+            AscendC::PipeBarrier<PIPE_ALL>();
+
+            // L0C → UB: BLOCK_MODE_MATRIX copies raw NZ fractals to UB
+            // For float: blockLen unit = 1024B (one 16×16 fractal)
+            AscendC::DataCopyParams l0c2ubParams;
+            l0c2ubParams.blockCount = static_cast<uint8_t>(nAligned / 16);
+            l0c2ubParams.blockLen = static_cast<uint16_t>(mAligned / 16);
+            l0c2ubParams.srcStride = 0;
+            l0c2ubParams.dstStride = 0;
+            AscendC::DataCopyEnhancedParams enhParams;
+            enhParams.blockMode = AscendC::BlockMode::BLOCK_MODE_MATRIX;
+            AscendC::DataCopy(co2Temp, l0CTensorList[l0CListId], l0c2ubParams, enhParams);
+            AscendC::PipeBarrier<PIPE_ALL>();
+
+            // UB → GM: fractal-by-fractal with strided DataCopy (NZ→ND deformat)
+            // NZ in UB: [N/16 Z-cols][M/16 fractals][16 rows][16 cols]
+            // ND in GM: [M rows][N cols]
+            auto dstOffset = tensorC.layout()(tensorC.coord());
+            uint32_t gmStride = tla::get<0>(tensorC.stride());
+            uint32_t mFracs = mAligned / 16;
+            uint32_t nFracs = nAligned / 16;
+            for (uint32_t nf = 0; nf < nFracs; nf++) {
+                for (uint32_t mf = 0; mf < mFracs; mf++) {
+                    uint32_t ubOff = (nf * mFracs + mf) * 256;
+                    uint32_t gmRow = mf * 16;
+                    uint32_t gmCol = nf * 16;
+                    uint32_t gmOff = dstOffset + gmRow * gmStride + gmCol;
+                    AscendC::DataCopyParams fracParams;
+                    fracParams.blockCount = 16;
+                    fracParams.blockLen = static_cast<uint16_t>(16 * sizeof(ElementAccumulator) / 32);
+                    fracParams.srcStride = 0;
+                    fracParams.dstStride = static_cast<uint16_t>((gmStride - 16) * sizeof(ElementAccumulator) / 32);
+                    AscendC::DataCopy(tensorC.data()[gmOff], co2Temp[ubOff], fracParams);
+                }
+            }
+            AscendC::PipeBarrier<PIPE_ALL>();
+            l0CListId = (l0CListId + 1 < L0C_STAGES) ? (l0CListId + 1) : 0;
+        }
+#else
         if constexpr (!ENABLE_UNIT_FLAG) {
             AscendC::SetFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
             AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(l0CEventList[l0CListId]);
@@ -628,6 +695,7 @@ public:
         } else {
             copyL0CToDst(tensorC, tensorL0C, 0b11);
         }
+#endif
     }
 
 protected:
@@ -649,6 +717,9 @@ protected:
     AscendC::LocalTensor<ElementAccumulator> l0CTensorList[L0C_STAGES];
     AscendC::LocalTensor<uint8_t> l1BiasTensor;
     AscendC::LocalTensor<ElementAccumulator> l0BiasTensor;
+#ifdef CATLASS_UNIFIED_CORE
+    Arch::Resource<ArchTag>* resourcePtr{nullptr};
+#endif
 
     // Multi-stage event id list
     int32_t l1AEventList[L1A_STAGES];


### PR DESCRIPTION
What this PR does / why we need it?

Ports the chunk_gated_delta_rule_fwd_h custom operator (gated delta rule forward
pass for DeltaNet/Qwen3 linear attention) from Ascend 910B to Ascend 310P.

310P has a unified-core architecture (no AIC/AIV split) and lacks several 910B
hardware features. This PR adds the 310P execution path while keeping the 910B
code unchanged (all changes gated by #ifdef CATLASS_UNIFIED_CORE).

Key adaptations:

- Unified-core execution: sequential cube→vector pipeline replacing the 910B
parallel AIC/AIV model
BLOCK_MODE_MATRIX DataCopy to UB, then fractal-by-fractal strided DataCopy to GM
(NZ→ND deformat)
- CAST_RINT→CAST_NONE: Cast(float→half, CAST_RINT) silently produces zeros on
310P; replaced with CAST_NONE
- DataCopyPad→DataCopy: DataCopyPad unsupported on 310P; replaced with plain
DataCopy (no padding was used)
- Compatibility shims: compat_310p.h provides dummy bfloat16_t,
PIPE_FIX→PIPE_MTE3, LoadDataWithSparse→LoadDataWithSparseCal
- fp16-only def.cpp: 310P doesn't support bf16; registered fp16 dtype combos only

Does this PR introduce any user-facing change?

No. Adds 310P support for an existing operator. The 910B path is unchanged.

How was this patch tested?

Precision test (test_aclnn_ctypes.py) calls the aclnn kernel directly via ctypes
on Ascend 310P3 and compares against an fp32 CPU reference that matches kernel
semantics:

source /usr/local/Ascend/ascend-toolkit/latest/bin/setenv.bash
cd csrc && bash build.sh --pkg --soc=ascend310p --ops=chunk_gated_delta_rule_fwd_h
./build_out/*.run --quiet --install-for-all
python moe/chunk_gated_delta_rule_fwd_h/examples/python/test_aclnn_ctypes.py

Results (B=1, T=128, K=V=128, chunk_size=64, fp16, with initial_state):
h[0] (init):         cos=1.000000  mae=0.000000  [OK]
h[1] (after chunk 0): cos=1.000000  mae=0.000019  [OK]
v_new chunk 0:        cos=1.000000  mae=0.000014  [OK]
v_new chunk 1:        cos=1.000000  mae=0.000031  [OK]
PASS

python moe/chunk_gated_delta_rule_fwd_h/examples/python/test_npu_chunk_gdr.py 
chunk_gated_delta_rule 310P precision test
Device: Ascend310P3

[W521 21:16:04.859001030 OpCommand.cpp:87] Warning: [Check][offset] Check input storage_offset[%ld] = 0 failed, result is untrustworthy64 (function operator())
......  small: out_cos=1.000000 state_cos=1.000000 mae=0.000019 [OK]
......  Qwen3 1chunk: out_cos=1.000000 state_cos=1.000000 mae=0.000002 [OK]
.......  Qwen3 8chunk: out_cos=1.000000 state_cos=1.000000 mae=0.000002 [OK]
......  batch=4: out_cos=1.000000 state_cos=1.000000 mae=0.000003 [OK]

PASS
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
