### PR TITLE
[Performance] Support NZ format for w4a8 MoE of compressed tensor

### DIFF
--- a/tests/ut/quantization/methods/test_w4a8.py
+++ b/tests/ut/quantization/methods/test_w4a8.py
@@ -303,11 +303,13 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.assertEqual(result["w13_weight_scale"].dtype, torch.bfloat16)
         self.assertEqual(result["w2_weight_scale"].dtype, torch.bfloat16)
 
+    @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
     @patch("torch.Tensor.npu")
-    def test_process_weights_after_loading_compressed_tensors(self, mock_npu, mock_npu_quantize):
+    def test_process_weights_after_loading_compressed_tensors(self, mock_npu, mock_npu_quantize, mock_npu_format_cast):
         mock_npu.return_value = torch.Tensor()
         mock_npu_quantize.return_value = torch.Tensor()
+        mock_npu_format_cast.side_effect = identity
 
         layer = self.build_layer(is_new_quant_version=False)
         self.quant_method.quant_method = COMPRESSED_TENSORS_METHOD

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -473,7 +473,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             layer.register_parameter("w2_scale_bias", w2_scale_bias)
 
     def pack_to_int32(self, weight: torch.Tensor):
-        if self.new_quant_version:
+        if self.new_quant_version or self.quant_method == COMPRESSED_TENSORS_METHOD:
             # pack 4 int8(int4*2) to int32, because in pytorch, we need to use int32 to represent int4
             assert weight.shape[-1] % 4 == 0, "the last dim of weight needs to be divided by 4"
             return weight.view(torch.int32).contiguous()
@@ -481,6 +481,17 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             return torch_npu.npu_quantize(
                 weight.to(torch.float32), torch.tensor([1.0]).npu(), None, torch.quint4x2, -1, False
             )
+
+    def pack_int4_to_int8(self, weight: torch.Tensor) -> torch.Tensor:
+        shape = weight.shape
+        weight = weight.reshape(-1, 2)
+        weight0 = weight[:, :1]
+        weight1 = weight[:, 1:]
+        weight1_4 = torch.bitwise_left_shift(weight1, 4)
+        weight2_4 = weight0 & 0b00001111
+        weight_add = torch.bitwise_or(weight1_4, weight2_4)
+        # The clone() call is used to break the view chain
+        return weight_add.reshape(shape[:-1] + (shape[-1] // 2,)).clone()
 
     @staticmethod
     def maybe_squeeze_per_channel_weight_scale(scale: torch.Tensor) -> torch.Tensor:
@@ -539,9 +550,11 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         w2_scale_bias = torch.nn.Parameter(w2_bias, requires_grad=False)
         layer.register_parameter("w2_scale_bias", w2_scale_bias)
 
-        # Accuracy problem in nz format
-        # layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
-        # layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
+        # Packs 2 int4 into 1 int8 on-the-fly to mirror the modelslim new_quant_version path
+        layer.w13_weight.data = self.pack_int4_to_int8(layer.w13_weight.data)
+        layer.w2_weight.data = self.pack_int4_to_int8(layer.w2_weight.data)
+        layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+        layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
         layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
         layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)
 


### PR DESCRIPTION
### What this PR does / why we need it?

Replace npu_quantize -based weight packing with _pack_int4 in the compressed-tensors MoE path, matching the modelslim v1.0.0 format (2 int4 values packed into 1 int8 byte), then apply NZ format conversion and view(torch.int32).contiguous() for the final int32 packing — consistently with the modelslim path.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
Verified on Ascend 910B (A2) using Qwen3-30B quantized by ModelSlim and LLM Compressed separately.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
