### PR TITLE
[BugFix] Fix Qwen3-Next PCP full graph accuracy

### DIFF
--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -68,6 +68,9 @@ class _DummyTensor:
     def contiguous(self):
         return self
 
+    def clone(self):
+        return self
+
     def to(self, *args, **kwargs):
         return self
 
@@ -177,13 +180,13 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
     non_pcp_calls: list[tuple[str, object]] = []
     pcp_calls: list[tuple[str, object]] = []
 
-    def run_case(world_size: int, calls: list[tuple[str, object]]):
+    def run_case(world_size: int, rank_in_group: int, calls: list[tuple[str, object]]):
         group = type(
             "Group",
             (),
             {
                 "world_size": world_size,
-                "rank_in_group": 0,
+                "rank_in_group": rank_in_group,
                 "all_gather": lambda self, value, dim: _GatherResult([_DummyTensor("g0"), _DummyTensor("g1")]),
             },
         )()
@@ -194,11 +197,14 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
         monkeypatch.setattr(chunk, "chunk_scaled_dot_kkt_fwd", lambda *args, **kwargs: _DummyTensor("A"))
         monkeypatch.setattr(chunk, "solve_tril", lambda *args, **kwargs: _DummyTensor("A_solved"))
         monkeypatch.setattr(chunk, "recompute_w_u_fwd", lambda *args, **kwargs: (_DummyTensor("w"), _DummyTensor("u")))
