### PR TITLE
[BugFix] Fix A5 custom opapi symbol shadowing

### DIFF
--- a/csrc/cmake/custom_build.cmake
+++ b/csrc/cmake/custom_build.cmake
@@ -80,13 +80,14 @@ if (BUILD_OPEN_PROJECT)
     target_compile_definitions(cust_opapi PRIVATE
             -DACLNN_LOG_FMT_CHECK
     )
-    if(BUILD_WITH_3_8_PACKAGE)  #3~8包 依赖opapi, 不依赖opbase
+    if(BUILD_WITH_3_8_PACKAGE)  # 3~8 package links opapi_math and does not depend on opsbase.
     target_link_libraries(cust_opapi PRIVATE
         $<BUILD_INTERFACE:intf_pub>
         -Wl,--whole-archive
         ops_aclnn
         -Wl,--no-whole-archive
-        -lopapi
+        # Avoid exporting CANN built-in ACLNN symbols through libcust_opapi.so.
+        $<$<BOOL:${BUILD_WITH_INSTALLED_DEPENDENCY_CANN_PKG}>:$<BUILD_INTERFACE:opapi_math>>
         nnopbase
         profapi
         ge_common_base


### PR DESCRIPTION
### What this PR does / why we need it?

Fix A5 custom opapi symbol shadowing in the legacy `BUILD_WITH_3_8_PACKAGE` custom-op build path.

The A5 custom `libcust_opapi.so` should not link against the full CANN `libopapi.so`, because that can expose or shadow opapi symbols from the CANN package instead of keeping the custom opapi symbols isolated in vLLM Ascend's build output.

This PR updates `csrc/cmake/custom_build.cmake` to use `opapi_math` for the legacy A5 path, matching the current upstream `cann/ops-transformer` custom opapi link model.

### Does this PR introduce _any_ user-facing change?

No. This is an internal custom-op build/linkage fix and does not add a public API, CLI flag, or default behavior change.

### How was this patch tested?

- `git diff --check`
- confirmed the diff is limited to `csrc/cmake/custom_build.cmake`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
