### PR TITLE
[BugFix] Cap DSv4 DSA admission to startup pool-sizing bound

### DIFF
--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -11,7 +11,13 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     SingleTypeKVCacheManager,
     spec_manager_map,
 )
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+    SlidingWindowSpec,
+)
 from vllm.v1.request import Request
 
 
@@ -239,5 +245,18 @@ def get_manager_for_kv_cache_spec(
             block_size = kv_cache_spec.block_size
             max_compressed_tokens = max_model_len // compress_ratio
             kwargs["max_admission_blocks_per_request"] = cdiv(max_compressed_tokens, block_size) + compress_ratio
+    elif isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
+        # Replicate the upstream PR #40946 cap setting for recycling specs.
+        # We override the vLLM factory above, so the upstream block that does
+        # this lives in dead code (never reached); without re-applying it here
+        # SlidingWindowMLASpec / ChunkedLocalAttentionSpec groups have no cap
+        # and ``full_sequence_must_fit`` admission reserves the full
+        # ``max_model_len`` worth of blocks per request, exhausting the pool
+        # at cc>=2 on DSv4 (see vLLM issue #40863).
+        if max_num_batched_tokens is not None and max_model_len is not None:
+            kwargs["max_admission_blocks_per_request"] = kv_cache_spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
+            )
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -204,9 +204,40 @@ class CompressAttentionManager(FullAttentionManager):
         return computed_blocks
 
 
-def get_manager_for_kv_cache_spec(kv_cache_spec: KVCacheSpec, **kwargs) -> SingleTypeKVCacheManager:
+def get_manager_for_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec,
+    max_num_batched_tokens: int | None = None,
+    max_model_len: int | None = None,
+    **kwargs,
+) -> SingleTypeKVCacheManager:
+    """Build the per-spec KV cache manager.
+
+    For DSv4 / DSA path (``MLAAttentionSpec`` with ``compress_ratio>1``), align
+    the runtime admission gate with the startup pool-sizing bound the same way
+    vLLM PR #40946 does for ``SlidingWindowSpec`` / ``ChunkedLocalAttentionSpec``.
+    Without this cap, an admitted request can demand more blocks than the pool
+    was sized to back, and ``allocate_slots`` silently returns ``None`` from
+    the ``full_sequence_must_fit`` branch, leaving long-input requests stuck
+    in the waiting queue (see vLLM issue #40863, observed on DSv4 + MTP with
+    cc>=1 and prompt>=32K).
+
+    The compressed-MLA peak per request is bounded by
+    ``cdiv(max_model_len // compress_ratio, block_size)`` (it does not shrink
+    via recycling like SWA, but neither does it ever exceed this). Capping at
+    this value matches the pool sizer and makes admission consistent with the
+    block budget actually held.
+    """
     manager_class = spec_manager_map[type(kv_cache_spec)]
     if isinstance(kv_cache_spec, MLAAttentionSpec) and kv_cache_spec.compress_ratio > 1:
         manager_class = CompressAttentionManager
