### PR TITLE
[Feature] Support DSA PCP/DCP with FlashComm

### DIFF
--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -88,7 +88,7 @@ class TestAscendSFACPMetadataBuilder(TestBase):
         self.mock_cfg.compilation_config.pass_config = MagicMock()
         self.mock_cfg.compilation_config.pass_config.enable_sp = False
 
-        self.mock_cfg.speculative_config.num_speculative_tokens = 0
+        self.mock_cfg.speculative_config = None
 
         self.patcher = patch("vllm.config.get_current_vllm_config", return_value=self.mock_cfg)
         self.patcher.start()
@@ -128,9 +128,7 @@ class TestAscendSFACPMetadataBuilder(TestBase):
         vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
         vllm_config.model_config.hf_text_config = MagicMock(qk_rope_head_dim=64)
         vllm_config.model_config.hf_config.model_type = "deepseek_v3"
-        speculative_config = MagicMock()
-        speculative_config.num_speculative_tokens = 0
-        vllm_config.speculative_config = speculative_config
+        vllm_config.speculative_config = None
         vllm_config.scheduler_config.max_num_seqs = 16
         vllm_config.scheduler_config.max_num_batched_tokens = 256
         vllm_config.parallel_config = MagicMock()
@@ -906,6 +904,8 @@ class TestAscendSFACPImpl(TestBase):
         sfa_cp_metadata.pcp_allgather_restore_idx = torch.arange(4)
         attn_metadata.sfa_cp_metadata = sfa_cp_metadata
         attn_metadata.slot_mapping = slots
+        attn_metadata.num_decode_tokens = 2
+        attn_metadata.num_prefills = 0
 
         result = self.impl.exec_kv(kv_no_split, cos, sin, kv_cache, slots, attn_metadata)
         self.assertEqual(result, (None, None))

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -87,7 +87,6 @@ class TestAscendSFACPMetadataBuilder(TestBase):
         self.mock_cfg.compilation_config = MagicMock()
         self.mock_cfg.compilation_config.pass_config = MagicMock()
         self.mock_cfg.compilation_config.pass_config.enable_sp = False
-
         self.mock_cfg.speculative_config = None
 
         self.patcher = patch("vllm.config.get_current_vllm_config", return_value=self.mock_cfg)
@@ -900,14 +899,21 @@ class TestAscendSFACPImpl(TestBase):
         slots = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
 
         attn_metadata = MagicMock()
+
         sfa_cp_metadata = MagicMock()
+
         sfa_cp_metadata.pcp_allgather_restore_idx = torch.arange(4)
+
         attn_metadata.sfa_cp_metadata = sfa_cp_metadata
+
         attn_metadata.slot_mapping = slots
+
         attn_metadata.num_decode_tokens = 2
+
         attn_metadata.num_prefills = 0
 
         result = self.impl.exec_kv(kv_no_split, cos, sin, kv_cache, slots, attn_metadata)
+
         self.assertEqual(result, (None, None))
         mock_torch_npu._npu_reshape_and_cache.assert_called_once()
 

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -185,6 +185,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
         common_attn_metadata.max_query_len = 1
+        common_attn_metadata.prefill_context_parallel_metadata = None
         common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
@@ -241,6 +242,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
         common_attn_metadata.max_query_len = 1
+        common_attn_metadata.prefill_context_parallel_metadata = None
         common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -95,7 +95,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         self.mock_cfg.compilation_config.pass_config = MagicMock()
         self.mock_cfg.compilation_config.pass_config.enable_sp = False
 
-        self.mock_cfg.speculative_config.num_speculative_tokens = 0
+        self.mock_cfg.speculative_config = None
 
         self.patcher = patch("vllm.config.get_current_vllm_config", return_value=self.mock_cfg)
         self.patcher.start()
@@ -139,9 +139,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         vllm_config.model_config.get_head_size.return_value = 64
         vllm_config.model_config.dtype = torch.float16
         vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
