### PR TITLE
[Feature] vllm-ascend sleep mode optimization for residual memory usage

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -80,6 +80,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `multistream_overlap_gate`          | bool | `False` | Whether to enable multi-stream overlap gate. This option only takes effect on MoE models with shared experts.  |
 | `recompute_scheduler_enable`        | bool | `False` | Whether to enable the recompute scheduler. **Only valid in PD-disaggregated mode** (`kv_role` is `kv_producer` or `kv_consumer`). **Do not enable in PD-mixed mode** (no `kv_transfer_config`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
+| `enable_sleep_mode_extra_cleanup`   | bool | `False` | Enables extra sleep-mode cleanup for RL workloads, including HCCL process-group release and ACL graph workspace cleanup. Disabled by default because wakeup may need to restore HCCL and recapture ACL graphs. |
 | `SLO_limits_for_dynamic_batch`      | int  | `-1`    | SLO limits for dynamic batch. This is new scheduler to support dynamic batch feature                            |
 | `enable_npugraph_ex`                | bool | `False` | Whether to enable npugraph_ex graph mode.                                                                 |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |

--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -25,6 +25,48 @@ The engine (v0/v1) supports two sleep levels to manage memory during idle period
 
 Since this feature uses the low-level API [AscendCL](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/82RC1alpha002/API/appdevgapi/appdevgapi_07_0000.html), in order to use sleep mode, you should follow the [installation guide](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) and build from source. If you are using < v0.12.0rc1, remember to set `export COMPILE_CUSTOM_KERNELS=1`.
 
+## Optional extra cleanup
+
+By default, sleep mode only releases memory managed by the sleep-mode allocator. For RL workloads that need to return more NPU memory to the trainer, vLLM Ascend also provides an optional extra cleanup path:
+
+```python
+llm = LLM(
+    "Qwen/Qwen2.5-0.5B-Instruct",
+    enable_sleep_mode=True,
+    additional_config={"enable_sleep_mode_extra_cleanup": True},
+)
+```
+
+For online serving, pass the same option through `--additional-config`:
+
+```bash
+vllm serve Qwen/Qwen2.5-0.5B-Instruct \
+    --enable-sleep-mode \
+    --additional-config '{"enable_sleep_mode_extra_cleanup": true}'
+```
+
+When `enable_sleep_mode_extra_cleanup` is enabled, `sleep()` additionally:
+
+- clears ACL graph attention workspaces and invalidates captured ACL graph caches when ACL graph is enabled;
+- resets the model runner graph manager so ACL graphs can be captured again after wakeup;
+- waits for pending pipeline-parallel send work, synchronizes the NPU, and destroys HCCL process groups.
+
+During `wake_up()`, vLLM Ascend restores the HCCL process groups, refreshes MoE dispatcher HCCL metadata, restores sleep-mode allocator memory, and recaptures ACL graphs when needed.
+
+:::{note}
+Extra cleanup trades lower sleep-time NPU memory usage for longer wakeup latency. In particular, if ACL graph is enabled, `wake_up()` must call `capture_model()` again after the model state has been restored. Keep `enable_sleep_mode_extra_cleanup` disabled when lower wakeup latency is more important than releasing HCCL and ACL graph workspace memory.
+:::
+
+For level 2 sleep, wakeup can be split into two phases:
+
+```python
+llm.wake_up(tags=["weights"])
+# Reload or update model weights here.
+llm.wake_up(tags=["kv_cache"])
+```
+
+With extra cleanup enabled, ACL graphs are recaptured only when `tags` is `None` or contains `"kv_cache"`. This avoids recapturing graphs before externally reloaded weights and KV-cache state are ready.
+
 ## Usage
 
 The following is a simple example of how to use sleep mode.

--- a/examples/offline_external_launcher.py
+++ b/examples/offline_external_launcher.py
@@ -70,6 +70,7 @@ from vllm.distributed.parallel_state import (  # noqa E402
     destroy_model_parallel,
     get_tp_group,
 )
+from vllm.model_executor.model_loader.utils import process_weights_after_loading
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.network_utils import get_open_port
 
@@ -77,13 +78,34 @@ os.environ["VLLM_USE_MODELSCOPE"] = "True"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
+def iter_transformer_layers(model):
+    visited_modules = set()
+    pending_modules = [model]
+    while pending_modules:
+        module = pending_modules.pop(0)
+        if id(module) in visited_modules:
+            continue
+        visited_modules.add(id(module))
+
+        layers = getattr(module, "layers", None)
+        if layers is not None:
+            if hasattr(layers, "values"):
+                layers = layers.values()
+            transformer_layers = [layer for layer in layers if hasattr(layer, "mlp")]
+            if transformer_layers:
+                return transformer_layers
+
+        pending_modules.extend(module.children())
+
+    raise ValueError("The provided model does not have transformer layers.")
+
+
 def patch_vllm_moe_model_weight_loader(model):
-    model = getattr(model, "model", None) or getattr(model, "language_model", None)
-    if model is None:
-        raise ValueError("The provided model does not have a valid 'model' or 'language_model' attribute.")
-    for layer in model.layers:
+    for layer in iter_transformer_layers(model):
         mlp_attr = "mlp"
         mlp = getattr(layer, mlp_attr)
+        if not hasattr(mlp, "experts"):
+            continue
         param_dict = dict(mlp.named_parameters())
         for name, param in param_dict.items():
             if "w13_weight" in name or "w2_weight" in name:
@@ -228,6 +250,10 @@ def main(
             run_model.load_weights(sd.items())
             llm.wake_up(tags=["kv_cache"])
 
+        run_model = llm.llm_engine.model_executor.driver_worker.worker.model_runner.model
+        vllm_config = llm.llm_engine.vllm_config.model_config
+        device = next(run_model.parameters()).device
+        process_weights_after_loading(run_model, vllm_config, device)
         outputs_after_wakeup = llm.generate(prompts, sampling_params)
         if rank == 0:
             # cmp output

--- a/examples/offline_external_launcher.py
+++ b/examples/offline_external_launcher.py
@@ -70,7 +70,6 @@ from vllm.distributed.parallel_state import (  # noqa E402
     destroy_model_parallel,
     get_tp_group,
 )
-from vllm.model_executor.model_loader.utils import process_weights_after_loading
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.network_utils import get_open_port
 
@@ -78,34 +77,13 @@ os.environ["VLLM_USE_MODELSCOPE"] = "True"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
-def iter_transformer_layers(model):
-    visited_modules = set()
-    pending_modules = [model]
-    while pending_modules:
-        module = pending_modules.pop(0)
-        if id(module) in visited_modules:
-            continue
-        visited_modules.add(id(module))
-
-        layers = getattr(module, "layers", None)
-        if layers is not None:
-            if hasattr(layers, "values"):
-                layers = layers.values()
-            transformer_layers = [layer for layer in layers if hasattr(layer, "mlp")]
-            if transformer_layers:
-                return transformer_layers
-
-        pending_modules.extend(module.children())
-
-    raise ValueError("The provided model does not have transformer layers.")
-
-
 def patch_vllm_moe_model_weight_loader(model):
-    for layer in iter_transformer_layers(model):
+    model = getattr(model, "model", None) or getattr(model, "language_model", None)
+    if model is None:
+        raise ValueError("The provided model does not have a valid 'model' or 'language_model' attribute.")
+    for layer in model.layers:
         mlp_attr = "mlp"
         mlp = getattr(layer, mlp_attr)
-        if not hasattr(mlp, "experts"):
-            continue
         param_dict = dict(mlp.named_parameters())
         for name, param in param_dict.items():
             if "w13_weight" in name or "w2_weight" in name:
@@ -250,10 +228,6 @@ def main(
             run_model.load_weights(sd.items())
             llm.wake_up(tags=["kv_cache"])
 
-        run_model = llm.llm_engine.model_executor.driver_worker.worker.model_runner.model
-        vllm_config = llm.llm_engine.vllm_config.model_config
-        device = next(run_model.parameters()).device
-        process_weights_after_loading(run_model, vllm_config, device)
         outputs_after_wakeup = llm.generate(prompts, sampling_params)
         if rank == 0:
             # cmp output

--- a/tests/ut/compilation/a2/test_acl_graph.py
+++ b/tests/ut/compilation/a2/test_acl_graph.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-
+import weakref
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
@@ -26,15 +26,18 @@ from vllm_ascend.attention.attention_v1 import AscendMetadata, AscendMetadataFor
 from vllm_ascend.attention.context_parallel.attention_cp import AscendAttentionCPImpl
 from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaCPImpl
 from vllm_ascend.attention.mla_v1 import AscendMLADecodeMetadata, AscendMLAMetadata
+from vllm_ascend.compilation import acl_graph
 from vllm_ascend.compilation.acl_graph import (
     ACLGraphEntry,
     ACLGraphWrapper,
+    GraphParams,
     get_draft_graph_params,
     get_graph_params,
     set_draft_graph_params,
     set_graph_params,
     update_draft_graph_params_workspaces,
 )
+from vllm_ascend.device_allocator.sleep_mem_optimized import AclGraphSleepWakeupManager
 
 
 class TestACLGraphEntry(TestBase):
@@ -757,6 +760,57 @@ class TestACLGraphWrapper(TestBase):
 
         unwrapped = wrapper.unwrap()
         self.assertEqual(unwrapped, self.mock_runnable)
+
+    def test_acl_graph_wrappers_use_weak_refs(self):
+        self.assertIsInstance(acl_graph._acl_graph_wrappers, weakref.WeakSet)
+
+
+class TestSleepGraphParams(TestBase):
+    def test_clear_attention_workspaces_preserves_capture_size_keys(self):
+        graph_params = GraphParams(
+            events={4: [], 8: []},
+            workspaces={4: torch.empty(1), 8: torch.empty(2)},
+            handles={4: [], 8: []},
+            attn_params={4: [], 8: []},
+            conv1d_params={4: [], 8: []},
+            conv1d_handles={4: [], 8: []},
+            conv1d_events={4: [], 8: []},
+        )
+
+        with (
+            patch("vllm_ascend.compilation.acl_graph._graph_params", graph_params),
+            patch("vllm_ascend.compilation.acl_graph._draft_graph_params", None),
+            patch("vllm_ascend.compilation.acl_graph._draft_graph_prefill_params", None),
+        ):
+            AclGraphSleepWakeupManager.clear_all_attention_workspaces()
+
+        self.assertEqual(set(graph_params.workspaces), {4, 8})
+        self.assertIsNone(graph_params.workspaces[4])
+        self.assertIsNone(graph_params.workspaces[8])
+
+    def test_reset_graph_params_for_sleep_clears_registered_wrappers(self):
+        wrapper = MagicMock()
+        wrapper.concrete_aclgraph_entries = {"entry": object()}
+        wrapper.first_run_finished = True
+        empty_params = GraphParams(
+            events={},
+            workspaces={},
+            handles={},
+            attn_params={},
+            conv1d_params={},
+            conv1d_handles={},
+            conv1d_events={},
+        )
+        with (
+            patch("vllm_ascend.compilation.acl_graph._graph_params", empty_params),
+            patch("vllm_ascend.compilation.acl_graph._draft_graph_params", empty_params),
+            patch("vllm_ascend.compilation.acl_graph._draft_graph_prefill_params", empty_params),
+            patch("vllm_ascend.compilation.acl_graph._acl_graph_wrappers", [wrapper]),
+        ):
+            AclGraphSleepWakeupManager.reset_all_graph_params()
+
+        self.assertEqual(wrapper.concrete_aclgraph_entries, {})
+        self.assertFalse(wrapper.first_run_finished)
 
 
 class TestDraftGraphParams(TestBase):

--- a/tests/ut/device_allocator/test_sleep_mem_optimized.py
+++ b/tests/ut/device_allocator/test_sleep_mem_optimized.py
@@ -16,6 +16,7 @@
 #
 
 from contextlib import nullcontext
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 from vllm_ascend.device_allocator.sleep_mem_optimized import (
@@ -23,6 +24,31 @@ from vllm_ascend.device_allocator.sleep_mem_optimized import (
     HcclSleepWakeupManager,
     SleepWakeupManager,
 )
+
+
+@dataclass
+class DummyGraphParams:
+    events: dict[int, list]
+    workspaces: dict[int, object]
+    extra_handles: dict[int, list]
+    metadata: dict[int, tuple]
+
+
+def test_acl_graph_reset_graph_params_clears_list_values_only():
+    workspace = object()
+    params = DummyGraphParams(
+        events={1: ["event"]},
+        workspaces={1: workspace},
+        extra_handles={1: ["handle"]},
+        metadata={1: ("keep",)},
+    )
+
+    AclGraphSleepWakeupManager.reset_graph_params(params)
+
+    assert params.events == {1: []}
+    assert params.extra_handles == {1: []}
+    assert params.workspaces == {1: workspace}
+    assert params.metadata == {1: ("keep",)}
 
 
 def test_acl_graph_wakeup_waits_for_kv_cache_tag():

--- a/tests/ut/device_allocator/test_sleep_mem_optimized.py
+++ b/tests/ut/device_allocator/test_sleep_mem_optimized.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from vllm_ascend.device_allocator.sleep_mem_optimized import (
+    AclGraphSleepWakeupManager,
+    HcclSleepWakeupManager,
+    SleepWakeupManager,
+)
+
+
+def test_acl_graph_wakeup_waits_for_kv_cache_tag():
+    model_runner = MagicMock()
+    manager = AclGraphSleepWakeupManager(MagicMock(), lambda: model_runner)
+
+    manager.wakeup(tags=["weights"])
+    model_runner.capture_model.assert_not_called()
+
+    manager.wakeup(tags=["kv_cache"])
+    model_runner.capture_model.assert_called_once_with()
+
+
+def test_sleep_wakeup_manager_skips_acl_sleep_when_aclgraph_disabled():
+    model_runner = MagicMock()
+    model_runner.use_aclgraph = False
+    manager = SleepWakeupManager(MagicMock(), MagicMock(), lambda: model_runner)
+    manager.acl_graph.sleep = MagicMock()
+    manager.hccl.sleep = MagicMock()
+    with patch(
+        "vllm_ascend.device_allocator.sleep_mem_optimized.torch.npu.mem_get_info",
+        side_effect=[(10, 20), (12, 20)],
+    ):
+        manager.sleep()
+
+    manager.acl_graph.sleep.assert_not_called()
+    manager.hccl.sleep.assert_called_once_with()
+
+
+def test_sleep_wakeup_manager_cleans_acl_before_hccl_when_aclgraph_enabled():
+    model_runner = MagicMock()
+    model_runner.use_aclgraph = True
+    manager = SleepWakeupManager(MagicMock(), MagicMock(), lambda: model_runner)
+    calls = []
+    manager.acl_graph.sleep = MagicMock(side_effect=lambda: calls.append("acl"))
+    manager.hccl.sleep = MagicMock(side_effect=lambda: calls.append("hccl"))
+
+    mem_info = [(10, 20), (12, 20), (12, 20), (13, 20)]
+    with patch("vllm_ascend.device_allocator.sleep_mem_optimized.torch.npu.mem_get_info", side_effect=mem_info):
+        manager.sleep()
+
+    assert calls == ["acl", "hccl"]
+
+
+def test_hccl_wakeup_restores_and_refreshes_moe_groups():
+    manager = HcclSleepWakeupManager(MagicMock(), MagicMock())
+
+    with (
+        patch("vllm_ascend.device_allocator.sleep_mem_optimized.set_current_vllm_config", return_value=nullcontext()),
+        patch.object(manager, "restore_hccl", return_value=2) as mock_restore,
+        patch.object(manager, "refresh_moe_hccl_groups") as mock_refresh,
+    ):
+        manager.wakeup()
+
+    mock_restore.assert_called_once_with()
+    mock_refresh.assert_called_once_with()

--- a/tests/ut/patch/worker/patch_common/test_patch_distributed.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_distributed.py
@@ -390,14 +390,20 @@ def test_destroy_releases_all_acquired_keys_in_reverse_order(module_env):
 
     cpu_group = group.cpu_group
     shared_device_group = group.device_group
+    communicator = group.device_communicator
     acquired_keys = list(group._acquired_hccl_keys)
+
+    destroy_order = []
+    communicator.destroy.side_effect = lambda: destroy_order.append("communicator")
+    module_env.destroy_process_group.side_effect = lambda group: destroy_order.append(group)
 
     group.destroy()
     group.destroy()
 
     assert len(acquired_keys) == 2
     assert release_mock.call_args_list == [call(acquired_keys[1]), call(acquired_keys[0])]
-    assert module_env.destroy_process_group.call_args_list == [call(cpu_group), call(shared_device_group)]
+    assert module_env.destroy_process_group.call_args_list == [call(shared_device_group), call(cpu_group)]
+    assert destroy_order == ["communicator", shared_device_group, cpu_group]
     assert group.device_communicator is None
     assert group.mq_broadcaster is None
     assert not hasattr(group, "cpu_group")
@@ -492,8 +498,8 @@ def test_shared_hccl_group_is_destroyed_only_after_last_coordinator(module_env):
 
     assert module_env.destroy_process_group.call_args_list == [
         call(cpu_group_first),
-        call(cpu_group_second),
         call(shared_device_group),
+        call(cpu_group_second),
     ]
 
 
@@ -554,8 +560,8 @@ def test_destroy_cleans_up_fail_closed_hccl_device_group(module_env):
     group.destroy()
 
     assert module_env.destroy_process_group.call_args_list == [
-        call(cpu_group),
         call(device_group),
+        call(cpu_group),
     ]
     assert group._acquired_hccl_keys == []
     assert not hasattr(group, "cpu_group")
@@ -608,8 +614,8 @@ def test_non_hccl_destroy_path_destroys_device_group_directly(module_env):
     group.destroy()
 
     assert module_env.destroy_process_group.call_args_list == [
-        call(cpu_group),
         call(device_group),
+        call(cpu_group),
     ]
     assert not hasattr(group, "cpu_group")
     assert not hasattr(group, "device_group")

--- a/tests/ut/patch/worker/patch_common/test_patch_distributed.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_distributed.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import sys
+import weakref
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
@@ -94,6 +95,7 @@ def _load_patch_distributed_module():
     communicator_instances: list[object] = []
     unique_name_counter = {"value": 0}
     sequence_counter = {"value": 0}
+    registered_groups = {}
     shared_hccl_options = {"hccl_config": {"hccl_buffer_size": 200}}
 
     torch_module: Any = ModuleType("torch")
@@ -147,9 +149,13 @@ def _load_patch_distributed_module():
         unique_name_counter["value"] += 1
         return f"{group_name}-{unique_name_counter['value']}"
 
+    def _register_group(group):
+        registered_groups[group.unique_name] = weakref.ref(group)
+
     parallel_state_module.GroupCoordinator = BaseGroupCoordinator
     parallel_state_module._get_unique_name = _get_unique_name
-    parallel_state_module._register_group = MagicMock()
+    parallel_state_module._register_group = MagicMock(side_effect=_register_group)
+    parallel_state_module._groups = registered_groups
     parallel_state_module.destroy_distributed_environment = destroy_distributed_environment
 
     shm_broadcast_module: Any = ModuleType("vllm.distributed.device_communicators.shm_broadcast")
@@ -554,6 +560,38 @@ def test_destroy_cleans_up_fail_closed_hccl_device_group(module_env):
     assert group._acquired_hccl_keys == []
     assert not hasattr(group, "cpu_group")
     assert not hasattr(group, "device_group")
+
+
+def test_hccl_sleep_destroy_and_restore_shared_group(module_env):
+    group = _make_group(
+        module_env,
+        group_ranks=[[0, 1]],
+        group_name="tp",
+        use_device_communicator=True,
+    )
+    original_device_group = group.device_group
+    original_communicator = group.device_communicator
+
+    assert len(_calls_with_backend(module_env, "hccl")) == 1
+
+    assert group.destroy_hccl() is True
+
+    original_communicator.destroy.assert_called_once()
+    assert group.device_communicator is None
+    assert group.device_group is None
+    assert group._acquired_hccl_keys == []
+    assert module_env.destroy_process_group.call_args_list == [call(original_device_group)]
+
+    assert group.restore_hccl() is True
+
+    assert len(_calls_with_backend(module_env, "hccl")) == 2
+    assert group.device_group is not None
+    assert group.device_group is not original_device_group
+    assert group.device_communicator is not None
+    assert group.device_communicator is not original_communicator
+    assert group.device == "npu:0"
+
+    assert group.restore_hccl() is False
 
 
 def test_non_hccl_destroy_path_destroys_device_group_directly(module_env):

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -216,6 +216,7 @@ class TestNPUWorker(TestBase):
     def test_wake_up_mode_enabled(self, mock_get_config, mock_allocator_class):
         mock_config = MagicMock()
         mock_config.weight_nz_mode = 0
+        mock_config.enable_sleep_mode_extra_cleanup = True
         mock_get_config.return_value = mock_config
         """Test wake_up method when sleep mode is enabled"""
         from vllm_ascend.worker.worker import NPUWorker
@@ -241,10 +242,12 @@ class TestNPUWorker(TestBase):
             worker.model_runner = mock_model_runner
             worker.vllm_config = mock_vllm_config
             worker._sleep_saved_buffers = {}
+            worker.sleep_wakeup_manager = MagicMock()
             # Test wake_up method
             worker.wake_up(tags=["test_tag"])
 
             mock_allocator.wake_up.assert_called_once_with(tags=["test_tag"])
+            worker.sleep_wakeup_manager.wakeup.assert_called_once_with(["test_tag"])
 
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
@@ -975,6 +978,7 @@ class TestNPUWorker(TestBase):
             worker.vllm_config.model_config = MagicMock()
             worker.vllm_config.model_config.enable_sleep_mode = True
             worker.vllm_config.weight_transfer_config = None
+            worker.vllm_config.kv_transfer_config = None
 
             # Setup allocator mock
             mock_allocator = MagicMock()
@@ -1161,13 +1165,17 @@ class TestNPUWorker(TestBase):
         from vllm_ascend.worker.worker import NPUWorker
 
         # Create worker mock
-        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+        with (
+            patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
+            patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized"),
+        ):
             worker = NPUWorker()
             worker.model_runner = MagicMock()
             worker.vllm_config = MagicMock()
             worker.vllm_config.speculative_config = None
             worker.vllm_config.model_config = MagicMock()
             worker.vllm_config.model_config.enable_sleep_mode = True
+            worker.vllm_config.kv_transfer_config = None
 
             # Setup allocator mock
             mock_allocator = MagicMock()
@@ -1186,19 +1194,75 @@ class TestNPUWorker(TestBase):
             mock_allocator.use_memory_pool.assert_called_once_with(tag="kv_cache")
             worker.model_runner.initialize_kv_cache.assert_called_once_with(mock_kv_cache_config)
 
+    def test_acl_graph_sleep_wakeup_manager_sleep_resets_acl_graph_state(self):
+        from vllm_ascend.device_allocator.sleep_mem_optimized import AclGraphSleepWakeupManager
+
+        model_runner = MagicMock()
+        model_runner.use_aclgraph = True
+        graph_manager = MagicMock()
+        graph_manager.graphs = MagicMock()
+        graph_manager.pool = None
+        model_runner.cudagraph_manager = graph_manager
+        saver = AclGraphSleepWakeupManager(MagicMock(), lambda: model_runner)
+        with (
+            patch(
+                "vllm_ascend.device_allocator.sleep_mem_optimized.AclGraphSleepWakeupManager"
+                ".clear_all_attention_workspaces"
+            ) as mock_clear,
+            patch(
+                "vllm_ascend.device_allocator.sleep_mem_optimized.AclGraphSleepWakeupManager.reset_all_graph_params"
+            ) as mock_reset,
+        ):
+            saver.sleep()
+        mock_clear.assert_called_once()
+        mock_reset.assert_called_once()
+        graph_manager.graphs.clear.assert_called_once()
+
+    def test_hccl_sleep_wakeup_manager_sleep_waits_and_destroys(self):
+        from vllm_ascend.device_allocator.sleep_mem_optimized import HcclSleepWakeupManager
+
+        worker = MagicMock()
+        handle = MagicMock()
+        worker._pp_send_work = [handle]
+        saver = HcclSleepWakeupManager(MagicMock(), worker)
+        saver._destroyed = False
+
+        with (
+            patch("vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.is_available", return_value=True),
+            patch(
+                "vllm_ascend.device_allocator.sleep_mem_optimized.torch.distributed.is_initialized",
+                return_value=True,
+            ),
+            patch("vllm_ascend.device_allocator.sleep_mem_optimized.torch.npu.synchronize") as mock_synchronize,
+            patch(
+                "vllm_ascend.device_allocator.sleep_mem_optimized.HcclSleepWakeupManager.destroy_hccl",
+                return_value=2,
+            ) as mock_destroy,
+        ):
+            saver.sleep()
+
+        handle.wait.assert_called_once()
+        self.assertEqual(worker._pp_send_work, [])
+        mock_synchronize.assert_called_once()
+        mock_destroy.assert_called_once()
+
     @patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized")
     def test_initialize_from_config_without_sleep_mode(self, mock_ensure_kv_transfer):
         """Test initialize_from_config method - without sleep mode enabled"""
         from vllm_ascend.worker.worker import NPUWorker
 
         # Create worker mock
-        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+        with (
+            patch.object(NPUWorker, "__init__", lambda x, **kwargs: None),
+            patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized"),
+        ):
             worker = NPUWorker()
             worker.model_runner = MagicMock()
             worker.vllm_config = MagicMock()
             worker.vllm_config.speculative_config = None
             worker.vllm_config.model_config = MagicMock()
             worker.vllm_config.model_config.enable_sleep_mode = False
+            worker.vllm_config.kv_transfer_config = None
 
             # Create mock kv_cache_config
             mock_kv_cache_config = MagicMock()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -140,7 +140,11 @@ class AscendConfig:
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
+        self.multistream_dsa_preprocess = additional_config.get("multistream_dsa_preprocess", False)
+        self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
+        self.prefill_comm_compute_overlap = additional_config.get("prefill_comm_compute_overlap", False)
+
         self.enable_matmul_allreduce = self._get_config_value(
             additional_config,
             "enable_matmul_allreduce",

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -140,10 +140,8 @@ class AscendConfig:
         # PD-disaggregated only (kv_producer/kv_consumer); invalid in PD-mixed (kv_both / no kv_transfer_config).
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
-        self.multistream_dsa_preprocess = additional_config.get("multistream_dsa_preprocess", False)
         self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
-        self.prefill_comm_compute_overlap = additional_config.get("prefill_comm_compute_overlap", False)
 
         self.enable_matmul_allreduce = self._get_config_value(
             additional_config,

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -24,6 +24,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
 from ..utils import weak_ref_tensors
 
+_acl_graph_wrappers: weakref.WeakSet[Any] = weakref.WeakSet()
 _STREAM_RESOURCE_ERROR_CODE = "207008"
 _STREAM_RESOURCE_ERROR_MARKERS = (
     "insufficient_stream_resources",
@@ -125,6 +126,7 @@ class ACLGraphWrapper:
         self.concrete_aclgraph_entries: dict[BatchDescriptor, ACLGraphEntry] = {}
         self.enable_enpu = enable_enpu
         self.use_eagle = use_eagle
+        _acl_graph_wrappers.add(self)
 
         ACLGraphWrapper._all_instances.add(self)
 

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -18,7 +18,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, MutableMapping
+from dataclasses import fields
 from typing import Any
 
 import torch
@@ -85,19 +86,13 @@ class AclGraphSleepWakeupManager:
     def reset_graph_params(params) -> None:
         if params is None:
             return
-        for attr_name in (
-            "events",
-            "handles",
-            "attn_params",
-            "conv1d_params",
-            "conv1d_handles",
-            "conv1d_events",
-        ):
-            attr_dict = getattr(params, attr_name, None)
-            if attr_dict is None:
+        for graph_field in fields(params):
+            attr_dict = getattr(params, graph_field.name, None)
+            if not isinstance(attr_dict, MutableMapping):
                 continue
-            for num_tokens in attr_dict:
-                attr_dict[num_tokens] = []
+            for num_tokens, value in attr_dict.items():
+                if isinstance(value, list):
+                    attr_dict[num_tokens] = []
 
     @classmethod
     def reset_all_graph_params(cls) -> None:

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -1,0 +1,191 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed.parallel_state import _groups
+from vllm.logger import logger
+from vllm.utils.mem_constants import GiB_bytes
+
+from vllm_ascend.compilation import acl_graph
+
+
+class SleepWakeupManager:
+    def __init__(self, vllm_config: VllmConfig, worker: Any, model_runner_getter: Callable[[], Any]):
+        self.acl_graph = AclGraphSleepWakeupManager(vllm_config, model_runner_getter)
+        self.hccl = HcclSleepWakeupManager(vllm_config, worker)
+        self._model_runner_getter = model_runner_getter
+
+    @staticmethod
+    def _measure_memory_released(cleanup: Callable[[], None]) -> int:
+        free_bytes_before_cleanup = torch.npu.mem_get_info()[0]
+        cleanup()
+        free_bytes_after_cleanup = torch.npu.mem_get_info()[0]
+        return max(free_bytes_after_cleanup - free_bytes_before_cleanup, 0)
+
+    def sleep(self) -> None:
+        model_runner = self._model_runner_getter()
+        free_bytes_before_cleanup = torch.npu.mem_get_info()[0]
+        if model_runner.use_aclgraph:
+            self.acl_graph.sleep()
+        self.hccl.sleep()
+        free_bytes_after_cleanup = torch.npu.mem_get_info()[0]
+        free_mem = free_bytes_after_cleanup - free_bytes_before_cleanup
+        logger.info(
+            "Sleep mode released HCCL and attention workspace memory: %.3f GiB.",
+            free_mem / GiB_bytes,
+        )
+
+    def wakeup(self, tags: list[str] | None = None) -> None:
+        self.hccl.wakeup()
+        model_runner = self._model_runner_getter()
+        if model_runner.use_aclgraph:
+            self.acl_graph.wakeup(tags)
+
+
+class AclGraphSleepWakeupManager:
+    def __init__(self, vllm_config: VllmConfig, model_runner_getter: Callable[[], Any]):
+        self.vllm_config = vllm_config
+        self._model_runner_getter = model_runner_getter
+
+    @staticmethod
+    def clear_attention_workspaces(params) -> None:
+        if params is None:
+            return
+        for num_tokens in params.workspaces:
+            params.workspaces[num_tokens] = None
+
+    @classmethod
+    def clear_all_attention_workspaces(cls) -> None:
+        cls.clear_attention_workspaces(acl_graph._graph_params)
+        cls.clear_attention_workspaces(acl_graph._draft_graph_params)
+        cls.clear_attention_workspaces(acl_graph._draft_graph_prefill_params)
+
+    @staticmethod
+    def reset_graph_params(params) -> None:
+        if params is None:
+            return
+        for attr_name in (
+            "events",
+            "handles",
+            "attn_params",
+            "conv1d_params",
+            "conv1d_handles",
+            "conv1d_events",
+        ):
+            attr_dict = getattr(params, attr_name, None)
+            if attr_dict is None:
+                continue
+            for num_tokens in attr_dict:
+                attr_dict[num_tokens] = []
+
+    @classmethod
+    def reset_all_graph_params(cls) -> None:
+        cls.reset_graph_params(acl_graph._graph_params)
+        cls.reset_graph_params(acl_graph._draft_graph_params)
+        cls.reset_graph_params(acl_graph._draft_graph_prefill_params)
+        for wrapper in list(acl_graph._acl_graph_wrappers):
+            wrapper.concrete_aclgraph_entries.clear()
+            wrapper.first_run_finished = False
+
+    @staticmethod
+    def reset_model_runner_graph_manager(model_runner: Any) -> None:
+        manager = getattr(model_runner, "cudagraph_manager", None)
+        if manager is None:
+            return
+        if hasattr(manager, "graphs"):
+            manager.graphs.clear()
+        if hasattr(manager, "_graphs_captured"):
+            manager._graphs_captured = False
+
+    def sleep(self) -> None:
+        self.clear_all_attention_workspaces()
+        self.reset_all_graph_params()
+        self.reset_model_runner_graph_manager(self._model_runner_getter())
+
+    def wakeup(self, tags: list[str] | None = None) -> None:
+        if tags is not None and "kv_cache" not in tags:
+            # Level-2 wakeup restores weights before external weight loading;
+            # recapture graphs only after KV cache is restored.
+            return
+        model_runner = self._model_runner_getter()
+        with set_current_vllm_config(self.vllm_config):
+            model_runner.capture_model()
+
+
+class HcclSleepWakeupManager:
+    def __init__(self, vllm_config: VllmConfig, worker: Any):
+        self.vllm_config = vllm_config
+        self.worker = worker
+
+    @staticmethod
+    def iter_alive_group_coordinators():
+        seen: set[int] = set()
+        for group_ref in list(_groups.values()):
+            group = group_ref()
+            if group is None or id(group) in seen:
+                continue
+            seen.add(id(group))
+            yield group
+
+    @classmethod
+    def destroy_hccl(cls) -> int:
+        num_destroyed = 0
+        for group in cls.iter_alive_group_coordinators():
+            if group.destroy_hccl():
+                num_destroyed += 1
+        return num_destroyed
+
+    @classmethod
+    def restore_hccl(cls) -> int:
+        num_restored = 0
+        for group in cls.iter_alive_group_coordinators():
+            if group.restore_hccl():
+                num_restored += 1
+        return num_restored
+
+    @staticmethod
+    def refresh_moe_hccl_groups() -> None:
+        from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
+
+        for comm_method in _MoECommMethods.values():
+            dispatcher = getattr(comm_method, "token_dispatcher", None)
+            refresh_fn = getattr(dispatcher, "refresh_hccl_group_for_sleep_wakeup", None)
+            if callable(refresh_fn):
+                refresh_fn()
+
+    def sleep(self) -> None:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            for handle in getattr(self.worker, "_pp_send_work", []):
+                handle.wait()
+            self.worker._pp_send_work = []
+            torch.npu.synchronize()
+            num_destroyed = self.destroy_hccl()
+            if num_destroyed > 0:
+                logger.info("Destroyed %d HCCL process groups for sleep mode.", num_destroyed)
+
+    def wakeup(self) -> None:
+        with set_current_vllm_config(self.vllm_config):
+            num_restored = self.restore_hccl()
+            self.refresh_moe_hccl_groups()
+        logger.info("Restored %d HCCL process groups after sleep mode.", num_restored)

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -170,7 +170,7 @@ class HcclSleepWakeupManager:
 
         for comm_method in _MoECommMethods.values():
             dispatcher = getattr(comm_method, "token_dispatcher", None)
-            refresh_fn = getattr(dispatcher, "refresh_hccl_group_for_sleep_wakeup", None)
+            refresh_fn = getattr(dispatcher, "refresh_hccl_group", None)
             if callable(refresh_fn):
                 refresh_fn()
 

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -148,6 +148,13 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
                 "PTA and CANN version is too old to support mc2 hierarchy comm, please upgrade your version."
             )
 
+    def refresh_hccl_group_for_sleep_wakeup(self) -> None:
+        """Refresh MC2 communicator metadata after HCCL groups are recreated."""
+        device_group = get_mc2_group().device_group
+        local_rank = torch.distributed.get_rank(group=device_group)
+        backend = device_group._get_backend(torch.device("npu"))
+        self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
+
     def get_dispatch_mc2_kwargs(
         self,
         token_dispatch_input: MoETokenDispatchInput,

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -148,7 +148,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
                 "PTA and CANN version is too old to support mc2 hierarchy comm, please upgrade your version."
             )
 
-    def refresh_hccl_group_for_sleep_wakeup(self) -> None:
+    def refresh_hccl_group(self) -> None:
         """Refresh MC2 communicator metadata after HCCL groups are recreated."""
         device_group = get_mc2_group().device_group
         local_rank = torch.distributed.get_rank(group=device_group)

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -25,7 +25,7 @@ from torch.distributed import Backend
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
-from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgRegistry, make_hccl_pg_key
+from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgKey, HcclPgRegistry, make_hccl_pg_key
 from vllm_ascend.utils import create_hccl_pg_options
 
 _HCCL_PG_REGISTRY = HcclPgRegistry()
@@ -114,54 +114,25 @@ class GroupCoordinatorPatch(GroupCoordinator):
         self.rank = torch.distributed.get_rank()
         self.local_rank = local_rank
         self.backend = _normalize_backend(torch_distributed_backend)
-        self._acquired_hccl_keys = []
-        self._unshared_hccl_groups = []
+        self._acquired_hccl_keys: list[HcclPgKey] = []
+        self._unshared_hccl_groups: list[object] = []
         self.use_device_communicator = use_device_communicator
-        self.device_communicator = None
+        self.device_communicator: NPUCommunicator | None = None
         self.mq_broadcaster = None
         self.cpu_group = None
         self.device_group = None
         self.device = None
         self.use_custom_op_call = True
         self.use_cpu_custom_send_recv = False
-
-        reuse_domain = _resolve_reuse_domain(group_name)
+        self.group_name = group_name
+        self.group_ranks = group_ranks
 
         try:
-            for ranks in group_ranks:
-                hccl_pg_options = create_hccl_pg_options(group_name)
-                device_group, hccl_key = _acquire_hccl_group(
-                    ranks=ranks,
-                    backend=self.backend,
-                    hccl_pg_options=hccl_pg_options,
-                    reuse_domain=reuse_domain,
-                )
-                if hccl_key is not None:
-                    self._acquired_hccl_keys.append(hccl_key)
-                elif self.backend == "hccl" and self.rank in ranks:
-                    self._unshared_hccl_groups.append(device_group)
-
-                # a group with `gloo` backend, to allow direct coordination between
-                # processes through the CPU.
-                cpu_group = torch.distributed.new_group(ranks, backend="gloo")
-                if self.rank in ranks:
-                    self.ranks = ranks
-                    self.world_size = len(ranks)
-                    self.rank_in_group = ranks.index(self.rank)
-                    self.device_group = device_group
-                    self.cpu_group = cpu_group
-
+            self._init_device_groups(create_cpu_group=True)
             assert self.cpu_group is not None
             assert self.device_group is not None
 
-            self.device = torch.npu.current_device()
-            if use_device_communicator and self.world_size > 1:
-                self.device_communicator = NPUCommunicator(
-                    cpu_group=self.cpu_group,
-                    device=self.device,
-                    device_group=self.device_group,
-                    unique_name=self.unique_name,
-                )
+            self._init_device_communicator()
 
             from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
 
@@ -178,6 +149,65 @@ class GroupCoordinatorPatch(GroupCoordinator):
                 logger.exception("Failed to clean up partially initialized GroupCoordinatorPatch")
             raise
 
+    def _init_device_groups(self, create_cpu_group: bool) -> None:
+        reuse_domain = _resolve_reuse_domain(self.group_name)
+        self_device_group = None
+        for ranks in self.group_ranks:
+            hccl_pg_options = create_hccl_pg_options(self.group_name)
+            device_group, hccl_key = _acquire_hccl_group(
+                ranks=ranks,
+                backend=self.backend,
+                hccl_pg_options=hccl_pg_options,
+                reuse_domain=reuse_domain,
+            )
+            if hccl_key is not None:
+                self._acquired_hccl_keys.append(hccl_key)
+            elif self.backend == "hccl" and self.rank in ranks:
+                self._unshared_hccl_groups.append(device_group)
+
+            cpu_group = torch.distributed.new_group(ranks, backend="gloo") if create_cpu_group else None
+            if self.rank in ranks:
+                if create_cpu_group:
+                    self.ranks = ranks
+                    self.world_size = len(ranks)
+                    self.rank_in_group = ranks.index(self.rank)
+                    self.cpu_group = cpu_group
+                self_device_group = device_group
+
+        if self_device_group is not None:
+            self.device_group = self_device_group
+
+    def _init_device_communicator(self) -> None:
+        self.device = torch.npu.current_device()
+        if self.use_device_communicator and self.world_size > 1:
+            self.device_communicator = NPUCommunicator(
+                cpu_group=self.cpu_group,
+                device=self.device,
+                device_group=self.device_group,
+                unique_name=self.unique_name,
+            )
+
+    def _release_hccl_resources(self) -> bool:
+        destroyed = False
+        if hasattr(self, "_acquired_hccl_keys"):
+            for hccl_key in reversed(self._acquired_hccl_keys):
+                _HCCL_PG_REGISTRY.release(hccl_key)
+            self._acquired_hccl_keys = []
+            destroyed = True
+
+        if hasattr(self, "_unshared_hccl_groups"):
+            for device_group in reversed(self._unshared_hccl_groups):
+                torch.distributed.destroy_process_group(device_group)
+            self._unshared_hccl_groups = []
+            destroyed = True
+
+        device_communicator = getattr(self, "device_communicator", None)
+        if device_communicator is not None:
+            device_communicator.destroy()
+            self.device_communicator = None
+            destroyed = True
+        return destroyed
+
     def destroy(self):
         cpu_group = getattr(self, "cpu_group", None)
         if cpu_group is not None:
@@ -185,15 +215,7 @@ class GroupCoordinatorPatch(GroupCoordinator):
         if hasattr(self, "cpu_group"):
             del self.cpu_group
 
-        if hasattr(self, "_acquired_hccl_keys"):
-            for hccl_key in reversed(self._acquired_hccl_keys):
-                _HCCL_PG_REGISTRY.release(hccl_key)
-            self._acquired_hccl_keys = []
-
-        if hasattr(self, "_unshared_hccl_groups"):
-            for device_group in reversed(self._unshared_hccl_groups):
-                torch.distributed.destroy_process_group(device_group)
-            self._unshared_hccl_groups = []
+        self._release_hccl_resources()
 
         device_group = getattr(self, "device_group", None)
         if device_group is not None and self.backend != "hccl":
@@ -201,13 +223,26 @@ class GroupCoordinatorPatch(GroupCoordinator):
         if hasattr(self, "device_group"):
             del self.device_group
 
-        device_communicator = getattr(self, "device_communicator", None)
-        if device_communicator is not None:
-            device_communicator.destroy()
-            self.device_communicator = None
-
         if getattr(self, "mq_broadcaster", None) is not None:
             self.mq_broadcaster = None
+
+    def destroy_hccl(self) -> bool:
+        """Release the HCCL process group."""
+        destroyed = self._release_hccl_resources()
+
+        if hasattr(self, "device_group"):
+            self.device_group = None
+        return destroyed
+
+    def restore_hccl(self) -> bool:
+        """Recreate the HCCL process group in place after sleep mode."""
+        if self.device_group is not None:
+            return False
+
+        self._init_device_groups(create_cpu_group=False)
+        assert self.device_group is not None
+        self._init_device_communicator()
+        return True
 
     def all_to_all(
         self,

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -189,6 +189,12 @@ class GroupCoordinatorPatch(GroupCoordinator):
 
     def _release_hccl_resources(self) -> bool:
         destroyed = False
+        device_communicator = getattr(self, "device_communicator", None)
+        if device_communicator is not None:
+            device_communicator.destroy()
+            self.device_communicator = None
+            destroyed = True
+
         if hasattr(self, "_acquired_hccl_keys"):
             for hccl_key in reversed(self._acquired_hccl_keys):
                 _HCCL_PG_REGISTRY.release(hccl_key)
@@ -201,19 +207,11 @@ class GroupCoordinatorPatch(GroupCoordinator):
             self._unshared_hccl_groups = []
             destroyed = True
 
-        device_communicator = getattr(self, "device_communicator", None)
-        if device_communicator is not None:
-            device_communicator.destroy()
-            self.device_communicator = None
-            destroyed = True
         return destroyed
 
     def destroy(self):
-        cpu_group = getattr(self, "cpu_group", None)
-        if cpu_group is not None:
-            torch.distributed.destroy_process_group(cpu_group)
-        if hasattr(self, "cpu_group"):
-            del self.cpu_group
+        if getattr(self, "mq_broadcaster", None) is not None:
+            self.mq_broadcaster = None
 
         self._release_hccl_resources()
 
@@ -223,8 +221,11 @@ class GroupCoordinatorPatch(GroupCoordinator):
         if hasattr(self, "device_group"):
             del self.device_group
 
-        if getattr(self, "mq_broadcaster", None) is not None:
-            self.mq_broadcaster = None
+        cpu_group = getattr(self, "cpu_group", None)
+        if cpu_group is not None:
+            torch.distributed.destroy_process_group(cpu_group)
+        if hasattr(self, "cpu_group"):
+            del self.cpu_group
 
     def destroy_hccl(self) -> bool:
         """Release the HCCL process group."""

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -246,7 +246,6 @@ class NPUWorker(WorkerBase):
                 "in the RL scenarios. Please set weight_nz_mode=0 via --additional-config."
             )
         allocator = CaMemAllocator.get_instance()
-        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
         allocator.wake_up(tags=tags)
 
         hidden_size = self.vllm_config.model_config.hf_text_config.hidden_size
@@ -276,6 +275,7 @@ class NPUWorker(WorkerBase):
                 if name in self._sleep_saved_buffers:
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
+        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
         if cleanup_enabled:
             self.sleep_wakeup_manager.wakeup(tags)
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -58,6 +58,7 @@ from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
+from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
@@ -143,6 +144,7 @@ class NPUWorker(WorkerBase):
         if vllm_config.model_config and vllm_config.model_config.enable_sleep_mode:
             # Buffers saved before sleep
             self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
+        self.sleep_wakeup_manager = SleepWakeupManager(vllm_config, self, lambda: getattr(self, "model_runner", None))
 
         # Weight transfer engine is created in `load_model` once the model
         # is available, since the engine needs a reference to the model.
@@ -218,12 +220,18 @@ class NPUWorker(WorkerBase):
         if level == 2:
             model = self.model_runner.model
             self._sleep_saved_buffers = {name: buffer.cpu().clone() for name, buffer in model.named_buffers()}
+
+        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", True)
+        if cleanup_enabled:
+            self.sleep_wakeup_manager.sleep()
+
         allocator = CaMemAllocator.get_instance()
         allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
         free_bytes_after_sleep, total = torch.npu.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
         assert freed_bytes >= 0, "Memory usage increased after sleeping."
+
         logger.info(
             "Sleep mode freed %.2f GiB memory, %.2f GiB memory is still in use.",
             freed_bytes / GiB_bytes,
@@ -238,6 +246,7 @@ class NPUWorker(WorkerBase):
                 "in the RL scenarios. Please set weight_nz_mode=0 via --additional-config."
             )
         allocator = CaMemAllocator.get_instance()
+        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", True)
         allocator.wake_up(tags=tags)
 
         hidden_size = self.vllm_config.model_config.hf_text_config.hidden_size
@@ -267,6 +276,8 @@ class NPUWorker(WorkerBase):
                 if name in self._sleep_saved_buffers:
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
+        if cleanup_enabled:
+            self.sleep_wakeup_manager.wakeup(tags)
 
     def _check_weight_transfer_engine(self) -> None:
         if self.weight_transfer_engine is None:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -221,7 +221,7 @@ class NPUWorker(WorkerBase):
             model = self.model_runner.model
             self._sleep_saved_buffers = {name: buffer.cpu().clone() for name, buffer in model.named_buffers()}
 
-        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", True)
+        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
         if cleanup_enabled:
             self.sleep_wakeup_manager.sleep()
 
@@ -246,7 +246,7 @@ class NPUWorker(WorkerBase):
                 "in the RL scenarios. Please set weight_nz_mode=0 via --additional-config."
             )
         allocator = CaMemAllocator.get_instance()
-        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", True)
+        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
         allocator.wake_up(tags=tags)
 
         hidden_size = self.vllm_config.model_config.hf_text_config.hidden_size


### PR DESCRIPTION
### What this PR does / why we need it?
This PR improves RL sleep/wakeup support for vLLM Ascend.

It makes sleep mode release more NPU memory by cleaning up resources that were previously kept alive during sleep, including:

HCCL process groups and communicators.
ACL graph attention workspaces and captured graph state.
Global rotary embedding cos/sin runtime caches.
It also restores the required runtime state on wakeup:

Recreates HCCL process groups after sleep.
Recaptures ACL graphs when needed.
Rebuilds rotary cos/sin caches after wakeup.
Refreshes MoE MC2 communicator metadata after HCCL restoration.
This is needed for RL scenarios where the inference worker enters sleep mode to release NPU memory for other workloads, then wakes up and continues serving correctly.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
This patch was tested with sleep/wakeup memory measurements in both expert-parallel and non-expert-parallel scenarios.

With expert parallel enabled:

Before this patch, sleep mode still left about 3.2 GB NPU memory in use.
After this patch, sleep mode leaves about 0.7 GB NPU memory in use.
Without expert parallel:

Before this patch, sleep mode still left about 1.26 GB NPU memory in use.
After this patch, sleep mode leaves about 0.72 GB NPU memory in use.
Unit tests were also added/updated for HCCL sleep/wakeup handling, ACL graph cleanup, rotary cache cleanup, and worker sleep/wakeup helper paths.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
