### PR TITLE
[1/N][Feature] Support `FULL_AND_PIECEWISE`

### DIFF
--- a/.github/workflows/scripts/config.yaml
+++ b/.github/workflows/scripts/config.yaml
@@ -1,5 +1,5 @@
 e2e-singlecard-light:
-- name: tests/e2e/light/single-card/test_qwen3_0_6b.py::test_dense_piecewise_graph
+- name: tests/e2e/light/single-card/test_qwen3_0_6b.py::test_dense_default_full_and_piecewise_graph
   estimated_time: 226
 - name: tests/e2e/light/single-card/test_qwen3_embedding_0_6b.py::test_embedding_full_decode_only
   estimated_time: 170

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ pytest -sv tests/ut/ops/test_prepare_finalize.py
 pytest -sv tests/ut/ops/test_prepare_finalize.py::test_prepare_inputs
 
 # Run NPU-specific tests (requires NPU hardware)
-pytest -sv tests/e2e/singlecard/test_piecewise_res_consistency.py
+pytest -sv tests/e2e/singlecard/test_aclgraph_accuracy.py::test_default_full_and_piecewise_res_consistency
 ```
 
 **Requirement**: Run all tests locally before requesting review. Verify tests pass on NPU hardware for NPU-specific changes.

--- a/docs/source/developer_guide/Design_Documents/ACL_Graph.md
+++ b/docs/source/developer_guide/Design_Documents/ACL_Graph.md
@@ -66,7 +66,6 @@ The communication execution mode also matters. `update_aclgraph_sizes()` uses di
 
 Ascend currently narrows some generic upstream modes in `vllm_ascend.platform.NPUPlatform.check_and_update_config()`.
 
-- `FULL_AND_PIECEWISE` is normalized to `PIECEWISE`.
 - Encoder-decoder models are forced to `PIECEWISE`.
 - `use_inductor` is disabled for ACL graph paths.
 - `ASCEND_LAUNCH_BLOCKING=1` is rejected when ACL graph is enabled.

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -213,7 +213,8 @@ ERROR 09-26 10:48:07 [model_runner_v1.py:3029] ACLgraph has insufficient availab
 Recommended mitigation strategies:
 
 1. Manually configure the compilation_config parameter with a reduced size set: '{"cudagraph_capture_sizes":[size1, size2, size3, ...]}'.
-2. Employ ACLgraph's full graph mode as an alternative to the piecewise approach.
+2. If your workload is mostly uniform decode, employ ACLGraph's `FULL` or `FULL_DECODE_ONLY` mode as an alternative to the piecewise approach.
+3. If you use `PIECEWISE` or `FULL_AND_PIECEWISE`, it is recommended to set `cudagraph_capture_sizes` manually according to your workload.
 
 Root cause analysis:
 The current stream requirement calculation for size captures only accounts for measurable factors including: data parallel size, tensor parallel size, expert parallel configuration, piece graph count, multistream-overlap shared expert settings, and HCCL communication mode (AIV/AICPU). However, numerous unquantifiable elements, such as operator characteristics and specific hardware features, consume additional streams outside of this calculation framework, resulting in stream resource exhaustion during size capture operations.

--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -32,13 +32,15 @@ vLLM Ascend provides two graph paths:
 
 The default graph path on Ascend involves two stages: **compile-time optimization** and **runtime capture/replay**. ACLGraph handles the runtime capture/replay. The compile-time stage differs by `cudagraph_mode`:
 
+- **FULL_AND_PIECEWISE**: Default mode, same as the upstream vLLM strategy. The compile-time path follows PIECEWISE compilation, while the runtime may still use full-graph behavior for uniform decode batches.
 - **FULL / FULL_DECODE_ONLY**: Npugraph_ex optimizes the FX graph via npugraph_ex (`force_eager=True`, compile-time only, no capture). The optimized callable is then captured and replayed by ACLGraph at runtime.
 - **PIECEWISE**: Npugraph_ex is disabled. Only basic FX fusion passes are applied at compile-time. ACLGraph captures and replays the resulting callable at runtime.
 - **NONE**: No compilation or graph capture. The model runs in eager mode.
 
 | `cudagraph_mode` | Compile-time | Runtime | Npugraph_ex |
 |---|---|---|---|
-| FULL / FULL_DECODE_ONLY | Npugraph_ex FX optimization | ACLGraph capture/replay | Enabled (default) |
+| FULL_AND_PIECEWISE | Piecewise compilation path | Mixed: PIECEWISE for mixed batches, FULL-capable for uniform decode batches | Disabled |
+| FULL / FULL_DECODE_ONLY | Npugraph_ex FX optimization | ACLGraph capture/replay | Enabled |
 | PIECEWISE | Fusion pass only | ACLGraph capture/replay | Disabled |
 | NONE | None | Eager execution | Disabled |
 
@@ -252,6 +254,7 @@ For more details about Xlite, see the [Xlite README](https://atomgit.com/openeul
 
 - XliteGraph should be treated as an alternative graph path, not as a drop-in replacement for ACLGraph in all scenarios.
 - Model and backend coverage is still evolving, so a configuration that works for one model family may not yet be recommended for another.
+- Encoder-decoder models currently do not keep `FULL_AND_PIECEWISE`; on Ascend they fall back to `PIECEWISE` or `NONE` depending on compilation support.
 
 ## Fallback to Eager Mode
 

--- a/tests/e2e/light/coverage.md
+++ b/tests/e2e/light/coverage.md
@@ -13,7 +13,7 @@ The coverage of e2e light is as follows:
 | EP                   | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
 | EPLB                 | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Full Graph           | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| PIECEWISE Graph      | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Default FULL_AND_PIECEWISE Graph | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | PD disaggregation    | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | W8A8                 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | MTP                  | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |

--- a/tests/e2e/light/single-card/test_qwen3_0_6b.py
+++ b/tests/e2e/light/single-card/test_qwen3_0_6b.py
@@ -21,8 +21,8 @@ from tests.e2e.singlecard.utils import PROMPTS_SHORT, compare_logprobs
 
 
 @wait_until_npu_memory_free()
-def test_dense_piecewise_graph():
-    """Verify dense generation on the piecewise graph path."""
+def test_dense_default_full_and_piecewise_graph():
+    """Verify dense generation on the default FULL_AND_PIECEWISE graph path."""
     runner_kwargs = {
         "model_name": "Qwen/Qwen3-0.6B",
         "max_model_len": 1024,

--- a/tests/e2e/multicard/2-cards/test_llama32_lora_tp2.py
+++ b/tests/e2e/multicard/2-cards/test_llama32_lora_tp2.py
@@ -24,6 +24,7 @@ def test_llama_lora_tp2(llama32_lora_files, fully_sharded_loras):
         max_loras=4,
         tensor_parallel_size=2,
         fully_sharded_loras=fully_sharded_loras,
+        compilation_config={"cudagraph_mode": "PIECEWISE"},
     ) as vllm_model:
         llm = vllm_model.model
         generate_and_test(llm, llama32_lora_files)

--- a/tests/e2e/multicard/4-cards/long_sequence/test_chunked_prefill_cp.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_chunked_prefill_cp.py
@@ -166,7 +166,7 @@ def test_models_chunked_prefill_with_cp_basic(model: str, max_tokens: int) -> No
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [2])
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "768"})
-def test_models_chunked_prefill_with_cp_piecewise(model: str, max_tokens: int) -> None:
+def test_models_chunked_prefill_with_cp_default_full_and_piecewise(model: str, max_tokens: int) -> None:
     with VllmRunner(
         model,
         block_size=128,

--- a/tests/e2e/multicard/4-cards/long_sequence/test_prefix_caching_cp.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_prefix_caching_cp.py
@@ -81,7 +81,9 @@ def test_models_prefix_cache_with_cp_basic(model: str, max_tokens: int, monkeypa
 
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [2])
-def test_models_prefix_cache_with_cp_piecewise(model: str, max_tokens: int, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_models_prefix_cache_with_cp_default_full_and_piecewise(
+    model: str, max_tokens: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("HCCL_BUFFSIZE", "768")
     with VllmRunner(
         model,

--- a/tests/e2e/multicard/4-cards/test_pipeline_parallel.py
+++ b/tests/e2e/multicard/4-cards/test_pipeline_parallel.py
@@ -102,7 +102,10 @@ def test_models_pp2_tp2(model: str, tp_size: int, pp_size: int, distributed_exec
         model,
         tensor_parallel_size=tp_size,
         pipeline_parallel_size=pp_size,
-        cudagraph_capture_sizes=[1, 2, 4],
+        compilation_config={
+            "cudagraph_mode": "PIECEWISE",
+            "cudagraph_capture_sizes": [1, 2, 4],
+        },
         distributed_executor_backend=distributed_executor_backend,
         gpu_memory_utilization=0.7,
         enable_expert_parallel=model in MOE_MODELS,
@@ -126,7 +129,10 @@ def test_models_pp2_dp2(model: str, dp_size: int, pp_size: int, distributed_exec
         model,
         data_parallel_size=dp_size,
         pipeline_parallel_size=pp_size,
-        cudagraph_capture_sizes=[1, 2, 4],
+        compilation_config={
+            "cudagraph_mode": "PIECEWISE",
+            "cudagraph_capture_sizes": [1, 2, 4],
+        },
         distributed_executor_backend=distributed_executor_backend,
         gpu_memory_utilization=0.7,
         enable_expert_parallel=model in MOE_MODELS,

--- a/tests/e2e/singlecard/model_runner_v2/test_basic.py
+++ b/tests/e2e/singlecard/model_runner_v2/test_basic.py
@@ -71,7 +71,14 @@ def test_qwen3_dense_eager_mode(
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [False])
 @pytest.mark.parametrize(
-    "compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]}, {}]
+    "compilation_config",
+    [
+        pytest.param(
+            {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]},
+            id="full_decode_only",
+        ),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
 )
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 def test_egale_spec_decoding(
@@ -108,7 +115,13 @@ def test_egale_spec_decoding(
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [False])
-@pytest.mark.parametrize("compilation_config", [{"cudagraph_mode": "FULL_DECODE_ONLY"}, {}])
+@pytest.mark.parametrize(
+    "compilation_config",
+    [
+        pytest.param({"cudagraph_mode": "FULL_DECODE_ONLY"}, id="full_decode_only"),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
+)
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 def test_qwen3_dense_graph_mode(
     model: str,

--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -157,7 +157,10 @@ def test_ngram_npu_async_acceptance(
         "num_speculative_tokens": num_speculative_tokens,
     }
 
-    compilation_config = CompilationConfig(cudagraph_capture_sizes=[12])
+    compilation_config = CompilationConfig(
+        cudagraph_mode="PIECEWISE",
+        cudagraph_capture_sizes=[12],
+    )
 
     with VllmRunner(
         model_name,
@@ -431,7 +434,10 @@ def test_parallel_drafting_acceptance(
         "parallel_drafting": True,
     }
 
-    compilation_config = CompilationConfig(cudagraph_capture_sizes=[12])
+    compilation_config = CompilationConfig(
+        cudagraph_mode="PIECEWISE",
+        cudagraph_capture_sizes=[12],
+    )
 
     with VllmRunner(
         main_model_name,

--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -248,7 +248,10 @@ def test_suffix_acceptance(
             "num_speculative_tokens": 10,
         },
         max_model_len=1024,
-        cudagraph_capture_sizes=[1, 2, 4, 8],
+        compilation_config={
+            "cudagraph_mode": "PIECEWISE",
+            "cudagraph_capture_sizes": [1, 2, 4, 8],
+        },
         disable_log_stats=False,
     ) as runner:
         for i in range(10):

--- a/tests/e2e/singlecard/test_aclgraph_accuracy.py
+++ b/tests/e2e/singlecard/test_aclgraph_accuracy.py
@@ -77,7 +77,7 @@ CASE_DS_EX = LLMTestCase(
 
 @wait_until_npu_memory_free(0.7)
 @pytest.mark.parametrize("cur_case", [CASE_QWEN_ACLGRAPH, CASE_DS_ACLGRAPH])
-def test_piecewise_res_consistency(cur_case: LLMTestCase):
+def test_default_full_and_piecewise_res_consistency(cur_case: LLMTestCase):
     runner_kwargs = {
         "model_name": cur_case.model,
         "max_model_len": 1024,

--- a/tests/e2e/singlecard/test_aclgraph_mem.py
+++ b/tests/e2e/singlecard/test_aclgraph_mem.py
@@ -63,9 +63,17 @@ def test_aclgraph_mem_use(model: str, max_tokens: int) -> None:
         ]
         sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
         if model == "vllm-ascend/DeepSeek-V2-Lite-W8A8":
-            vllm_model = VllmRunner(model, max_model_len=1024, quantization="ascend")
+            vllm_model = VllmRunner(
+                model,
+                max_model_len=1024,
+                quantization="ascend",
+                compilation_config={"cudagraph_mode": "PIECEWISE"},
+            )
         else:
-            vllm_model = VllmRunner(model)
+            vllm_model = VllmRunner(
+                model,
+                compilation_config={"cudagraph_mode": "PIECEWISE"},
+            )
         _ = vllm_model.generate(prompts, sampling_params)
 
     assert capture_called.value == 1, "capture_model was not called during test"

--- a/tests/e2e/singlecard/test_guided_decoding.py
+++ b/tests/e2e/singlecard/test_guided_decoding.py
@@ -89,7 +89,7 @@ def test_guided_json_completion(guided_decoding_backend: str, sample_json_schema
         "seed": 0,
         "structured_outputs_config": {"backend": guided_decoding_backend},
     }
-    with VllmRunner(MODEL_NAME, **runner_kwargs) as vllm_model:
+    with VllmRunner(MODEL_NAME, compilation_config={"cudagraph_mode": "PIECEWISE"}, **runner_kwargs) as vllm_model:
         prompts = [f"Give an example JSON for an employee profile that fits this schema: {sample_json_schema}"] * 2
         inputs = vllm_model.get_inputs(prompts)
         outputs = vllm_model.model.generate(inputs, sampling_params=sampling_params)

--- a/tests/e2e/singlecard/test_llama32_lora.py
+++ b/tests/e2e/singlecard/test_llama32_lora.py
@@ -134,6 +134,7 @@ def test_llama_lora(llama32_lora_files):
         max_num_seqs=7,
         max_model_len=1024,
         max_loras=4,
+        compilation_config={"cudagraph_mode": "PIECEWISE"},
     )
     llm = vllm_model.model
     generate_and_test(llm, llama32_lora_files)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -33,7 +33,8 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_config import init_ascend_config
 
 # isort: off
 from vllm_ascend.utils import (
@@ -375,10 +376,6 @@ class NPUPlatform(Platform):
                 compilation_config.cudagraph_capture_sizes = sp_aclgraph_sizes
                 update_cudagraph_capture_sizes(vllm_config, sp_aclgraph_sizes)
 
-        # TODO: Full graph is fully supported later, and the default value will be set to full graph.
-        if compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
-            compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
-
         # Encoder-decoder models currently only support PIECEWISE mode
         # TODO(Jian Li): Confirm this behavior and explain why
         if (
@@ -401,11 +398,35 @@ class NPUPlatform(Platform):
         # get custom compile backend for graph fusion
         compilation_config.oot_compiler = cls.get_compile_backend()
 
+        piecewise_modes = {
+            CUDAGraphMode.PIECEWISE,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        }
+        full_graph_modes = {
+            CUDAGraphMode.FULL,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        }
+        full_graph_warning_message = """\033[91m
+            **********************************************************************************
+            * WARNING: You have enabled the *full graph* feature.
+            * This is an early experimental stage and may involve various unknown issues.
+            * A known problem is that capturing too many batch sizes can lead to OOM
+            * (Out of Memory) errors or inference hangs. If you encounter such issues,
+            * consider reducing `gpu_memory_utilization` or manually specifying a smaller
+            * batch size for graph capture.
+            * For more details, please refer to:
+            * https://docs.vllm.ai/en/stable/configuration/conserving_memory.html#reduce-cuda-graphs
+            **********************************************************************************\033[0m
+            """
+
         if compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
             compilation_config.mode = CompilationMode.NONE
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
-        elif compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE:
-            logger.info("PIECEWISE compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode")
+        elif compilation_config.cudagraph_mode in piecewise_modes:
+            logger.info(
+                "%s compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode",
+                compilation_config.cudagraph_mode,
+            )
             assert compilation_config.mode == CompilationMode.VLLM_COMPILE, (
                 "When enabling VLLM_COMPILE aclgraph, please make sure compilation_config.mode == "
                 "CompilationMode.VLLM_COMPILE and compilation_config.cudagraph_mode == CUDAGraphMode.VLLM_COMPILE"
@@ -421,31 +442,18 @@ class NPUPlatform(Platform):
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
             # If splitting ops does not contain the vllm::mla forward value, this configuration issue will
             # not be detected in advance assert.
-            compilation_config.splitting_ops.extend(["vllm::mla_forward"])
+            if "vllm::mla_forward" not in compilation_config.splitting_ops:
+                compilation_config.splitting_ops.append("vllm::mla_forward")
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
-        elif (
-            compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
-            or compilation_config.cudagraph_mode == CUDAGraphMode.FULL
-        ):
-            logger.info(
-                "FULL_DECODE_ONLY compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode"
-            )
+            if compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
+                logger.info("FULL_AND_PIECEWISE enabled on NPU: mixed batches use PIECEWISE, decode batches use FULL.")
+                logger.warning(full_graph_warning_message)
+        elif compilation_config.cudagraph_mode in full_graph_modes:
+            logger.info("Full graph compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode")
             compilation_config.use_inductor = False
             compilation_config.splitting_ops = []
-            warning_message = """\033[91m
-            **********************************************************************************
-            * WARNING: You have enabled the *full graph* feature.
-            * This is an early experimental stage and may involve various unknown issues.
-            * A known problem is that capturing too many batch sizes can lead to OOM
-            * (Out of Memory) errors or inference hangs. If you encounter such issues,
-            * consider reducing `gpu_memory_utilization` or manually specifying a smaller
-            * batch size for graph capture.
-            * For more details, please refer to:
-            * https://docs.vllm.ai/en/stable/configuration/conserving_memory.html#reduce-cuda-graphs
-            **********************************************************************************\033[0m
-            """
-            logger.warning(warning_message)
+            logger.warning(full_graph_warning_message)
         else:
             logger.info(
                 "%s cudagraph_mode is not support on NPU. falling back to NONE", compilation_config.cudagraph_mode
@@ -486,12 +494,12 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
-        if ascend_config.enable_balance_scheduling:
+        if envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is not None and kv_role != "kv_both":
                 raise ValueError(
-                    "enable_balance_scheduling only supports PD-mixed mode "
+                    "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) only supports PD-mixed mode "
                     "(kv_role='kv_both' or no kv_transfer_config), and is not supported in "
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
@@ -580,7 +588,7 @@ class NPUPlatform(Platform):
             os.environ["PYTORCH_NPU_ALLOC_CONF"] = npu_alloc_configs
             logger.info("Set PYTORCH_NPU_ALLOC_CONF=%s", npu_alloc_configs)
 
-        if ascend_config.enable_mc2_hierarchy_comm and get_ascend_config().enable_fused_mc2:
+        if ascend_config.enable_mc2_hierarchy_comm and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2:
             raise ValueError(
                 "fused mc2 op cannot be used with hierarchy communication."
                 "Please disable VLLM_ASCEND_ENABLE_FUSED_MC2 by setting it to 0."

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -33,8 +33,7 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-import vllm_ascend.envs as envs_ascend
-from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
 # isort: off
 from vllm_ascend.utils import (
@@ -398,62 +397,35 @@ class NPUPlatform(Platform):
         # get custom compile backend for graph fusion
         compilation_config.oot_compiler = cls.get_compile_backend()
 
-        piecewise_modes = {
-            CUDAGraphMode.PIECEWISE,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-        }
-        full_graph_modes = {
-            CUDAGraphMode.FULL,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-        }
-        full_graph_warning_message = """\033[91m
-            **********************************************************************************
-            * WARNING: You have enabled the *full graph* feature.
-            * This is an early experimental stage and may involve various unknown issues.
-            * A known problem is that capturing too many batch sizes can lead to OOM
-            * (Out of Memory) errors or inference hangs. If you encounter such issues,
-            * consider reducing `gpu_memory_utilization` or manually specifying a smaller
-            * batch size for graph capture.
-            * For more details, please refer to:
-            * https://docs.vllm.ai/en/stable/configuration/conserving_memory.html#reduce-cuda-graphs
-            **********************************************************************************\033[0m
-            """
-
+        compilation_config.use_inductor = False
         if compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
             compilation_config.mode = CompilationMode.NONE
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
-        elif compilation_config.cudagraph_mode in piecewise_modes:
-            logger.info(
-                "%s compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode",
-                compilation_config.cudagraph_mode,
-            )
+        elif compilation_config.cudagraph_mode.requires_piecewise_compilation():
+            # Our is_cuda_alike is False so we cannot reuse the assertion of upstream
             assert compilation_config.mode == CompilationMode.VLLM_COMPILE, (
-                "When enabling VLLM_COMPILE aclgraph, please make sure compilation_config.mode == "
-                "CompilationMode.VLLM_COMPILE and compilation_config.cudagraph_mode == CUDAGraphMode.VLLM_COMPILE"
+                "Compilation mode should be CompilationMode.VLLM_COMPILE "
+                "when cudagraph_mode piecewise cudagraphs is used, "
+                "cudagraph_mode=%s",
+                compilation_config.cudagraph_mode,
             )
             compilation_config.set_splitting_ops_for_v1(
                 all2all_backend=vllm_config.parallel_config.all2all_backend,
                 data_parallel_size=vllm_config.parallel_config.data_parallel_size,
             )
-            compilation_config.use_inductor = False
             # NOTE: Theoretically, we should also add vllm::mla_forward in the attention ops.
             # Since the process is created in the spawn mode, the value of the class attribute
             # attention ops transmitted is still the one before modification, so it has not been modified.
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
             # If splitting ops does not contain the vllm::mla forward value, this configuration issue will
             # not be detected in advance assert.
-            if "vllm::mla_forward" not in compilation_config.splitting_ops:
-                compilation_config.splitting_ops.append("vllm::mla_forward")
+            compilation_config.splitting_ops.extend(["vllm::mla_forward"])
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
-            if compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
-                logger.info("FULL_AND_PIECEWISE enabled on NPU: mixed batches use PIECEWISE, decode batches use FULL.")
-                logger.warning(full_graph_warning_message)
-        elif compilation_config.cudagraph_mode in full_graph_modes:
-            logger.info("Full graph compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode")
-            compilation_config.use_inductor = False
+        elif compilation_config.cudagraph_mode.has_full_cudagraphs():
+            # We don't want to have our FX graph split for the sake of static kernel feature,
+            # because it will compile multiple times, so we set splitting_ops to empty manually.
             compilation_config.splitting_ops = []
-            logger.warning(full_graph_warning_message)
         else:
             logger.info(
                 "%s cudagraph_mode is not support on NPU. falling back to NONE", compilation_config.cudagraph_mode
@@ -494,12 +466,12 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
-        if envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING:
+        if ascend_config.enable_balance_scheduling:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is not None and kv_role != "kv_both":
                 raise ValueError(
-                    "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) only supports PD-mixed mode "
+                    "enable_balance_scheduling only supports PD-mixed mode "
                     "(kv_role='kv_both' or no kv_transfer_config), and is not supported in "
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
@@ -588,7 +560,7 @@ class NPUPlatform(Platform):
             os.environ["PYTORCH_NPU_ALLOC_CONF"] = npu_alloc_configs
             logger.info("Set PYTORCH_NPU_ALLOC_CONF=%s", npu_alloc_configs)
 
-        if ascend_config.enable_mc2_hierarchy_comm and envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2:
+        if ascend_config.enable_mc2_hierarchy_comm and get_ascend_config().enable_fused_mc2:
             raise ValueError(
                 "fused mc2 op cannot be used with hierarchy communication."
                 "Please disable VLLM_ASCEND_ENABLE_FUSED_MC2 by setting it to 0."

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -108,6 +108,15 @@ def get_dsv4_compress_ratio(config: Any, layer_idx: int) -> int:
     return compress_ratios[layer_idx]
 
 
+def clear_enable_sp():
+    global _ENABLE_SP
+    _ENABLE_SP = None
+    enable_dsa_cp.cache_clear()
+    enable_dsa_cp_with_layer_shard.cache_clear()
+    enable_dsa_cp_with_o_proj_tp.cache_clear()
+    _libc_getenv.cache_clear()
+
+
 def is_310p():
     return get_ascend_device_type() == AscendDeviceType._310P
 
@@ -200,13 +209,17 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if is_310p():
         return True
 
-    # NZ is disabled on non-310P.
-    if not envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+    # Get config value instead of env
+    config = get_ascend_config()
+    nz_mode = config.weight_nz_mode
+
+    # NZ is disabled when mode is 0.
+    if not nz_mode:
         return False
 
-    # BF16/FP16 convert only when enable_nz == 2.
+    # BF16/FP16 convert only when nz_mode == 2.
     if weight.dtype in {torch.bfloat16, torch.float16}:
-        return envs_ascend.VLLM_ASCEND_ENABLE_NZ == 2
+        return nz_mode == 2
 
     # Quantized or other supported dtypes convert by default.
     return True
@@ -558,7 +571,6 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
     # the number of streams, which is 2048, we save 248 streams
     # as a buffer.
     # Maximum number of graphs that can be captured by ACL Graph
-    # TODO: Find out whether we need to solve allreduce function
     MAX_CAPTURE_SIZE = 1800
 
     # enable pcp or dcp will add new communication and consume additional approximately less than 100 streams
@@ -567,8 +579,13 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
     # Store original configuration and temporarily clear it
     compilation_config = vllm_config.compilation_config
     original_sizes, compilation_config.cudagraph_capture_sizes = compilation_config.cudagraph_capture_sizes, None
+
+    # TODO: Find out if we can have different sizes for mixed batch and uniform batch
+    # If so, we'll only have to reduce the sizes for mixed batch
+    from vllm.config.compilation import CUDAGraphMode
+
     cudagraph_mode = compilation_config.cudagraph_mode
-    if cudagraph_mode.has_full_cudagraphs() and cudagraph_mode.has_piecewise_cudagraphs():
+    if cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
         MAX_CAPTURE_SIZE = max(0, MAX_CAPTURE_SIZE - len(original_sizes))
 
     # Calculate parallel configuration factor
@@ -579,6 +596,7 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
         )
 
         return
+
     hf_config = vllm_config.model_config.hf_text_config
     if hasattr(hf_config, "num_hidden_layers"):
         num_hidden_layers = hf_config.num_hidden_layers
@@ -875,7 +893,7 @@ def mlp_tp_enable() -> bool:
 
 
 def matmul_allreduce_enable() -> bool:
-    return envs_ascend.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE
+    return get_ascend_config().enable_matmul_allreduce
 
 
 def enable_sp_by_pass():
@@ -884,23 +902,31 @@ def enable_sp_by_pass():
 
 def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
     global _ENABLE_SP
-    if _ENABLE_SP is None:
-        if vllm_config is None:
+    if vllm_config is None:
+        try:
             from vllm.config import get_current_vllm_config
 
             vllm_config = get_current_vllm_config()
-        _ENABLE_SP = (
-            envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
-            # Flash comm 1 should be enabled by env VLLM_ASCEND_ENABLE_FLASHCOMM1
-            # We retain the env VLLM_ASCEND_ENABLE_FLASHCOMM here for backward compatibility.
-            or bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM", "0")))
-        )
+        except AssertionError:
+            vllm_config = None
+
+    additional_config = getattr(vllm_config, "additional_config", None) if vllm_config is not None else None
+    refresh = additional_config.get("refresh", False) if additional_config else False
+
+    if _ENABLE_SP is None or refresh:
+        if additional_config is not None and "enable_flashcomm1" in additional_config:
+            _ENABLE_SP = bool(additional_config["enable_flashcomm1"])
+        else:
+            try:
+                _ENABLE_SP = get_ascend_config().enable_flashcomm1
+            except RuntimeError:
+                _ENABLE_SP = envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
 
         if not _ENABLE_SP and enable_shared_expert_dp:
             _ENABLE_SP = True
             logger.info("shared_expert_dp requires enable_sp = True. has set enable_sp to True")
 
-    return _ENABLE_SP
+    return bool(_ENABLE_SP)
 
 
 # TODO remove it after vllm has this func
@@ -909,7 +935,7 @@ def shared_expert_dp_enabled() -> bool:
 
 
 def prefill_context_parallel_enable() -> bool:
-    return envs_ascend.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL
+    return get_ascend_config().enable_context_parallel
 
 
 def is_moe_model(vllm_config: VllmConfig):
@@ -1193,7 +1219,8 @@ def has_layer_idx(model_instance: torch.nn.Module) -> bool:
 
 
 def flashcomm2_enable() -> bool:
-    return envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE > 0
+    config_val = get_ascend_config().enable_flashcomm2_parallel_size
+    return config_val > 0
 
 
 def o_shard_enable() -> bool:
@@ -1204,10 +1231,10 @@ def o_shard_enable() -> bool:
 
 
 def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
-    flashcomm2_oproj_tp_size = envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE
+    flashcomm2_oproj_tp_size = ascend_config.enable_flashcomm2_parallel_size
     global_tp_size = vllm_config.parallel_config.tensor_parallel_size
 
-    if not flashcomm2_enable():
+    if ascend_config.enable_flashcomm2_parallel_size <= 0:
         return 0
 
     logger.info("Enable FLASHCOMM2 with flashcomm2_oproj_tensor_parallel_size = %s", flashcomm2_oproj_tp_size)
@@ -1221,7 +1248,7 @@ def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
                 "FLASHCOMM2 only supports 'o_proj' as the sole layer sharding configuration! "
                 f"Found invalid layer_sharding: {layer_sharding}"
             )
-    if not envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1:
+    if not ascend_config.enable_flashcomm1:
         logger.warning_once(
             "It is recommended to enable FLASHCOMM1 simultaneously when starting FLASHCOMM2 for optimal performance."
         )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -108,15 +108,6 @@ def get_dsv4_compress_ratio(config: Any, layer_idx: int) -> int:
     return compress_ratios[layer_idx]
 
 
-def clear_enable_sp():
-    global _ENABLE_SP
-    _ENABLE_SP = None
-    enable_dsa_cp.cache_clear()
-    enable_dsa_cp_with_layer_shard.cache_clear()
-    enable_dsa_cp_with_o_proj_tp.cache_clear()
-    _libc_getenv.cache_clear()
-
-
 def is_310p():
     return get_ascend_device_type() == AscendDeviceType._310P
 
@@ -209,17 +200,13 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if is_310p():
         return True
 
-    # Get config value instead of env
-    config = get_ascend_config()
-    nz_mode = config.weight_nz_mode
-
-    # NZ is disabled when mode is 0.
-    if not nz_mode:
+    # NZ is disabled on non-310P.
+    if not envs_ascend.VLLM_ASCEND_ENABLE_NZ:
         return False
 
-    # BF16/FP16 convert only when nz_mode == 2.
+    # BF16/FP16 convert only when enable_nz == 2.
     if weight.dtype in {torch.bfloat16, torch.float16}:
-        return nz_mode == 2
+        return envs_ascend.VLLM_ASCEND_ENABLE_NZ == 2
 
     # Quantized or other supported dtypes convert by default.
     return True
@@ -580,6 +567,9 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
     # Store original configuration and temporarily clear it
     compilation_config = vllm_config.compilation_config
     original_sizes, compilation_config.cudagraph_capture_sizes = compilation_config.cudagraph_capture_sizes, None
+    cudagraph_mode = compilation_config.cudagraph_mode
+    if cudagraph_mode.has_full_cudagraphs() and cudagraph_mode.has_piecewise_cudagraphs():
+        MAX_CAPTURE_SIZE = max(0, MAX_CAPTURE_SIZE - len(original_sizes))
 
     # Calculate parallel configuration factor
     if not vllm_config.model_config:
@@ -670,13 +660,14 @@ def update_aclgraph_sizes(vllm_config: VllmConfig) -> None:
     # If original sizes exceed maximum, sample a representative subset
     if max_num_batch_sizes < len(original_sizes):
         # Sample uniformly from original sizes
-        step = (len(original_sizes) - 1) / (max_num_batch_sizes - 1)
-        indices = [round(i * step) for i in range(max_num_batch_sizes)]
-
-        # Ensure first and last elements are preserved
-        indices[0], indices[-1] = 0, len(original_sizes) - 1
-
-        sampled_sizes = [original_sizes[i] for i in indices]
+        if max_num_batch_sizes <= 1:
+            # Avoid division by zero when only one capture size can be kept.
+            sampled_sizes = [original_sizes[-1]]
+        else:
+            step = (len(original_sizes) - 1) / (max_num_batch_sizes - 1)
+            indices = [round(i * step) for i in range(max_num_batch_sizes)]
+            indices[0], indices[-1] = 0, len(original_sizes) - 1
+            sampled_sizes = [original_sizes[i] for i in indices]
         update_cudagraph_capture_sizes(vllm_config, sampled_sizes)
         logger.info(
             "Adjusted ACL graph batch sizes for %s model (layers: %d): %d → %d sizes",
@@ -884,7 +875,7 @@ def mlp_tp_enable() -> bool:
 
 
 def matmul_allreduce_enable() -> bool:
-    return get_ascend_config().enable_matmul_allreduce
+    return envs_ascend.VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE
 
 
 def enable_sp_by_pass():
@@ -893,31 +884,23 @@ def enable_sp_by_pass():
 
 def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
     global _ENABLE_SP
-    if vllm_config is None:
-        try:
+    if _ENABLE_SP is None:
+        if vllm_config is None:
             from vllm.config import get_current_vllm_config
 
             vllm_config = get_current_vllm_config()
-        except AssertionError:
-            vllm_config = None
-
-    additional_config = getattr(vllm_config, "additional_config", None) if vllm_config is not None else None
-    refresh = additional_config.get("refresh", False) if additional_config else False
-
-    if _ENABLE_SP is None or refresh:
-        if additional_config is not None and "enable_flashcomm1" in additional_config:
-            _ENABLE_SP = bool(additional_config["enable_flashcomm1"])
-        else:
-            try:
-                _ENABLE_SP = get_ascend_config().enable_flashcomm1
-            except RuntimeError:
-                _ENABLE_SP = envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
+        _ENABLE_SP = (
+            envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
+            # Flash comm 1 should be enabled by env VLLM_ASCEND_ENABLE_FLASHCOMM1
+            # We retain the env VLLM_ASCEND_ENABLE_FLASHCOMM here for backward compatibility.
+            or bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM", "0")))
+        )
 
         if not _ENABLE_SP and enable_shared_expert_dp:
             _ENABLE_SP = True
             logger.info("shared_expert_dp requires enable_sp = True. has set enable_sp to True")
 
-    return bool(_ENABLE_SP)
+    return _ENABLE_SP
 
 
 # TODO remove it after vllm has this func
@@ -926,7 +909,7 @@ def shared_expert_dp_enabled() -> bool:
 
 
 def prefill_context_parallel_enable() -> bool:
-    return get_ascend_config().enable_context_parallel
+    return envs_ascend.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL
 
 
 def is_moe_model(vllm_config: VllmConfig):
@@ -1210,8 +1193,7 @@ def has_layer_idx(model_instance: torch.nn.Module) -> bool:
 
 
 def flashcomm2_enable() -> bool:
-    config_val = get_ascend_config().enable_flashcomm2_parallel_size
-    return config_val > 0
+    return envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE > 0
 
 
 def o_shard_enable() -> bool:
@@ -1222,10 +1204,10 @@ def o_shard_enable() -> bool:
 
 
 def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
-    flashcomm2_oproj_tp_size = ascend_config.enable_flashcomm2_parallel_size
+    flashcomm2_oproj_tp_size = envs_ascend.VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE
     global_tp_size = vllm_config.parallel_config.tensor_parallel_size
 
-    if ascend_config.enable_flashcomm2_parallel_size <= 0:
+    if not flashcomm2_enable():
         return 0
 
     logger.info("Enable FLASHCOMM2 with flashcomm2_oproj_tensor_parallel_size = %s", flashcomm2_oproj_tp_size)
@@ -1239,7 +1221,7 @@ def get_flashcomm2_config_and_validate(ascend_config, vllm_config):
                 "FLASHCOMM2 only supports 'o_proj' as the sole layer sharding configuration! "
                 f"Found invalid layer_sharding: {layer_sharding}"
             )
-    if not ascend_config.enable_flashcomm1:
+    if not envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1:
         logger.warning_once(
             "It is recommended to enable FLASHCOMM1 simultaneously when starting FLASHCOMM2 for optimal performance."
         )


### PR DESCRIPTION
### What this PR does / why we need it?
This is the initial support of `FULL_AND_PIECEWISE` and there are several issues remain to be resolved:
1. Mixed batch and uniform batch should have seperated sizes for capturint;
2. The logics of `update_aclgraph_sizes` is getting more and more complicated and requires an overhaul.

### Does this PR introduce _any_ user-facing change?
Yes, the default graph mode is changed to `FULL_AND_PIECEWISE` which aligns to upstream defaults.

### How was this patch tested?
With existed test cases.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
