### PR TITLE
[Doc][Skill] Auto-refresh adapt-guide lookup tables

### DIFF
--- a/.agents/skills/main2main/SKILL.md
+++ b/.agents/skills/main2main/SKILL.md
@@ -192,7 +192,41 @@ Normal long-running CI with regular output is not a hang and must keep running.
 
 7. **Write step summary.** After committing, write a brief summary for this step: what upstream changes were absorbed, what vllm-ascend files were modified, and any version guards added. Save to `/tmp/main2main/steps/<step-id>/summary.md`. This is important because later steps and the final report depend on it.
 
-### Phase 3: Final summary
+### Phase 3: Refresh adapt-guide tables (after all steps are committed)
+
+The lookup tables in `reference/adapt-guide.md` drift as vllm-ascend evolves —
+new modules appear, old paths get renamed or deleted. Refresh them once per run
+*after every step is committed* (not per step), so the next main2main run reads
+an up-to-date guide. Only run this when the run is on track to reach `completed`
+or a clean partial stop; skip it if the pipeline rolled back.
+
+1. Run the linter to surface drift:
+```bash
+python3 <skill_dir>/scripts/lint_adapt_guide.py \
+  --ascend-path <ascend_path>
+```
+This writes `/tmp/main2main/adapt-guide-refresh/check_report.md` with three
+sections: invalidated paths, uncovered vllm_ascend/ directories, and upstream
+paths touched this run that the file-mapping table doesn't cover.
+
+2. Update **only the three AUTO-MAINTAINED regions** in
+`reference/adapt-guide.md` — `key-areas`, `file-locations`, `file-mapping`.
+Use the report plus this run's `changed-files.txt` to decide what to add,
+rename, or remove. Do not touch the surrounding prose, headings, or any other
+section of the file.
+
+3. Commit the refresh as a separate commit, only if the guide actually changed:
+```bash
+git -C <ascend_path> diff --quiet \
+  .agents/skills/main2main/reference/adapt-guide.md \
+  || git -C <ascend_path> commit -s \
+       -m "docs(main2main): refresh adapt-guide tables" \
+       -- .agents/skills/main2main/reference/adapt-guide.md
+```
+Use `git add <file>`, never `git add .`. Keep this commit separate from any
+step's functional commit so reviewers can audit the table changes alone.
+
+### Phase 4: Final summary
 
 Output a reviewer-facing Markdown summary only when one of these is true:
 1. Every planned step has been completed, verified, committed, and the target
@@ -220,4 +254,5 @@ These are the things most commonly missed, based on past experience:
 - [ ] Each commit message includes the upstream commit range
 - [ ] Each step has a summary in `/tmp/main2main/steps/<step-id>/summary.md`
 - [ ] If partial stop: patch + failure details saved
+- [ ] `lint_adapt_guide.py` ran and any updates to the three AUTO-MAINTAINED regions in `reference/adapt-guide.md` were committed as a separate commit
 - [ ] Final summary output to user

--- a/.agents/skills/main2main/reference/adapt-guide.md
+++ b/.agents/skills/main2main/reference/adapt-guide.md
@@ -99,6 +99,7 @@ a missing version guard here is cheaper to fix than a CI round-trip.
 
 When analyzing vLLM changes, pay special attention to these areas that typically require vLLM Ascend adaptation:
 
+<!-- BEGIN AUTO-MAINTAINED: key-areas -->
 1. **Platform Interface** (`vllm/platforms/`)
    - New abstract methods — implement immediately; missing ones cause `TypeError: Can't instantiate abstract class AscendPlatform` at runtime, not at import time, so they won't surface until a test actually executes
    - Method signature changes
@@ -146,11 +147,13 @@ When analyzing vLLM changes, pay special attention to these areas that typically
 10. **Models** (`vllm/model_executor/models/`)
     - Changes to model forward signatures — when vllm-ascend overrides a model's forward method, signature changes break inference
     - New model architectures
+<!-- END AUTO-MAINTAINED: key-areas -->
 
 ---
 
 ## vllm-ascend Key File Locations
 
+<!-- BEGIN AUTO-MAINTAINED: file-locations -->
 | Project | Path |
 |---------|------|
 | vLLM Ascend version compatibility | `vllm-ascend/docs/source/conf.py` |
@@ -179,6 +182,7 @@ When analyzing vLLM changes, pay special attention to these areas that typically
 | Common utilities | `vllm_ascend/utils.py` |
 | Ascend config | `vllm_ascend/ascend_config.py` |
 | Environment variables | `vllm_ascend/envs.py` |