-        speculative_config = MagicMock()
-        speculative_config.num_speculative_tokens = 4
-        vllm_config.speculative_config = speculative_config
+        vllm_config.speculative_config = None
         device = torch.device("cpu")
 
         builder = AscendSFAMetadataBuilder(
@@ -176,9 +174,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         vllm_config.model_config.get_head_size.return_value = 64
         vllm_config.model_config.dtype = torch.float16
         vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
-        speculative_config = MagicMock()
-        speculative_config.num_speculative_tokens = 4
-        vllm_config.speculative_config = speculative_config
+        vllm_config.speculative_config = None
         device = torch.device("cpu")
 
         builder = AscendSFAMetadataBuilder(
@@ -188,6 +184,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
+        common_attn_metadata.max_query_len = 1
         common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
@@ -233,9 +230,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         vllm_config.model_config.get_head_size.return_value = 64
         vllm_config.model_config.dtype = torch.float16
         vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
-        speculative_config = MagicMock()
-        speculative_config.num_speculative_tokens = 4
-        vllm_config.speculative_config = speculative_config
+        vllm_config.speculative_config = None
         device = torch.device("cpu")
 
         builder = AscendSFAMetadataBuilder(
@@ -245,6 +240,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 10
         common_attn_metadata.num_actual_tokens = 100
+        common_attn_metadata.max_query_len = 1
         common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
         common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -7,25 +7,23 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON
-from vllm.logger import logger
 
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
+from vllm_ascend.attention.mla_v1 import MAX_O_PROJ_PREFETCH_SIZE, MLAPO_MAX_SUPPORTED_TOKENS
 from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enabling_mlapo, split_decodes_and_prefills
-from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.utils import (
-    get_weight_prefetch_method,
-)
 from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    enabling_mlapo,
     maybe_save_kv_layer_to_connector,
+    split_decodes_and_prefills,
     wait_for_kv_layer_from_connector,
 )
-from vllm_ascend.ops.layer_shard_linear import (
-    is_hidden_layer,
-    reach_layer_for_shard_weight_series
+from vllm_ascend.ops.layer_shard_linear import is_hidden_layer, reach_layer_for_shard_weight_series
+from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
+from vllm_ascend.utils import ( 
+    get_weight_prefetch_method,  
 )
-from vllm_ascend.attention.mla_v1 import MAX_O_PROJ_PREFETCH_SIZE, MLAPO_MAX_SUPPORTED_TOKENS
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -174,7 +172,7 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
                 inverse_idx.scatter_(
                     0, 
                     restore_idx, 
-                    torch.arange(num_tokens_pcp_padded, device=restore_idx.device, dtype=restore_idx.dtype)
+                    torch.arange(num_tokens_pcp_padded, device=restore_idx.device, dtype=restore_idx.dtype),
                 )
 
                 prefill_start_in_slot_mapping = num_decode_tokens * self.pcp_size
@@ -183,10 +181,12 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
                 self.prefill_slot_mapping = torch.where(
                     inverse_idx < num_decode_tokens * self.pcp_size,
                     torch.tensor(-1, device=restore_idx.device, dtype=torch.long),
-                    prefill_slots[inverse_idx - num_decode_tokens * self.pcp_size]
+                    prefill_slots[inverse_idx - num_decode_tokens * self.pcp_size],
                 )
             metadata_cls.slot_mapping = self.slot_mapping_buf[:num_actual_tokens_pcp_padded]
-            metadata_cls.prefill_slot_mapping = self.prefill_slot_mapping if hasattr(self, 'prefill_slot_mapping') else None
+            metadata_cls.prefill_slot_mapping = (
+                self.prefill_slot_mapping if hasattr(self, 'prefill_slot_mapping') else None
+            )
             # if torch.distributed.get_rank()  == 0:
             #     logger.info(f"metadata_cls.slot_mapping = {metadata_cls.slot_mapping}")
             #     logger.info(f"long_seq_metadata.pcp_allgather_restore_idx = {long_seq_metadata.pcp_allgather_restore_idx}")
@@ -451,10 +451,10 @@ class AscendSFACPImpl(AscendSFAImpl):
     ):
         kw, _ = self.wk_weights_proj(x)
         k_li = kw[:, : self.head_dim]
-        weight = kw[:, self.head_dim:]
+        weight = kw[:, self.head_dim :]
         k_li = self.k_norm(k_li).unsqueeze(1)
         k_li = k_li.view(-1, 1, self.head_dim)
- 
+
         if HAS_TRITON:
             cos = cos.view(-1, self.qk_rope_head_dim)
             sin = sin.view(-1, self.qk_rope_head_dim)
@@ -465,16 +465,16 @@ class AscendSFACPImpl(AscendSFAImpl):
             k_li_pe, k_li_nope = torch.split(
                 k_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
             )
- 
+
             cos = cos.view(-1, 1, 1, self.qk_rope_head_dim)
             sin = sin.view(-1, 1, 1, self.qk_rope_head_dim)
- 
+
             k_li_pe = k_li_pe.unsqueeze(2)
             k_li_pe = torch_npu.npu_rotary_mul(k_li_pe, cos, sin)
             k_li_pe = k_li_pe.squeeze(2)
- 
+
             k_li = torch.cat([k_li_pe, k_li_nope], dim=-1)  # [b*s,128]
- 
+
         if self.use_sparse_c8_indexer:
             k_li = k_li @ AscendSFAImpl.k_hadamard
             k_li, k_li_scale = torch_npu.npu_dynamic_quant(k_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
@@ -482,7 +482,7 @@ class AscendSFACPImpl(AscendSFAImpl):
             k_li_scale = k_li_scale.unsqueeze(-1)  # [b*s,1]
         else:
             k_li_scale = None
- 
+
         return k_li, k_li_scale, weight
 
     def indexer_select_post_process(
@@ -752,7 +752,7 @@ class AscendSFACPImpl(AscendSFAImpl):
                     if is_hidden_layer(layer):
                         reach_layer_for_shard_weight_series(layer)
             return output.fill_(0)
- 
+
         cos = attn_metadata.cos
         sin = attn_metadata.sin
         slot_mapping = attn_metadata.slot_mapping
@@ -766,11 +766,11 @@ class AscendSFACPImpl(AscendSFAImpl):
             cos_cp, sin_cp = cos, sin
         actual_seq_lengths_query = attn_metadata.cum_query_lens
         actual_seq_lengths_key = attn_metadata.seq_lens
- 
+
         # Inputs and outputs may be padded for CUDA graphs
         num_input_tokens = attn_metadata.num_input_tokens
         output_padded = output
- 
+
         # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
         if self.enable_mlapo and num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS:
             hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_with_mlapo(
@@ -797,24 +797,37 @@ class AscendSFACPImpl(AscendSFAImpl):
             )
             assert self.q_a_layernorm is not None, "q_a_layernorm must be initialized"
             q_c = self.q_a_layernorm(q_c)
- 
+
             k_li, k_li_scale, weight = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
- 
+
             wait_for_kv_layer_from_connector(layer_name)
- 
+
             if self.enable_dsa_cp:
                 # AG
-                fused_kv_no_split = torch.cat([kv_no_split.view(-1, kv_no_split.shape[-1]), k_li.view(-1, k_li.shape[-1]),], dim=1)
-                fused_kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(fused_kv_no_split.contiguous(), need_gather_q_kv)[:num_actual_tokens]   
-                kv_no_split, k_li = fused_kv_no_split.split([self.qk_rope_head_dim + self.kv_lora_rank, self.head_dim], dim=-1)
-                weight = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(weight.contiguous(), need_gather_q_kv)[:num_actual_tokens]
-                q_c = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(q_c.contiguous(), need_gather_q_kv)[:num_actual_tokens]
-            
+                fused_kv_no_split = torch.cat(
+                    [
+                        kv_no_split.view(-1, kv_no_split.shape[-1]), k_li.view(-1, k_li.shape[-1]),
+                    ], 
+                    dim=1
+                )
+                fused_kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                    fused_kv_no_split.contiguous(), need_gather_q_kv
+                )[:num_actual_tokens]   
+                kv_no_split, k_li = fused_kv_no_split.split(
+                    [self.qk_rope_head_dim + self.kv_lora_rank, self.head_dim], dim=-1
+                )
+                weight = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(weight.contiguous(), need_gather_q_kv)[
+                    :num_actual_tokens
+                ]
+                q_c = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(q_c.contiguous(), need_gather_q_kv)[
+                    :num_actual_tokens
+                ]
+
             k_pe, k_nope = self.exec_kv(kv_no_split, cos_cp, sin_cp, kv_cache, slot_mapping, attn_metadata)
 
             ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
             q_pe = self.rope_single(q_pe, cos_cp, sin_cp)
- 
+
             k_li = self._get_full_kv(k_li, attn_metadata)
 
         if kv_cache is not None:
@@ -822,7 +835,9 @@ class AscendSFACPImpl(AscendSFAImpl):
                 attn_metadata.reshape_cache_event = torch.npu.Event()
             if num_decode_tokens > 0:
                 torch_npu.npu_scatter_nd_update_(
-                    kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping[:num_decode_tokens].view(-1, 1), k_li[:num_decode_tokens].view(-1, k_li.shape[-1])
+                    kv_cache[2].view(-1, k_li.shape[-1]),
+                    slot_mapping[:num_decode_tokens].view(-1, 1),
+                    k_li[:num_decode_tokens].view(-1, k_li.shape[-1]),
                 )  # b, s, n, d
                 if self.use_sparse_c8_indexer:
                     assert len(kv_cache) == 4
@@ -848,7 +863,7 @@ class AscendSFACPImpl(AscendSFAImpl):
                     )
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
- 
+
         topk_num_tokens = num_input_tokens or hidden_states.shape[0]
         if self.skip_topk:
             topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
@@ -865,11 +880,11 @@ class AscendSFACPImpl(AscendSFAImpl):
             )
             if self.use_index_cache:
                 self._update_indexcache_topk_indices(topk_indices)
- 
+
         attn_output = self._execute_sparse_flash_attention_process(
             ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
         )
- 
+
         attn_output = self._v_up_proj(attn_output)
         weight_prefetch_method = get_weight_prefetch_method()
         weight_prefetch_method.maybe_prefetch_mla_or_sla_weight_in_current_stream(
@@ -879,9 +894,8 @@ class AscendSFACPImpl(AscendSFAImpl):
             linear_layer=self.o_proj,
         )
 
- 
         output[...] = self.o_proj(attn_output)[0]
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
- 
+
         return output_padded
 

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -7,11 +7,26 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON
+from vllm.logger import logger
 
 from vllm_ascend.attention.context_parallel.common_cp import AscendPCPMetadata
 from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, AscendSFAMetadataBuilder
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enabling_mlapo, split_decodes_and_prefills
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
+from vllm_ascend.utils import (
+    get_weight_prefetch_method,
+)
+from vllm_ascend.attention.utils import (
+    maybe_save_kv_layer_to_connector,
+    wait_for_kv_layer_from_connector,
+)
+from vllm_ascend.ops.layer_shard_linear import (
+    is_hidden_layer,
+    reach_layer_for_shard_weight_series
+)
+from vllm_ascend.attention.mla_v1 import MAX_O_PROJ_PREFETCH_SIZE, MLAPO_MAX_SUPPORTED_TOKENS
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
 
 M = TypeVar("M", bound=AscendSFAMetadata)
 
@@ -132,12 +147,12 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             self.slot_mapping_buf[:num_actual_tokens_pcp_padded].copy_(
                 common_attn_metadata.slot_mapping[:num_actual_tokens_pcp_padded], non_blocking=True
             )
-            if self.enable_mlapo:
-                self.slot_mapping_buf[:num_decode_tokens] = self.slot_mapping_buf[
-                    : num_decode_tokens * self.pcp_size : self.pcp_size
-                ]
-                self.slot_mapping_buf[num_decode_tokens : num_decode_tokens * self.pcp_size].fill_(-1)
-            elif self.speculative_config is not None and num_decodes > 0:
+            self.slot_mapping_buf[:num_decode_tokens] = self.slot_mapping_buf[
+                : num_decode_tokens * self.pcp_size : self.pcp_size
+            ]
+            self.slot_mapping_buf[num_decode_tokens : num_decode_tokens * self.pcp_size].fill_(-1)
+
+            if self.speculative_config is not None and num_decodes > 0:
                 # when mtp, pcp_allgather_restore_idx=[696,-1,697,-1,560,-1,561,-1,100,101,102],
                 # slot_mapping should be [696,697,-1,-1,560,561,-1,-1,100,101,102]
                 # corner case: decode requests in the same MTP batch can have
@@ -150,7 +165,32 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
                     decode_slot_mapping,
                     decode_query_lens,
                 )
