### PR TITLE
[BugFix]Use Compress ratio to avoid obtaining illegal attributes

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -367,6 +367,7 @@ class KVCacheRecvingThread(threading.Thread):
         self.kv_cache_config = kv_cache_config
         self.model_config = self.vllm_config.model_config
         self.use_mla = self.model_config.is_deepseek_mla
+        self.use_compress = hasattr(self.vllm_config.model_config.hf_config, "compress_ratios")
         self.use_hybrid = use_hybrid
         self.has_mamba = has_mamba
         self.kv_cache_specs = [g.kv_cache_spec for g in kv_cache_config.kv_cache_groups]
@@ -376,7 +377,7 @@ class KVCacheRecvingThread(threading.Thread):
             rank: get_prefill_pp_indices(self.num_layers, rank, self._prefill_pp_size, prefill_pp_layer_partition)
             for rank in range(self._prefill_pp_size)
         }
-        if not is_vl_model(vllm_config):
+        if not is_vl_model(vllm_config) and not self.use_compress:
             if self.use_mla:
                 self.k_head_dim = self.model_config.hf_text_config.kv_lora_rank
                 self.v_head_dim = self.model_config.hf_text_config.qk_rope_head_dim


### PR DESCRIPTION
### What this PR does / why we need it?
Deepseek-V4 does not have attribute `kv_lora_rank`, this PR use `compress_ratio` to aviod obtaining these illegal attributes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested by A3 PD disaggregation.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
