### PR TITLE
[BugFix][DeepSeek] Apply SwiGLU clamp before MoE quantization

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -733,6 +733,59 @@ class TestAscendFusedMoE:
 
 
 class TestAscendFusedMoESharedExperts:
+    def test_shared_swiglu_applies_deepseek_v4_clamp_before_dynamic_quant(self, monkeypatch):
+        hidden_states = torch.tensor([[20, -20, 40, -40]], dtype=torch.int32)
+        weight_scale = torch.ones(4, dtype=torch.float32)
+        activation_scale = torch.ones(1, dtype=torch.float32)
+        public_dequant = MagicMock()
+
+        def fake_dynamic_quant(tensor):
+            return tensor.round().to(torch.int8), tensor.abs().amax(dim=-1).to(torch.float32) / 127
+
+        monkeypatch.setattr(fused_moe_module.torch_npu, "npu_dynamic_quant", fake_dynamic_quant)
+        monkeypatch.setattr(
+            fused_moe_module.torch.ops._C_ascend,
+            "npu_dequant_swiglu_quant",
+            public_dequant,
+            raising=False,
+        )
+
+        output, output_scale = fused_moe_module._shared_dequant_swiglu_quant(
+            hidden_states,
+            weight_scale,
+            activation_scale,
+            10.0,
+            torch.bfloat16,
+        )
+
+        gate = torch.clamp(hidden_states[..., :2].float(), max=10.0)
+        up = torch.clamp(hidden_states[..., 2:].float(), min=-10.0, max=10.0)
+        expected = (F.silu(gate) * up).to(torch.bfloat16)
+        torch.testing.assert_close(output, expected.round().to(torch.int8))
+        torch.testing.assert_close(output_scale, expected.abs().amax(dim=-1).to(torch.float32) / 127)
+        public_dequant.assert_not_called()
+
+    def test_shared_swiglu_keeps_public_dequant_for_unlimited_clamp(self, monkeypatch):
+        expected = (torch.ones(1, 2, dtype=torch.int8), torch.ones(1, dtype=torch.float32))
+        public_dequant = MagicMock(return_value=expected)
+        monkeypatch.setattr(
+            fused_moe_module.torch.ops._C_ascend,
+            "npu_dequant_swiglu_quant",
+            public_dequant,
+            raising=False,
+        )
+
+        output = fused_moe_module._shared_dequant_swiglu_quant(
+            torch.ones(1, 4, dtype=torch.int32),
+            torch.ones(4, dtype=torch.float32),
+            torch.ones(1, dtype=torch.float32),
+            1_000_000,
+            torch.bfloat16,
+        )
+
+        assert output is expected
+        assert public_dequant.call_args.kwargs["clamp_limit"] == 1_000_000
+
     def test_properties_and_forward_delegate(self, monkeypatch):
         layer = AscendFusedMoE.__new__(AscendFusedMoE)
         if not hasattr(type(layer), "gate"):

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -1,10 +1,11 @@
 import unittest
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 
-from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, unified_apply_mlp
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, quant_apply_mlp, unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
     MoEQuantParams,
@@ -60,6 +61,123 @@ class TestW4A8RuntimeFlags(unittest.TestCase):
         self.assertFalse(
             MoEQuantParams(quant_type=QuantType.W8A8, is_per_channel_weight=True).use_w4a8_per_channel_gmm_swiglu
         )