+            # prefill slot mapping
+            if num_prefills > 0:
+                restore_idx = long_seq_metadata.pcp_allgather_restore_idx
+                num_tokens_pcp_padded = len(restore_idx)
+                
+                inverse_idx = torch.empty_like(restore_idx)
+                inverse_idx.scatter_(
+                    0, 
+                    restore_idx, 
+                    torch.arange(num_tokens_pcp_padded, device=restore_idx.device, dtype=restore_idx.dtype)
+                )
+
+                prefill_start_in_slot_mapping = num_decode_tokens * self.pcp_size
+                prefill_slots = self.slot_mapping_buf[prefill_start_in_slot_mapping:].clone()
+                
+                self.prefill_slot_mapping = torch.where(
+                    inverse_idx < num_decode_tokens * self.pcp_size,
+                    torch.tensor(-1, device=restore_idx.device, dtype=torch.long),
+                    prefill_slots[inverse_idx - num_decode_tokens * self.pcp_size]
+                )
             metadata_cls.slot_mapping = self.slot_mapping_buf[:num_actual_tokens_pcp_padded]
+            metadata_cls.prefill_slot_mapping = self.prefill_slot_mapping if hasattr(self, 'prefill_slot_mapping') else None
+            # if torch.distributed.get_rank()  == 0:
+            #     logger.info(f"metadata_cls.slot_mapping = {metadata_cls.slot_mapping}")
+            #     logger.info(f"long_seq_metadata.pcp_allgather_restore_idx = {long_seq_metadata.pcp_allgather_restore_idx}")
+            #     logger.info(f"metadata_cls.prefill_slot_mapping = {metadata_cls.prefill_slot_mapping}")
         metadata_cls.sfa_cp_metadata = sfa_cp_metadata
         return metadata_cls
 
@@ -231,6 +271,7 @@ class AscendSFACPImpl(AscendSFAImpl):
         self.dcp_size = get_dcp_group().world_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
         self.dcp_group = get_dcp_group().device_group if self.dcp_size > 1 else None
