### PR TITLE
[Feature][Attention] Support Model GLM4.7-Flash

### DIFF
--- a/tests/ut/attention/test_mla_cp_precision.py
+++ b/tests/ut/attention/test_mla_cp_precision.py
@@ -397,6 +397,8 @@ def _populate_impl_attrs(
     impl.vllm_config = vllm_config
     impl.scale = scale
     impl.num_heads = num_heads
+    impl.num_heads_padded = 1 << (num_heads - 1).bit_length()
+    impl.head_padding = impl.num_heads_padded - num_heads
     impl.num_kv_heads = 1
     impl.kv_lora_rank = kv_lora_rank
     impl.qk_nope_head_dim = qk_nope_head_dim

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1071,6 +1071,47 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
+        # 256 is power of 2, so padding should be 0
+        self.assertEqual(self.impl.num_heads_padded, 256)
+        self.assertEqual(self.impl.head_padding, 0)
+
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):
+        """Test head padding computation for num_heads that are not power of 2 (e.g. GLM-4.7-Flash with 20 heads)."""
+        mock_get_current_vllm_config.return_value = MagicMock()
+        kwargs = {
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": MagicMock(),
+        }
+        impl = AscendMLAImpl(
+            num_heads=20,
+            head_size=1024,
+            scale=0.1,
+            num_kv_heads=20,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        self.assertEqual(impl.num_heads, 20)
+        self.assertEqual(impl.num_heads_padded, 32)  # next power of 2
+        self.assertEqual(impl.head_padding, 12)  # 32 - 20
 
     @patch("vllm_ascend.attention.mla_v1.get_ascend_config")
     @patch("vllm_ascend.attention.mla_v1.register_all_layers_to_shard_weight_series")
@@ -1551,6 +1592,74 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[0], batch_size)
         self.assertEqual(result.shape[1], self.impl.num_heads * self.impl.v_head_dim)
 
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
+        """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
+        mock_get_current_vllm_config.return_value = MagicMock()
+        num_heads = 20
+        kwargs = {
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": MagicMock(),
+        }
+        impl = AscendMLAImpl(
+            num_heads=num_heads,
+            head_size=1024,
+            scale=0.1,
+            num_kv_heads=num_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        batch_size = 2
+        q_nope = torch.randn(batch_size, num_heads, impl.qk_nope_head_dim)
+        q_pe = torch.randn(batch_size, num_heads, impl.qk_rope_head_dim)
+        k_nope = torch.randn(batch_size, num_heads, impl.qk_nope_head_dim)
+        k_pe = torch.randn(batch_size, num_heads, impl.qk_rope_head_dim)
+        value = torch.randn(batch_size, num_heads, impl.v_head_dim)
+        kv_c_and_k_pe_cache = [torch.randn(10, 1, 1, 192), torch.randn(10, 1, 1, 32)]
+
+        attn_metadata = MagicMock()
+        prefill_metadata = MagicMock()
+        prefill_metadata.actual_seq_lengths_q = [10, 20]
+        prefill_metadata.attn_mask = torch.randn(1, 1, 20, 20)
+        prefill_metadata.chunked_context = None
+        attn_metadata.prefill = prefill_metadata
+
+        mock_device_operator.kv_cache_load = MagicMock()
+        mock_fia.return_value = (
+            torch.randn(batch_size, num_heads, impl.v_head_dim),
+            torch.randn(num_heads, batch_size),
+        )
+
+        result = impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
+
+        # FIA should be called without query_rope/key_rope when head_padding > 0
+        mock_fia.assert_called_once()
+        call_kwargs = mock_fia.call_args.kwargs
+        self.assertNotIn("query_rope", call_kwargs)
+        self.assertNotIn("key_rope", call_kwargs)
+        self.assertEqual(call_kwargs.get("num_heads"), num_heads)
+        self.assertEqual(result.shape, (batch_size, num_heads * impl.v_head_dim))
+
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading(self, mock_format_cast):
         layer = MagicMock(spec=LinearBase)
@@ -1841,6 +1950,86 @@ class TestAscendMLAImpl(TestBase):
 
         self.assertEqual(out.shape, prefix_out.shape)
 
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    @patch("torch_npu.atb.npu_paged_cache_load")
+    @patch("torch_npu.npu_attention_update")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    def test_compute_prefill_context_non_power_of_two_heads(
+        self, mock_fia, mock_update, mock_load, mock_get_current_vllm_config
+    ):
+        """Test prefill context with non-power-of-2 heads uses concat for query and key."""
+        mock_get_current_vllm_config.return_value = MagicMock()
+        num_heads = 20
+        kwargs = {
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": MagicMock(),
+        }
+        impl = AscendMLAImpl(
+            num_heads=num_heads,
+            head_size=1024,
+            scale=0.1,
+            num_kv_heads=num_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        S, N, D, VD = 2, num_heads, impl.qk_head_dim, impl.v_head_dim
+        latent_kv_dim = impl.kv_lora_rank
+        num_blocks, block_size = 100, 20
+        query = torch.randn(S, N, D)
+        q_nope = query[..., : impl.qk_nope_head_dim]
+        q_pe = query[..., impl.qk_nope_head_dim :]
+        kv_cache_0 = torch.randn(num_blocks, block_size, N, latent_kv_dim)
+        kv_cache_1 = torch.randn(num_blocks, block_size, N, D)
+        kv_cache = [kv_cache_0, kv_cache_1]
+        prefix_out = torch.randn(S, N, VD)
+        prefix_lse = torch.randn(N, S)
+
+        impl.kv_b_proj.return_value = (torch.randn(8, N, VD + impl.qk_nope_head_dim),)
+
+        mock_fia.return_value = (torch.randn(S, N, VD), torch.randn(N, S))
+        mock_update.return_value = (torch.randn(S * N, VD), None)
+
+        chunk_ctx = MagicMock()
+        chunk_ctx.seq_tot = [8]
+        chunk_ctx.chunk_seq_lens = [torch.tensor([8])]
+        chunk_ctx.chunk_seq_lens_npu = [torch.tensor([8])]
+        chunk_ctx.starts = [torch.tensor([0])]
+        chunk_ctx.chunk_actual_seq_lengths_kv_list = [[8]]
+
+        prefill_meta = MagicMock()
+        prefill_meta.chunked_context = chunk_ctx
+        prefill_meta.query_lens = torch.tensor([S])
+        prefill_meta.block_table = torch.randint(0, 100, (S, 4))
+
+        meta = MagicMock()
+        meta.prefill = prefill_meta
+
+        out, lse = impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse)
+
+        mock_fia.assert_called_once()
+        call_kwargs = mock_fia.call_args.kwargs
+        self.assertNotIn("query_rope", call_kwargs)
+        self.assertNotIn("key_rope", call_kwargs)
+        self.assertEqual(out.shape, prefix_out.shape)
+
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.attention.mla_v1.AscendMLAImpl._v_up_proj")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
@@ -2046,6 +2235,154 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], N)
         self.assertEqual(result.shape[2], HD)
+
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("torch_npu.npu_fused_infer_attention_score_v2")
+    def test_forward_decode_non_power_of_two_heads(
+        self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
+    ):
+        """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
+        mock_get_current_vllm_config.return_value = MagicMock()
+        num_heads = 20
+        kwargs = {
+            "kv_lora_rank": 256,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": MagicMock(),
+        }
+        impl = AscendMLAImpl(
+            num_heads=num_heads,
+            head_size=1024,
+            scale=0.1,
+            num_kv_heads=num_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        B = 2
+        BS = 100
+        HD = impl.v_head_dim
+        impl.spec_token_num = 1
+        impl._v_up_proj = MagicMock()
+        impl._v_up_proj.return_value = torch.randn(B, num_heads, HD)
+        q_nope = torch.randn(B, num_heads, impl.qk_nope_head_dim)
+        q_pe = torch.randn(B, num_heads, impl.qk_rope_head_dim)
+        k_nope = torch.randn(BS, num_heads, impl.kv_lora_rank)
+        k_pe = torch.randn(BS, num_heads, impl.qk_rope_head_dim)
+        attn_metadata = MagicMock()
+        attn_metadata.attn_state = AscendAttentionState.SpecDecoding
+        attn_metadata.decode = MagicMock()
+        attn_metadata.decode.actual_seq_qlen = MagicMock()
+        attn_metadata.decode.actual_seq_kvlen = MagicMock()
+        impl.enable_kv_nz = True
+        impl.fa_quant_layer = False
+
+        # Return padded output so slice logic works
+        mock_npu_fused_infer_attention_score_v2.return_value = [
+            torch.randn(impl.num_heads_padded, B, impl.kv_lora_rank),
+            None,
+        ]
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        result = impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS, attn_metadata)
+
+        self.assertEqual(result.shape[0], B)
+        self.assertEqual(result.shape[1], num_heads)
+        self.assertEqual(result.shape[2], HD)
+
+        # Verify num_query_heads passed to FIA is padded
+        mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
+        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("torch_npu.npu_fused_infer_attention_score_v2")
+    def test_forward_decode_non_power_of_two_heads_normal(
+        self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
+    ):
+        """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
+        mock_get_current_vllm_config.return_value = MagicMock()
+        num_heads = 20
+        kwargs = {
+            "kv_lora_rank": 256,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": MagicMock(),
+        }
+        impl = AscendMLAImpl(
+            num_heads=num_heads,
+            head_size=1024,
+            scale=0.1,
+            num_kv_heads=num_heads,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        B = 2
+        BS = 100
+        HD = impl.v_head_dim
+        impl.spec_token_num = 1
+        impl._v_up_proj = MagicMock()
+        impl._v_up_proj.return_value = torch.randn(B, num_heads, HD)
+        q_nope = torch.randn(B, num_heads, impl.qk_nope_head_dim)
+        q_pe = torch.randn(B, num_heads, impl.qk_rope_head_dim)
+        k_nope = torch.randn(BS, num_heads, impl.kv_lora_rank)
+        k_pe = torch.randn(BS, num_heads, impl.qk_rope_head_dim)
+        attn_metadata = MagicMock()
+        attn_metadata.attn_state = AscendAttentionState.DecodeOnly
+        attn_metadata.decode = MagicMock()
+        attn_metadata.decode.actual_seq_qlen = MagicMock()
+        attn_metadata.decode.actual_seq_kvlen = MagicMock()
+        attn_metadata.decode.block_table = MagicMock()
+        impl.enable_kv_nz = False
+        impl.fa_quant_layer = False
+        impl.speculative_config = None
+
+        mock_npu_fused_infer_attention_score_v2.return_value = [
+            torch.randn(impl.num_heads_padded, B, 1, impl.kv_lora_rank),
+            None,
+        ]
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        result = impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS, attn_metadata)
+
+        self.assertEqual(result.shape[0], B)
+        self.assertEqual(result.shape[1], num_heads)
+        self.assertEqual(result.shape[2], HD)
+
+        mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
+        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 import torch_npu
 import vllm.envs as envs_vllm
 from vllm.config import VllmConfig, get_current_vllm_config
@@ -773,6 +774,12 @@ class AscendMLAImpl(MLAAttentionImpl):
                 )
         register_all_layers_to_shard_weight_series(self.layer_sharding_kwargs)
 
+        # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
+        # with 20 heads), ascend attention ops require padding heads to the
+        # next power of 2.
+        self.num_heads_padded = 1 << (self.num_heads - 1).bit_length()
+        self.head_padding = self.num_heads_padded - self.num_heads
+
     @staticmethod
     def update_graph_params(
         update_stream,
@@ -1162,6 +1169,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         out_list = [prefix_output.reshape(num_tokens * H, D)]
         lse_list = [prefix_lse.reshape(num_tokens * H)]
 
+        if self.head_padding > 0:
+            query = torch.cat((q_nope, q_pe), dim=-1)
+
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
             context_seq_len_npu = self.get_context_seq_len_npu(i, attn_metadata)
@@ -1195,24 +1205,43 @@ class AscendMLAImpl(MLAAttentionImpl):
 
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
 
-            chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
-                q_nope,
-                k_nope,
-                v,
-                query_rope=q_pe,
-                key_rope=k_pe,
-                num_heads=self.num_heads,
-                num_key_value_heads=self.num_heads,
-                input_layout="TND",
-                atten_mask=None,
-                sparse_mode=0,
-                scale=self.scale,
-                antiquant_mode=0,
-                antiquant_scale=None,
-                softmax_lse_flag=True,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-            )
+            if self.head_padding > 0:
+                key = torch.cat((k_nope, k_pe), dim=-1)
+                chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
+                    query,
+                    key,
+                    v,
+                    num_heads=self.num_heads,
+                    num_key_value_heads=self.num_heads,
+                    input_layout="TND",
+                    atten_mask=None,
+                    sparse_mode=0,
+                    scale=self.scale,
+                    antiquant_mode=0,
+                    antiquant_scale=None,
+                    softmax_lse_flag=True,
+                    actual_seq_lengths=actual_seq_lengths_q,
+                    actual_seq_lengths_kv=actual_seq_lengths_kv,
+                )
+            else:
+                chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
+                    q_nope,
+                    k_nope,
+                    v,
+                    query_rope=q_pe,
+                    key_rope=k_pe,
+                    num_heads=self.num_heads,
+                    num_key_value_heads=self.num_heads,
+                    input_layout="TND",
+                    atten_mask=None,
+                    sparse_mode=0,
+                    scale=self.scale,
+                    antiquant_mode=0,
+                    antiquant_scale=None,
+                    softmax_lse_flag=True,
+                    actual_seq_lengths=actual_seq_lengths_q,
+                    actual_seq_lengths_kv=actual_seq_lengths_kv,
+                )
             if chunk_lse.dim() == 2:
                 chunk_lse = chunk_lse.transpose(0, 1).unsqueeze(-1)
             chunk_out = chunk_out.to(torch.float32)
@@ -1254,25 +1283,44 @@ class AscendMLAImpl(MLAAttentionImpl):
         attn_output = torch.empty(num_tokens, self.num_heads, self.v_head_dim, dtype=q_nope.dtype, device=q_nope.device)
         attn_lse = torch.empty(self.num_heads, num_tokens, dtype=torch.float32, device=q_nope.device)
 
-        common_kwargs = {
-            "query_rope": q_pe,
-            "key_rope": k_pe,
-            "num_heads": self.num_heads,
-            "num_key_value_heads": self.num_heads,
-            "input_layout": "TND",
-            "atten_mask": prefill_meta.attn_mask,
-            "sparse_mode": 3,
-            "scale": self.scale,
-            "antiquant_mode": 0,
-            "antiquant_scale": None,
-            "block_table": None,
-            "block_size": 0,
-            "softmax_lse_flag": True,
-            "actual_seq_lengths": actual_seq_lengths_q,
-            "actual_seq_lengths_kv": actual_seq_lengths_kv,
-        }
-
-        attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(q_nope, k_nope, value, **common_kwargs)
+        if self.head_padding > 0:
+            query = torch.cat((q_nope, q_pe), dim=-1)
+            key = torch.cat((k_nope, k_pe), dim=-1)
+            attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
+                query,
+                key,
+                value,
+                num_heads=self.num_heads,
+                num_key_value_heads=self.num_heads,
+                input_layout="TND",
+                atten_mask=prefill_meta.attn_mask,
+                sparse_mode=3,
+                scale=self.scale,
+                antiquant_mode=0,
+                antiquant_scale=None,
+                softmax_lse_flag=True,
+                actual_seq_lengths=actual_seq_lengths_q,
+                actual_seq_lengths_kv=actual_seq_lengths_kv,
+            )
+        else:
+            common_kwargs = {
+                "query_rope": q_pe,
+                "key_rope": k_pe,
+                "num_heads": self.num_heads,
+                "num_key_value_heads": self.num_heads,
+                "input_layout": "TND",
+                "atten_mask": prefill_meta.attn_mask,
+                "sparse_mode": 3,
+                "scale": self.scale,
+                "antiquant_mode": 0,
+                "antiquant_scale": None,
+                "block_table": None,
+                "block_size": 0,
+                "softmax_lse_flag": True,
+                "actual_seq_lengths": actual_seq_lengths_q,
+                "actual_seq_lengths_kv": actual_seq_lengths_kv,
+            }
+            attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(q_nope, k_nope, value, **common_kwargs)
 
         attn_output, attn_lse = self._compute_prefill_context(
             q_nope, q_pe, kv_c_and_k_pe_cache, self.qk_rope_head_dim, attn_metadata, attn_output, attn_lse
@@ -1400,6 +1448,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             k_pe = k_pe.view(-1, self.num_kv_heads, block_size, self.qk_rope_head_dim)
 
         attn_output_shape: tuple | None = None
+        num_heads_for_op = self.num_heads_padded
         if (
             attn_metadata.attn_state
             in [
@@ -1418,8 +1467,11 @@ class AscendMLAImpl(MLAAttentionImpl):
             # Input shape: [num_tokens, num_heads, dim]
             q_nope = q_nope.view(num_tokens, self.num_heads, -1).contiguous()
             q_pe = q_pe.view(num_tokens, self.num_heads, -1)
+            if self.head_padding > 0:
+                q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
+                q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
-            attn_output_shape = (self.num_heads, num_tokens, self.kv_lora_rank)
+            attn_output_shape = (num_heads_for_op, num_tokens, self.kv_lora_rank)
             sparse_mode = 3
             attn_mask = attn_metadata.decode.attn_mask  # type:ignore
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
@@ -1439,8 +1491,11 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
+                if self.head_padding > 0:
+                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
+                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
+                attn_output_shape = (num_heads_for_op, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1449,20 +1504,26 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1)
+                if self.head_padding > 0:
+                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
+                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             else:
                 # Input shape: [num_tokens, num_heads, seq_len, dim]
                 input_layout = "BNSD_NBSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
+                if self.head_padding > 0:
+                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
+                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (num_heads_for_op, num_tokens, 1, self.kv_lora_rank)
             sparse_mode = 0
             attn_mask = None
 
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
-            "num_query_heads": self.num_heads,
+            "num_query_heads": num_heads_for_op,
             "num_key_value_heads": self.num_kv_heads,
             "input_layout": input_layout,
             "atten_mask": attn_mask,
@@ -1506,7 +1567,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 weak_ref_tensors(k_nope),
                 weak_ref_tensors(q_pe),
                 weak_ref_tensors(k_pe),
-                self.num_heads,
+                num_heads_for_op,
                 self.num_kv_heads,
                 input_layout,
                 weak_ref_tensors(attn_mask) if attn_mask is not None else None,
@@ -1547,6 +1608,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         else:
             attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(q_nope, k_nope, k_nope, **common_kwargs)
 
+        if self.head_padding > 0:
+            attn_output = attn_output[: self.num_heads]
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1425,7 +1425,6 @@ class AscendMLAImpl(MLAAttentionImpl):
             k_pe = k_pe.view(-1, self.num_kv_heads, block_size, self.qk_rope_head_dim)
 
         attn_output_shape: tuple | None = None
-        num_heads_for_op = self.num_heads_padded
         if (
             attn_metadata.attn_state
             in [
@@ -1448,7 +1447,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
                 q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
-            attn_output_shape = (num_heads_for_op, num_tokens, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
             sparse_mode = 3
             attn_mask = attn_metadata.decode.attn_mask  # type:ignore
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
@@ -1462,8 +1461,11 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
+                if self.head_padding > 0:
+                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
+                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-                attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
+                attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
             else:
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
@@ -1472,7 +1474,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                     q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
                     q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (num_heads_for_op, num_tokens, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1493,14 +1495,14 @@ class AscendMLAImpl(MLAAttentionImpl):
                     q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                     q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (num_heads_for_op, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
             sparse_mode = 0
             attn_mask = None
 
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
-            "num_query_heads": num_heads_for_op,
+            "num_query_heads": self.num_heads_padded,
             "num_key_value_heads": self.num_kv_heads,
             "input_layout": input_layout,
             "atten_mask": attn_mask,
@@ -1544,7 +1546,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 weak_ref_tensors(k_nope),
                 weak_ref_tensors(q_pe),
                 weak_ref_tensors(k_pe),
-                num_heads_for_op,
+                self.num_heads_padded,
                 self.num_kv_heads,
                 input_layout,
                 weak_ref_tensors(attn_mask) if attn_mask is not None else None,

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1172,7 +1172,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         if self.head_padding > 0:
             query = torch.cat((q_nope, q_pe), dim=-1)
 
-        kwargs = {
+        common_kwargs = {
             "num_heads": self.num_heads,
             "num_key_value_heads": self.num_heads,
             "input_layout": "TND",
@@ -1217,18 +1217,17 @@ class AscendMLAImpl(MLAAttentionImpl):
             k_pe = k_pe.expand((*k_nope.shape[:-1], -1))
 
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
-            kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
+            common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
             if self.head_padding > 0:
                 key = torch.cat((k_nope, k_pe), dim=-1)
             else:
-                kwargs["query_rope"] = q_pe
-                kwargs["key_rope"] = k_pe
+                common_kwargs["query_rope"] = q_pe
+                common_kwargs["key_rope"] = k_pe
                 query = q_nope
                 key = k_nope
 
-            chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
-                query, key, v, **kwargs)
+            chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(query, key, v, **common_kwargs)
 
             if chunk_lse.dim() == 2:
                 chunk_lse = chunk_lse.transpose(0, 1).unsqueeze(-1)
@@ -1271,7 +1270,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         attn_output = torch.empty(num_tokens, self.num_heads, self.v_head_dim, dtype=q_nope.dtype, device=q_nope.device)
         attn_lse = torch.empty(self.num_heads, num_tokens, dtype=torch.float32, device=q_nope.device)
 
-        kwargs = {
+        common_kwargs = {
             "num_heads": self.num_heads,
             "num_key_value_heads": self.num_heads,
             "input_layout": "TND",
@@ -1291,12 +1290,11 @@ class AscendMLAImpl(MLAAttentionImpl):
             query = torch.cat((q_nope, q_pe), dim=-1)
             key = torch.cat((k_nope, k_pe), dim=-1)
         else:
-            kwargs["query_rope"] = q_pe
-            kwargs["key_rope"] = k_pe
+            common_kwargs["query_rope"] = q_pe
+            common_kwargs["key_rope"] = k_pe
             query, key = q_nope, k_nope
 
-        attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
-            query, key, value, **kwargs)
+        attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(query, key, value, **common_kwargs)
 
         attn_output, attn_lse = self._compute_prefill_context(
             q_nope, q_pe, kv_c_and_k_pe_cache, self.qk_rope_head_dim, attn_metadata, attn_output, attn_lse
@@ -1399,6 +1397,9 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
+        # TODO: The CANN package is expected to support num_heads that are not
+        # powers of 2 in 2026 Q2. Once supported, all padding operations under
+        # `if self.head_padding > 0` in this function can be removed.
         num_tokens = q_nope.size(0)
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1172,6 +1172,19 @@ class AscendMLAImpl(MLAAttentionImpl):
         if self.head_padding > 0:
             query = torch.cat((q_nope, q_pe), dim=-1)
 
+        kwargs = {
+            "num_heads": self.num_heads,
+            "num_key_value_heads": self.num_heads,
+            "input_layout": "TND",
+            "atten_mask": None,
+            "sparse_mode": 0,
+            "scale": self.scale,
+            "antiquant_mode": 0,
+            "antiquant_scale": None,
+            "softmax_lse_flag": True,
+            "actual_seq_lengths": actual_seq_lengths_q,
+        }
+
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
             context_seq_len_npu = self.get_context_seq_len_npu(i, attn_metadata)
@@ -1204,44 +1217,19 @@ class AscendMLAImpl(MLAAttentionImpl):
             k_pe = k_pe.expand((*k_nope.shape[:-1], -1))
 
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
+            kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
             if self.head_padding > 0:
                 key = torch.cat((k_nope, k_pe), dim=-1)
-                chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
-                    query,
-                    key,
-                    v,
-                    num_heads=self.num_heads,
-                    num_key_value_heads=self.num_heads,
-                    input_layout="TND",
-                    atten_mask=None,
-                    sparse_mode=0,
-                    scale=self.scale,
-                    antiquant_mode=0,
-                    antiquant_scale=None,
-                    softmax_lse_flag=True,
-                    actual_seq_lengths=actual_seq_lengths_q,
-                    actual_seq_lengths_kv=actual_seq_lengths_kv,
-                )
             else:
-                chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
-                    q_nope,
-                    k_nope,
-                    v,
-                    query_rope=q_pe,
-                    key_rope=k_pe,
-                    num_heads=self.num_heads,
-                    num_key_value_heads=self.num_heads,
-                    input_layout="TND",
-                    atten_mask=None,
-                    sparse_mode=0,
-                    scale=self.scale,
-                    antiquant_mode=0,
-                    antiquant_scale=None,
-                    softmax_lse_flag=True,
-                    actual_seq_lengths=actual_seq_lengths_q,
-                    actual_seq_lengths_kv=actual_seq_lengths_kv,
-                )
+                kwargs["query_rope"] = q_pe
+                kwargs["key_rope"] = k_pe
+                query = q_nope
+                key = k_nope
+
+            chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
+                query, key, v, **kwargs)
+
             if chunk_lse.dim() == 2:
                 chunk_lse = chunk_lse.transpose(0, 1).unsqueeze(-1)
             chunk_out = chunk_out.to(torch.float32)
@@ -1283,44 +1271,32 @@ class AscendMLAImpl(MLAAttentionImpl):
         attn_output = torch.empty(num_tokens, self.num_heads, self.v_head_dim, dtype=q_nope.dtype, device=q_nope.device)
         attn_lse = torch.empty(self.num_heads, num_tokens, dtype=torch.float32, device=q_nope.device)
 
+        kwargs = {
+            "num_heads": self.num_heads,
+            "num_key_value_heads": self.num_heads,
+            "input_layout": "TND",
+            "atten_mask": prefill_meta.attn_mask,
+            "sparse_mode": 3,
+            "scale": self.scale,
+            "antiquant_mode": 0,
+            "antiquant_scale": None,
+            "block_table": None,
+            "block_size": 0,
+            "softmax_lse_flag": True,
+            "actual_seq_lengths": actual_seq_lengths_q,
+            "actual_seq_lengths_kv": actual_seq_lengths_kv,
+        }
+
         if self.head_padding > 0:
             query = torch.cat((q_nope, q_pe), dim=-1)
             key = torch.cat((k_nope, k_pe), dim=-1)
-            attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
-                query,
-                key,
-                value,
-                num_heads=self.num_heads,
-                num_key_value_heads=self.num_heads,
-                input_layout="TND",
-                atten_mask=prefill_meta.attn_mask,
-                sparse_mode=3,
-                scale=self.scale,
-                antiquant_mode=0,
-                antiquant_scale=None,
-                softmax_lse_flag=True,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-            )
         else:
-            common_kwargs = {
-                "query_rope": q_pe,
-                "key_rope": k_pe,
-                "num_heads": self.num_heads,
-                "num_key_value_heads": self.num_heads,
-                "input_layout": "TND",
-                "atten_mask": prefill_meta.attn_mask,
-                "sparse_mode": 3,
-                "scale": self.scale,
-                "antiquant_mode": 0,
-                "antiquant_scale": None,
-                "block_table": None,
-                "block_size": 0,
-                "softmax_lse_flag": True,
-                "actual_seq_lengths": actual_seq_lengths_q,
-                "actual_seq_lengths_kv": actual_seq_lengths_kv,
-            }
-            attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(q_nope, k_nope, value, **common_kwargs)
+            kwargs["query_rope"] = q_pe
+            kwargs["key_rope"] = k_pe
+            query, key = q_nope, k_nope
+
+        attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
+            query, key, value, **kwargs)
 
         attn_output, attn_lse = self._compute_prefill_context(
             q_nope, q_pe, kv_c_and_k_pe_cache, self.qk_rope_head_dim, attn_metadata, attn_output, attn_lse


### PR DESCRIPTION
### What this PR does / why we need it?

  This PR adds **support for model GLM-4.7-Flash**.

  Background: Ascend NPU fused attention ops (npu_fused_infer_attention_score / npu_fused_infer_attention_score_v2) require the number of query heads to be a power of 2. When num_heads is not (e.g. 20), the op will fail or produce incorrect results.

  Changes in vllm_ascend/attention/**mla_v1**.py:

  1. Head padding computation in **__init__**:
    - Compute num_heads_padded as the next power of 2: 1 << (num_heads - 1).bit_length()
    - Compute head_padding = num_heads_padded - num_heads
  2. Prefill path (**_forward_prefill** & **_compute_prefill_context**):
    - The fia operator has specific requirements for the shapes of qk_nope_head_dim and qj_rope_head_dim, v_head_dim,  which currently only affects glm4.7-flash now, so we we use head_padding > 0 to judge. Then, concatenate q_nope with q_pe (and k_nope with k_pe) along the last dimension, and pass them as the main query/key tensors to npu_fused_infer_attention_score
    - Omit the query_rope and key_rope kwargs, which are not compatible with the padded-head path
  4. Decode path (**_forward_decode**):
    - Pad q_nope and q_pe with F.pad along the head dimension to num_heads_padded
    - Pass num_query_heads = num_heads_padded to npu_fused_infer_attention_score_v2
    - Slice the attention output back to the original num_heads with attn_output[:self.num_heads] before feeding to _v_up_proj
    - Covers all decode branches: TND_NTD (SpecDecoding), BSND_NBSD (fa_quant / enable_kv_nz), and BNSD_NBSD (normal decode)

  Changes in tests/ut/attention/test_mla_v1.py:

  - Added test_init_head_padding_for_non_power_of_two to verify padding arithmetic (20 -> 32)
  - Added test_forward_prefill_non_power_of_two_heads to verify prefill uses concat without query_rope/key_rope
  - Added test_compute_prefill_context_non_power_of_two_heads to verify prefill context uses concat
  - Added test_forward_decode_non_power_of_two_heads to verify decode with SpecDecoding state pads num_query_heads and slices output
  - Added test_forward_decode_non_power_of_two_heads_normal to verify decode with DecodeOnly + BNSD_NBSD path

 ###  Does this PR introduce any user-facing change?

  No. This is a backend compatibility fix for Ascend NPU attention ops. Users can now run GLM-4.7-Flash on Ascend without changing APIs or configurations.

###  How was this patch tested?

Accuracy Test: 
The markdown format results is as below:

| dataset | version | metric | mode | vllm-api-stream-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | 401e4c | accuracy | gen | 86.05 |
| aime25 |  | accuracy |  | 93.33 |

  - All new unit tests pass locally via the existing pytest suite in tests/ut/attention/test_mla_v1.py
  - The 5 new test cases collectively cover:
    - __init__ padding computation
    - Prefill forward (concat path)
    - Prefill context (concat path)
    - Decode forward with SpecDecoding / TND_NTD (pad + slice)
    - Decode forward with DecodeOnly / BNSD_NBSD (pad + slice)


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
