### PR TITLE
[Doc][Misc] Keep VLLM_USE_MODELSCOPE instruction in quickstart

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -88,6 +88,14 @@ The default workdir is `/workspace`, vLLM and vLLM Ascend code are placed in `/v
 
 ## Usage
 
+You can use ModelScope mirror to speed up download:
+
+<!-- tests/e2e/doctests/001-quickstart-test.sh should be considered updating as well -->
+
+```bash
+export VLLM_USE_MODELSCOPE=True
+```
+
 There are two ways to start vLLM on Ascend NPU:
 
 :::::{tab-set}


### PR DESCRIPTION
### What this PR does / why we need it?

This PR addresses the review feedback from PR #9484 by retaining the `export VLLM_USE_MODELSCOPE=True` instruction in the quickstart guide. This environment variable is necessary for users in regions with limited access to the HuggingFace Hub, as ModelScope serves as an efficient mirror. The redundant `pip install modelscope` command is omitted as it is pre-installed in the provided Docker images.

Fixes #9454

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change.

### How was this patch tested?

Documentation changes were verified for consistency.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