+        self.local_num_heads = self.num_heads
 
     def _execute_sparse_flash_attention_process(
         self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
@@ -402,9 +443,51 @@ class AscendSFACPImpl(AscendSFAImpl):
         )
         return block_tables
 
-    def indexer_select_post_process(
+    def indexer_select_pre_process(
         self,
         x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ):
+        kw, _ = self.wk_weights_proj(x)
+        k_li = kw[:, : self.head_dim]
+        weight = kw[:, self.head_dim:]
+        k_li = self.k_norm(k_li).unsqueeze(1)
+        k_li = k_li.view(-1, 1, self.head_dim)
+ 
+        if HAS_TRITON:
+            cos = cos.view(-1, self.qk_rope_head_dim)
+            sin = sin.view(-1, self.qk_rope_head_dim)
+            k_li = rope_forward_triton_siso(
+                k_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
+            )
+        else:
+            k_li_pe, k_li_nope = torch.split(
+                k_li, [self.qk_rope_head_dim, self.head_dim - self.qk_rope_head_dim], dim=-1
+            )
+ 
+            cos = cos.view(-1, 1, 1, self.qk_rope_head_dim)
+            sin = sin.view(-1, 1, 1, self.qk_rope_head_dim)
+ 
+            k_li_pe = k_li_pe.unsqueeze(2)
+            k_li_pe = torch_npu.npu_rotary_mul(k_li_pe, cos, sin)
+            k_li_pe = k_li_pe.squeeze(2)
+ 
+            k_li = torch.cat([k_li_pe, k_li_nope], dim=-1)  # [b*s,128]
+ 
+        if self.use_sparse_c8_indexer:
+            k_li = k_li @ AscendSFAImpl.k_hadamard
+            k_li, k_li_scale = torch_npu.npu_dynamic_quant(k_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
+            k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
+            k_li_scale = k_li_scale.unsqueeze(-1)  # [b*s,1]
+        else:
+            k_li_scale = None
+ 
+        return k_li, k_li_scale, weight
+
+    def indexer_select_post_process(
+        self,
+        weights: torch.Tensor,
         q_c: torch.Tensor,
         kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
         attn_metadata: M,
@@ -413,8 +496,6 @@ class AscendSFACPImpl(AscendSFAImpl):
         actual_seq_lengths_query: torch.Tensor,
         actual_seq_lengths_key: torch.Tensor,
     ):
-        kw, _ = self.wk_weights_proj(x)
-        weights = kw[:, self.head_dim :]
         q_li, _ = self.wq_b(q_c)  # [b,s,1536] @ [1536,64*128] = [b,s,64*128]
         q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
         if HAS_TRITON:
@@ -557,15 +638,93 @@ class AscendSFACPImpl(AscendSFAImpl):
         kv_c_normed = kv_c_normed.view([kv_c_normed.shape[0], self.num_kv_heads, -1])
         k_pe = k_pe.unsqueeze(1)
         k_pe = self.rope_single(k_pe, cos, sin)
-        kv_c_k_pe = torch.cat([kv_c_normed, k_pe], dim=-1)
-        kv_c_k_pe = get_pcp_group().all_gather(kv_c_k_pe, 0)
-        kv_c_k_pe = torch.index_select(kv_c_k_pe, 0, attn_metadata.sfa_cp_metadata.pcp_allgather_restore_idx)
-        kv_c_normed, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        slot_mapping = attn_metadata.slot_mapping
-        torch_npu._npu_reshape_and_cache(
-            key=kv_c_normed, value=k_pe, key_cache=kv_cache[0], value_cache=kv_cache[1], slot_indices=slot_mapping
-        )
+
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        if num_decode_tokens > 0:
+            torch_npu._npu_reshape_and_cache(
+                key=kv_c_normed[:num_decode_tokens],
+                value=k_pe[:num_decode_tokens],
+                key_cache=kv_cache[0],
+                value_cache=kv_cache[1],
+                slot_indices=attn_metadata.slot_mapping[:num_decode_tokens],
+            )
+
+        if attn_metadata.num_prefills > 0:
+            assert attn_metadata.prefill_slot_mapping is not None
+            prefill_kv_c_k_pe = torch.cat([kv_c_normed, k_pe], dim=-1)
+            prefill_kv_c_k_pe = get_pcp_group().all_gather(prefill_kv_c_k_pe, 0)
+            prefill_kv_c_normed, prefill_k_pe = prefill_kv_c_k_pe.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim],
+                dim=-1,
+            )
+            torch_npu._npu_reshape_and_cache(
+                key=prefill_kv_c_normed,
+                value=prefill_k_pe,
+                key_cache=kv_cache[0],
+                value_cache=kv_cache[1],
+                slot_indices=attn_metadata.prefill_slot_mapping,
+            )
         return None, None
