### PR TITLE
[Feature] Enable prefix caching with PCP/DCP

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+    MambaSpec,
+)
+
+from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
+    AscendHybridKVCacheCoordinator,
+)
+from vllm_ascend.patch.platform.patch_kv_cache_utils import (
+    _ascend_resolve_kv_cache_block_sizes,
+)
+from vllm_ascend.patch.platform.patch_mamba_manager import AscendMambaManager
+
+
+def _make_hybrid_kv_cache_config(
+    full_block_size: int = 16,
+    mamba_block_size: int = 16,
+) -> KVCacheConfig:
+    full_spec = FullAttentionSpec(
+        block_size=full_block_size,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.float16,
+    )
+    mamba_spec = MambaSpec(
+        block_size=mamba_block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    return KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[
+            KVCacheTensor(size=full_spec.page_size_bytes * 10, shared_by=["attn"]),
+            KVCacheTensor(size=mamba_spec.page_size_bytes * 10, shared_by=["mamba"]),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["attn"], kv_cache_spec=full_spec),
+            KVCacheGroupSpec(layer_names=["mamba"], kv_cache_spec=mamba_spec),
+        ],
+    )
+
+
+def _make_vllm_config(
+    *,
+    enable_prefix_caching: bool,
+    dcp: int,
+    pcp: int,
+    block_size: int = 16,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=block_size,
+            enable_prefix_caching=enable_prefix_caching,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp,
+            prefill_context_parallel_size=pcp,
+        ),
+    )
+
+
+def _make_coordinator_for_effective_block_size(
+    *,
+    dcp_world_size: int,
+    pcp_world_size: int,
+    enable_caching: bool,
+) -> AscendHybridKVCacheCoordinator:
+    coordinator = AscendHybridKVCacheCoordinator.__new__(AscendHybridKVCacheCoordinator)
+    coordinator.dcp_world_size = dcp_world_size
+    coordinator.pcp_world_size = pcp_world_size
+    coordinator.enable_caching = enable_caching
+    return coordinator
+
+
+@pytest.mark.parametrize(
+    ("enable_prefix_caching", "expected_hash_block_size"),
+    [
+        pytest.param(False, math.lcm(16, 32) * 2 * 2, id="cp-without-prefix-caching"),
+        pytest.param(True, math.gcd(16, 32), id="cp-with-prefix-caching"),
+    ],
+)
+def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
+    enable_prefix_caching: bool,
+    expected_hash_block_size: int,
+) -> None:
+    kv_cache_config = _make_hybrid_kv_cache_config(full_block_size=16, mamba_block_size=32)
+    vllm_config = _make_vllm_config(
+        enable_prefix_caching=enable_prefix_caching,
+        dcp=2,
+        pcp=2,
+    )
+
+    scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(
+        kv_cache_config,
+        vllm_config,
+    )
+
+    expected_scheduler_block_size = math.lcm(16, 32) * 2 * 2
+    assert scheduler_block_size == expected_scheduler_block_size
+    assert hash_block_size == expected_hash_block_size
+
+
+@pytest.mark.parametrize(
+    ("spec_factory", "dcp", "pcp", "enable_caching", "expected"),
+    [
+        pytest.param(
+            lambda: FullAttentionSpec(
+                block_size=16,
+                num_kv_heads=8,
+                head_size=64,
+                dtype=torch.float16,
+            ),
+            2,
+            2,
+            True,
+            64,
+            id="full-attention-scales-with-cp",
+        ),
+        pytest.param(
+            lambda: MambaSpec(
+                block_size=16,
+                shapes=((1,),),
+                dtypes=(torch.float32,),
+                mamba_cache_mode="none",
+            ),
+            2,
+            2,
+            True,
+            16,
+            id="mamba-keeps-physical-block-size-with-prefix-caching",
+        ),
+        pytest.param(
+            lambda: FullAttentionSpec(
+                block_size=16,
+                num_kv_heads=8,
+                head_size=64,
+                dtype=torch.float16,
+            ),
+            1,
+            1,
+            True,
+            16,
+            id="full-attention-no-cp",
+        ),
+    ],
+)
+def test_get_effective_block_size(
+    spec_factory,
+    dcp: int,
+    pcp: int,
+    enable_caching: bool,
+    expected: int,
+) -> None:
+    coordinator = _make_coordinator_for_effective_block_size(
+        dcp_world_size=dcp,
+        pcp_world_size=pcp,
+        enable_caching=enable_caching,
+    )
+
+    assert coordinator._get_effective_block_size(spec_factory()) == expected
+
+
+def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> None:
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    block_pool = BlockPool(
+        num_blocks=10,
+        enable_caching=True,
+        hash_block_size=16,
+        enable_kv_cache_events=False,
+        metrics_collector=MagicMock(),
+    )
+
+    manager = AscendMambaManager(
+        kv_cache_spec=mamba_spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=1,
+        dcp_world_size=2,
+        pcp_world_size=2,
+    )
+
+    assert manager.block_size == mamba_spec.block_size

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -32,12 +32,14 @@ import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
+import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
+import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
+
 if envs.VLLM_ASCEND_APPLY_DSV4_PATCH:
-    import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -17,7 +17,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec, MambaSpec
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
 
@@ -47,6 +47,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         metrics_collector: KVCacheMetricsCollector | None = None,
         max_num_batched_tokens: int | None = None,
     ):
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
         self.enable_caching = enable_caching
@@ -91,14 +93,21 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # can be a multiple of hash_block_size.
         self.hash_block_size = hash_block_size
         if enable_caching:
-            assert all(g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_config.kv_cache_groups), (
-                "block_size must be divisible by hash_block_size"
-            )
-        assert dcp_world_size == 1, "DCP not support hybrid attn now."
-        assert pcp_world_size == 1, "PCP not support hybrid attn now."
+            assert all(
+                self._get_effective_block_size(g.kv_cache_spec) % hash_block_size == 0
+                for g in kv_cache_config.kv_cache_groups
+            ), "block_size must be divisible by hash_block_size"
         self.verify_and_split_kv_cache_groups()
 
         self.use_eagle = use_eagle
+
+    def _get_effective_block_size(self, kv_cache_spec: KVCacheSpec) -> int:
+        block_size = kv_cache_spec.block_size
+        if isinstance(kv_cache_spec, MambaSpec) and self.enable_caching:
+            return block_size
+        if self.dcp_world_size * self.pcp_world_size > 1:
+            block_size *= self.dcp_world_size * self.pcp_world_size
+        return block_size
 
     def verify_and_split_kv_cache_groups(self) -> None:
         """
@@ -143,7 +152,10 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # each attention type. Requiring this because we don't support partial
         # block cache hit yet.
         # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [spec.block_size * getattr(spec, "compress_ratio", 1) for spec, _, _ in self.attention_groups]
+        block_sizes = [
+            self._get_effective_block_size(spec) * getattr(spec, "compress_ratio", 1)
+            for spec, _, _ in self.attention_groups
+        ]
         self.lcm_block_size = lcm(*block_sizes)
 
     def find_longest_cache_hit(
@@ -170,9 +182,10 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         """
 
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
-            if kv_cache_spec.block_size == self.hash_block_size:
+            effective_block_size = self._get_effective_block_size(kv_cache_spec)
+            if effective_block_size == self.hash_block_size:
                 return block_hashes
-            return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size)
+            return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, effective_block_size)
 
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_length = max_cache_hit_length
@@ -191,14 +204,15 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         while True:
             curr_hit_length = hit_length
-
             for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
+                effective_block_size = self._get_effective_block_size(spec)
                 cached_blocks = hit_blocks_by_group[group_ids[0]]
                 if isinstance(spec, FullAttentionSpec) and cached_blocks is not None:
                     # Full attention is downward-closed: we only need to look
                     # up cached blocks once; on subsequent iterations just trim
                     # to the (reduced) current hit length.
-                    curr_hit_length = curr_hit_length // spec.block_size * spec.block_size
+                    num_blocks = curr_hit_length // effective_block_size
+                    curr_hit_length = num_blocks * effective_block_size
                     continue
 
                 use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
@@ -215,8 +229,10 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     kv_cache_spec=spec,
                     use_eagle=use_eagle,
                     alignment_tokens=self.lcm_block_size,
