### PR TITLE
Fix W4A8 GMMSwigluQuantV2 shape handling

### DIFF
--- a/csrc/gmm/grouped_matmul_swiglu_quant_v2/op_host/grouped_matmul_swiglu_quant_v2_base_tiling.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant_v2/op_host/grouped_matmul_swiglu_quant_v2_base_tiling.cpp
@@ -23,6 +23,8 @@ namespace GroupedMatmulSwigluQuantV2Tiling {
 
 constexpr int64_t ND_WEIGHT_MULTI_TENSOR_DIM = 2;
 constexpr int64_t NZ_WEIGHT_MULTI_TENSOR_DIM = 4;
+constexpr int64_t OUTPUT_INDEX = 0;
+constexpr int64_t SWIGLU_SPLIT_FACTOR = 2;
 constexpr float EFFECTIVE_TASK_RATIO = 0.95f;
 constexpr int32_t MIN_BASE_M = 16;
 
@@ -43,7 +45,6 @@ auto CeilDiv(T1 a, T2 b) -> T1
     }
     return (a + b - 1) / b;
 }
-
 
 static inline uint32_t SixteenAlign(uint32_t a, bool up = false)
 {
@@ -209,8 +210,10 @@ ge::graphStatus GroupedMatmulSwigluQuantV2BaseTiling::ParseInputAndAttr()
     tuningConfig_ = tuningConfigPtr != nullptr && tuningConfigPtr->GetSize() > 1?
                     (reinterpret_cast<const int64_t*>(tuningConfigPtr->GetData()))[0] : 0;
 
-    if (isA4W4_) {
-        n_ = wScaleTensor->GetStorageShape().GetDim(wScaleDimNum - DIM_1);
+    if (isA8W4MSD_ || isA4W4_) {
+        auto outputShape = context_->GetOutputShape(OUTPUT_INDEX);
+        OP_CHECK_NULL_WITH_CONTEXT(context_, outputShape);
+        n_ = outputShape->GetOriginShape().GetDim(DIM_1) * SWIGLU_SPLIT_FACTOR;
     } else {
         if (wTensor->GetStorageShape().GetDimNum() == ND_WEIGHT_DIM_LIMIT) {
             // ND SingleTensor [E, K, N]

--- a/csrc/gmm/grouped_matmul_swiglu_quant_v2/op_host/op_api/aclnn_grouped_matmul_swiglu_quant_v2.cpp
+++ b/csrc/gmm/grouped_matmul_swiglu_quant_v2/op_host/op_api/aclnn_grouped_matmul_swiglu_quant_v2.cpp
@@ -115,23 +115,15 @@ aclnnStatus aclnnGroupedMatmulSwigluQuantWeightNzV2GetWorkspaceSize(const aclTen
     if (wLength == 1) {
         // 单Tensor场景
         auto w = (*weight)[0];
-        auto storgeShape = w->GetStorageShape();
         auto viewShape = w->GetViewShape();
         aclTensor *weightNZ = const_cast<aclTensor *>(w);
         auto storageShape = w->GetStorageShape();
         auto groupListViewShape = groupList->GetViewShape();
         auto expertNum = groupListViewShape[0];
-        auto weightScale0 = (*weightScale)[0];
-        auto weightScaleStorageShape = weightScale0->GetViewShape();
-        auto n = weightScaleStorageShape[1];
+        auto outputViewShape = output->GetViewShape();
+        auto n = outputViewShape[1] * 2;
         auto xViewShape = x->GetViewShape();
         auto k = xViewShape[1];
-        storageShape = {expertNum, n / 64, k / 16, 16, 8};
-        w->SetStorageShape(storageShape);
-        CHECK_COND((storgeShape.GetDimNum() == WEIGHT_NZ_DIM_LIMIT), ACLNN_ERR_PARAM_INVALID,
-                   "aclnnGroupedMatmulSwigluQuantWeightNzV2, The dimnum of storageShape for second input (weight)"
-                 "must be 5. \n But StorageShape got %s , and dimNum is %lu.",
-                   op::ToString(storgeShape).GetString(), storgeShape.GetDimNum());
         // weight的StorageFormat无条件视为NZ
         weightNZ->SetStorageFormat(op::Format::FORMAT_FRACTAL_NZ);
         if (viewShape.GetDimNum() == WEIGHT_NZ_DIM_LIMIT) {
@@ -141,26 +133,24 @@ aclnnStatus aclnnGroupedMatmulSwigluQuantWeightNzV2GetWorkspaceSize(const aclTen
             // 若weight的viewShape为3维则视为ND
             weightNZ->SetViewFormat(op::Format::FORMAT_ND);
         }
+        storageShape = {expertNum, n / 64, k / 16, 16, 8};
+        weightNZ->SetStorageShape(storageShape);
+        storageShape = weightNZ->GetStorageShape();
+        CHECK_COND((storageShape.GetDimNum() == WEIGHT_NZ_DIM_LIMIT), ACLNN_ERR_PARAM_INVALID,
+                   "aclnnGroupedMatmulSwigluQuantWeightNzV2, The dimnum of storageShape for second input (weight)"
+                 "must be 5. \n But StorageShape got %s , and dimNum is %lu.",
+                   op::ToString(storageShape).GetString(), storageShape.GetDimNum());
     } else {
         // 多Tensor场景
         for (size_t i = 0; i < wLength; i++) {
             auto w = (*weight)[i];
-            auto storgeShape = w->GetStorageShape();
             auto viewShape = w->GetViewShape();
             aclTensor *weightNZ = const_cast<aclTensor *>(w);
             auto storageShape = w->GetStorageShape();
-            auto groupListViewShape = groupList->GetViewShape();
-            auto weightScale0 = (*weightScale)[i];
-            auto weightScaleStorageShape = weightScale0->GetViewShape();
-            auto n = weightScaleStorageShape[0];
+            auto outputViewShape = output->GetViewShape();
+            auto n = outputViewShape[1] * 2;
             auto xViewShape = x->GetViewShape();
             auto k = xViewShape[1];
-            storageShape = {n / 64, k / 16, 16, 8};
-            w->SetStorageShape(storageShape);
-            CHECK_COND((storgeShape.GetDimNum() == MULTI_WEIGHT_NZ_DIM_LIMIT), ACLNN_ERR_PARAM_INVALID,
-                       "aclnnGroupedMatmulSwigluQuantWeightNzV2, The dimnum of storageShape for second input (weight)"
-                     "must be 4. \n But StorageShape got %s , and dimNum is %lu.",
-                       op::ToString(storgeShape).GetString(), storgeShape.GetDimNum());
             // weight的StorageFormat无条件视为NZ
             weightNZ->SetStorageFormat(op::Format::FORMAT_FRACTAL_NZ);
             if (viewShape.GetDimNum() == MULTI_WEIGHT_NZ_DIM_LIMIT) {
@@ -170,6 +160,13 @@ aclnnStatus aclnnGroupedMatmulSwigluQuantWeightNzV2GetWorkspaceSize(const aclTen
                 // 若weight的viewShape为2维则视为ND
                 weightNZ->SetViewFormat(op::Format::FORMAT_ND);
             }
+            storageShape = {n / 64, k / 16, 16, 8};
+            weightNZ->SetStorageShape(storageShape);
+            storageShape = weightNZ->GetStorageShape();
+            CHECK_COND((storageShape.GetDimNum() == MULTI_WEIGHT_NZ_DIM_LIMIT), ACLNN_ERR_PARAM_INVALID,
+                       "aclnnGroupedMatmulSwigluQuantWeightNzV2, The dimnum of storageShape for second input (weight)"
+                     "must be 4. \n But StorageShape got %s , and dimNum is %lu.",
+                       op::ToString(storageShape).GetString(), storageShape.GetDimNum());
         }
     }
     GroupedMatmulSwigluQuantParamsBase params =

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -733,6 +733,59 @@ class TestAscendFusedMoE:
 
 
 class TestAscendFusedMoESharedExperts:
+    def test_shared_swiglu_applies_deepseek_v4_clamp_before_dynamic_quant(self, monkeypatch):
+        hidden_states = torch.tensor([[20, -20, 40, -40]], dtype=torch.int32)
+        weight_scale = torch.ones(4, dtype=torch.float32)
+        activation_scale = torch.ones(1, dtype=torch.float32)
+        public_dequant = MagicMock()
+
+        def fake_dynamic_quant(tensor):
+            return tensor.round().to(torch.int8), tensor.abs().amax(dim=-1).to(torch.float32) / 127
+
+        monkeypatch.setattr(fused_moe_module.torch_npu, "npu_dynamic_quant", fake_dynamic_quant)
+        monkeypatch.setattr(
+            fused_moe_module.torch.ops._C_ascend,
+            "npu_dequant_swiglu_quant",
+            public_dequant,
+            raising=False,
+        )
+
+        output, output_scale = fused_moe_module._shared_dequant_swiglu_quant(
+            hidden_states,
+            weight_scale,
+            activation_scale,
+            10.0,
+            torch.bfloat16,
+        )
+
+        gate = torch.clamp(hidden_states[..., :2].float(), max=10.0)
+        up = torch.clamp(hidden_states[..., 2:].float(), min=-10.0, max=10.0)
+        expected = (F.silu(gate) * up).to(torch.bfloat16)
+        torch.testing.assert_close(output, expected.round().to(torch.int8))
+        torch.testing.assert_close(output_scale, expected.abs().amax(dim=-1).to(torch.float32) / 127)
+        public_dequant.assert_not_called()
+
+    def test_shared_swiglu_keeps_public_dequant_for_unlimited_clamp(self, monkeypatch):
+        expected = (torch.ones(1, 2, dtype=torch.int8), torch.ones(1, dtype=torch.float32))
+        public_dequant = MagicMock(return_value=expected)
+        monkeypatch.setattr(
+            fused_moe_module.torch.ops._C_ascend,
+            "npu_dequant_swiglu_quant",
+            public_dequant,
+            raising=False,
+        )
+
+        output = fused_moe_module._shared_dequant_swiglu_quant(
+            torch.ones(1, 4, dtype=torch.int32),
+            torch.ones(4, dtype=torch.float32),
+            torch.ones(1, dtype=torch.float32),
+            1_000_000,
+            torch.bfloat16,
+        )
+
+        assert output is expected
+        assert public_dequant.call_args.kwargs["clamp_limit"] == 1_000_000
+
     def test_properties_and_forward_delegate(self, monkeypatch):
         layer = AscendFusedMoE.__new__(AscendFusedMoE)
         if not hasattr(type(layer), "gate"):

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -1,10 +1,11 @@
 import unittest
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 
-from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, unified_apply_mlp
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, quant_apply_mlp, unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
     MoEQuantParams,
@@ -60,6 +61,123 @@ class TestW4A8RuntimeFlags(unittest.TestCase):
         self.assertFalse(
             MoEQuantParams(quant_type=QuantType.W8A8, is_per_channel_weight=True).use_w4a8_per_channel_gmm_swiglu
         )
+
+
+class TestQuantApplyMlpW4A8PerChannel(unittest.TestCase):
+    def test_effective_swiglu_limit_clamps_before_dynamic_quant(self):
+        hidden_states = torch.arange(12, dtype=torch.int8).view(3, 4)
+        dynamic_scale = torch.ones(3, dtype=torch.float32)
+        group_list = torch.tensor([2, 1], dtype=torch.int64)
+        w1 = [torch.ones(1, 8, 4, dtype=torch.int32)]
+        w2 = [torch.ones(1, 4, 4, dtype=torch.int32)]
+        w1_scale = [torch.ones(1, 8, dtype=torch.float32)]
+        w2_scale = [torch.ones(1, 4, dtype=torch.float32)]
+        w1_scale_bias = [torch.ones(1, 8, dtype=torch.float32)]
+        w2_scale_bias = [torch.ones(1, 4, dtype=torch.float32)]
+        gate_up_out = torch.tensor([[20.0, -20.0, 20.0, -20.0]], dtype=torch.bfloat16).repeat(3, 1)
+        quantized = torch.ones(3, 2, dtype=torch.int8)
+        swiglu_out_scale = torch.ones(3, dtype=torch.float32)
+        expected = torch.randn(3, 4)
+        event = object()
+        stream = MagicMock()
+        stream.record_event.return_value = event
+        extra_ctx = MagicMock()
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp._EXTRA_CTX", extra_ctx),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.enable_custom_op", return_value=True),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream", return_value=stream),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
+                return_value=[gate_up_out],
+            ),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_dynamic_quant",
+                return_value=(quantized, swiglu_out_scale),
+            ) as mock_dynamic_quant,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2",
+                create=True,
+            ) as mock_gmm_swiglu_v2,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                return_value=expected,
+            ),
+        ):
+            output, before_gmm2_evt = quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                group_list=group_list,
+                group_list_type=1,
+                dynamic_scale=dynamic_scale,
+                w1_scale_bias=w1_scale_bias,
+                w2_scale_bias=w2_scale_bias,
+                use_w4a8_per_channel_gmm_swiglu=True,
+                swiglu_limit=10.0,
+            )
+
+        gate = torch.clamp(gate_up_out[..., :2], max=10.0)
+        up = torch.clamp(gate_up_out[..., 2:], min=-10.0, max=10.0)
+        torch.testing.assert_close(mock_dynamic_quant.call_args.args[0], torch.nn.functional.silu(gate) * up)
+        mock_gmm_swiglu_v2.assert_not_called()
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, event)
+
+    def test_unlimited_swiglu_limit_keeps_fused_op_path(self):
+        hidden_states = torch.arange(12, dtype=torch.int8).view(3, 4)
+        dynamic_scale = torch.ones(3, dtype=torch.float32)
+        group_list = torch.tensor([2, 1], dtype=torch.int64)
+        w1 = [torch.ones(1, 8, 4, dtype=torch.int32)]
+        w2 = [torch.ones(1, 4, 4, dtype=torch.int32)]
+        w1_scale = [torch.ones(1, 8, dtype=torch.float32)]
+        w2_scale = [torch.ones(1, 4, dtype=torch.float32)]
+        swiglu_out = torch.ones(3, 2, dtype=torch.int8)
+        swiglu_out_scale = torch.ones(3, dtype=torch.float32)
+        expected = torch.randn(3, 4)
+        event = object()
+        stream = MagicMock()
+        stream.record_event.return_value = event
+        extra_ctx = MagicMock()
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp._EXTRA_CTX", extra_ctx),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.enable_custom_op", return_value=True),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream", return_value=stream),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2",
+                return_value=(swiglu_out, swiglu_out_scale),
+                create=True,
+            ) as mock_gmm_swiglu_v2,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
+            ) as mock_gmm,
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                return_value=expected,
+            ),
+        ):
+            output, before_gmm2_evt = quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                group_list=group_list,
+                group_list_type=1,
+                dynamic_scale=dynamic_scale,
+                use_w4a8_per_channel_gmm_swiglu=True,
+                swiglu_limit=1_000_000,
+            )
+
+        mock_gmm_swiglu_v2.assert_called_once()
+        mock_gmm.assert_not_called()
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, event)
 
 
 class TestUnifiedApplyMlpRequest(unittest.TestCase):

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -64,7 +64,7 @@ class TestW4A8RuntimeFlags(unittest.TestCase):
 
 
 class TestQuantApplyMlpW4A8PerChannel(unittest.TestCase):
