### PR TITLE
[CI][Doc] Add Qwen3.6 model support and update E2E tests

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -274,7 +274,9 @@
       "Eco-Tech/GLM-5.1-w8a8",
       "Eco-Tech/Qwen3.5-397B-A17B-w4a8-mtp", 
       "lightseekorg/kimi-k2.5-eagle3",
-      "Eco-Tech/Qwen3.5-122B-A10B-w8a8-mtp"
+      "Eco-Tech/Qwen3.5-122B-A10B-w8a8-mtp",
+      "Qwen/Qwen3.6-27B",
+      "Qwen/Qwen3.6-35B-A3B"
     ],
     "datasets": [
       "vllm-ascend/GSM8K-in1024-bs210",

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -331,7 +331,7 @@
     - vllm_ascend/ops/triton/gdn_chunk_meta.py
   tests:
     - tests/ut/ops
-    - tests/e2e/pull_request/four_card/test_qwen3_5.py
+    - tests/e2e/pull_request/four_card/test_qwen3_6.py
     - tests/e2e/pull_request/four_card/test_qwen3_next.py
 
 - name: ops_triton
@@ -342,7 +342,7 @@
     - vllm_ascend/ops/triton/batch_invariant
   tests:
     - tests/ut/ops
-    - tests/e2e/pull_request/four_card/test_qwen3_5.py
+    - tests/e2e/pull_request/four_card/test_qwen3_6.py
 
 - name: ops_no_test
   optional: true

--- a/docs/source/tutorials/models/Qwen3.5-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B.md
@@ -1,4 +1,4 @@
-# Qwen3.5-27B
+# Qwen3.5-27B/Qwen3.6-27B
 
 ## Introduction
 
@@ -20,7 +20,8 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 - `Qwen3.5-27B`(BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.5-27B)
 - `Qwen3.5-27B-w8a8`(Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)
-
+- `Qwen3.6-27B`(BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-27B)
+- `Qwen3.6-27B-w8a8`(Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8)
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 
 ### Verify Multi-node Communication(Optional)
@@ -87,7 +88,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 ### Single-node Deployment
 
-`Qwen3.5-27B` and `Qwen3.5-27B-w8a8` can both be deployed on 1 Atlas 800 A3(64G × 16), 1 Atlas 800 A2(64G × 8). Quantized version needs to start with parameter `--quantization ascend`.
+`Qwen3.5/6-27B` and `Qwen3.5/6-27B-w8a8` can both be deployed on 1 Atlas 800 A3(64G × 16), 1 Atlas 800 A2(64G × 8). Quantized version needs to start with parameter `--quantization ascend`.
 
 Run the following script to execute online 128k inference.
 

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -85,7 +85,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Qwen3-VL                       | ✅            |                                                                      ||A2/A3|||||||✅|||||✅|✅||| [Qwen-VL-Dense](../../tutorials/models/Qwen-VL-Dense.md) |
 | Qwen3-VL-MOE                   | ✅            |                                                                      | ✅ | A2/A3||✅|✅|||✅|✅|✅|✅|✅|✅|✅|✅|256k||[Qwen3-VL-MOE](../../tutorials/models/Qwen3-VL-235B-A22B-Instruct.md)|
 | Qwen3.5-397B-A17B              | ✅            |                                                                      |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|1010000|| [Qwen3.5-397B-A17B](../../tutorials/models/Qwen3.5-397B-A17B.md) |
-| Qwen3.5-27B                    | ✅            |                                                                      |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|1010000|| [Qwen3.5-27B](../../tutorials/models/Qwen3.5-27B.md) |
+| Qwen3.5-27B/Qwen3.6-27B                    | ✅            |                                                          |✅| A2/A3 |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|1010000|| [Qwen3.5-27B](../../tutorials/models/Qwen3.5-27B.md) |
 | Qwen3-Omni-30B-A3B-Thinking    | 🔵            |                                                                      ||A2/A3|||||||✅||✅|||||||[Qwen3-Omni-30B-A3B-Thinking](../../tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md)|
 
 #### Extended Compatible Models

--- a/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py
@@ -54,13 +54,13 @@ def test_qwen3_moe_tp2_w8a8():
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
 
-def test_qwen3_5_moe_tp4_fp16():
+def test_qwen3_6_moe_tp4_fp16():
     example_prompts = [
         "Hello, my name is",
     ]
     max_tokens = 5
     with VllmRunner(
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-35B-A3B",
         tensor_parallel_size=4,
         enforce_eager=True,
         dtype="float16",

--- a/tests/e2e/pull_request/four_card/test_qwen3_6.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_6.py
@@ -22,13 +22,13 @@ from unittest.mock import patch
 from tests.e2e.conftest import DPVllmRunner, VllmRunner
 
 
-def test_qwen3_5_27b_distributed_mp_tp4():
+def test_qwen3_6_27b_distributed_mp_tp4():
     example_prompts = [
         "Hello, my name is",
     ] * 4
     max_tokens = 5
     with VllmRunner(
-        "Qwen/Qwen3.5-27B",
+        "Qwen/Qwen3.6-27B",
         tensor_parallel_size=4,
         cudagraph_capture_sizes=[1, 2, 4, 8],
         max_model_len=4096,
@@ -39,13 +39,13 @@ def test_qwen3_5_27b_distributed_mp_tp4():
         del vllm_model
 
 
-def test_qwen3_5_35b_distributed_mp_tp4():
+def test_qwen3_6_35b_distributed_mp_tp4():
     example_prompts = [
         "Hello, my name is",
     ] * 4
     max_tokens = 5
     with VllmRunner(
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-35B-A3B",
         tensor_parallel_size=4,
         cudagraph_capture_sizes=[1, 2, 4, 8],
         max_model_len=4096,
@@ -56,7 +56,7 @@ def test_qwen3_5_35b_distributed_mp_tp4():
         del vllm_model
 
 
-def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3():
+def test_qwen3_6_35b_distributed_mp_tp4_full_decode_only_mtp3():
     example_prompts = [
         "Hello, my name is",
         "The president of the United States is",
@@ -66,7 +66,7 @@ def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3():
 
     max_tokens = 20
     with VllmRunner(
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-35B-A3B",
         tensor_parallel_size=4,
         max_model_len=4096,
         gpu_memory_utilization=0.90,
@@ -85,7 +85,7 @@ def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3():
 
 
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"})
-def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3_flashcomm():
+def test_qwen3_6_35b_distributed_mp_tp4_full_decode_only_mtp3_flashcomm():
     example_prompts = [
         "Hello, my name is",
         "The president of the United States is",
@@ -95,7 +95,7 @@ def test_qwen3_5_35b_distributed_mp_tp4_full_decode_only_mtp3_flashcomm():
 
     max_tokens = 20
     with DPVllmRunner(
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-35B-A3B",
         data_parallel_size=2,
         tensor_parallel_size=2,
         enable_expert_parallel=True,


### PR DESCRIPTION
### What this PR does / why we need it?
Add Qwen3.6 model support and update E2E tests

Qwen/Qwen3.5-35B-A3B   --->  Qwen/Qwen3.6-35B-A3B
Qwen/Qwen3.5-27B    --->  Qwen/Qwen3.6-27B

1. Add Qwen/Qwen3.6-27B and Qwen/Qwen3.6-35B-A3B to the model/dataset download list for CI Rename 4-cards E2E test file from test_qwen3_5.py to test_qwen3_6.py, adding test cases for Qwen3.6-27B (TP4) and Qwen3.6-35B-A3B (TP4, MTP, FlashComm)
2. Update 310P multicard test to replace Qwen3.5-35B-A3B with Qwen3.6-35B-A3B 
3. Update docs: expand Qwen3.5-27B.md tutorial to cover Qwen3.6-27B (BF16 + w8a8), and add Qwen3.5-27B/Qwen3.6-27B to the supported models matrix

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