+<!-- END AUTO-MAINTAINED: file-locations -->
 
 ---
 
@@ -186,6 +190,7 @@ When analyzing vLLM changes, pay special attention to these areas that typically
 
 Use this table after identifying a changed upstream symbol. It points to likely vllm-ascend locations, not guaranteed locations.
 
+<!-- BEGIN AUTO-MAINTAINED: file-mapping -->
 | vLLM upstream path | vllm-ascend path | What to check |
 |:---|:---|:---|
 | `vllm/platforms/` | `vllm_ascend/platform.py` | Abstract methods, platform capabilities |
@@ -203,3 +208,4 @@ Use this table after identifying a changed upstream symbol. It points to likely 
 | `vllm/model_executor/custom_op.py` | `vllm_ascend/ops/` | Custom op registration |
 | `vllm/v1/worker/gpu/spec_decode/` | `vllm_ascend/spec_decode/` | MTP/Eagle proposer interfaces |
 | `requirements*`, `constraints*`, `pyproject.toml`, `setup.py`, `setup.cfg` | Matching dependency files in vllm-ascend | Dependency versions |
+<!-- END AUTO-MAINTAINED: file-mapping -->

--- a/.agents/skills/main2main/reference/adapt-guide.md
+++ b/.agents/skills/main2main/reference/adapt-guide.md
@@ -162,6 +162,10 @@ When analyzing vLLM changes, pay special attention to these areas that typically
 | Ascend-specific attention | `vllm_ascend/attention/` |
 | Ascend-specific executor | `vllm_ascend/worker/` |
 | Ascend-specific ops | `vllm_ascend/ops/` |
+| Scheduling extensions | `vllm_ascend/core/` |
+| Device abstractions | `vllm_ascend/device/` |
+| Device memory allocator | `vllm_ascend/device_allocator/` |
+| Custom CANN ops (placeholder dir) | `vllm_ascend/_cann_ops_custom/` |
 | **Specialized Implementations** | |
 | Ascend 310P specific | `vllm_ascend/_310p/` |
 | EPLB load balancing | `vllm_ascend/eplb/` |
@@ -171,13 +175,21 @@ When analyzing vLLM changes, pay special attention to these areas that typically
 | Compilation passes | `vllm_ascend/compilation/passes/` |
 | **Quantization** | |
 | Quantization methods | `vllm_ascend/quantization/` |
-| ModelSlim integration | `vllm_ascend/quantization/methods/modelslim/` |
+| ModelSlim integration | `vllm_ascend/quantization/modelslim_config.py` |
 | **Distributed & KV Cache** | |
 | KV transfer | `vllm_ascend/distributed/kv_transfer/` |
 | Device communicators | `vllm_ascend/distributed/device_communicators/` |
+| KV cache offload (CPU/NPU) | `vllm_ascend/kv_offload/` |
 | **Speculative Decoding** | |
-| MTP proposer | `vllm_ascend/spec_decode/mtp_proposer.py` |
-| Eagle proposer | `vllm_ascend/spec_decode/eagle_proposer.py` |
+| Eagle proposer (also dispatches MTP via `method="mtp"`) | `vllm_ascend/spec_decode/eagle_proposer.py` |
+| **Sampling & LoRA** | |
+| Sampler, rejection sampler, penalties | `vllm_ascend/sample/` |
+| LoRA NPU ops | `vllm_ascend/lora/` |
+| **Plugin & Model Loading** | |
+| Upstream patches (platform / worker) | `vllm_ascend/patch/` |
+| Custom model loader | `vllm_ascend/model_loader/` |
+| **Profiling** | |
+| Torch NPU profiler wrapper | `vllm_ascend/profiler/` |
 | **Utility Modules** | |
 | Common utilities | `vllm_ascend/utils.py` |
 | Ascend config | `vllm_ascend/ascend_config.py` |
@@ -207,5 +219,8 @@ Use this table after identifying a changed upstream symbol. It points to likely 
 | `vllm/model_executor/layers/layernorm.py` | `vllm_ascend/ops/layernorm.py` | LayerNorm op interface |
 | `vllm/model_executor/custom_op.py` | `vllm_ascend/ops/` | Custom op registration |
 | `vllm/v1/worker/gpu/spec_decode/` | `vllm_ascend/spec_decode/` | MTP/Eagle proposer interfaces |