-    def test_effective_swiglu_limit_clamps_before_dynamic_quant(self):
+    def test_effective_swiglu_limit_keeps_fused_op_path(self):
         hidden_states = torch.arange(12, dtype=torch.int8).view(3, 4)
         dynamic_scale = torch.ones(3, dtype=torch.float32)
         group_list = torch.tensor([2, 1], dtype=torch.int64)
@@ -74,7 +74,6 @@ class TestQuantApplyMlpW4A8PerChannel(unittest.TestCase):
         w2_scale = [torch.ones(1, 4, dtype=torch.float32)]
         w1_scale_bias = [torch.ones(1, 8, dtype=torch.float32)]
         w2_scale_bias = [torch.ones(1, 4, dtype=torch.float32)]
-        gate_up_out = torch.tensor([[20.0, -20.0, 20.0, -20.0]], dtype=torch.bfloat16).repeat(3, 1)
         quantized = torch.ones(3, 2, dtype=torch.int8)
         swiglu_out_scale = torch.ones(3, dtype=torch.float32)
         expected = torch.randn(3, 4)
@@ -90,14 +89,14 @@ class TestQuantApplyMlpW4A8PerChannel(unittest.TestCase):
             patch("vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream", return_value=stream),
             patch(
                 "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
-                return_value=[gate_up_out],
-            ),
+            ) as mock_gmm,
             patch(
                 "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_dynamic_quant",
                 return_value=(quantized, swiglu_out_scale),
             ) as mock_dynamic_quant,
             patch(
                 "vllm_ascend.ops.fused_moe.moe_mlp.torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2",
+                return_value=(quantized, swiglu_out_scale),
                 create=True,
             ) as mock_gmm_swiglu_v2,
             patch(
@@ -120,10 +119,10 @@ class TestQuantApplyMlpW4A8PerChannel(unittest.TestCase):
                 swiglu_limit=10.0,
             )
 
