### PR TITLE
[Feature] Adapt FlashComm1 SP for Step3.5

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -169,12 +169,10 @@ class TestAscendReplicatedLinear(BaseLinearTest):
 
 
 class TestColumnParallelOpDispatch(unittest.TestCase):
-    """Tests for _get_column_parallel_op factory — DSV4 removal, share_expert, g_proj."""
+    """Tests for _get_column_parallel_op factory — share_expert, g_proj."""
 
     def setUp(self):
         self.mock_layer = MagicMock()
-        self.mock_layer.tp_size = 2
-        self.mock_layer.tp_rank = 0
         self._patches = [
             patch("vllm_ascend.ops.linear_op.mlp_tp_enable", return_value=False),
             patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=False),
@@ -194,13 +192,6 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
 
         return _get_column_parallel_op(prefix, self.mock_layer)
 
-    def test_wo_a_returns_none(self):
-        """DSV4OProjColumnParallelOp removed — wo_a no longer resolves."""
-        self.assertIsNone(self._get_column_op("wo_a"))
-        self._patches.append(patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=True))
-        self._patches[-1].start()
-        self.assertIsNone(self._get_column_op("wo_a"))
-
     def test_share_expert_disabled_with_sp_column(self):
         """share_expert / shared_expert prefix → None when SP enabled."""
         self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
@@ -216,12 +207,10 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
 
 
 class TestRowParallelOpDispatch(unittest.TestCase):
-    """Tests for _get_row_parallel_op factory — DSV4 removal, share_expert."""
+    """Tests for _get_row_parallel_op factory — share_expert."""
 
     def setUp(self):
         self.mock_layer = MagicMock()
-        self.mock_layer.tp_size = 2
-        self.mock_layer.tp_rank = 0
         self._patches = [
             patch("vllm_ascend.ops.linear_op.mlp_tp_enable", return_value=False),
             patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=False),
@@ -242,13 +231,6 @@ class TestRowParallelOpDispatch(unittest.TestCase):
 
         return _get_row_parallel_op(prefix, self.mock_layer)
 
-    def test_wo_b_returns_none(self):
-        """DSV4OProjRowParallelOp removed — wo_b no longer resolves."""
-        self.assertIsNone(self._get_row_op("wo_b"))
-        self._patches.append(patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=True))
-        self._patches[-1].start()
-        self.assertIsNone(self._get_row_op("wo_b"))
-
     def test_share_expert_disabled_with_sp_row(self):
         """share_expert / shared_expert prefix → None when SP enabled."""
         self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
@@ -263,11 +245,9 @@ class TestGetParallelOpShareExpert(unittest.TestCase):
     def setUp(self):
         self.mock_layer = MagicMock()
         self.mock_group = MagicMock()
-        self.mock_group.world_size = 4
-        self.mock_group.rank_in_group = 1
         self._patches = [
             patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=self.mock_group),
-            patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=False),
+            patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=True),
         ]
         for p in self._patches:
             p.start()
@@ -286,18 +266,12 @@ class TestGetParallelOpShareExpert(unittest.TestCase):
         for prefix in (
             "model.layers.0.mlp.share_expert.gate_up_proj",
             "model.layers.0.mlp.shared_expert.gate_up_proj",
+            "model.layers.0.mlp.shared_experts.gate_up_proj",
         ):
             custom_op, tp_rank, tp_size = self._call(prefix)
             self.assertIsNone(custom_op)
             self.assertEqual(tp_rank, 0)
             self.assertEqual(tp_size, 1)
-
-        self._patches.append(patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=True))
-        self._patches[-1].start()
-        custom_op, tp_rank, tp_size = self._call("model.layers.0.mlp.shared_experts.gate_up_proj")
-        self.assertIsNone(custom_op)
-        self.assertEqual(tp_rank, 0)
-        self.assertEqual(tp_size, 1)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -168,5 +168,137 @@ class TestAscendReplicatedLinear(BaseLinearTest):
         self.assertTrue(isinstance(linear.quant_method, AscendUnquantizedLinearMethod))
 
 
