### PR TITLE
[Misc] Adapt the new issue processing group and align stale label with issue using

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,13 +1,11 @@
 core-features:
-  - '/((pd|(prefill[- ]?decode))\s+disaggregation|kv cache pool|aclgraph|async scheduler|cpu binding|quantization)/i'
+  - '/((pd|(prefill[- ]?decode))\s+disaggregation|kv cache pool|aclgraph|cpu binding|quantization)/i'
 pd-disaggregation:
   - '/((pd|(prefill[- ]?decode))\s+disaggregation)/i'
 kv-cache-pool:
   - '/(kv cache pool)/i'
 aclgraph:
   - '/(aclgraph)/i'
-async-scheduler:
-  - '/(async scheduler)/i'
 cpu-binding:
   - '/(cpu binding)/i'
 quantization:
@@ -20,6 +18,18 @@ mtp/speculative-decode:
   - '/(mtp|speculative decode)/i'
 eplb:
   - '/(\beplb)/i'
+architecture-features:
+  - '/(async scheduler|dplb\b|post.(processing|process)|(sample|sampling)|flashcomm|\b(verl|rl)\b)/i'
+async-scheduler:
+  - '/(async scheduler)/i'
+dplb:
+  - '/(dplb\b)/i'
+post-processing:
+  - '/(post.(processing|process)|(sample|sampling))/i'
+flashcomm:
+  - '/(flashcomm)/i'
+rl:
+  - '/(\b(verl|rl)\b)/i'
 llm-model:
   - '/(deepseek(?:[- ]*(?:r1|v3(?:\.2)?))?\S*|(kimi k2|kimik2|kimi-k2)(?!\.5)|(kimi k2\.5|kimik2\.5|kimi-k2\.5)|glm5|glm-5|glm 5|qwen3-(?:235b|480b)\S*|Qwen3-(?:32B|8B|30B)\S*|qwen3-next\S*|\bglm[- ]?4\.[0-9]+(?![^v\s]*v)\S*)/i'
 deepseek:
@@ -30,16 +40,20 @@ kimi-k2.5:
   - '/((kimi k2\.5|kimik2\.5|kimi-k2\.5))/i'
 glm5:
   - '/(glm5|glm-5|glm 5)/i'
-qwen3-moe:
-  - '/(Qwen3-(?:235B|480B)\S*)/i'
-qwen3-dense:
-  - '/(Qwen3-(?:32B|8B|30B)\S*)/i'
 qwen3-next:
   - '/(qwen3-next\S*)/i'
 glm-4:
   - '/(\bglm[- ]?4\.[0-9]+(?![^v\s]*v)\S*)/i'
+gqa-model:
+  - '/(qwen3.(?:235b|480b)\S*|qwen3.(?:32b|8b|30b)\S*|minimax\S*)/i'
+qwen3-moe:
+  - '/(qwen3.(?:235b|480b)\S*)/i'
+qwen3-dense:
+  - '/(qwen3.(?:32b|8b|30b)\S*)/i'
+minimax:
+  - '/(minimax\S*)/i'
 multi-modality-generate:
-  - '/(seedance\S*|seedream\S*|\bwan\d[\d.]*|hunyuan\S*|fLux\S*|kimi k2\.5|kimi-k2\.5|kimik2\.5|minimax\S*|qwen-image\S*)/i'
+  - '/(seedance\S*|seedream\S*|\bwan\d[\d.]*|hunyuan\S*|fLux\S*|kimi k2\.5|kimi-k2\.5|kimik2\.5|qwen-image\S*)/i'
 seedance:
   - '/(seedance\S*)/i'
 seedream:
@@ -52,8 +66,6 @@ fLux:
   - '/(fLux\S*)/i'
 qwen-image:
   - '/(qwen-image\S*)/i'
-minimax:
-  - '/(minimax\S*)/i'
 multimodal-understanding:
   - '/(glm-?4\.\S*v\b|qwen3\.5\S*|deepseek-ocr\S*)/i'
 glm-4v:

--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -1,4 +1,4 @@
-name: "Close stale resolved/awaiting-feedback issues"
+name: "Close stale resolved/wait-feedback issues"
 on:
   schedule:
     - cron: '0 2 * * *' 
@@ -39,14 +39,14 @@ jobs:
           days-before-pr-close: -1
       - uses: actions/stale@v10
         with:
-          # Process issues with the 'awaiting-feedback' label
-          any-of-labels: 'awaiting-feedback'
+          # Process issues with the 'wait-feedback' label
+          any-of-labels: 'wait-feedback'
 
           # Mark as stale after a period of inactivity
           days-before-stale: 7
           stale-issue-label: 'stale'
           stale-issue-message: |
-            This issue has been marked as `awaiting-feedback` but has not received any feedback for some time, so it is now labeled as `stale`. 
+            This issue has been marked as `wait-feedback` but has not received any feedback for some time, so it is now labeled as `stale`. 
             To more accurately locate and resolve the issue, we need you to provide the relevant information mentioned above. 
             `Stale` issues will automatically be closed after 14 days of inactivity.
 
@@ -58,8 +58,8 @@ jobs:
 
           # Automatically remove the 'stale' label when the issue is updated (default is true)
           remove-stale-when-updated: true
-          # Also remove the 'awaiting-feedback' label
-          labels-to-remove-when-unstale: 'awaiting-feedback'
+          # Also remove the 'wait-feedback' label
+          labels-to-remove-when-unstale: 'wait-feedback'
 
           # Avoid accidental PR processing (PRs can be handled if needed; this is issue-only)
           days-before-pr-stale: -1


### PR DESCRIPTION
### What this PR does / why we need it?
1. Align stale label with issues using: awaiting-feedback-> wait-feedback.
2. Adapt the new issue processing group: architecture-features and gqa-model issue process group added

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Test on local regex formula.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