+
+
+class TestQuantApplyMlpW4A8PerChannel(unittest.TestCase):
+    def test_effective_swiglu_limit_clamps_before_dynamic_quant(self):
+        hidden_states = torch.arange(12, dtype=torch.int8).view(3, 4)
+        dynamic_scale = torch.ones(3, dtype=torch.float32)
+        group_list = torch.tensor([2, 1], dtype=torch.int64)
+        w1 = [torch.ones(1, 8, 4, dtype=torch.int32)]
+        w2 = [torch.ones(1, 4, 4, dtype=torch.int32)]
+        w1_scale = [torch.ones(1, 8, dtype=torch.float32)]
+        w2_scale = [torch.ones(1, 4, dtype=torch.float32)]
+        w1_scale_bias = [torch.ones(1, 8, dtype=torch.float32)]
+        w2_scale_bias = [torch.ones(1, 4, dtype=torch.float32)]
+        gate_up_out = torch.tensor([[20.0, -20.0, 20.0, -20.0]], dtype=torch.bfloat16).repeat(3, 1)
+        quantized = torch.ones(3, 2, dtype=torch.int8)
+        swiglu_out_scale = torch.ones(3, dtype=torch.float32)
+        expected = torch.randn(3, 4)
+        event = object()
+        stream = MagicMock()
+        stream.record_event.return_value = event
+        extra_ctx = MagicMock()
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp._EXTRA_CTX", extra_ctx),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.enable_custom_op", return_value=True),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream", return_value=stream),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
+                return_value=[gate_up_out],
+            ),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_dynamic_quant",
+                return_value=(quantized, swiglu_out_scale),
+            ) as mock_dynamic_quant,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2",
+                create=True,
+            ) as mock_gmm_swiglu_v2,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                return_value=expected,
+            ),
+        ):
+            output, before_gmm2_evt = quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                group_list=group_list,
+                group_list_type=1,
+                dynamic_scale=dynamic_scale,
+                w1_scale_bias=w1_scale_bias,
+                w2_scale_bias=w2_scale_bias,
+                use_w4a8_per_channel_gmm_swiglu=True,
+                swiglu_limit=10.0,
+            )
+
+        gate = torch.clamp(gate_up_out[..., :2], max=10.0)
+        up = torch.clamp(gate_up_out[..., 2:], min=-10.0, max=10.0)
+        torch.testing.assert_close(mock_dynamic_quant.call_args.args[0], torch.nn.functional.silu(gate) * up)
+        mock_gmm_swiglu_v2.assert_not_called()
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, event)
+
+    def test_unlimited_swiglu_limit_keeps_fused_op_path(self):
+        hidden_states = torch.arange(12, dtype=torch.int8).view(3, 4)
+        dynamic_scale = torch.ones(3, dtype=torch.float32)
+        group_list = torch.tensor([2, 1], dtype=torch.int64)
+        w1 = [torch.ones(1, 8, 4, dtype=torch.int32)]
+        w2 = [torch.ones(1, 4, 4, dtype=torch.int32)]
+        w1_scale = [torch.ones(1, 8, dtype=torch.float32)]
+        w2_scale = [torch.ones(1, 4, dtype=torch.float32)]
+        swiglu_out = torch.ones(3, 2, dtype=torch.int8)
+        swiglu_out_scale = torch.ones(3, dtype=torch.float32)
+        expected = torch.randn(3, 4)
+        event = object()
+        stream = MagicMock()
+        stream.record_event.return_value = event
+        extra_ctx = MagicMock()
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp._EXTRA_CTX", extra_ctx),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.enable_custom_op", return_value=True),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream", return_value=stream),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2",
+                return_value=(swiglu_out, swiglu_out_scale),
+                create=True,
+            ) as mock_gmm_swiglu_v2,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
+            ) as mock_gmm,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                return_value=expected,
+            ),
+        ):
+            output, before_gmm2_evt = quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                group_list=group_list,
+                group_list_type=1,
+                dynamic_scale=dynamic_scale,
+                use_w4a8_per_channel_gmm_swiglu=True,
+                swiglu_limit=1_000_000,
+            )
+
+        mock_gmm_swiglu_v2.assert_called_once()
+        mock_gmm.assert_not_called()
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, event)
 
 
 class TestUnifiedApplyMlpRequest(unittest.TestCase):

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -44,7 +44,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
-from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.deepseek_compressor import CompressorStateCache
 from vllm.model_executor.layers.deepseek_v4_attention import DeepseekV4IndexerCache
 from vllm.model_executor.layers.fused_moe import FusedMoE
@@ -183,6 +183,7 @@ class DeepseekV2MLP(nn.Module):
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         is_sequence_parallel=False,
+        swiglu_limit: float | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -210,7 +211,7 @@ class DeepseekV2MLP(nn.Module):
         )
         if hidden_act != "silu":
             raise ValueError(f"Unsupported activation: {hidden_act}. Only silu is supported for now.")
-        self.act_fn = SiluAndMul()
+        self.act_fn = SiluAndMulWithClamp(swiglu_limit) if swiglu_limit is not None else SiluAndMul()
 
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
@@ -278,6 +279,7 @@ class DeepseekV4MoE(nn.Module):
                 quant_config=quant_config,
                 is_sequence_parallel=self.is_sequence_parallel,
                 reduce_results=False,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
                 prefix=f"{prefix}.shared_experts",
             )
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import wraps
@@ -88,6 +89,56 @@ def mock_false():
 
 def mock_true():
     return True