+| `vllm/lora/` | `vllm_ascend/lora/` | LoRA op interface, punica integration |
+| `vllm/v1/sample/`, `vllm/model_executor/layers/sampler.py` | `vllm_ascend/sample/` | Sampler, rejection sampler, penalty kernels |
+| `vllm/model_executor/model_loader/` | `vllm_ascend/model_loader/` | Model loading hooks, weight format adapters |
 | `requirements*`, `constraints*`, `pyproject.toml`, `setup.py`, `setup.cfg` | Matching dependency files in vllm-ascend | Dependency versions |
 <!-- END AUTO-MAINTAINED: file-mapping -->

--- a/.agents/skills/main2main/reference/final-summary.md
+++ b/.agents/skills/main2main/reference/final-summary.md
@@ -50,6 +50,17 @@ If partial, state the valid partial-stop condition.>
 - Treated as env flakes: <brief list, or "none">
 - Last successful step: <step-id>
 
+### Adapt Guide Refresh
+Only include this section when `lint_adapt_guide.py` was run and produced
+output. Helps the PR reviewer audit machine-driven changes to the lookup
+tables in `reference/adapt-guide.md`.
+
+- Lint report: `/tmp/main2main/adapt-guide-refresh/check_report.md`
+- Adapt-guide commit: <sha or "no change — guide already up to date">
+- What changed and why: <one bullet per AUTO-MAINTAINED region touched —
+  e.g., "file-mapping: added row for `vllm/v1/foo/` since step-2's patch
+  introduced it; removed row for `vllm/old_path/` since the directory is gone">
+
 ### Partial Stop
 Only include this section when Status is `partial`.
 
@@ -80,6 +91,7 @@ Only include this section when Status is `partial`.
   only `env_flakes` and no actionable `code_bugs`. This is allowed to proceed
   to commit, but it is not the same as `passed`.
 - For `partial`, make the unresolved failure actionable: name the failing test, exception type, and likely area if known.
+- Include `Adapt Guide Refresh` only when the linter actually ran. If the guide was unchanged, still include the section so the reviewer sees the lint was performed and produced no diff.
 - Do not add "Remaining Steps (Not Started)" for a normal in-progress run; continue executing the next step instead.
 - Do not use "session time", "estimated remaining time", "too many hours", or "additional CI runs required" as the reason for `partial`.
 - Omit `Follow-up` when there is no concrete next action.

