### PR TITLE
[Attention][BugFix] Fix scheduler dead lock for long requests by adding admission cap to KV cache manager

### DIFF
--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -12,6 +12,7 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     spec_manager_map,
 )
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import SlidingWindowSpec, ChunkedLocalAttentionSpec
 from vllm.v1.request import Request
 
 
@@ -203,10 +204,27 @@ class CompressAttentionManager(FullAttentionManager):
                 computed.pop()
         return computed_blocks
 
-
-def get_manager_for_kv_cache_spec(kv_cache_spec: KVCacheSpec, **kwargs) -> SingleTypeKVCacheManager:
+def get_manager_for_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec,
+    max_num_batched_tokens: int | None = None,
+    max_model_len: int | None = None,
+    **kwargs,
+) -> SingleTypeKVCacheManager:
     manager_class = spec_manager_map[type(kv_cache_spec)]
     if isinstance(kv_cache_spec, MLAAttentionSpec) and kv_cache_spec.compress_ratio > 1:
         manager_class = CompressAttentionManager
+    # SlidingWindow / ChunkedLocalAttention 的准入上限（与上游一致）
+    if (
+        hasattr(kv_cache_spec, "max_admission_blocks_per_request")
+        and max_num_batched_tokens is not None
+        and max_model_len is not None
+    ):
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
+            )
+        )
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager
+

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -227,4 +227,3 @@ def get_manager_for_kv_cache_spec(
         )
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager
-

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -11,8 +11,11 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     SingleTypeKVCacheManager,
     spec_manager_map,
 )
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec, MLAAttentionSpec
-from vllm.v1.kv_cache_interface import SlidingWindowSpec, ChunkedLocalAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+)
 from vllm.v1.request import Request
 
 
@@ -204,6 +207,7 @@ class CompressAttentionManager(FullAttentionManager):
                 computed.pop()
         return computed_blocks
 
+
 def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
     max_num_batched_tokens: int | None = None,
@@ -219,11 +223,9 @@ def get_manager_for_kv_cache_spec(
         and max_num_batched_tokens is not None
         and max_model_len is not None
     ):
-        kwargs["max_admission_blocks_per_request"] = (
-            kv_cache_spec.max_admission_blocks_per_request(
-                max_num_batched_tokens=max_num_batched_tokens,
-                max_model_len=max_model_len,
-            )
+        kwargs["max_admission_blocks_per_request"] = kv_cache_spec.max_admission_blocks_per_request(
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
         )
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -37,6 +37,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
+        max_num_batched_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -67,6 +68,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
@@ -252,6 +255,7 @@ def get_kv_cache_coordinator(
     return AscendHybridKVCacheCoordinator(
         kv_cache_config,
         max_model_len,
+        max_num_batched_tokens,
         use_eagle,
         enable_caching,
         enable_kv_cache_events,


### PR DESCRIPTION

### What this PR does / why we need it?
This PR fixes a scheduler deadlock where long requests (e.g., >32k tokens) would hang indefinitely in the WAITING queue. The root cause was the missing admission cap for  and  in the Ascend-specific KV cache manager, which caused block allocations to exceed available free blocks. This fix aligns the implementation with upstream vLLM by correctly computing and applying the  cap.

### Does this PR introduce _any_ user-facing change? 
No.

### How was this patch tested?
- End-to-end NPU hardware testing with sequences up to 32k tokens (DeepSeek-V4 Flash).
- Verified resolution of the scheduler deadlock without regressions.

Signed-off-by: lizhe.li <147392333@qq.com>


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
