### PR TITLE
[Feature] Support layerwise KV cache events

### DIFF
--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -371,6 +371,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_handle_request_puts_missing(self):
         t, store = self._make_thread([1, 0])
         req = self._make_layer_req(layer_id=0)
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 1)
@@ -380,6 +381,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_handle_request_all_exist_not_last(self):
         t, store = self._make_thread([1, 1])
         req = self._make_layer_req(layer_id=0, is_last_chunk=False)
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 0)
@@ -387,6 +389,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_handle_request_all_exist_last_chunk_final_layer(self):
         t, store = self._make_thread([1, 1], num_layers=2)
         req = self._make_layer_req(layer_id=1, is_last_chunk=True)
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         finished = t.get_and_clear_finished_requests()
@@ -404,10 +407,11 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
             layer_id=0,
             is_last_chunk=True,
         )
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         finished = t.get_and_clear_finished_requests()
-        self.assertIn("r1", finished)
+        self.assertNotIn("r1", finished)
 
     def test_handle_request_with_current_event(self):
         t, store = self._make_thread([0])
@@ -423,6 +427,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
             is_last_chunk=False,
             current_event=event,
         )
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         event.synchronize.assert_called_once()
@@ -430,6 +435,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_handle_request_last_chunk_final_layer_with_missing(self):
         t, store = self._make_thread([0], num_layers=2)
         req = self._make_layer_req(layer_id=1, is_last_chunk=True, num_keys=1)
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         finished = t.get_and_clear_finished_requests()
@@ -438,6 +444,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_layerwise_kv_event_published_on_final_layer(self):
         t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
         req = self._make_layer_req(layer_id=1, is_last_chunk=True, num_keys=1)
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         events = t.get_kv_events()
@@ -449,6 +456,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_layerwise_kv_event_not_published_before_final_layer(self):
         t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
         req = self._make_layer_req(layer_id=0, is_last_chunk=False, num_keys=1)
+        t.add_stored_request(req.req_id)
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(t.get_kv_events(), [])
@@ -456,6 +464,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
     def test_layerwise_kv_event_uses_missing_blocks_from_previous_layers(self):
         t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
         first_layer_req = self._make_layer_req(layer_id=0, is_last_chunk=True, num_keys=1)
+        t.add_stored_request(first_layer_req.req_id)
         t.request_queue.put(first_layer_req)
         t._handle_request(first_layer_req)
         t.m_store.exists_result = [1]

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -140,8 +140,24 @@ class TestKVTransferThread(unittest.TestCase):
 
     def test_update_and_get_kv_events(self):
         t, _ = self._make_thread()
-        event1 = BlockStored(block_hashes=["h1"])
-        event2 = BlockStored(block_hashes=["h2"])
+        event1 = BlockStored(
+            block_hashes=["h1"],
+            parent_block_hash=None,
+            token_ids=[1, 2, 3],
+            block_size=16,
+            lora_id=None,
+            medium="cpu",
+            lora_name=None,
+        )
+        event2 = BlockStored(
+            block_hashes=["h2"],
+            parent_block_hash="h1",
+            token_ids=[4, 5, 6],
+            block_size=16,
+            lora_id=None,
+            medium="cpu",
+            lora_name=None,
+        )
         t.update_kv_event([event1, event2])
         events = t.get_kv_events()
         self.assertEqual(len(events), 2)

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -335,7 +335,7 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
 
 
 class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
-    def _make_thread(self, exists_result=None, num_layers=2):
+    def _make_thread(self, exists_result=None, num_layers=2, enable_kv_event=False):
         store = FakeStore(exists_result or [0, 0])
         db = FakeTokenDatabase()
         t = KVCacheStoreLayerSendingThread(
@@ -347,6 +347,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
             put_step=1,
             ready_event=threading.Event(),
             num_layers=num_layers,
+            enable_kv_event=enable_kv_event,
         )
         return t, store
 
@@ -362,6 +363,9 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
             layer_id=layer_id,
             is_last_chunk=is_last_chunk,
             current_event=None,
+            token_ids=list(range(num_keys * 16)),
+            original_block_size=16,
+            block_hashes=[f"h{i}" for i in range(num_keys)],
         )
 
     def test_handle_request_puts_missing(self):
@@ -400,6 +404,7 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
             layer_id=0,
             is_last_chunk=True,
         )
