### PR TITLE
[BugFix] fix bug of qwen3-next and qwen3.5 + pcp

### DIFF
--- a/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
@@ -94,7 +94,14 @@ def test_models_pcp_dcp_basic():
         gpu_memory_utilization=0.8,
         block_size=128,
     ) as runner:
-        runner.model.generate(prompts, sampling_params)
+        outputs = runner.generate_greedy(prompts, 5)
+        results = [item[1] for item in outputs]
+        golden = ["The capital of France is Paris.\nThe capital",
+            "Hello, my name is Tom, I am a 20 years",
+            "The president of United States is the head of state and",
+            "AI future is not just about technology,"]
+        res_percent = calculate_total_char_match_percent(results, golden)
+        assert res_percent > 80
 
 
 @wait_until_npu_memory_free()
@@ -458,3 +465,24 @@ def test_qwen3_5_4b_multimodal_single_and_multi_image():
         assert len(outputs) == len(inputs)
         for output in outputs:
             assert output.outputs and output.outputs[0].text.strip()
+
+
+def calculate_total_char_match_percent(pred_list: list[str], target_list: list[str]) -> float:
+    if len(pred_list) != len(target_list):
+        raise ValueError("list length not same")
+
+    total_matched = 0
+    total_checked = 0
+    for pred_str, target_str in zip(pred_list, target_list):
+        check_len = min(len(pred_str), len(target_str))
+        if check_len == 0:
+            continue
+        matched = sum(1 for a, b in zip(pred_str, target_str) if a == b)
+        total_matched += matched
+        total_checked += check_len
+
+    if total_checked == 0:
+        return 0.0
+
+    percent = (total_matched / total_checked) * 100
+    return round(percent, 2)

--- a/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
@@ -96,10 +96,12 @@ def test_models_pcp_dcp_basic():
     ) as runner:
         outputs = runner.generate_greedy(prompts, 5)
         results = [item[1] for item in outputs]
-        golden = ["The capital of France is Paris.\nThe capital",
+        golden = [
+            "The capital of France is Paris.\nThe capital",
             "Hello, my name is Tom, I am a 20 years",
             "The president of United States is the head of state and",
-            "AI future is not just about technology,"]
+            "AI future is not just about technology,",
+        ]
         res_percent = calculate_total_char_match_percent(results, golden)
         assert res_percent > 80
 

--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -231,12 +231,7 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
             calls.append(("o", kwargs["chunk_offsets"]))
             return _DummyTensor("o")
 
-        def fake_chunk_fwd_o_update(*args, **kwargs):
-            calls.append(("o_update", kwargs["chunk_offsets"]))
-            return _DummyTensor("h_updated")
-
         monkeypatch.setattr(chunk, "chunk_fwd_o", fake_chunk_fwd_o)
