### PR TITLE
[BugFix][SpecDecode] Fix MTP draft graph capture with DSA backend

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -86,9 +86,7 @@ class TestAscendDSAMetadataBuilderBuildForGraphCapture(TestBase):
         block_size = 128
 
         sentinel_metadata = MagicMock()
-        with patch.object(
-            AscendDSAMetadataBuilder, "build", return_value=sentinel_metadata
-        ) as mock_build:
+        with patch.object(AscendDSAMetadataBuilder, "build", return_value=sentinel_metadata) as mock_build:
             result = builder.build_for_graph_capture(
                 common_attn_metadata=common_attn_metadata,
                 attn_state=AscendAttentionState.SpecDecoding,

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1,0 +1,123 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import sys
+from unittest.mock import MagicMock, patch
+
+if "torch_npu._inductor" not in sys.modules:
+    sys.modules["torch_npu._inductor"] = MagicMock()
+
+from tests.ut.base import TestBase
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_v1 import AscendDSAImpl, AscendDSAMetadataBuilder
+
+
+class TestAscendDSAImplUpdateGraphParams(TestBase):
+    """Regression guard for `AscendDSAImpl.update_graph_params`.
+
+    `acl_graph.update_full_graph_params` unconditionally invokes
+    `attn_backend.get_impl_cls().update_graph_params(...)` whenever a
+    forward context runs in `CUDAGraphMode.FULL`. If `AscendDSAImpl`
+    forgets to define this method (as was the case before the
+    accompanying fix), the very first inference request crashes with
+    `AttributeError: type object 'AscendDSAImpl' has no attribute
+    'update_graph_params'`. This test pins the method's existence and
+    no-op contract.
+    """
+
+    def test_update_graph_params_is_noop(self):
+        # The method is a staticmethod and intentionally does nothing
+        # (DSA's NPU graph path does not need parameter refresh, mirroring
+        # `AscendSFAImpl.update_graph_params`).
+        update_stream = MagicMock()
+        forward_context = MagicMock()
+        # Should not raise, regardless of optional kwargs being supplied.
+        AscendDSAImpl.update_graph_params(update_stream, forward_context, 100)
+        AscendDSAImpl.update_graph_params(
+            update_stream,
+            forward_context,
+            100,
+            vllm_config=MagicMock(),
+            speculative_config=MagicMock(),
+            num_dcp_pcp_tokens=None,
+            draft_attn_metadatas=None,
+        )
+
+
+class TestAscendDSAMetadataBuilderBuildForGraphCapture(TestBase):
+    """Regression guard for the SAS-metadata kwargs contract.
+
+    `AscendDSAMetadataBuilder.build()` asserts that
+    `prefill_ratio_to_sas_metadata`, `decode_ratio_to_sas_metadata`, and
+    `common_ratio_to_sas_metadata` are all non-None when invoked with
+    `use_compress=True`. `build_for_graph_capture` is the entrypoint used
+    by the MTP draft `dummy_run` path, so any caller that forgets to
+    forward these kwargs (as `llm_base_proposer.dummy_run` did before
+    the accompanying fix) silently breaks graph capture with an
+    `AssertionError` deep inside `build()`.
+
+    This test patches out `build` and only verifies that
+    `build_for_graph_capture` faithfully forwards the kwargs it receives,
+    without exercising any NPU-specific code paths.
+    """
+
+    def test_build_for_graph_capture_forwards_sas_metadata_kwargs(self):
+        # Construct a builder instance without running the real __init__
+        # (which touches scheduler config, scipy.linalg.hadamard and NPU
+        # buffers — none of which are available in a unit-test sandbox).
+        builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+
+        common_attn_metadata = MagicMock()
+        prefill_sas = {"sentinel": "prefill"}
+        decode_sas = {"sentinel": "decode"}
+        common_sas = {"sentinel": "common"}
+        block_size = 128
+
+        sentinel_metadata = MagicMock()
+        with patch.object(
+            AscendDSAMetadataBuilder, "build", return_value=sentinel_metadata
+        ) as mock_build:
+            result = builder.build_for_graph_capture(
+                common_attn_metadata=common_attn_metadata,
+                attn_state=AscendAttentionState.SpecDecoding,
+                prefill_ratio_to_sas_metadata=prefill_sas,
+                decode_ratio_to_sas_metadata=decode_sas,
+                common_ratio_to_sas_metadata=common_sas,
+                block_size=block_size,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        self.assertIs(kwargs["common_attn_metadata"], common_attn_metadata)
+        self.assertEqual(kwargs["common_prefix_len"], 0)
+        self.assertIs(kwargs["prefill_ratio_to_sas_metadata"], prefill_sas)
+        self.assertIs(kwargs["decode_ratio_to_sas_metadata"], decode_sas)
+        self.assertIs(kwargs["common_ratio_to_sas_metadata"], common_sas)
+        self.assertEqual(kwargs["block_size"], block_size)
+
+        # Returned metadata should have its attn_state stamped by
+        # build_for_graph_capture.
+        self.assertIs(result, sentinel_metadata)
+        self.assertEqual(sentinel_metadata.attn_state, AscendAttentionState.SpecDecoding)
+
+    def test_build_for_graph_capture_rejects_unsupported_state(self):
+        builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+        common_attn_metadata = MagicMock()
+
+        with self.assertRaises(NotImplementedError):
+            builder.build_for_graph_capture(
+                common_attn_metadata=common_attn_metadata,
+                attn_state=AscendAttentionState.ChunkedPrefill,
+            )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1479,6 +1479,19 @@ class AscendDSAImpl(DSAAttentionImpl):
             x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
         return x
 
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # dsa does not need to update graph params
+        pass
+
     def forward(  # type: ignore[override]
         self,
         layer_name,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -448,6 +448,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # This is used to hold a position.
                 slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
                 positions=self.runner.positions,
+                positions_cpu=self.runner._dsa_positions_cpu_buf if self.use_compress else None,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
                 max_seq_len=0,
@@ -461,6 +462,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             assert len(self.draft_attn_groups) > 0
             builder = self.draft_attn_groups[0].get_metadata_builder()
+            extra_attn_metadata_args: dict = {}
+            if self.use_compress:
+                extra_attn_metadata_args = dict(
+                    prefill_ratio_to_sas_metadata=dict(),
+                    decode_ratio_to_sas_metadata=dict(),
+                    common_ratio_to_sas_metadata=dict(),
+                    block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
+                )
             # update the tensor's address for each step.
             for draft_step in range(self.num_speculative_tokens):
                 common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
@@ -475,6 +484,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 attn_metadata_eagle = builder.build_for_graph_capture(
                     common_attn_metadata,
                     AscendAttentionState.SpecDecoding if self.method == "mtp" else AscendAttentionState.ChunkedPrefill,
+                    **extra_attn_metadata_args,
                 )
                 per_layer_attn_metadata = dict()
                 for layer_name in self.attn_layer_names:


### PR DESCRIPTION
### What this PR does / why we need it?

Fix three issues that together blocked startup and first-request inference of DeepSeek V4 in pdmix mode (DSA attention + MTP speculative decoding) when `use_compress=True`:

1. **`vllm_ascend/spec_decode/llm_base_proposer.py`** — the `build_for_graph_capture` call inside the draft-model `dummy_run` path did not pass the SAS metadata kwargs that `AscendDSAMetadataBuilder.build()` requires when `use_compress=True`. Two other call sites in the same file (lines ~715 and ~1494) already follow this convention; aligned this one with them by building `extra_attn_metadata_args` the same way. Without this fix `capture_model -> _warmup_and_capture -> _dummy_run` hits `AssertionError` at `dsa_v1.py:495` (`self.prefill_ratio_to_sas_metadata is not None`).

2. **`vllm_ascend/spec_decode/llm_base_proposer.py`** — the `AscendCommonAttentionMetadata` constructed for the draft-model graph-capture path was missing `positions_cpu`. The DSA decode metadata builder (`dsa_v1.py:856`) indexes into it, so once issue (1) was fixed the next layer surfaced as `TypeError: 'NoneType' object is not subscriptable`. Mirrored the main runner path (`model_runner_v1.py:2838`) and pass `self.runner._dsa_positions_cpu_buf` when `use_compress` is enabled, `None` otherwise.

3. **`vllm_ascend/attention/dsa_v1.py`** — `AscendDSAImpl` did not implement `update_graph_params`, which is unconditionally called by `acl_graph.update_full_graph_params` whenever the forward context runs in `CUDAGraphMode.FULL`. Other attention impls (`AscendSFAImpl`, `AscendMLAImpl`, `AscendAttentionImpl`, `AscendAttentionCPImpl`, `AscendMLACPImpl`) all provide it; SFA's implementation is an explicit no-op. Added the same no-op on DSA so the FULL_DECODE_ONLY cudagraph path can finish `dummy_run`. Without this fix the first inference request triggers `AttributeError: type object 'AscendDSAImpl' has no attribute 'update_graph_params'` and crashes EngineCore.

### Does this PR introduce _any_ user-facing change?

No. These are internal bug fixes that unblock an already-supported configuration (DSA + MTP + `use_compress=True` with full-decode cudagraph). No public API, CLI flag, or default behavior changes.

### How was this patch tested?

Manual end-to-end test on Ascend 910 (A3), pdmix mode, NNODES=1, TP=8, DP=2, MTP enabled, `enable_compress=True`, `cudagraph_mode=FULL_DECODE_ONLY`:

- Before this PR: `vllm serve` aborts during `compile_or_warm_up_model` with the AssertionError above; even after locally working around it, the first inference request crashes with the `AttributeError`.
- After this PR: `vllm serve` reaches `Application startup complete` in ~30s, and a chat completion request returns a coherent response:

  ```
  $ curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json'       -d '{"model":"auto","max_tokens":50,"messages":[{"role":"user","content":"Who are you?"}]}'
  {"choices":[{"message":{"content":"Hi there! I'm DeepSeek, an AI assistant created by ...", ...}}],"usage":{"prompt_tokens":8,"completion_tokens":50,...}}
  ```

No new unit tests added — the changes are aligning two existing call sites with an existing convention, and adding a no-op static method that mirrors the sibling `AscendSFAImpl` implementation. Happy to add coverage if reviewers prefer.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