+        t.request_queue.put(req)
         t._handle_request(req)
         finished = t.get_and_clear_finished_requests()
         self.assertIn("r1", finished)
@@ -429,6 +434,37 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
         t._handle_request(req)
         finished = t.get_and_clear_finished_requests()
         self.assertIn("r1", finished)
+
+    def test_layerwise_kv_event_published_on_final_layer(self):
+        t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
+        req = self._make_layer_req(layer_id=1, is_last_chunk=True, num_keys=1)
+        t.request_queue.put(req)
+        t._handle_request(req)
+        events = t.get_kv_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].block_hashes, ["h0"])
+        self.assertEqual(events[0].token_ids, list(range(16)))
+        self.assertEqual(events[0].block_size, 16)
+
+    def test_layerwise_kv_event_not_published_before_final_layer(self):
+        t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
+        req = self._make_layer_req(layer_id=0, is_last_chunk=False, num_keys=1)
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertEqual(t.get_kv_events(), [])
+
+    def test_layerwise_kv_event_uses_missing_blocks_from_previous_layers(self):
+        t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
+        first_layer_req = self._make_layer_req(layer_id=0, is_last_chunk=True, num_keys=1)
+        t.request_queue.put(first_layer_req)
+        t._handle_request(first_layer_req)
+        t.m_store.exists_result = [1]
+        final_layer_req = self._make_layer_req(layer_id=1, is_last_chunk=True, num_keys=1)
+        t.request_queue.put(final_layer_req)
+        t._handle_request(final_layer_req)
+        events = t.get_kv_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].block_hashes, ["h0"])
 
 
 class TestKVCacheStoreLayerRecvingThread(unittest.TestCase):

--- a/tests/ut/distributed/mooncake/test_mooncake_kv_transfer.py
+++ b/tests/ut/distributed/mooncake/test_mooncake_kv_transfer.py
@@ -114,6 +114,7 @@ class TestKVTransferMissingKeyPut(unittest.TestCase):
             current_event=None,
         )
         thread.request_queue.put(req_meta)
+        thread.add_stored_request(req_meta.req_id)
         thread._handle_request(req_meta)
 
         self.assertEqual(len(store.put_calls), 1)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 import torch
@@ -701,8 +701,12 @@ class LayerMultiBlockReqMeta:
     ends: list[int]
     block_ids_by_group: list[list[int]]
     layer_id: int
+    block_hashes: list[Any] = field(default_factory=list)
     is_last_chunk: bool | None = True
     current_event: torch.npu.Event | None = None
+    token_ids: list[int] | None = None
+    original_block_size: list[int] | int | None = None
+    kv_cache_group_id: int = 0
 
     def __init__(
         self,
@@ -715,6 +719,10 @@ class LayerMultiBlockReqMeta:
         is_last_chunk: bool | None = True,
         current_event: torch.npu.Event | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
+        token_ids: list[int] | None = None,
+        original_block_size: list[int] | int | None = None,
+        block_hashes: list[Any] | None = None,
+        kv_cache_group_id: int = 0,
     ) -> None:
         self.req_id = req_id
         self.keys = keys
@@ -726,6 +734,10 @@ class LayerMultiBlockReqMeta:
         self.layer_id = layer_id
         self.is_last_chunk = is_last_chunk
         self.current_event = current_event
+        self.token_ids = token_ids
+        self.original_block_size = original_block_size
+        self.block_hashes = [] if block_hashes is None else block_hashes
+        self.kv_cache_group_id = kv_cache_group_id
 
     @property
     def block_ids(self) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -334,18 +334,19 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         if isinstance(req_meta.original_block_size, list)
                         else req_meta.original_block_size
                     )
