### PR TITLE
[Attention][Feature] adapt attention for head_size > 192 where TND layout is unsupported by aclnnFusedInferAttentionScoreV3

### DIFF
--- a/.agents/skills/main2main/scripts/check_and_commit.py
+++ b/.agents/skills/main2main/scripts/check_and_commit.py
@@ -17,6 +17,7 @@ Output (stdout):
     JSON with commit_sha and files_committed on success.
     Exits with code 1 and an error description on validation failure.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -105,12 +106,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Validate and commit changes for a main2main step.",
     )
-    parser.add_argument("--ascend-path", type=Path, required=True,
-                        help="Path to the vllm-ascend repository")
-    parser.add_argument("--step-id", required=True,
-                        help="Step identifier for the commit message context")
-    parser.add_argument("--message", required=True,
-                        help="Commit message")
+    parser.add_argument("--ascend-path", type=Path, required=True, help="Path to the vllm-ascend repository")
+    parser.add_argument("--step-id", required=True, help="Step identifier for the commit message context")
+    parser.add_argument("--message", required=True, help="Commit message")
     args = parser.parse_args()
 
     repo = args.ascend_path
@@ -128,8 +126,7 @@ def main() -> None:
     forbidden = _check_forbidden(committable)
     if forbidden:
         print(
-            f"Error: forbidden files in working tree:\n"
-            + "\n".join(f"  - {f}" for f in forbidden),
+            "Error: forbidden files in working tree:\n" + "\n".join(f"  - {f}" for f in forbidden),
             file=sys.stderr,
         )
         sys.exit(1)
@@ -137,8 +134,7 @@ def main() -> None:
     if not committable:
         if skipped:
             print(
-                f"Error: no committable changes to commit; skipped files:\n"
-                + "\n".join(f"  - {f}" for f in skipped),
+                "Error: no committable changes to commit; skipped files:\n" + "\n".join(f"  - {f}" for f in skipped),
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/.agents/skills/main2main/scripts/detect_commits.py
+++ b/.agents/skills/main2main/scripts/detect_commits.py
@@ -20,6 +20,7 @@ Side-effects:
     - Creates /tmp/main2main/ and /tmp/main2main/steps/ directories.
     - Writes /tmp/main2main/detect.json with the same JSON.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -75,10 +76,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Detect base/target commits for main2main pipeline.",
     )
-    parser.add_argument("--vllm-path", type=Path, required=True,
-                        help="Path to the local vLLM repository")
-    parser.add_argument("--ascend-path", type=Path, required=True,
-                        help="Path to the local vllm-ascend repository")
+    parser.add_argument("--vllm-path", type=Path, required=True, help="Path to the local vLLM repository")
+    parser.add_argument("--ascend-path", type=Path, required=True, help="Path to the local vllm-ascend repository")
     args = parser.parse_args()
 
     conf = extract_from_conf_py(args.ascend_path)
@@ -97,7 +96,8 @@ def main() -> None:
     (workspace / "steps").mkdir(exist_ok=True)
 
     (workspace / "detect.json").write_text(
-        json.dumps(result, indent=2) + "\n", encoding="utf-8",
+        json.dumps(result, indent=2) + "\n",
+        encoding="utf-8",
     )
 
     print(json.dumps(result, indent=2))

--- a/.agents/skills/main2main/scripts/lint_adapt_guide.py
+++ b/.agents/skills/main2main/scripts/lint_adapt_guide.py
@@ -24,6 +24,7 @@ Output:
       3. Untouched upstream    : vllm/ paths changed this run but missing from
                                  the file-mapping region (only if patches found)
 """
+
 from __future__ import annotations
 
 import argparse
@@ -184,8 +185,7 @@ def _collect_changed_files(patches_dir: Path) -> list[str]:
     return sorted(files)
 
 
-def _check_untouched_upstream(regions: dict[str, str | None],
-                              changed_files: list[str]) -> list[str]:
+def _check_untouched_upstream(regions: dict[str, str | None], changed_files: list[str]) -> list[str]:
     """List vllm/ paths touched this run that file-mapping doesn't cover.
 
     Coverage rule: a row covers a changed file when the row's upstream cell
