### PR TITLE
Pack Sparse C8 indexer KV cache

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -12,6 +12,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.triton_utils import HAS_TRITON
+from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import (
     AttentionBackend,  # type: ignore
     AttentionCGSupport,
@@ -53,6 +54,7 @@ from vllm_ascend.utils import (
     enable_dsa_cp,
     enable_dsa_cp_with_layer_shard,
     enable_dsa_cp_with_o_proj_tp,
+    fuse_sparse_c8_kv_cache,
     get_weight_prefetch_method,
     maybe_trans_nz,
 )
@@ -438,6 +440,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         if self.use_sparse_c8_indexer:
             self.c8_k_cache_dtype = torch.int8
             self.c8_k_scale_cache_dtype = torch.float16
+        self.fuse_sparse_c8_kv = self.use_sparse_c8_indexer and fuse_sparse_c8_kv_cache()
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
@@ -795,6 +798,26 @@ class AscendSFAImpl(MLAAttentionImpl):
         # Convert from (N, B, L) to (B, N, L)
         return ql_nope.transpose(0, 1), q_pe
 
+    def _is_packed_sparse_c8_kv_cache(self, kv_cache: tuple[torch.Tensor, ...]) -> bool:
+        return self.use_sparse_c8_indexer and self.fuse_sparse_c8_kv and len(kv_cache) == 3
+
+    def _split_sparse_c8_kv_cache(self, kv_cache: tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._is_packed_sparse_c8_kv_cache(kv_cache):
+            packed_k_cache = kv_cache[2]
+            packed_head_dim = self.head_dim + get_dtype_size(self.c8_k_scale_cache_dtype)
+            assert packed_k_cache.shape[-1] == packed_head_dim
+            k_cache = packed_k_cache[..., : self.head_dim]
+            k_scale_cache = packed_k_cache[..., self.head_dim :].view(self.c8_k_scale_cache_dtype)
+            return k_cache, k_scale_cache
+
+        assert len(kv_cache) == 4
+        return kv_cache[2], kv_cache[3]
+
+    def _pack_sparse_c8_kv_update(self, k_li: torch.Tensor, k_li_scale: torch.Tensor) -> torch.Tensor:
+        k_i8 = k_li.reshape(k_li.shape[0], -1)
+        scale_i8 = k_li_scale.contiguous().view(torch.int8).view(k_li.shape[0], -1)
+        return torch.cat((k_i8, scale_i8), dim=-1)
+
     def _v_up_proj(self, x):
         num_input_tokens, _, _ = x.shape
         if (
@@ -922,7 +945,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self,
         x: torch.Tensor,
         q_c: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: M,
         cos: torch.Tensor,
         sin: torch.Tensor,
@@ -961,14 +984,14 @@ class AscendSFAImpl(MLAAttentionImpl):
         # So two branches are maintained temporarily.
         # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
         if self.use_sparse_c8_indexer:
-            assert len(kv_cache) == 4
+            k_cache, k_scale_cache = self._split_sparse_c8_kv_cache(kv_cache)
             weights = weights.to(torch.float16)
             topk_indices = torch.ops._C_ascend.npu_lightning_indexer_quant(
                 query=q_li.view(q_li_shape_ori),
-                key=kv_cache[2],
+                key=k_cache,
                 weights=weights,
                 query_dequant_scale=q_li_scale.view(q_li_shape_ori[:-1]),
-                key_dequant_scale=kv_cache[3].squeeze(2),  # B S N D -> B S D
+                key_dequant_scale=k_scale_cache.squeeze(2),  # B S N D -> B S D
                 actual_seq_lengths_query=actual_seq_lengths_query,
                 actual_seq_lengths_key=actual_seq_lengths_key,
                 block_table=attn_metadata.block_table,
@@ -1036,7 +1059,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self,
         layer_name,
         hidden_states: torch.Tensor,  # query in unified attn
-        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: M,
         need_gather_q_kv: bool = False,
         output: torch.Tensor | None = None,
@@ -1195,17 +1218,31 @@ class AscendSFAImpl(MLAAttentionImpl):
         if kv_cache is not None:
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event = torch.npu.Event()
-            torch_npu.npu_scatter_nd_update_(
-                kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping.view(-1, 1), k_li.view(-1, k_li.shape[-1])
-            )  # b, s, n, d
             if self.use_sparse_c8_indexer:
-                assert len(kv_cache) == 4
                 assert k_li_scale is not None
+                if self._is_packed_sparse_c8_kv_cache(kv_cache):
+                    packed_k_li = self._pack_sparse_c8_kv_update(k_li, k_li_scale)
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[2].view(-1, packed_k_li.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        packed_k_li,
+                    )
+                else:
+                    assert len(kv_cache) == 4
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[2].view(-1, k_li.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li.view(-1, k_li.shape[-1]),
+                    )  # b, s, n, d
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[3].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li_scale.view(-1, k_li_scale.shape[-1]),
+                    )
+            else:
                 torch_npu.npu_scatter_nd_update_(
-                    kv_cache[3].view(-1, k_li_scale.shape[-1]),
-                    slot_mapping.view(-1, 1),
-                    k_li_scale.view(-1, k_li_scale.shape[-1]),
-                )
+                    kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping.view(-1, 1), k_li.view(-1, k_li.shape[-1])
+                )  # b, s, n, d
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -18,6 +18,9 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     (kv_cache[0]: bfloat16, kv_cache[1]: bfloat16, kv_cache[2]: bfloat16)
     to
     (kv_cache[0]: bfloat16, kv_cache[1]: bfloat16, kv_cache[2]: int8, kv_cache[3]: float16).
+    When VLLM_ASCEND_FUSE_SPARSE_C8_KV=1, kv_cache[2] packs the int8 key and
+    the float16 scale bytes together, so the tuple stays
+    (kv_cache[0], kv_cache[1], packed kv_cache[2]).
 
     The semantic meaning of each KV cache entry is as follows:
     1. kv_cache[0] stores kv_lora.

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1276,6 +1276,11 @@ def enable_dsa_cp_with_o_proj_tp() -> bool:
     return kv_transfer_config is None or kv_transfer_config.kv_role == "kv_both"
 
 
+@lru_cache(maxsize=1)
+def fuse_sparse_c8_kv_cache() -> bool:
+    return os.getenv("VLLM_ASCEND_FUSE_SPARSE_C8_KV", "0") == "1"
+
+
 def check_gdn_layer(vllm_config) -> bool:
     """
     gdn layer is marked with `linear_attention`.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -123,6 +123,7 @@ from vllm_ascend.utils import (
     check_gdn_layer,
     enable_sp,
     enable_sp_by_pass,
+    fuse_sparse_c8_kv_cache,
     get_c_env,
     global_stream,
     lmhead_tp_enable,
@@ -2745,6 +2746,7 @@ class NPUModelRunner(GPUModelRunner):
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
+        fuse_sparse_c8_kv = self.use_sparse_c8_indexer and fuse_sparse_c8_kv_cache()
         # If some tensors are shared by linear layers and attention layers,
         # the same tensor format must be maintained even if some layers
         # have only linear or attention layers, for example, the mtp layer.
@@ -2812,7 +2814,12 @@ class NPUModelRunner(GPUModelRunner):
                     if self.use_sparse:
                         dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
                     if self.use_sparse_c8_indexer:
+                        assert dsa_k_tensor_size is not None
+                        assert dsa_k_scale_tensor_split_factor is not None
                         dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
+                        if fuse_sparse_c8_kv:
+                            dsa_k_tensor_size += dsa_k_scale_tensor_size
+                            dsa_k_scale_tensor_size = None
 
                     # for other attentions, e.g., self_attn, sliding window attn
                     if self.vllm_config.kv_transfer_config is None:
@@ -2849,9 +2856,12 @@ class NPUModelRunner(GPUModelRunner):
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
                             if self.use_sparse:
                                 if self.use_sparse_c8_indexer:
-                                    kv_cache_raw_tensors[layer_name_inner] = (
-                                        k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
-                                    )
+                                    if fuse_sparse_c8_kv:
+                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor, dsa_k_tensor)
+                                    else:
+                                        kv_cache_raw_tensors[layer_name_inner] = (
+                                            k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
+                                        )
                                 else:
                                     kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor, dsa_k_tensor)
                             else:
@@ -2884,6 +2894,7 @@ class NPUModelRunner(GPUModelRunner):
         """
         kv_caches: dict[str, torch.Tensor] = {}
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
+        fuse_sparse_c8_kv = self.use_sparse_c8_indexer and fuse_sparse_c8_kv_cache()
         for group in self._kv_cache_spec_attn_group_iterator():
             attn_backend = group.backend
             for layer_name in group.layer_names:
@@ -2897,16 +2908,29 @@ class NPUModelRunner(GPUModelRunner):
                 if isinstance(current_kv_cache_spec, AttentionSpec):
                     if self.use_sparse:
                         if self.use_sparse_c8_indexer:
-                            raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
-                                layer_name]
-                            assert raw_dsa_k_tensor is not None
-                            assert raw_dsa_k_scale_tensor is not None
-                            sum_page_size_bytes = (
-                                raw_k_tensor.numel()
-                                + raw_v_tensor.numel()
-                                + raw_dsa_k_tensor.numel()
-                                + raw_dsa_k_scale_tensor.numel()
-                            )
+                            if fuse_sparse_c8_kv:
+                                raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor = kv_cache_raw_tensors[  # type: ignore
+                                    layer_name]
+                                assert raw_dsa_k_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel() + raw_v_tensor.numel() + raw_dsa_k_tensor.numel()
+                                )
+                            else:
+                                raw_c8_kv_tensors = kv_cache_raw_tensors[layer_name]  # type: ignore
+                                (
+                                    raw_k_tensor,
+                                    raw_v_tensor,
+                                    raw_dsa_k_tensor,
+                                    raw_dsa_k_scale_tensor,
+                                ) = raw_c8_kv_tensors
+                                assert raw_dsa_k_tensor is not None
+                                assert raw_dsa_k_scale_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel()
+                                    + raw_v_tensor.numel()
+                                    + raw_dsa_k_tensor.numel()
+                                    + raw_dsa_k_scale_tensor.numel()
+                                )
                         else:
                             raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor = kv_cache_raw_tensors[  # type: ignore
                                 layer_name]