+
+    # def exec_kv_prefill(
+    #     self,
+    #     kv_no_split: torch.Tensor,
+    #     cos: torch.Tensor,
+    #     sin: torch.Tensor,
+    #     kv_cache: tuple,
+    #     attn_metadata: M,
+    # ):
+    #     num_decode_tokens = attn_metadata.num_decode_tokens
+    #     num_actual_tokens = attn_metadata.num_actual_tokens
+    #     kv_c, k_pe = kv_no_split.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+    #     kv_c_normed = self.kv_a_layernorm(kv_c.contiguous())  # type: ignore[misc]
+    #     assert len(kv_cache) > 1, "the number of kv cache should be greater than 1, namely (nope_cache and rope_cache)"
+    #     assert attn_metadata.sfa_cp_metadata is not None
+    #     kv_c_normed = kv_c_normed.view([kv_c_normed.shape[0], self.num_kv_heads, -1])
+    #     k_pe = k_pe.unsqueeze(1)
+    #     prefill_k_pe = k_pe
+    #     prefill_k_pe[num_decode_tokens:num_actual_tokens] = self.rope_single(
+    #         prefill_k_pe[num_decode_tokens:num_actual_tokens], cos, sin
+    #     )
+    #     kv_c_k_pe = torch.cat([kv_c_normed, k_pe], dim=-1)
+    #     kv_c_k_pe = get_pcp_group().all_gather(kv_c_k_pe, 0)
+
+    #     # cache
+    #     kv_c_normed, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+    #     assert attn_metadata.prefill_slot_mapping is not None
+    #     slot_mapping = attn_metadata.prefill_slot_mapping
+    #     torch_npu._npu_reshape_and_cache(
+    #         key=kv_c_normed, value=k_pe, key_cache=kv_cache[0], value_cache=kv_cache[1], slot_indices=slot_mapping
+    #     )
+    #     return None, None
+
+    # def exec_kv_decode(
+    #     self,
+    #     kv_no_split: torch.Tensor,
+    #     cos: torch.Tensor,
+    #     sin: torch.Tensor,
+    #     kv_cache: tuple,
+    #     slots: torch.Tensor,
+    # ):
+    #     assert self.kv_a_layernorm is not None
+    #     B = kv_no_split.shape[0]
+    #     N = self.num_kv_heads
+    #     S = 1
+    #     # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
+    #     kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
+    #     cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
+    #     k_pe, k_nope, _, _ = torch_npu.npu_kv_rmsnorm_rope_cache(
+    #         kv_no_split,
+    #         self.kv_a_layernorm.weight,  # type: ignore[union-attr]
+    #         cos,
+    #         sin,
+    #         slots.to(torch.int64),
+    #         kv_cache[1],
+    #         kv_cache[0],
+    #         epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
+    #         cache_mode=cache_mode,
+    #     )
+    #     return k_pe, k_nope
 
     def _get_full_kv(self, k, attn_metadata: M):
         if self.pcp_size == 1 or self.enable_mlapo:
@@ -573,5 +732,156 @@ class AscendSFACPImpl(AscendSFAImpl):
         else:
             assert attn_metadata.sfa_cp_metadata is not None
             k = get_pcp_group().all_gather(k.contiguous(), 0)
-            k = torch.index_select(k, 0, attn_metadata.sfa_cp_metadata.pcp_allgather_restore_idx)
+            # k = torch.index_select(k, 0, attn_metadata.sfa_cp_metadata.pcp_allgather_restore_idx)
             return k
