### PR TITLE
[BugFix][Ops] Fix wo_a weight reload in DeepSeek V4 RL scenario

### DIFF
--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -452,9 +452,9 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         if "wo_a" in self.prefix:
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
-                self.weight.data = self.weight.data.view(
-                    self.n_local_groups, self.o_lora_rank,
-                    -1).transpose(2, 1).contiguous()
+                self.weight.data = (
+                    self.weight.data.view(self.n_local_groups, self.o_lora_rank, -1).transpose(2, 1).contiguous()
+                )
             else:
                 # In RL update flows, wo_a can be loaded again after being
                 # transformed into [n_local_groups, hidden_size, o_lora_rank].
@@ -462,11 +462,15 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
                 start_idx = self.tp_rank * shard_size
                 if loaded_weight.shape[0] != shard_size:
                     loaded_weight = loaded_weight.narrow(0, start_idx, shard_size)
-                loaded_weight = loaded_weight.view(
-                    self.n_local_groups,
-                    self.o_lora_rank,
-                    -1,
-                ).transpose(2, 1).contiguous()
+                loaded_weight = (
+                    loaded_weight.view(
+                        self.n_local_groups,
+                        self.o_lora_rank,
+                        -1,
+                    )
+                    .transpose(2, 1)
+                    .contiguous()
+                )
 
                 if loaded_weight.shape != self.weight.shape:
                     raise ValueError(

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -449,11 +449,33 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        super().weight_loader(param, loaded_weight)
         if "wo_a" in self.prefix:
-            self.weight.data = (
-                self.weight.data.view(self.n_local_groups, self.o_lora_rank, -1).transpose(2, 1).contiguous()
-            )
+            if self.weight.ndim == 2:
+                super().weight_loader(param, loaded_weight)
+                self.weight.data = self.weight.data.view(
+                    self.n_local_groups, self.o_lora_rank,
+                    -1).transpose(2, 1).contiguous()
+            else:
+                # In RL update flows, wo_a can be loaded again after being
+                # transformed into [n_local_groups, hidden_size, o_lora_rank].
+                shard_size = self.n_local_groups * self.o_lora_rank
+                start_idx = self.tp_rank * shard_size
+                if loaded_weight.shape[0] != shard_size:
+                    loaded_weight = loaded_weight.narrow(0, start_idx, shard_size)
+                loaded_weight = loaded_weight.view(
+                    self.n_local_groups,
+                    self.o_lora_rank,
+                    -1,
+                ).transpose(2, 1).contiguous()
+
+                if loaded_weight.shape != self.weight.shape:
+                    raise ValueError(
+                        f"Unexpected wo_a weight shape {tuple(loaded_weight.shape)}, "
+                        f"expected {tuple(self.weight.shape)}"
+                    )
+                self.weight.data.copy_(loaded_weight)
+        else:
+            super().weight_loader(param, loaded_weight)
 
 
 class AscendReplicatedLinear(ReplicatedLinear):


### PR DESCRIPTION
### What this PR does / why we need it?

What this PR does / why we need it?

This PR fixes wo_a weight loading in AscendColumnParallelLinear.weight_loader for DeepSeek V4 RL update flows.
Previously, wo_a always went through the initial loading path. In RL scenarios, however, wo_a can be loaded again after it has already been transformed into the runtime layout `[n_local_groups, hidden_size, o_lora_rank]`. Reusing the original loading path in this case can lead to incorrect weight updates or shape mismatches.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