+class TestColumnParallelOpDispatch(unittest.TestCase):
+    """Tests for _get_column_parallel_op factory — DSV4 removal, share_expert, g_proj."""
+
+    def setUp(self):
+        self.mock_layer = MagicMock()
+        self.mock_layer.tp_size = 2
+        self.mock_layer.tp_rank = 0
+        self._patches = [
+            patch("vllm_ascend.ops.linear_op.mlp_tp_enable", return_value=False),
+            patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_sp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.is_moe_layer", return_value=False),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def _get_column_op(self, prefix: str):
+        from vllm_ascend.ops.linear_op import _get_column_parallel_op
+
+        return _get_column_parallel_op(prefix, self.mock_layer)
+
+    def test_wo_a_returns_none(self):
+        """DSV4OProjColumnParallelOp removed — wo_a no longer resolves."""
+        self.assertIsNone(self._get_column_op("wo_a"))
+        self._patches.append(patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=True))
+        self._patches[-1].start()
+        self.assertIsNone(self._get_column_op("wo_a"))
+
+    def test_share_expert_disabled_with_sp_column(self):
+        """share_expert / shared_expert prefix → None when SP enabled."""
+        self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
+        self._patches[-1].start()
+        self.assertIsNone(self._get_column_op("model.layers.0.mlp.share_expert.gate_up_proj"))
+        self.assertIsNone(self._get_column_op("model.layers.0.mlp.shared_expert.gate_up_proj"))
+
+    def test_g_proj_matches_sp_column_path(self):
+        """g_proj (Step3p5 attention gate) is included in SP column prefixes."""
+        self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
+        self._patches[-1].start()
+        self.assertIsNotNone(self._get_column_op("model.layers.0.self_attn.g_proj"))
+
+
+class TestRowParallelOpDispatch(unittest.TestCase):
+    """Tests for _get_row_parallel_op factory — DSV4 removal, share_expert."""
+
+    def setUp(self):
+        self.mock_layer = MagicMock()
+        self.mock_layer.tp_size = 2
+        self.mock_layer.tp_rank = 0
+        self._patches = [
+            patch("vllm_ascend.ops.linear_op.mlp_tp_enable", return_value=False),
+            patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp_with_layer_shard", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_sp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.is_moe_layer", return_value=False),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def _get_row_op(self, prefix: str):
+        from vllm_ascend.ops.linear_op import _get_row_parallel_op
+
+        return _get_row_parallel_op(prefix, self.mock_layer)
+
+    def test_wo_b_returns_none(self):
+        """DSV4OProjRowParallelOp removed — wo_b no longer resolves."""
+        self.assertIsNone(self._get_row_op("wo_b"))
+        self._patches.append(patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=True))
+        self._patches[-1].start()
+        self.assertIsNone(self._get_row_op("wo_b"))
+
+    def test_share_expert_disabled_with_sp_row(self):
+        """share_expert / shared_expert prefix → None when SP enabled."""
+        self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
+        self._patches[-1].start()
+        self.assertIsNone(self._get_row_op("model.layers.0.mlp.share_expert.down_proj"))
+        self.assertIsNone(self._get_row_op("model.layers.0.mlp.shared_expert.down_proj"))
+
+
+class TestGetParallelOpShareExpert(unittest.TestCase):
+    """Tests for get_parallel_op — share_expert/shared_expert disables TP."""
+
+    def setUp(self):
+        self.mock_layer = MagicMock()
+        self.mock_group = MagicMock()
+        self.mock_group.world_size = 4
+        self.mock_group.rank_in_group = 1
+        self._patches = [
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=self.mock_group),
+            patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=False),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def _call(self, prefix: str):
+        from vllm_ascend.ops.linear_op import get_parallel_op
+
+        return get_parallel_op(False, prefix, self.mock_layer, False)
+
+    def test_share_expert_disables_tp(self):
+        """share_expert / shared_expert / shared_experts → (None, 0, 1)."""
+        for prefix in (
+            "model.layers.0.mlp.share_expert.gate_up_proj",
+            "model.layers.0.mlp.shared_expert.gate_up_proj",
+        ):
+            custom_op, tp_rank, tp_size = self._call(prefix)
+            self.assertIsNone(custom_op)
+            self.assertEqual(tp_rank, 0)
+            self.assertEqual(tp_size, 1)
+
+        self._patches.append(patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=True))
+        self._patches[-1].start()
+        custom_op, tp_rank, tp_size = self._call("model.layers.0.mlp.shared_experts.gate_up_proj")
+        self.assertIsNone(custom_op)
+        self.assertEqual(tp_rank, 0)
+        self.assertEqual(tp_size, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -179,6 +179,7 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
             patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
             patch("vllm_ascend.ops.linear_op.enable_sp", return_value=False),
             patch("vllm_ascend.ops.linear_op.is_moe_layer", return_value=False),
+            patch("vllm_ascend.ops.linear_op.flashcomm2_oshard_manager.flashcomm2_oshard_enable", return_value=False),
         ]
         for p in self._patches:
             p.start()