-        gate = torch.clamp(gate_up_out[..., :2], max=10.0)
-        up = torch.clamp(gate_up_out[..., 2:], min=-10.0, max=10.0)
-        torch.testing.assert_close(mock_dynamic_quant.call_args.args[0], torch.nn.functional.silu(gate) * up)
-        mock_gmm_swiglu_v2.assert_not_called()
+        mock_gmm_swiglu_v2.assert_called_once()
+        self.assertEqual(mock_gmm_swiglu_v2.call_args.kwargs["swiglu_limit"], 10.0)
+        mock_dynamic_quant.assert_not_called()
+        mock_gmm.assert_not_called()
         self.assertIs(output, expected)
         self.assertIs(before_gmm2_evt, event)
 

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -44,7 +44,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
-from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.deepseek_compressor import CompressorStateCache
 from vllm.model_executor.layers.deepseek_v4_attention import DeepseekV4IndexerCache
 from vllm.model_executor.layers.fused_moe import FusedMoE
@@ -183,6 +183,7 @@ class DeepseekV2MLP(nn.Module):
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         is_sequence_parallel=False,
+        swiglu_limit: float | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -210,7 +211,7 @@ class DeepseekV2MLP(nn.Module):
         )
         if hidden_act != "silu":
             raise ValueError(f"Unsupported activation: {hidden_act}. Only silu is supported for now.")