@@ -202,20 +202,18 @@ def _check_untouched_upstream(regions: dict[str, str | None],
     for changed in changed_files:
         if not changed.startswith(UPSTREAM_PREFIX):
             continue
-        if any(changed.startswith(prefix.rstrip("/") + "/")
-               or changed == prefix.rstrip("/")
-               or changed.startswith(prefix)
-               for prefix in covered_prefixes):
+        if any(
+            changed.startswith(prefix.rstrip("/") + "/") or changed == prefix.rstrip("/") or changed.startswith(prefix)
+            for prefix in covered_prefixes
+        ):
             continue
         untouched.append(changed)
     return untouched
 
 
-def _render_report(invalid: list[dict],
-                   uncovered: list[str],
-                   untouched: list[str],
-                   patches_dir: Path,
-                   patches_seen: bool) -> str:
+def _render_report(
+    invalid: list[dict], uncovered: list[str], untouched: list[str], patches_dir: Path, patches_seen: bool
+) -> str:
     lines: list[str] = ["# Adapt Guide Lint Report", ""]
 
     lines.append("## 1. Invalidated paths")
@@ -231,8 +229,7 @@ def _render_report(invalid: list[dict],
 
     lines.append("## 2. Uncovered directories")
     lines.append("")
-    lines.append("vllm_ascend/ subdirectories that no AUTO-MAINTAINED region "
-                 "currently references.")
+    lines.append("vllm_ascend/ subdirectories that no AUTO-MAINTAINED region currently references.")
     lines.append("")
     if uncovered:
         for path in uncovered:
@@ -246,8 +243,7 @@ def _render_report(invalid: list[dict],
     if not patches_seen:
         lines.append(f"_No step patches found under `{patches_dir}` — section skipped._")
     else:
-        lines.append("vLLM paths changed in this run's step patches but not "
-                     "covered by any file-mapping row.")
+        lines.append("vLLM paths changed in this run's step patches but not covered by any file-mapping row.")
         lines.append("")
         if untouched:
             for path in untouched:
@@ -262,15 +258,19 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Lint the AUTO-MAINTAINED tables in adapt-guide.md.",
     )
-    parser.add_argument("--ascend-path", type=Path, required=True,
-                        help="Path to the vllm-ascend repository.")
-    parser.add_argument("--patches-dir", type=Path,
-                        default=Path("/tmp/main2main/steps"),
-                        help="Directory containing per-step patch outputs.")
+    parser.add_argument("--ascend-path", type=Path, required=True, help="Path to the vllm-ascend repository.")
     parser.add_argument(
-        "--output", type=Path,
+        "--patches-dir",
+        type=Path,
+        default=Path("/tmp/main2main/steps"),
+        help="Directory containing per-step patch outputs.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
         default=Path("/tmp/main2main/adapt-guide-refresh/check_report.md"),
-        help="Where to write the Markdown report.")
+        help="Where to write the Markdown report.",
+    )
     args = parser.parse_args()
 
     guide = args.ascend_path / ".agents/skills/main2main/reference/adapt-guide.md"
@@ -283,8 +283,7 @@ def main() -> int:
     missing = [name for name, body in regions.items() if body is None]
     if missing:
         print(
-            "error: missing AUTO-MAINTAINED region(s) in adapt-guide.md: "
-            + ", ".join(missing),
+            "error: missing AUTO-MAINTAINED region(s) in adapt-guide.md: " + ", ".join(missing),
             file=sys.stderr,
         )
         return 1
@@ -307,8 +306,7 @@ def main() -> int:
     print(f"Wrote {args.output}")
     print(f"  invalidated paths   : {len(invalid)}")
     print(f"  uncovered dirs      : {len(uncovered)}")
-    print(f"  untouched upstream  : {len(untouched)}"
-          + ("" if changed else " (no patches found)"))
+    print(f"  untouched upstream  : {len(untouched)}" + ("" if changed else " (no patches found)"))
     return 0
 
 

--- a/.agents/skills/main2main/scripts/plan_steps.py
+++ b/.agents/skills/main2main/scripts/plan_steps.py
@@ -29,13 +29,13 @@ Usage:
       --base-commit <sha> \\
       --target-commit <sha>
 """
+
 from __future__ import annotations
 
 import argparse
 import json
 import math
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -47,9 +47,7 @@ REQUIREMENTS_FILES = {
     "setup.py",
     "requirements/common.txt",
 }
-REQUIREMENTS_PREFIXES = (
-    "requirements/build/",
-)
+REQUIREMENTS_PREFIXES = ("requirements/build/",)
 
 
 def _commit_count_budget(line_budget: int = LINE_BUDGET) -> int:
@@ -74,17 +72,23 @@ def _run_git(repo: Path, *args: str) -> str:
 def _list_commits(repo: Path, base: str, target: str) -> list[dict[str, str]]:
     """Return commits in chronological order (oldest first)."""
     log_output = _run_git(
-        repo, "log", "--reverse", "--format=%H%x1f%s", f"{base}..{target}",
+        repo,
+        "log",
+        "--reverse",
+        "--format=%H%x1f%s",
+        f"{base}..{target}",
     )
     commits: list[dict[str, str]] = []
     for line in log_output.strip().splitlines():
         if not line.strip():
             continue
         parts = line.split("\x1f", 1)
-        commits.append({
-            "sha": parts[0].strip(),
-            "subject": parts[1].strip() if len(parts) > 1 else "",
-        })
+        commits.append(
+            {
+                "sha": parts[0].strip(),
+                "subject": parts[1].strip() if len(parts) > 1 else "",
+            }
+        )
     return commits
 
 
@@ -101,12 +105,14 @@ def _numstat(repo: Path, sha: str) -> list[dict[str, Any]]:
         added = int(parts[0]) if parts[0] != "-" else 0
         deleted = int(parts[1]) if parts[1] != "-" else 0
         filepath = parts[2]
-        files.append({
-            "path": filepath,
-            "added": added,
-            "deleted": deleted,
-            "lines": added + deleted,
-        })
+        files.append(
+            {
+                "path": filepath,
+                "added": added,
+                "deleted": deleted,
+                "lines": added + deleted,
+            }
+        )
     return files
 
 
@@ -163,20 +169,22 @@ def plan_steps(
         nonlocal current_cats, current_files
         if not current_commits:
             return
-        steps.append({
-            "index": len(steps) + 1,
-            "id": f"step-{len(steps) + 1}",
-            "commits": list(current_commits),
-            "commit_count": len(current_commits),
-            "start_commit": start,
-            "end_commit": current_commits[-1]["sha"],
-            "categories": sorted(current_cats),
-            "vllm_changed_lines": current_vllm_lines,
-            "total_changed_lines": current_total_lines,
-            "line_budget": LINE_BUDGET,
-            "commit_count_budget": _commit_count_budget(),
-            "files_changed": sorted(set(current_files)),
-        })
+        steps.append(
+            {
+                "index": len(steps) + 1,
+                "id": f"step-{len(steps) + 1}",
+                "commits": list(current_commits),
+                "commit_count": len(current_commits),
+                "start_commit": start,
+                "end_commit": current_commits[-1]["sha"],
+                "categories": sorted(current_cats),
+                "vllm_changed_lines": current_vllm_lines,
+                "total_changed_lines": current_total_lines,
+                "line_budget": LINE_BUDGET,
+                "commit_count_budget": _commit_count_budget(),
+                "files_changed": sorted(set(current_files)),
+            }
+        )
         current_commits = []
         current_vllm_lines = 0
         current_total_lines = 0
@@ -219,10 +227,7 @@ def plan_steps(
             continue
 
         # Would exceed a step budget? → flush first
-        if (
-            current_vllm_lines + vllm_lines > LINE_BUDGET
-            or len(current_commits) >= _commit_count_budget()
-        ):
+        if current_vllm_lines + vllm_lines > LINE_BUDGET or len(current_commits) >= _commit_count_budget():
             _flush(prev_end)
             prev_end = steps[-1]["end_commit"] if steps else base_commit
 
@@ -248,9 +253,11 @@ def _render_markdown(plan: dict[str, Any]) -> str:
         "",
     ]
     for step in plan["steps"]:
-        lines.append(f"## {step['id']} (commits: {step['commit_count']}, "
-                      f"vllm: {step['vllm_changed_lines']} lines, "
-                      f"total: {step['total_changed_lines']} lines)")
+        lines.append(
+            f"## {step['id']} (commits: {step['commit_count']}, "
+            f"vllm: {step['vllm_changed_lines']} lines, "
+            f"total: {step['total_changed_lines']} lines)"
+        )
         lines.append("")
         lines.append(f"- Categories: {', '.join(step['categories'])}")
         lines.append(f"- Range: `{step['start_commit'][:8]}..{step['end_commit'][:8]}`")
@@ -298,10 +305,12 @@ def main() -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     (output_dir / "steps.json").write_text(
-        json.dumps(plan, indent=2) + "\n", encoding="utf-8",
+        json.dumps(plan, indent=2) + "\n",
+        encoding="utf-8",
     )
     (output_dir / "steps.md").write_text(
-        _render_markdown(plan), encoding="utf-8",
+        _render_markdown(plan),
+        encoding="utf-8",
     )
 
     for step in plan["steps"]:

--- a/.agents/skills/main2main/scripts/pre_ci_check.py
+++ b/.agents/skills/main2main/scripts/pre_ci_check.py
@@ -22,6 +22,7 @@ Design note:
     version boundary. Scanning the full repo would flag all historical guards
     as mismatches whenever the release tag advances.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -70,16 +71,18 @@ def _get_added_lines(repo: Path) -> list[dict[str, str]]:
         if line.startswith("+++ b/"):
             current_file = line[6:]
         elif line.startswith("@@ "):
-            match = re.search(r'\+(\d+)', line)
+            match = re.search(r"\+(\d+)", line)
             if match:
                 current_line = int(match.group(1))
         elif line.startswith("+") and not line.startswith("+++"):
             if current_file:
-                added.append({
-                    "file": current_file,
-                    "line_no": str(current_line),
-                    "text": line[1:],
-                })
+                added.append(
+                    {
+                        "file": current_file,
+                        "line_no": str(current_line),
+                        "text": line[1:],
+                    }
+                )
             current_line += 1
         elif not line.startswith("-"):
             current_line += 1
@@ -149,10 +152,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run pre-CI verification checks for main2main.",
     )
-    parser.add_argument("--ascend-path", type=Path, required=True,
-                        help="Path to the vllm-ascend repository")
-    parser.add_argument("--release-tag", required=True,
-                        help="Expected release version string (main_vllm_tag from conf.py)")
+    parser.add_argument("--ascend-path", type=Path, required=True, help="Path to the vllm-ascend repository")
+    parser.add_argument(
+        "--release-tag", required=True, help="Expected release version string (main_vllm_tag from conf.py)"
+    )
     args = parser.parse_args()
 
     repo = args.ascend_path
@@ -169,31 +172,31 @@ def main() -> None:
 
     # Check 1: version strings in new code only
     version_ok = len(versions["mismatched"]) == 0
-    checks.append({
-        "name": "version_strings",
-        "passed": version_ok,
-        "detail": (
-            f"{versions['new_calls_count']} new vllm_version_is() calls all use {args.release_tag}"
-            if version_ok
-            else f"{len(versions['mismatched'])} new vllm_version_is() calls use wrong version"
-        ),
-        "mismatched": versions["mismatched"],
-    })
+    checks.append(
+        {
+            "name": "version_strings",
+            "passed": version_ok,
+            "detail": (
+                f"{versions['new_calls_count']} new vllm_version_is() calls all use {args.release_tag}"
+                if version_ok
+                else f"{len(versions['mismatched'])} new vllm_version_is() calls use wrong version"
+            ),
+            "mismatched": versions["mismatched"],
+        }
+    )
     if not version_ok:
         all_passed = False
 
     # Check 2: temp files
     temp_ok = len(temps["violations"]) == 0
-    checks.append({
-        "name": "temp_files",
-        "passed": temp_ok,
-        "detail": (
-            "no temp files in repo"
-            if temp_ok
-            else f"{len(temps['violations'])} temp files found in repo"
-        ),
-        "violations": temps["violations"],
-    })
+    checks.append(
+        {
+            "name": "temp_files",
+            "passed": temp_ok,
+            "detail": ("no temp files in repo" if temp_ok else f"{len(temps['violations'])} temp files found in repo"),
+            "violations": temps["violations"],
+        }
+    )
     if not temp_ok:
         all_passed = False
 

--- a/.agents/skills/main2main/scripts/run_main2main_ci.py
+++ b/.agents/skills/main2main/scripts/run_main2main_ci.py
@@ -14,6 +14,7 @@ agent context stay small.
 The raw run_suite.py status is always stored as run_suite_exit_code. The wrapper
 process exits 0 only when main2main may proceed: passed CI or env_flake_pass.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -121,17 +122,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run e2e-main2main CI for one main2main step.",
     )
-    parser.add_argument("--ascend-path", type=Path, required=True,
-                        help="Path to the vllm-ascend repository")
-    parser.add_argument("--step-id", required=True,
-                        help="Step identifier, for example step-1")
-    parser.add_argument("--round", type=int, default=1,
-                        help="CI round number for this step")
-    parser.add_argument("--suite", action="append",
-                        help="run_suite.py suite name. Can be specified multiple times. "
-                             "Defaults to e2e-singlecard-light.")
-    parser.add_argument("--workspace", type=Path, default=Path("/tmp/main2main"),
-                        help="main2main workspace directory")
+    parser.add_argument("--ascend-path", type=Path, required=True, help="Path to the vllm-ascend repository")
+    parser.add_argument("--step-id", required=True, help="Step identifier, for example step-1")
+    parser.add_argument("--round", type=int, default=1, help="CI round number for this step")
+    parser.add_argument(
+        "--suite",
+        action="append",
+        help="run_suite.py suite name. Can be specified multiple times. Defaults to e2e-singlecard-light.",
+    )
+    parser.add_argument("--workspace", type=Path, default=Path("/tmp/main2main"), help="main2main workspace directory")
     args = parser.parse_args()
 
     ascend_path = args.ascend_path.resolve()

--- a/.agents/skills/main2main/scripts/update_commit_reference.py
+++ b/.agents/skills/main2main/scripts/update_commit_reference.py
@@ -14,6 +14,7 @@ Usage:
 Output (stdout):
     JSON with files_updated and replacement_count.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -74,10 +75,12 @@ def _replace_in_tracked_files(
             continue
         if not dry_run:
             path.write_bytes(data.replace(old_bytes, new_bytes))
-        updated.append({
-            "path": str(path.relative_to(repo)),
-            "replacements": count,
-        })
+        updated.append(
+            {
+                "path": str(path.relative_to(repo)),
+                "replacements": count,
+            }
+        )
 
     return updated
 
@@ -86,14 +89,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Replace old vLLM commit references in tracked vllm-ascend files.",
     )
-    parser.add_argument("--ascend-path", type=Path, required=True,
-                        help="Path to the vllm-ascend repository")
-    parser.add_argument("--old-commit", required=True,
-                        help="Existing 40-character vLLM commit SHA")
-    parser.add_argument("--new-commit", required=True,
-                        help="Replacement 40-character vLLM commit SHA")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Report matching files without modifying them")
+    parser.add_argument("--ascend-path", type=Path, required=True, help="Path to the vllm-ascend repository")
+    parser.add_argument("--old-commit", required=True, help="Existing 40-character vLLM commit SHA")
+    parser.add_argument("--new-commit", required=True, help="Replacement 40-character vLLM commit SHA")
+    parser.add_argument("--dry-run", action="store_true", help="Report matching files without modifying them")
     args = parser.parse_args()
 
     repo = args.ascend_path

--- a/csrc/scripts/util/build_opp_kernel_static.py
+++ b/csrc/scripts/util/build_opp_kernel_static.py
@@ -58,7 +58,7 @@ def shell_checkout_key_func(symbol_file, key_str):
 
 def to_upper_camel_case(x) -> str:
     """转大驼峰法命名"""
-    s = re.sub("_([a-zA-Z])", lambda m: (m.group(1).upper()), x.lower())
+    s = re.sub("_([a-zA-Z])", lambda m: m.group(1).upper(), x.lower())
     return s[0].upper() + s[1:]
 
 

--- a/tests/ut/attention/test_mla_cp_precision.py
+++ b/tests/ut/attention/test_mla_cp_precision.py
@@ -423,7 +423,7 @@ def _make_fake_self(*, dtype: torch.dtype, **kwargs) -> MagicMock:
     _populate_impl_attrs(fake_self, **kwargs)
     fake_self.dtype = dtype
     fake_self._v_up_proj = lambda x: AscendMlaCPImpl._v_up_proj(fake_self, x)
-    fake_self._compute_prefill_context = lambda *a, **kw: (AscendMLAImpl._compute_prefill_context(fake_self, *a, **kw))
+    fake_self._compute_prefill_context = lambda *a, **kw: AscendMLAImpl._compute_prefill_context(fake_self, *a, **kw)
     return fake_self
 
 

--- a/tests/ut/attention/test_sfa_cp_precision.py
+++ b/tests/ut/attention/test_sfa_cp_precision.py
@@ -377,11 +377,11 @@ def _make_fake_self(
     if gather_kv_cross_cp_compact_fn is not None:
         fake_self.gather_kv_cross_cp_compact = MagicMock(side_effect=gather_kv_cross_cp_compact_fn)
 
-    fake_self.gather_block_table = lambda block_num, block_tables, block_arange: (
-        AscendSFACPImpl.gather_block_table(fake_self, block_num, block_tables, block_arange)
+    fake_self.gather_block_table = lambda block_num, block_tables, block_arange: AscendSFACPImpl.gather_block_table(
+        fake_self, block_num, block_tables, block_arange
     )
-    fake_self._execute_sparse_flash_attention = lambda *args, **kwargs: (
-        AscendSFACPImpl._execute_sparse_flash_attention(fake_self, *args, **kwargs)
+    fake_self._execute_sparse_flash_attention = lambda *args, **kwargs: AscendSFACPImpl._execute_sparse_flash_attention(
+        fake_self, *args, **kwargs
     )
     fake_self._align_to_graph_bucket_tokens = lambda x, m: x
     return fake_self

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -638,7 +638,7 @@ class TestAscendFusedMoE:
         )
         moe_comm_method = MagicMock()
         moe_comm_method.prepare.return_value = prepare_output
-        moe_comm_method.finalize.side_effect = lambda hidden_states, **_: (hidden_states + 2)
+        moe_comm_method.finalize.side_effect = lambda hidden_states, **_: hidden_states + 2
         before_dispatch_evt = MagicMock()
         before_combine_evt = MagicMock()
         layer.quant_method.apply.return_value = FusedExpertsResult(
@@ -713,7 +713,7 @@ class TestAscendFusedMoE:
             mc2_mask=None,
             padded_hidden_states_shape=None,
         )
-        moe_comm_method.finalize.side_effect = lambda hidden_states, **_: (hidden_states)
+        moe_comm_method.finalize.side_effect = lambda hidden_states, **_: hidden_states
         layer.quant_method.apply.return_value = FusedExpertsResult(
             routed_out=torch.ones(2, 4),
             expert_tokens=torch.tensor([4, 6]),

--- a/tests/ut/worker/test_kvcomp_utils.py
+++ b/tests/ut/worker/test_kvcomp_utils.py
@@ -144,7 +144,7 @@ def test_recover_request_lengths_empty():
 @patch("vllm_ascend.worker.kvcomp_utils.extract_layer_index")
 def test_bind_hashk_cache_basic(mock_extract):
     """Test bind_hashk_cache populates runner and forward_context."""
-    mock_extract.side_effect = lambda name, _: (0 if "layers.0" in name else (1 if "layers.1" in name else 2))
+    mock_extract.side_effect = lambda name, _: 0 if "layers.0" in name else (1 if "layers.1" in name else 2)
 
     cache0 = torch.zeros(2, 8, 128, 16, dtype=torch.uint8)
     cache1 = torch.ones(2, 8, 128, 16, dtype=torch.uint8)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1057,18 +1057,30 @@ class AscendAttentionBackendImpl(AttentionImpl):
         num_kv_groups = num_heads // num_kv_heads
         scale = self.scale
         causal = attn_metadata.causal
-
+        
         # 将 seq_lengths 转为 Python list
         seq_lens_q = attn_metadata.actual_seq_lengths_q
         if isinstance(seq_lens_q, list):
             seq_lens_q_list = seq_lens_q
         else:
             seq_lens_q_list = seq_lens_q.tolist() if hasattr(seq_lens_q, 'numel') and seq_lens_q.numel() > 1 else [int(seq_lens_q)]
+        
         if isinstance(actual_seq_lengths_kv, list):
             seq_lens_kv_list = actual_seq_lengths_kv
         else:
             seq_lens_kv_list = actual_seq_lengths_kv.tolist() if hasattr(actual_seq_lengths_kv, 'numel') and actual_seq_lengths_kv.numel() > 1 else [int(actual_seq_lengths_kv)]
-
+        
+        query_lens = []
+        prev = 0
+        for q_len in seq_lens_q_list:
+            query_lens.append(q_len - prev)
+            prev = q_len
+        
+        if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache:
+            kv_lens = query_lens
+        else:
+            kv_lens = seq_lens_kv_list
+        
         # Validate sequence length (similar to NPU operator C++ layer validation)
         # Get max_seq_len from config (equivalent to operator internal access)
         max_seq_len = getattr(
@@ -1076,7 +1088,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             getattr(self.vllm_config.model_config, 'max_seq_len', 32768)
         )
         
-        max_kv_len = max(seq_lens_kv_list) if seq_lens_kv_list else 0
+        max_kv_len = max(kv_lens) if kv_lens else 0
         if max_kv_len > max_seq_len:
             # Truncate sequences that exceed max_model_len to prevent service crash
             # This handles the case where prompt + generated tokens > max_model_len
@@ -1090,20 +1102,32 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 stacklevel=2
             )
             # Truncate all sequences to max_seq_len
-            seq_lens_kv_list = [min(s, max_seq_len) for s in seq_lens_kv_list]
-            max_kv_len = max_seq_len
-
+            kv_lens = [min(s, max_seq_len) for s in kv_lens]
+        
         prev_q = 0
         prev_kv = 0
         outputs = []
-        for i in range(len(seq_lens_q_list)):
-            cur_q = seq_lens_q_list[i]
-            cur_kv = seq_lens_kv_list[i]
-
-            # 提取当前序列的 query, reshape 为 [1, num_heads, cur_q, head_size]
+        
+        for i in range(len(query_lens)):
+            cur_q = query_lens[i]
+            cur_kv = kv_lens[i]
+            
+            # 提取当前序列的 query
             q_i = query[prev_q:prev_q + cur_q]
+            
+            actual_cur_q = q_i.size(0)
+            if actual_cur_q != cur_q:
+                import warnings
+                warnings.warn(
+                    f"Query size mismatch at batch {i}: metadata says {cur_q}, but actual tensor has {actual_cur_q} tokens. "
+                    f"This is expected with Chunked Prefill + Speculative Decoding. Using actual size.",
+                    UserWarning,
+                    stacklevel=2
+                )
+                cur_q = actual_cur_q
+            
             q_i = q_i.view(1, cur_q, num_heads, head_size).transpose(1, 2)
-
+            
             # 提取 key/value：支持 paged kv_cache 和 PrefillNoCache 两种情况
             if block_table is not None and self.key_cache is not None:
                 bt_i = block_table[i]
@@ -1123,7 +1147,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 else:
                     k_i = key[:cur_kv]
                     v_i = value[:cur_kv]
-
+            
             # Adjust cur_kv based on actual KV data size (mimics NPU operator behavior)
             # NPU operator internally checks block_table and truncates to actual available length
             # This prevents RuntimeError when requested length exceeds cached tokens
@@ -1138,9 +1162,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     stacklevel=2
                 )
                 cur_kv = actual_kv_tokens
-                # Also update seq_lens_kv_list for consistency
-                seq_lens_kv_list[i] = cur_kv
-
+            
             # reshape key/value 为 [1, num_kv_heads, cur_kv, head_size]
             
             # Sanity check before reshape to prevent cryptic errors
@@ -1158,16 +1180,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 raise RuntimeError(
                     f"Internal error in FallbackSDPA: value tensor size mismatch "
                     f"(expected {expected_v_elements}, got {v_i.numel()})."
-                )           
+                )
             
             k_i = k_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
             v_i = v_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
-
+            
             # GQA: expand kv heads 以匹配 query heads
             if num_kv_groups > 1:
                 k_i = k_i.unsqueeze(2).expand(-1, -1, num_kv_groups, -1, -1).reshape(1, num_heads, cur_kv, head_size)
                 v_i = v_i.unsqueeze(2).expand(-1, -1, num_kv_groups, -1, -1).reshape(1, num_heads, cur_kv, head_size)
-
+            
             # causal mask
             attn_mask_i = None
             if causal:
@@ -1175,16 +1197,29 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     torch.full((cur_q, cur_kv), float('-inf'), device=q_i.device, dtype=q_i.dtype),
                     diagonal=cur_kv - cur_q + 1
                 )
-
+            
             out_i = F.scaled_dot_product_attention(q_i, k_i, v_i, attn_mask=attn_mask_i, scale=scale)
             out_i = out_i.transpose(1, 2).reshape(cur_q, num_heads * head_size)
             outputs.append(out_i)
-            prev_q = cur_q
-            prev_kv = cur_kv
-
+            
+            prev_q += cur_q
+            prev_kv += cur_kv
+        
         attn_output = torch.cat(outputs, dim=0)
-        return attn_output.view(num_tokens, num_heads, head_size)
-
+        
+        actual_num_tokens = attn_output.size(0)
+        if actual_num_tokens != num_tokens:
+            import warnings
+            warnings.warn(
+                f"Output size mismatch: metadata says {num_tokens} tokens, but actual output has {actual_num_tokens} tokens. "
+                f"This is expected with Chunked Prefill + Speculative Decoding. Using actual size.",
+                UserWarning,
+                stacklevel=2
+            )
+        
+        return attn_output.view(actual_num_tokens, num_heads, head_size)
+    
+    
     def forward_fused_infer_attention(
         self,
         query: torch.Tensor,
@@ -1306,7 +1341,27 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     sparse_mode=3,
                 )
 
-            attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
+            # Fix: Handle size mismatch from _fallback_sdpa or NPU operator
+            if attn_output.dim() == 2:
+                # attn_output is [tokens, hidden_size], need to reshape
+                actual_tokens = attn_output.size(0)
+                attn_output = attn_output.view(actual_tokens, self.num_heads, self.head_size)
+            elif attn_output.dim() == 3:
+                # attn_output is already [tokens, num_heads, head_size]
+                # Verify the shape is correct
+                actual_tokens = attn_output.size(0)
+                if actual_tokens != num_tokens:
+                    import warnings
+                    warnings.warn(
+                        f"Attention output size mismatch in FIA: metadata says {num_tokens} tokens, "
+                        f"but actual output has {actual_tokens} tokens. Using actual size.",
+                        UserWarning,
+                        stacklevel=2
+                    )
+            else:
+                raise RuntimeError(f"Unexpected attn_output shape: {attn_output.shape}")
+            
+            
         output[:num_tokens] = attn_output[:num_tokens]
         return output
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1051,83 +1051,94 @@ class AscendAttentionBackendImpl(AttentionImpl):
         num_tokens,
     ):
         import torch.nn.functional as F
+
         num_heads = self.num_heads
         num_kv_heads = self.num_kv_heads
         head_size = self.head_size
         num_kv_groups = num_heads // num_kv_heads
         scale = self.scale
         causal = attn_metadata.causal
-        
+
         # 将 seq_lengths 转为 Python list
         seq_lens_q = attn_metadata.actual_seq_lengths_q
         if isinstance(seq_lens_q, list):
             seq_lens_q_list = seq_lens_q
         else:
-            seq_lens_q_list = seq_lens_q.tolist() if hasattr(seq_lens_q, 'numel') and seq_lens_q.numel() > 1 else [int(seq_lens_q)]
-        
+            seq_lens_q_list = (
+                seq_lens_q.tolist() if hasattr(seq_lens_q, "numel") and seq_lens_q.numel() > 1 else [int(seq_lens_q)]
+            )
+
         if isinstance(actual_seq_lengths_kv, list):
             seq_lens_kv_list = actual_seq_lengths_kv
         else:
-            seq_lens_kv_list = actual_seq_lengths_kv.tolist() if hasattr(actual_seq_lengths_kv, 'numel') and actual_seq_lengths_kv.numel() > 1 else [int(actual_seq_lengths_kv)]
-        
+            seq_lens_kv_list = (
+                actual_seq_lengths_kv.tolist()
+                if hasattr(actual_seq_lengths_kv, "numel") and actual_seq_lengths_kv.numel() > 1
+                else [int(actual_seq_lengths_kv)]
+            )
+
         query_lens = []
         prev = 0
         for q_len in seq_lens_q_list:
             query_lens.append(q_len - prev)
             prev = q_len
-        
+
         if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache:
             kv_lens = query_lens
         else:
             kv_lens = seq_lens_kv_list
-        
+
         # Validate sequence length (similar to NPU operator C++ layer validation)
         # Get max_seq_len from config (equivalent to operator internal access)
         max_seq_len = getattr(
-            self.vllm_config.model_config, 'max_model_len',
-            getattr(self.vllm_config.model_config, 'max_seq_len', 32768)
+            self.vllm_config.model_config, 
+            "max_model_len", 
+            getattr(self.vllm_config.model_config, "max_seq_len", 32768)
         )
-        
+
         max_kv_len = max(kv_lens) if kv_lens else 0
         if max_kv_len > max_seq_len:
             # Truncate sequences that exceed max_model_len to prevent service crash
             # This handles the case where prompt + generated tokens > max_model_len
             # Note: The scheduler should ideally stop generation before reaching this point
             import warnings
+
             warnings.warn(
                 f"Sequence length {max_kv_len} exceeds maximum model length {max_seq_len}. "
                 f"Truncating to {max_seq_len}. This indicates the scheduler allowed "
                 f"generation beyond max_model_len.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             # Truncate all sequences to max_seq_len
             kv_lens = [min(s, max_seq_len) for s in kv_lens]
-        
+
         prev_q = 0
         prev_kv = 0
         outputs = []
-        
+
         for i in range(len(query_lens)):
             cur_q = query_lens[i]
             cur_kv = kv_lens[i]
-            
+
             # 提取当前序列的 query
-            q_i = query[prev_q:prev_q + cur_q]
-            
+            q_i = query[prev_q : prev_q + cur_q]
+
             actual_cur_q = q_i.size(0)
             if actual_cur_q != cur_q:
                 import warnings
+
                 warnings.warn(
-                    f"Query size mismatch at batch {i}: metadata says {cur_q}, but actual tensor has {actual_cur_q} tokens. "
+                    f"Query size mismatch at batch {i}: metadata says {cur_q}, "
+                    f"but actual tensor has {actual_cur_q} tokens. "
                     f"This is expected with Chunked Prefill + Speculative Decoding. Using actual size.",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
                 cur_q = actual_cur_q
-            
+
             q_i = q_i.view(1, cur_q, num_heads, head_size).transpose(1, 2)
-            
+
             # 提取 key/value：支持 paged kv_cache 和 PrefillNoCache 两种情况
             if block_table is not None and self.key_cache is not None:
                 bt_i = block_table[i]
@@ -1142,84 +1153,86 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     v_i = v_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
             else:
                 if key.shape[0] == num_tokens:
-                    k_i = key[prev_kv:prev_kv + cur_kv]
-                    v_i = value[prev_kv:prev_kv + cur_kv]
+                    k_i = key[prev_kv : prev_kv + cur_kv]
+                    v_i = value[prev_kv : prev_kv + cur_kv]
                 else:
                     k_i = key[:cur_kv]
                     v_i = value[:cur_kv]
-            
+
             # Adjust cur_kv based on actual KV data size (mimics NPU operator behavior)
             # NPU operator internally checks block_table and truncates to actual available length
             # This prevents RuntimeError when requested length exceeds cached tokens
             actual_kv_tokens = k_i.numel() // (num_kv_heads * head_size)
             if actual_kv_tokens < cur_kv:
                 import warnings
+
                 warnings.warn(
                     f"Requested KV length {cur_kv} exceeds actual cached tokens {actual_kv_tokens}. "
                     f"Truncating to {actual_kv_tokens}. This indicates the scheduler allowed "
                     f"generation beyond max_model_len (similar to how NPU operator handles this).",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
                 cur_kv = actual_kv_tokens
-            
+
             # reshape key/value 为 [1, num_kv_heads, cur_kv, head_size]
-            
+
             # Sanity check before reshape to prevent cryptic errors
             expected_k_elements = cur_kv * num_kv_heads * head_size
             expected_v_elements = cur_kv * num_kv_heads * head_size
-            
+
             if k_i.numel() != expected_k_elements:
                 raise RuntimeError(
                     f"Internal error in FallbackSDPA: key tensor size mismatch "
                     f"(expected {expected_k_elements}, got {k_i.numel()}). "
                     f"This indicates a bug in KV cache implementation."
                 )
-            
+
             if v_i.numel() != expected_v_elements:
                 raise RuntimeError(
                     f"Internal error in FallbackSDPA: value tensor size mismatch "
                     f"(expected {expected_v_elements}, got {v_i.numel()})."
                 )
-            
+
             k_i = k_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
             v_i = v_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
-            
+
             # GQA: expand kv heads 以匹配 query heads
             if num_kv_groups > 1:
                 k_i = k_i.unsqueeze(2).expand(-1, -1, num_kv_groups, -1, -1).reshape(1, num_heads, cur_kv, head_size)
                 v_i = v_i.unsqueeze(2).expand(-1, -1, num_kv_groups, -1, -1).reshape(1, num_heads, cur_kv, head_size)
-            
+
             # causal mask
             attn_mask_i = None
             if causal:
                 attn_mask_i = torch.triu(
-                    torch.full((cur_q, cur_kv), float('-inf'), device=q_i.device, dtype=q_i.dtype),
-                    diagonal=cur_kv - cur_q + 1
+                    torch.full((cur_q, cur_kv), float("-inf"), device=q_i.device, dtype=q_i.dtype),
+                    diagonal=cur_kv - cur_q + 1,
                 )
-            
+
             out_i = F.scaled_dot_product_attention(q_i, k_i, v_i, attn_mask=attn_mask_i, scale=scale)
             out_i = out_i.transpose(1, 2).reshape(cur_q, num_heads * head_size)
             outputs.append(out_i)
-            
+
             prev_q += cur_q
             prev_kv += cur_kv
-        
+
         attn_output = torch.cat(outputs, dim=0)
-        
+
         actual_num_tokens = attn_output.size(0)
         if actual_num_tokens != num_tokens:
             import warnings
+
             warnings.warn(
-                f"Output size mismatch: metadata says {num_tokens} tokens, but actual output has {actual_num_tokens} tokens. "
+                f"Output size mismatch: metadata says {num_tokens} tokens, "
+                f"but actual output has {actual_num_tokens} tokens. "
                 f"This is expected with Chunked Prefill + Speculative Decoding. Using actual size.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
-        
+
         return attn_output.view(actual_num_tokens, num_heads, head_size)
-    
-    
+
     def forward_fused_infer_attention(
         self,
         query: torch.Tensor,
@@ -1289,8 +1302,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
         else:
             if self.head_size > 192:
                 attn_output = self._fallback_sdpa(
-                    query, key, value, block_table, block_size,
-                    attn_metadata, actual_seq_lengths_kv, num_tokens)
+                    query, key, value, block_table, block_size, attn_metadata, actual_seq_lengths_kv, num_tokens
+                )
             elif not attn_metadata.causal:
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score(
                     query=query,
@@ -1352,16 +1365,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_tokens = attn_output.size(0)
                 if actual_tokens != num_tokens:
                     import warnings
+
                     warnings.warn(
                         f"Attention output size mismatch in FIA: metadata says {num_tokens} tokens, "
                         f"but actual output has {actual_tokens} tokens. Using actual size.",
                         UserWarning,
-                        stacklevel=2
+                        stacklevel=2,
                     )
             else:
                 raise RuntimeError(f"Unexpected attn_output shape: {attn_output.shape}")
-            
-            
+
         output[:num_tokens] = attn_output[:num_tokens]
         return output
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1090,11 +1090,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
         # Validate sequence length (similar to NPU operator C++ layer validation)
         # Get max_seq_len from config (equivalent to operator internal access)
+        # fmt: off
         max_seq_len = getattr(
             self.vllm_config.model_config, 
             "max_model_len", 
             getattr(self.vllm_config.model_config, "max_seq_len", 32768)
         )
+        # fmt: on
 
         max_kv_len = max(kv_lens) if kv_lens else 0
         if max_kv_len > max_seq_len:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1150,7 +1150,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
             # 提取 key/value：支持 paged kv_cache 和 PrefillNoCache 两种情况
             if block_table is not None and self.key_cache is not None:
-                bt_i = block_table[i]
+                bt_i = block_table[i].long()
                 valid_blocks = bt_i[bt_i >= 0]
                 if valid_blocks.numel() == 0:
                     k_i = key[:cur_kv]

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1084,7 +1084,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
             prev = q_len
 
         if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache:
-            kv_lens = query_lens
+            if self.attn_type == AttentionType.ENCODER_DECODER:
+                kv_lens = []
+                prev = 0
+                for kv_len in seq_lens_kv_list:
+                    kv_lens.append(kv_len - prev)
+                    prev = kv_len
+            else:
+                kv_lens = query_lens
         else:
             kv_lens = seq_lens_kv_list
 
@@ -1154,12 +1161,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     k_i = k_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
                     v_i = v_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
             else:
-                if key.shape[0] == num_tokens:
-                    k_i = key[prev_kv : prev_kv + cur_kv]
-                    v_i = value[prev_kv : prev_kv + cur_kv]
-                else:
-                    k_i = key[:cur_kv]
-                    v_i = value[:cur_kv]
+                k_i = key[prev_kv : prev_kv + cur_kv]
+                v_i = value[prev_kv : prev_kv + cur_kv]
 
             # Adjust cur_kv based on actual KV data size (mimics NPU operator behavior)
             # NPU operator internally checks block_table and truncates to actual available length
@@ -1244,6 +1247,44 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output: torch.Tensor,
         kv_cache=None,
     ):
+        if self.head_size > 192:
+            # Get necessary parameters before calling _fallback_sdpa
+            passed_key = key
+            key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(
+                key, value, attn_metadata, kv_cache
+            )
+            num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+            query_input = query[:num_tokens]
+            
+            # Call fallback SDPA
+            attn_output = self._fallback_sdpa(
+                query_input, key, value, block_table, block_size,
+                attn_metadata, actual_seq_lengths_kv, num_tokens)
+                
+            # Fix: Handle size mismatch from _fallback_sdpa or NPU operator
+            if attn_output.dim() == 2:
+                # attn_output is [tokens, hidden_size], need to reshape
+                actual_tokens = attn_output.size(0)
+                attn_output = attn_output.view(actual_tokens, self.num_heads, self.head_size)
+            elif attn_output.dim() == 3:
+                # attn_output is already [tokens, num_heads, head_size]
+                # Verify the shape is correct
+                actual_tokens = attn_output.size(0)
+                if actual_tokens != num_tokens:
+                    import warnings
+                    warnings.warn(
+                        f"Attention output size mismatch in FIA: metadata says {num_tokens} tokens, "
+                        f"but actual output has {actual_tokens} tokens. Using actual size.",
+                        UserWarning,
+                        stacklevel=2
+                    )
+            else:
+                raise RuntimeError(f"Unexpected attn_output shape: {attn_output.shape}")
+            
+            safe_tokens = min(num_tokens, actual_tokens)
+            output[:safe_tokens] = attn_output[:safe_tokens]
+            return output
+        
         # we inherit ForwardContext in model runner v2, when enable model
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
@@ -1355,28 +1396,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     scale=self.scale,
                     sparse_mode=3,
                 )
-
-            # Fix: Handle size mismatch from _fallback_sdpa or NPU operator
-            if attn_output.dim() == 2:
-                # attn_output is [tokens, hidden_size], need to reshape
-                actual_tokens = attn_output.size(0)
-                attn_output = attn_output.view(actual_tokens, self.num_heads, self.head_size)
-            elif attn_output.dim() == 3:
-                # attn_output is already [tokens, num_heads, head_size]
-                # Verify the shape is correct
-                actual_tokens = attn_output.size(0)
-                if actual_tokens != num_tokens:
-                    import warnings
-
-                    warnings.warn(
-                        f"Attention output size mismatch in FIA: metadata says {num_tokens} tokens, "
-                        f"but actual output has {actual_tokens} tokens. Using actual size.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-            else:
-                raise RuntimeError(f"Unexpected attn_output shape: {attn_output.shape}")
-
+                
+            attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
         output[:num_tokens] = attn_output[:num_tokens]
         return output
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1255,14 +1255,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
             )
             num_tokens = attn_metadata.actual_seq_lengths_q[-1]
             query_input = query[:num_tokens]
-            
+
             # Call fallback SDPA
             # fmt:off
             attn_output = self._fallback_sdpa(
                 query_input, key, value, block_table, block_size,
                 attn_metadata, actual_seq_lengths_kv, num_tokens)
             # fmt:on
-            
+
             # Fix: Handle size mismatch from _fallback_sdpa or NPU operator
             if attn_output.dim() == 2:
                 # attn_output is [tokens, hidden_size], need to reshape
@@ -1274,19 +1274,20 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_tokens = attn_output.size(0)
                 if actual_tokens != num_tokens:
                     import warnings
+
                     warnings.warn(
                         f"Attention output size mismatch in FIA: metadata says {num_tokens} tokens, "
                         f"but actual output has {actual_tokens} tokens. Using actual size.",
                         UserWarning,
-                        stacklevel=2
+                        stacklevel=2,
                     )
             else:
                 raise RuntimeError(f"Unexpected attn_output shape: {attn_output.shape}")
-            
+
             safe_tokens = min(num_tokens, actual_tokens)
             output[:safe_tokens] = attn_output[:safe_tokens]
             return output
-        
+
         # we inherit ForwardContext in model runner v2, when enable model
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
@@ -1394,7 +1395,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     scale=self.scale,
                     sparse_mode=3,
                 )
-                
+
             attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
         output[:num_tokens] = attn_output[:num_tokens]
         return output

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1150,16 +1150,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
             # 提取 key/value：支持 paged kv_cache 和 PrefillNoCache 两种情况
             if block_table is not None and self.key_cache is not None:
-                bt_i = block_table[i].long()
-                valid_blocks = bt_i[bt_i >= 0]
-                if valid_blocks.numel() == 0:
-                    k_i = key[:cur_kv]
-                    v_i = value[:cur_kv]
-                else:
-                    k_cache_i = self.key_cache[valid_blocks]
-                    v_cache_i = self.value_cache[valid_blocks]
-                    k_i = k_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
-                    v_i = v_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
+                bt_i = block_table[i]
+                num_needed_blocks = (cur_kv + block_size - 1) // block_size
+                valid_blocks = bt_i[:num_needed_blocks].long()
+                k_cache_i = self.key_cache[valid_blocks]
+                v_cache_i = self.value_cache[valid_blocks]
+                k_i = k_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
+                v_i = v_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
             else:
                 k_i = key[prev_kv : prev_kv + cur_kv]
                 v_i = value[prev_kv : prev_kv + cur_kv]

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1069,6 +1069,30 @@ class AscendAttentionBackendImpl(AttentionImpl):
         else:
             seq_lens_kv_list = actual_seq_lengths_kv.tolist() if hasattr(actual_seq_lengths_kv, 'numel') and actual_seq_lengths_kv.numel() > 1 else [int(actual_seq_lengths_kv)]
 
+        # Validate sequence length (similar to NPU operator C++ layer validation)
+        # Get max_seq_len from config (equivalent to operator internal access)
+        max_seq_len = getattr(
+            self.vllm_config.model_config, 'max_model_len',
+            getattr(self.vllm_config.model_config, 'max_seq_len', 32768)
+        )
+        
+        max_kv_len = max(seq_lens_kv_list) if seq_lens_kv_list else 0
+        if max_kv_len > max_seq_len:
+            # Truncate sequences that exceed max_model_len to prevent service crash
+            # This handles the case where prompt + generated tokens > max_model_len
+            # Note: The scheduler should ideally stop generation before reaching this point
+            import warnings
+            warnings.warn(
+                f"Sequence length {max_kv_len} exceeds maximum model length {max_seq_len}. "
+                f"Truncating to {max_seq_len}. This indicates the scheduler allowed "
+                f"generation beyond max_model_len.",
+                UserWarning,
+                stacklevel=2
+            )
+            # Truncate all sequences to max_seq_len
+            seq_lens_kv_list = [min(s, max_seq_len) for s in seq_lens_kv_list]
+            max_kv_len = max_seq_len
+
         prev_q = 0
         prev_kv = 0
         outputs = []
@@ -1100,7 +1124,42 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     k_i = key[:cur_kv]
                     v_i = value[:cur_kv]
 
+            # Adjust cur_kv based on actual KV data size (mimics NPU operator behavior)
+            # NPU operator internally checks block_table and truncates to actual available length
+            # This prevents RuntimeError when requested length exceeds cached tokens
+            actual_kv_tokens = k_i.numel() // (num_kv_heads * head_size)
+            if actual_kv_tokens < cur_kv:
+                import warnings
+                warnings.warn(
+                    f"Requested KV length {cur_kv} exceeds actual cached tokens {actual_kv_tokens}. "
+                    f"Truncating to {actual_kv_tokens}. This indicates the scheduler allowed "
+                    f"generation beyond max_model_len (similar to how NPU operator handles this).",
+                    UserWarning,
+                    stacklevel=2
+                )
+                cur_kv = actual_kv_tokens
+                # Also update seq_lens_kv_list for consistency
+                seq_lens_kv_list[i] = cur_kv
+
             # reshape key/value 为 [1, num_kv_heads, cur_kv, head_size]
+            
+            # Sanity check before reshape to prevent cryptic errors
+            expected_k_elements = cur_kv * num_kv_heads * head_size
+            expected_v_elements = cur_kv * num_kv_heads * head_size
+            
+            if k_i.numel() != expected_k_elements:
+                raise RuntimeError(
+                    f"Internal error in FallbackSDPA: key tensor size mismatch "
+                    f"(expected {expected_k_elements}, got {k_i.numel()}). "
+                    f"This indicates a bug in KV cache implementation."
+                )
+            
+            if v_i.numel() != expected_v_elements:
+                raise RuntimeError(
+                    f"Internal error in FallbackSDPA: value tensor size mismatch "
+                    f"(expected {expected_v_elements}, got {v_i.numel()})."
+                )           
+            
             k_i = k_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
             v_i = v_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1039,6 +1039,93 @@ class AscendAttentionBackendImpl(AttentionImpl):
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         return key, value, block_size, block_table, actual_seq_lengths_kv
 
+    def _fallback_sdpa(
+        self,
+        query,
+        key,
+        value,
+        block_table,
+        block_size,
+        attn_metadata,
+        actual_seq_lengths_kv,
+        num_tokens,
+    ):
+        import torch.nn.functional as F
+        num_heads = self.num_heads
+        num_kv_heads = self.num_kv_heads
+        head_size = self.head_size
+        num_kv_groups = num_heads // num_kv_heads
+        scale = self.scale
+        causal = attn_metadata.causal
+
+        # 将 seq_lengths 转为 Python list
+        seq_lens_q = attn_metadata.actual_seq_lengths_q
+        if isinstance(seq_lens_q, list):
+            seq_lens_q_list = seq_lens_q
+        else:
+            seq_lens_q_list = seq_lens_q.tolist() if hasattr(seq_lens_q, 'numel') and seq_lens_q.numel() > 1 else [int(seq_lens_q)]
+        if isinstance(actual_seq_lengths_kv, list):
+            seq_lens_kv_list = actual_seq_lengths_kv
+        else:
+            seq_lens_kv_list = actual_seq_lengths_kv.tolist() if hasattr(actual_seq_lengths_kv, 'numel') and actual_seq_lengths_kv.numel() > 1 else [int(actual_seq_lengths_kv)]
+
+        prev_q = 0
+        prev_kv = 0
+        outputs = []
+        for i in range(len(seq_lens_q_list)):
+            cur_q = seq_lens_q_list[i]
+            cur_kv = seq_lens_kv_list[i]
+
+            # 提取当前序列的 query, reshape 为 [1, num_heads, cur_q, head_size]
+            q_i = query[prev_q:prev_q + cur_q]
+            q_i = q_i.view(1, cur_q, num_heads, head_size).transpose(1, 2)
+
+            # 提取 key/value：支持 paged kv_cache 和 PrefillNoCache 两种情况
+            if block_table is not None and self.key_cache is not None:
+                bt_i = block_table[i]
+                valid_blocks = bt_i[bt_i >= 0]
+                if valid_blocks.numel() == 0:
+                    k_i = key[:cur_kv]
+                    v_i = value[:cur_kv]
+                else:
+                    k_cache_i = self.key_cache[valid_blocks]
+                    v_cache_i = self.value_cache[valid_blocks]
+                    k_i = k_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
+                    v_i = v_cache_i.view(-1, num_kv_heads, head_size)[:cur_kv]
+            else:
+                if key.shape[0] == num_tokens:
+                    k_i = key[prev_kv:prev_kv + cur_kv]
+                    v_i = value[prev_kv:prev_kv + cur_kv]
+                else:
+                    k_i = key[:cur_kv]
+                    v_i = value[:cur_kv]
+
+            # reshape key/value 为 [1, num_kv_heads, cur_kv, head_size]
+            k_i = k_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
+            v_i = v_i.view(1, cur_kv, num_kv_heads, head_size).transpose(1, 2)
+
+            # GQA: expand kv heads 以匹配 query heads
+            if num_kv_groups > 1:
+                k_i = k_i.unsqueeze(2).expand(-1, -1, num_kv_groups, -1, -1).reshape(1, num_heads, cur_kv, head_size)
+                v_i = v_i.unsqueeze(2).expand(-1, -1, num_kv_groups, -1, -1).reshape(1, num_heads, cur_kv, head_size)
+
+            # causal mask
+            attn_mask_i = None
+            if causal:
+                attn_mask_i = torch.triu(
+                    torch.full((cur_q, cur_kv), float('-inf'), device=q_i.device, dtype=q_i.dtype),
+                    diagonal=cur_kv - cur_q + 1
+                )
+
+            out_i = F.scaled_dot_product_attention(q_i, k_i, v_i, attn_mask=attn_mask_i, scale=scale)
+            out_i = out_i.transpose(1, 2).reshape(cur_q, num_heads * head_size)
+            outputs.append(out_i)
+            prev_q = cur_q
+            prev_kv = cur_kv
+
+        attn_output = torch.cat(outputs, dim=0)
+        return attn_output.view(num_tokens, num_heads, head_size)
+
     def forward_fused_infer_attention(
         self,
         query: torch.Tensor,
@@ -1106,7 +1193,11 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 learnable_sink=self.sinks,
             )
         else:
-            if not attn_metadata.causal:
+            if self.head_size > 192:
+                attn_output = self._fallback_sdpa(
+                    query, key, value, block_table, block_size,
+                    attn_metadata, actual_seq_lengths_kv, num_tokens)
+            elif not attn_metadata.causal:
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score(
                     query=query,
                     key=key,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1257,10 +1257,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
             query_input = query[:num_tokens]
             
             # Call fallback SDPA
+            # fmt:off
             attn_output = self._fallback_sdpa(
                 query_input, key, value, block_table, block_size,
                 attn_metadata, actual_seq_lengths_kv, num_tokens)
-                
+            # fmt:on
+            
             # Fix: Handle size mismatch from _fallback_sdpa or NPU operator
             if attn_output.dim() == 2:
                 # attn_output is [tokens, hidden_size], need to reshape
@@ -1343,11 +1345,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 learnable_sink=self.sinks,
             )
         else:
-            if self.head_size > 192:
-                attn_output = self._fallback_sdpa(
-                    query, key, value, block_table, block_size, attn_metadata, actual_seq_lengths_kv, num_tokens
-                )
-            elif not attn_metadata.causal:
+            if not attn_metadata.causal:
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score(
                     query=query,
                     key=key,

--- a/vllm_ascend/eplb/core/policy/policy_flashlb.py
+++ b/vllm_ascend/eplb/core/policy/policy_flashlb.py
@@ -473,15 +473,18 @@ class FlashTree:
 
             initial_replicas = (simulation_replicas[:interval_size] - 1).sum()
 
+            # fmt: off
             best_replica, _, _ = self.neighbor_search(
                 low,
                 high,
                 initial_replicas,
                 width,
-                lambda mid, ci=current_idx, crf=current_replicas_f, ri=remaind_idx, rrf=remaind_replicas_f, nar=num_available_replicas: ( # fmt: skip
+                lambda mid, ci=current_idx, crf=current_replicas_f, 
+                ri=remaind_idx, rrf=remaind_replicas_f, nar=num_available_replicas: (
                     get_score(_lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid])
                 ),
             )
+            # fmt: on
 
             deployed_replicas[current_idx] = current_replicas_f[best_replica]
             num_available_replicas -= best_replica

--- a/vllm_ascend/eplb/core/policy/policy_flashlb.py
+++ b/vllm_ascend/eplb/core/policy/policy_flashlb.py
@@ -478,13 +478,8 @@ class FlashTree:
                 high,
                 initial_replicas,
                 width,
-                lambda mid,
-                ci=current_idx,
-                crf=current_replicas_f,
-                ri=remaind_idx,
-                rrf=remaind_replicas_f,
-                nar=num_available_replicas: get_score(
-                    _lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid]
+                lambda mid, ci=current_idx, crf=current_replicas_f, ri=remaind_idx, rrf=remaind_replicas_f, nar=num_available_replicas: (
+                    get_score(_lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid])
                 ),
             )
 

--- a/vllm_ascend/eplb/core/policy/policy_flashlb.py
+++ b/vllm_ascend/eplb/core/policy/policy_flashlb.py
@@ -478,12 +478,7 @@ class FlashTree:
                 high,
                 initial_replicas,
                 width,
-                lambda mid, 
-                ci=current_idx, 
-                crf=current_replicas_f, 
-                ri=remaind_idx,
-                rrf=remaind_replicas_f, 
-                nar=num_available_replicas: (
+                lambda mid, ci=current_idx, crf=current_replicas_f, ri=remaind_idx, rrf=remaind_replicas_f, nar=num_available_replicas: ( # fmt: skip
                     get_score(_lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid])
                 ),
             )

--- a/vllm_ascend/eplb/core/policy/policy_flashlb.py
+++ b/vllm_ascend/eplb/core/policy/policy_flashlb.py
@@ -478,7 +478,12 @@ class FlashTree:
                 high,
                 initial_replicas,
                 width,
-                lambda mid, ci=current_idx, crf=current_replicas_f, ri=remaind_idx, rrf=remaind_replicas_f, nar=num_available_replicas: (
+                lambda mid, 
+                ci=current_idx, 
+                crf=current_replicas_f, 
+                ri=remaind_idx,
+                rrf=remaind_replicas_f, 
+                nar=num_available_replicas: (
                     get_score(_lpt_deployment, X_row, deployed_replicas, ci, crf[mid], ri, rrf[nar - mid])
                 ),
             )

--- a/vllm_ascend/patch/platform/patch_mla_prefill_backend.py
+++ b/vllm_ascend/patch/platform/patch_mla_prefill_backend.py
@@ -47,6 +47,6 @@ if not vllm_version_is("0.20.2"):
         ) -> tuple[torch.Tensor, torch.Tensor]:
             raise NotImplementedError("Ascend MLA prefill is handled by AscendSFAImpl/AscendMLAImpl")
 
-    vllm.model_executor.layers.attention.mla_attention.get_mla_prefill_backend = (
-        lambda vllm_config: AscendMLAPrefillBackend
+    vllm.model_executor.layers.attention.mla_attention.get_mla_prefill_backend = lambda vllm_config: (
+        AscendMLAPrefillBackend
     )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces a fallback mechanism to standard PyTorch `F.scaled_dot_product_attention` (SDPA) when `head_size > 192` is detected on Ascend NPU. This is because the NPU-specific operator `aclnnFusedInferAttentionScoreV3` under the TND layout only supports `head_dim` values of 64, 128, or 192, causing runtime errors for models like Qwen3.6-35B-A3B which use `head_dim=256`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Functional verification completed for the Qwen3.6-35B-A3B model, including single-turn/multi-turn dialogue, image/video recognition, thinking mode, tool calling.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