@@ -2999,22 +3023,38 @@ class NPUModelRunner(GPUModelRunner):
                             self.model_config.hf_text_config.index_head_dim,
                         )
                         if self.use_sparse_c8_indexer:
-                            # dsa_k
-                            dsa_k_cache = raw_dsa_k_tensor.view(self.c8_k_cache_dtype).view(dsa_k_cache_shape)
-                            # dsa_k_scale
-                            dsa_k_scale_cache_shape = (
-                                num_blocks,
-                                current_kv_cache_spec.block_size,
-                                current_kv_cache_spec.num_kv_heads,
-                                1,
-                            )
-                            assert raw_dsa_k_scale_tensor is not None
-                            dsa_k_scale_cache = (
-                                raw_dsa_k_scale_tensor
-                                .view(self.c8_k_scale_cache_dtype)
-                                .view(dsa_k_scale_cache_shape)
-                            )
-                            kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache, dsa_k_scale_cache)
+                            if fuse_sparse_c8_kv:
+                                packed_index_head_dim = (
+                                    self.model_config.hf_text_config.index_head_dim
+                                    + get_dtype_size(self.c8_k_scale_cache_dtype)
+                                )
+                                packed_dsa_k_cache_shape = (
+                                    num_blocks,
+                                    current_kv_cache_spec.block_size,
+                                    current_kv_cache_spec.num_kv_heads,
+                                    packed_index_head_dim,
+                                )
+                                dsa_k_cache = raw_dsa_k_tensor.view(self.c8_k_cache_dtype).view(
+                                    packed_dsa_k_cache_shape
+                                )
+                                kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache)
+                            else:
+                                # dsa_k
+                                dsa_k_cache = raw_dsa_k_tensor.view(self.c8_k_cache_dtype).view(dsa_k_cache_shape)
+                                # dsa_k_scale
+                                dsa_k_scale_cache_shape = (
+                                    num_blocks,
+                                    current_kv_cache_spec.block_size,
+                                    current_kv_cache_spec.num_kv_heads,
+                                    1,
+                                )
+                                assert raw_dsa_k_scale_tensor is not None
+                                dsa_k_scale_cache = (
+                                    raw_dsa_k_scale_tensor
+                                    .view(self.c8_k_scale_cache_dtype)
+                                    .view(dsa_k_scale_cache_shape)
+                                )
+                                kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache, dsa_k_scale_cache)
                         else:
                             # dsa_k
                             dsa_k_cache = raw_dsa_k_tensor.view(current_kv_cache_spec.dtype).view(dsa_k_cache_shape)