+        if max_model_len is not None:
+            # Compressed-MLA peak in blocks: ceil(max_model_len/compress/block).
+            # The "+ compress_ratio" margin matches the alignment headroom used
+            # elsewhere in DSA so admission never refuses what the pool sizer
+            # promised.
+            compress_ratio = kv_cache_spec.compress_ratio
+            block_size = kv_cache_spec.block_size
+            max_compressed_tokens = max_model_len // compress_ratio
+            kwargs["max_admission_blocks_per_request"] = cdiv(max_compressed_tokens, block_size) + compress_ratio
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -244,7 +244,7 @@ def get_manager_for_kv_cache_spec(
             compress_ratio = kv_cache_spec.compress_ratio
             block_size = kv_cache_spec.block_size
             max_compressed_tokens = max_model_len // compress_ratio
-            kwargs["max_admission_blocks_per_request"] = cdiv(max_compressed_tokens, block_size) + compress_ratio
+            kwargs["max_admission_blocks_per_request"] = cdiv(max_compressed_tokens, block_size) + 1
     elif isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
         # Replicate the upstream PR #40946 cap setting for recycling specs.
         # We override the vLLM factory above, so the upstream block that does

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -238,9 +238,6 @@ def get_manager_for_kv_cache_spec(
         manager_class = CompressAttentionManager
         if max_model_len is not None:
             # Compressed-MLA peak in blocks: ceil(max_model_len/compress/block).
-            # The "+ compress_ratio" margin matches the alignment headroom used
-            # elsewhere in DSA so admission never refuses what the pool sizer
-            # promised.
             compress_ratio = kv_cache_spec.compress_ratio
             block_size = kv_cache_spec.block_size
             max_compressed_tokens = max_model_len // compress_ratio

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -45,10 +45,17 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         hash_block_size: int,
         eagle_attn_layer_names: list[str] | None = None,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_num_batched_tokens: int | None = None,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
         self.enable_caching = enable_caching
+        # Fall back to `max_model_len` when unset so the recycling-aware
+        # admission cap (vLLM PR #40946) collapses to the prior uncapped
+        # behavior. The scheduler always supplies the real value at runtime.
+        if max_num_batched_tokens is None:
+            max_num_batched_tokens = max_model_len
+        self.max_num_batched_tokens = max_num_batched_tokens
 
         self.block_pool = BlockPool(
             kv_cache_config.num_blocks,
@@ -72,6 +79,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 kv_cache_group_id=i,
                 dcp_world_size=dcp_world_size,
                 pcp_world_size=pcp_world_size,
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
@@ -260,6 +269,7 @@ def get_kv_cache_coordinator(
         hash_block_size=hash_block_size,
         eagle_attn_layer_names=eagle_attn_layer_names,
         metrics_collector=metrics_collector,
+        max_num_batched_tokens=max_num_batched_tokens,
     )
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

Mirrors the admission-cap mechanism added in vLLM PR [#40946](https://github.com/vllm-project/vllm/pull/40946) into the DSv4 / DSA path of vllm-ascend. Fixes the long-prompt hang reproduced on Ascend, equivalent to the upstream cliff reported in vllm-project/vllm#40863 (observed on H200 for DSv4-Pro).

**Symptom**: with `--max-model-len 150000` and the v1 default `scheduler_reserve_full_isl=True`, prompts ≥32K sit forever in the waiting queue (`Running:0 Waiting:1`), engine throughput log goes silent and NPU AICore stays at 0%.

**Root cause**: DSv4 / DSA path uses `MLAAttentionSpec` with `compress_ratio>1` and goes through `AscendHybridKVCacheCoordinator`. Upstream PR #40946 added `max_admission_blocks_per_request` to bring runtime admission back in line with the startup pool sizer, but only wired it up for `SlidingWindowSpec` / `ChunkedLocalAttentionSpec`. The Ascend coordinator never received `max_num_batched_tokens`, never set the admission cap, and never threaded the new arg through to `get_manager_for_kv_cache_spec`, so compressed-MLA requests stayed on the un-capped path and `allocate_slots()` silently returned `None` from the `full_sequence_must_fit` branch.

**Fix**:
- Thread `max_num_batched_tokens` and `max_model_len` through `AscendHybridKVCacheCoordinator` into `get_manager_for_kv_cache_spec`.
- For `MLAAttentionSpec` with `compress_ratio>1`, set
  `max_admission_blocks_per_request = cdiv(max_model_len // compress_ratio, block_size) + compress_ratio`,
  matching the startup pool sizer. Compressed MLA does not shrink via recycling like SWA, but never exceeds this bound either.
- Default the new arg to `max_model_len` when unset so non-DSA call sites collapse to the previous uncapped behavior.

**Workaround until this lands**: `--no-scheduler-reserve-full-isl` at serve time (re-enables the pre-#37307 chunk-based admission, at the cost of giving up the thrash protection that flag was designed for).

### Does this PR introduce any user-facing change?

No. Default behavior for non-DSA paths is preserved by falling back to `max_model_len` when `max_num_batched_tokens` is unset. DSA users only see the bug go away — the runtime cap is exactly the pool sizer's bound, so nothing previously admissible becomes inadmissible.

### How was this patch tested?

- Repro on Ascend NPU before the fix: 32K-prompt request stuck in `Waiting`, NPU idle, no throughput log.
- After the fix on the same setup: 32K-prompt request admitted, decode proceeds normally.
- Existing short-prompt workloads unaffected (cap not triggered).

### References

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
