### PR TITLE
[CI][310p]add quantization model for e2e light 310p

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -273,7 +273,9 @@
       "Eco-Tech/GLM-5.1-w8a8",
       "Eco-Tech/Qwen3.5-397B-A17B-w4a8-mtp", 
       "lightseekorg/kimi-k2.5-eagle3",
-      "Eco-Tech/Qwen3.5-122B-A10B-w8a8-mtp"
+      "Eco-Tech/Qwen3.5-122B-A10B-w8a8-mtp",
+      "Eco-Tech/Qwen3-8B-w8a8sc-310-vllm",
+      "Eco-Tech/Qwen3-14B-w8a8sc-310-vllm"
     ],
     "datasets": [
       "vllm-ascend/GSM8K-in1024-bs210",


### PR DESCRIPTION
### What this PR does / why we need it?
we need to download quantization model for 310p e2e light
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
