### PR TITLE
[Doc] Fix vLLM-Ascend version in PD Disaggregation 

### DIFF
--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -111,7 +111,7 @@ docker run --rm \
 
 ## (Optional) Install Mooncake
 
-Mooncake is pre-installed and functional in the {vllm_ascend_version} image.
+Mooncake is pre-installed and functional in the {{vllm_ascend_version}} image.
 The following installation steps are optional.
 
 Mooncake is the serving platform for Kimi, a leading LLM service provided by

--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -7,7 +7,7 @@ This guide provides step-by-step instructions to test these features with
 constrained resources.
 
 Using the Qwen2.5-72B-Instruct model as an example, this guide demonstrates
-how to use vllm-ascend {vllm_ascend_version} (with vLLM {vllm_version}) on two Atlas 800T A2
+how to use vllm-ascend {{vllm_ascend_version}} (with vLLM {{vllm_version}}) on two Atlas 800T A2
 nodes to deploy two vLLM instances. Each instance occupies 4 NPU cards and
 uses PD-colocated deployment.
 

--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -7,7 +7,7 @@ This guide provides step-by-step instructions to test these features with
 constrained resources.
 
 Using the Qwen2.5-72B-Instruct model as an example, this guide demonstrates
-how to use vllm-ascend v0.11.0 (with vLLM v0.11.0) on two Atlas 800T A2
+how to use vllm-ascend |vllm_ascend_version| (with vLLM |vllm_version|) on two Atlas 800T A2
 nodes to deploy two vLLM instances. Each instance occupies 4 NPU cards and
 uses PD-colocated deployment.
 
@@ -80,7 +80,7 @@ Start a Docker container on each node.
 
 ```bash
 # Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:v0.11.0
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 export NAME=vllm-ascend
 
 # Run the container using the defined variables
@@ -111,7 +111,7 @@ docker run --rm \
 
 ## (Optional) Install Mooncake
 
-Mooncake is pre-installed and functional in the v0.11.0 image.
+Mooncake is pre-installed and functional in the |vllm_ascend_version| image.
 The following installation steps are optional.
 
 Mooncake is the serving platform for Kimi, a leading LLM service provided by

--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -7,7 +7,7 @@ This guide provides step-by-step instructions to test these features with
 constrained resources.
 
 Using the Qwen2.5-72B-Instruct model as an example, this guide demonstrates
-how to use vllm-ascend |vllm_ascend_version| (with vLLM |vllm_version|) on two Atlas 800T A2
+how to use vllm-ascend {vllm_ascend_version} (with vLLM {vllm_version}) on two Atlas 800T A2
 nodes to deploy two vLLM instances. Each instance occupies 4 NPU cards and
 uses PD-colocated deployment.
 
@@ -80,7 +80,7 @@ Start a Docker container on each node.
 
 ```bash
 # Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+export IMAGE=quay.io/ascend/vllm-ascend:||
 export NAME=vllm-ascend
 
 # Run the container using the defined variables
@@ -111,7 +111,7 @@ docker run --rm \
 
 ## (Optional) Install Mooncake
 
-Mooncake is pre-installed and functional in the |vllm_ascend_version| image.
+Mooncake is pre-installed and functional in the {vllm_ascend_version} image.
 The following installation steps are optional.
 
 Mooncake is the serving platform for Kimi, a leading LLM service provided by

--- a/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
+++ b/docs/source/tutorials/features/pd_colocated_mooncake_multi_instance.md
@@ -80,7 +80,7 @@ Start a Docker container on each node.
 
 ```bash
 # Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:||
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 export NAME=vllm-ascend
 
 # Run the container using the defined variables

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
@@ -4,7 +4,7 @@
 
 vLLM-Ascend now supports prefill-decode (PD) disaggregation. This guide provides step-by-step instructions to verify this features in resource-constrained environments.
 
-Using the Qwen2.5-VL-7B-Instruct model as an example, use vLLM-Ascend {vllm_ascend_version} (with vLLM {vllm_version}) on 1 Atlas 800T A2 server to deploy the "1P1D" architecture (one Prefiller and one Decoder on the same node). Assume the IP address is 192.0.0.1.
+Using the Qwen2.5-VL-7B-Instruct model as an example, use vLLM-Ascend {{vllm_ascend_version}} (with vLLM {{vllm_version}}) on 1 Atlas 800T A2 server to deploy the "1P1D" architecture (one Prefiller and one Decoder on the same node). Assume the IP address is 192.0.0.1.
 
 ## Verify Communication Environment
 

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
@@ -4,7 +4,7 @@
 
 vLLM-Ascend now supports prefill-decode (PD) disaggregation. This guide provides step-by-step instructions to verify this features in resource-constrained environments.
 
-Using the Qwen2.5-VL-7B-Instruct model as an example, use vLLM-Ascend v0.11.0rc1 (with vLLM v0.11.0) on 1 Atlas 800T A2 server to deploy the "1P1D" architecture (one Prefiller and one Decoder on the same node). Assume the IP address is 192.0.0.1.
+Using the Qwen2.5-VL-7B-Instruct model as an example, use vLLM-Ascend |vllm_ascend_version| (with vLLM |vllm_version|) on 1 Atlas 800T A2 server to deploy the "1P1D" architecture (one Prefiller and one Decoder on the same node). Assume the IP address is 192.0.0.1.
 
 ## Verify Communication Environment
 

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
@@ -4,7 +4,7 @@
 
 vLLM-Ascend now supports prefill-decode (PD) disaggregation. This guide provides step-by-step instructions to verify this features in resource-constrained environments.
 
-Using the Qwen2.5-VL-7B-Instruct model as an example, use vLLM-Ascend |vllm_ascend_version| (with vLLM |vllm_version|) on 1 Atlas 800T A2 server to deploy the "1P1D" architecture (one Prefiller and one Decoder on the same node). Assume the IP address is 192.0.0.1.
+Using the Qwen2.5-VL-7B-Instruct model as an example, use vLLM-Ascend {vllm_ascend_version} (with vLLM {vllm_version}) on 1 Atlas 800T A2 server to deploy the "1P1D" architecture (one Prefiller and one Decoder on the same node). Assume the IP address is 192.0.0.1.
 
 ## Verify Communication Environment
 


### PR DESCRIPTION
### What this PR does / why we need it?
PD Disaggregation feature document has been modified. The vLLM and vLLM-Ascend version in the document have not been promptly updated to the latest versions. Use the configured placeholder to automatically update them later.

### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only change.

### How was this patch tested?
Documentation changes were verified for consistency.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
