### PR TITLE
[CI] Fix CI external launcher test case NPU memory check failed error

### DIFF
--- a/tests/e2e/multicard/2-cards/test_external_launcher.py
+++ b/tests/e2e/multicard/2-cards/test_external_launcher.py
@@ -79,7 +79,7 @@ def test_qwen3_external_launcher(model):
 
 
 @pytest.mark.parametrize("model", MOE_MODELS)
-@wait_until_npu_memory_free()
+@wait_until_npu_memory_free(target_free_percentage=0.95)
 def test_qwen3_moe_external_launcher_ep_tp2(model):
     script = Path(__file__).parent.parent.parent.parent.parent / "examples" / "offline_external_launcher.py"
     env = os.environ.copy()
@@ -119,7 +119,7 @@ def test_qwen3_moe_external_launcher_ep_tp2(model):
 
 
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
-@wait_until_npu_memory_free()
+@wait_until_npu_memory_free(target_free_percentage=0.95)
 def test_qwen3_external_launcher_with_sleepmode():
     script = Path(__file__).parent.parent.parent.parent.parent / "examples" / "offline_external_launcher.py"
     env = os.environ.copy()
@@ -163,6 +163,7 @@ def test_qwen3_external_launcher_with_sleepmode():
 
 
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"})
+@wait_until_npu_memory_free(target_free_percentage=0.95)
 def test_qwen3_external_launcher_with_sleepmode_level2():
     script = Path(__file__).parent.parent.parent.parent.parent / "examples" / "offline_external_launcher.py"
     env = os.environ.copy()
@@ -216,7 +217,7 @@ def test_qwen3_external_launcher_with_sleepmode_level2():
     reason="This test is only for Ascend910B devices.",
 )
 @pytest.mark.parametrize("model", MODELS)
-@wait_until_npu_memory_free()
+@wait_until_npu_memory_free(target_free_percentage=0.95)
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1", "HCCL_BUFFSIZE": "500"})
 def test_qwen3_external_launcher_with_matmul_allreduce(model):
     script = Path(__file__).parent.parent.parent.parent.parent / "examples" / "offline_external_launcher.py"


### PR DESCRIPTION
### What this PR does / why we need it?
Fix CI external test case NPU memory check failed error. detail as following:
  Failed e2e-full test case is  tests/e2e/multicard/2-cards/test_external_launcher.py::test_qwen3_external_launcher_with_sleepmode_level2, error information:
  ` ValueError: Free memory on device (55.83/61.27 GiB) on startup is less than desired GPU memory utilization (0.92, 56.37 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.`
  Detail see link: https://github.com/vllm-project/vllm-ascend/actions/runs/26236804707/job/77212403940?pr=9429

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
e2e-full

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
