### PR TITLE
[Doc] Remove modelscope installation from quickstart

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -88,15 +88,6 @@ The default workdir is `/workspace`, vLLM and vLLM Ascend code are placed in `/v
 
 ## Usage
 
-You can use ModelScope mirror to speed up download:
-
-<!-- tests/e2e/doctest/001-quickstart-test.sh should be considered updating as well -->
-
-```bash
-pip install modelscope>=1.35.1
-export VLLM_USE_MODELSCOPE=True
-```
-
 There are two ways to start vLLM on Ascend NPU:
 
 :::::{tab-set}

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -88,12 +88,6 @@ The default workdir is `/workspace`, vLLM and vLLM Ascend code are placed in `/v
 
 ## Usage
 
-You can use ModelScope mirror to speed up download:
-
-```bash
-export VLLM_USE_MODELSCOPE=True
-```
-
 There are two ways to start vLLM on Ascend NPU:
 
 :::::{tab-set}

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -88,6 +88,12 @@ The default workdir is `/workspace`, vLLM and vLLM Ascend code are placed in `/v
 
 ## Usage
 
+You can use ModelScope mirror to speed up download:
+
+```bash
+export VLLM_USE_MODELSCOPE=True
+```
+
 There are two ways to start vLLM on Ascend NPU:
 
 :::::{tab-set}


### PR DESCRIPTION
### What this PR does / why we need it?

The `pip install modelscope>=1.35.1` in quickstart is redundant because modelscope is already installed in Dockerfile.

### Changes

- Remove `pip install modelscope>=1.35.1` from quickstart guide
- Remove related ModelScope mirror instructions

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change. Users who use the Docker image already have modelscope installed.

### How was this patch tested?

Documentation changes were verified for consistency.

Fixes #9454

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
