### PR TITLE
[Performance][310p] Discard native RmsNormGated ops on 310P

### DIFF
--- a/tests/ut/_310p/ops/test_layernorm_310.py
+++ b/tests/ut/_310p/ops/test_layernorm_310.py
@@ -16,8 +16,49 @@ def default_vllm_config():
         yield mock_config
 
 
-def test_rmsnorm_gated_310_forward_oot_uses_forward_native():
+@patch("torch.nn.functional.silu", side_effect=lambda tensor: tensor + 1)
+@patch("torch_npu.npu_rms_norm")
+def test_rmsnorm_gated_310_forward_oot_uses_rmsnorm_activation_mul(mock_rms_norm, mock_silu):
+    layer = AscendRMSNormGated310(hidden_size=8, eps=1e-5, norm_before_gate=True)
+    x = torch.randn(2, 8, dtype=torch.float32)
+    z = torch.randn(2, 8, dtype=torch.float32)
+    normed = torch.randn(2, 8, dtype=torch.float32)
+    mock_rms_norm.return_value = (normed, None)
+
+    with patch.object(RMSNormGated, "forward_native", autospec=True) as mock_forward_native:
+        out = layer.forward_oot(x, z)
+
+    mock_forward_native.assert_not_called()
+    mock_rms_norm.assert_called_once()
+    rms_norm_args = mock_rms_norm.call_args.args
+    assert rms_norm_args[0] is x
+    assert rms_norm_args[1] is layer.weight
+    assert rms_norm_args[2] == layer.eps
+    mock_silu.assert_called_once_with(z)
+    assert torch.allclose(out, normed * (z + 1))
+
+
+@patch("torch_npu.npu_rms_norm")
+def test_rmsnorm_gated_310_forward_oot_uses_rmsnorm_without_gate(mock_rms_norm):
     layer = AscendRMSNormGated310(hidden_size=8, eps=1e-5)
+    x = torch.randn(2, 8, dtype=torch.float32)
+    expected = torch.randn(2, 8, dtype=torch.float32)
+    mock_rms_norm.return_value = (expected, None)
+
+    with patch.object(RMSNormGated, "forward_native", autospec=True, return_value=expected) as mock_forward_native:
+        out = layer.forward_oot(x, None)
+
+    mock_forward_native.assert_not_called()
+    mock_rms_norm.assert_called_once()
+    rms_norm_args = mock_rms_norm.call_args.args
+    assert rms_norm_args[0] is x
+    assert rms_norm_args[1] is layer.weight
+    assert rms_norm_args[2] == layer.eps
+    assert out is expected
+
+
+def test_rmsnorm_gated_310_forward_oot_keeps_native_for_group_norm():
+    layer = AscendRMSNormGated310(hidden_size=8, eps=1e-5, group_size=4)
     x = torch.randn(2, 8, dtype=torch.float32)
     z = torch.randn(2, 8, dtype=torch.float32)
     expected = torch.randn(2, 8, dtype=torch.float32)
@@ -26,16 +67,4 @@ def test_rmsnorm_gated_310_forward_oot_uses_forward_native():
         out = layer.forward_oot(x, z)
 
     mock_forward_native.assert_called_once_with(layer, x, z)
-    assert out is expected
-
-
-def test_rmsnorm_gated_310_forward_oot_uses_forward_native_without_gate():
-    layer = AscendRMSNormGated310(hidden_size=8, eps=1e-5)
-    x = torch.randn(2, 8, dtype=torch.float32)
-    expected = torch.randn(2, 8, dtype=torch.float32)
-
-    with patch.object(RMSNormGated, "forward_native", autospec=True, return_value=expected) as mock_forward_native:
-        out = layer.forward_oot(x, None)
-
-    mock_forward_native.assert_called_once_with(layer, x, None)
     assert out is expected

--- a/vllm_ascend/_310p/ops/layernorm.py
+++ b/vllm_ascend/_310p/ops/layernorm.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.layernorm import RMSNormGated
 
@@ -41,11 +42,27 @@ class AscendGemmaRMSNorm310(AscendGemmaRMSNorm):
 
 
 class AscendRMSNormGated310(RMSNormGated):
+    def _apply_activation(self, z: torch.Tensor) -> torch.Tensor:
+        if self.activation == "sigmoid":
+            return torch.sigmoid(z)
+        if self.activation in ("silu", "swish"):
+            return F.silu(z)
+        raise AssertionError(f"Unsupported activation: {self.activation}")
+
     def forward_oot(
         self,
         x: torch.Tensor,
         z: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # 310P should not depend on the Triton-gated layernorm path.
-        # Reuse the upstream native implementation directly.
-        return super().forward_native(x, z)
+        if self.group_size is not None:
+            return super().forward_native(x, z)
+
+        if z is not None and not self.norm_before_gate:
+            x = torch.mul(x, self._apply_activation(z))
+
+        x, _ = torch_npu.npu_rms_norm(x, self.weight, self.eps)
+
+        if z is not None and self.norm_before_gate:
+            x = torch.mul(x, self._apply_activation(z))
+
+        return x


### PR DESCRIPTION
### What this PR does / why we need it?
Remove the native RMSNormGated implementation and replace it with a decomposed implementation using RMSNorm, Mul, and activation operators.
### Does this PR introduce _any_ user-facing change?
NA
### How was this patch tested?
UT and local test
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