-        self.act_fn = SiluAndMul()
+        self.act_fn = SiluAndMulWithClamp(swiglu_limit) if swiglu_limit is not None else SiluAndMul()
 
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
@@ -278,6 +279,7 @@ class DeepseekV4MoE(nn.Module):
                 quant_config=quant_config,
                 is_sequence_parallel=self.is_sequence_parallel,
                 reduce_results=False,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
                 prefix=f"{prefix}.shared_experts",
             )
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import wraps
@@ -88,6 +89,56 @@ def mock_false():
 
 def mock_true():
     return True
+
+
+def _has_effective_swiglu_limit(swiglu_limit: int | float | None) -> bool:
+    if swiglu_limit is None:
+        return False
+    limit = float(swiglu_limit)
+    return math.isfinite(limit) and 0.0 < limit < 1_000_000.0
+
+
+def _shared_dequant_swiglu_quant(
+    hidden_states: torch.Tensor,
+    weight_scale: torch.Tensor,
+    activation_scale: torch.Tensor,
+    swiglu_limit: int | float | None,
+    output_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not _has_effective_swiglu_limit(swiglu_limit):
+        return torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            x=hidden_states,
+            weight_scale=weight_scale,
+            activation_scale=activation_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            activate_left=True,
+            quant_mode=1,
+            swiglu_mode=1,
+            clamp_limit=0 if swiglu_limit is None else swiglu_limit,
+        )
+
+    if hidden_states.shape[0] == 0:
+        output_shape = hidden_states.shape[:-1] + (hidden_states.shape[-1] // 2,)
+        return (
+            hidden_states.new_empty(output_shape, dtype=torch.int8),
+            torch.empty(hidden_states.shape[:-1], dtype=torch.float32, device=hidden_states.device),
+        )
+
+    weight_scale = weight_scale.to(torch.float32).reshape((1,) * (hidden_states.dim() - 1) + (-1,))
+    activation_scale = activation_scale.to(torch.float32).reshape(hidden_states.shape[:-1] + (1,))
+    gate_up = hidden_states.to(torch.float32) * weight_scale * activation_scale
+
+    half = gate_up.shape[-1] // 2
+    limit = float(swiglu_limit)
+    gate = torch.clamp(gate_up[..., :half], max=limit)
+    up = torch.clamp(gate_up[..., half:], min=-limit, max=limit)
+    swiglu = F.silu(gate) * up
+    if swiglu.dtype not in (torch.float16, torch.bfloat16):
+        swiglu = swiglu.to(output_dtype if output_dtype in (torch.float16, torch.bfloat16) else torch.bfloat16)
+    return torch_npu.npu_dynamic_quant(swiglu)
 
 
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
@@ -752,18 +803,12 @@ class AscendFusedMoE(FusedMoE):
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
-                    x=hidden_states,
-                    weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
-                    activation_scale=pertoken_scale,
-                    bias=None,
-                    quant_scale=None,
-                    quant_offset=None,
-                    group_index=None,
-                    activate_left=True,
-                    quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
+                quantized_x, swiglu_out_scale = _shared_dequant_swiglu_quant(
+                    hidden_states,
+                    self._shared_experts.gate_up_proj.weight_scale_fp32,
+                    pertoken_scale,
+                    fused_moe_evts.swiglu_limit,
+                    original_dtype,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
+import math
 
 import torch
 import torch_npu
-from torch.nn.functional import pad
+from torch.nn.functional import pad, silu
 from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -78,6 +79,38 @@ def _require_single_tensor_for_swiglu_quant(
             raise ValueError(f"{name} must be a tensor or a single-element list, but got {len(tensor_or_list)}.")
         return tensor_or_list[0]
     return tensor_or_list
+
+
+def _has_effective_swiglu_limit(swiglu_limit: int | float | None) -> bool:
+    if swiglu_limit is None:
+        return False
+    limit = float(swiglu_limit)
+    return math.isfinite(limit) and 0.0 < limit < 1_000_000.0
+
+
+def _w4a8_per_channel_gmm_scale(w1_scale: list[torch.Tensor] | torch.Tensor) -> list[torch.Tensor]:
+    w1_scale_tensor = _require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale")
+    if w1_scale_tensor.dim() == 2:
+        w1_scale_tensor = w1_scale_tensor.unsqueeze(1)
+    return [w1_scale_tensor]
+
+
+def _w4a8_per_channel_swiglu_clamp_quant(
+    hidden_states: torch.Tensor,
+    swiglu_limit: int | float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if hidden_states.shape[0] == 0:
+        output_shape = hidden_states.shape[:-1] + (hidden_states.shape[-1] // 2,)
+        return (
+            hidden_states.new_empty(output_shape, dtype=torch.int8),
+            torch.empty(hidden_states.shape[:-1], dtype=torch.float32, device=hidden_states.device),
+        )
+
+    half = hidden_states.shape[-1] // 2
+    limit = float(swiglu_limit)
+    gate = torch.clamp(hidden_states[..., :half], max=limit)
+    up = torch.clamp(hidden_states[..., half:], min=-limit, max=limit)
+    return torch_npu.npu_dynamic_quant(silu(gate) * up)
 
 
 def quant_apply_mlp(
@@ -254,7 +287,11 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if use_w4a8_per_channel_gmm_swiglu and enable_custom_op():
+        if (
+            use_w4a8_per_channel_gmm_swiglu
+            and enable_custom_op()
+            and not _has_effective_swiglu_limit(swiglu_limit)
+        ):
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,
                 weight=w1,
@@ -293,12 +330,16 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
         else:
-            w1_scale[0] = w1_scale[0].to(w2_scale[0].dtype)
+            if use_w4a8_per_channel_gmm_swiglu:
+                gmm1_scale = _w4a8_per_channel_gmm_scale(w1_scale)
+            else:
+                w1_scale[0] = w1_scale[0].to(w2_scale[0].dtype)
+                gmm1_scale = w1_scale
             # gmm1: gate_up_proj
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
                 weight=w1,
-                scale=w1_scale,
+                scale=gmm1_scale,
                 bias=bias1,
                 per_token_scale=[pertoken_scale],
                 split_item=2,
@@ -310,7 +351,11 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
-            if HAS_TRITON:
+            if use_w4a8_per_channel_gmm_swiglu and _has_effective_swiglu_limit(swiglu_limit):
+                hidden_states, swiglu_out_scale = _w4a8_per_channel_swiglu_clamp_quant(
+                    hidden_states, swiglu_limit
+                )
+            elif HAS_TRITON:
                 from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
 
                 hidden_states, swiglu_out_scale = swiglu_quant(

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -290,7 +290,6 @@ def quant_apply_mlp(
         if (
             use_w4a8_per_channel_gmm_swiglu
             and enable_custom_op()
-            and not _has_effective_swiglu_limit(swiglu_limit)
         ):
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,


### PR DESCRIPTION
## Summary

Fix the W4A8 per-channel GMMSwigluQuantV2 path so it stays on the fused v2 op when `swiglu_limit` is set and uses the same effective clamp behavior as the MoE MLP small-op reference.

The root cause was in the fused op shape path: ModelSlim W4A8 weights arrive as int32-packed NZ tensors, and the aclnn entry was still letting the packed storage shape leak into the W4 tiling path. The fix derives the unpacked NZ storage shape from `output` and `x`, and the tiling side recovers the pre-SwiGLU `n` from the output shape.

This branch is based on upstream PR #9590. PR #9590 already adds `grouped_matmul_swiglu_quant_v2` to the A2/A3 build path and keeps A2/A3 on `arch32`; this follow-up does not add any new `arch35` mapping. Until #9590 lands, this PR's diff includes those base changes as well.

## Validation

- `git diff --check`
- 131 single-op rebuild: `bash build.sh --pkg --ops=grouped_matmul_swiglu_quant_v2 --soc=ascend910b -j16`
- 131 W4A8 compare script: `/tmp/pr9590_mlp_v2_compare.py`
  - custom op enabled: `enable_custom_op True has_v2 True`
  - W4A8 format path: `w_nz (4, 7168, 768) scale2d (4, 6144) scale3d (4, 1, 6144)`
  - fused vs small-op quantized max diff: `1`
  - exact match range: `0.9658203125` to `0.9818522334098816`
- 131 unit test: `python3 -m pytest tests/ut/ops/test_moe_mlp.py::TestQuantApplyMlpW4A8PerChannel -q`
  - `2 passed, 16 warnings`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
