### PR TITLE
[Feature][EPLB] Expose experts hotness metrics data and eplb time consuming

### DIFF
--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -18,6 +18,7 @@ from enum import Enum
 
 import torch.distributed as dist
 from vllm.logger import logger
+from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_ascend.distributed.parallel_state import get_dynamic_eplb_group
 
@@ -92,8 +93,10 @@ class D2DExpertWeightLoader:
             return
 
         # Waiting for send/recv tasks finish
-        for req in reqs:
-            req.wait()
+        if reqs:
+            with record_function_or_nullcontext("EPLB weight D2D wait"):
+                for req in reqs:
+                    req.wait()
 
         if self.comm_op_list is not None:
             self.comm_op_list = None

--- a/vllm_ascend/eplb/core/eplb_worker.py
+++ b/vllm_ascend/eplb/core/eplb_worker.py
@@ -67,8 +67,22 @@ class EplbWorker:
                 hotness = self._calculate_hotness(old_placement, load_info.sum(0))
             else:
                 hotness = self._calculate_hotness(old_placement, load_info)
-            current_mean, current_max = self._compute_imbalance(old_placement, hotness)
-            update_mean, update_max = self._compute_imbalance(new_placement, hotness)
+            # ms-service-metric begin: expose EPLB hotness details for metrics collection.
+            current_mean, current_max, current_imbalance_list = self._compute_imbalance(
+                old_placement, hotness, return_list=True
+            )
+            update_mean, update_max, update_imbalance_list = self._compute_imbalance(
+                new_placement, hotness, return_list=True
+            )
+            self.latest_expert_hotness = {
+                "current_mean": current_mean,
+                "current_max": current_max,
+                "update_mean": update_mean,
+                "update_max": update_max,
+                "current_imbalance_list": current_imbalance_list,
+                "update_imbalance_list": update_imbalance_list,
+            }
+            # ms-service-metric end.
             logger.info(
                 "[Expert Hotness] Current: mean=%.3f, max=%.3f, Updated: mean=%.3f, max=%.3f",
                 current_mean,
@@ -272,7 +286,7 @@ class EplbWorker:
         return list(zip(send_all, recv_all, maps, log2phy_all, layer_ids))
 
     @staticmethod
-    def _compute_imbalance(deployment_all_layer, hotness_all_layer: np.ndarray):
+    def _compute_imbalance(deployment_all_layer, hotness_all_layer: np.ndarray, return_list: bool = False):
         imbalance_list = []
         deployment_all_layer = np.array(deployment_all_layer)
         for deployment, hotness in zip(deployment_all_layer, hotness_all_layer):
@@ -286,6 +300,10 @@ class EplbWorker:
 
         max_val = max(imbalance_list)
         mean_val = sum(imbalance_list) / len(imbalance_list)
+        # ms-service-metric begin: optionally expose per-layer imbalance without recomputing it.
+        if return_list:
+            return mean_val, max_val, imbalance_list
+        # ms-service-metric end.
         return mean_val, max_val
 
     @staticmethod

--- a/vllm_ascend/eplb/eplb_updator.py
+++ b/vllm_ascend/eplb/eplb_updator.py
@@ -20,6 +20,7 @@ import torch
 import torch.distributed as dist
 import vllm.envs as envs
 from vllm.logger import logger
+from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_ascend.distributed.parallel_state import get_dynamic_eplb_group
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
@@ -103,27 +104,29 @@ class EplbUpdator:
         if self.get_update_info_flag():
             self.update_info_all = self.eplb_process.block_update_q.get()
         if self.update_expert_weight_flag():
-            (expert_send_info, expert_recv_info, updated_expert_map, log2phy_map, layer_id) = self.update_info_all.pop(
-                0
-            )
-            log2phy_map_this_rank = torch.from_numpy(numpy.array(log2phy_map))
-            self.eplb_loader.set_log2phy_map(log2phy_map_this_rank)
-            updated_expert_map_this_rank = torch.from_numpy(numpy.array(updated_expert_map))
-            self.eplb_loader.generate_expert_d2d_transfer_task(
-                expert_send_info,
-                expert_recv_info,
-                updated_expert_map_this_rank,
-                layer_id + self.adaptor.num_dense_layers,
-            )
+            with record_function_or_nullcontext("EPLB generate p2p task"):
+                (expert_send_info, expert_recv_info, updated_expert_map, log2phy_map, layer_id) = (
+                    self.update_info_all.pop(0)
+                )
+                log2phy_map_this_rank = torch.from_numpy(numpy.array(log2phy_map))
+                self.eplb_loader.set_log2phy_map(log2phy_map_this_rank)
+                updated_expert_map_this_rank = torch.from_numpy(numpy.array(updated_expert_map))
+                self.eplb_loader.generate_expert_d2d_transfer_task(
+                    expert_send_info,
+                    expert_recv_info,
+                    updated_expert_map_this_rank,
+                    layer_id + self.adaptor.num_dense_layers,
+                )
 
-            # set asynchronous stream for d2d expert weight update
-            self.reqs = []
-            self.eplb_loader.asyn_expert_weight_transfer(self.reqs)
+                # set asynchronous stream for d2d expert weight update
+                self.reqs = []
+                self.eplb_loader.asyn_expert_weight_transfer(self.reqs)
 
     def forward_end(self):
         if self.wakeup_eplb_worker_flag():
-            self.compute_and_set_moe_load()
-            self.wakeup_eplb_worker()
+            with record_function_or_nullcontext("EPLB gather moe load"):
+                self.compute_and_set_moe_load()
+                self.wakeup_eplb_worker()
 
         if self.update_expert_weight_flag() and self.expert_map_record_path is None:
             self.eplb_loader.update_expert_map_and_weight(self.reqs)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1927,8 +1927,7 @@ class NPUModelRunner(GPUModelRunner):
             update_cos_sin(positions)
 
         if self.dynamic_eplb:
-            with record_function_or_nullcontext("EPLB weight D2D"):
-                self.eplb_updator.forward_before()
+            self.eplb_updator.forward_before()
 
         # Set cudagraph mode to none if calc_kv_scales is true.
         # KV scales calculation involves dynamic operations that are incompatible
@@ -2241,8 +2240,7 @@ class NPUModelRunner(GPUModelRunner):
             model_runner_output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0
 
         if self.dynamic_eplb:
-            with record_function_or_nullcontext("EPLB update"):
-                self.eplb_updator.forward_end()
+            self.eplb_updator.forward_end()
 
         self._finalize_dump_data()
 


### PR DESCRIPTION

### What this PR does / why we need it?
Adds observability to EPLB (Expert Parallel Load Balancer):

1. **Expose expert hotness and imbalance details**: Store per-round pre/post-rebalance mean/max imbalance and per-layer imbalance lists in `self.latest_expert_hotness` within `EplbWorker.do_update`, enabling ms-service-metric collection. A `return_list` parameter is added to `_compute_imbalance` to avoid redundant computation.
2. Fine-grained weight transfer latency tracking**: Replace the coarse-grained `EPLB weight D2D` / `EPLB update` profiler spans with three distinct ones — `EPLB generate p2p task`, `EPLB weight D2D wait`, and `EPLB gather moe load` — for pinpointing specific latency bottlenecks.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
<img width="965" height="132" alt="Snipaste_2026-05-26_10-38-34" src="https://github.com/user-attachments/assets/eeecf54e-ac57-4fa9-94c3-fe4ee5e5615a" />


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
