### PR TITLE
[CI] Resolves the issue of occasional 503 errors when downloading packages

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -53,7 +53,7 @@ on:
         default: ''
 env:
   UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-  UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/"
+  UV_EXTRA_INDEX_URL: https://repo.huaweicloud.com/ascend/repos/pypi
   UV_INDEX_STRATEGY: unsafe-best-match
   UV_INSECURE_HOST: cache-service.nginx-pypi-cache.svc.cluster.local
   UV_HTTP_TIMEOUT: 120
@@ -140,7 +140,10 @@ jobs:
           MAX_JOBS: "23"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -272,7 +275,10 @@ jobs:
           MAX_JOBS: "23"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -411,7 +417,10 @@ jobs:
           MAX_JOBS: "46"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -541,7 +550,10 @@ jobs:
           MAX_JOBS: "46"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -728,7 +740,10 @@ jobs:
           MAX_JOBS: "92"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -857,7 +872,10 @@ jobs:
           MAX_JOBS: "92"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -986,7 +1004,10 @@ jobs:
           MAX_JOBS: "23"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .
@@ -1098,7 +1119,10 @@ jobs:
           MAX_JOBS: "92"
         run: |
           pip install uc-manager
+          # Use CPU version package
+          uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
+          # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.
           uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           if find vllm_ascend -maxdepth 1 -name '*.so' -type f 2>/dev/null | grep -q .; then
             COMPILE_CUSTOM_KERNELS=0 uv pip install -e .

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -141,6 +141,8 @@ jobs:
         run: |
           pip install uc-manager
           # Use CPU version package
+          # The torch-cpu repository cannot be placed in a public repository, as many packages are not available on torch-cpu. 
+          # If placed in a public repository, this will cause other package query requests to be frequently forwarded to the official repository, leading to probabilistic errors.
           uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --extra-index-url  http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu/
           uv pip install -r requirements-dev.txt
           # Concurrent installation of triton-ascend can cause files to be overwritten by other packages.


### PR DESCRIPTION
### What this PR does / why we need it?
1. `pip install` scans all specified indexes to check if the package to be downloaded exists. When there are many CIs (Content Query Objects), the query frequency is high.

2. frequent access to the upstream PyTorch repository will result in a 503 error.

### Does this PR introduce _any_ user-facing change?
PyTorch's repository is not placed in public access repositories; the PyTorch repository must be specified when downloading PyTorch-cpu.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
