### PR TITLE
[BugFix]Fix Deepseek-V4 P/D disaggregation kv_cache_tensor.shared_by may be empty

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1456,6 +1456,8 @@ class MooncakeConnectorWorker:
                 for layer_name in group.layer_names:
                     layer_group_idx[layer_name] = i
             for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
+                if not kv_cache_tensor.shared_by:
+                    continue
                 share_tensor_addr = []
                 share_tensor_stride = []
                 cur_tensor_group_idx = []


### PR DESCRIPTION
### What this PR does / why we need it?
Fix Deepseek-V4 P/D disaggregation where `kv_cache_tensor.shared_by` may be empty.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By nightly.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