+
+
+def _has_effective_swiglu_limit(swiglu_limit: int | float | None) -> bool:
+    if swiglu_limit is None:
+        return False
+    limit = float(swiglu_limit)
+    return math.isfinite(limit) and 0.0 < limit < 1_000_000.0
+
+
+def _shared_dequant_swiglu_quant(
+    hidden_states: torch.Tensor,
+    weight_scale: torch.Tensor,
+    activation_scale: torch.Tensor,
+    swiglu_limit: int | float | None,
+    output_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not _has_effective_swiglu_limit(swiglu_limit):
+        return torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            x=hidden_states,
+            weight_scale=weight_scale,
+            activation_scale=activation_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            activate_left=True,
+            quant_mode=1,
+            swiglu_mode=1,
+            clamp_limit=0 if swiglu_limit is None else swiglu_limit,
+        )
+
+    if hidden_states.shape[0] == 0:
+        output_shape = hidden_states.shape[:-1] + (hidden_states.shape[-1] // 2,)
+        return (
+            hidden_states.new_empty(output_shape, dtype=torch.int8),
+            torch.empty(hidden_states.shape[:-1], dtype=torch.float32, device=hidden_states.device),
+        )
+
+    weight_scale = weight_scale.to(torch.float32).reshape((1,) * (hidden_states.dim() - 1) + (-1,))
+    activation_scale = activation_scale.to(torch.float32).reshape(hidden_states.shape[:-1] + (1,))
+    gate_up = hidden_states.to(torch.float32) * weight_scale * activation_scale
+
+    half = gate_up.shape[-1] // 2
+    limit = float(swiglu_limit)
+    gate = torch.clamp(gate_up[..., :half], max=limit)
+    up = torch.clamp(gate_up[..., half:], min=-limit, max=limit)
+    swiglu = F.silu(gate) * up
+    if swiglu.dtype not in (torch.float16, torch.bfloat16):
+        swiglu = swiglu.to(output_dtype if output_dtype in (torch.float16, torch.bfloat16) else torch.bfloat16)
+    return torch_npu.npu_dynamic_quant(swiglu)
 
 
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
@@ -752,18 +803,12 @@ class AscendFusedMoE(FusedMoE):
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
-                    x=hidden_states,
-                    weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
-                    activation_scale=pertoken_scale,
-                    bias=None,
-                    quant_scale=None,
-                    quant_offset=None,
-                    group_index=None,
-                    activate_left=True,
-                    quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
+                quantized_x, swiglu_out_scale = _shared_dequant_swiglu_quant(
+                    hidden_states,
+                    self._shared_experts.gate_up_proj.weight_scale_fp32,
+                    pertoken_scale,
+                    fused_moe_evts.swiglu_limit,
+                    original_dtype,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
+import math
 
 import torch
 import torch_npu
-from torch.nn.functional import pad
+from torch.nn.functional import pad, silu
 from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -78,6 +79,38 @@ def _require_single_tensor_for_swiglu_quant(
             raise ValueError(f"{name} must be a tensor or a single-element list, but got {len(tensor_or_list)}.")
         return tensor_or_list[0]
     return tensor_or_list
+
+
+def _has_effective_swiglu_limit(swiglu_limit: int | float | None) -> bool:
+    if swiglu_limit is None:
+        return False
+    limit = float(swiglu_limit)
+    return math.isfinite(limit) and 0.0 < limit < 1_000_000.0
+
+
+def _w4a8_per_channel_gmm_scale(w1_scale: list[torch.Tensor] | torch.Tensor) -> list[torch.Tensor]:
+    w1_scale_tensor = _require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale")
+    if w1_scale_tensor.dim() == 2:
+        w1_scale_tensor = w1_scale_tensor.unsqueeze(1)
+    return [w1_scale_tensor]
+
+
+def _w4a8_per_channel_swiglu_clamp_quant(
+    hidden_states: torch.Tensor,
+    swiglu_limit: int | float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if hidden_states.shape[0] == 0:
+        output_shape = hidden_states.shape[:-1] + (hidden_states.shape[-1] // 2,)
+        return (
+            hidden_states.new_empty(output_shape, dtype=torch.int8),
+            torch.empty(hidden_states.shape[:-1], dtype=torch.float32, device=hidden_states.device),
+        )
+
+    half = hidden_states.shape[-1] // 2
+    limit = float(swiglu_limit)
+    gate = torch.clamp(hidden_states[..., :half], max=limit)
+    up = torch.clamp(hidden_states[..., half:], min=-limit, max=limit)
+    return torch_npu.npu_dynamic_quant(silu(gate) * up)
 
 
 def quant_apply_mlp(
@@ -254,7 +287,11 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if use_w4a8_per_channel_gmm_swiglu and enable_custom_op():
+        if (
+            use_w4a8_per_channel_gmm_swiglu
+            and enable_custom_op()
+            and not _has_effective_swiglu_limit(swiglu_limit)
+        ):
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,
                 weight=w1,
@@ -293,12 +330,16 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
         else:
-            w1_scale[0] = w1_scale[0].to(w2_scale[0].dtype)
+            if use_w4a8_per_channel_gmm_swiglu:
+                gmm1_scale = _w4a8_per_channel_gmm_scale(w1_scale)
+            else:
+                w1_scale[0] = w1_scale[0].to(w2_scale[0].dtype)
+                gmm1_scale = w1_scale
             # gmm1: gate_up_proj
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
                 weight=w1,
-                scale=w1_scale,
+                scale=gmm1_scale,
                 bias=bias1,
                 per_token_scale=[pertoken_scale],
                 split_item=2,
@@ -310,7 +351,11 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
-            if HAS_TRITON:
+            if use_w4a8_per_channel_gmm_swiglu and _has_effective_swiglu_limit(swiglu_limit):
+                hidden_states, swiglu_out_scale = _w4a8_per_channel_swiglu_clamp_quant(
+                    hidden_states, swiglu_limit
+                )
+            elif HAS_TRITON:
                 from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
 
                 hidden_states, swiglu_out_scale = swiglu_quant(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR applies the DeepSeek V4 `swiglu_limit` before MoE dynamic quantization in the Ascend Python/PTA path.

DeepSeek V4 Pro w4a8 has `swiglu_limit=10.0`. On the current fused routed/shared expert paths, that finite limit is passed into fused custom ops. A deterministic `bad_12` request can then emit abnormal tokens such as `Foracci`, `†source`, `dátummal`, and `böjnings`.

Changes:

- Routed W4A8 per-channel MoE: when `0 < swiglu_limit < 1_000_000`, run GMM1 and explicitly apply `clamp -> silu(gate) * up -> dynamic_quant` before GMM2. Non-effective limits still use the existing fused op path.
- Quantized shared experts: explicitly dequantize, apply the same DeepSeek V4 clamp ordering, then dynamic-quantize before the down projection.
- Shared-expert MLP fallback: pass `swiglu_limit` so unquantized shared experts use upstream `SiluAndMulWithClamp`.
- Add focused UT coverage for both routed and shared expert paths.

This is the PTA-side mitigation for #9589. The issue remains open for the follow-up custom-op investigation and fix in `csrc`.

### Does this PR introduce _any_ user-facing change?

Yes. It fixes incorrect DeepSeek V4 Pro w4a8 generation when a finite `swiglu_limit` is used in Ascend MoE routed/shared expert paths.

### How was this patch tested?

Unit/static validation on the latest `upstream/main` (`b26970e597222029d624261a8738a40f2d33ad17`):

```bash
python -m py_compile \
  vllm_ascend/ops/fused_moe/moe_mlp.py \
  vllm_ascend/ops/fused_moe/fused_moe.py \
  vllm_ascend/models/deepseek_v4.py

pytest -q tests/ut/ops/test_moe_mlp.py tests/ut/ops/test_fused_moe.py
# 37 passed, 6 skipped

ruff check \
  vllm_ascend/ops/fused_moe/moe_mlp.py \
  vllm_ascend/ops/fused_moe/fused_moe.py \
  vllm_ascend/models/deepseek_v4.py \
  tests/ut/ops/test_moe_mlp.py \
  tests/ut/ops/test_fused_moe.py
# All checks passed

git -c core.whitespace=cr-at-eol diff --check
```

Manual real-weight validation was also run before rebasing the same patch to the latest main:

- Model: `/models/DeepSeek-V4-Pro-w4a8-0505`
- Topology: TP16 / DP1 / EP enabled, single node
- Runtime flags: `max-model-len=2048`, `gpu-memory-utilization=0.95`, `max-num-seqs=16`, `HCCL_DETERMINISTIC=true`, `HCCL_BUFFSIZE=512`, `HCCL_OP_EXPANSION_MODE=AIV`, `cudagraph_mode=FULL_DECODE_ONLY`
- Fused MC2 and FlashComm envs were unset.

Clean main reproduced abnormal `bad_12` markers:

```text
Foracci=True, †source=True, dátummal=True, böjnings=True
```

With this patch, the same request no longer contained those abnormal markers:

```text
Foracci=False, †source=False, dátummal=False, böjnings=False, 16:51=False
```