### PR TITLE
[BugFix] Return None default from extra forward context proxy

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -363,8 +363,10 @@ class _ExtraForwardContextProxy:
         self.check_extra_attr(name)
         ctx = self._ctx()
         if envs_vllm.VLLM_USE_V2_MODEL_RUNNER:
-            return ctx.additional_kwargs[name]
-        return getattr(ctx, name)
+            # Unset known extras default to None so optional flags (e.g. `sinks`)
+            # can be read with truthiness checks before the V2 path populates them.
+            return ctx.additional_kwargs.get(name)
+        return getattr(ctx, name, None)
 
     def __setattr__(self, name: str, value: Any) -> None:
         self.check_extra_attr(name)


### PR DESCRIPTION
### What this PR does / why we need it?

The `_EXTRA_CTX` proxy currently raises `KeyError`/`AttributeError` when a known optional attribute (declared in `extra_attrs`) has not been populated.

On the V2 model runner path, `set_ascend_forward_context` is not used and `additional_kwargs["sinks"]` is never written, so the `elif _EXTRA_CTX.sinks:` truthiness check in `attention_v1.py:update_graph_params` crashes Eagle full-graph runs:

```
File "vllm_ascend/attention/attention_v1.py", line 466, in update_graph_params
    elif _EXTRA_CTX.sinks:
File "vllm_ascend/ascend_forward_context.py", line 366, in __getattr__
    return ctx.additional_kwargs[name]
KeyError: 'sinks'
```

This breaks `test_egale_spec_decoding[...EAGLE-LLaMA3.1...]` in the `singlecard-full (0) / vllm-main` job on multiple currently open PRs (e.g. #9413, #9473).

Make the proxy fall back to `None` for unset known extras so optional flags can be safely read with truthiness checks before the V2 path populates them. Names still go through `check_extra_attr`, so unknown attribute access continues to raise.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Manual code review: the only impacted readers do truthiness or equality checks (`if _EXTRA_CTX.flag:` / `_EXTRA_CTX.enum == X`), which behave correctly when the value is `None`.
- CI: the failing Eagle test in `singlecard-full / vllm-main` is expected to pass after this change.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