@@ -218,6 +219,8 @@ class TestRowParallelOpDispatch(unittest.TestCase):
             patch("vllm_ascend.ops.linear_op.enable_dsa_cp_with_layer_shard", return_value=False),
             patch("vllm_ascend.ops.linear_op.enable_sp", return_value=False),
             patch("vllm_ascend.ops.linear_op.is_moe_layer", return_value=False),
+            patch("vllm_ascend.ops.linear_op.matmul_allreduce_enable", return_value=False),
+            patch("vllm_ascend.ops.linear_op.flashcomm2_enable", return_value=False),
         ]
         for p in self._patches:
             p.start()

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -683,7 +683,8 @@ def _get_column_parallel_op(
         if any(p in prefix for p in ("qkv_proj", "conv1d", "query_key_value")):
             return Flashcomm2OshardQKVParallelOp(layer)
     if enable_sp():
-        if "shared_expert" in prefix:
+        # "share_expert" added for Step3p5
+        if "shared_expert" in prefix or "share_expert" in prefix:
             return None
         sp_column_prefix = [
             "gate_up_proj",  # first MLP of most LLMs
@@ -691,6 +692,7 @@ def _get_column_parallel_op(
             "qkv_proj",  # qkv linear of most LLMs
             "conv1d",  # gated deltanet of Qwen3 Next
             "query_key_value",  # qkv linear of Bailing
+            "g_proj",  # attention gate projection of Step3p5
         ]
         for a_prefix in sp_column_prefix:
             if a_prefix in prefix:
@@ -725,7 +727,8 @@ def _get_row_parallel_op(
         if "o_proj" in prefix or "out_proj" in prefix:
             return Flashcomm2OProjRowParallelOp(layer)
     if enable_sp():
-        if "shared_expert" in prefix:
+        # "share_expert" added for Step3p5
+        if "shared_expert" in prefix or "share_expert" in prefix:
             return None
         sp_row_prefixes = [
             "o_proj",  # attn output linear of most LLMs
@@ -746,6 +749,7 @@ def get_parallel_op(disable_tp, prefix, layer, direct):
         disable_tp
         or ("shared_experts" in prefix and shared_expert_dp_enabled())
         or ("shared_expert" in prefix and shared_expert_dp_enabled())
+        or ("share_expert" in prefix and shared_expert_dp_enabled())  # "share_expert" added for Step3p5
     ):
         return None, 0, 1
     custom_op: (


### PR DESCRIPTION
### What this PR does / why we need it?
Adapt FlashComm1 (SP) in vllm-ascend for the Step3.5 model with two fixes in `linear_op.py`:

  **1. Add `share_expert` prefix matching (3 places)**

  Step3.5 names its shared expert weights with `share_expert` (no trailing 's'), but the original code only matches `shared_expert` / `shared_experts`. This causes shared_expert  layers to incorrectly participate in SP column/row parallel ops. Added `share_expert` matching in `_get_column_parallel_op`, `_get_row_parallel_op`, and `get_parallel_op`.

**2.Add "g_proj" to SP column-parallel**
 Add "g_proj" to SP column-parallel dispatch prefixes for Step3p5 attention gate projection. Without this, the g_proj layer falls through to None and does not participate in sequence parallelism, causing a shape mismatch at the residual addition.

### Does this PR introduce _any_ user-facing change?
 No.

### How was this patch tested?
Tested on Ascend 910B with Step3.5 Flash model (MoE, W8A8, TP=8). Verified that shared_expert layers are correctly skipped and `g_proj` participates in SP column-parallel
  dispatch. Model runs without errors when `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