+
+    def forward(
+        self,
+        layer_name,
+        hidden_states: torch.Tensor,  # query in unified attn
+        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        attn_metadata: M,
+        need_gather_q_kv: bool = False,
+        output: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert output is not None, "Output tensor must be provided."
+        if attn_metadata is None:
+            # Profiling run.
+            if self.enable_dsa_cp_with_layer_shard and not _EXTRA_CTX.in_profile_run:
+                for layer in self.layer_sharding_kwargs or []:
+                    if is_hidden_layer(layer):
+                        reach_layer_for_shard_weight_series(layer)
+            return output.fill_(0)
+ 
+        cos = attn_metadata.cos
+        sin = attn_metadata.sin
+        slot_mapping = attn_metadata.slot_mapping
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        if self.enable_dsa_cp:
+            assert attn_metadata.dsa_cp_context is not None
+            cos_cp = attn_metadata.dsa_cp_context.cos_cp
+            sin_cp = attn_metadata.dsa_cp_context.sin_cp
+        else:
+            cos_cp, sin_cp = cos, sin
+        actual_seq_lengths_query = attn_metadata.cum_query_lens
+        actual_seq_lengths_key = attn_metadata.seq_lens
+ 
+        # Inputs and outputs may be padded for CUDA graphs
+        num_input_tokens = attn_metadata.num_input_tokens
+        output_padded = output
+ 
+        # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
+        if self.enable_mlapo and num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS:
+            hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_with_mlapo(
+                hidden_states=hidden_states,
+                kv_cache=kv_cache,
+                cos=cos,
+                sin=sin,
+                slot_mapping=slot_mapping,
+                num_input_tokens=num_input_tokens,
+            )
+            k_li, k_li_scale, weight = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+            wait_for_kv_layer_from_connector(layer_name)
+        # native
+        else:
+            assert self.fused_qkv_a_proj is not None, "q lora is required for DSA."
+            weight_prefetch_method = get_weight_prefetch_method()
+            weight_prefetch_method.maybe_prefetch_mla_or_sla_weight_in_current_stream(
+                inputs=self.fused_qkv_a_proj.weight, dependency=hidden_states
+            )
+            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            q_c, kv_no_split = qkv_lora.split(
+                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+                dim=-1,
+            )
+            assert self.q_a_layernorm is not None, "q_a_layernorm must be initialized"
+            q_c = self.q_a_layernorm(q_c)
+ 
+            k_li, k_li_scale, weight = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+ 
+            wait_for_kv_layer_from_connector(layer_name)
+ 
+            if self.enable_dsa_cp:
+                # AG
+                fused_kv_no_split = torch.cat([kv_no_split.view(-1, kv_no_split.shape[-1]), k_li.view(-1, k_li.shape[-1]),], dim=1)
+                fused_kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(fused_kv_no_split.contiguous(), need_gather_q_kv)[:num_actual_tokens]   
+                kv_no_split, k_li = fused_kv_no_split.split([self.qk_rope_head_dim + self.kv_lora_rank, self.head_dim], dim=-1)
+                weight = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(weight.contiguous(), need_gather_q_kv)[:num_actual_tokens]
+                q_c = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(q_c.contiguous(), need_gather_q_kv)[:num_actual_tokens]
+            
+            k_pe, k_nope = self.exec_kv(kv_no_split, cos_cp, sin_cp, kv_cache, slot_mapping, attn_metadata)
+
+            ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
+            q_pe = self.rope_single(q_pe, cos_cp, sin_cp)
+ 
+            k_li = self._get_full_kv(k_li, attn_metadata)
+
+        if kv_cache is not None:
+            if self.is_kv_producer:
+                attn_metadata.reshape_cache_event = torch.npu.Event()
+            if num_decode_tokens > 0:
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping[:num_decode_tokens].view(-1, 1), k_li[:num_decode_tokens].view(-1, k_li.shape[-1])
+                )  # b, s, n, d
+                if self.use_sparse_c8_indexer:
+                    assert len(kv_cache) == 4
+                    assert k_li_scale is not None
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[3].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping[:num_decode_tokens].view(-1, 1),
+                        k_li_scale[:num_decode_tokens].view(-1, k_li_scale.shape[-1]),
+                    )
+            if attn_metadata.num_prefills > 0:
+                assert attn_metadata.prefill_slot_mapping is not None
+                slot_mapping = attn_metadata.prefill_slot_mapping
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping.view(-1, 1), k_li.view(-1, k_li.shape[-1])
+                )  # b, s, n, d
+                if self.use_sparse_c8_indexer:
+                    assert len(kv_cache) == 4
+                    assert k_li_scale is not None
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[3].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li_scale.view(-1, k_li_scale.shape[-1]),
+                    )
+            if self.is_kv_producer:
+                attn_metadata.reshape_cache_event.record()
+ 
+        topk_num_tokens = num_input_tokens or hidden_states.shape[0]
+        if self.skip_topk:
+            topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
+        else:
+            topk_indices = self.indexer_select_post_process(
+                weights=weight,
+                q_c=q_c,
+                kv_cache=kv_cache,
+                attn_metadata=attn_metadata,
+                cos=cos_cp,
+                sin=sin_cp,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+            )
+            if self.use_index_cache:
+                self._update_indexcache_topk_indices(topk_indices)
+ 
+        attn_output = self._execute_sparse_flash_attention_process(
+            ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
+        )
+ 
+        attn_output = self._v_up_proj(attn_output)
+        weight_prefetch_method = get_weight_prefetch_method()
+        weight_prefetch_method.maybe_prefetch_mla_or_sla_weight_in_current_stream(
+            inputs=self.o_proj.weight,
+            dependency=attn_output,
+            max_size=MAX_O_PROJ_PREFETCH_SIZE,
+            linear_layer=self.o_proj,
+        )
+
+ 
+        output[...] = self.o_proj(attn_output)[0]
+        maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
+ 
+        return output_padded
+

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -142,10 +142,14 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             assert long_seq_metadata is not None
             num_actual_tokens_pcp_padded = long_seq_metadata.num_actual_tokens_pcp_padded
             self.slot_mapping_buf[:num_actual_tokens_pcp_padded].copy_(
+
                 common_attn_metadata.slot_mapping[:num_actual_tokens_pcp_padded], non_blocking=True
+
             )
             self.slot_mapping_buf[:num_decode_tokens] = self.slot_mapping_buf[
+
                 : num_decode_tokens * self.pcp_size : self.pcp_size
+
             ].clone()
             self.slot_mapping_buf[num_decode_tokens : num_decode_tokens * self.pcp_size].fill_(-1)
 

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -146,7 +146,7 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             )
             self.slot_mapping_buf[:num_decode_tokens] = self.slot_mapping_buf[
                 : num_decode_tokens * self.pcp_size : self.pcp_size
-            ]
+            ].clone()
             self.slot_mapping_buf[num_decode_tokens : num_decode_tokens * self.pcp_size].fill_(-1)
 
             if self.speculative_config is not None and num_decodes > 0:

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -21,10 +21,9 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.ops.layer_shard_linear import is_hidden_layer, reach_layer_for_shard_weight_series
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.utils import ( 
+from vllm_ascend.utils import (
     get_weight_prefetch_method,
 )
-
 
 M = TypeVar("M", bound=AscendSFAMetadata)
 
@@ -806,9 +805,10 @@ class AscendSFACPImpl(AscendSFAImpl):
                 # AG
                 fused_kv_no_split = torch.cat(
                     [
-                        kv_no_split.view(-1, kv_no_split.shape[-1]), k_li.view(-1, k_li.shape[-1]),
+                        kv_no_split.view(-1, kv_no_split.shape[-1]),
+                        k_li.view(-1, k_li.shape[-1]),
                     ],
-                    dim=1
+                    dim=1,
                 )
                 fused_kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                     fused_kv_no_split.contiguous(), need_gather_q_kv
@@ -898,4 +898,3 @@ class AscendSFACPImpl(AscendSFAImpl):
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output_padded
-

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -186,10 +186,6 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             metadata_cls.prefill_slot_mapping = (
                 self.prefill_slot_mapping if hasattr(self, "prefill_slot_mapping") else None
             )
-            # if torch.distributed.get_rank()  == 0:
-            #     logger.info(f"metadata_cls.slot_mapping = {metadata_cls.slot_mapping}")
-            #     logger.info(f"long_seq_metadata.pcp_allgather_restore_idx = {long_seq_metadata.pcp_allgather_restore_idx}")
-            #     logger.info(f"metadata_cls.prefill_slot_mapping = {metadata_cls.prefill_slot_mapping}")
         metadata_cls.sfa_cp_metadata = sfa_cp_metadata
         return metadata_cls
 
@@ -665,73 +661,12 @@ class AscendSFACPImpl(AscendSFAImpl):
             )
         return None, None
 
