### PR TITLE
[Doc] Clarify contributor and NPU deployment guidance

### DIFF
--- a/docs/source/_templates/Model-Deployment-Tutorial-Template.md
+++ b/docs/source/_templates/Model-Deployment-Tutorial-Template.md
@@ -142,6 +142,16 @@ Expected Result: Omitted (fill in according to actual output).
 
 After the service is started, the model can be invoked by sending a prompt:
 
+- Run the request from another terminal attached to the same container or from a
+  host that can reach the server port.
+- Replace `<node0_ip>` with the node address that exposes the vLLM server. Use
+  `localhost` when the request runs in the same container or host network
+  namespace.
+- Replace `<port>` with the port used by the startup command.
+- Set `model` to the same value as `--served-model-name`. If the startup command
+  omits `--served-model-name`, use the model path or model name passed to
+  `vllm serve`.
+
 ```shell
 curl http://<node0_ip>:<port>/v1/completions \
     -H "Content-Type: application/json" \

--- a/docs/source/developer_guide/contribution/index.md
+++ b/docs/source/developer_guide/contribution/index.md
@@ -34,15 +34,23 @@ bash format.sh
 
 #### Run CI locally
 
-After completing "Run lint" setup, you can run CI (Continuous integration) locally:
+After completing "Run lint" setup, you can run CI (Continuous integration) locally.
+Choose the vLLM ref according to the vllm-ascend branch you are testing. For
+the `main` branch, use the vLLM commit or tag listed in the [Versioning
+policy](../../community/versioning_policy.md).
+For a release branch, use the matching vLLM release tag from the release
+compatibility matrix.
 
 ```{code-block} bash
    :substitutions:
 cd ~/vllm-project/
 
-# Run CI needs vLLM installed
-git clone --branch |vllm_version| https://github.com/vllm-project/vllm.git
+# Run CI needs vLLM installed.
+# For main branch development, this should match the Versioning policy main matrix.
+export VLLM_REF="|main_vllm_commit|"
+git clone https://github.com/vllm-project/vllm.git
 cd vllm
