### PR TITLE
[BugFix] Route GDN recurrent op through vLLM Ascend torch binding

### DIFF
--- a/csrc/attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h
+++ b/csrc/attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef RECURRENT_GATED_DELTA_RULE_TORCH_ADPT_H
+#define RECURRENT_GATED_DELTA_RULE_TORCH_ADPT_H
+
+namespace vllm_ascend {
+
+at::Tensor npu_recurrent_gated_delta_rule(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& state,
+    const c10::optional<at::Tensor>& beta,
+    const c10::optional<double> scale,
+    const c10::optional<at::Tensor>& actual_seq_lengths,
+    const c10::optional<at::Tensor>& ssm_state_indices,
+    const c10::optional<at::Tensor>& num_accepted_tokens,
+    const c10::optional<at::Tensor>& g,
+    const c10::optional<at::Tensor>& gk)
+{
+    TORCH_CHECK(scale.has_value(), "scale cannot be empty.");
+
+    auto options = value.options().dtype(at::ScalarType::BFloat16);
+    at::Tensor output = at::empty(value.sizes(), options);
+    float scale_real = static_cast<float>(scale.value());
+    EXEC_NPU_CMD(aclnnRecurrentGatedDeltaRule,
+                 query,
+                 key,
+                 value,
+                 beta,
+                 state,
+                 actual_seq_lengths,
+                 ssm_state_indices,
+                 g,
+                 gk,
+                 num_accepted_tokens,
+                 scale_real,
+                 output);
+    return output;
+}
+
+} // namespace vllm_ascend
+#endif

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -49,6 +49,7 @@
 #include "attention/lightning_indexer_quant/lightning_indexer_quant_torch_adpt.h"
 #include "attention/ngram_spec_decode/ngram_spec_decode_torch_adpt.h"
 #include "moe/causal_conv1d_v310/causal_conv1d_310_torch_adpt.h"
+#include "attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
 #include <c10/core/Device.h>
 #include <c10/core/Scalar.h>
@@ -2315,6 +2316,21 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "-> (Tensor y ,Tensor rstd)"
         );
     ops.impl("npu_gemma_rms_norm", torch::kPrivateUse1, &vllm_ascend::npu_gemma_rms_norm);
+
+    ops.def(
+        "npu_recurrent_gated_delta_rule(Tensor query, "
+        "                               Tensor key, "
+        "                               Tensor value, "
+        "                               Tensor(a!) state, "
+        "                               *, "
+        "                               Tensor? beta=None, "
+        "                               float? scale=None, "
+        "                               Tensor? actual_seq_lengths=None, "
+        "                               Tensor? ssm_state_indices=None, "
+        "                               Tensor? num_accepted_tokens=None, "
+        "                               Tensor? g=None, "
+        "                               Tensor? gk=None) -> Tensor");
+    ops.impl("npu_recurrent_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule);
 
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
     // Direct kernel custom ops

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -634,6 +634,25 @@ at::Tensor npu_recurrent_gated_delta_rule_310_meta(
     return output;
 }
 
+at::Tensor npu_recurrent_gated_delta_rule_meta(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& state,
+    const c10::optional<at::Tensor>& beta,
+    const c10::optional<double> scale,
+    const c10::optional<at::Tensor>& actual_seq_lengths,
+    const c10::optional<at::Tensor>& ssm_state_indices,
+    const c10::optional<at::Tensor>& num_accepted_tokens,
+    const c10::optional<at::Tensor>& g,
+    const c10::optional<at::Tensor>& gk)
+{
+
+    auto options = value.options().dtype(at::ScalarType::BFloat16);
+    at::Tensor output = at::empty_symint(value.sym_sizes(), options);
+    return output;
+}
+
 std::vector<at::Tensor> moe_grouped_matmul_meta(
     at::Tensor x,
     at::Tensor weight,
@@ -1540,6 +1559,8 @@ namespace {
 TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     //Gemma rmsnorm meta implementation
     ops.impl("npu_gemma_rms_norm", &vllm_ascend::meta::npu_gemma_rms_norm_meta);
+    // recurrent_gated_delta_rule meta implementation
+    ops.impl("npu_recurrent_gated_delta_rule", &vllm_ascend::meta::npu_recurrent_gated_delta_rule_meta);
     // Launch host print from device
     ops.impl("device_print", &vllm_ascend::meta::device_print_meta);
     // launch host print from device for tensors

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -587,7 +587,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
             # The custom op extends dtype support (e.g. float32 state) and is
             # loaded at runtime via ASCEND_CUSTOM_OPP_PATH.
-            core_attn_out_spec = torch_npu.npu_recurrent_gated_delta_rule(
+            core_attn_out_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
                 query=query_spec.squeeze(0),
                 key=key_spec.squeeze(0),
                 value=value_spec.squeeze(0),
@@ -629,7 +629,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             key_non_spec = l2norm_fwd(key_non_spec)
             # Dispatches to the vllm-ascend AscendC custom operator
             # (csrc/recurrent_gated_delta_rule), NOT the built-in CANN operator.
-            core_attn_out_non_spec = torch_npu.npu_recurrent_gated_delta_rule(
+            core_attn_out_non_spec = torch.ops._C_ascend.npu_recurrent_gated_delta_rule(
                 query=query_non_spec.squeeze(0),
                 key=key_non_spec.squeeze(0),
                 value=value_non_spec.squeeze(0),


### PR DESCRIPTION
### What this PR does / why we need it?

Fix Qwen3.5 GDN offline decode when `torch_npu.npu_recurrent_gated_delta_rule` resolves the PTA/CANN op-plugin implementation of `aclnnRecurrentGatedDeltaRule` instead of vLLM Ascend's overridden custom opapi. The PTA path rejects FP32 state tensors, while the vLLM Ascend custom opapi path supports the decode case used by GDN.

This PR keeps the custom opapi lookup inside vLLM Ascend by routing GDN through a dedicated `_C_ascend` binding:

- add the `recurrent_gated_delta_rule` torch adapter for `aclnnRecurrentGatedDeltaRule`
- register `_C_ascend.npu_recurrent_gated_delta_rule` and its meta implementation
- call `torch.ops._C_ascend.npu_recurrent_gated_delta_rule` from `vllm_ascend/ops/gdn.py` instead of depending on `torch_npu` binding state or loader ordering

### Does this PR introduce _any_ user-facing change?

No. This is an internal custom-op binding and dispatch fix for an existing GDN decode path. It does not add a public API, CLI flag, or default behavior change.

### How was this patch tested?

Manual validation on `173.131.1.2`:

- `python3 -m py_compile vllm_ascend/ops/gdn.py`
- `TORCH_DEVICE_BACKEND_AUTOLOAD=0 MAX_JOBS=4 CMAKE_BUILD_TYPE=Release python3 setup.py build_ext --inplace`
- minimal BF16 query/key/value + FP32 state smoke test through `torch.ops._C_ascend.npu_recurrent_gated_delta_rule` on NPU 5
- confirmed that direct `torch_npu.npu_recurrent_gated_delta_rule` still reproduces the CANN op-plugin dtype failure for FP32 state

PR CI passed for the current head, including title lint, pre-commit, smart tests, docs, and e2e-full lanes.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
