### PR TITLE
[Doc]Update MiniMax-M2.5.md change A2 to single node

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.5.md
+++ b/docs/source/tutorials/models/MiniMax-M2.5.md
@@ -7,7 +7,7 @@ MiniMax‑M2.5 is MiniMax’s flagship large language model, reinforced for high
 This document provides a unified deployment guide for `MiniMax-M2.5` on vLLM Ascend, covering both:
 
 - **A3 single-node** deployment (Atlas 800 A3)
-- **A2 dual-node** deployment (2× Atlas 800I A2)
+- **A2 single-node** deployment (Atlas 800I A2)
 
 ## Supported Features
 
@@ -19,7 +19,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### Model Weights
 
-- `MiniMax-M2.5` (fp8 checkpoint): recommended to use **1× Atlas 800 A3** or **2× Atlas 800I A2** nodes. Download the model weights from [MiniMax/MiniMax-M2.5](https://modelscope.cn/models/MiniMax/MiniMax-M2.5).
+- `MiniMax-M2.5` (fp8 checkpoint): recommended to use **1× Atlas 800 A3** or **1× Atlas 800I A2** nodes. Download the model weights from [MiniMax/MiniMax-M2.5](https://modelscope.cn/models/MiniMax/MiniMax-M2.5).
 - `MiniMax-M2.5-w8a8-QuaRot` : Download the model weights from [Eco-Tech/MiniMax-M2.5-w8a8-QuaRot](https://modelscope.cn/models/Eco-Tech/MiniMax-M2.5-w8a8-QuaRot).
 - `Eagle3` : Download the model weights from [vllm-ascend/MiniMax-M2.5-eagel-model](https://modelscope.cn/models/vllm-ascend/MiniMax-M2.5-eagel-model-0318).
 
@@ -76,9 +76,9 @@ docker run --rm \
 -it $IMAGE bash
 ```
 
-### A2 (dual node, run on both nodes)
+### A2 (single node)
 
-Create and run `minimax25-docker-run.sh` on **both** A2 nodes.
+Create and run `minimax25-docker-run.sh`.
 
 Notes:
 
@@ -190,132 +190,51 @@ Remarks:
     --reasoning-parser minimax_m2_append_think \
 ```
 
-### A2 (dual node, tp=8 + dp=2)
-
-Since cross-node tensor parallelism (TP) can be unstable, the dual-node guide uses a **tp=8 + dp=2** setup (8 NPUs per node, 16 NPUs total).
-
-#### Node0 (primary) startup script
-
-Edit `minimax25_service_node0.sh` inside the node0 container, and replace the placeholders with your actual values:
-
-- `{PrimaryNodeIP}`: the primary node's IP address (public/cluster network)
-- `{NIC}`: the NIC name for the public/cluster network (check via `ifconfig`, e.g., `enp67s0f0np0`)
-- `VLLM_TORCH_PROFILER_DIR`: optional, directory to store profiling outputs
+### A2 (single node)
 
 ```{code-block} bash
-# Primary node (node0)
-export HCCL_IF_IP={PrimaryNodeIP}
-export GLOO_SOCKET_IFNAME="{NIC}"
-export TP_SOCKET_IFNAME="{NIC}"
-export HCCL_SOCKET_IFNAME="{NIC}"
-export HCCL_BUFFSIZE=1024
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_BUFFSIZE=512
+sysctl -w vm.swappiness=0
+sysctl -w kernel.numa_balancing=0
+sysctl kernel.sched_migration_cost_ns=50000
+export TASK_QUEUE_ENABLE=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-
 export HCCL_INTRA_PCIE_ENABLE=1
 export HCCL_INTRA_ROCE_ENABLE=0
-
-# profiling (optional)
-export VLLM_TORCH_PROFILER_WITH_STACK=0
-export VLLM_TORCH_PROFILER_DIR="{profiling_dir}"
-
-vllm serve /opt/data/verification/models/MiniMax-M2.5/ \
-  --served-model-name "minimax25" \
-  --host {PrimaryNodeIP} \
-  --port 20004 \
-  --tensor-parallel-size 8 \
-  --data-parallel-size 2 \
-  --data-parallel-size-local 1 \
-  --data-parallel-start-rank 0 \
-  --data-parallel-address {PrimaryNodeIP} \
-  --data-parallel-rpc-port 2347 \
-  --max-num-seqs 128 \
-  --max-num-batched-tokens 65536 \
-  --gpu-memory-utilization 0.92 \
-  --enable-expert-parallel \
-  --trust-remote-code \
-  --enable-auto-tool-choice \
-  --tool-call-parser minimax_m2 \
-  --reasoning-parser minimax_m2_append_think \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --mm_processor_cache_type="shm" \
-  --additional-config '{"enable_cpu_binding":true}'
-```
-
-#### Node1 (secondary) startup script
-
-Edit `minimax25_service_node1.sh` inside the node1 container:
-
-- `{SecondaryNodeIP}`: the secondary node's IP address
-- `{PrimaryNodeIP}`: the primary node's IP address (same as node0)
-- `{NIC}`: same as above
-
-```{code-block} bash
-# Secondary node (node1)
-export HCCL_IF_IP={SecondaryNodeIP}
-export GLOO_SOCKET_IFNAME="{NIC}"
-export TP_SOCKET_IFNAME="{NIC}"
-export HCCL_SOCKET_IFNAME="{NIC}"
-export HCCL_BUFFSIZE=1024
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-export HCCL_INTRA_PCIE_ENABLE=1
-export HCCL_INTRA_ROCE_ENABLE=0
-
-# profiling (optional)
-export VLLM_TORCH_PROFILER_WITH_STACK=0
-export VLLM_TORCH_PROFILER_DIR="{profiling_dir}"
-
-vllm serve /opt/data/verification/models/MiniMax-M2.5/ \
-  --served-model-name "minimax25" \
-  --host {SecondaryNodeIP} \
-  --port 20004 \
-  --headless \
-  --tensor-parallel-size 8 \
-  --data-parallel-size 2 \
-  --data-parallel-size-local 1 \
-  --data-parallel-start-rank 1 \
-  --data-parallel-address {PrimaryNodeIP} \
-  --data-parallel-rpc-port 2347 \
-  --max-num-seqs 128 \
-  --max-num-batched-tokens 65536 \
-  --gpu-memory-utilization 0.92 \
-  --enable-expert-parallel \
-  --trust-remote-code \
-  --enable-auto-tool-choice \
-  --tool-call-parser minimax_m2 \
-  --reasoning-parser minimax_m2_append_think \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --mm_processor_cache_type="shm" \
-  --additional-config '{"enable_cpu_binding":true}'
+vllm serve /path/to/weight/MiniMax-M2.5-w8a8-QuaRot \
+    --served-model-name MiniMax-M2.5 \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --quantization ascend \
+    --enable-expert-parallel \
+    --max-num-seqs 32 \
+    --seed 1024 \
+    --max-num-batched-tokens 32768 \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,16,20,32,80,96,128,200,256,320]}' \
+    --gpu-memory-utilization 0.9 \
+    --enable-auto-tool-choice \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think \
+    --enable-force-include-usage \
+    --additional-config '{"enable_cpu_binding":true}' \
+    --model-loader-extra-config '{"enable_multithread_load":true,"num_threads":16}' \
+    --speculative_config '{"method": "eagle3", "model": "/path/to/weight/Eagle3/",  "num_speculative_tokens":3}'
 ```
 
-#### Startup order
+Remarks:
 
-Start the service on both nodes:
-
-```{code-block} bash
-# node0
-bash minimax25_service_node0.sh
-
-# node1
-bash minimax25_service_node1.sh
-```
-
-After node0 prints `service start` in logs, you can verify the service.
+- `--max-num-seqs` parameter can be adjusted according to actual request conditions.
+- `--max-num-batched-tokens 32768` is applicable to the input sequence length of 32k or longer.
+- `--max-num-batched-tokens 16384` is applicable to the input sequence length of 16k.
+- `--max-num-batched-tokens 6144` is applicable to short sequence input scenarios such as 2k and 3.5k.
 
 ## Verify the Service
 
@@ -365,15 +284,15 @@ curl http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-### A2 (dual node)
+### A2 (single node)
 
-Run the following from any machine that can reach the primary node (replace `{PrimaryNodeIP}` with the real IP):
+Run the following from any machine that can reach the service node (replace `{NodeIP}` with the real IP):
 
 ```{code-block} bash
-curl http://{PrimaryNodeIP}:20004/v1/chat/completions \
+curl http://{NodeIP}:8000/v1/chat/completions \
   -H "Content-type: application/json" \
   -d '{
-    "model": "minimax25",
+    "model": "MiniMax-M2.5",
     "messages": [{"role": "user", "content": "Hello, who are you?"}],
     "stream": false,
     "ignore_eos": true,
@@ -408,41 +327,27 @@ curl http://{PrimaryNodeIP}:20004/v1/chat/completions \
 | Mean TPOT | `105.54 ms` |
 | Mean ITL | `105.54 ms` |
 
-### A2 (dual node, 190k/1k, concurrency=4, 16 prompts)
-
-#### Benchmark method
-
-Use vLLM bench for the **190k/1k, concurrency=4, 16 prompts** scenario:
-
-```{code-block} bash
-vllm bench serve --backend vllm \
-  --dataset-name prefix_repetition \
-  --prefix-repetition-prefix-len 175104 \   # Input: 190×1024 tokens with 90% prefix repetition
-  --prefix-repetition-suffix-len 19440 \    # Input: 190×1024 tokens minus the prefix length above
-  --prefix-repetition-output-len 1024 \     # Output: 1024 tokens
-  --prefix-repetition-num-prefixes 1 \
-  --num-prompts 16 \
-  --max-concurrency 4 \
-  --ignore-eos \
-  --model minimax25 \
-  --tokenizer {model_path} \
-  --endpoint /v1/completions \
-  --request-rate inf \
-  --seed 1000 \
-  --host {service_ip} \
-  --port 20004
-```
+### A2 (single node)
 
 #### Results
 
-**190k/1k, concurrency=4, 16 prompts**
+**32k/0.5k, concurrency=40, 160 prompts**
 
 | Metric | Result |
 | --- | --- |
-| TTFT (avg) | 3305.25 ms |
-| TPOT (avg) | 109.83 ms |
-| Output throughput | 35.29 tok/s |
-| Prefix hit rate | 85% |
+| TTFT (avg) | 6944.5 ms |
+| TPOT (avg) | 50.1 ms |
+| Output throughput | 585.79 tok/s |
+| Prefix hit rate | 90% |
+
+**190k/1k, concurrency=2, 4 prompts**
+
+| Metric | Result |
+| --- | --- |
+| TTFT (avg) | 48575.1 ms |
+| TPOT (avg) | 85.3 ms |
+| Output throughput | 15.03 tok/s |
+| Prefix hit rate | 0% |
 
 ## FAQ
 
@@ -462,14 +367,10 @@ vllm bench serve --backend vllm \
 
   A: Reduce `--max-num-seqs` and `--max-num-batched-tokens` first. If needed, reduce concurrency and load-testing pressure (e.g., `max-concurrency` / `num-prompts`).
 
-- **Q: Why not use cross-node tp=16?**
-
-  A: The referenced practice noted that cross-node TP may be unstable, so `tp=8, dp=2` is recommended for dual-node deployment.
-
 - **Q: How should I choose `--reasoning-parser`?**
 
   A: This guide uses `minimax_m2_append_think` so that `<think>...</think>` is kept in `content`. If you mainly rely on the reasoning semantics of `/v1/responses`, consider using `--reasoning-parser minimax_m2`.
 
 - **Q: Which ports must be accessible?**
 
-  A: At minimum, expose the serving port (e.g., `20004`) and the data-parallel RPC port (e.g., `2347`), and ensure the two nodes can reach each other over the network.
+  A: At minimum, expose the serving port (e.g., `8000`)

--- a/docs/source/tutorials/models/MiniMax-M2.5.md
+++ b/docs/source/tutorials/models/MiniMax-M2.5.md
@@ -302,53 +302,6 @@ curl http://{NodeIP}:8000/v1/chat/completions \
   }'
 ```
 
-## Performance Reference
-
-### A3 (single node, tp=16, 4k/1k@bs16)
-
-#### Results
-
-**Baseline** (`3.5k/1k@bs=217`)
-
-| Metric | Result |
-| --- | --- |
-| Success/Failure | `217/0` |
-| Mean TTFT | `10316.56 ms` |
-| Mean TPOT | `34.28 ms` |
-| Output tok/s | `4803.81` |
-| Total tok/s | `16096.59` |
-
-**Long-context reference** (`190k/1k@bs=4`)
-
-| Metric | Result |
-| --- | --- |
-| Output tok/s | `37.12` |
-| Mean TTFT | `2002.37 ms` |
-| Mean TPOT | `105.54 ms` |
-| Mean ITL | `105.54 ms` |
-
-### A2 (single node)
-
-#### Results
-
-**32k/0.5k, concurrency=40, 160 prompts**
-
-| Metric | Result |
-| --- | --- |
-| TTFT (avg) | 6944.5 ms |
-| TPOT (avg) | 50.1 ms |
-| Output throughput | 585.79 tok/s |
-| Prefix hit rate | 90% |
-
-**190k/1k, concurrency=2, 4 prompts**
-
-| Metric | Result |
-| --- | --- |
-| TTFT (avg) | 48575.1 ms |
-| TPOT (avg) | 85.3 ms |
-| Output throughput | 15.03 tok/s |
-| Prefix hit rate | 0% |
-
 ## FAQ
 
 - **Q: What should I do if the output is garbled in EP mode?**


### PR DESCRIPTION
### What this PR does / why we need it?
Modify the MiniMax-M2.5 document to change the A2 two-node deployment scheme to a single-node deployment scheme.

### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.

### How was this patch tested?
Documentation changes were verified for consistency with the existing tutorial steps.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
