### PR TITLE
[BugFix] Keep the router gate in FP32 on NPU for DeepSeek-like models

### DIFF
--- a/tests/e2e/multicard/4-cards/test_pipeline_parallel.py
+++ b/tests/e2e/multicard/4-cards/test_pipeline_parallel.py
@@ -55,13 +55,13 @@ GOLDEN = [
             29,
             285,
             304,
-            608,
+            6,
+            76,
             245,
             459,
             6946,
-            29,
         ],
-        "Hello, my name is <strong>Alessandro</strong> and I am a <strong>",
+        "Hello, my name is <strong>Alessandro</strong> and I'm a <strong",
     ),
     (
         [

--- a/tests/ut/ops/test_gate_linear.py
+++ b/tests/ut/ops/test_gate_linear.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
+
+
+class TestAscendGateLinear(TestBase):
+    def setUp(self):
+        super().setUp()
+
+        self.mock_group = mock.MagicMock()
+        self.mock_group.world_size = 1
+        self.mock_group.rank_in_group = 0
+
+        self.patches = [
+            patch(
+                "vllm.distributed.parallel_state.get_tp_group",
+                return_value=self.mock_group,
+            ),
+        ]
+
+        for p in self.patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self.patches:
+            p.stop()
+
+        super().tearDown()
+
+    def test_forward_keeps_router_logits_fp32(self):
+        gate = AscendGateLinear(
+            input_size=16,
+            output_size=4,
+            bias=False,
+            prefix="test.gate",
+        )
+
+        self.assertEqual(gate.weight.dtype, torch.float32)
+
+        hidden_states = torch.randn(2, 16, dtype=torch.bfloat16)
+        output, output_bias = gate(hidden_states)
+
+        self.assertEqual(output.dtype, torch.float32)
+        self.assertIsNone(output_bias)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -391,12 +391,12 @@ class AscendFusedMoE(FusedMoE):
         self.multistream_overlap_gate = ascend_config.multistream_overlap_gate
         if self.multistream_overlap_gate and AscendFusedMoE.gate_stream is None:
             AscendFusedMoE.gate_stream = torch.npu.Stream()
+        vllm_config = get_current_vllm_config()
         if (
             self.custom_routing_function is None
             and self.e_score_correction_bias is not None
-            and self.scoring_func != "sqrtsoftplus"
+            and not vllm_config.model_config.is_deepseek_mla
         ):
-            vllm_config = get_current_vllm_config()
             self.e_score_correction_bias.data = self.e_score_correction_bias.data.to(
                 dtype=vllm_config.model_config.dtype
             )

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import torch
+from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
+from vllm.model_executor.layers.linear import ReplicatedLinear
+
+
+class AscendGateLinear(GateLinear):
+    """Ascend replacement for vLLM GateLinear.
+    Router logits are sensitive to numerical precision because they directly
+    affect expert selection in MoE models. On NPU, computing the router gate in
+    lower precision may lead to accuracy issues in some agent workloads.
+    Therefore, this layer forces the gate input and weights to fp32 for the
+    router linear computation, and keeps the router logits in fp32.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        bias: bool = False,
+        out_dtype: torch.dtype | None = None,
+        params_dtype: torch.dtype | None = None,
+        force_fp32_compute: bool = False,
+        prefix: str = "",
+    ):
+        super().__init__(
+            input_size=input_size,
+            output_size=output_size,
+            bias=bias,
+            params_dtype=torch.float32,
+            out_dtype=out_dtype,
+            force_fp32_compute=True,
+            prefix=prefix,
+        )
+
+    def forward(self, x: torch.Tensor):
+        # TODO: Remove this workaround after upgrading to a vLLM version that
+        # no longer forces router logits to bf16 via
+        # self.gate.set_out_dtype(torch.bfloat16).
+        if x.dtype != torch.float32:
+            x = x.to(torch.float32)
+
+        output, output_bias = ReplicatedLinear.forward(self, x)
+
+        return output, output_bias

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -774,6 +774,18 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         "BailingMoELinearAttention": AscendBailingMoELinearAttention,
     }
 
+    if vllm_config is None:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            vllm_config = get_current_vllm_config()
+        except AssertionError:
+            vllm_config = None
+    if vllm_config is not None and vllm_config.model_config.is_deepseek_mla:
+        from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
+
+        REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
+
     # 310P: override selected ops with 310P implementations (keep minimal changes outside _310p)
     if is_310p():
         from vllm_ascend._310p.fused_moe.fused_moe import AscendFusedMoE310


### PR DESCRIPTION
### What this PR does / why we need it?

This PR keeps the router gate in FP32 on NPU for DeepSeek-like MoE models.

For DeepSeek-like models, router logits directly affect MoE expert selection and are sensitive to numerical precision. We observed that lower-precision router gate computation may cause accuracy issues in some agent workloads on NPU. To avoid this, this PR introduces an Ascend-specific `GateLinear` replacement that casts the gate input to FP32, uses FP32 gate weights, and preserves FP32 router logits.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

After applying this change, GLM-5.1 passed the evaluation on the agent dataset SWE-Bench. To verify whether converting from BF16/FP16 to FP32 has any impact on performance, we selected GLM-5.1 and DeepSeek-V3.2 for performance testing. The results confirmed that this change has no impact on the performance of all three models.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