-    # def exec_kv_prefill(
-    #     self,
-    #     kv_no_split: torch.Tensor,
-    #     cos: torch.Tensor,
-    #     sin: torch.Tensor,
-    #     kv_cache: tuple,
-    #     attn_metadata: M,
-    # ):
-    #     num_decode_tokens = attn_metadata.num_decode_tokens
-    #     num_actual_tokens = attn_metadata.num_actual_tokens
-    #     kv_c, k_pe = kv_no_split.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-    #     kv_c_normed = self.kv_a_layernorm(kv_c.contiguous())  # type: ignore[misc]
-    #     assert len(kv_cache) > 1, "the number of kv cache should be greater than 1, namely (nope_cache and rope_cache)"
-    #     assert attn_metadata.sfa_cp_metadata is not None
-    #     kv_c_normed = kv_c_normed.view([kv_c_normed.shape[0], self.num_kv_heads, -1])
-    #     k_pe = k_pe.unsqueeze(1)
-    #     prefill_k_pe = k_pe
-    #     prefill_k_pe[num_decode_tokens:num_actual_tokens] = self.rope_single(
-    #         prefill_k_pe[num_decode_tokens:num_actual_tokens], cos, sin
-    #     )
-    #     kv_c_k_pe = torch.cat([kv_c_normed, k_pe], dim=-1)
-    #     kv_c_k_pe = get_pcp_group().all_gather(kv_c_k_pe, 0)
-
-    #     # cache
-    #     kv_c_normed, k_pe = kv_c_k_pe.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-    #     assert attn_metadata.prefill_slot_mapping is not None
-    #     slot_mapping = attn_metadata.prefill_slot_mapping
-    #     torch_npu._npu_reshape_and_cache(
-    #         key=kv_c_normed, value=k_pe, key_cache=kv_cache[0], value_cache=kv_cache[1], slot_indices=slot_mapping
-    #     )
-    #     return None, None
-
-    # def exec_kv_decode(
-    #     self,
-    #     kv_no_split: torch.Tensor,
-    #     cos: torch.Tensor,
-    #     sin: torch.Tensor,
-    #     kv_cache: tuple,
-    #     slots: torch.Tensor,
-    # ):
-    #     assert self.kv_a_layernorm is not None
-    #     B = kv_no_split.shape[0]
-    #     N = self.num_kv_heads
-    #     S = 1
-    #     # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
-    #     kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
-    #     cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
-    #     k_pe, k_nope, _, _ = torch_npu.npu_kv_rmsnorm_rope_cache(
-    #         kv_no_split,
-    #         self.kv_a_layernorm.weight,  # type: ignore[union-attr]
-    #         cos,
-    #         sin,
-    #         slots.to(torch.int64),
-    #         kv_cache[1],
-    #         kv_cache[0],
-    #         epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
-    #         cache_mode=cache_mode,
-    #     )
-    #     return k_pe, k_nope
-
     def _get_full_kv(self, k, attn_metadata: M):
         if self.pcp_size == 1 or self.enable_mlapo:
             return k
         else:
             assert attn_metadata.sfa_cp_metadata is not None
             k = get_pcp_group().all_gather(k.contiguous(), 0)
-            # k = torch.index_select(k, 0, attn_metadata.sfa_cp_metadata.pcp_allgather_restore_idx)
             return k
 
     def forward(

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -22,7 +22,7 @@ from vllm_ascend.attention.utils import (
 from vllm_ascend.ops.layer_shard_linear import is_hidden_layer, reach_layer_for_shard_weight_series
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
 from vllm_ascend.utils import ( 
-    get_weight_prefetch_method,  
+    get_weight_prefetch_method,
 )
 
 
@@ -167,17 +167,17 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             if num_prefills > 0:
                 restore_idx = long_seq_metadata.pcp_allgather_restore_idx
                 num_tokens_pcp_padded = len(restore_idx)
-                
+
                 inverse_idx = torch.empty_like(restore_idx)
                 inverse_idx.scatter_(
-                    0, 
-                    restore_idx, 
+                    0,
+                    restore_idx,
                     torch.arange(num_tokens_pcp_padded, device=restore_idx.device, dtype=restore_idx.dtype),
                 )
 
                 prefill_start_in_slot_mapping = num_decode_tokens * self.pcp_size
                 prefill_slots = self.slot_mapping_buf[prefill_start_in_slot_mapping:].clone()
-                
+
                 self.prefill_slot_mapping = torch.where(
                     inverse_idx < num_decode_tokens * self.pcp_size,
                     torch.tensor(-1, device=restore_idx.device, dtype=torch.long),
@@ -185,7 +185,7 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
                 )
             metadata_cls.slot_mapping = self.slot_mapping_buf[:num_actual_tokens_pcp_padded]
             metadata_cls.prefill_slot_mapping = (
-                self.prefill_slot_mapping if hasattr(self, 'prefill_slot_mapping') else None
+                self.prefill_slot_mapping if hasattr(self, "prefill_slot_mapping") else None
             )
             # if torch.distributed.get_rank()  == 0:
             #     logger.info(f"metadata_cls.slot_mapping = {metadata_cls.slot_mapping}")
@@ -807,12 +807,12 @@ class AscendSFACPImpl(AscendSFAImpl):
                 fused_kv_no_split = torch.cat(
                     [
                         kv_no_split.view(-1, kv_no_split.shape[-1]), k_li.view(-1, k_li.shape[-1]),
-                    ], 
+                    ],
                     dim=1
                 )
                 fused_kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                     fused_kv_no_split.contiguous(), need_gather_q_kv
-                )[:num_actual_tokens]   
+                )[:num_actual_tokens]
                 kv_no_split, k_li = fused_kv_no_split.split(
                     [self.qk_rope_head_dim + self.kv_lora_rank, self.head_dim], dim=-1
                 )

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -142,14 +142,10 @@ class AscendSFACPMetadataBuilder(AscendSFAMetadataBuilder):
             assert long_seq_metadata is not None
             num_actual_tokens_pcp_padded = long_seq_metadata.num_actual_tokens_pcp_padded
             self.slot_mapping_buf[:num_actual_tokens_pcp_padded].copy_(
-
                 common_attn_metadata.slot_mapping[:num_actual_tokens_pcp_padded], non_blocking=True
-
             )
             self.slot_mapping_buf[:num_decode_tokens] = self.slot_mapping_buf[
-
                 : num_decode_tokens * self.pcp_size : self.pcp_size
-
             ].clone()
             self.slot_mapping_buf[num_decode_tokens : num_decode_tokens * self.pcp_size].fill_(-1)
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -19,7 +19,6 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-from vllm_ascend import envs
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -436,7 +436,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # The MLAPO operator fuses the pre-processing steps on Q/K/V in MLA into a single operator
         # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
-        self.enable_mlapo = envs.VLLM_ASCEND_ENABLE_MLAPO
+        self.enable_mlapo = ascend_config.enable_mlapo
 
         assert self.indexer is not None, "Indexer is required for DSA."
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeVar
 
@@ -32,10 +31,10 @@ from vllm_ascend.attention.utils import (
     ascend_chunked_prefill_workspace_size,
     enable_cp,
     maybe_save_kv_layer_to_connector,
+    split_decodes_and_prefills,
     trans_rope_weight,
     transdata,
     wait_for_kv_layer_from_connector,
-    split_decodes_and_prefills
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
@@ -238,9 +237,10 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         num_input_tokens = common_attn_metadata.num_input_tokens
-        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+            common_attn_metadata, decode_threshold=self.decode_threshold
         )
+        
 
         block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
