### PR TITLE
[BugFix] Fix precision anomaly of DeepSeek-V4 on A2 when FlashComm is enabled

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -504,17 +504,23 @@ class TestAscendUnquantizedFusedMoEMethod:
 
 class TestAscendMoERunner:
     @pytest.mark.parametrize(
-        "moe_comm_type, expected",
+        "moe_comm_type, flash_comm_v1_enabled, expected",
         [
-            (MoECommType.ALLTOALL, True),
-            (MoECommType.MC2, True),
-            (MoECommType.FUSED_MC2, True),
-            (MoECommType.ALLGATHER, False),
+            (MoECommType.ALLTOALL, False, True),
+            (MoECommType.MC2, False, True),
+            (MoECommType.FUSED_MC2, False, True),
+            (MoECommType.ALLGATHER, False, False),
+            (MoECommType.ALLGATHER, True, True),
         ],
     )
-    def test_runner_reduction_properties(self, monkeypatch, moe_comm_type, expected):
+    def test_runner_reduction_properties(self, monkeypatch, moe_comm_type, flash_comm_v1_enabled, expected):
         runner = AscendMoERunner.__new__(AscendMoERunner)
         monkeypatch.setattr(fused_moe_module, "_EXTRA_CTX", SimpleNamespace(moe_comm_type=moe_comm_type))
+        monkeypatch.setattr(
+            fused_moe_module,
+            "_EXTRA_CTX",
+            SimpleNamespace(moe_comm_type=moe_comm_type, flash_comm_v1_enabled=flash_comm_v1_enabled),
+        )
 
         assert runner.use_dp_chunking is False
         if hasattr(type(runner), "_fused_output_is_reduced"):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -279,7 +279,7 @@ class AscendMoERunner(MoERunner):
             MoECommType.ALLTOALL,
             MoECommType.MC2,
             MoECommType.FUSED_MC2,
-        }
+        } or (moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
 
     def _maybe_reduce_shared_expert_output(
         self,


### PR DESCRIPTION
What this PR does / why we need it?
[BugFix] Fix precision anomaly of DeepSeek-V4 on A2 when FlashComm is enabled

Does this PR introduce any user-facing change?
no

How was this patch tested?
curl请求后响应无乱码：
curl http://xxx:xxxx/v1/chat/completions -H "Content-Type: application/json" -d '{
"model": "dsv4",
"messages": [
{"role": "user", "content": "你好"}
],
"temperature": 1,
"top_p": 0.95,
"top_k": 20,
"max_tokens": 100
}'

{"id":"chatcmpl-9670656f45c2bca6","object":"chat.completion","created":1779496285,"model":"dsv4","choices":[{"index":0,"message":{"role":"assistant","content":"你好！很高兴见到你。有什么我可以帮你的吗？无论是聊天、解答问题还是提供建议，我都乐意陪伴你。😊","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":5,"total_tokens":34,"completion_tokens":29,"prompt_tokens_details":null,"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":null,"accepted_prediction_tokens":null,"rejected_prediction_tokens":null}},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}

Under the FlashComm1 + MoECommType.ALLGATHER scenario, the Ascend finalize() path has already obtained the TP-reduced token shards via reduce_scatter. However, the upstream MoERunner still treats this output as "unreduced" and proceeds to execute an additional TP all_reduce. This causes different token shards to be incorrectly added element-wise, directly resulting in abnormal inference output.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
