### PR TITLE
[BugFix][Model] Fix NaN hidden states and low MTP acceptance rate when FlashComm1 is enabled

### DIFF
--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -933,8 +933,25 @@ class DeepseekV4Model(nn.Module):
             hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
-        num_tokens = hidden_states.shape[0]
-        self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
+        # When FlashComm1 (sequence parallelism) is enabled, tokens are
+        # partitioned across TP ranks via reduce_scatter in each layer's
+        # row-parallel output projection.  We must all_gather here so the
+        # MTP layers receive the full token set — otherwise only rank 0's
+        # partition is valid and the rest of the buffer holds stale data,
+        # leading to NaN values and low acceptance rate.
+        from vllm_ascend.ascend_forward_context import get_forward_context
+
+        forward_ctx = get_forward_context()
+        if forward_ctx is not None and forward_ctx.flash_comm_v1_enabled:
+            h_states_flat = tensor_model_parallel_all_gather(hidden_states.flatten(1), dim=0)
+            pad_size = forward_ctx.pad_size
+            if pad_size > 0:
+                h_states_flat = h_states_flat[:-pad_size]
+            num_tokens = h_states_flat.shape[0]
+            self._mtp_hidden_buffer[:num_tokens].copy_(h_states_flat)
+        else:
+            num_tokens = hidden_states.shape[0]
+            self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
 
         hidden_states = self.hc_head(hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base)
         if not get_pp_group().is_last_rank:


### PR DESCRIPTION
  ### Description                                                     

  What this PR does / why we need it?

  When FlashComm1 (sequence parallelism, VLLM_ASCEND_ENABLE_FLASHCOMM1=1) is enabled, DeepSeek V4's attention output projection (wo_b, RowParallelLinear) uses
  tensor_model_parallel_reduce_scatter instead of all_reduce, partitioning tokens across TP ranks.

  DeepseekV4Model.forward() stashes the pre-hc_head hidden states into _mtp_hidden_buffer for the MTP draft model via get_mtp_target_hidden_states(). However, these hidden
  states are still TP-partitioned at stash time — each rank only stores N/tp valid token entries. The remaining buffer positions hold stale data from previous runs.

  When the MTP draft model reads from this buffer, it encounters stale / NaN values for token positions that belong to other TP ranks, causing a drastic drop in speculative
  decoding acceptance rate.

  This PR fixes the issue by performing a tensor_model_parallel_all_gather on the hidden states before stashing into _mtp_hidden_buffer when FlashComm1 is active.

  ### Does this PR introduce any user-facing change?

  No. This is a bug fix that restores correct MTP speculative decoding behavior when FlashComm1 is enabled.

  ### How was this patch tested?

  - Manual testing with DeepSeek V4 + FlashComm1 enabled: verified MTP acceptance rate recovers to normal levels and hidden state NaN values are eliminated.
  - The fix follows the same all_gather + pad_size removal pattern already used in NPUModelRunner._all_gather_hidden_states().

  ### Root Cause Analysis

  Target model forward (FlashComm1 enabled):
    Layer 0..N:
      wo_b (RowParallelLinear) → reduce_scatter → tokens partitioned [N/tp per rank]
    _mtp_hidden_buffer[:N/tp].copy_(partitioned_hidden_states)  ← BUG: stores partitioned data
    hc_head → norm → return gathered_hidden_states  ← OK: final output is all_gathered

  ### MTP draft forward:
    hidden_states = get_mtp_target_hidden_states()  ← returns partitioned buffer
    MTP reads entries beyond rank's partition → stale data → NaN → low acceptance
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