-                    stored_event = BlockStored(
-                        block_hashes=[new_block_hashes[index]],
-                        parent_block_hash=prev_key,
-                        token_ids=token_ids,
-                        block_size=block_size,
-                        lora_id=None,
-                        medium="cpu",
-                        lora_name=None,
-                    )
-                    stored_events.append(stored_event)
-                    prev_key = new_block_hashes[index]
-                    logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+                    if block_size is not None:
+                        stored_event = BlockStored(
+                            block_hashes=[new_block_hashes[index]],
+                            parent_block_hash=prev_key,
+                            token_ids=token_ids,
+                            block_size=block_size,
+                            lora_id=None,
+                            medium="cpu",
+                            lora_name=None,
+                        )
+                        stored_events.append(stored_event)
+                        prev_key = new_block_hashes[index]
+                        logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
             if self.kv_role == "kv_consumer":
                 keys, addrs, sizes = self._decode_adaptor_prefill_pp(
@@ -482,6 +483,62 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.final_layer_id = num_layers - 1
         self.put_step = put_step
         self.enable_kv_event = enable_kv_event
+        self.layerwise_event_starts: dict[str, set[int]] = defaultdict(set)
+        self.stored_requests: dict[str, int] = defaultdict(int)
+        self.done_task_lock = threading.Lock()
+
+    def add_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            self.stored_requests[req_id] += 1
+
+    def dec_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                self.stored_requests[req_id] -= 1
+
+    def delete_finished_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                del self.stored_requests[req_id]
+        self.layerwise_event_starts.pop(req_id, None)
+
+    def _record_layerwise_event_starts(self, req_meta: LayerMultiBlockReqMeta, starts: list[int]) -> None:
+        if self.enable_kv_event:
+            self.layerwise_event_starts[req_meta.req_id].update(starts)
+
+    def _build_stored_events(self, req_meta: LayerMultiBlockReqMeta) -> list[BlockStored]:
+        if not self.enable_kv_event or req_meta.layer_id != self.final_layer_id:
+            return []
+        block_size = (
+            req_meta.original_block_size[req_meta.kv_cache_group_id]
+            if isinstance(req_meta.original_block_size, list)
+            else req_meta.original_block_size
+        )
+        if block_size is None:
+            return []
+        stored_events: list[BlockStored] = []
+        group_block_size = self._get_block_size(req_meta.kv_cache_group_id)
+        new_block_hashes = [maybe_convert_block_hash(bh) for bh in req_meta.block_hashes]
+        for start in sorted(self.layerwise_event_starts.pop(req_meta.req_id, set())):
+            block_idx = start // group_block_size
+            if block_idx >= len(new_block_hashes):
+                continue
+            block_hash = new_block_hashes[block_idx]
+            parent_block_hash = new_block_hashes[block_idx - 1] if block_idx > 0 else None
+            end = min(start + group_block_size, len(req_meta.token_ids or []))
+            token_ids = req_meta.token_ids[start:end] if req_meta.token_ids is not None else None
+            stored_event = BlockStored(
+                block_hashes=[block_hash],
+                parent_block_hash=parent_block_hash,
+                token_ids=token_ids,
+                block_size=block_size,
+                lora_id=None,
+                medium="cpu",
+                lora_name=None,
+            )
+            stored_events.append(stored_event)
+            logger.debug("Added layerwise kv cache event '%s' to kv cache events queue", stored_event)
+        return stored_events
 
     def add_request(  # type: ignore[override]
         self, req_meta: ReqMeta
@@ -504,8 +561,14 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             keys = keys[self.tp_rank % self.put_step :: self.put_step]
 
         if not keys:
+            if layer_id == self.final_layer_id:
+                stored_events = self._build_stored_events(req_meta)
+                if stored_events:
+                    self.update_kv_event(stored_events)
             if is_last_chunk:
+                self.dec_stored_request(req_meta.req_id)
                 self.set_finished_request(req_meta.req_id)
+            self.request_queue.task_done()
             return
 
         key_list = []
@@ -516,8 +579,14 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
 
         if not missing_indices:
-            if is_last_chunk and layer_id == self.final_layer_id:
+            if layer_id == self.final_layer_id:
+                stored_events = self._build_stored_events(req_meta)
+                if stored_events:
+                    self.update_kv_event(stored_events)
+            if is_last_chunk:
+                self.dec_stored_request(req_meta.req_id)
                 self.set_finished_request(req_meta.req_id)
+            self.request_queue.task_done()
             return
 
         starts = [starts[index] for index in missing_indices]
@@ -536,18 +605,35 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         if current_event is not None:
             current_event.synchronize()
         self.m_store.put(key_list, addr_list, size_list)
+        self._record_layerwise_event_starts(req_meta, starts)
+        stored_events = self._build_stored_events(req_meta)
+        if stored_events:
+            self.update_kv_event(stored_events)
 
         if layer_id == self.final_layer_id and is_last_chunk:
+            self.layerwise_event_starts.pop(req_meta.req_id, None)
+            self.dec_stored_request(req_meta.req_id)
             self.set_finished_request(req_meta.req_id)
         self.request_queue.task_done()
 
-        logger.info(
-            "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s",
-            len(key_list),
-            total_block,
-            len(missing_indices),
-            req_meta.req_id,
-        )
+        if layer_id == self.final_layer_id:
+            logger.info(
+                "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
+                len(key_list),
+                total_block,
+                len(missing_indices),
+                req_meta.req_id,
+                layer_id,
+            )
+        else:
+            logger.debug(
+                "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
+                len(key_list),
+                total_block,
+                len(missing_indices),
+                req_meta.req_id,
+                layer_id,
+            )
 
 
 class KVCacheStoreLayerRecvingThread(KVTransferThread):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -486,6 +486,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.layerwise_event_starts: dict[str, set[int]] = defaultdict(set)
         self.stored_requests: dict[str, int] = defaultdict(int)
         self.done_task_lock = threading.Lock()
+        self.layerwise_event_lock = threading.Lock()
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -500,11 +501,13 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
-        self.layerwise_event_starts.pop(req_id, None)
+        with self.layerwise_event_lock:
+            self.layerwise_event_starts.pop(req_id, None)
 
     def _record_layerwise_event_starts(self, req_meta: LayerMultiBlockReqMeta, starts: list[int]) -> None:
         if self.enable_kv_event:
-            self.layerwise_event_starts[req_meta.req_id].update(starts)
+            with self.layerwise_event_lock:
+                self.layerwise_event_starts[req_meta.req_id].update(starts)
 
     def _build_stored_events(self, req_meta: LayerMultiBlockReqMeta) -> list[BlockStored]:
         if not self.enable_kv_event or req_meta.layer_id != self.final_layer_id:
@@ -519,7 +522,9 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         stored_events: list[BlockStored] = []
         group_block_size = self._get_block_size(req_meta.kv_cache_group_id)
         new_block_hashes = [maybe_convert_block_hash(bh) for bh in req_meta.block_hashes]
-        for start in sorted(self.layerwise_event_starts.pop(req_meta.req_id, set())):
+        with self.layerwise_event_lock:
+            starts_set = self.layerwise_event_starts.pop(req_meta.req_id, set())
+        for start in sorted(starts_set):
             block_idx = start // group_block_size
             if block_idx >= len(new_block_hashes):
                 continue
@@ -555,6 +560,9 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         current_event = req_meta.current_event
         total_block = len(keys)
         is_last_chunk = req_meta.is_last_chunk
+        if req_meta.req_id not in self.stored_requests:
+            self.request_queue.task_done()
+            return
         if not self.dcp_size > 1:
             starts = starts[self.tp_rank % self.put_step :: self.put_step]
             ends = ends[self.tp_rank % self.put_step :: self.put_step]
@@ -611,7 +619,8 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             self.update_kv_event(stored_events)
 
         if layer_id == self.final_layer_id and is_last_chunk:
-            self.layerwise_event_starts.pop(req_meta.req_id, None)
+            with self.layerwise_event_lock:
+                self.layerwise_event_starts.pop(req_meta.req_id, None)
             self.dec_stored_request(req_meta.req_id)
             self.set_finished_request(req_meta.req_id)
         self.request_queue.task_done()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -560,9 +560,10 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         current_event = req_meta.current_event
         total_block = len(keys)
         is_last_chunk = req_meta.is_last_chunk
-        if req_meta.req_id not in self.stored_requests:
-            self.request_queue.task_done()
-            return
+        with self.done_task_lock:
+            if req_meta.req_id not in self.stored_requests:
+                self.request_queue.task_done()
+                return
         if not self.dcp_size > 1:
             starts = starts[self.tp_rank % self.put_step :: self.put_step]
             ends = ends[self.tp_rank % self.put_step :: self.put_step]
@@ -573,7 +574,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 stored_events = self._build_stored_events(req_meta)
                 if stored_events:
                     self.update_kv_event(stored_events)
-            if is_last_chunk:
+            if is_last_chunk and layer_id == self.final_layer_id:
                 self.dec_stored_request(req_meta.req_id)
                 self.set_finished_request(req_meta.req_id)
             self.request_queue.task_done()
@@ -591,7 +592,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 stored_events = self._build_stored_events(req_meta)
                 if stored_events:
                     self.update_kv_event(stored_events)
-            if is_last_chunk:
+            if is_last_chunk and layer_id == self.final_layer_id:
                 self.dec_stored_request(req_meta.req_id)
                 self.set_finished_request(req_meta.req_id)
             self.request_queue.task_done()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -30,6 +30,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     KeyMetadata,
     LayerMultiBlockReqMeta,
     ReqMeta,
+    get_block_hashes,
     get_cache_family_granularity,
     infer_group_cache_families,
 )
@@ -593,6 +594,12 @@ class KVPoolWorker:
                 if can_save is None or not can_save:
                     continue
 
+                request.skip_null_blocks_by_group = self.group_uses_align_state
+                request.disable_tp_key_sharding = (self.use_mla or self.use_sparse) and self.put_step > 1
+                request.current_event = current_event
+                self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
+                    request.req_id
+                )
                 layerwise_storer = self.store_layer(request, current_event)
                 self.layerwise_storers.append(layerwise_storer)
         for layerwise_storer in self.layerwise_storers:
@@ -736,6 +743,9 @@ class KVPoolWorker:
         starts = []
         ends = []
         keys = []
+        group_id = 0
+        group_block_size = self.grouped_block_size[group_id]
+        group_block_hashes = get_block_hashes(request.block_hashes, group_block_size, self.hash_block_size)
         for start, end, key in self.token_database.process_tokens(request.token_len_chunk, request.block_hashes):
             keys_multi_layer = key.split_layers(self.num_layers)
             starts.append(start)
@@ -754,6 +764,10 @@ class KVPoolWorker:
                     layer_id,
                     request.is_last_chunk,
                     current_event,
+                    token_ids=request.token_ids,
+                    original_block_size=request.original_block_size,
+                    block_hashes=group_block_hashes,
+                    kv_cache_group_id=group_id,
                 )
                 self.kv_send_thread.add_request(  # type: ignore[union-attr, call-arg]
                     req_meta

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -594,8 +594,6 @@ class KVPoolWorker:
                 if can_save is None or not can_save:
                     continue
 
-                request.skip_null_blocks_by_group = self.group_uses_align_state
-                request.disable_tp_key_sharding = (self.use_mla or self.use_sparse) and self.put_step > 1
                 request.current_event = current_event
                 self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
                     request.req_id


### PR DESCRIPTION
### What this PR does / why we need it?
This PR implements layerwise KV cache events support for distributed inference, which provides precise synchronization and event tracking at the final layer of model processing.

Key Features:

1. Layerwise Event Generation :
   
   - In layerwise mode ( use_layerwise=true ), KV cache events are generated only at the final layer
   - Previous layers only record information, final layer generates a cumulative event containing all layers' block information
   - This ensures precise synchronization in distributed inference scenarios
2. Thread Safety Improvements :
   
   - Added layerwise_event_lock to protect layerwise_event_starts data structure
   - Added done_task_lock to protect stored_requests during concurrent access
   - Fixed race conditions in multi-threaded environments
3. Metadata Expansion :
   
   - Extended LayerMultiBlockReqMeta to include:
     - token_ids : Token ID list for granular tracking
     - original_block_size : Original block size information
     - block_hashes : Block hash list
     - kv_cache_group_id : KV cache group identifier
4. Request Lifecycle Management :
   
   - Fixed dec_stored_request and set_finished_request to only execute on final layer
   - Proper cleanup of layerwise_event_starts in all code paths
   - Memory leak prevention
### Does this PR introduce _any_ user-facing change?
1. New Configuration Option :
   
   - use_layerwise : Enable layerwise KV cache event mode (default: false)
   - When enabled, events are generated only at the final layer
2. Behavior Change :
   
   - Before : KV events generated for each layer independently
   - After : With use_layerwise=true , one cumulative event generated at final layer
3. Backward Compatibility :
   
   - Default behavior unchanged ( use_layerwise=false )
   - Existing configurations continue to work as before
   - No breaking changes to API or configuration
### How was this patch tested?
Unit Tests :

- Modified tests/ut/distributed/ascend_store/test_kv_transfer.py
- Added test for update_and_get_kv_events with proper BlockStored instantiation
- Verified event generation and retrieval logic


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
