### PR TITLE
[BugFix]Fix hidden size dimension mismatch in first-layer attention o…

### DIFF
--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -156,7 +156,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         kv_cache: torch.Tensor | None = None,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        hidden_dim = hidden_states.shape[-1]
+        hidden_dim = self.hidden_size
 
         if _EXTRA_CTX.flash_comm_v1_enabled and self.tp_size > 1 and self.is_vl_first_layer:
             need_gather_q_kv = False


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a hidden size dimension mismatch in the first-layer attention output for the Eagle3 scenario.

For Eagle3, the first-layer attention output should use the target hidden size instead of the draft hidden size. Using the wrong hidden size can cause a shape mismatch when preparing the attention output buffer.

### Does this PR introduce _any_ user-facing change?

No. This is a bug fix for Eagle3 attention output shape handling and does not introduce any user-facing API or behavior change.

### How was this patch tested?

Not run locally. This change is a one-line fix to use the correct hidden size for the Eagle3 first-layer attention output path.

Relevant validation should be covered by existing Eagle3 / MLA CI tests.