+                    dcp_world_size=self.dcp_world_size,
+                    pcp_world_size=self.pcp_world_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                _new_hit_length = len(hit_blocks[0]) * effective_block_size
                 if use_eagle:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -224,7 +240,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     eagle_verified.clear()
                 curr_hit_length = _new_hit_length
                 compress_ratio = getattr(spec, "compress_ratio", 1)
-                curr_hit_length = len(hit_blocks[0]) * spec.block_size * max(compress_ratio, 1)
+                curr_hit_length = len(hit_blocks[0]) * effective_block_size * max(compress_ratio, 1)
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 
@@ -237,7 +253,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         spec, group_ids, _ = self.attention_groups[0]
         if isinstance(spec, FullAttentionSpec):
-            num_blocks = hit_length // spec.block_size
+            num_blocks = hit_length // self._get_effective_block_size(spec)
             for group_id in group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -50,7 +50,10 @@ def _ascend_resolve_kv_cache_block_sizes(
         # multiplied by the CP factors for proper alignment.
         group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp * pcp
-        return scheduler_block_size, scheduler_block_size
+        if not cache_config.enable_prefix_caching:
+            return scheduler_block_size, scheduler_block_size
+        hash_block_size = math.gcd(*group_block_sizes)
+        return scheduler_block_size, hash_block_size
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
 

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+import vllm.v1.core.single_type_kv_cache_manager as single_type_kv_cache_manager
+from vllm.v1.core.single_type_kv_cache_manager import (
+    BlockHashList,
+    BlockPool,
+    KVCacheBlock,
+    KVCacheSpec,
+    MambaManager,
+    MambaSpec,
+)
+
+
+class AscendMambaManager(MambaManager):
+    def __init__(self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs) -> None:
+        super().__init__(kv_cache_spec, block_pool, **kwargs)
+        if self.enable_caching:
+            self.block_size = kv_cache_spec.block_size
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, MambaSpec), "MambaManager can only be used for mamba groups"
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
+        block_size = kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(block_hashes[i], kv_cache_group_ids):
+                if block_size != alignment_tokens and (i + 1) * block_size % alignment_tokens != 0:
+                    continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.extend([block_pool.null_block] * i)
+                    computed.append(cached)
+                break
+        return computed_blocks
+
+
+single_type_kv_cache_manager.MambaManager = AscendMambaManager
+single_type_kv_cache_manager.spec_manager_map[MambaSpec] = AscendMambaManager

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -1,6 +1,5 @@
 # mypy: ignore-errors
 
-
 from vllm.v1.worker import mamba_utils
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel


### PR DESCRIPTION
### What this PR does / why we need it?

With PCP or DCP enabled, vllm-ascend uses a virtual KV block size (block_size * pcp_world_size * dcp_world_size) for scheduling and full-attention allocation. Upstream prefix caching assumes logical block size equals kv_cache_spec.block_size, so --enable-prefix-caching misses or mis-aligns cache hits unless scheduler, hasher, and coordinator paths agree on the same effective block size.

This change adds CP-aware platform patches so prefix caching works under context parallel:

- Hybrid KV cache coordinator: remove PCP/DCP unsupported asserts on hybrid models; scale effective block size by pcp * dcp for full-attention lookup; keep MambaSpec on physical block_size when prefix caching is enabled; pass dcp/pcp world sizes into find_longest_cache_hit.
- KV cache block size resolution: when prefix caching is enabled with CP, use gcd(group block sizes) as hash_block_size instead of the scheduler virtual block size.
- Mamba manager: AscendMambaManager uses logical mamba block_size for prefix cache hit lookup on hybrid models.

### Does this PR introduce any user-facing change?

Yes. Users can enable --enable-prefix-caching together with PCP and/or DCP; prefix cache hits use consistent virtual block sizing instead of silently missing or mis-aligning blocks.

### How was this patch tested?
Testing under the scenario where PCP, DCP, and the prefix cache are simultaneously enabled.

vLLM version: v0.20.2
vLLM main:
https://github.com/vllm-project/vllm/commit/0d4d334eaa583b9c09aa4eb7538c22db99fd84b3
