### PR TITLE
[BugFix] Correct prompt_tokens_details in layerwise proxy server

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -359,7 +359,7 @@ async def send_request_to_service(
                 proxy_state.prefill_usage_dict[request_id] = response_json["usage"]
             if request_id in proxy_state.req_id_future:
                 result_future = proxy_state.req_id_future[request_id]
-                result_future.set_result(response.json()["kv_transfer_params"])
+                result_future.set_result(response_json["kv_transfer_params"])
             return
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -501,12 +501,12 @@ async def _handle_completions(api: str, request: Request):
                         choices = chunk_json.get("choices", [])
                         decode_usage = chunk_json.get("usage", {})
                         if decode_usage: 
-                            prefill_usage = proxy_state.prefill_usage_dict.pop(request_id)
+                            prefill_usage = proxy_state.prefill_usage_dict.pop(request_id, None)
                             if prefill_usage:
-                                prompt_tokens = decode_usage.get("prompt_tokens", 0) #or prefill ģ 
+                                prompt_tokens = decode_usage.get("prompt_tokens", 0)
                                 completion_tokens = decode_usage.get("completion_tokens", 0)
-                                total_tokens = decode_usage.get("total_tokens", 0) # or prompt_tokens+completion_tokens?
-                                prompt_tokens_details = prefill_usage.get("prompt_tokens_details", {}) # "prefill_usage.get("prompt_tokens_details", {})"
+                                total_tokens = decode_usage.get("total_tokens", 0)
+                                prompt_tokens_details = prefill_usage.get("prompt_tokens_details", {})
                                 completion_tokens_details = decode_usage.get("completion_tokens_details", {})
                                 merged_usage = {
                                     "prompt_tokens": prompt_tokens,

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py
@@ -153,6 +153,7 @@ class ProxyState:
         heapq.heapify(self.decoder_heap)
         self.req_id_future = {}
         self.req_data_dict = {}
+        self.prefill_usage_dict = {}
 
     def _update_prefiller_priority(self, server_idx: int):
         """Update the priority of a prefiller server in the heap."""
@@ -353,6 +354,9 @@ async def send_request_to_service(
         try:
             response = await client.post(endpoint, json=req_data, headers=headers)
             response.raise_for_status()
+            response_json = response.json()
+            if "usage" in response_json:
+                proxy_state.prefill_usage_dict[request_id] = response_json["usage"]
             if request_id in proxy_state.req_id_future:
                 result_future = proxy_state.req_id_future[request_id]
                 result_future.set_result(response.json()["kv_transfer_params"])
@@ -495,6 +499,23 @@ async def _handle_completions(api: str, request: Request):
                             yield chunk
                             continue
                         choices = chunk_json.get("choices", [])
+                        decode_usage = chunk_json.get("usage", {})
+                        if decode_usage: 
+                            prefill_usage = proxy_state.prefill_usage_dict.pop(request_id)
+                            if prefill_usage:
+                                prompt_tokens = decode_usage.get("prompt_tokens", 0) #or prefill ģ 
+                                completion_tokens = decode_usage.get("completion_tokens", 0)
+                                total_tokens = decode_usage.get("total_tokens", 0) # or prompt_tokens+completion_tokens?
+                                prompt_tokens_details = prefill_usage.get("prompt_tokens_details", {}) # "prefill_usage.get("prompt_tokens_details", {})"
+                                completion_tokens_details = decode_usage.get("completion_tokens_details", {})
+                                merged_usage = {
+                                    "prompt_tokens": prompt_tokens,
+                                    "total_tokens": total_tokens,
+                                    "completion_tokens": completion_tokens,
+                                    "prompt_tokens_details": prompt_tokens_details,
+                                    "completion_tokens_details": completion_tokens_details}
+                                chunk_json["usage"] = merged_usage
+                                chunk = f"data: {json.dumps(chunk_json, ensure_ascii=False)}\n\n".encode("utf-8")
                         if not choices:
                             yield chunk
                             continue


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes an issue where the final usage returned from the last chunk of the Decoder is inaccurate (specifically cached_tokens in prompt_tokens_details) when using the disaggregated prefill proxy. It ensures that the precise prompt_tokens_details generated from the Prefill response is preserved and merged into the final decoder response usage.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