### PR DESCRIPTION
### What this PR does / why we need it?

This adds an opt-in packed KV cache path for Sparse C8 indexer cache with `VLLM_ASCEND_FUSE_SPARSE_C8_KV=1`.

When Sparse C8 is enabled today, the DSA KV cache tuple is split as `(k, v, k_li, k_li_scale)`. With this flag, `k_li` and `k_li_scale` are allocated, reshaped, transferred, and saved as one packed cache tensor, so the tuple becomes `(k, v, packed_k_li_with_scale)` while keeping the default path unchanged.

This is meant to validate whether the DSA-CP + C8 TPOT regression is caused by the extra C8 scale cache segment in the P-side cache/PD transfer path rather than by the D-side C8 sparse indexer compute itself.

### Changes

- Add `VLLM_ASCEND_FUSE_SPARSE_C8_KV=1` helper gate.
- Allocate one packed Sparse C8 DSA cache buffer instead of separate `k_li` and `k_li_scale` buffers when the gate is enabled.
- Reshape packed cache as an int8 tensor with last dim `index_head_dim + sizeof(scale_dtype)`.
- Split packed key/scale as non-contiguous views for `npu_lightning_indexer_quant`.
- Scatter packed `k_li + k_li_scale` into the cache with one update.
- Document the packed tuple format in the Ascend MLA KV cache spec patch.

### Notes

Both P and D instances must use the same `VLLM_ASCEND_FUSE_SPARSE_C8_KV` setting. The packed path relies on the Sparse C8 indexer op accepting non-contiguous key and scale views.

### How was this patch tested?

- `git diff --check`

I could not run Python unit tests or compile checks in this local environment because `python`, `py`, and `uv` are not available in PATH.