### PR TITLE
[Feature] Fix the precision issue of dsV4 caused by dequant_swiglu_quant

### DIFF
--- a/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_def.cpp
+++ b/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_def.cpp
@@ -21,7 +21,7 @@ namespace ops
 constexpr uint32_t DEQUANT_SWIGLU_QUANT_VERSION_TWO = 2;
 constexpr uint32_t DEQUANT_SWIGLU_QUANT_DEFAULT_VALUE = 2;
 constexpr float CLAMP_LIMIT_DEFAULT_VALUE = 0.0;
-constexpr float GLU_ALPHA_DEFAULT_VALUE = 1.702;
+constexpr float GLU_ALPHA_DEFAULT_VALUE =1.00;// 1.702;
 class DequantSwigluQuant : public OpDef
 {
   public:
@@ -98,8 +98,8 @@ class DequantSwigluQuant : public OpDef
     this->Attr("activate_dim").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Int(-1); // default value
     this->Attr("swiglu_mode").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Int(0); // default value
     this->Attr("clamp_limit").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Float(CLAMP_LIMIT_DEFAULT_VALUE); // default value
-    this->Attr("glu_alpha").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Float(GLU_ALPHA_DEFAULT_VALUE); // default value
-    this->Attr("glu_bias").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Float(1.0); // default value
+    this->Attr("glu_alpha").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Float(GLU_ALPHA_DEFAULT_VALUE); // default value 1.702;
+    this->Attr("glu_bias").AttrType(OPTIONAL).Version(DEQUANT_SWIGLU_QUANT_VERSION_TWO).Float(0.0); // default value 1.0
        OpAICoreConfig aicoreConfig;
         aicoreConfig.DynamicCompileStaticFlag(true)
             .DynamicFormatFlag(false)

--- a/csrc/moe/dequant_swiglu_quant/op_kernel/dequant_swiglu_quant.h
+++ b/csrc/moe/dequant_swiglu_quant/op_kernel/dequant_swiglu_quant.h
@@ -631,11 +631,19 @@ __aicore__ inline void DequantSwigluQuantBase<TEMPLATE_DSQ_ARGS>::SwiGluGate(
     LocalTensor<float> tmpUbF32 = tmpBuf1_.AllocTensor<float>();
     LocalTensor<float> tmpUbF32Act = tmpUbF32;
     LocalTensor<float> tmpUbF32Gate = tmpUbF32[calEleNum];
-    // 前一半作为 tmpUbF32Act，后一半作为 tmpUbF32Gate
-    CopyLocalContiguousFloat(tmpUbF32Act, xLocalF32, calEleNum);
-    CopyLocalContiguousFloat(tmpUbF32Gate, xLocalF32[calEleNum], calEleNum);
+    SetMaskCount();
+    SetVectorMask<float, MaskMode::COUNTER>(tl_->UbFactorDimy);
+    Copy<float, false>(
+    tmpUbF32Act, xLocalF32[actOffset_], AscendC::MASK_PLACEHOLDER, proDimsx,
+    {1, 1, static_cast<uint16_t>(tl_->UbFactorDimy / BLOCK_ELEM),
+        static_cast<uint16_t>(tl_->UbFactorDimy / BLOCK_ELEM * SWI_FACTOR)});
+    Copy<float, false>(
+    tmpUbF32Gate, xLocalF32[gateOffset_], AscendC::MASK_PLACEHOLDER, proDimsx,
+    {1, 1, static_cast<uint16_t>(tl_->UbFactorDimy / BLOCK_ELEM),
+        static_cast<uint16_t>(tl_->UbFactorDimy / BLOCK_ELEM * SWI_FACTOR)});
+    SetMaskNorm();
+    ResetMask();
     PipeBarrier<PIPE_V>();
-
     if (tl_->clampLimit > 0.0f) {
         // tmpUbF32Gate
         Mins(tmpUbF32Gate, tmpUbF32Gate, tl_->clampLimit, calEleNum);
@@ -643,11 +651,10 @@ __aicore__ inline void DequantSwigluQuantBase<TEMPLATE_DSQ_ARGS>::SwiGluGate(
         Maxs(tmpUbF32Gate, tmpUbF32Gate, -(tl_->clampLimit), calEleNum);
         PipeBarrier<PIPE_V>();
     }
-    Adds(tmpUbF32Gate, tmpUbF32Gate, tl_->gluBias, calEleNum);
-    PipeBarrier<PIPE_V>();
-
+        Adds(tmpUbF32Gate, tmpUbF32Gate, tl_->gluBias, calEleNum);
+        PipeBarrier<PIPE_V>();
     if (tl_->clampLimit > 0.0f) {
-        // tmpUbF32Act
+    // tmpUbF32Act
         Mins(tmpUbF32Act, tmpUbF32Act, tl_->clampLimit, calEleNum);
         PipeBarrier<PIPE_V>();
     }
@@ -655,7 +662,7 @@ __aicore__ inline void DequantSwigluQuantBase<TEMPLATE_DSQ_ARGS>::SwiGluGate(
     PipeBarrier<PIPE_V>();
     Exp(xLocalF32, xLocalF32, calEleNum);
     PipeBarrier<PIPE_V>();
-    Adds(xLocalF32, xLocalF32, (float)1.0, calEleNum);
+    Adds(xLocalF32, xLocalF32,  static_cast<float>(1.0), calEleNum);
     PipeBarrier<PIPE_V>();
     Div(tmpUbF32Act, tmpUbF32Act, xLocalF32, calEleNum);
     PipeBarrier<PIPE_V>();

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2116,7 +2116,7 @@ std::tuple<at::Tensor, at::Tensor> npu_dequant_swiglu_quant(
     TORCH_CHECK(x.dim() > 1, "x dim should larger than 1");
     TORCH_CHECK(quant_mode == 0 || quant_mode == 1, "quant_mode only support 0 or 1, but got ", quant_mode);
     TORCH_CHECK(swiglu_mode == 0 || swiglu_mode == 1, "swiglu_mode only support 0 or 1, but got ", swiglu_mode);
-    TORCH_CHECK(clamp_limit >= 0.0, "clamp_limit should be non-negative");
+    TORCH_CHECK(std::isfinite(clamp_limit) && clamp_limit >= 0.0, "clamp_limit should be positive finite");
     TORCH_CHECK(std::isfinite(glu_alpha), "glu_alpha should be finite");
     TORCH_CHECK(std::isfinite(glu_bias), "glu_bias should be finite");
     TORCH_CHECK(x.size(x.dim() - 1) % 2 == 0, "x last dim should be even");
@@ -2135,26 +2135,28 @@ std::tuple<at::Tensor, at::Tensor> npu_dequant_swiglu_quant(
     std::string quant_mode_str = quant_mode == 1 ? "dynamic" : "static";
     char* quant_mode_ptr = const_cast<char*>(quant_mode_str.c_str());
 
-    const at::Tensor& weight_scale_opt = c10::value_or_else(weight_scale, [] { return at::Tensor(); });
+    const at::Tensor& weight_scale_value = c10::value_or_else(weight_scale, [] { return at::Tensor(); });
     const at::Tensor& activation_scale_opt = c10::value_or_else(activation_scale, [] { return at::Tensor(); });
     const at::Tensor& bias_opt = c10::value_or_else(bias, [] { return at::Tensor(); });
     const at::Tensor& quant_scale_opt = c10::value_or_else(quant_scale, [] { return at::Tensor(); });
     const at::Tensor& quant_offset_opt = c10::value_or_else(quant_offset, [] { return at::Tensor(); });
-    const at::Tensor& group_index_opt = c10::value_or_else(group_index, [] { return at::Tensor(); });
+    const at::Tensor& group_index_value = c10::value_or_else(group_index, [&x] {
+        return at::empty({1}, x.options().dtype(c10::ScalarType::Long)).fill_(x.size(0));
+    });
 
     static const bool is_v2_available =
         GetOpApiFuncAddr("aclnnDequantSwigluQuantV2") != nullptr &&
         GetOpApiFuncAddr("aclnnDequantSwigluQuantV2GetWorkspaceSize") != nullptr;
 
     if (swiglu_mode == 0 && !is_v2_available) {
-        EXEC_NPU_CMD(aclnnDequantSwigluQuant, x, weight_scale_opt, activation_scale_opt, bias_opt, quant_scale_opt,
-                     quant_offset_opt, group_index_opt, activate_left, quant_mode_ptr, y, scale);
+        EXEC_NPU_CMD(aclnnDequantSwigluQuant, x, weight_scale_value, activation_scale_opt, bias_opt, quant_scale_opt,
+                     quant_offset_opt, group_index_value, activate_left, quant_mode_ptr, y, scale);
     } else {
         int64_t dst_type = 2;
         char* round_mode = const_cast<char*>("rint");
         int64_t activate_dim = -1;
-        EXEC_NPU_CMD(aclnnDequantSwigluQuantV2, x, weight_scale_opt, activation_scale_opt, bias_opt, quant_scale_opt,
-                     quant_offset_opt, group_index_opt, activate_left, quant_mode_ptr, dst_type, round_mode,
+        EXEC_NPU_CMD(aclnnDequantSwigluQuantV2, x, weight_scale_value, activation_scale_opt, bias_opt, quant_scale_opt,
+                     quant_offset_opt, group_index_value, activate_left, quant_mode_ptr, dst_type, round_mode,
                      activate_dim, swiglu_mode, clamp_limit, glu_alpha, glu_bias, y, scale);
     }
 
@@ -2892,8 +2894,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
             "int quant_mode=0, "
             "int swiglu_mode=0, "
             "float clamp_limit=0.0, "
-            "float glu_alpha=1.702, "
-            "float glu_bias=1.0"
+            "float glu_alpha=1.0, "
+            "float glu_bias=0.0"
         ") -> (Tensor y, Tensor scale)"
     );
     ops.impl("npu_dequant_swiglu_quant", torch::kPrivateUse1, &vllm_ascend::npu_dequant_swiglu_quant);

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -1,0 +1,109 @@
+import gc
+import math
+
+import torch
+import torch.nn.functional as F
+import torch_npu
+
+from vllm_ascend.utils import enable_custom_op
+
+# enable internal format
+torch_npu.npu.config.allow_internal_format = True
+# enable vllm-ascend custom ops
+enable_custom_op()
+
+
+def _has_effective_swiglu_limit(swiglu_limit: int | float) -> bool:
+    limit = float(swiglu_limit)
+    return math.isfinite(limit) and 0.0 < limit < 1_000_000.0
+
+
+def _shared_dequant_swiglu_quant(
+    hidden_states: torch.Tensor,
+    weight_scale: torch.Tensor,
+    activation_scale: torch.Tensor,
+    swiglu_limit: int | float,
+    output_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not _has_effective_swiglu_limit(swiglu_limit):
+        return torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            x=hidden_states,
+            weight_scale=weight_scale,
+            activation_scale=activation_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            activate_left=True,
+            quant_mode=1,
+            swiglu_mode=1,
+            clamp_limit=swiglu_limit,
+        )
+
+    if hidden_states.shape[0] == 0:
+        output_shape = hidden_states.shape[:-1] + (hidden_states.shape[-1] // 2,)
+        return (
+            hidden_states.new_empty(output_shape, dtype=torch.int8),
+            torch.empty(hidden_states.shape[:-1], dtype=torch.float32, device=hidden_states.device),
+        )
+
+    weight_scale = weight_scale.to(torch.float32).reshape((1,) * (hidden_states.dim() - 1) + (-1,))
+    activation_scale = activation_scale.to(torch.float32).reshape(hidden_states.shape[:-1] + (1,))
+    gate_up = hidden_states.to(torch.float32) * weight_scale * activation_scale
+
+    half = gate_up.shape[-1] // 2
+    limit = float(swiglu_limit)
+    gate = torch.clamp(gate_up[..., :half], max=limit)
+    up = torch.clamp(gate_up[..., half:], min=-limit, max=limit)
+    swiglu = F.silu(gate) * up
+    if swiglu.dtype not in (torch.float16, torch.bfloat16):
+        swiglu = swiglu.to(output_dtype if output_dtype in (torch.float16, torch.bfloat16) else torch.bfloat16)
+    return torch_npu.npu_dynamic_quant(swiglu)
+
+
+@torch.inference_mode()
+def test_npu_dequant_swiglu_quant_with_limit():
+    swiglu_mode = 1
+    x_shape = [4608, 2048]
+    x = torch.randint(-10, 10, x_shape, dtype=torch.int32)
+    weight_scale = torch.randn(x_shape[1], dtype=torch.float32)
+    activate_scale = torch.randn((x_shape[0], 1), dtype=torch.float32)
+    clamp_limit = 2.0
+    quant_mode = 1
+
+    output_golden, output_scale_golden = _shared_dequant_swiglu_quant(
+        x.npu(),
+        weight_scale.npu(),
+        activate_scale.npu(),
+        clamp_limit,
+        torch.bfloat16,
+    )
+
+    x = x.npu()
+    weight_scale = weight_scale.npu()
+    activate_scale = activate_scale.npu()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph, capture_error_mode="thread_local", auto_dispatch_capture=True):
+        output, output_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            x=x,
+            weight_scale=weight_scale,
+            activation_scale=activate_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            activate_left=True,
+            quant_mode=quant_mode,
+            swiglu_mode=swiglu_mode,
+            clamp_limit=clamp_limit,
+            glu_alpha=1.0,
+            glu_bias=0.0,
+        )
+    graph.replay()
+
+    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
+    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=1e-4, rtol=5e-3)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()


### PR DESCRIPTION
### What this PR does / why we need it?
#### 1、Fix the precision issue of dsV4 caused by a bug in the operator:
    1. The default values of the last two parameters of the operator should be changed to 1, 0.
    2. If the groupindex parameter is not passed, it will cause the clamp function to be disabled.
    3. when clamp_limit==0，the clamp function is turned off.
#### 2、Add operator test cases.
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

#9589 
#9590 


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