@@ -1318,4 +1318,3 @@ class AscendSFAImpl(MLAAttentionImpl):
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output_padded
-

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -240,7 +240,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
             common_attn_metadata, decode_threshold=self.decode_threshold
         )
-        
 
         block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1,3 +1,4 @@
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeVar
 
@@ -19,6 +20,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
+from vllm_ascend import envs
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
@@ -33,6 +35,7 @@ from vllm_ascend.attention.utils import (
     trans_rope_weight,
     transdata,
     wait_for_kv_layer_from_connector,
+    split_decodes_and_prefills
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
@@ -115,6 +118,8 @@ class DSACPContext:
     slot_mapping_cp: torch.Tensor
     actual_seq_lengths_query: torch.Tensor
     actual_seq_lengths_key: torch.Tensor
+    sin_cp: torch.Tensor
+    cos_cp: torch.Tensor
 
 
 @dataclass
@@ -151,6 +156,7 @@ class AscendSFAMetadata:
     dsa_cp_context: DSACPContext | None = None
     reshape_cache_event: torch.npu.Event = None
     sfa_cp_metadata: AscendPCPMetadata | None = None
+    prefill_slot_mapping: torch.Tensor | None = None
     num_decodes: int = 0
     num_decode_tokens: int = 0
     num_prefills: int = 0
@@ -232,6 +238,9 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         num_input_tokens = common_attn_metadata.num_input_tokens
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+        )
 
         block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
@@ -275,6 +284,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 slot_mapping = slot_mapping[:num_tokens_pad]
             slot_mapping_cp = slot_mapping[local_start:local_end_with_pad]
 
+            cos_cp, sin_cp = cos, sin
             cos = cos[local_start:local_end_with_pad]
             sin = sin[local_start:local_end_with_pad]
 
@@ -328,11 +338,14 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 slot_mapping_cp=slot_mapping_cp,
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
+                sin_cp=sin_cp[:num_actual_tokens],
+                cos_cp=cos_cp[:num_actual_tokens],
             )
 
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=num_actual_tokens,
+            num_decode_tokens=num_decode_tokens,
             cum_query_lens=cum_query_lens,
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens_cpu,
@@ -424,7 +437,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # The MLAPO operator fuses the pre-processing steps on Q/K/V in MLA into a single operator
         # NOTE: it imposes a limit on the number of input tokens and conflicts with FlashComm
-        self.enable_mlapo = get_ascend_config().enable_mlapo
+        self.enable_mlapo = envs.VLLM_ASCEND_ENABLE_MLAPO
 
         assert self.indexer is not None, "Indexer is required for DSA."
 
@@ -1305,3 +1318,4 @@ class AscendSFAImpl(MLAAttentionImpl):
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output_padded
+

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -61,6 +61,7 @@ from vllm.model_executor.models.utils import extract_layer_index
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.attention.utils import enable_cp
 from vllm_ascend.distributed.parallel_state import (
     get_flashcomm2_odp_group,
     get_flashcomm2_otp_group,
@@ -81,7 +82,6 @@ from vllm_ascend.utils import (
     oproj_tp_enable,
     shared_expert_dp_enabled,
 )
-from vllm_ascend.attention.utils import enable_cp
 
 
 class CustomLinearOp:
@@ -750,4 +750,3 @@ def is_moe_layer(prefix: str) -> bool:
     n_routed_experts, first_k_dense_replace, moe_layer_freq = get_moe_params()
 
     return n_routed_experts is not None and layer_idx >= first_k_dense_replace and layer_idx % moe_layer_freq == 0
-

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -682,6 +682,7 @@ def _get_row_parallel_op(
             "out_proj",  # attn output linear of Qwen3 Next
             "down_proj",  # second MLP of most LLMs
             "attention.dense",  # attn output linear of Bailing
+            "wo_b",  # attn output linear of v4
         ]
         for a_prefix in sp_row_prefixes:
             if a_prefix in prefix:

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -81,6 +81,7 @@ from vllm_ascend.utils import (
     oproj_tp_enable,
     shared_expert_dp_enabled,
 )
+from vllm_ascend.attention.utils import enable_cp
 
 
 class CustomLinearOp:
@@ -627,7 +628,7 @@ class ShardedCPColumnParallelOp(CustomColumnParallelOp):
 def _get_column_parallel_op(
     prefix, layer
 ) -> MLPColumnParallelOp | SequenceColumnParallelOp | ShardedCPColumnParallelOp | Flashcomm2OshardQKVParallelOp | None:
-    if enable_dsa_cp() and ("q_b_proj" in prefix or "kv_b_proj" in prefix):
+    if enable_dsa_cp() and ("q_b_proj" in prefix or "kv_b_proj" in prefix) and not enable_cp():
         return ShardedCPColumnParallelOp(layer)
     if "gate_up_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPColumnParallelOp(layer)
@@ -681,7 +682,6 @@ def _get_row_parallel_op(
             "out_proj",  # attn output linear of Qwen3 Next
             "down_proj",  # second MLP of most LLMs
             "attention.dense",  # attn output linear of Bailing
-            "wo_b",  # attn output linear of v4
         ]
         for a_prefix in sp_row_prefixes:
             if a_prefix in prefix:
@@ -750,3 +750,4 @@ def is_moe_layer(prefix: str) -> bool:
     n_routed_experts, first_k_dense_replace, moe_layer_freq = get_moe_params()
 
     return n_routed_experts is not None and layer_idx >= first_k_dense_replace and layer_idx % moe_layer_freq == 0
+


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables DSA models to use PCP/DCP together with SP/FlashComm in SFA CP.
Previously, when PCP/DCP was enabled, the sequence could not be split in the TP domain through FlashComm. This PR updates `AscendSFACPImpl.forward()` to use FlashComm for sequence partitioning in the TP domain when `pcp_size` / `dcp_size` is greater than 1, and performs an all-gather in the TP domain to restore the original sequence length before returning.
This PR also updates `AscendSFACPMetadataBuilder.build()` to pre-build the reordered slot mapping, so that KV reordering does not need to be performed during computation.
With these changes, DSA models can now enable PCP and SP/FlashComm at the same time, reducing redundant computation and improving the SFA CP execution path.

### Does this PR introduce _any_ user-facing change?

Yes. DSA models now support enabling PCP/DCP together with SP/FlashComm.

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
