### PR TITLE
[Doc][Misc] Clarify vLLM ref for local CI setup

### DIFF
--- a/docs/source/developer_guide/contribution/index.md
+++ b/docs/source/developer_guide/contribution/index.md
@@ -36,12 +36,22 @@ bash format.sh
 
 After completing "Run lint" setup, you can run CI (Continuous integration) locally:
 
+Choose the vLLM ref according to the branch you are targeting. For vLLM Ascend
+`main` development, prefer the vLLM commit listed in the [Versioning Policy](../../community/versioning_policy.md)
+main branch compatibility matrix. For release branch fixes, use the matching
+vLLM release tag from the release compatibility matrix.
+
 ```bash
 cd ~/vllm-project/
 
-# Run CI needs vLLM installed
-git clone --branch {{ vllm_version }} https://github.com/vllm-project/vllm.git
+# Run CI needs vLLM installed.
+# If you are developing against vLLM Ascend main, use the vLLM commit
+# listed for main in the Versioning Policy. If you are fixing a release
+# branch, use the corresponding vLLM release tag.
+export VLLM_REF="{{ vllm_version }}"
+git clone https://github.com/vllm-project/vllm.git
 cd vllm
+git checkout "${VLLM_REF}"
 pip install -r requirements/build.txt
 VLLM_TARGET_DEVICE="empty" pip install .
 cd ..


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #9540.

This PR updates the contributor guide's local CI setup so contributors explicitly choose the vLLM ref according to the branch they are targeting.

The previous command cloned vLLM directly with `--branch |vllm_version|`, which renders as the latest release tag in the published docs. That is correct for release-branch work, but it can be confusing for contributors working against vLLM Ascend `main`, where the Versioning Policy may point to a specific vLLM commit instead of the release tag.

The updated guide:

- points contributors to the Versioning Policy for the `main` compatibility matrix,
- tells release-branch contributors to use the matching vLLM release tag,
- uses `VLLM_REF` plus `git checkout` so the same command supports both tags and commit hashes.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only contributor guide update.

### How was this patch tested?

- `git diff --check`
- `pre-commit run codespell --files docs/source/developer_guide/contribution/index.md`
- `pre-commit run typos --files docs/source/developer_guide/contribution/index.md`
- `pre-commit run markdownlint --hook-stage manual --files docs/source/developer_guide/contribution/index.md`
- `SKIP=actionlint pre-commit run --files docs/source/developer_guide/contribution/index.md`

`pre-commit run --files docs/source/developer_guide/contribution/index.md` without `SKIP=actionlint` was attempted, but local installation of the `actionlint` hook failed while downloading Go dependencies from `proxy.golang.org`. The changed-file hooks relevant to this Markdown change passed.

AI assistance was used to prepare this documentation-only change.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