-        monkeypatch.setattr(chunk, "chunk_fwd_o_update", fake_chunk_fwd_o_update)
 
         chunk.chunk_gated_delta_rule_fwd(
             q=q,

--- a/tests/ut/ops/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/test_gdn_chunk_meta.py
@@ -231,7 +231,13 @@ def test_chunk_gated_delta_rule_fwd_threads_prebuilt_chunk_offsets(
             calls.append(("o", kwargs["chunk_offsets"]))
             return _DummyTensor("o")
 
+        def fake_chunk_fwd_o_update(*args, **kwargs):
+            calls.append(("o_update", kwargs["chunk_offsets"]))
+            return _DummyTensor("h_updated")
+
         monkeypatch.setattr(chunk, "chunk_fwd_o", fake_chunk_fwd_o)
+        if world_size > 1:
+            monkeypatch.setattr(chunk, "chunk_gated_delta_rule_fwd_hupdate", fake_chunk_fwd_o_update)
 
         chunk.chunk_gated_delta_rule_fwd(
             q=q,

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 #
 
+from typing import Any
 import torch
+import torch.nn.functional as F
 import torch_npu
 from einops import rearrange
+from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
 from vllm.model_executor.layers.mamba.gdn_linear_attn import GatedDeltaNetAttention
@@ -36,6 +39,7 @@ from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
+from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_fn
 from vllm_ascend.utils import vllm_version_is, weak_ref_tensors
 
 
@@ -458,29 +462,46 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
             if mixed_qkv_non_spec is not None:
-                conv_weights_T = conv_weights.transpose(0, 1)
-                activation_num = 1 if self.activation else 0
-                (
-                    query_start_loc_opt,
-                    cache_indices_opt,
-                    initial_state_mode_opt,
-                ) = get_non_spec_causal_conv1d_host_args(attn_metadata)
-                mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
-                torch.ops._C_ascend.npu_causal_conv1d_custom(
-                    mixed_qkv_non_spec_output,
-                    mixed_qkv_non_spec,
-                    conv_weights_T,
-                    conv_state=self_kv_cache[0],
-                    bias_opt=self.conv1d.bias,
-                    query_start_loc_opt=query_start_loc_opt,
-                    cache_indices_opt=cache_indices_opt,
-                    initial_state_mode_opt=initial_state_mode_opt,
-                    num_accepted_tokens_opt=[],
-                    activation_mode=activation_num,
-                    pad_slot_id=PAD_SLOT_ID,
-                    run_mode=0,
-                )
-                mixed_qkv_non_spec = mixed_qkv_non_spec_output
+                if get_pcp_group().world_size > 1:
+                    mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+                    has_initial_state = attn_metadata.has_initial_state
+                    non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+                    conv_state = self_kv_cache[0].transpose(-1, -2)
+                    mixed_qkv_non_spec = causal_conv1d_fn(
+                        mixed_qkv_non_spec_T,
+                        conv_weights,
+                        self.conv1d.bias,
+                        activation=self.activation,
+                        conv_states=conv_state,
+                        has_initial_state=has_initial_state,
+                        cache_indices=non_spec_state_indices_tensor,
+                        query_start_loc=non_spec_query_start_loc,
+                        metadata=attn_metadata,
+                    ).transpose(0, 1)
+                else:
+                    conv_weights_T = conv_weights.transpose(0, 1)
+                    activation_num = 1 if self.activation else 0
+                    (
+                        query_start_loc_opt,
+                        cache_indices_opt,
+                        initial_state_mode_opt,
+                    ) = get_non_spec_causal_conv1d_host_args(attn_metadata)
+                    mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
+                    torch.ops._C_ascend.npu_causal_conv1d_custom(
+                        mixed_qkv_non_spec_output,
+                        mixed_qkv_non_spec,
+                        conv_weights_T,
+                        conv_state=self_kv_cache[0],
+                        bias_opt=self.conv1d.bias,
+                        query_start_loc_opt=query_start_loc_opt,
+                        cache_indices_opt=cache_indices_opt,
+                        initial_state_mode_opt=initial_state_mode_opt,
+                        num_accepted_tokens_opt=[],
+                        activation_mode=activation_num,
+                        pad_slot_id=PAD_SLOT_ID,
+                        run_mode=0,
+                    )
+                    mixed_qkv_non_spec = mixed_qkv_non_spec_output
         elif attn_metadata.num_decodes > 0:
             conv_weights_T = conv_weights.transpose(0, 1)
             activation_num = 1 if self.activation else 0

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -15,9 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Any
 import torch
-import torch.nn.functional as F
 import torch_npu
 from einops import rearrange
 from vllm.distributed import get_pcp_group

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -144,15 +144,23 @@ def chunk_gated_delta_rule_fwd(
         else:
             updated_h_state = updated_state[get_pcp_group().rank_in_group - 1, ...]
 
-        h = chunk_fwd_o_update(
-            q=q,
-            v=v_new,
-            h=h,
-            h_update=h_update,
-            updated_h_state=updated_h_state,
-            cu_seqlens=cu_seqlens,
-            chunk_offsets=chunk_offsets_chunk64,
-        )
+        if get_pcp_group().rank_in_group > 0:
+            rerun_initial_state = initial_state.clone()
+            prefill_slice = slice(num_decodes, final_state.shape[0])
+            rerun_initial_state[prefill_slice] = updated_h_state[prefill_slice]
+            h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+                k=k,
+                w=w,
+                u=u,
+                g=g,
+                initial_state=rerun_initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices_chunk64,
+                chunk_offsets=chunk_offsets_chunk64,
+            )
+            h = h.transpose(1, 2).contiguous()
+            v_new = v_new.transpose(1, 2).contiguous()
 
     o_ascendc = torch.ops._C_ascend.chunk_fwd_o(
         q_ascendc,

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -19,7 +19,6 @@ from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa: F401
 from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
 from .chunk_o import chunk_fwd_o  # noqa: F401
-from .chunk_o_update import chunk_fwd_o_update
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 import torch
 import vllm.v1.attention.backends.gdn_attn as gdn_attn
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 from vllm_ascend.ops.triton.gdn_chunk_meta import (
     _build_seq_lens,

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -739,7 +739,7 @@ def _patched_build(
         and attn_metadata.num_spec_decodes == 0
         and attn_metadata.num_decodes <= self.decode_cudagraph_max_bs
     ):
-        self.non_spec_state_indices_tensor[attn_metadata.num_actual_tokens:].fill_(NULL_BLOCK_ID)
+        self.non_spec_state_indices_tensor[attn_metadata.num_actual_tokens :].fill_(NULL_BLOCK_ID)
     return attn_metadata
 
 

--- a/vllm_ascend/patch/worker/patch_gdn_attn.py
+++ b/vllm_ascend/patch/worker/patch_gdn_attn.py
@@ -733,6 +733,13 @@ def _patched_build(
     if attn_metadata.num_decodes > 0:
         _patched_build_decode(self, attn_metadata, common_attn_metadata, num_decode_draft_tokens_cpu)
 
+    if (
+        self.use_full_cuda_graph
+        and attn_metadata.num_prefills == 0
+        and attn_metadata.num_spec_decodes == 0
+        and attn_metadata.num_decodes <= self.decode_cudagraph_max_bs
+    ):
+        self.non_spec_state_indices_tensor[attn_metadata.num_actual_tokens:].fill_(NULL_BLOCK_ID)
     return attn_metadata
 
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -875,6 +875,15 @@ class NPUModelRunner(GPUModelRunner):
         if self.uses_mrope:
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
             self._calc_mrope_positions(scheduler_output)
+            if self.pcp_size > 1:
+                self.pcp_manager.remap_mrope_positions_for_pcp(
+                    positions_np,
+                    num_scheduled_tokens,
+                    num_reqs,
+                    self.input_batch,
+                    self.requests,
+                    self.mrope_positions,
+                )
             self.mrope_positions.gpu.copy_(
                 self.mrope_positions.cpu,
                 non_blocking=True,

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -24,6 +24,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from vllm.config import VllmConfig
+from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
@@ -127,7 +128,7 @@ class PCPManager:
         self.pcp_enter_fa_restore_idx = torch.zeros(
             self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
         )
-        self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type == "qwen3_next"
+        self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type in ("qwen3_next", "qwen3_5", "qwen3_5_moe")
 
         self.pcp_pads_logits_hybrid_attn = torch.ones(self.max_num_reqs, dtype=torch.int32) * (self.pcp_world_size - 1)
         self.pcp_padded_tokens_fla = 0
@@ -1275,3 +1276,105 @@ class PCPManager:
         tensor_npu = torch.zeros(len(lst), dtype=dtype, device=device)
         tensor_npu.copy_(torch.tensor(lst, dtype=dtype), non_blocking=True)
         return tensor_npu
+    
+    def remap_mrope_positions_for_pcp(
+        self,
+        positions_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        num_reqs: int,
+        input_batch: "NPUInputBatch",
+        requests: dict[str, Any],
+        mrope_positions: CpuGpuBuffer,
+    ):
+        """Remap mrope_positions after PCP split.
+
+        _calc_mrope_positions fills mrope_positions using the original
+        (pre-PCP-split) sequential token ordering from scheduler_output.
+        After PCP splits tokens across ranks, each rank only processes a
+        subset of tokens (head+tail chunks), so we must remap mrope_positions
+        to match the PCP-local token ordering.
+
+        positions_np already contains the correct absolute position for each
+        token on this PCP rank (computed by update_tokens_for_pcp). We use
+        these positions to gather the correct mrope_positions from
+        req.mrope_positions (for prompt tokens) or compute them on-the-fly
+        (for completion/decode tokens).
+        """
+        mrope_pos_ptr = 0
+        for index, req_id in enumerate(input_batch.req_ids):
+            req = requests[req_id]
+            num_sched = int(num_scheduled_tokens[index])
+            local_positions = positions_np[
+                mrope_pos_ptr:mrope_pos_ptr + num_sched
+            ]
+
+            if (
+                req.mrope_positions is not None
+                and req.mrope_positions.shape[1] > 0
+            ):
+                num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
+                    req.prompt_token_ids, req.prompt_embeds
+                )
+                max_mrope_idx = req.mrope_positions.shape[1]
+
+                # Build the mrope_positions for this request's PCP-local
+                # tokens. For each token, gather from req.mrope_positions
+                # using its absolute position from positions_np.
+                mrope_dst = np.empty((3, num_sched), dtype=np.int64)
+
+                # Prompt tokens: positions within prompt range,
+                # gather from pre-computed req.mrope_positions.
+                prompt_mask = local_positions < min(
+                    num_prompt_tokens, max_mrope_idx
+                )
+                if prompt_mask.any():
+                    prompt_indices = local_positions[prompt_mask].astype(
+                        np.int64
+                    )
+                    prompt_indices = np.clip(
+                        prompt_indices, 0, max_mrope_idx - 1
+                    )
+                    mrope_dst[:, prompt_mask] = req.mrope_positions[
+                        :, torch.from_numpy(prompt_indices)
+                    ].numpy()
+
+                # Completion/decode tokens: all 3 dims use the same
+                # position.
+                completion_mask = local_positions >= num_prompt_tokens
+                if completion_mask.any():
+                    # For completion tokens, use mrope_position_delta to
+                    # compute the correct position, same as
+                    # get_next_input_positions_tensor.
+                    if req.mrope_position_delta is not None:
+                        comp_positions = (
+                            local_positions[completion_mask]
+                            + req.mrope_position_delta
+                        )
+                    else:
+                        comp_positions = local_positions[completion_mask]
+                    mrope_dst[:, completion_mask] = comp_positions[
+                        np.newaxis, :
+                    ]
+
+                # Padding tokens beyond req.mrope_positions shape:
+                # use the last valid mrope position.
+                padding_mask = (~prompt_mask) & (~completion_mask)
+                if padding_mask.any():
+                    last_idx = max_mrope_idx - 1
+                    mrope_dst[:, padding_mask] = req.mrope_positions[
+                        :, last_idx : last_idx + 1
+                    ].numpy()
+
+                mrope_positions.cpu[
+                    :, mrope_pos_ptr : mrope_pos_ptr + num_sched
+                ] = torch.from_numpy(mrope_dst)
+            else:
+                # No mrope_positions available:
+                # all 3 dims equal the 1D position.
+                mrope_positions.cpu[
+                    :, mrope_pos_ptr : mrope_pos_ptr + num_sched
+                ] = torch.from_numpy(
+                    local_positions[np.newaxis, :].astype(np.int64)
+                )
+
+            mrope_pos_ptr += num_sched

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -128,7 +128,11 @@ class PCPManager:
         self.pcp_enter_fa_restore_idx = torch.zeros(
             self.max_num_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32, device=self.device
         )
-        self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type in ("qwen3_next", "qwen3_5", "qwen3_5_moe")
+        self.pcp_use_hybrid_attn = self.vllm_config.model_config.hf_config.model_type in (
+            "qwen3_next",
+            "qwen3_5",
+            "qwen3_5_moe",
+        )
 
         self.pcp_pads_logits_hybrid_attn = torch.ones(self.max_num_reqs, dtype=torch.int32) * (self.pcp_world_size - 1)
         self.pcp_padded_tokens_fla = 0
@@ -1276,7 +1280,7 @@ class PCPManager:
         tensor_npu = torch.zeros(len(lst), dtype=dtype, device=device)
         tensor_npu.copy_(torch.tensor(lst, dtype=dtype), non_blocking=True)
         return tensor_npu
-    
+
     def remap_mrope_positions_for_pcp(
         self,
         positions_np: np.ndarray,
@@ -1304,17 +1308,10 @@ class PCPManager:
         for index, req_id in enumerate(input_batch.req_ids):
             req = requests[req_id]
             num_sched = int(num_scheduled_tokens[index])
-            local_positions = positions_np[
-                mrope_pos_ptr:mrope_pos_ptr + num_sched
-            ]
+            local_positions = positions_np[mrope_pos_ptr : mrope_pos_ptr + num_sched]
 
-            if (
-                req.mrope_positions is not None
-                and req.mrope_positions.shape[1] > 0
-            ):
-                num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
-                    req.prompt_token_ids, req.prompt_embeds
-                )
+            if req.mrope_positions is not None and req.mrope_positions.shape[1] > 0:
+                num_prompt_tokens = length_from_prompt_token_ids_or_embeds(req.prompt_token_ids, req.prompt_embeds)
                 max_mrope_idx = req.mrope_positions.shape[1]
 
                 # Build the mrope_positions for this request's PCP-local
@@ -1324,19 +1321,11 @@ class PCPManager:
 
                 # Prompt tokens: positions within prompt range,
                 # gather from pre-computed req.mrope_positions.
-                prompt_mask = local_positions < min(
-                    num_prompt_tokens, max_mrope_idx
-                )
+                prompt_mask = local_positions < min(num_prompt_tokens, max_mrope_idx)
                 if prompt_mask.any():
-                    prompt_indices = local_positions[prompt_mask].astype(
-                        np.int64
-                    )
-                    prompt_indices = np.clip(
-                        prompt_indices, 0, max_mrope_idx - 1
-                    )
-                    mrope_dst[:, prompt_mask] = req.mrope_positions[
-                        :, torch.from_numpy(prompt_indices)
-                    ].numpy()
+                    prompt_indices = local_positions[prompt_mask].astype(np.int64)
+                    prompt_indices = np.clip(prompt_indices, 0, max_mrope_idx - 1)
+                    mrope_dst[:, prompt_mask] = req.mrope_positions[:, torch.from_numpy(prompt_indices)].numpy()
 
                 # Completion/decode tokens: all 3 dims use the same
                 # position.
@@ -1346,34 +1335,23 @@ class PCPManager:
                     # compute the correct position, same as
                     # get_next_input_positions_tensor.
                     if req.mrope_position_delta is not None:
-                        comp_positions = (
-                            local_positions[completion_mask]
-                            + req.mrope_position_delta
-                        )
+                        comp_positions = local_positions[completion_mask] + req.mrope_position_delta
                     else:
                         comp_positions = local_positions[completion_mask]
-                    mrope_dst[:, completion_mask] = comp_positions[
-                        np.newaxis, :
-                    ]
+                    mrope_dst[:, completion_mask] = comp_positions[np.newaxis, :]
 
                 # Padding tokens beyond req.mrope_positions shape:
                 # use the last valid mrope position.
                 padding_mask = (~prompt_mask) & (~completion_mask)
                 if padding_mask.any():
                     last_idx = max_mrope_idx - 1
-                    mrope_dst[:, padding_mask] = req.mrope_positions[
-                        :, last_idx : last_idx + 1
-                    ].numpy()
+                    mrope_dst[:, padding_mask] = req.mrope_positions[:, last_idx : last_idx + 1].numpy()
 
-                mrope_positions.cpu[
-                    :, mrope_pos_ptr : mrope_pos_ptr + num_sched
-                ] = torch.from_numpy(mrope_dst)
+                mrope_positions.cpu[:, mrope_pos_ptr : mrope_pos_ptr + num_sched] = torch.from_numpy(mrope_dst)
             else:
                 # No mrope_positions available:
                 # all 3 dims equal the 1D position.
-                mrope_positions.cpu[
-                    :, mrope_pos_ptr : mrope_pos_ptr + num_sched
-                ] = torch.from_numpy(
+                mrope_positions.cpu[:, mrope_pos_ptr : mrope_pos_ptr + num_sched] = torch.from_numpy(
                     local_positions[np.newaxis, :].astype(np.int64)
                 )
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the precision issue of qwen3-next with pcp overlay and adapt the qwen3.5 to support the pcp overlay function.

1、The PCP head and tail splicing function has been adapted to support mrop.  
2、The part of the linear layer state_indices that exceeds the actual token count has been set to 0 to prevent the introduction of dirty data and to resolve precision issues in graph mode.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