+git checkout "$VLLM_REF"
 pip install -r requirements/build.txt
 VLLM_TARGET_DEVICE="empty" pip install .
 cd ..

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -144,6 +144,35 @@ In scenarios where NPUs have limited high bandwidth memory (on-chip memory) capa
 
 - **Configure `PYTORCH_NPU_ALLOC_CONF`**: Set this environment variable to optimize NPU memory management. For example, you can use `export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True` to enable virtual memory feature to mitigate memory fragmentation caused by frequent dynamic memory size adjustments during runtime. See details in [PYTORCH_NPU_ALLOC_CONF](https://www.hiascend.com/document/detail/zh/Pytorch/700/comref/Envvariables/Envir_012.html).
 
+For Ascend 910B cards with 64 GB HBM, start with a conservative memory budget
+and then increase it after the model starts reliably. A practical first pass is:
+
+- **Single model instance**: keep `--gpu-memory-utilization` around `0.80` to
+  `0.90`. Use the lower end when the model uses eager mode, multi-modal inputs,
+  large batch sizes, speculative decoding, or long context.
+
+- **Multiple instances on one NPU**: make the sum of all instance
+  `--gpu-memory-utilization` values lower than one NPU's capacity. Keep at least
+  10% to 20% HBM for framework, operator workspace, graph capture, and memory
+  fragmentation. For example, two small models on one 64 GB card can start from
+  `0.35` to `0.40` each instead of `0.50` each.
+
+- **Long context and KV cache**: reduce `--max-model-len`,
+  `--max-num-seqs`, or `--max-num-batched-tokens` before increasing memory
+  utilization. These parameters directly affect how much KV cache is reserved
+  and are usually safer to tune than pushing utilization to the limit.
+
+- **Eager mode**: when a model or feature requires `enforce_eager=True`,
+  reserve more headroom than graph mode. Eager execution can have a different
+  temporary workspace profile on NPU, so a value that fits with graph capture may
+  still OOM in eager mode.
+
+When the service fails at startup, run `npu-smi info` inside the same container
+used to start vLLM and verify that no old process is still holding HBM. If the
+host looks idle but the container still reports device or memory errors, inspect
+`/proc/uda/namespace_node` for stale namespace records and terminate the
+corresponding `root_tgid` process after confirming it is safe to do so.
+
 ### 13. Failed to enable NPU graph mode when running DeepSeek
 
 Enabling NPU graph mode for DeepSeek may trigger an error. This is because when both MLA (Multi-Head Latent Attention) and NPU graph mode are active, the number of queries per KV head must be 32, 64, or 128. However, DeepSeek-V2-Lite has only 16 attention heads, which results in 16 queries per KV—a value outside the supported range. Support for NPU graph mode on DeepSeek-V2-Lite will be added in a future update.

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -870,6 +870,11 @@ Once your server is started, you can query the model with input prompts:
 
 - `<node0_ip>`: The IP address of the node where the server is running (e.g., localhost).
 - `<port>`: The port number specified in the server startup command (e.g., 8000).
+- Run the request from another terminal attached to the same container or from a
+  host that can reach the server port.
+- Set `model` to the same value as `--served-model-name` in the startup
+  command. For example, if the server was started with `--served-model-name ds`,
+  use `"model": "ds"`.
 
 ```shell
 curl http://<node0_ip>:<port>/v1/completions \

--- a/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
+++ b/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
@@ -191,6 +191,43 @@ export HCCL_OP_EXPANSION_MODE=AIV
 vllm serve Qwen/Qwen3-Omni-30B-A3B-Thinking --tensor-parallel-size 2 --enable_expert_parallel
 ```
 
+#### NPU Device Allocation
+
+Use `ASCEND_RT_VISIBLE_DEVICES` to select visible NPU devices for vLLM Ascend.
+The value should contain the physical device IDs that this server process can
+use. For a 2-NPU 910B deployment, keep both devices visible and use tensor
+parallelism across the thinker model:
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1
+export HCCL_BUFFSIZE=512
+export HCCL_OP_EXPANSION_MODE=AIV
+
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Thinking \
+    --tensor-parallel-size 2 \
+    --enable_expert_parallel \
+    --gpu-memory-utilization 0.8
+```
+
+For a 4-NPU node, dedicate the visible device list to the server process and
+increase tensor parallelism only after the 2-NPU configuration is stable:
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+export HCCL_BUFFSIZE=512
+export HCCL_OP_EXPANSION_MODE=AIV
+
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Thinking \
+    --tensor-parallel-size 4 \
+    --enable_expert_parallel \
+    --gpu-memory-utilization 0.75
+```
+
+If multiple model stages or services share the same NPU, lower each service's
+`--gpu-memory-utilization` so the total leaves 10% to 20% HBM headroom. Stages
+that require eager mode should reserve extra headroom because their temporary
+workspace usage can differ from graph mode.
+
 ## Functional Verification
 
 Once your server is started, you can query the model with input prompts.


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #9540
Fixes #9374
Fixes #9337
Fixes #9336
Fixes #8963
Addresses #8753

This PR clarifies several documentation gaps that are currently actionable without NPU hardware:

- Makes the local CI setup use the vLLM ref from the Versioning Policy main compatibility matrix instead of implying a fixed release-only checkout.
- Adds Ascend 910B 64 GB HBM memory budgeting guidance for single-instance, multi-instance, long-context/KV cache, and eager-mode scenarios.
- Adds container-side NPU memory troubleshooting notes for stale processes and `/proc/uda/namespace_node`.
- Documents `ASCEND_RT_VISIBLE_DEVICES` usage and 2-NPU/4-NPU examples for Qwen3-Omni deployment.
- Clarifies model functional verification placeholders and `--served-model-name` consistency in the template and DeepSeek-V3.2 doc.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change.

### How was this patch tested?

- `git diff --check` passed.
- `python -m py_compile docs/source/conf.py` passed.
- `npx --yes markdownlint-cli2 docs/source/_templates/Model-Deployment-Tutorial-Template.md docs/source/developer_guide/contribution/index.md docs/source/faqs.md docs/source/tutorials/models/DeepSeek-V3.2.md docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md` passed.

Limitations:

- `bash format.sh ci` could not run in this Windows checkout because the shell parsed CRLF line endings in `format.sh` as `$'\r'` tokens.
- A normal `git commit` pre-commit run attempted to install `actionlint`, but Go dependency downloads from `proxy.golang.org` timed out. The commit was created with `--no-verify` after the targeted changed-file checks above passed.
- Full Sphinx docs build was not run because `docs/requirements-docs.txt` installation did not complete within the local timeout.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