-        monkeypatch.setattr(
-            chunk,
-            "chunk_gated_delta_rule_fwd_h",
-            lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
-        )
+        h_calls: list[object] = []
+        o_calls: list[tuple[str, str]] = []
+
+        def fake_chunk_gated_delta_rule_fwd_h(*args, **kwargs):
+            h_calls.append(kwargs["chunk_offsets"])
+            return _DummyTensor("h_rerun"), _DummyTensor("v_new_rerun"), _DummyTensor("final_state")
+
+        monkeypatch.setattr(chunk, "chunk_gated_delta_rule_fwd_h", fake_chunk_gated_delta_rule_fwd_h)
         monkeypatch.setattr(
             chunk,
             "chunk_gated_delta_rule_fwd_hupdate",
@@ -219,24 +225,22 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
         monkeypatch.setattr(
             torch.ops._C_ascend,
             "chunk_gated_delta_rule_fwd_h",
-            lambda *args, **kwargs: (_DummyTensor("h"), _DummyTensor("v_new"), _DummyTensor("final_state")),
+            lambda *args, **kwargs: (
+                _DummyTensor("h_original"),
+                _DummyTensor("v_new_original"),
+                _DummyTensor("final_state"),
+            ),
         )
+
+        def fake_chunk_fwd_o(q, k, v, h, *args, **kwargs):
+            o_calls.append((v.name, h.name))
+            return _DummyTensor("o_ascend")
+
         monkeypatch.setattr(
             torch.ops._C_ascend,
             "chunk_fwd_o",
-            lambda *args, **kwargs: _DummyTensor("o_ascend"),
+            fake_chunk_fwd_o,
         )
-
-        def fake_chunk_fwd_o(*args, **kwargs):
-            calls.append(("o", kwargs["chunk_offsets"]))
-            return _DummyTensor("o")
-
-        def fake_chunk_fwd_o_update(*args, **kwargs):
-            calls.append(("o_update", kwargs["chunk_offsets"]))
-            return _DummyTensor("h_updated")
-
-        monkeypatch.setattr(chunk, "chunk_fwd_o", fake_chunk_fwd_o)
-        monkeypatch.setattr(chunk, "chunk_fwd_o_update", fake_chunk_fwd_o_update)
 
         chunk.chunk_gated_delta_rule_fwd(
             q=q,
@@ -250,12 +254,22 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
             cu_seqlens=torch.tensor([0, 4, 7], dtype=torch.int32),
             prebuilt_meta=prebuilt_meta,
         )
+        return h_calls, o_calls
 
-    run_case(1, non_pcp_calls)
+    non_pcp_h_calls, non_pcp_o_calls = run_case(1, 0, non_pcp_calls)
     assert non_pcp_calls == []
+    assert non_pcp_h_calls == []
+    assert non_pcp_o_calls == [("v_new_original", "h_original")]
 
-    run_case(2, pcp_calls)
-    assert pcp_calls == [("o_update", chunk_offsets)]
+    pcp_rank0_h_calls, pcp_rank0_o_calls = run_case(2, 0, pcp_calls)
+    assert pcp_calls == []
+    assert pcp_rank0_h_calls == []
+    assert pcp_rank0_o_calls == [("v_new_original", "h_original")]
+
+    pcp_rank1_h_calls, pcp_rank1_o_calls = run_case(2, 1, pcp_calls)
+    assert pcp_calls == []
+    assert pcp_rank1_h_calls == [chunk_offsets]
+    assert pcp_rank1_o_calls == [("v_new_rerun", "h_rerun")]
 
 
 def test_build_chunk_meta_device_rejects_non_npu_input():

--- a/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py
@@ -14,6 +14,7 @@ from vllm.v1.kv_cache_interface import MambaSpec
 
 import vllm_ascend.patch.worker.patch_gdn_attn as patch_gdn_attn
 from vllm_ascend.ops.gdn import (
+    _extract_last_conv_state,
     get_non_spec_causal_conv1d_host_args,
     get_non_spec_chunked_prefill_meta,
     to_int64_tuple,
@@ -102,6 +103,38 @@ def create_common_attn_metadata(
     )
 
 
+def test_extract_last_conv_state_matches_state_first_cache_layout():
+    x = torch.arange(5 * 4, dtype=torch.float32).reshape(5, 4)
+    query_start_loc = torch.tensor([0, 2, 5], dtype=torch.int32)
+    conv_state = torch.empty(2, 3, 4)
+
+    actual = _extract_last_conv_state(x, query_start_loc, conv_state)
+    expected = torch.stack(
+        (
+            torch.stack((torch.zeros(4), x[0], x[1])),
+            torch.stack((x[2], x[3], x[4])),
+        )
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_extract_last_conv_state_matches_dim_first_cache_layout():
+    x = torch.arange(5 * 4, dtype=torch.float32).reshape(5, 4)
+    query_start_loc = torch.tensor([0, 2, 5], dtype=torch.int32)
+    conv_state = torch.empty(2, 4, 3)
+
+    actual = _extract_last_conv_state(x, query_start_loc, conv_state)
+    expected = torch.stack(
+        (
+            torch.stack((torch.zeros(4), x[0], x[1])),
+            torch.stack((x[2], x[3], x[4])),
+        )
+    ).permute(0, 2, 1)
+
+    assert torch.equal(actual, expected)
+
+
 def _make_vllm_config(
     *,
     max_model_len: int = 8192,
@@ -109,6 +142,8 @@ def _make_vllm_config(
     max_num_batched_tokens: int = 8192,
     num_heads: int = 32,
     num_speculative_tokens: int = 0,
+    cudagraph_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    max_cudagraph_capture_size: int | None = None,
 ):
     speculative_config = None
     if num_speculative_tokens > 0:
@@ -123,8 +158,8 @@ def _make_vllm_config(
     return SimpleNamespace(
         cache_config=SimpleNamespace(mamba_cache_mode="none"),
         compilation_config=SimpleNamespace(
-            cudagraph_mode=CUDAGraphMode.NONE,
-            max_cudagraph_capture_size=None,
+            cudagraph_mode=cudagraph_mode,
+            max_cudagraph_capture_size=max_cudagraph_capture_size,
         ),
         speculative_config=speculative_config,
         scheduler_config=SimpleNamespace(
@@ -139,10 +174,19 @@ def _make_vllm_config(
     )
 
 
-def _make_builder(*, device: torch.device, num_heads: int, num_speculative_tokens: int):
+def _make_builder(
+    *,
+    device: torch.device,
+    num_heads: int,
+    num_speculative_tokens: int,
+    cudagraph_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    max_cudagraph_capture_size: int | None = None,
+):
     vllm_config = _make_vllm_config(
         num_heads=num_heads,
         num_speculative_tokens=num_speculative_tokens,
+        cudagraph_mode=cudagraph_mode,
+        max_cudagraph_capture_size=max_cudagraph_capture_size,
     )
     spec = MambaSpec(
         block_size=16,
@@ -508,3 +552,100 @@ def test_builder_skips_prebuilt_meta_without_non_spec_prefill(batch_spec: BatchS
     )
 
     assert getattr(attn_metadata, "non_spec_prefill_fallback_meta", None) is None
+
+
+def test_full_graph_decode_metadata_ignores_zero_length_padded_rows():
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=0,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        max_cudagraph_capture_size=4,
+    )
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=BatchSpec(
+            seq_lens=[5, 6, 7, 0],
+            query_lens=[1, 1, 1, 0],
+            name="decode_with_padding",
+        ),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.block_table_tensor = torch.tensor(
+        [[2], [14], [10], [99]],
+        dtype=torch.int32,
+    )
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert attn_metadata.num_decodes == 3
+    assert attn_metadata.num_decode_tokens == 3
+    assert torch.equal(
+        attn_metadata.non_spec_query_start_loc,
+        torch.tensor([0, 1, 2, 3], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.non_spec_state_indices_tensor,
+        torch.tensor([2, 14, 10], dtype=torch.int32),
+    )
+
+
+def test_full_graph_decode_metadata_ignores_graph_virtual_row():
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=0,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        max_cudagraph_capture_size=4,
+    )
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=BatchSpec(
+            seq_lens=[5, 6, 7, 1],
+            query_lens=[1, 1, 1, 1],
+            name="decode_with_virtual_graph_row",
+        ),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.num_actual_tokens = 3
+    common_attn_metadata.num_input_tokens = 4
+    common_attn_metadata.block_table_tensor = torch.tensor(
+        [[2], [14], [10], [99]],
+        dtype=torch.int32,
+    )
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert attn_metadata.num_actual_tokens == 3
+    assert attn_metadata.num_decodes == 3
+    assert attn_metadata.num_decode_tokens == 3
+    assert torch.equal(
+        attn_metadata.non_spec_query_start_loc,
+        torch.tensor([0, 1, 2, 3, 3], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.non_spec_state_indices_tensor,
+        torch.tensor([2, 14, 10, 0], dtype=torch.int32),
+    )
+
+    fallback_meta = attn_metadata.non_spec_decode_fallback_meta
+    assert fallback_meta is not None
+    assert torch.equal(
+        fallback_meta.causal_conv1d.query_start_loc_cpu,
+        torch.tensor([0, 1, 2, 3], dtype=torch.int32),
+    )
+    assert torch.equal(
+        fallback_meta.causal_conv1d.cache_indices_cpu,
+        torch.tensor([2, 14, 10], dtype=torch.int32),
+    )
+
+    fallback_meta = attn_metadata.non_spec_decode_fallback_meta
+    assert fallback_meta is not None
+    assert torch.equal(
+        fallback_meta.causal_conv1d.query_start_loc_cpu,
+        torch.tensor([0, 1, 2, 3], dtype=torch.int32),
+    )
+    assert torch.equal(
+        fallback_meta.causal_conv1d.cache_indices_cpu,
+        torch.tensor([2, 14, 10], dtype=torch.int32),
+    )

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -847,7 +847,7 @@ class AscendAttentionCPImpl(AscendAttentionBackendImpl):
             attn_metadata.prefill.pcp_metadata.pcp_enter_fa_restore_idx if attn_metadata.prefill.pcp_metadata else None
         )
         actual_qkv = torch.index_select(all_qkv, 0, pcp_enter_fa_restore_idx)
-        qkv_fa_padding_workspace = query.new_empty(
+        qkv_fa_padding_workspace = query.new_zeros(
             (num_actual_tokens_pcp_padded, (self.num_heads + 2 * self.num_kv_heads) * self.head_size)
         )
 

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -18,9 +18,16 @@
 import torch
 import torch_npu
 from einops import rearrange
+from vllm.config import CUDAGraphMode
+from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.fla.ops.fused_recurrent import (
+    fused_recurrent_gated_delta_rule_packed_decode,
+)
 from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
 from vllm.model_executor.layers.mamba.gdn_linear_attn import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
@@ -127,6 +134,93 @@ def _pad_conv1d_host_args_to_capture(
     if with_num_accepted:
         num_accepted_host = tuple(num_accepted_host) + (1,) * pad_seqs
     return qsl_host, cidx_host, num_accepted_host
+
+
+def _extract_last_conv_state(
+    x: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    conv_state: torch.Tensor,
+) -> torch.Tensor:
+    if conv_state.shape[-1] == x.shape[-1]:
+        state_len = conv_state.shape[-2]
+        dim_first = False
+    elif conv_state.shape[-2] == x.shape[-1]:
+        state_len = conv_state.shape[-1]
+        dim_first = True
+    else:
+        raise RuntimeError(
+            f"Cannot infer conv_state layout from x.shape={tuple(x.shape)} "
+            f"and conv_state.shape={tuple(conv_state.shape)}"
+        )
+    start_loc = query_start_loc[:-1]
+    end_loc = query_start_loc[1:]
+    offsets = torch.arange(state_len, device=x.device)
+    indices = end_loc.unsqueeze(1) - state_len + offsets.unsqueeze(0)
+    valid = indices >= start_loc.unsqueeze(1)
+    indices = indices.clamp(min=0)
+    states = x.index_select(0, indices.reshape(-1))
+    states = states.reshape(indices.shape[0], state_len, x.shape[-1])
+    if dim_first:
+        states = states.permute(0, 2, 1).contiguous()
+        valid = valid.unsqueeze(1)
+    else:
+        valid = valid.unsqueeze(-1)
+    return torch.where(valid, states, torch.zeros_like(states))
+
+
+def _prepare_pcp_prefill_conv_state(
+    mixed_qkv: torch.Tensor,
+    conv_state: torch.Tensor,
+    cache_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    num_decodes: int,
+    initial_state_mode: tuple[int, ...],
+) -> tuple[tuple[int, ...], torch.Tensor | None, torch.Tensor | None]:
+    pcp_group = get_pcp_group()
+    if pcp_group.world_size <= 1:
+        return initial_state_mode, None, None
+
+    prefill_cache_indices = cache_indices[num_decodes:]
+    if prefill_cache_indices.numel() == 0:
+        return initial_state_mode, None, None
+
+    prefill_query_start_loc = query_start_loc[num_decodes:]
+    last_conv_state = _extract_last_conv_state(
+        mixed_qkv,
+        prefill_query_start_loc,
+        conv_state,
+    )
+    all_last_conv_state = pcp_group.all_gather(
+        last_conv_state.unsqueeze(0).contiguous(),
+        0,
+    )
+
+    valid_cache_mask = prefill_cache_indices != PAD_SLOT_ID
+    valid_cache_indices = prefill_cache_indices[valid_cache_mask]
+    final_conv_state = all_last_conv_state[-1, valid_cache_mask]
+    if valid_cache_indices.numel() > 0 and pcp_group.rank_in_group > 0:
+        conv_state[valid_cache_indices] = all_last_conv_state[
+            pcp_group.rank_in_group - 1,
+            valid_cache_mask,
+        ]
+
+    if pcp_group.rank_in_group > 0:
+        initial_state_mode = tuple(value if idx < num_decodes else 1 for idx, value in enumerate(initial_state_mode))
+    return initial_state_mode, final_conv_state, valid_cache_indices
+
+
+def _finalize_pcp_prefill_conv_state(
+    conv_state: torch.Tensor,
+    final_conv_state: torch.Tensor | None,
+    valid_cache_indices: torch.Tensor | None,
+) -> None:
+    if final_conv_state is None or valid_cache_indices is None or valid_cache_indices.numel() == 0:
+        return
+    conv_state[valid_cache_indices] = final_conv_state
+
+
+def _is_full_aclgraph_decode(forward_context) -> bool:
+    return getattr(forward_context, "cudagraph_runtime_mode", CUDAGraphMode.NONE) == CUDAGraphMode.FULL
 
 
 def update_conv1d_graph_params(
@@ -465,6 +559,18 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     cache_indices_opt,
                     initial_state_mode_opt,
                 ) = get_non_spec_causal_conv1d_host_args(attn_metadata)
+                (
+                    initial_state_mode_opt,
+                    final_conv_state,
+                    valid_cache_indices,
+                ) = _prepare_pcp_prefill_conv_state(
+                    mixed_qkv_non_spec,
+                    self_kv_cache[0],
+                    non_spec_state_indices_tensor,
+                    non_spec_query_start_loc,
+                    attn_metadata.num_decodes,
+                    initial_state_mode_opt,
+                )
                 mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
                 torch.ops._C_ascend.npu_causal_conv1d_custom(
                     mixed_qkv_non_spec_output,
@@ -480,13 +586,29 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     pad_slot_id=PAD_SLOT_ID,
                     run_mode=0,
                 )
+                _finalize_pcp_prefill_conv_state(
+                    self_kv_cache[0],
+                    final_conv_state,
+                    valid_cache_indices,
+                )
                 mixed_qkv_non_spec = mixed_qkv_non_spec_output
         elif attn_metadata.num_decodes > 0:
             conv_weights_T = conv_weights.transpose(0, 1)
             activation_num = 1 if self.activation else 0
             non_spec_qsl_host, non_spec_ci_host = get_causal_conv1d_update_host_args(attn_metadata)
             # graph capture branch
-            if _EXTRA_CTX.capturing:
+            if _is_full_aclgraph_decode(forward_context):
+                conv_state = self_kv_cache[0] if is_conv_state_dim_first() else self_kv_cache[0].transpose(-1, -2)
+                mixed_qkv_non_spec = causal_conv1d_update(
+                    mixed_qkv_non_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],
+                    validate_data=False,
+                )
+            elif _EXTRA_CTX.capturing:
                 stream = torch_npu.npu.current_stream()
                 event = torch.npu.ExternalEvent()
                 event.wait(stream)
@@ -623,23 +745,39 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
             )
         elif attn_metadata.num_decodes > 0:
-            cu_seqlens = non_spec_query_start_loc[: attn_metadata.num_decodes + 1]
-            actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
-            query_non_spec = l2norm_fwd(query_non_spec)
-            key_non_spec = l2norm_fwd(key_non_spec)
-            # Dispatches to the vllm-ascend AscendC custom operator
-            # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
-            core_attn_out_non_spec = torch_npu.npu_recurrent_gated_delta_rule(
-                query=query_non_spec.squeeze(0),
-                key=key_non_spec.squeeze(0),
-                value=value_non_spec.squeeze(0),
-                g=g_non_spec.squeeze(0) if g_non_spec is not None else g_non_spec,
-                beta=beta_non_spec.squeeze(0) if beta_non_spec is not None else beta_non_spec,
-                state=ssm_state,
-                scale=key_non_spec.shape[-1] ** -0.5,
-                actual_seq_lengths=actual_seq_lengths,
-                ssm_state_indices=non_spec_state_indices_tensor,
-            ).unsqueeze(0)
+            if _is_full_aclgraph_decode(forward_context):
+                out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
+                fused_recurrent_gated_delta_rule_packed_decode(
+                    mixed_qkv=mixed_qkv_non_spec,
+                    a=a,
+                    b=b,
+                    A_log=self.A_log,
+                    dt_bias=self.dt_bias,
+                    scale=self.head_k_dim**-0.5,
+                    initial_state=ssm_state,
+                    out=out_buf,
+                    ssm_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],
+                    use_qk_l2norm_in_kernel=True,
+                )
+                core_attn_out_non_spec = core_attn_out[:num_actual_tokens].unsqueeze(0)
+            else:
+                cu_seqlens = non_spec_query_start_loc[: attn_metadata.num_decodes + 1]
+                actual_seq_lengths = torch.cat([cu_seqlens[:1], cu_seqlens[1:] - cu_seqlens[:-1]])
+                query_non_spec = l2norm_fwd(query_non_spec)
+                key_non_spec = l2norm_fwd(key_non_spec)
+                # Dispatches to the vllm-ascend AscendC custom operator
+                # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
+                core_attn_out_non_spec = torch_npu.npu_recurrent_gated_delta_rule(
+                    query=query_non_spec.squeeze(0),
+                    key=key_non_spec.squeeze(0),
+                    value=value_non_spec.squeeze(0),
+                    g=g_non_spec.squeeze(0) if g_non_spec is not None else g_non_spec,
+                    beta=beta_non_spec.squeeze(0) if beta_non_spec is not None else beta_non_spec,
+                    state=ssm_state,
+                    scale=key_non_spec.shape[-1] ** -0.5,
+                    actual_seq_lengths=actual_seq_lengths,
+                    ssm_state_indices=non_spec_state_indices_tensor,
+                ).unsqueeze(0)
         else:
             core_attn_out_non_spec, last_recurrent_state = None, None
 

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -19,7 +19,6 @@ from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
 from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
 from .chunk_o import chunk_fwd_o  # noqa: F401
-from .chunk_o_update import chunk_fwd_o_update
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd
@@ -144,15 +143,23 @@ def chunk_gated_delta_rule_fwd(
         else:
             updated_h_state = updated_state[get_pcp_group().rank_in_group - 1, ...]
 
-        h = chunk_fwd_o_update(
-            q=q,
-            v=v_new,
-            h=h,
-            h_update=h_update,
-            updated_h_state=updated_h_state,
-            cu_seqlens=cu_seqlens,
-            chunk_offsets=chunk_offsets_chunk64,
-        )
+        if get_pcp_group().rank_in_group > 0:
+            rerun_initial_state = initial_state.clone()
+            prefill_slice = slice(num_decodes, final_state.shape[0])
+            rerun_initial_state[prefill_slice] = updated_h_state[prefill_slice]
+            h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+                k=k,
+                w=w,
+                u=u,
+                g=g,
+                initial_state=rerun_initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices_chunk64,
+                chunk_offsets=chunk_offsets_chunk64,
+            )
+            h = h.transpose(1, 2).contiguous()
+            v_new = v_new.transpose(1, 2).contiguous()
 
     o_ascendc = torch.ops._C_ascend.chunk_fwd_o(
         q_ascendc,

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -434,7 +434,10 @@ def _build_non_spec_query_start_loc_cpu(
     query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
     spec_sequence_masks_cpu = _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu)
     if spec_sequence_masks_cpu is None:
-        return query_start_loc_cpu
+        return _compact_query_start_loc_cpu(
+            query_start_loc_cpu,
+            _active_query_mask_cpu(common_attn_metadata),
+        )
 
     query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
     non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
@@ -473,6 +476,184 @@ def _build_spec_query_start_loc_cpu(
         out=spec_query_start_loc_cpu[1:],
     )
     return spec_query_start_loc_cpu
+
+
+def _compact_query_start_loc_cpu(query_start_loc_cpu: torch.Tensor, active_mask: torch.Tensor) -> torch.Tensor:
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    active_query_lens_cpu = query_lens_cpu[active_mask]
+    compact_query_start_loc_cpu = torch.zeros(
+        active_query_lens_cpu.numel() + 1,
+        dtype=query_start_loc_cpu.dtype,
+    )
+    torch.cumsum(
+        active_query_lens_cpu,
+        dim=0,
+        out=compact_query_start_loc_cpu[1:],
+    )
+    return compact_query_start_loc_cpu
+
+
+def _compact_query_start_loc(query_start_loc: torch.Tensor, active_mask: torch.Tensor) -> torch.Tensor:
+    active_mask = active_mask.to(device=query_start_loc.device)
+    query_lens = query_start_loc[1:] - query_start_loc[:-1]
+    active_query_lens = query_lens[active_mask]
+    compact_query_start_loc = torch.zeros(
+        active_query_lens.numel() + 1,
+        dtype=query_start_loc.dtype,
+        device=query_start_loc.device,
+    )
+    torch.cumsum(
+        active_query_lens,
+        dim=0,
+        out=compact_query_start_loc[1:],
+    )
+    return compact_query_start_loc
+
+
+def _active_query_mask_cpu(common_attn_metadata) -> torch.Tensor:
+    query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    return (query_lens_cpu > 0) & (query_start_loc_cpu[:-1] < common_attn_metadata.num_actual_tokens)
+
+
+def _trim_no_spec_decode_padding(
+    builder,
+    attn_metadata,
+    common_attn_metadata,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+) -> None:
+    if (
+        attn_metadata.num_decodes == 0
+        or attn_metadata.num_prefills > 0
+        or _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu) is not None
+    ):
+        return
+
+    query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    active_mask = _active_query_mask_cpu(common_attn_metadata)
+    num_active_rows = int(active_mask.sum().item())
+    if num_active_rows == attn_metadata.num_decodes:
+        return
+
+    attn_metadata.num_decodes = num_active_rows
+    attn_metadata.num_decode_tokens = int(query_lens_cpu[active_mask].sum().item())
+    attn_metadata.non_spec_query_start_loc = _compact_query_start_loc(
+        common_attn_metadata.query_start_loc,
+        active_mask,
+    )
+    attn_metadata.non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor[:num_active_rows]
+
+
+def _patch_full_graph_no_spec_decode_metadata(
+    builder,
+    attn_metadata,
+    common_attn_metadata,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+) -> None:
+    if (
+        not getattr(builder, "use_full_cuda_graph", False)
+        or attn_metadata.num_prefills > 0
+        or attn_metadata.num_decodes == 0
+        or _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu) is not None
+    ):
+        return
+
+    active_mask = _active_query_mask_cpu(common_attn_metadata)
+    num_active_rows = int(active_mask.sum().item())
+    if num_active_rows == 0:
+        return
+
+    query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    batch_size = max(
+        int(common_attn_metadata.num_actual_tokens),
+        int(getattr(common_attn_metadata, "num_input_tokens", common_attn_metadata.num_actual_tokens)),
+    )
+
+    if batch_size > builder.decode_cudagraph_max_bs:
+        return
+
+    state_indices = attn_metadata.non_spec_state_indices_tensor
+    if state_indices is None:
+        return
+    if state_indices.numel() >= active_mask.numel():
+        active_state_indices = state_indices[: active_mask.numel()][active_mask.to(device=state_indices.device)]
+    else:
+        active_state_indices = state_indices[:num_active_rows]
+    active_state_indices = active_state_indices.contiguous()
+
+    compact_query_start_loc = _compact_query_start_loc(
+        common_attn_metadata.query_start_loc,
+        active_mask,
+    )
+
+    builder.non_spec_state_indices_tensor[:num_active_rows].copy_(
+        active_state_indices,
+        non_blocking=True,
+    )
+    non_spec_state_indices_tensor = builder.non_spec_state_indices_tensor[:batch_size]
+    non_spec_state_indices_tensor[num_active_rows:].fill_(gdn_attn.NULL_BLOCK_ID)
+
+    builder.non_spec_query_start_loc[: num_active_rows + 1].copy_(
+        compact_query_start_loc,
+        non_blocking=True,
+    )
+    num_query_tokens = compact_query_start_loc[-1]
+    non_spec_query_start_loc = builder.non_spec_query_start_loc[: batch_size + 1]
+    non_spec_query_start_loc[num_active_rows + 1 :].fill_(num_query_tokens)
+
+    attn_metadata.num_decodes = num_active_rows
+    attn_metadata.num_decode_tokens = int(query_lens_cpu[active_mask].sum().item())
+    attn_metadata.non_spec_state_indices_tensor = non_spec_state_indices_tensor
+    attn_metadata.non_spec_query_start_loc = non_spec_query_start_loc
+
+
+def _patch_no_spec_prefill_metadata(
+    builder,
+    attn_metadata,
+    common_attn_metadata,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+    non_spec_query_start_loc_cpu: torch.Tensor,
+) -> None:
+    if _build_spec_sequence_masks_cpu(builder, num_decode_draft_tokens_cpu) is not None:
+        return
+
+    active_mask = _active_query_mask_cpu(common_attn_metadata)
+    num_active_rows = int(active_mask.sum().item())
+    if num_active_rows == 0:
+        return
+
+    attn_metadata.non_spec_query_start_loc = non_spec_query_start_loc_cpu.to(
+        device=common_attn_metadata.query_start_loc.device,
+        non_blocking=True,
+    )
+
+    active_mask_device = active_mask.to(device=attn_metadata.non_spec_state_indices_tensor.device)
+    if attn_metadata.non_spec_state_indices_tensor.numel() >= active_mask.numel():
+        attn_metadata.non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor[
+            : active_mask.numel()
+        ][active_mask_device].contiguous()
+    else:
+        attn_metadata.non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor[
+            :num_active_rows
+        ].contiguous()
+
+    if attn_metadata.has_initial_state is not None:
+        active_mask_device = active_mask.to(device=attn_metadata.has_initial_state.device)
+        if attn_metadata.has_initial_state.numel() >= active_mask.numel():
+            attn_metadata.has_initial_state = attn_metadata.has_initial_state[: active_mask.numel()][
+                active_mask_device
+            ].contiguous()
+        else:
+            attn_metadata.has_initial_state = attn_metadata.has_initial_state[:num_active_rows].contiguous()
+
+
+def _build_non_spec_decode_query_start_loc_cpu(common_attn_metadata) -> torch.Tensor:
+    return _compact_query_start_loc_cpu(
+        common_attn_metadata.query_start_loc_cpu,
+        _active_query_mask_cpu(common_attn_metadata),
+    )
 
 
 def _allocate_causal_conv1d_host_slot(
@@ -605,12 +786,13 @@ def _build_non_spec_causal_conv1d_host_meta(
     ):
         slot = _acquire_causal_conv1d_host_slot(builder)
 
+    num_host_seqs = non_spec_query_start_loc_cpu.numel() - 1
     cache_indices_cpu = _copy_to_pinned_cpu(
-        attn_metadata.non_spec_state_indices_tensor,
+        attn_metadata.non_spec_state_indices_tensor[:num_host_seqs],
         None if slot is None else slot.cache_indices_cpu,
     )
     has_initial_state_cpu = _copy_to_pinned_cpu(
-        attn_metadata.has_initial_state,
+        attn_metadata.has_initial_state[:num_host_seqs],
         None if slot is None else slot.has_initial_state_cpu,
     )
 
@@ -634,8 +816,9 @@ def _build_non_spec_decode_causal_conv1d_host_meta(
     if attn_metadata.non_spec_state_indices_tensor.device.type != "cpu":
         slot = _acquire_causal_conv1d_host_slot(builder)
 
+    num_host_seqs = non_spec_query_start_loc_cpu.numel() - 1
     non_spec_cache_indices_cpu = _copy_to_pinned_cpu(
-        attn_metadata.non_spec_state_indices_tensor,
+        attn_metadata.non_spec_state_indices_tensor[:num_host_seqs],
         None if slot is None else slot.cache_indices_cpu,
     )
 
@@ -724,6 +907,13 @@ def _patched_build(
     attn_metadata.non_spec_prefill_fallback_meta = None
     attn_metadata.non_spec_decode_fallback_meta = None
     attn_metadata.spec_decode_fallback_meta = None
+    _trim_no_spec_decode_padding(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
+    _patch_full_graph_no_spec_decode_metadata(
+        self,
+        attn_metadata,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu,
+    )
     if attn_metadata.spec_sequence_masks is not None:
         _patched_build_spec(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
 
@@ -757,6 +947,13 @@ def _patched_build_prefill(
     assert non_spec_query_start_loc_cpu is not None
     if attn_metadata.non_spec_query_start_loc is None:
         raise RuntimeError("Expected attn_metadata.non_spec_query_start_loc for patched GDN non-spec prefill path.")
+    _patch_no_spec_prefill_metadata(
+        self,
+        attn_metadata,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu,
+        non_spec_query_start_loc_cpu,
+    )
     attn_metadata.non_spec_prefill_fallback_meta = GDNPrefillFallbackMeta(
         causal_conv1d=_build_non_spec_causal_conv1d_host_meta(
             self,
@@ -835,13 +1032,16 @@ def _patched_build_decode(
         self,
         common_attn_metadata.query_start_loc.device,
     )
-    non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
-        self,
-        common_attn_metadata,
-        num_decode_draft_tokens_cpu,
-    )
-    if non_spec_query_start_loc_cpu is None:
-        raise RuntimeError("Expected non-spec query_start_loc_cpu for patched GDN non-spec decode path.")
+    if attn_metadata.num_prefills > 0:
+        non_spec_query_start_loc_cpu = _build_non_spec_query_start_loc_cpu(
+            self,
+            common_attn_metadata,
+            num_decode_draft_tokens_cpu,
+        )
+        if non_spec_query_start_loc_cpu is None:
+            raise RuntimeError("Expected non-spec query_start_loc_cpu for patched GDN non-spec decode path.")
+    else:
+        non_spec_query_start_loc_cpu = _build_non_spec_decode_query_start_loc_cpu(common_attn_metadata)
     attn_metadata.non_spec_decode_fallback_meta = GDNDecodeFallbackMeta(
         causal_conv1d=_build_non_spec_decode_causal_conv1d_host_meta(
             self,


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #9478.

Qwen3-Next can produce repeated exclamation output when prefill context parallelism is used together with FULL_DECODE_ONLY graph mode. The same focused request passes when graph mode is disabled, which points to PCP/full-graph state handling rather than prompt construction.

This PR fixes the PCP + full decode graph path by:

- compacting active GDN rows while preserving full-graph static metadata buffer shapes;
- trimming padded non-spec decode rows in vllm-ascend's GDN metadata patch;
- carrying PCP prefill conv/GDN state across PCP ranks;
- rerunning the GDN chunk state path with the previous PCP rank state where needed;
- zero-initializing PCP hybrid attention QKV padding before restored rows are written.

### Does this PR introduce _any_ user-facing change?

No API or CLI change. It fixes incorrect output for Qwen3-Next PCP + FULL_DECODE_ONLY graph inference.

### How was this patch tested?

Unit and lint checks:

```bash
PYTHONPATH=/mnt/share_space/j00513044/home/tmp/q35graph/vllm_clean_for_pr:/mnt/share_space/j00513044/home/tmp/q35graph/vllm_ascend_pr:${PYTHONPATH} \
  pytest -q tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py tests/ut/ops/test_gdn_chunk_meta.py
# 21 passed

python -m ruff check \
  vllm_ascend/attention/context_parallel/attention_cp.py \
  vllm_ascend/ops/gdn.py \
  vllm_ascend/ops/triton/fla/chunk.py \
  vllm_ascend/patch/worker/patch_gdn_attn.py \
  tests/ut/patch/worker/patch_common/test_patch_gdn_attn.py \
  tests/ut/ops/test_gdn_chunk_meta.py
# All checks passed
```

Real model validation on /models/Qwen3-Next-80B-A3B-Instruct-W8A8:

```bash
# PCP2TP4 + FULL_DECODE_ONLY, GSM8K 10 prompts, concurrency 10:
# wrong=0, bang_indices=[]

# PCP4TP4 + FULL_DECODE_ONLY, 16 NPUs, GSM8K 10 prompts, concurrency 10:
# wrong=0, bang_indices=[]
```

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