--- a/.agents/skills/main2main/scripts/lint_adapt_guide.py
+++ b/.agents/skills/main2main/scripts/lint_adapt_guide.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Lint the lookup tables in reference/adapt-guide.md.
+
+The adapt-guide carries three lookup regions that route per-step adapt work:
+  - key-areas     : upstream vLLM subsystems with adaptation hints
+  - file-locations: where Ascend-specific code lives
+  - file-mapping  : upstream path -> vllm-ascend path
+
+These regions reference concrete paths that drift as vllm-ascend evolves.
+This script reports drift; it does not edit the guide. The agent reads the
+report (plus the current step patches) and updates the AUTO-MAINTAINED
+regions itself, so the human-written prose around the tables stays untouched.
+
+Usage:
+    python3 lint_adapt_guide.py \
+      --ascend-path <path> \
+      [--patches-dir /tmp/main2main/steps] \
+      [--output /tmp/main2main/adapt-guide-refresh/check_report.md]
+
+Output:
+    A Markdown report at --output with three sections:
+      1. Invalidated paths     : paths the guide cites that no longer exist
+      2. Uncovered directories : vllm_ascend/ subdirs that no region mentions
+      3. Untouched upstream    : vllm/ paths changed this run but missing from
+                                 the file-mapping region (only if patches found)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REGION_NAMES = ("key-areas", "file-locations", "file-mapping")
+
+REGION_RE = {
+    name: re.compile(
+        r"<!-- BEGIN AUTO-MAINTAINED: " + re.escape(name) + r" -->\n"
+        r"(?P<body>.*?)\n"
+        r"<!-- END AUTO-MAINTAINED: " + re.escape(name) + r" -->",
+        re.DOTALL,
+    )
+    for name in REGION_NAMES
+}
+
+# Match backtick-quoted paths like `vllm_ascend/foo/bar.py` or `vllm/v1/...`.
+# Trailing slash is treated as a directory reference.
+PATH_RE = re.compile(r"`([a-zA-Z_][a-zA-Z0-9_./*-]*)`")
+
+# Path prefixes we consider "concrete enough" to lint.
+ASCEND_PREFIX = "vllm_ascend/"
+UPSTREAM_PREFIX = "vllm/"
+
+# Directories under vllm_ascend/ that don't represent adaptation surface area
+# and are intentionally not listed in the guide.
+ASCEND_IGNORED_DIRS = {
+    "__pycache__",
+    "tests",
+    "test",
+}
+
+
+def _extract_region(text: str, name: str) -> str | None:
+    match = REGION_RE[name].search(text)
+    if not match:
+        return None
+    return match.group("body")
+
+
+def _paths_in(region_body: str, prefix: str) -> list[str]:
+    """Pull backtick-quoted paths that start with prefix out of region body.
+
+    Glob-like entries (containing `*`) are skipped — they're patterns, not
+    concrete paths.
+    """
+    found: list[str] = []
+    for match in PATH_RE.finditer(region_body):
+        raw = match.group(1)
+        if not raw.startswith(prefix):
+            continue
+        if "*" in raw:
+            continue
+        found.append(raw)
+    # Preserve order but dedupe.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for path in found:
+        if path not in seen:
+            seen.add(path)
+            deduped.append(path)
+    return deduped
+
+
+def _path_exists(repo: Path, rel: str) -> bool:
+    """Check existence treating trailing-slash entries as directories."""
+    candidate = repo / rel.rstrip("/")
+    if rel.endswith("/"):
+        return candidate.is_dir()
+    return candidate.exists()
+
+
+def _check_invalidated(repo: Path, regions: dict[str, str | None]) -> list[dict]:
+    """List ascend paths referenced in any region but missing from the repo."""
+    invalid: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for name in REGION_NAMES:
+        body = regions[name]
+        if body is None:
+            continue
+        for path in _paths_in(body, ASCEND_PREFIX):
+            if _path_exists(repo, path):
+                continue
+            key = (name, path)
+            if key in seen:
+                continue
+            seen.add(key)
+            invalid.append({"region": name, "path": path})
+    return invalid
+
+
+def _ascend_top_level_dirs(repo: Path) -> list[str]:
+    """Return top-level subdirectories under vllm_ascend/ as `vllm_ascend/<x>/`."""
+    base = repo / "vllm_ascend"
+    if not base.is_dir():
+        return []
+    dirs: list[str] = []
+    for child in sorted(base.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith(".") or child.name.startswith("_"):
+            # Skip dotfiles and Python private modules like __pycache__.
+            if child.name not in ASCEND_IGNORED_DIRS and not child.name.startswith("__"):
+                dirs.append(f"vllm_ascend/{child.name}/")
+            continue
+        if child.name in ASCEND_IGNORED_DIRS:
+            continue
+        dirs.append(f"vllm_ascend/{child.name}/")
+    return dirs
+
+
+def _check_uncovered_dirs(repo: Path, regions: dict[str, str | None]) -> list[str]:
+    """List vllm_ascend/<dir>/ that no region mentions (even as prefix)."""
+    actual = _ascend_top_level_dirs(repo)
+    mentioned: set[str] = set()
+    for name in REGION_NAMES:
+        body = regions[name]
+        if body is None:
+            continue
+        # Any backtick path beginning with vllm_ascend/<x>/ counts as coverage.
+        for path in _paths_in(body, ASCEND_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 2 and parts[0] == "vllm_ascend":
+                mentioned.add(f"vllm_ascend/{parts[1]}/")
+    return [d for d in actual if d not in mentioned]
+
+
+def _collect_changed_files(patches_dir: Path) -> list[str]:
+    """Read every changed-files.txt under patches_dir/<step-id>/, dedupe.
+
+    Falls back to parsing `diff --git` lines from upstream.patch when
+    changed-files.txt is absent.
+    """
+    if not patches_dir.is_dir():
+        return []
+
+    files: set[str] = set()
+    for step_dir in sorted(patches_dir.iterdir()):
+        if not step_dir.is_dir():
+            continue
+        changed = step_dir / "changed-files.txt"
+        if changed.is_file():
+            for line in changed.read_text().splitlines():
+                line = line.strip()
+                if line:
+                    files.add(line)
+            continue
+        patch = step_dir / "upstream.patch"
+        if patch.is_file():
+            for line in patch.read_text(errors="replace").splitlines():
+                if line.startswith("diff --git a/"):
+                    parts = line.split()
+                    if len(parts) >= 3:
+                        files.add(parts[2][2:])  # strip "a/"
+    return sorted(files)
+
+
+def _check_untouched_upstream(regions: dict[str, str | None],
+                              changed_files: list[str]) -> list[str]:
+    """List vllm/ paths touched this run that file-mapping doesn't cover.
+
+    Coverage rule: a row covers a changed file when the row's upstream cell
+    is a prefix of the changed file. Comparison is path-prefix only; this
+    deliberately overflags rather than missing real gaps — the agent decides
+    what to add.
+    """
+    body = regions["file-mapping"]
+    if body is None:
+        return []
+    covered_prefixes = [p for p in _paths_in(body, UPSTREAM_PREFIX)]
+
+    untouched: list[str] = []
+    for changed in changed_files:
+        if not changed.startswith(UPSTREAM_PREFIX):
+            continue
+        if any(changed.startswith(prefix.rstrip("/") + "/")
+               or changed == prefix.rstrip("/")
+               or changed.startswith(prefix)
+               for prefix in covered_prefixes):
+            continue
+        untouched.append(changed)
+    return untouched
+
+
+def _render_report(invalid: list[dict],
+                   uncovered: list[str],
+                   untouched: list[str],
+                   patches_dir: Path,
+                   patches_seen: bool) -> str:
+    lines: list[str] = ["# Adapt Guide Lint Report", ""]
+
+    lines.append("## 1. Invalidated paths")
+    lines.append("")
+    lines.append("Paths the guide cites that no longer exist in vllm_ascend/.")
+    lines.append("")
+    if invalid:
+        for entry in invalid:
+            lines.append(f"- [{entry['region']}] `{entry['path']}`")
+    else:
+        lines.append("_None._")
+    lines.append("")
+
+    lines.append("## 2. Uncovered directories")
+    lines.append("")
+    lines.append("vllm_ascend/ subdirectories that no AUTO-MAINTAINED region "
+                 "currently references.")
+    lines.append("")
+    if uncovered:
+        for path in uncovered:
+            lines.append(f"- `{path}`")
+    else:
+        lines.append("_None._")
+    lines.append("")
+
+    lines.append("## 3. Untouched upstream paths (this run)")
+    lines.append("")
+    if not patches_seen:
+        lines.append(f"_No step patches found under `{patches_dir}` — section skipped._")
+    else:
+        lines.append("vLLM paths changed in this run's step patches but not "
+                     "covered by any file-mapping row.")
+        lines.append("")
+        if untouched:
+            for path in untouched:
+                lines.append(f"- `{path}`")
+        else:
+            lines.append("_None._")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint the AUTO-MAINTAINED tables in adapt-guide.md.",
+    )
+    parser.add_argument("--ascend-path", type=Path, required=True,
+                        help="Path to the vllm-ascend repository.")
+    parser.add_argument("--patches-dir", type=Path,
+                        default=Path("/tmp/main2main/steps"),
+                        help="Directory containing per-step patch outputs.")
+    parser.add_argument(
+        "--output", type=Path,
+        default=Path("/tmp/main2main/adapt-guide-refresh/check_report.md"),
+        help="Where to write the Markdown report.")
+    args = parser.parse_args()
+
+    guide = args.ascend_path / ".agents/skills/main2main/reference/adapt-guide.md"
+    if not guide.is_file():
+        print(f"error: adapt-guide.md not found at {guide}", file=sys.stderr)
+        return 1
+
+    text = guide.read_text()
+    regions = {name: _extract_region(text, name) for name in REGION_NAMES}
+    missing = [name for name, body in regions.items() if body is None]
+    if missing:
+        print(
+            "error: missing AUTO-MAINTAINED region(s) in adapt-guide.md: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+
+    invalid = _check_invalidated(args.ascend_path, regions)
+    uncovered = _check_uncovered_dirs(args.ascend_path, regions)
+    changed = _collect_changed_files(args.patches_dir)
+    untouched = _check_untouched_upstream(regions, changed)
+
+    report = _render_report(
+        invalid=invalid,
+        uncovered=uncovered,
+        untouched=untouched,
+        patches_dir=args.patches_dir,
+        patches_seen=bool(changed),
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report)
+    print(f"Wrote {args.output}")
+    print(f"  invalidated paths   : {len(invalid)}")
+    print(f"  uncovered dirs      : {len(uncovered)}")
+    print(f"  untouched upstream  : {len(untouched)}"
+          + ("" if changed else " (no patches found)"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### What this PR does / why we need it?

This PR lets main2main detect and refresh them automatically at the end of each run. Follow-up #9232.

- `scripts/lint_adapt_guide.py` — reports drift to`/tmp/main2main/adapt-guide-refresh/check_report.md`.
- `adapt-guide.md` — three tables wrapped with AUTO-MAINTAINED sentinels; the agent edits only inside.
- `SKILL.md` Phase 3 — runs the linter, updates the regions, commits as a separate `docs(main2main): refresh adapt-guide tables`.
- `final-summary.md` — template gained an Adapt Guide Refresh section.

**Test** ：Ran the linter against the current repo:  found 2 invalidated paths and 10 uncovered dirs; after applying fixes, re-lint reports zero drift.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
