### PR TITLE
[Feature][Worker] Skip fused mc2 when weight_nz_mode is disabled

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 import vllm.envs as envs_vllm
 from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.logger import logger
 from vllm.distributed import get_dp_group, get_ep_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import BatchDescriptor, get_forward_context, set_forward_context
 
@@ -283,8 +284,21 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
     elif soc_version in {AscendDeviceType.A3}:
         # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
         # TODO: drop speculative method guard when dispatch_gmm_combine_decode supports w16a16
-        fused_mc2_enable = get_ascend_config().enable_fused_mc2
+        ascend_config = get_ascend_config()
+        fused_mc2_enable = ascend_config.enable_fused_mc2
         dispatch_ffn_combine_enable = get_ep_group().world_size <= 32 and (not is_draft_model)
+        # TODO: Current dispatch_ffn_combine fusion operator ONLY supports NZ format.
+        # Therefore, we must cast weights to NZ when fusion is enabled.
+        # Once the dispatch_ffn_combine operator is updated to support
+        # ND format (or other formats), remove this enabling logic and
+        # always allow fused MC2 regardless of weight_nz_mode.
+        fused_mc2_requires_nz = fused_mc2_enable in {1, 2}
+        weight_nz_enabled = ascend_config.weight_nz_mode != 0
+        if fused_mc2_requires_nz and not weight_nz_enabled:
+            logger.info_once(
+                "Skip FUSED_MC2 because weight_nz_mode=0 disables the NZ weights required by fused MC2 ops."
+            )
+            fused_mc2_enable = 0
         if num_tokens <= mc2_tokens_capacity:
             fused_decode_enable = fused_mc2_enable
             if fused_mc2_enable == 1:

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -7,9 +7,9 @@ from typing import Any
 import torch
 import vllm.envs as envs_vllm
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.logger import logger
 from vllm.distributed import get_dp_group, get_ep_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import BatchDescriptor, get_forward_context, set_forward_context
+from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.utils import (

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -41,7 +41,6 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
-    ACL_FORMAT_FRACTAL_NZ,
     enable_sp,
     maybe_trans_nz,
     npu_stream_switch,
@@ -114,18 +113,8 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
         layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
 
-        # TODO: Current dispatch_ffn_combine fusion operator ONLY supports NZ format.
-        # Therefore, we must cast weights to NZ when fusion is enabled.
-        # Once the underlying dispatch_ffn_combine operator is updated to support
-        # ND format (or other formats), remove this specific 'if' check and the forced
-        # npu_format_cast. At that point, the operator should be able to handle weights
-        # in their native format without explicit casting here.
-        if get_ascend_config().enable_fused_mc2:
-            layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
-            layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
-        else:
-            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
-            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
+        layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+        layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
 
     def apply(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR makes fused MC2 selection respect weight_nz_mode on A3 devices.
    
Currently, dispatch_ffn_combine only supports NZ-format weights. When enable_fused_mc2 is enabled but weight_nz_mode=0, some weights will still be converted to NZ-format silently, which may cause weight update problems or accuracy problem in RL scenario.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
