### PR TITLE
[Feature] WeightTransfer: Add NPUIPCWeightTransferEngine backend for Ascend NPU

### DIFF
--- a/examples/rl/rlhf_http_hccl.py
+++ b/examples/rl/rlhf_http_hccl.py
@@ -107,6 +107,29 @@ def update_weights(
     response.raise_for_status()
 
 
+def start_weight_update(base_url: str, is_checkpoint_format: bool = True) -> None:
+    """Start weight update via HTTP endpoint.
+
+    Prepares the model for layerwise reload on the vLLM server side.
+    Must be called before update_weights.
+    """
+    url = f"{base_url}/start_weight_update"
+    payload = {"is_checkpoint_format": is_checkpoint_format}
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+
+
+def finish_weight_update(base_url: str) -> None:
+    """Finish weight update via HTTP endpoint.
+
+    Finalizes layerwise reload on the vLLM server side.
+    Must be called after all update_weights calls are complete.
+    """
+    url = f"{base_url}/finish_weight_update"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
 def pause_generation(base_url: str) -> None:
     """Pause generation via HTTP endpoint."""
     url = f"{base_url}/pause"
@@ -198,6 +221,9 @@ def main():
     # Pause generation before weight sync
     pause_generation(BASE_URL)
 
+    # Start weight update (prepares layerwise reload on the vLLM server)
+    start_weight_update(BASE_URL)
+
     # Collect weight metadata for the update request.
     # Also track the largest tensor to auto-size the packed buffer.
     names = []
@@ -243,6 +269,9 @@ def main():
 
     # Wait for update_weights to complete
     update_thread.join()
+
+    # Finish weight update (finalizes layerwise reload on the vLLM server)
+    finish_weight_update(BASE_URL)
 
     # Resume generation after weight sync
     resume_generation(BASE_URL)

--- a/examples/rl/rlhf_http_hccl.py
+++ b/examples/rl/rlhf_http_hccl.py
@@ -89,6 +89,7 @@ def update_weights(
     dtype_names: list[str],
     shapes: list[list[int]],
     packed: bool = False,
+    packed_buffer_size_bytes: int | None = None,
 ) -> None:
     """Update weights via HTTP endpoint."""
     url = f"{base_url}/update_weights"
@@ -100,6 +101,8 @@ def update_weights(
             packed=packed,
         )
     }
+    if packed and packed_buffer_size_bytes is not None:
+        payload["update_info"]["packed_buffer_size_bytes"] = packed_buffer_size_bytes
     response = requests.post(url, json=payload, timeout=300)
     response.raise_for_status()
 
@@ -195,21 +198,34 @@ def main():
     # Pause generation before weight sync
     pause_generation(BASE_URL)
 
-    # Collect weight metadata for the update request
+    # Collect weight metadata for the update request.
+    # Also track the largest tensor to auto-size the packed buffer.
     names = []
     dtype_names = []
     shapes = []
+    max_tensor_bytes = 0
     for name, p in train_model.named_parameters():
         names.append(name)
         dtype_names.append(str(p.dtype).split(".")[-1])
         shapes.append(list(p.shape))
+        tensor_bytes = p.numel() * p.element_size()
+        if tensor_bytes > max_tensor_bytes:
+            max_tensor_bytes = tensor_bytes
+
+    # Size the packed buffer to fit the largest tensor with 128 MB headroom,
+    # but keep the default 1 GB when the largest tensor is smaller than that.
+    packed_buffer_size_bytes = max(max_tensor_bytes + 128 * 2**20, 2**30)
+    print(
+        f"Largest tensor: {max_tensor_bytes / 2**30:.2f} GiB, "
+        f"packed buffer: {packed_buffer_size_bytes / 2**30:.2f} GiB"
+    )
 
     # Start the update_weights call in a separate thread since it will block
     # waiting for HCCL broadcasts
     # packed=True enables efficient batched tensor broadcasting
     update_thread = threading.Thread(
         target=update_weights,
-        args=(BASE_URL, names, dtype_names, shapes, True),  # packed=True
+        args=(BASE_URL, names, dtype_names, shapes, True, packed_buffer_size_bytes),
     )
     update_thread.start()
 
@@ -218,6 +234,7 @@ def main():
     trainer_args = HCCLTrainerSendWeightsArgs(
         group=model_update_group,
         packed=True,
+        packed_buffer_size_bytes=packed_buffer_size_bytes,
     )
     HCCLWeightTransferEngine.trainer_send_weights(
         iterator=train_model.named_parameters(),

--- a/examples/rl/rlhf_http_hccl.py
+++ b/examples/rl/rlhf_http_hccl.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Demonstrates reinforcement learning from human feedback (RLHF) using vLLM
+via HTTP API, with native weight syncing APIs.
+
+Unlike rlhf.py which creates a vLLM instance programmatically, this script
+assumes you have already started a vLLM server using `vllm serve`. It uses:
+- OpenAI-compatible API for inference requests
+- HTTP endpoints for weight transfer control plane
+- HCCL for actual weight data transfer
+
+Prerequisites:
+    Start a vLLM server with weight transfer enabled:
+
+    $ VLLM_SERVER_DEV_MODE=1 vllm serve qwen/qwen3-0.6b \
+        --enforce-eager \
+        --weight-transfer-config '{"backend": "nccl"}' \
+        --load-format dummy
+
+    Then run this script:
+
+    $ python rlhf_http_hccl.py
+
+The example performs the following steps:
+
+* Load the training model on NPU 0.
+* Generate text using the vLLM server via OpenAI-compatible API. The output
+  is expected to be nonsense because the server is initialized with dummy weights.
+* Initialize weight transfer via HTTP endpoint.
+* Broadcast the real weights from the training model to the vLLM server
+  using HCCL.
+* Generate text again to show normal output after the weight update.
+"""
+
+import requests
+import torch
+from openai import OpenAI
+from transformers import AutoModelForCausalLM
+
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLTrainerSendWeightsArgs,
+    HCCLWeightTransferEngine,
+)
+from vllm.utils.network_utils import get_ip, get_open_port
+
+BASE_URL = "http://localhost:8000"
+MODEL_NAME = "qwen/qwen3-0.6b"
+
+
+def generate_completions(client: OpenAI, model: str, prompts: list[str]) -> list[str]:
+    """Generate completions using the OpenAI-compatible API."""
+    results = []
+    for prompt in prompts:
+        response = client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=32,
+            temperature=0,
+        )
+        results.append(response.choices[0].text)
+    return results
+
+
+def init_weight_transfer_engine(
+    base_url: str,
+    master_address: str,
+    master_port: int,
+    rank_offset: int,
+    world_size: int,
+) -> None:
+    """Initialize weight transfer via HTTP endpoint."""
+    url = f"{base_url}/init_weight_transfer_engine"
+    payload = {
+        "init_info": dict(
+            master_address=master_address,
+            master_port=master_port,
+            rank_offset=rank_offset,
+            world_size=world_size,
+        )
+    }
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+
+
+def update_weights(
+    base_url: str,
+    names: list[str],
+    dtype_names: list[str],
+    shapes: list[list[int]],
+    packed: bool = False,
+) -> None:
+    """Update weights via HTTP endpoint."""
+    url = f"{base_url}/update_weights"
+    payload = {
+        "update_info": dict(
+            names=names,
+            dtype_names=dtype_names,
+            shapes=shapes,
+            packed=packed,
+        )
+    }
+    response = requests.post(url, json=payload, timeout=300)
+    response.raise_for_status()
+
+
+def pause_generation(base_url: str) -> None:
+    """Pause generation via HTTP endpoint."""
+    url = f"{base_url}/pause"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def resume_generation(base_url: str) -> None:
+    """Resume generation via HTTP endpoint."""
+    url = f"{base_url}/resume"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def get_world_size(base_url: str) -> int:
+    """Get world size from the vLLM server."""
+    url = f"{base_url}/get_world_size"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()["world_size"]
+
+
+def main():
+    # Get the inference world size from the vLLM server
+    inference_world_size = get_world_size(BASE_URL)
+    world_size = inference_world_size + 1  # +1 for the trainer
+    device = f"npu:{inference_world_size}"
+    torch.accelerator.set_device_index(device)
+
+    # Load the training model
+    print(f"Loading training model: {MODEL_NAME}")
+    train_model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype=torch.bfloat16)
+    train_model.to(device)
+
+    # Create OpenAI client pointing to the vLLM server
+    client = OpenAI(
+        base_url=f"{BASE_URL}/v1",
+        api_key="EMPTY",  # vLLM doesn't require an API key by default
+    )
+
+    # Test prompts
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    # Generate text before weight update. The output is expected to be nonsense
+    # because the server is initialized with dummy weights.
+    print("-" * 50)
+    print("Generating text BEFORE weight update (expect nonsense):")
+    print("-" * 50)
+    outputs = generate_completions(client, MODEL_NAME, prompts)
+    for prompt, generated_text in zip(prompts, outputs):
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+    # Set up the communication channel between the training process and the
+    # vLLM server. The trainer is rank 0, vLLM worker(s) start at rank_offset.
+    master_address = get_ip()
+    master_port = get_open_port()
+    rank_offset = 1
+
+    print(f"Initializing weight transfer: master={master_address}:{master_port}")
+
+    # Initialize weight transfer on vLLM server (this is async, server will
+    # wait for HCCL connection)
+    import threading
+
+    init_thread = threading.Thread(
+        target=init_weight_transfer_engine,
+        args=(BASE_URL, master_address, master_port, rank_offset, world_size),
+    )
+    init_thread.start()
+
+    # Initialize HCCL process group on trainer side
+    model_update_group = HCCLWeightTransferEngine.trainer_init(
+        dict(
+            master_address=master_address,
+            master_port=master_port,
+            world_size=world_size,
+        ),
+    )
+
+    # Wait for init_weight_transfer_engine to complete
+    init_thread.join()
+
+    # Pause generation before weight sync
+    pause_generation(BASE_URL)
+
+    # Collect weight metadata for the update request
+    names = []
+    dtype_names = []
+    shapes = []
+    for name, p in train_model.named_parameters():
+        names.append(name)
+        dtype_names.append(str(p.dtype).split(".")[-1])
+        shapes.append(list(p.shape))
+
+    # Start the update_weights call in a separate thread since it will block
+    # waiting for HCCL broadcasts
+    # packed=True enables efficient batched tensor broadcasting
+    update_thread = threading.Thread(
+        target=update_weights,
+        args=(BASE_URL, names, dtype_names, shapes, True),  # packed=True
+    )
+    update_thread.start()
+
+    # Broadcast all weights from trainer to vLLM workers
+    print("Broadcasting weights via HCCL...")
+    trainer_args = HCCLTrainerSendWeightsArgs(
+        group=model_update_group,
+        packed=True,
+    )
+    HCCLWeightTransferEngine.trainer_send_weights(
+        iterator=train_model.named_parameters(),
+        trainer_args=trainer_args,
+    )
+
+    # Wait for update_weights to complete
+    update_thread.join()
+
+    # Resume generation after weight sync
+    resume_generation(BASE_URL)
+
+    # Generate text after weight update. The output is expected to be normal
+    # because the real weights are now loaded.
+    print("-" * 50)
+    print("Generating text AFTER weight update:")
+    print("-" * 50)
+    outputs_updated = generate_completions(client, MODEL_NAME, prompts)
+    for prompt, generated_text in zip(prompts, outputs_updated):
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl/rlhf_http_npu_ipc.py
+++ b/examples/rl/rlhf_http_npu_ipc.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Demonstrates reinforcement learning from human feedback (RLHF) using vLLM
+via HTTP API, with NPU IPC-based weight syncing APIs.
+
+Unlike rlhf_http_hccl.py which uses HCCL and can use separate NPUs, this script
+uses Ascend NPU IPC which requires the training model and vLLM server to be on
+the same physical NPU. Memory must be carefully managed to fit both models.
+
+Prerequisites:
+    Start a vLLM server with weight transfer enabled and reduced NPU memory
+    utilization to leave room for the training model:
+
+    $ VLLM_SERVER_DEV_MODE=1 VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+        vllm serve qwen/qwen3-0.6b --enforce-eager \
+        --weight-transfer-config '{"backend": "ipc"}' \
+        --load-format dummy \
+        --gpu-memory-utilization 0.5
+
+    Then run this script:
+
+    $ python rlhf_http_npu_ipc.py
+
+The example performs the following steps:
+
+* Load the training model on NPU 0 (same NPU as the vLLM server).
+* Generate text using the vLLM server via OpenAI-compatible API. The output
+  is expected to be nonsense because the server is initialized with dummy weights.
+* Initialize weight transfer via HTTP endpoint (no-op for NPU IPC).
+* Pause generation and broadcast the real weights from the training model to
+  the vLLM server using NPU IPC handles (via HTTP). The pause/resume is
+  handled by ``trainer_send_weights`` — it calls ``update_weights`` internally.
+* Generate text again to show normal output after the weight update.
+"""
+
+import os
+
+import requests
+import torch
+from openai import OpenAI
+from transformers import AutoModelForCausalLM
+
+from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+    NPUIPCTrainerSendWeightsArgs,
+    NPUIPCWeightTransferEngine,
+)
+
+BASE_URL = "http://localhost:8000"
+MODEL_NAME = "qwen/qwen3-0.6b"
+
+# Enable insecure serialization for IPC handle serialization over HTTP
+os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
+
+
+def generate_completions(client: OpenAI, model: str, prompts: list[str]) -> list[str]:
+    """Generate completions using the OpenAI-compatible API."""
+    results = []
+    for prompt in prompts:
+        response = client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=32,
+            temperature=0,
+        )
+        results.append(response.choices[0].text)
+    return results
+
+
+def init_weight_transfer_engine(base_url: str) -> None:
+    """Initialize weight transfer via HTTP endpoint (no-op for NPU IPC)."""
+    url = f"{base_url}/init_weight_transfer_engine"
+    payload = {"init_info": dict()}
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+
+
+def start_weight_update(base_url: str, is_checkpoint_format: bool = True) -> None:
+    """Start weight update via HTTP endpoint.
+
+    Prepares the model for layerwise reload on the vLLM server side.
+    Must be called before update_weights.
+    """
+    url = f"{base_url}/start_weight_update"
+    payload = {"is_checkpoint_format": is_checkpoint_format}
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+
+
+def finish_weight_update(base_url: str) -> None:
+    """Finish weight update via HTTP endpoint.
+
+    Finalizes layerwise reload on the vLLM server side.
+    Must be called after all update_weights calls are complete.
+    """
+    url = f"{base_url}/finish_weight_update"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def pause_generation(base_url: str) -> None:
+    """Pause generation via HTTP endpoint."""
+    url = f"{base_url}/pause"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def resume_generation(base_url: str) -> None:
+    """Resume generation via HTTP endpoint."""
+    url = f"{base_url}/resume"
+    response = requests.post(url, timeout=60)
+    response.raise_for_status()
+
+
+def main():
+    # NPU IPC requires the training model to be on the same NPU as the vLLM server.
+    # The server should be started on NPU 0 with reduced memory utilization.
+    device = "npu:0"
+    torch.accelerator.set_device_index(device)
+
+    # Load the training model on the same NPU as the server.
+    # Use bfloat16 to reduce memory footprint.
+    print(f"Loading training model: {MODEL_NAME} on {device}")
+    print(
+        "Note: Ensure the vLLM server was started with --gpu-memory-utilization 0.5 "
+        "or lower to leave room for the training model."
+    )
+    train_model = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME, dtype=torch.bfloat16
+    )
+    train_model.to(device)
+    train_model.eval()
+
+    # Create OpenAI client pointing to the vLLM server
+    client = OpenAI(
+        base_url=f"{BASE_URL}/v1",
+        api_key="EMPTY",
+    )
+
+    # Test prompts
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    # Generate text before weight update. The output is expected to be nonsense
+    # because the server is initialized with dummy weights.
+    print("-" * 50)
+    print("Generating text BEFORE weight update (expect nonsense):")
+    print("-" * 50)
+    outputs = generate_completions(client, MODEL_NAME, prompts)
+    for prompt, generated_text in zip(prompts, outputs):
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+    # Initialize weight transfer on vLLM server (no-op for NPU IPC)
+    print("Initializing weight transfer (NPU IPC backend)...")
+    init_weight_transfer_engine(BASE_URL)
+
+    # Pause generation before weight sync
+    pause_generation(BASE_URL)
+
+    # Start weight update (prepares layerwise reload on the vLLM server)
+    start_weight_update(BASE_URL)
+
+    # Send weights via NPU IPC handles using HTTP mode.
+    # trainer_send_weights internally collects all parameters,
+    # creates IPC handles, and POSTs them to /update_weights.
+    print("Broadcasting weights via NPU IPC (HTTP)...")
+    trainer_args = NPUIPCTrainerSendWeightsArgs(mode="http", url=BASE_URL)
+    NPUIPCWeightTransferEngine.trainer_send_weights(
+        iterator=train_model.named_parameters(),
+        trainer_args=trainer_args,
+    )
+
+    # Finish weight update (finalizes layerwise reload on the vLLM server)
+    finish_weight_update(BASE_URL)
+
+    # Resume generation after weight sync
+    resume_generation(BASE_URL)
+
+    # Generate text after weight update. The output is expected to be normal
+    # because the real weights are now loaded.
+    print("-" * 50)
+    print("Generating text AFTER weight update:")
+    print("-" * 50)
+    outputs_updated = generate_completions(client, MODEL_NAME, prompts)
+    for prompt, generated_text in zip(prompts, outputs_updated):
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 50)
+
+    # Note: The training model and IPC handles remain in memory.
+    # In a real RLHF training loop, you would update the training model
+    # and create new IPC handles for each weight update.
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ut/distributed/test_hccl_weight_transfer.py
+++ b/tests/ut/distributed/test_hccl_weight_transfer.py
@@ -1,0 +1,1130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for HCCL weight transfer engine backend.
+
+Unit tests for engine classes (parsing, validation, registry).
+Integration tests for HCCL weight transfer between processes using Ray.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.config.parallel import ParallelConfig
+from vllm.config.weight_transfer import WeightTransferConfig
+from vllm.distributed.weight_transfer import WeightTransferEngineFactory
+
+from vllm_ascend.distributed.weight_transfer import register_engine
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLTrainerSendWeightsArgs,
+    HCCLWeightTransferEngine,
+    HCCLWeightTransferInitInfo,
+    HCCLWeightTransferUpdateInfo,
+)
+from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+    DEFAULT_PACKED_BUFFER_SIZE_BYTES,
+    DEFAULT_PACKED_NUM_BUFFERS,
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _register_hccl_engine():
+    """Ensure HCCL engine is registered before tests (idempotent)."""
+    try:
+        register_engine()
+    except ValueError:
+        # Already registered from a previous test module
+        pass
+
+
+def create_mock_parallel_config(
+    rank: int = 0,
+    world_size: int = 1,
+    dp_rank: int = 0,
+) -> ParallelConfig:
+    """Create a mock ParallelConfig for testing."""
+    config = MagicMock(spec=ParallelConfig)
+    config.rank = rank
+    config.world_size = world_size
+    config.data_parallel_rank = dp_rank
+    config.data_parallel_index = dp_rank
+    return config
+
+
+def create_mock_weight_transfer_config(backend: str = "hccl") -> MagicMock:
+    """Create a mock WeightTransferConfig for testing.
+
+    Uses MagicMock instead of real WeightTransferConfig because "hccl"
+    is not in the upstream Pydantic Literal type. In production, vllm-ascend
+    patches the config to accept "hccl".
+    """
+    config = MagicMock(spec=WeightTransferConfig)
+    config.backend = backend
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: HCCLWeightTransferUpdateInfo Validation
+# ---------------------------------------------------------------------------
+
+
+class TestHCCLWeightTransferUpdateInfoValidation:
+    """Test HCCLWeightTransferUpdateInfo dataclass validation."""
+
+    def test_valid_update_info(self):
+        """Test creating valid HCCLWeightTransferUpdateInfo."""
+        info = HCCLWeightTransferUpdateInfo(
+            names=["layer.weight", "layer.bias"],
+            dtype_names=["float32", "float32"],
+            shapes=[[10, 10], [10]],
+        )
+        assert info.names == ["layer.weight", "layer.bias"]
+        assert info.dtype_names == ["float32", "float32"]
+        assert info.shapes == [[10, 10], [10]]
+        assert info.packed is False
+
+    def test_mismatched_dtype_names_raises(self):
+        """Test that mismatched dtype_names length raises ValueError."""
+        with pytest.raises(ValueError, match="dtype_names"):
+            HCCLWeightTransferUpdateInfo(
+                names=["layer.weight", "layer.bias"],
+                dtype_names=["float32"],  # Only one dtype
+                shapes=[[10, 10], [10]],
+            )
+
+    def test_mismatched_shapes_raises(self):
+        """Test that mismatched shapes length raises ValueError."""
+        with pytest.raises(ValueError, match="shapes"):
+            HCCLWeightTransferUpdateInfo(
+                names=["layer.weight", "layer.bias"],
+                dtype_names=["float32", "float32"],
+                shapes=[[10, 10]],  # Only one shape
+            )
+
+    def test_empty_lists_valid(self):
+        """Test that empty lists are valid."""
+        info = HCCLWeightTransferUpdateInfo(
+            names=[],
+            dtype_names=[],
+            shapes=[],
+        )
+        assert len(info.names) == 0
+
+    def test_packed_default_false(self):
+        """Test that packed defaults to False."""
+        info = HCCLWeightTransferUpdateInfo(
+            names=["layer.weight"],
+            dtype_names=["float32"],
+            shapes=[[10, 10]],
+        )
+        assert info.packed is False
+
+    def test_packed_can_be_set_true(self):
+        """Test that packed can be set to True."""
+        info = HCCLWeightTransferUpdateInfo(
+            names=["layer.weight"],
+            dtype_names=["float32"],
+            shapes=[[10, 10]],
+            packed=True,
+        )
+        assert info.packed is True
+
+    def test_packed_buffer_size_default(self):
+        """Test default packed_buffer_size_bytes."""
+        info = HCCLWeightTransferUpdateInfo(
+            names=["w"],
+            dtype_names=["float32"],
+            shapes=[[10]],
+        )
+        assert info.packed_buffer_size_bytes == DEFAULT_PACKED_BUFFER_SIZE_BYTES
+
+    def test_packed_num_buffers_default(self):
+        """Test default packed_num_buffers."""
+        info = HCCLWeightTransferUpdateInfo(
+            names=["w"],
+            dtype_names=["float32"],
+            shapes=[[10]],
+        )
+        assert info.packed_num_buffers == DEFAULT_PACKED_NUM_BUFFERS
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: HCCLWeightTransferInitInfo
+# ---------------------------------------------------------------------------
+
+
+class TestHCCLWeightTransferInitInfo:
+    """Test HCCLWeightTransferInitInfo dataclass."""
+
+    def test_valid_init_info(self):
+        """Test creating valid HCCLWeightTransferInitInfo."""
+        info = HCCLWeightTransferInitInfo(
+            master_address="127.0.0.1",
+            master_port=12345,
+            rank_offset=1,
+            world_size=3,
+        )
+        assert info.master_address == "127.0.0.1"
+        assert info.master_port == 12345
+        assert info.rank_offset == 1
+        assert info.world_size == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: HCCLTrainerSendWeightsArgs
+# ---------------------------------------------------------------------------
+
+
+class TestHCCLTrainerSendWeightsArgs:
+    """Test HCCLTrainerSendWeightsArgs dataclass defaults."""
+
+    def test_defaults(self):
+        """Test default values for trainer send weights args."""
+        mock_group = MagicMock()
+        args = HCCLTrainerSendWeightsArgs(group=mock_group)
+        assert args.group is mock_group
+        assert args.src == 0
+        assert args.post_iter_func is None
+        assert args.packed is False
+        assert args.stream is None
+        assert args.packed_buffer_size_bytes == DEFAULT_PACKED_BUFFER_SIZE_BYTES
+        assert args.packed_num_buffers == DEFAULT_PACKED_NUM_BUFFERS
+
+    def test_packed_can_be_set_true(self):
+        """Test packed can be enabled."""
+        mock_group = MagicMock()
+        args = HCCLTrainerSendWeightsArgs(group=mock_group, packed=True)
+        assert args.packed is True
+
+    def test_custom_post_iter_func(self):
+        """Test custom post_iter_func can be set."""
+        mock_group = MagicMock()
+        custom_func = lambda x: x[1]
+        args = HCCLTrainerSendWeightsArgs(
+            group=mock_group, post_iter_func=custom_func
+        )
+        assert args.post_iter_func is custom_func
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: HCCL Engine Parsing
+# ---------------------------------------------------------------------------
+
+
+class TestHCCLEngineParsing:
+    """Test HCCLWeightTransferEngine parsing methods."""
+
+    def test_parse_init_info_valid(self):
+        """Test parsing valid init info dict."""
+        config = create_mock_weight_transfer_config()
+        parallel_config = create_mock_parallel_config()
+        engine = HCCLWeightTransferEngine(config, parallel_config)
+
+        init_info = engine.parse_init_info(
+            {
+                "master_address": "127.0.0.1",
+                "master_port": 12345,
+                "rank_offset": 1,
+                "world_size": 3,
+            }
+        )
+
+        assert isinstance(init_info, HCCLWeightTransferInitInfo)
+        assert init_info.master_address == "127.0.0.1"
+        assert init_info.master_port == 12345
+        assert init_info.rank_offset == 1
+        assert init_info.world_size == 3
+
+    def test_parse_init_info_missing_field_raises(self):
+        """Test parsing init info with missing required field."""
+        config = create_mock_weight_transfer_config()
+        parallel_config = create_mock_parallel_config()
+        engine = HCCLWeightTransferEngine(config, parallel_config)
+
+        with pytest.raises(ValueError, match="Invalid init_info"):
+            engine.parse_init_info(
+                {
+                    "master_address": "127.0.0.1",
+                    # Missing master_port, rank_offset, world_size
+                }
+            )
+
+    def test_parse_update_info_valid(self):
+        """Test parsing valid update info dict."""
+        config = create_mock_weight_transfer_config()
+        parallel_config = create_mock_parallel_config()
+        engine = HCCLWeightTransferEngine(config, parallel_config)
+
+        update_info = engine.parse_update_info(
+            {
+                "names": ["w1", "w2"],
+                "dtype_names": ["float32", "bfloat16"],
+                "shapes": [[100, 100], [50]],
+            }
+        )
+
+        assert isinstance(update_info, HCCLWeightTransferUpdateInfo)
+        assert update_info.names == ["w1", "w2"]
+        assert update_info.dtype_names == ["float32", "bfloat16"]
+        assert update_info.shapes == [[100, 100], [50]]
+        assert update_info.packed is False
+
+    def test_parse_update_info_with_packed(self):
+        """Test parsing update info dict with packed enabled."""
+        config = create_mock_weight_transfer_config()
+        parallel_config = create_mock_parallel_config()
+        engine = HCCLWeightTransferEngine(config, parallel_config)
+
+        update_info = engine.parse_update_info(
+            {
+                "names": ["w1"],
+                "dtype_names": ["float32"],
+                "shapes": [[100, 100]],
+                "packed": True,
+                "packed_buffer_size_bytes": 1024,
+                "packed_num_buffers": 3,
+            }
+        )
+
+        assert isinstance(update_info, HCCLWeightTransferUpdateInfo)
+        assert update_info.packed is True
+        assert update_info.packed_buffer_size_bytes == 1024
+        assert update_info.packed_num_buffers == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: Engine Registry
+# ---------------------------------------------------------------------------
+
+
+class TestEngineRegistry:
+    """Test weight transfer engine registry for HCCL backend."""
+
+    def test_create_engine_hccl(self):
+        """Test factory creates HCCL engine."""
+        config = create_mock_weight_transfer_config()
+        parallel_config = create_mock_parallel_config()
+        engine = WeightTransferEngineFactory.create_engine(config, parallel_config)
+        assert isinstance(engine, HCCLWeightTransferEngine)
+
+    def test_create_engine_nccl_still_works(self):
+        """Test factory still creates NCCL engine for 'nccl' backend."""
+        config = create_mock_weight_transfer_config(backend="nccl")
+        parallel_config = create_mock_parallel_config()
+        engine = WeightTransferEngineFactory.create_engine(config, parallel_config)
+        # NCCL engine should be importable
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLWeightTransferEngine,
+        )
+        assert isinstance(engine, NCCLWeightTransferEngine)
+
+    def test_register_duplicate_raises(self):
+        """Test registering duplicate engine name raises."""
+        with pytest.raises(ValueError, match="already registered"):
+            WeightTransferEngineFactory.register_engine(
+                "hccl", HCCLWeightTransferEngine
+            )
+
+    def test_create_engine_invalid_backend(self):
+        """Test factory raises for invalid backend."""
+        from pydantic import ValidationError
+
+        # Pydantic prevents invalid backend at construction
+        with pytest.raises(ValidationError):
+            WeightTransferConfig(backend="invalid_backend_name")
+
+        # Test factory error by creating config with valid backend then
+        # bypassing Pydantic validation
+        config = WeightTransferConfig(backend="nccl")
+        object.__setattr__(config, "backend", "invalid_backend_name")
+        parallel_config = create_mock_parallel_config()
+        with pytest.raises(ValueError, match="Invalid weight transfer backend"):
+            WeightTransferEngineFactory.create_engine(config, parallel_config)
+
+
+# ---------------------------------------------------------------------------
+# Error Case: receive_weights without init
+# ---------------------------------------------------------------------------
+
+
+def test_hccl_receive_weights_without_init_raises():
+    """Test that receive_weights raises if init_transfer_engine wasn't called."""
+    if torch.accelerator.device_count() < 1:
+        pytest.skip("Need at least 1 NPU for this test")
+
+    config = create_mock_weight_transfer_config()
+    parallel_config = create_mock_parallel_config()
+    engine = HCCLWeightTransferEngine(config, parallel_config)
+
+    update_info = HCCLWeightTransferUpdateInfo(
+        names=["w"],
+        dtype_names=["float32"],
+        shapes=[[10]],
+    )
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        engine.receive_weights(update_info, lambda x: None)
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: Non-packed weight transfer (with mocked communicator)
+# ---------------------------------------------------------------------------
+
+
+def test_hccl_receive_weights_non_packed():
+    """Test receive_weights in non-packed mode with mocked communicator."""
+    if torch.accelerator.device_count() < 1:
+        pytest.skip("Need at least 1 NPU for this test")
+
+    config = create_mock_weight_transfer_config()
+    parallel_config = create_mock_parallel_config()
+    engine = HCCLWeightTransferEngine(config, parallel_config)
+
+    # Mock the model_update_group
+    mock_group = MagicMock()
+    engine.model_update_group = mock_group
+
+    # Set up update info for two tensors
+    update_info = HCCLWeightTransferUpdateInfo(
+        names=["w1", "w2"],
+        dtype_names=["float32", "float16"],
+        shapes=[[100, 100], [50]],
+        packed=False,
+    )
+
+    received = []
+
+    def load_weights(weights):
+        for name, tensor in weights:
+            received.append((name, tensor.shape, tensor.dtype))
+
+    engine.receive_weights(update_info, load_weights)
+
+    # Verify broadcast was called for each tensor
+    assert mock_group.broadcast.call_count == 2
+
+    # Verify load_weights received both tensors
+    assert len(received) == 2
+    assert received[0][0] == "w1"
+    assert received[0][1] == (100, 100)
+    assert received[0][2] == torch.float32
+    assert received[1][0] == "w2"
+    assert received[1][1] == (50,)
+    assert received[1][2] == torch.float16
+
+
+def test_hccl_trainer_send_weights_non_packed():
+    """Test trainer_send_weights in non-packed mode with mocked communicator."""
+    if torch.accelerator.device_count() < 1:
+        pytest.skip("Need at least 1 NPU for this test")
+
+    # Create mock group
+    mock_group = MagicMock()
+
+    # Create params as real tensors on NPU
+    params = [
+        ("w1", torch.ones(10, 10, dtype=torch.float32, device="npu")),
+        ("w2", torch.ones(5, dtype=torch.float16, device="npu")),
+    ]
+
+    args = HCCLTrainerSendWeightsArgs(group=mock_group, src=0)
+    HCCLWeightTransferEngine.trainer_send_weights(iter(params), args)
+
+    # Verify broadcast was called for each tensor
+    assert mock_group.broadcast.call_count == 2
+
+
+def test_hccl_trainer_send_weights_with_dict_args():
+    """Test trainer_send_weights accepts dict arguments."""
+    if torch.accelerator.device_count() < 1:
+        pytest.skip("Need at least 1 NPU for this test")
+
+    mock_group = MagicMock()
+
+    params = [
+        ("w1", torch.ones(10, 10, dtype=torch.float32, device="npu")),
+    ]
+
+    dict_args = {"group": mock_group, "src": 0}
+    HCCLWeightTransferEngine.trainer_send_weights(iter(params), dict_args)
+
+    assert mock_group.broadcast.call_count == 1
+
+
+def test_hccl_shutdown_clears_group():
+    """Test shutdown clears the model_update_group."""
+    config = create_mock_weight_transfer_config()
+    parallel_config = create_mock_parallel_config()
+    engine = HCCLWeightTransferEngine(config, parallel_config)
+
+    engine.model_update_group = MagicMock()
+    engine.shutdown()
+    assert engine.model_update_group is None
+
+
+# ---------------------------------------------------------------------------
+# Integration Test: HCCL Weight Transfer Between Ray Tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 NPUs to run HCCL weight transfer test.",
+)
+def test_hccl_weight_transfer_between_processes():
+    """Test HCCL weight transfer from trainer to inference process using Ray.
+
+    This test verifies that the HCCLWeightTransferEngine can receive
+    tensors broadcast by a trainer process via HCCL.
+    """
+    import ray
+
+    from vllm.utils.network_utils import get_open_port
+
+    ray.init(ignore_reinit_error=True)
+
+    @ray.remote(num_gpus=1)
+    def trainer_broadcast_tensor(
+        master_address: str,
+        master_port: int,
+        world_size: int,
+        tensor_shape: list[int],
+        tensor_dtype: str,
+    ) -> bool:
+        """Trainer task that broadcasts a tensor via HCCL."""
+        import torch
+
+        from vllm.distributed.utils import StatelessProcessGroup
+        from vllm_ascend.distributed.device_communicators.pyhccl import (
+            PyHcclCommunicator,
+        )
+
+        pg = StatelessProcessGroup.create(
+            host=master_address,
+            port=master_port,
+            rank=0,
+            world_size=world_size,
+        )
+        device = torch.accelerator.current_device_index()
+        comm = PyHcclCommunicator(pg, device=device)
+
+        dtype = getattr(torch, tensor_dtype)
+        tensor_to_send = torch.ones(tensor_shape, dtype=dtype, device="npu")
+        comm.broadcast(
+            tensor_to_send, src=0, stream=torch.npu.current_stream()
+        )
+        torch.accelerator.synchronize()
+
+        return True
+
+    @ray.remote(num_gpus=1)
+    def inference_receive_tensor(
+        master_address: str,
+        master_port: int,
+        world_size: int,
+        tensor_shape: list[int],
+        tensor_dtype: str,
+    ) -> dict:
+        """Inference task that receives tensor via HCCLWeightTransferEngine."""
+        from unittest.mock import MagicMock
+
+        import torch
+
+        from vllm.config.parallel import ParallelConfig
+        from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+            HCCLWeightTransferEngine,
+            HCCLWeightTransferInitInfo,
+            HCCLWeightTransferUpdateInfo,
+        )
+
+        config = MagicMock()
+        config.backend = "hccl"
+
+        parallel_config = MagicMock(spec=ParallelConfig)
+        parallel_config.rank = 0
+        parallel_config.world_size = 1
+        parallel_config.data_parallel_rank = 0
+        parallel_config.data_parallel_index = 0
+
+        engine = HCCLWeightTransferEngine(config, parallel_config)
+
+        init_info = HCCLWeightTransferInitInfo(
+            master_address=master_address,
+            master_port=master_port,
+            rank_offset=1,
+            world_size=world_size,
+        )
+        engine.init_transfer_engine(init_info)
+
+        received_tensors = []
+
+        def noop_load_weights(weights: list[tuple[str, torch.Tensor]]):
+            for name, tensor in weights:
+                received_tensors.append((name, tensor.clone()))
+
+        update_info = HCCLWeightTransferUpdateInfo(
+            names=["test.weight"],
+            dtype_names=[tensor_dtype],
+            shapes=[tensor_shape],
+        )
+        engine.receive_weights(update_info, noop_load_weights)
+        torch.accelerator.synchronize()
+
+        success = False
+        received_shape = None
+        received_sum = None
+
+        if len(received_tensors) == 1:
+            name, tensor = received_tensors[0]
+            received_shape = list(tensor.shape)
+            received_sum = tensor.sum().item()
+            if received_shape == tensor_shape:
+                expected_sum = 1.0 * torch.tensor(tensor_shape).prod().item()
+                if abs(received_sum - expected_sum) < 0.01:
+                    success = True
+
+        engine.shutdown()
+
+        return {
+            "success": success,
+            "received_shape": received_shape,
+            "received_sum": received_sum,
+        }
+
+    master_address = "127.0.0.1"
+    master_port = get_open_port()
+    world_size = 2
+
+    tensor_shape = [100, 100]
+    tensor_dtype = "float32"
+
+    inference_future = inference_receive_tensor.remote(
+        master_address, master_port, world_size, tensor_shape, tensor_dtype
+    )
+    trainer_future = trainer_broadcast_tensor.remote(
+        master_address, master_port, world_size, tensor_shape, tensor_dtype
+    )
+
+    trainer_result, result = ray.get([trainer_future, inference_future])
+
+    assert trainer_result, "Trainer should complete successfully"
+    assert result["success"], (
+        f"Weight transfer failed. "
+        f"Received shape: {result['received_shape']}, "
+        f"Received sum: {result['received_sum']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Packed Tensor Unit Tests (NPU)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 1,
+    reason="Need at least 1 NPU for packed tensor tests.",
+)
+class TestPackedBroadcastProducer:
+    """Test packed_broadcast_producer function with NPU."""
+
+    @staticmethod
+    def _create_params(
+        num_layers: int = 3,
+        dtype: torch.dtype = torch.float32,
+    ) -> list[tuple[str, torch.Tensor]]:
+        """Create mock model parameters on NPU."""
+        params = []
+        for i in range(num_layers):
+            params.append((f"layer{i}.weight", torch.randn(10, 20, dtype=dtype,
+                             device="npu")))
+            params.append((f"layer{i}.bias", torch.randn(10, dtype=dtype,
+                             device="npu")))
+        return params
+
+    def test_producer_broadcasts_tensors(self):
+        """Test that producer broadcasts all tensors."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_producer,
+        )
+
+        params = self._create_params()
+        mock_group = MagicMock()
+        mock_group.device = torch.device("npu:0")
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=mock_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=500,
+        )
+
+        assert mock_group.broadcast.call_count > 0
+
+    def test_producer_single_large_tensor(self):
+        """Test with a single tensor larger than target size."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_producer,
+        )
+
+        large_tensor = torch.randn(1000, 1000, dtype=torch.float32, device="npu")
+        params = [("large_weight", large_tensor)]
+
+        mock_group = MagicMock()
+        mock_group.device = torch.device("npu:0")
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=mock_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=100,
+        )
+
+        assert mock_group.broadcast.call_count >= 1
+
+        # Verify the total broadcasted size matches the tensor
+        broadcasted_tensors = [
+            call.args[0]
+            for call in mock_group.broadcast.call_args_list
+        ]
+        actual_size = sum(t.numel() for t in broadcasted_tensors)
+        expected_size = large_tensor.numel() * large_tensor.element_size()
+        assert actual_size == expected_size
+
+    def test_producer_multiple_batches(self):
+        """Test that tensors are properly batched when exceeding target size."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_producer,
+        )
+
+        params = [
+            (f"weight_{i}", torch.randn(10, 10, dtype=torch.float32, device="npu"))
+            for i in range(20)
+        ]
+
+        mock_group = MagicMock()
+        mock_group.device = torch.device("npu:0")
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=mock_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=2000,
+        )
+
+        assert mock_group.broadcast.call_count > 1
+
+        broadcasted_tensors = [
+            call.args[0]
+            for call in mock_group.broadcast.call_args_list
+        ]
+        expected_total = sum(
+            t.numel() * t.element_size() for _, t in params
+        )
+        actual_total = sum(t.numel() for t in broadcasted_tensors)
+        assert actual_total == expected_total
+
+    def test_producer_empty_iterator(self):
+        """Test producer handles empty iterator gracefully."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_producer,
+        )
+
+        mock_group = MagicMock()
+        mock_group.device = torch.device("npu:0")
+
+        packed_broadcast_producer(
+            iterator=iter([]),
+            group=mock_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=1000,
+        )
+
+        assert mock_group.broadcast.call_count == 0
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 1,
+    reason="Need at least 1 NPU for packed tensor tests.",
+)
+class TestPackedBroadcastConsumer:
+    """Test packed_broadcast_consumer function with NPU."""
+
+    @staticmethod
+    def _create_params(
+        num_layers: int = 3,
+        dtype: torch.dtype = torch.float32,
+    ) -> list[tuple[str, torch.Tensor]]:
+        params = []
+        for i in range(num_layers):
+            params.append((f"layer{i}.weight", torch.randn(10, 20, dtype=dtype,
+                             device="npu")))
+            params.append((f"layer{i}.bias", torch.randn(10, dtype=dtype,
+                             device="npu")))
+        return params
+
+    @staticmethod
+    def _state_dict_info(params):
+        return {
+            name: (tuple(tensor.shape), tensor.dtype)
+            for name, tensor in params
+        }
+
+    def test_consumer_receives_tensors(self):
+        """Test that consumer receives and unpacks tensors."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_consumer,
+            packed_broadcast_producer,
+        )
+
+        params = self._create_params()
+        buffer_size = 2000
+
+        # First run producer to capture broadcasted tensors
+        producer_group = MagicMock()
+        producer_group.device = torch.device("npu:0")
+        producer_broadcasted = []
+
+        def producer_broadcast(tensor, src):
+            producer_broadcasted.append(tensor.clone())
+
+        producer_group.broadcast = producer_broadcast
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=producer_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=buffer_size,
+        )
+
+        # Now run consumer with captured tensors
+        consumer_group = MagicMock()
+        consumer_group.device = torch.device("npu:0")
+        call_idx = [0]
+
+        def consumer_broadcast(tensor, src):
+            if call_idx[0] < len(producer_broadcasted):
+                tensor.copy_(producer_broadcasted[call_idx[0]])
+                call_idx[0] += 1
+
+        consumer_group.broadcast = consumer_broadcast
+
+        state_dict_info = self._state_dict_info(params)
+        unpacked = {}
+
+        def post_unpack_func(tensor_list):
+            for name, tensor in tensor_list:
+                unpacked[name] = tensor.clone()
+
+        packed_broadcast_consumer(
+            iterator=iter(state_dict_info.items()),
+            group=consumer_group,
+            src=0,
+            post_unpack_func=post_unpack_func,
+            buffer_size_bytes=buffer_size,
+        )
+
+        assert len(unpacked) == len(params)
+        for name, original_tensor in params:
+            assert name in unpacked
+            assert unpacked[name].shape == original_tensor.shape
+            assert unpacked[name].dtype == original_tensor.dtype
+            assert torch.allclose(
+                unpacked[name], original_tensor, rtol=1e-5, atol=1e-7
+            )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 1,
+    reason="Need at least 1 NPU for packed tensor roundtrip tests.",
+)
+class TestPackedBroadcastRoundtrip:
+    """Test producer-consumer roundtrip with different configurations."""
+
+    @staticmethod
+    def _create_params(
+        num_layers: int = 2,
+        dtype: torch.dtype = torch.float32,
+    ) -> list[tuple[str, torch.Tensor]]:
+        params = []
+        for i in range(num_layers):
+            params.append((f"layer{i}.weight", torch.randn(10, 20, dtype=dtype,
+                             device="npu")))
+            params.append((f"layer{i}.bias", torch.randn(10, dtype=dtype,
+                             device="npu")))
+        return params
+
+    @staticmethod
+    def _state_dict_info(params):
+        return {
+            name: (tuple(tensor.shape), tensor.dtype)
+            for name, tensor in params
+        }
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_roundtrip_different_dtypes(self, dtype):
+        """Test roundtrip with different data types."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_consumer,
+            packed_broadcast_producer,
+        )
+
+        params = self._create_params(dtype=dtype)
+        buffer_size = 1000
+
+        producer_group = MagicMock()
+        producer_group.device = torch.device("npu:0")
+        producer_broadcasted = []
+
+        def producer_broadcast(tensor, src):
+            producer_broadcasted.append(tensor.clone())
+
+        producer_group.broadcast = producer_broadcast
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=producer_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=buffer_size,
+        )
+
+        consumer_group = MagicMock()
+        consumer_group.device = torch.device("npu:0")
+        call_idx = [0]
+
+        def consumer_broadcast(tensor, src):
+            if call_idx[0] < len(producer_broadcasted):
+                tensor.copy_(producer_broadcasted[call_idx[0]])
+                call_idx[0] += 1
+
+        consumer_group.broadcast = consumer_broadcast
+
+        state_dict_info = self._state_dict_info(params)
+        unpacked = {}
+
+        def post_unpack_func(tensor_list):
+            for name, tensor in tensor_list:
+                unpacked[name] = tensor.clone()
+
+        packed_broadcast_consumer(
+            iterator=iter(state_dict_info.items()),
+            group=consumer_group,
+            src=0,
+            post_unpack_func=post_unpack_func,
+            buffer_size_bytes=buffer_size,
+        )
+
+        for name, original_tensor in params:
+            assert name in unpacked
+            assert unpacked[name].dtype == dtype
+            assert torch.allclose(
+                unpacked[name], original_tensor, rtol=1e-4, atol=1e-6
+            )
+
+    def test_roundtrip_mixed_dtypes(self):
+        """Test roundtrip with mixed data types."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_consumer,
+            packed_broadcast_producer,
+        )
+
+        params = [
+            ("layer1.weight", torch.randn(10, 20, dtype=torch.float32, device="npu")),
+            ("layer1.bias", torch.randn(10, dtype=torch.float16, device="npu")),
+            ("layer2.weight", torch.randn(20, 30, dtype=torch.bfloat16, device="npu")),
+        ]
+
+        buffer_size = 500
+
+        producer_group = MagicMock()
+        producer_group.device = torch.device("npu:0")
+        producer_broadcasted = []
+
+        def producer_broadcast(tensor, src):
+            producer_broadcasted.append(tensor.clone())
+
+        producer_group.broadcast = producer_broadcast
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=producer_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=buffer_size,
+        )
+
+        consumer_group = MagicMock()
+        consumer_group.device = torch.device("npu:0")
+        call_idx = [0]
+
+        def consumer_broadcast(tensor, src):
+            if call_idx[0] < len(producer_broadcasted):
+                tensor.copy_(producer_broadcasted[call_idx[0]])
+                call_idx[0] += 1
+
+        consumer_group.broadcast = consumer_broadcast
+
+        state_dict_info = self._state_dict_info(params)
+        unpacked = {}
+
+        def post_unpack_func(tensor_list):
+            for name, tensor in tensor_list:
+                unpacked[name] = tensor.clone()
+
+        packed_broadcast_consumer(
+            iterator=iter(state_dict_info.items()),
+            group=consumer_group,
+            src=0,
+            post_unpack_func=post_unpack_func,
+            buffer_size_bytes=buffer_size,
+        )
+
+        for name, original_tensor in params:
+            assert name in unpacked
+            assert unpacked[name].shape == original_tensor.shape
+            assert unpacked[name].dtype == original_tensor.dtype
+            assert torch.allclose(
+                unpacked[name], original_tensor, rtol=1e-4, atol=1e-6
+            )
+
+    @pytest.mark.parametrize("target_size", [100, 1000, 10000, 100000])
+    def test_roundtrip_different_batch_sizes(self, target_size):
+        """Test roundtrip with different target batch sizes."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_consumer,
+            packed_broadcast_producer,
+        )
+
+        params = self._create_params(num_layers=5)
+
+        producer_group = MagicMock()
+        producer_group.device = torch.device("npu:0")
+        producer_broadcasted = []
+
+        def producer_broadcast(tensor, src):
+            producer_broadcasted.append(tensor.clone())
+
+        producer_group.broadcast = producer_broadcast
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=producer_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=target_size,
+        )
+
+        consumer_group = MagicMock()
+        consumer_group.device = torch.device("npu:0")
+        call_idx = [0]
+
+        def consumer_broadcast(tensor, src):
+            if call_idx[0] < len(producer_broadcasted):
+                tensor.copy_(producer_broadcasted[call_idx[0]])
+                call_idx[0] += 1
+
+        consumer_group.broadcast = consumer_broadcast
+
+        state_dict_info = self._state_dict_info(params)
+        unpacked = {}
+
+        def post_unpack_func(tensor_list):
+            for name, tensor in tensor_list:
+                unpacked[name] = tensor.clone()
+
+        packed_broadcast_consumer(
+            iterator=iter(state_dict_info.items()),
+            group=consumer_group,
+            src=0,
+            post_unpack_func=post_unpack_func,
+            buffer_size_bytes=target_size,
+        )
+
+        assert len(unpacked) == len(params)
+        for name, original_tensor in params:
+            assert name in unpacked
+            assert torch.allclose(
+                unpacked[name], original_tensor, rtol=1e-5, atol=1e-7
+            )
+
+    def test_roundtrip_non_contiguous_tensors(self):
+        """Test roundtrip with non-contiguous tensors from the trainer."""
+        from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+            packed_broadcast_consumer,
+            packed_broadcast_producer,
+        )
+
+        weight1 = torch.randn(20, 10, dtype=torch.float32, device="npu").T
+        weight2 = torch.randn(40, 30, dtype=torch.float16, device="npu")[::2, ::2]
+        weight3 = (
+            torch.randn(5, 10, 15, dtype=torch.bfloat16, device="npu")
+            .permute(2, 0, 1)
+        )
+
+        params = [
+            ("layer1.weight", weight1),
+            ("layer2.weight", weight2),
+            ("layer3.weight", weight3),
+        ]
+
+        for name, tensor in params:
+            assert not tensor.is_contiguous(), f"{name} should be non-contiguous"
+
+        buffer_size = 500
+
+        producer_group = MagicMock()
+        producer_group.device = torch.device("npu:0")
+        producer_broadcasted = []
+
+        def producer_broadcast(tensor, src):
+            producer_broadcasted.append(tensor.clone())
+
+        producer_group.broadcast = producer_broadcast
+
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=producer_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+            buffer_size_bytes=buffer_size,
+        )
+
+        consumer_group = MagicMock()
+        consumer_group.device = torch.device("npu:0")
+        call_idx = [0]
+
+        def consumer_broadcast(tensor, src):
+            if call_idx[0] < len(producer_broadcasted):
+                tensor.copy_(producer_broadcasted[call_idx[0]])
+                call_idx[0] += 1
+
+        consumer_group.broadcast = consumer_broadcast
+
+        state_dict_info = self._state_dict_info(params)
+        unpacked = {}
+
+        def post_unpack_func(tensor_list):
+            for name, tensor in tensor_list:
+                unpacked[name] = tensor.clone()
+
+        packed_broadcast_consumer(
+            iterator=iter(state_dict_info.items()),
+            group=consumer_group,
+            src=0,
+            post_unpack_func=post_unpack_func,
+            buffer_size_bytes=buffer_size,
+        )
+
+        for name, original_tensor in params:
+            assert name in unpacked
+            assert unpacked[name].shape == original_tensor.shape
+            assert unpacked[name].dtype == original_tensor.dtype
+            assert torch.allclose(
+                unpacked[name], original_tensor, rtol=1e-4, atol=1e-6
+            )

--- a/tests/ut/distributed/test_hccl_weight_transfer.py
+++ b/tests/ut/distributed/test_hccl_weight_transfer.py
@@ -6,10 +6,13 @@ Unit tests for engine classes (parsing, validation, registry).
 Integration tests for HCCL weight transfer between processes using Ray.
 """
 
+import pickle
 from unittest.mock import MagicMock
 
+import pybase64 as base64
 import pytest
 import torch
+from torch.multiprocessing.reductions import reduce_tensor
 
 from vllm.config.parallel import ParallelConfig
 from vllm.config.weight_transfer import WeightTransferConfig
@@ -21,6 +24,12 @@ from vllm_ascend.distributed.weight_transfer.hccl_engine import (
     HCCLWeightTransferEngine,
     HCCLWeightTransferInitInfo,
     HCCLWeightTransferUpdateInfo,
+)
+from vllm_ascend.distributed.weight_transfer import npu_ipc_engine
+from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+    NPUIPCWeightTransferEngine,
+    NPUIPCWeightTransferInitInfo,
+    NPUIPCWeightTransferUpdateInfo,
 )
 from vllm_ascend.distributed.weight_transfer.packed_tensor import (
     DEFAULT_PACKED_BUFFER_SIZE_BYTES,
@@ -1128,3 +1137,416 @@ class TestPackedBroadcastRoundtrip:
             assert torch.allclose(
                 unpacked[name], original_tensor, rtol=1e-4, atol=1e-6
             )
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: NPU IPC Weight Transfer Engine
+# ---------------------------------------------------------------------------
+
+# NPU devices don't expose a uuid property via torch.npu.get_device_properties.
+# npu_generate_uuid() uses npu-smi to derive a physical chip identifier.
+# In tests we patch it to return a constant value.
+_TEST_NPU_UUID = "test-npu-uuid-0"
+
+
+@pytest.fixture(autouse=True)
+def _patch_npu_generate_uuid(monkeypatch):
+    """Patch npu_generate_uuid to return a constant test UUID."""
+    monkeypatch.setattr(
+        npu_ipc_engine, "npu_generate_uuid", lambda: _TEST_NPU_UUID
+    )
+
+
+class TestNPUIPCWeightTransferUpdateInfoValidation:
+    """Test NPUIPCWeightTransferUpdateInfo dataclass validation."""
+
+    def test_valid_update_info(self):
+        """Test creating valid NPUIPCWeightTransferUpdateInfo."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        dummy_tensor = torch.ones(10, 10, device="npu")
+        ipc_handle = reduce_tensor(dummy_tensor)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle}]
+
+        info = NPUIPCWeightTransferUpdateInfo(
+            names=["layer.weight"],
+            dtype_names=["float32"],
+            shapes=[[10, 10]],
+            ipc_handles=ipc_handles,
+        )
+        assert info.names == ["layer.weight"]
+        assert info.dtype_names == ["float32"]
+        assert info.shapes == [[10, 10]]
+        assert len(info.ipc_handles) == 1
+
+    def test_mismatched_dtype_names_raises(self):
+        """Test that mismatched dtype_names length raises ValueError."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        dummy_tensor = torch.ones(10, 10, device="npu")
+        ipc_handle = reduce_tensor(dummy_tensor)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle}, {npu_uuid: ipc_handle}]
+
+        with pytest.raises(ValueError, match="dtype_names"):
+            NPUIPCWeightTransferUpdateInfo(
+                names=["layer.weight", "layer.bias"],
+                dtype_names=["float32"],  # Only one dtype
+                shapes=[[10, 10], [10]],
+                ipc_handles=ipc_handles,
+            )
+
+    def test_mismatched_shapes_raises(self):
+        """Test that mismatched shapes length raises ValueError."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        dummy_tensor = torch.ones(10, 10, device="npu")
+        ipc_handle = reduce_tensor(dummy_tensor)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle}, {npu_uuid: ipc_handle}]
+
+        with pytest.raises(ValueError, match="shapes"):
+            NPUIPCWeightTransferUpdateInfo(
+                names=["layer.weight", "layer.bias"],
+                dtype_names=["float32", "float32"],
+                shapes=[[10, 10]],  # Only one shape
+                ipc_handles=ipc_handles,
+            )
+
+    def test_mismatched_ipc_handles_raises(self):
+        """Test that mismatched ipc_handles length raises ValueError."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        dummy_tensor = torch.ones(10, 10, device="npu")
+        ipc_handle = reduce_tensor(dummy_tensor)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle}]  # Only one handle
+
+        with pytest.raises(ValueError, match="ipc_handles"):
+            NPUIPCWeightTransferUpdateInfo(
+                names=["layer.weight", "layer.bias"],
+                dtype_names=["float32", "float32"],
+                shapes=[[10, 10], [10]],
+                ipc_handles=ipc_handles,
+            )
+
+    def test_both_handles_and_pickled_raises(self):
+        """Test that providing both ipc_handles and ipc_handles_pickled raises."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        dummy_tensor = torch.ones(10, 10, device="npu")
+        ipc_handle = reduce_tensor(dummy_tensor)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle}]
+
+        pickled = base64.b64encode(pickle.dumps(ipc_handles)).decode("utf-8")
+
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            NPUIPCWeightTransferUpdateInfo(
+                names=["layer.weight"],
+                dtype_names=["float32"],
+                shapes=[[10, 10]],
+                ipc_handles=ipc_handles,
+                ipc_handles_pickled=pickled,
+            )
+
+    def test_neither_handles_nor_pickled_raises(self):
+        """Test that providing neither ipc_handles nor ipc_handles_pickled raises."""
+        with pytest.raises(ValueError, match="must be provided"):
+            NPUIPCWeightTransferUpdateInfo(
+                names=["layer.weight"],
+                dtype_names=["float32"],
+                shapes=[[10, 10]],
+            )
+
+    def test_empty_lists_valid(self):
+        """Test that empty lists are valid."""
+        info = NPUIPCWeightTransferUpdateInfo(
+            names=[],
+            dtype_names=[],
+            shapes=[],
+            ipc_handles=[],
+        )
+        assert len(info.names) == 0
+
+
+class TestNPUIPCEngineParsing:
+    """Test NPUIPCWeightTransferEngine parsing methods."""
+
+    def test_parse_update_info_valid(self):
+        """Test parsing valid update info dict."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        config = create_mock_weight_transfer_config(backend="npu_ipc")
+        parallel_config = create_mock_parallel_config()
+        engine = NPUIPCWeightTransferEngine(config, parallel_config)
+
+        dummy_tensor1 = torch.ones(100, 100, device="npu")
+        dummy_tensor2 = torch.ones(50, device="npu")
+        ipc_handle1 = reduce_tensor(dummy_tensor1)
+        ipc_handle2 = reduce_tensor(dummy_tensor2)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle1}, {npu_uuid: ipc_handle2}]
+
+        update_info = engine.parse_update_info(
+            {
+                "names": ["w1", "w2"],
+                "dtype_names": ["float32", "bfloat16"],
+                "shapes": [[100, 100], [50]],
+                "ipc_handles": ipc_handles,
+            }
+        )
+
+        assert isinstance(update_info, NPUIPCWeightTransferUpdateInfo)
+        assert update_info.names == ["w1", "w2"]
+        assert update_info.dtype_names == ["float32", "bfloat16"]
+        assert update_info.shapes == [[100, 100], [50]]
+        assert len(update_info.ipc_handles) == 2
+
+    def test_parse_update_info_pickled(self, monkeypatch):
+        """Test parsing update info with pickled IPC handles (HTTP path)."""
+        if torch.accelerator.device_count() < 1:
+            pytest.skip("Need at least 1 NPU for this test")
+
+        monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+        config = create_mock_weight_transfer_config(backend="npu_ipc")
+        parallel_config = create_mock_parallel_config()
+        engine = NPUIPCWeightTransferEngine(config, parallel_config)
+
+        dummy_tensor1 = torch.ones(100, 100, device="npu")
+        dummy_tensor2 = torch.ones(50, device="npu")
+        ipc_handle1 = reduce_tensor(dummy_tensor1)
+        ipc_handle2 = reduce_tensor(dummy_tensor2)
+        npu_uuid = _TEST_NPU_UUID
+        ipc_handles = [{npu_uuid: ipc_handle1}, {npu_uuid: ipc_handle2}]
+
+        pickled = base64.b64encode(pickle.dumps(ipc_handles)).decode("utf-8")
+
+        update_info = engine.parse_update_info(
+            {
+                "names": ["w1", "w2"],
+                "dtype_names": ["float32", "bfloat16"],
+                "shapes": [[100, 100], [50]],
+                "ipc_handles_pickled": pickled,
+            }
+        )
+
+        assert isinstance(update_info, NPUIPCWeightTransferUpdateInfo)
+        assert update_info.names == ["w1", "w2"]
+        assert len(update_info.ipc_handles) == 2
+        assert update_info.ipc_handles_pickled is None
+        assert npu_uuid in update_info.ipc_handles[0]
+        assert npu_uuid in update_info.ipc_handles[1]
+
+
+class TestNPUIPCEngineRegistry:
+    """Test registry for NPU IPC backend."""
+
+    def test_create_engine_npu_ipc(self):
+        """Test factory creates NPU IPC engine."""
+        config = create_mock_weight_transfer_config(backend="npu_ipc")
+        parallel_config = create_mock_parallel_config()
+        engine = WeightTransferEngineFactory.create_engine(config, parallel_config)
+        assert isinstance(engine, NPUIPCWeightTransferEngine)
+
+    def test_register_duplicate_raises(self):
+        """Test registering duplicate engine name raises."""
+        with pytest.raises(ValueError, match="already registered"):
+            WeightTransferEngineFactory.register_engine(
+                "npu_ipc", NPUIPCWeightTransferEngine
+            )
+
+
+def test_npu_ipc_receive_weights_missing_uuid_raises():
+    """Test that receive_weights raises if NPU UUID not found in IPC handles."""
+    if torch.accelerator.device_count() < 1:
+        pytest.skip("Need at least 1 NPU for this test")
+
+    config = create_mock_weight_transfer_config(backend="npu_ipc")
+    parallel_config = create_mock_parallel_config()
+    engine = NPUIPCWeightTransferEngine(config, parallel_config)
+
+    dummy_tensor = torch.ones(10, 10, device="npu")
+    ipc_handle = reduce_tensor(dummy_tensor)
+    wrong_uuid = "wrong-uuid-12345"
+    ipc_handles = [{wrong_uuid: ipc_handle}]
+
+    update_info = NPUIPCWeightTransferUpdateInfo(
+        names=["w"],
+        dtype_names=["float32"],
+        shapes=[[10, 10]],
+        ipc_handles=ipc_handles,
+    )
+
+    with pytest.raises(ValueError, match="IPC handle not found"):
+        engine.receive_weights(update_info, lambda x: None)
+
+
+# ---------------------------------------------------------------------------
+# Integration Test: NPU IPC Weight Transfer Between Ray Tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 1,
+    reason="Need at least 1 NPU to run NPU IPC weight transfer test.",
+)
+def test_npu_ipc_weight_transfer_between_processes():
+    """Test NPU IPC weight transfer from trainer to inference process using Ray.
+
+    NPU IPC requires same-NPU access, so we use a placement group to
+    co-locate the trainer actor and inference task on the same NPU.
+    """
+    import ray
+    from ray.util.placement_group import placement_group
+    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+    ray.init(ignore_reinit_error=True)
+
+    pg = placement_group([{"GPU": 1, "CPU": 2}])
+    ray.get(pg.ready())
+
+    scheduling_strategy = PlacementGroupSchedulingStrategy(
+        placement_group=pg,
+        placement_group_capture_child_tasks=True,
+    )
+
+    # Use a shared UUID constant that works across Ray worker boundaries
+    _TEST_NPU_UUID = "test-npu-uuid-0"
+
+    @ray.remote(num_gpus=0.5)
+    class TrainerActor:
+        """Trainer actor that creates and holds NPU IPC handles."""
+
+        def __init__(
+            self, tensor_shape: list[int], tensor_dtype: str, npu_uuid: str
+        ):
+            import torch
+            from torch.multiprocessing.reductions import reduce_tensor
+
+            dtype = getattr(torch, tensor_dtype)
+            self.tensor = torch.ones(tensor_shape, dtype=dtype, device="npu")
+            self.tensor.fill_(42.0)
+
+            ipc_handle = reduce_tensor(self.tensor)
+            torch.accelerator.synchronize()
+
+            self.ipc_handle_dict = {
+                "ipc_handle": ipc_handle,
+                "npu_uuid": npu_uuid,
+                "shape": tensor_shape,
+                "dtype": tensor_dtype,
+            }
+
+        def get_ipc_handle_dict(self) -> dict:
+            return self.ipc_handle_dict
+
+    @ray.remote(num_gpus=0.5)
+    def inference_receive_ipc_tensor(ipc_handle_dict: dict) -> dict:
+        """Inference task that receives tensor via NPUIPCWeightTransferEngine."""
+        from unittest.mock import MagicMock, patch
+
+        import torch
+
+        from vllm.config.parallel import ParallelConfig
+        from vllm_ascend.distributed.weight_transfer import npu_ipc_engine
+        from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+            NPUIPCWeightTransferEngine,
+            NPUIPCWeightTransferInitInfo,
+        )
+
+        config = MagicMock()
+        config.backend = "npu_ipc"
+
+        parallel_config = MagicMock(spec=ParallelConfig)
+        parallel_config.rank = 0
+        parallel_config.world_size = 1
+        parallel_config.data_parallel_rank = 0
+        parallel_config.data_parallel_index = 0
+
+        engine = NPUIPCWeightTransferEngine(config, parallel_config)
+
+        init_info = NPUIPCWeightTransferInitInfo()
+        engine.init_transfer_engine(init_info)
+
+        received_tensors = []
+
+        def noop_load_weights(weights: list[tuple[str, torch.Tensor]]):
+            for name, tensor in weights:
+                received_tensors.append((name, tensor.clone()))
+
+        ipc_handles = [
+            {ipc_handle_dict["npu_uuid"]: ipc_handle_dict["ipc_handle"]}
+        ]
+
+        update_info = engine.parse_update_info(
+            {
+                "names": ["test.weight"],
+                "dtype_names": [ipc_handle_dict["dtype"]],
+                "shapes": [ipc_handle_dict["shape"]],
+                "ipc_handles": ipc_handles,
+            }
+        )
+
+        # Patch npu_generate_uuid inside the Ray worker to match the
+        # UUID used by the trainer side.
+        with patch.object(
+            npu_ipc_engine,
+            "npu_generate_uuid",
+            return_value=ipc_handle_dict["npu_uuid"],
+        ):
+            engine.receive_weights(update_info, noop_load_weights)
+        torch.accelerator.synchronize()
+
+        success = False
+        received_shape = None
+        received_sum = None
+
+        if len(received_tensors) == 1:
+            name, tensor = received_tensors[0]
+            received_shape = list(tensor.shape)
+            received_sum = tensor.sum().item()
+            if received_shape == ipc_handle_dict["shape"]:
+                expected_sum = 42.0 * torch.tensor(
+                    ipc_handle_dict["shape"]
+                ).prod().item()
+                if abs(received_sum - expected_sum) < 0.01:
+                    success = True
+
+        engine.shutdown()
+
+        return {
+            "success": success,
+            "received_shape": received_shape,
+            "received_sum": received_sum,
+        }
+
+    tensor_shape = [100, 100]
+    tensor_dtype = "float32"
+    test_uuid = _TEST_NPU_UUID
+
+    trainer_actor = TrainerActor.options(
+        scheduling_strategy=scheduling_strategy
+    ).remote(tensor_shape, tensor_dtype, test_uuid)
+
+    ipc_handle_dict = ray.get(trainer_actor.get_ipc_handle_dict.remote())
+
+    inference_result = ray.get(
+        inference_receive_ipc_tensor.options(
+            scheduling_strategy=scheduling_strategy
+        ).remote(ipc_handle_dict)
+    )
+
+    assert inference_result["success"], (
+        f"NPU IPC weight transfer failed. "
+        f"Received shape: {inference_result['received_shape']}, "
+        f"Received sum: {inference_result['received_sum']}"
+    )

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -1272,8 +1272,8 @@ class TestNPUWorkerWeightUpdate(TestBase):
 
         engine.receive_weights.side_effect = fake_receive
         worker = self._make_worker(engine=engine)
-        fake_param = MagicMock()
-        worker.model_runner.model.get_parameter.return_value = fake_param
+        param = torch.nn.Parameter(torch.ones(2), requires_grad=True)
+        worker.model_runner.model.get_parameter.return_value = param
 
         if vllm_version_is("0.20.2"):
             typed = MagicMock()
@@ -1287,7 +1287,8 @@ class TestNPUWorkerWeightUpdate(TestBase):
         worker.update_weights({"foo": "bar"})
 
         worker.model_runner.model.get_parameter.assert_called_once_with("layer.weight")
-        fake_param.copy_.assert_called_once()
+        torch.testing.assert_close(param.detach(), torch.zeros(2))
+        self.assertTrue(param.requires_grad)
 
     @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
     def test_update_weights_rejects_nz(self):

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -5,6 +5,7 @@ import torch
 from vllm.config import CacheConfig, ModelConfig, ParallelConfig, ProfilerConfig, VllmConfig
 
 from tests.ut.base import TestBase
+from vllm_ascend.utils import vllm_version_is
 
 init_cached_hf_modules_path = "vllm.utils.import_utils.init_cached_hf_modules"
 
@@ -38,6 +39,7 @@ class TestNPUWorker(TestBase):
         self.vllm_config_mock.scheduler_config = None
         self.vllm_config_mock.device_config = None
         self.vllm_config_mock.compilation_config = None
+        self.vllm_config_mock.weight_transfer_config = None
 
         self.local_rank = 0
         self.rank = 0
@@ -1137,3 +1139,221 @@ class TestNPUWorker(TestBase):
 
             # When both flags are False, return EMPTY_MODEL_RUNNER_OUTPUT directly.
             self.assertEqual(result, mock_empty_output)
+
+
+class TestNPUWorkerWeightUpdate(TestBase):
+    def _make_worker(self, engine=None):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+        worker.weight_transfer_engine = engine
+        worker._weight_update_active = False
+        worker._is_checkpoint_format = True
+        worker.device = torch.device("cpu")
+        worker.model_runner = MagicMock()
+        worker.model_runner.model = MagicMock()
+        worker.model_config = MagicMock()
+        return worker
+
+    def test_check_engine_raises_when_unconfigured(self):
+        worker = self._make_worker(engine=None)
+        with self.assertRaises(RuntimeError):
+            worker.init_weight_transfer_engine({})
+        with self.assertRaises(RuntimeError):
+            worker.start_weight_update()
+        with self.assertRaises(RuntimeError):
+            worker.update_weights({})
+        with self.assertRaises(RuntimeError):
+            worker.finish_weight_update()
+
+    def test_init_weight_transfer_engine_dispatches_to_engine(self):
+        engine = MagicMock()
+        engine.parse_init_info.return_value = "typed_init"
+        worker = self._make_worker(engine=engine)
+
+        init_info = {"master_address": "127.0.0.1", "master_port": 12345}
+        worker.init_weight_transfer_engine(init_info)
+
+        engine.parse_init_info.assert_called_once_with(init_info)
+        engine.init_transfer_engine.assert_called_once_with("typed_init")
+
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_checkpoint_format(self, mock_init_reload):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        worker.start_weight_update(is_checkpoint_format=True)
+
+        mock_init_reload.assert_called_once_with(worker.model_runner.model)
+        self.assertTrue(worker._weight_update_active)
+        self.assertTrue(worker._is_checkpoint_format)
+
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_kernel_format(self, mock_init_reload):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        worker.start_weight_update(is_checkpoint_format=False)
+
+        mock_init_reload.assert_not_called()
+        self.assertTrue(worker._weight_update_active)
+        self.assertFalse(worker._is_checkpoint_format)
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_rejects_reentry(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+
+        with self.assertRaises(RuntimeError):
+            worker.start_weight_update()
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    def test_start_weight_update_rejects_nz(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        with self.assertRaises(ValueError):
+            worker.start_weight_update()
+
+    def test_update_weights_requires_start(self):
+        if vllm_version_is("0.20.2"):
+            return  # v0.20.2 update_weights is self-contained; no start_weight_update guard
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        with self.assertRaises(RuntimeError):
+            worker.update_weights({"names": [], "dtype_names": [], "shapes": []})
+
+    @patch("torch.npu.synchronize", create=True)
+    @patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload")
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_update_weights_checkpoint_format(self, mock_init_reload, mock_finalize_reload, mock_sync):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        if vllm_version_is("0.20.2"):
+            typed = MagicMock()
+            typed.is_checkpoint_format = True
+            engine.parse_update_info.return_value = typed
+            # no start_weight_update phase: _weight_update_active stays False
+        else:
+            engine.parse_update_info.return_value = "typed_update"
+            worker._weight_update_active = True
+            worker._is_checkpoint_format = True
+
+        worker.update_weights({"foo": "bar"})
+
+        engine.parse_update_info.assert_called_once_with({"foo": "bar"})
+        engine.receive_weights.assert_called_once()
+        _, kwargs = engine.receive_weights.call_args
+        self.assertIs(kwargs["load_weights"], worker.model_runner.model.load_weights)
+        mock_sync.assert_called_once()
+
+        if vllm_version_is("0.20.2"):
+            # self-contained: reload lifecycle is managed inside update_weights
+            mock_init_reload.assert_called_once_with(worker.model_runner.model)
+            mock_finalize_reload.assert_called_once_with(worker.model_runner.model, worker.model_config)
+        else:
+            # main: reload lifecycle is split across start_weight_update / finish_weight_update
+            mock_init_reload.assert_not_called()
+            mock_finalize_reload.assert_not_called()
+
+    @patch("torch.npu.synchronize", create=True)
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_update_weights_kernel_format(self, mock_sync):
+        engine = MagicMock()
+
+        def fake_receive(update_info, load_weights):
+            load_weights([("layer.weight", torch.zeros(2))])
+
+        engine.receive_weights.side_effect = fake_receive
+        worker = self._make_worker(engine=engine)
+        fake_param = MagicMock()
+        worker.model_runner.model.get_parameter.return_value = fake_param
+
+        if vllm_version_is("0.20.2"):
+            typed = MagicMock()
+            typed.is_checkpoint_format = False
+            engine.parse_update_info.return_value = typed
+        else:
+            engine.parse_update_info.return_value = "typed_update"
+            worker._weight_update_active = True
+            worker._is_checkpoint_format = False
+
+        worker.update_weights({"foo": "bar"})
+
+        worker.model_runner.model.get_parameter.assert_called_once_with("layer.weight")
+        fake_param.copy_.assert_called_once()
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
+    def test_update_weights_rejects_nz(self):
+        # On main, NZ is caught in start_weight_update (see test_start_weight_update_rejects_nz).
+        # On v0.20.2, there is no start phase, so update_weights itself enforces the check.
+        if not vllm_version_is("0.20.2"):
+            return
+        engine = MagicMock()
+        typed = MagicMock()
+        typed.is_checkpoint_format = True
+        engine.parse_update_info.return_value = typed
+        worker = self._make_worker(engine=engine)
+        with self.assertRaises(ValueError):
+            worker.update_weights({"foo": "bar"})
+
+    @patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload")
+    def test_finish_weight_update_resets_state(self, mock_finalize_reload):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+        worker._is_checkpoint_format = True
+
+        worker.finish_weight_update()
+
+        mock_finalize_reload.assert_called_once_with(worker.model_runner.model, worker.model_config)
+        self.assertFalse(worker._weight_update_active)
+        self.assertTrue(worker._is_checkpoint_format)
+
+    def test_finish_without_start_raises(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+
+        with self.assertRaises(RuntimeError):
+            worker.finish_weight_update()
+
+    def test_double_finish_raises(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+        worker._is_checkpoint_format = False
+
+        worker.finish_weight_update()
+
+        with self.assertRaises(RuntimeError):
+            worker.finish_weight_update()
+
+    @patch("torch.npu.synchronize", create=True)
+    def test_update_after_finish_requires_restart(self, _mock_sync):
+        if vllm_version_is("0.20.2"):
+            return  # v0.20.2 has no start/finish state machine
+        engine = MagicMock()
+        engine.parse_update_info.return_value = "typed"
+        worker = self._make_worker(engine=engine)
+        worker._weight_update_active = True
+        worker._is_checkpoint_format = False
+        worker.finish_weight_update()
+
+        with self.assertRaises(RuntimeError):
+            worker.update_weights({"names": [], "dtype_names": [], "shapes": []})
+
+    @patch("vllm.distributed.kv_transfer.ensure_kv_transfer_shutdown", create=True)
+    def test_shutdown_releases_engine(self, _mock_kv_shutdown):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker.profiler = None
+
+        worker.shutdown()
+
+        engine.shutdown.assert_called_once()

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -45,8 +45,10 @@ def register_connector():
     _ensure_global_patch()
 
     from vllm_ascend.distributed.kv_transfer import register_connector
+    from vllm_ascend.distributed.weight_transfer import register_engine
 
     register_connector()
+    register_engine()
 
 
 def register_model_loader():

--- a/vllm_ascend/distributed/weight_transfer/__init__.py
+++ b/vllm_ascend/distributed/weight_transfer/__init__.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
+
+
+def register_engine():
+    """Register HCCL weight transfer engine as a vLLM plugin."""
+    WeightTransferEngineFactory.register_engine(
+        "hccl",
+        "vllm_ascend.distributed.weight_transfer.hccl_engine",
+        "HCCLWeightTransferEngine",
+    )

--- a/vllm_ascend/distributed/weight_transfer/__init__.py
+++ b/vllm_ascend/distributed/weight_transfer/__init__.py
@@ -19,9 +19,14 @@ from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 
 
 def register_engine():
-    """Register HCCL weight transfer engine as a vLLM plugin."""
+    """Register Ascend weight transfer engines as vLLM plugins."""
     WeightTransferEngineFactory.register_engine(
         "hccl",
         "vllm_ascend.distributed.weight_transfer.hccl_engine",
         "HCCLWeightTransferEngine",
+    )
+    WeightTransferEngineFactory.register_engine(
+        "npu_ipc",
+        "vllm_ascend.distributed.weight_transfer.npu_ipc_engine",
+        "NPUIPCWeightTransferEngine",
     )

--- a/vllm_ascend/distributed/weight_transfer/hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_engine.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HCCL-based weight transfer engine."""
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator
+
+from vllm.config.parallel import ParallelConfig
+from vllm.config.weight_transfer import WeightTransferConfig
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferEngine,
+    WeightTransferInitInfo,
+    WeightTransferUpdateInfo,
+)
+from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+    DEFAULT_PACKED_BUFFER_SIZE_BYTES,
+    DEFAULT_PACKED_NUM_BUFFERS,
+    packed_broadcast_consumer,
+)
+
+
+@dataclass
+class HCCLWeightTransferInitInfo(WeightTransferInitInfo):
+    """Initialization info for HCCL weight transfer backend."""
+
+    master_address: str
+    """IP address of the trainer (rank 0) for HCCL process group setup."""
+    master_port: int
+    """Port on the trainer for HCCL process group setup."""
+    rank_offset: int
+    """Offset added to each vLLM worker's rank within the HCCL group.
+    Typically 1 (trainer is rank 0, workers start at rank 1)."""
+    world_size: int
+    """Total number of participants in the HCCL group (trainer + all workers)."""
+
+
+@dataclass
+class HCCLTrainerSendWeightsArgs:
+    """Arguments for HCCL trainer_send_weights method."""
+
+    group: Any
+    """Process group (PyHcclCommunicator) for HCCL communication."""
+    src: int = 0
+    """Source rank (default 0, trainer is typically rank 0)."""
+    post_iter_func: Callable[[tuple[str, torch.Tensor]], torch.Tensor] | None = None
+    """Optional function to apply to each (name, tensor) pair before broadcasting.
+    If None, extracts just the tensor."""
+    packed: bool = False
+    """Whether to use packed tensor broadcasting for efficiency.
+    When True, multiple tensors are batched together before broadcasting
+    to reduce HCCL communication overhead."""
+    stream: torch.npu.Stream | None = None
+    """ACL stream to use for broadcasting if packed is False.
+    If packed is True, new streams will be created for each buffer."""
+    packed_buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES
+    """Size in bytes for each packed tensor buffer.
+    Must match the value used in HCCLWeightTransferUpdateInfo."""
+    packed_num_buffers: int = DEFAULT_PACKED_NUM_BUFFERS
+    """Number of buffers for double/triple buffering during packed transfer.
+    Must match the value used in HCCLWeightTransferUpdateInfo."""
+
+
+@dataclass
+class HCCLWeightTransferUpdateInfo(WeightTransferUpdateInfo):
+    """Update info for HCCL weight transfer backend."""
+
+    names: list[str]
+    dtype_names: list[str]
+    shapes: list[list[int]]
+    packed: bool = False
+    """Whether to use packed tensor broadcasting for efficiency.
+    When True, multiple tensors are batched together before broadcasting
+    to reduce HCCL communication overhead."""
+    packed_buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES
+    """Size in bytes for each packed tensor buffer.
+    Both producer and consumer must use the same value."""
+    packed_num_buffers: int = DEFAULT_PACKED_NUM_BUFFERS
+    """Number of buffers for double/triple buffering during packed transfer.
+    Both producer and consumer must use the same value."""
+
+    def __post_init__(self):
+        """Validate that all lists have the same length."""
+        num_params = len(self.names)
+        if len(self.dtype_names) != num_params:
+            raise ValueError(
+                f"`dtype_names` should be of the same size as `names`: "
+                f"got {len(self.dtype_names)} and {len(self.names)}"
+            )
+        if len(self.shapes) != num_params:
+            raise ValueError(
+                f"`shapes` should be of the same size as `names`: "
+                f"got {len(self.shapes)} and {len(self.names)}"
+            )
+
+
+class HCCLWeightTransferEngine(
+    WeightTransferEngine[HCCLWeightTransferInitInfo, HCCLWeightTransferUpdateInfo]
+):
+    """
+    Weight transfer engine using HCCL for communication between trainer and workers.
+
+    This implementation uses HCCL broadcast operations to transfer weights from
+    the trainer (rank 0) to all inference workers in a process group.
+    """
+
+    # Define backend-specific dataclass types
+    init_info_cls = HCCLWeightTransferInitInfo
+    update_info_cls = HCCLWeightTransferUpdateInfo
+
+    def __init__(
+        self, config: WeightTransferConfig, parallel_config: ParallelConfig
+    ) -> None:
+        """
+        Initialize the HCCL weight transfer engine.
+
+        Args:
+            config: The configuration for the weight transfer engine
+            parallel_config: The configuration for the parallel setup
+        """
+        super().__init__(config, parallel_config)
+        self.model_update_group: PyHcclCommunicator | None = None
+
+    def init_transfer_engine(self, init_info: HCCLWeightTransferInitInfo) -> None:
+        """
+        Initialize HCCL process group with the trainer.
+
+        Args:
+            init_info: HCCL initialization info containing master address, port,
+                      rank offset, and world size
+        """
+
+        # Calculate the global rank in the trainer-worker process group
+        # Must account for data parallel to get unique ranks across all workers
+        dp_rank = self.parallel_config.data_parallel_index
+        world_size_per_dp = self.parallel_config.world_size  # TP * PP
+        rank_within_dp = self.parallel_config.rank
+
+        # Unique rank across all DP groups
+        worker_rank = dp_rank * world_size_per_dp + rank_within_dp
+        rank = worker_rank + init_info.rank_offset
+        # Create stateless process group
+        device = torch.accelerator.current_device_index()
+        self.model_update_group = (
+            HCCLWeightTransferEngine._stateless_init_process_group(
+                init_info.master_address,
+                init_info.master_port,
+                rank,
+                init_info.world_size,
+                device=device,
+            )
+        )
+
+    def receive_weights(
+        self,
+        update_info: HCCLWeightTransferUpdateInfo,
+        load_weights: Callable[[list[tuple[str, torch.Tensor]]], None],
+    ) -> None:
+        """
+        Receive weights from trainer via HCCL broadcast and load them incrementally.
+
+        If update_info.packed is True, uses packed tensor broadcasting for
+        efficient transfer of multiple weights in batches. Otherwise, uses simple
+        one-by-one broadcasting.
+
+        Args:
+            update_info: HCCL update info containing parameter names, dtypes, shapes,
+                        and packed flag
+            load_weights: Callable that loads weights into the model. Called
+                         incrementally for each batch of weights to avoid OOM.
+        """
+        if self.model_update_group is None:
+            raise RuntimeError(
+                "HCCL weight transfer not initialized. "
+                "Call init_transfer_engine() first."
+            )
+
+        if update_info.packed:
+            # Build iterator of (name, (shape, dtype)) from update_info
+            def state_dict_info_iterator():
+                for name, dtype_name, shape in zip(
+                    update_info.names, update_info.dtype_names, update_info.shapes
+                ):
+                    dtype = getattr(torch, dtype_name)
+                    yield (name, (shape, dtype))
+
+            packed_broadcast_consumer(
+                iterator=state_dict_info_iterator(),
+                group=self.model_update_group,
+                src=0,
+                post_unpack_func=load_weights,
+                buffer_size_bytes=update_info.packed_buffer_size_bytes,
+                num_buffers=update_info.packed_num_buffers,
+            )
+        else:
+            # Use simple one-by-one broadcasting
+            for name, dtype_name, shape in zip(
+                update_info.names, update_info.dtype_names, update_info.shapes
+            ):
+                dtype = getattr(torch, dtype_name)
+                weight = torch.empty(shape, dtype=dtype, device="npu")
+                self.model_update_group.broadcast(
+                    weight, src=0, stream=torch.npu.current_stream()
+                )
+                load_weights([(name, weight)])
+                del weight
+
+    def shutdown(self) -> None:
+        if self.model_update_group is not None:
+            # Clean up the communicator by removing the reference
+            self.model_update_group = None
+
+    @staticmethod
+    def trainer_send_weights(
+        iterator: Iterator[tuple[str, torch.Tensor]],
+        trainer_args: dict[str, Any] | HCCLTrainerSendWeightsArgs,
+    ) -> None:
+        """Broadcast weights from trainer to vLLM workers.
+
+        Args:
+            iterator: Iterator of model parameters. Returns (name, tensor) tuples
+            trainer_args: Dictionary or HCCLTrainerSendWeightsArgs instance containing
+                         HCCL-specific arguments. If a dict, should contain keys from
+                         HCCLTrainerSendWeightsArgs.
+
+        Example:
+            >>> from vllm.distributed.weight_transfer.hccl_engine import (
+            ...     HCCLWeightTransferEngine,
+            ...     HCCLTrainerSendWeightsArgs,
+            ... )
+            >>> param_iter = ((n, p) for n, p in model.named_parameters())
+            >>> args = HCCLTrainerSendWeightsArgs(group=group, packed=True)
+            >>> HCCLWeightTransferEngine.trainer_send_weights(param_iter, args)
+        """
+        # Parse trainer args - accept either dict or dataclass instance
+        if isinstance(trainer_args, dict):
+            args = HCCLTrainerSendWeightsArgs(**trainer_args)
+        else:
+            args = trainer_args
+
+        if args.post_iter_func is None:
+            # Default: extract just the tensor from (name, tensor) tuple
+            post_iter_func = lambda x: x[1]
+        else:
+            post_iter_func = args.post_iter_func
+
+        if args.packed:
+            # Use packed tensor broadcasting for efficiency
+            from vllm_ascend.distributed.weight_transfer.packed_tensor import (
+                packed_broadcast_producer,
+            )
+
+            packed_broadcast_producer(
+                iterator=iterator,
+                group=args.group,
+                src=args.src,
+                post_iter_func=post_iter_func,
+                buffer_size_bytes=args.packed_buffer_size_bytes,
+                num_buffers=args.packed_num_buffers,
+            )
+        else:
+            # Use simple one-by-one broadcasting
+            for item in iterator:
+                tensor = post_iter_func(item)
+                args.group.broadcast(
+                    tensor,
+                    src=args.src,
+                    stream=args.stream or torch.npu.current_stream(),
+                )
+
+    @staticmethod
+    def trainer_init(
+        init_info: HCCLWeightTransferInitInfo | dict,
+    ) -> "PyHcclCommunicator":
+        """
+        Initialize HCCL process group for trainer-side weight transfer.
+
+        The trainer is always rank 0 in the process group. Uses the current
+        Ascend device (torch.accelerator.current_device_index()).
+
+        Args:
+            init_info: Either an HCCLWeightTransferInitInfo object or a dict with keys:
+                - master_address: str
+                - master_port: int
+                - world_size: int
+
+        Returns:
+            PyHcclCommunicator for weight transfer.
+
+        Example:
+            >>> from vllm.distributed.weight_transfer.hccl_engine import (
+            ...     HCCLWeightTransferEngine,
+            ... )
+            >>> group = HCCLWeightTransferEngine.trainer_init(
+            ...     dict(
+            ...         master_address=master_address,
+            ...         master_port=master_port,
+            ...         world_size=world_size,
+            ...     ),
+            ... )
+        """
+        if isinstance(init_info, dict):
+            master_address = init_info["master_address"]
+            master_port = init_info["master_port"]
+            world_size = init_info["world_size"]
+        else:
+            # HCCLWeightTransferInitInfo object
+            master_address = init_info.master_address
+            master_port = init_info.master_port
+            world_size = init_info.world_size
+
+        # Trainer is always rank 0
+        device = torch.accelerator.current_device_index()
+        return HCCLWeightTransferEngine._stateless_init_process_group(
+            master_address,
+            master_port,
+            0,
+            world_size,
+            device,
+        )
+
+    @staticmethod
+    def _stateless_init_process_group(
+        master_address, master_port, rank, world_size, device
+    ):
+        """
+        vLLM provides `StatelessProcessGroup` to create a process group
+        without considering the global process group in torch.distributed.
+        It is recommended to create `StatelessProcessGroup`, and then initialize
+        the data-plane communication (HCCL) between external (train processes)
+        and vLLM workers.
+        """
+        from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator
+        from vllm.distributed.utils import StatelessProcessGroup
+
+        pg = StatelessProcessGroup.create(
+            host=master_address, port=master_port, rank=rank, world_size=world_size
+        )
+        pyhccl = PyHcclCommunicator(pg, device=device)
+        return pyhccl

--- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NPU IPC-based weight transfer engine using Ascend IPC for communication."""
+
+import os
+import pickle
+import socket
+from collections.abc import Callable, Iterator
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from typing import Any
+
+import pybase64 as base64
+import requests
+import torch
+from torch.multiprocessing.reductions import reduce_tensor
+
+from vllm import envs
+from vllm.config.parallel import ParallelConfig
+from vllm.config.weight_transfer import WeightTransferConfig
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferEngine,
+    WeightTransferInitInfo,
+    WeightTransferUpdateInfo,
+)
+
+
+@dataclass
+class NPUIPCTrainerSendWeightsArgs:
+    """Arguments for NPU IPC trainer_send_weights method."""
+
+    mode: str
+    """Transport mode: 'http' or 'ray'."""
+    llm_handle: Any = None
+    """Ray ObjectRef to LLM handle (required for 'ray' mode)."""
+    url: str | None = None
+    """Base URL for HTTP endpoint (required for 'http' mode)."""
+
+    def __post_init__(self):
+        """Validate that required arguments are provided for the selected mode."""
+        if self.mode == "ray" and self.llm_handle is None:
+            raise ValueError("llm_handle is required for 'ray' mode")
+        if self.mode == "http" and self.url is None:
+            raise ValueError("url is required for 'http' mode")
+        if self.mode not in ("ray", "http"):
+            raise ValueError(f"mode must be 'ray' or 'http', got {self.mode}")
+
+
+@dataclass
+class NPUIPCWeightTransferInitInfo(WeightTransferInitInfo):
+    """Initialization info for NPU IPC weight transfer backend.
+
+    No initialization needed for NPU IPC."""
+
+    pass
+
+
+@dataclass
+class NPUIPCWeightTransferUpdateInfo(WeightTransferUpdateInfo):
+    """Update info for NPU IPC weight transfer backend.
+
+    Accepts IPC handles either directly via ``ipc_handles`` (Ray transport)
+    or as a base64-encoded pickle via ``ipc_handles_pickled`` (HTTP transport).
+    Exactly one of the two must be provided; if ``ipc_handles_pickled`` is set
+    it is unpickled into ``ipc_handles`` during ``__post_init__``.
+    """
+
+    names: list[str]
+    dtype_names: list[str]
+    shapes: list[list[int]]
+    ipc_handles: list[dict[str, tuple[Callable, tuple]]] | None = None
+    """IPC handles mapping physical NPU UUID to (func, args) tuple.
+    Each handle is a dictionary mapping NPU UUID strings to IPC handle tuples."""
+    ipc_handles_pickled: str | None = None
+    """Base64-encoded pickled IPC handles, used for HTTP transport."""
+
+    def __post_init__(self):
+        if self.ipc_handles_pickled is not None:
+            if self.ipc_handles is not None:
+                raise ValueError(
+                    "Cannot specify both `ipc_handles` and `ipc_handles_pickled`"
+                )
+
+            if not envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
+                raise ValueError(
+                    "Refusing to deserialize `ipc_handles_pickled` without "
+                    "VLLM_ALLOW_INSECURE_SERIALIZATION=1"
+                )
+
+            self.ipc_handles = pickle.loads(
+                base64.b64decode(self.ipc_handles_pickled)
+            )
+            self.ipc_handles_pickled = None
+
+        if self.ipc_handles is None:
+            raise ValueError(
+                "Either `ipc_handles` or `ipc_handles_pickled` must be provided"
+            )
+
+        num_params = len(self.names)
+        if len(self.dtype_names) != num_params:
+            raise ValueError(
+                f"`dtype_names` should be of the same size as `names`: "
+                f"got {len(self.dtype_names)} and {len(self.names)}"
+            )
+        if len(self.shapes) != num_params:
+            raise ValueError(
+                f"`shapes` should be of the same size as `names`: "
+                f"got {len(self.shapes)} and {len(self.names)}"
+            )
+        if len(self.ipc_handles) != num_params:
+            raise ValueError(
+                f"`ipc_handles` should be of the same size as `names`: "
+                f"got {len(self.ipc_handles)} and {len(self.names)}"
+            )
+
+
+@lru_cache(maxsize=1)
+def get_ip() -> str:
+    try:
+        # try to get ip from network interface
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception as e:  # noqa: BLE001
+        # fallback to get ip from hostname
+        return socket.gethostbyname(socket.gethostname())
+
+
+@lru_cache(maxsize=1)
+def npu_generate_uuid() -> str:
+    """Generate a unique identifier for the current process's physical NPU chip.
+
+    Returns ``{host_ip}-{physical_chip_id}`` where ``host_ip`` is the local
+    machine's IP address and ``physical_chip_id`` is derived from the current
+    logical device index mapped through ``ASCEND_RT_VISIBLE_DEVICES``.
+
+    On Ascend NPU, ``torch.accelerator.current_device_index()`` returns the
+    *logical* device index. When ``ASCEND_RT_VISIBLE_DEVICES`` is set, it
+    maps logical indices to physical chip IDs (e.g., ``ASCEND_RT_VISIBLE_DEVICES=2,3``
+    means logical device 0 → physical chip 2, logical device 1 → physical chip 3).
+    If the env var is not set, the logical index is used directly as the
+    physical chip ID (identity mapping).
+
+    The result is cached because it is constant for the lifetime of the
+    process. Both the trainer and inference worker processes co-located
+    on the same physical NPU chip will produce the same UUID, which is
+    required for NPU IPC handle matching.
+    """
+    logical_device = torch.accelerator.current_device_index()
+    visible_devices = os.environ.get("ASCEND_RT_VISIBLE_DEVICES", None)
+    if visible_devices:
+        physical_device = int(visible_devices.split(",")[logical_device].strip())
+    else:
+        physical_device = logical_device
+    return f"{get_ip()}-{physical_device}"
+
+
+class NPUIPCWeightTransferEngine(
+    WeightTransferEngine[
+        NPUIPCWeightTransferInitInfo, NPUIPCWeightTransferUpdateInfo
+    ]
+):
+    """
+    Weight transfer engine using NPU IPC for communication between
+    trainer and workers.
+
+    This implementation uses Ascend NPU IPC to transfer weights from the
+    trainer (rank 0) to all inference workers. IPC handles are used to
+    share memory between processes on the same node.
+
+    Requires ``torch_npu`` to be imported (which patches
+    ``torch.multiprocessing.reductions.reduce_tensor`` to support
+    NPU tensors via ``_share_npu_()`` / ``rebuild_npu_tensor``).
+    """
+
+    init_info_cls = NPUIPCWeightTransferInitInfo
+    update_info_cls = NPUIPCWeightTransferUpdateInfo
+
+    def __init__(
+        self, config: WeightTransferConfig, parallel_config: ParallelConfig
+    ) -> None:
+        super().__init__(config, parallel_config)
+
+    def init_transfer_engine(
+        self, init_info: NPUIPCWeightTransferInitInfo
+    ) -> None:
+        """No initialization needed for NPU IPC backend."""
+        pass
+
+    def receive_weights(
+        self,
+        update_info: NPUIPCWeightTransferUpdateInfo,
+        load_weights: Callable[[list[tuple[str, torch.Tensor]]], None],
+    ) -> None:
+        """Receive weights from the trainer via NPU IPC handles.
+
+        Args:
+            update_info: NPU IPC update info containing parameter names,
+                dtypes, shapes, and IPC handles. Each IPC handle is a
+                mapping between physical NPU UUID and the IPC handle tuple
+                (func, args).
+            load_weights: Callable that loads weights into the model.
+        """
+        assert update_info.ipc_handles is not None
+        device_index = torch.accelerator.current_device_index()
+        physical_npu_id = npu_generate_uuid()
+
+        weights = []
+        for name, _dtype_name, _shape, ipc_handle in zip(
+            update_info.names,
+            update_info.dtype_names,
+            update_info.shapes,
+            update_info.ipc_handles,
+        ):
+            if physical_npu_id not in ipc_handle:
+                raise ValueError(
+                    f"IPC handle not found for NPU UUID {physical_npu_id}. "
+                    f"Available UUIDs: {list(ipc_handle.keys())}. "
+                    f"This may indicate that the trainer and worker are "
+                    f"not co-located on the same physical NPU (node)."
+                )
+
+            handle = ipc_handle[physical_npu_id]
+
+            func, args = handle
+            list_args = list(args)  # type: ignore
+            # Index 6 is the device_index parameter in torch's
+            # IPC handle tuple (rebuild_npu_tensor). Update it
+            # to the current device since the logical index can
+            # differ between sender and receiver.
+            list_args[6] = device_index
+            weight = func(*list_args)  # type: ignore
+            weights.append((name, weight))
+
+        load_weights(weights)
+
+    def shutdown(self) -> None:
+        pass
+
+    @staticmethod
+    def trainer_send_weights(
+        iterator: Iterator[tuple[str, torch.Tensor]],
+        trainer_args: dict[str, Any] | NPUIPCTrainerSendWeightsArgs,
+    ) -> None:
+        """Send weights from trainer to inference workers via NPU IPC.
+
+        Supports two modes:
+        - 'ray': Sends weights via Ray RPC to a Ray-based LLM handle
+        - 'http': Sends weights via HTTP POST to a vLLM HTTP server
+
+        Args:
+            iterator: Iterator of model parameters. Returns (name, tensor)
+                tuples. Tensors should be on the same NPU as the inference
+                workers.
+            trainer_args: Dictionary or NPUIPCTrainerSendWeightsArgs instance.
+
+        Example (Ray mode):
+            >>> from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+            ...     NPUIPCWeightTransferEngine,
+            ...     NPUIPCTrainerSendWeightsArgs,
+            ... )
+            >>> param_iter = ((n, p) for n, p in model.named_parameters())
+            >>> args = NPUIPCTrainerSendWeightsArgs(
+            ...     mode="ray", llm_handle=llm_handle
+            ... )
+            >>> NPUIPCWeightTransferEngine.trainer_send_weights(
+            ...     param_iter, asdict(args)
+            ... )
+
+        Example (HTTP mode):
+            >>> args = NPUIPCTrainerSendWeightsArgs(
+            ...     mode="http", url="http://localhost:8000"
+            ... )
+            >>> NPUIPCWeightTransferEngine.trainer_send_weights(
+            ...     param_iter, asdict(args)
+            ... )
+        """
+        if isinstance(trainer_args, dict):
+            args = NPUIPCTrainerSendWeightsArgs(**trainer_args)
+        else:
+            args = trainer_args
+
+        # Get physical NPU UUID
+        npu_uuid = npu_generate_uuid()
+
+        names = []
+        dtype_names = []
+        shapes = []
+        ipc_handles = []
+
+        for name, tensor in iterator:
+            names.append(name)
+            dtype_names.append(str(tensor.dtype).split(".")[-1])
+            shapes.append(list(tensor.shape))
+
+            # Create IPC handle for this weight tensor
+            # The tensor must remain in memory for IPC to work
+            weight = tensor.detach().contiguous()
+            ipc_handle = reduce_tensor(weight)
+            ipc_handles.append({npu_uuid: ipc_handle})
+
+        if args.mode == "ray":
+            import ray
+
+            update_info = asdict(
+                NPUIPCWeightTransferUpdateInfo(
+                    names=names,
+                    dtype_names=dtype_names,
+                    shapes=shapes,
+                    ipc_handles=ipc_handles,
+                )
+            )
+            ray.get(
+                args.llm_handle.update_weights.remote(
+                    dict(update_info=update_info)
+                )
+            )
+        elif args.mode == "http":
+            pickled_handles = base64.b64encode(
+                pickle.dumps(ipc_handles)
+            ).decode("utf-8")
+
+            url = f"{args.url}/update_weights"
+            payload = {
+                "update_info": {
+                    "names": names,
+                    "dtype_names": dtype_names,
+                    "shapes": shapes,
+                    "ipc_handles_pickled": pickled_handles,
+                }
+            }
+            response = requests.post(url, json=payload, timeout=300)
+            response.raise_for_status()

--- a/vllm_ascend/distributed/weight_transfer/packed_tensor.py
+++ b/vllm_ascend/distributed/weight_transfer/packed_tensor.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Packed tensor utilities for efficient weight transfer."""
+
+import math
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+
+# Default values for packed tensor configuration.
+# These are imported by HCCLWeightTransferUpdateInfo and trainer_send_weights.
+DEFAULT_PACKED_BUFFER_SIZE_BYTES = 1024 * 1024 * 1024  # 1GB
+DEFAULT_PACKED_NUM_BUFFERS = 2
+
+
+def packed_broadcast_producer(
+    iterator: Iterator[tuple[str, torch.Tensor]],
+    group: Any,
+    src: int,
+    post_iter_func: Callable[[tuple[str, torch.Tensor]], torch.Tensor],
+    buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES,
+    num_buffers: int = DEFAULT_PACKED_NUM_BUFFERS,
+) -> None:
+    """Broadcast tensors in a packed manner from trainer to workers.
+
+    Args:
+        iterator: Iterator of model parameters. Returns a tuple of (name, tensor)
+        group: Process group (PyHcclCommunicator)
+        src: Source rank (0 in current implementation)
+        post_iter_func: Function to apply to each (name, tensor) pair before
+                       packing, should return a tensor
+        buffer_size_bytes: Size in bytes for each packed tensor buffer.
+                          Both producer and consumer must use the same value.
+        num_buffers: Number of buffers for double/triple buffering.
+                    Both producer and consumer must use the same value.
+    """
+    target_packed_tensor_size = buffer_size_bytes
+
+    streams = [torch.npu.Stream() for _ in range(num_buffers)]
+    buffer_idx = 0
+
+    packing_tensor_list: list[list[torch.Tensor]] = [[] for _ in range(num_buffers)]
+    packing_tensor_sizes: list[int] = [0 for _ in range(num_buffers)]
+    packed_tensors: list[torch.Tensor] = [
+        torch.empty(0, dtype=torch.uint8, device="npu") for _ in range(num_buffers)
+    ]
+
+    done = False
+    while not done:
+        # Synchronize the current stream (waits for previous
+        # iteration's work on this buffer to finish)
+        streams[buffer_idx].synchronize()
+        # Start tasks for the new buffer in a new stream
+        with torch.npu.stream(streams[buffer_idx]):
+            # Initialize the packing tensor list and sizes
+            packing_tensor_list[buffer_idx] = []
+            packing_tensor_sizes[buffer_idx] = 0
+            # Pack the tensors
+            while True:
+                try:
+                    item = next(iterator)
+                except StopIteration:
+                    done = True
+                    break
+                # Apply post processing and convert to linearized uint8 tensor
+                tensor = (
+                    post_iter_func(item).contiguous().view(torch.uint8).view(-1)
+                )
+                packing_tensor_list[buffer_idx].append(tensor)
+                packing_tensor_sizes[buffer_idx] += tensor.numel()
+                if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
+                    break
+            if len(packing_tensor_list[buffer_idx]) > 0:
+                # Pack the tensors
+                packed_tensors[buffer_idx] = torch.cat(
+                    packing_tensor_list[buffer_idx], dim=0
+                )
+
+        if len(packing_tensor_list[buffer_idx]) == 0:
+            # No more tensors — nothing left to broadcast
+            break
+
+        # torch.cat runs on the custom stream.  Synchronize before
+        # broadcasting on the default stream so the packed data is ready.
+        streams[buffer_idx].synchronize()
+        group.broadcast(packed_tensors[buffer_idx], src=src)
+
+        # Move to the next buffer
+        buffer_idx = (buffer_idx + 1) % num_buffers
+
+    # Ensure the last broadcast on the default stream has completed
+    # before returning, so NPU tensor cleanup at exit doesn't hang.
+    torch.npu.current_stream().synchronize()
+
+
+def packed_broadcast_consumer(
+    iterator: Iterator[tuple[str, tuple[list[int], torch.dtype]]],
+    group: Any,
+    src: int,
+    post_unpack_func: Callable[[list[tuple[str, torch.Tensor]]], None],
+    buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES,
+    num_buffers: int = DEFAULT_PACKED_NUM_BUFFERS,
+) -> None:
+    """Consume packed tensors and unpack them into a list of tensors.
+
+    Args:
+        iterator: Iterator of parameter metadata. Returns (name, (shape, dtype))
+        group: Process group (PyHcclCommunicator)
+        src: Source rank (0 in current implementation)
+        post_unpack_func: Function to apply to each list of (name, tensor) after
+                         unpacking
+        buffer_size_bytes: Size in bytes for each packed tensor buffer.
+                          Both producer and consumer must use the same value.
+        num_buffers: Number of buffers for double/triple buffering.
+                    Both producer and consumer must use the same value.
+    """
+
+    def unpack_tensor(
+        packed_tensor: torch.Tensor,
+        names: list[str],
+        shapes: list[list[int]],
+        dtypes: list[torch.dtype],
+        tensor_sizes: list[int],
+    ) -> list[tuple[str, torch.Tensor]]:
+        """Unpack a packed uint8 tensor into a list of typed tensors."""
+        unpacked_tensors = packed_tensor.split(tensor_sizes)
+        unpacked_list = [
+            (name, tensor.contiguous().view(dtype).view(*shape))
+            for name, shape, dtype, tensor in zip(
+                names, shapes, dtypes, unpacked_tensors
+            )
+        ]
+        return unpacked_list
+
+    target_packed_tensor_size = buffer_size_bytes
+
+    streams = [torch.npu.Stream() for _ in range(num_buffers)]
+    default_stream = torch.npu.current_stream()
+    buffer_idx = 0
+
+    packing_tensor_meta_data: list[
+        list[tuple[str, list[int], torch.dtype, int]]
+    ] = [[] for _ in range(num_buffers)]
+    packing_tensor_sizes: list[int] = [0 for _ in range(num_buffers)]
+    packed_tensors: list[torch.Tensor] = [
+        torch.empty(0, dtype=torch.uint8, device="npu") for _ in range(num_buffers)
+    ]
+
+    done = False
+    while not done:
+        # Synchronize the current stream (waits for previous
+        # iteration's load_weights on this buffer to finish)
+        streams[buffer_idx].synchronize()
+        with torch.npu.stream(streams[buffer_idx]):
+            # Collect parameter metadata for this buffer
+            packing_tensor_meta_data[buffer_idx] = []
+            packing_tensor_sizes[buffer_idx] = 0
+            while True:
+                try:
+                    name, (shape, dtype) = next(iterator)
+                except StopIteration:
+                    done = True
+                    break
+                tensor_size = math.prod(shape) * dtype.itemsize
+                packing_tensor_meta_data[buffer_idx].append(
+                    (name, shape, dtype, tensor_size)
+                )
+                packing_tensor_sizes[buffer_idx] += tensor_size
+                if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
+                    break
+            if len(packing_tensor_meta_data[buffer_idx]) > 0:
+                packed_tensors[buffer_idx] = torch.empty(
+                    packing_tensor_sizes[buffer_idx],
+                    dtype=torch.uint8,
+                    device="npu",
+                )
+
+        if len(packing_tensor_meta_data[buffer_idx]) == 0:
+            break
+
+        # Broadcast on the default stream.
+        group.broadcast(packed_tensors[buffer_idx], src=src)
+
+        # Synchronize the default stream so broadcast completes before
+        # load_weights (running on the custom stream) reads the data.
+        default_stream.synchronize()
+
+        # Unpack and load weights on the custom stream
+        with torch.npu.stream(streams[buffer_idx]):
+            names, shapes, dtypes, tensor_sizes = zip(
+                *packing_tensor_meta_data[buffer_idx]
+            )
+            post_unpack_func(
+                unpack_tensor(
+                    packed_tensors[buffer_idx],
+                    list(names),
+                    list(shapes),
+                    list(dtypes),
+                    list(tensor_sizes),
+                )
+            )
+
+        # Move to the next buffer
+        buffer_idx = (buffer_idx + 1) % num_buffers
+
+    # Wait for all in-flight load_weights (on custom streams) to finish.
+    # Otherwise NPU tensor cleanup at exit may hang.
+    for s in streams:
+        s.synchronize()

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -31,6 +31,7 @@ import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
+import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 

--- a/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
+++ b/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Patch target: vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory
+#
+# Replace the "nccl" factory entry with HCCLWeightTransferEngine so that
+# --weight-transfer-config '{"backend": "nccl"}' loads the HCCL engine
+# instead of the (unavailable) NCCL engine on Ascend NPU.
+#
+# Why this approach (factory swap) instead of patching Literal["nccl", "ipc"]:
+#   WeightTransferConfig.backend is a pydantic Literal["nccl", "ipc"].
+#   Adding "hccl" would require modifying pydantic core schemas — fragile
+#   across pydantic versions.  Swapping the factory entry means users pass
+#   the already-accepted "nccl" string, but the factory resolves it to HCCL.
+#
+# Timing — guaranteed to run before first factory usage:
+#
+#   vllm serve main()
+#     line 24: from vllm.entrypoints.utils import ...
+#       → vllm.platforms.__getattr__("current_platform")
+#       → resolve_current_platform_cls_qualname()
+#       → vllm_ascend:register() → NPUPlatform()
+#       → NPUPlatform.pre_register_and_update()
+#       → adapt_patch(is_global_patch=True)
+#       → imports vllm_ascend.patch.platform
+#       → THIS PATCH RUNS  ← "nccl" now points to HCCLWeightTransferEngine
+#     ...
+#     lines 82-86: subparser_init() → make_arg_parser()
+#     line 87: parse_args() → validates backend="nccl" via Literal (passes)
+#     ...
+#     later: worker init → WeightTransferEngineFactory.create_engine(config)
+#       → config.backend == "nccl" → factory loads HCCLWeightTransferEngine
+#
+# Future Plan:
+#   Remove this patch when upstream vllm relaxes the Literal type to str
+#   or provides an extension point for out-of-tree backends.
+
+from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLWeightTransferEngine,
+)
+
+WeightTransferEngineFactory._registry["nccl"] = lambda: HCCLWeightTransferEngine

--- a/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
+++ b/vllm_ascend/patch/platform/patch_weight_transfer_engine.py
@@ -15,15 +15,17 @@
 #
 # Patch target: vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory
 #
-# Replace the "nccl" factory entry with HCCLWeightTransferEngine so that
-# --weight-transfer-config '{"backend": "nccl"}' loads the HCCL engine
-# instead of the (unavailable) NCCL engine on Ascend NPU.
+# Replace the "nccl" and "ipc" factory entries with Ascend equivalents so that
+# --weight-transfer-config '{"backend": "nccl"}' loads HCCLWeightTransferEngine
+# and '{"backend": "ipc"}' loads NPUIPCWeightTransferEngine instead of the
+# (unavailable) NCCL / CUDA IPC engines on Ascend NPU.
 #
 # Why this approach (factory swap) instead of patching Literal["nccl", "ipc"]:
 #   WeightTransferConfig.backend is a pydantic Literal["nccl", "ipc"].
-#   Adding "hccl" would require modifying pydantic core schemas — fragile
-#   across pydantic versions.  Swapping the factory entry means users pass
-#   the already-accepted "nccl" string, but the factory resolves it to HCCL.
+#   Adding "hccl" / "npu_ipc" would require modifying pydantic core schemas —
+#   fragile across pydantic versions. Swapping the factory entries means users
+#   pass the already-accepted "nccl" / "ipc" strings, but the factory resolves
+#   them to HCCL / NPU IPC.
 #
 # Timing — guaranteed to run before first factory usage:
 #
@@ -51,5 +53,9 @@ from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 from vllm_ascend.distributed.weight_transfer.hccl_engine import (
     HCCLWeightTransferEngine,
 )
+from vllm_ascend.distributed.weight_transfer.npu_ipc_engine import (
+    NPUIPCWeightTransferEngine,
+)
 
 WeightTransferEngineFactory._registry["nccl"] = lambda: HCCLWeightTransferEngine
+WeightTransferEngineFactory._registry["ipc"] = lambda: NPUIPCWeightTransferEngine

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -31,9 +31,14 @@ from torch_npu.profiler import dynamic_profile as dp
 from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
 from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
-from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized, get_kv_transfer_group, has_kv_transfer_group
-from vllm.distributed.weight_transfer import WeightTransferEngineFactory
+from vllm.distributed.kv_transfer import (
+    ensure_kv_transfer_initialized,
+    ensure_kv_transfer_shutdown,
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
 from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
+from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
 from vllm.sequence import IntermediateTensors
@@ -148,14 +153,6 @@ class NPUWorker(WorkerBase):
             self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
 
         # Weight transfer engine (initialized on-demand)
-        # Ensure HCCL engine is registered before creating it.
-        # register_engine() is not idempotent, so guard against double-registration
-        # which can happen if the plugin connector already registered it.
-        from vllm_ascend.distributed.weight_transfer import register_engine
-        try:
-            register_engine()
-        except ValueError:
-            pass  # already registered
         self.weight_transfer_engine = (
             WeightTransferEngineFactory.create_engine(
                 self.vllm_config.weight_transfer_config,
@@ -284,6 +281,110 @@ class NPUWorker(WorkerBase):
                 if name in self._sleep_saved_buffers:
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
+
+    def _check_weight_transfer_engine(self) -> None:
+        if self.weight_transfer_engine is None:
+            raise RuntimeError(
+                "Weight transfer not configured. Please set weight_transfer_config to enable weight transfer."
+            )
+
+    def init_weight_transfer_engine(self, init_info: dict) -> None:
+        """Initialize the HCCL weight transfer process group with the trainer."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
+        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+    def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
+        """Begin a new weight update; prepares the model for layerwise reload."""
+        self._check_weight_transfer_engine()
+
+        if self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update called while a weight update is already active. Call finish_weight_update first."
+            )
+
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is enabled. This may cause model parameter "
+                "precision issues in the RL scenarios. Please set "
+                "VLLM_ASCEND_ENABLE_NZ=0."
+            )
+
+        if is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                initialize_layerwise_reload(model)
+
+        self._is_checkpoint_format = is_checkpoint_format
+        self._weight_update_active = True
+
+    def update_weights(self, update_info: dict) -> None:
+        """Receive a chunk of weights from the trainer and load them in place."""
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if not self._weight_update_active:
+            raise RuntimeError("start_weight_update must be called before update_weights.")
+
+        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
+        model = self.model_runner.model
+
+        with torch.device(self.device):
+            if self._is_checkpoint_format:
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=model.load_weights,
+                )
+            else:
+
+                def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
+                    for name, weight in weights:
+                        param = model.get_parameter(name)
+                        param.copy_(weight)
+
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=load_weights_direct,
+                )
+
+        # HCCL broadcast / packed paths are asynchronous.
+        # Sync so the next step uses the new weights.
+        torch.npu.synchronize()
+
+    def finish_weight_update(self) -> None:
+        """Finish the current weight update; runs layerwise postprocessing."""
+        self._check_weight_transfer_engine()
+
+        if not self._weight_update_active:
+            raise RuntimeError("start_weight_update must be called before finish_weight_update.")
+
+        if self._is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import finalize_layerwise_reload
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                finalize_layerwise_reload(model, self.model_config)
+
+        self._weight_update_active = False
+        self._is_checkpoint_format = True
+
+    def shutdown(self) -> None:
+        if ensure_kv_transfer_shutdown is not None:
+            ensure_kv_transfer_shutdown()
+
+        if self.profiler is not None:
+            self.profiler.shutdown()
+
+        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
+            weight_transfer_engine.shutdown()
+
+        if model_runner := getattr(self, "model_runner", None):
+            shutdown_fn = getattr(model_runner, "shutdown", None)
+            if callable(shutdown_fn):
+                shutdown_fn()
 
     def initialize_cache(self, num_gpu_blocks: int, num_cpu_blocks: int) -> None:
         self.cache_config.num_gpu_blocks = num_gpu_blocks
@@ -611,142 +712,6 @@ class NPUWorker(WorkerBase):
         weight = torch.rand((2, 4), dtype=torch.float16).npu()
         c = torch.rand((4, 4), dtype=torch.float32).npu()
         torch_npu._npu_matmul_add_fp32(x, weight, c)
-
-    def _check_weight_transfer_engine(self) -> None:
-        if self.weight_transfer_engine is None:
-            raise RuntimeError(
-                "Weight transfer not configured. "
-                "Please set weight_transfer_config to enable weight transfer."
-            )
-
-    def init_weight_transfer_engine(self, init_info: dict) -> None:
-        """Initialize weight transfer mechanism for HCCL backend.
-
-        This creates a stateless process group with the trainer process
-        for HCCL weight broadcasting.
-
-        Args:
-            init_info: Dictionary containing backend-specific initialization info
-                (master_address, master_port, rank_offset, world_size)
-        """
-        self._check_weight_transfer_engine()
-        assert self.weight_transfer_engine is not None
-        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
-        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
-
-    def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
-        """Start a new weight update.
-
-        Prepares the model for receiving weights. For checkpoint format,
-        this initializes state for layerwise processing. For kernel format,
-        this is a no-op but must still be called for consistency.
-
-        Args:
-            is_checkpoint_format: Whether incoming weights are in checkpoint
-                format (need layerwise processing) or kernel format (direct
-                copy). Stored as state for finish_weight_update.
-        """
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
-            raise ValueError(
-                "FRACTAL_NZ mode is not supported for weight update. "
-                "Please set VLLM_ASCEND_ENABLE_NZ=0."
-            )
-        self._check_weight_transfer_engine()
-
-        if self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update called while a weight update is "
-                "already active. Call finish_weight_update first."
-            )
-
-        if is_checkpoint_format:
-            from vllm.model_executor.model_loader.reload import (
-                initialize_layerwise_reload,
-            )
-
-            model = self.model_runner.model
-            with torch.device(self.device):
-                initialize_layerwise_reload(model)
-
-        self._is_checkpoint_format = is_checkpoint_format
-        self._weight_update_active = True
-
-    def update_weights(self, update_info: dict) -> None:
-        """Receive weights from the trainer (one or more chunks).
-
-        start_weight_update must be called before update_weights and
-        finish_weight_update must be called after.
-
-        Args:
-            update_info: Dictionary containing backend-specific update info
-                (names, dtype_names, shapes, packed, etc.)
-        """
-        self._check_weight_transfer_engine()
-        assert self.weight_transfer_engine is not None
-
-        if not self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update must be called before update_weights."
-            )
-
-        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
-
-        model = self.model_runner.model
-
-        with torch.device(self.device):
-            if self._is_checkpoint_format:
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=model.load_weights,
-                )
-            else:
-                def load_weights_direct(
-                    weights: list[tuple[str, torch.Tensor]],
-                ) -> None:
-                    for name, weight in weights:
-                        param = model.get_parameter(name)
-                        param.copy_(weight)
-
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=load_weights_direct,
-                )
-
-        # HCCL broadcast/packed path are asynchronous.
-        # Sync here so the next step uses the new weights.
-        torch.npu.synchronize()
-
-    def finish_weight_update(self) -> None:
-        """Finish the current weight update.
-
-        For checkpoint format, this runs layerwise postprocessing.
-        Uses the is_checkpoint_format state stored by start_weight_update.
-        """
-        self._check_weight_transfer_engine()
-
-        if not self._weight_update_active:
-            raise RuntimeError(
-                "start_weight_update must be called before finish_weight_update."
-            )
-
-        is_checkpoint_format = self._is_checkpoint_format
-
-        if is_checkpoint_format:
-            from vllm.model_executor.model_loader.reload import (
-                finalize_layerwise_reload,
-            )
-
-            model = self.model_runner.model
-            with torch.device(self.device):
-                finalize_layerwise_reload(model, self.model_config)
-
-        # Reset state
-        self._weight_update_active = False
-        self._is_checkpoint_format = True
-
-    def shutdown(self) -> None:
-        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
-            weight_transfer_engine.shutdown()
 
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -32,6 +32,7 @@ from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
 from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
 from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized, get_kv_transfer_group, has_kv_transfer_group
+from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
@@ -145,6 +146,26 @@ class NPUWorker(WorkerBase):
         if vllm_config.model_config and vllm_config.model_config.enable_sleep_mode:
             # Buffers saved before sleep
             self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
+
+        # Weight transfer engine (initialized on-demand)
+        # Ensure HCCL engine is registered before creating it.
+        # register_engine() is not idempotent, so guard against double-registration
+        # which can happen if the plugin connector already registered it.
+        from vllm_ascend.distributed.weight_transfer import register_engine
+        try:
+            register_engine()
+        except ValueError:
+            pass  # already registered
+        self.weight_transfer_engine = (
+            WeightTransferEngineFactory.create_engine(
+                self.vllm_config.weight_transfer_config,
+                self.vllm_config.parallel_config,
+            )
+            if self.vllm_config.weight_transfer_config is not None
+            else None
+        )
+        self._weight_update_active = False
+        self._is_checkpoint_format = True
 
         # FixMe: this is a patch to fix the issue cause by https://github.com/vllm-project/vllm/commit/de94289a98d7ec52a5ef02719e01a1db8b505170
         from vllm.model_executor.layers.linear import WEIGHT_LOADER_V2_SUPPORTED
@@ -590,6 +611,142 @@ class NPUWorker(WorkerBase):
         weight = torch.rand((2, 4), dtype=torch.float16).npu()
         c = torch.rand((4, 4), dtype=torch.float32).npu()
         torch_npu._npu_matmul_add_fp32(x, weight, c)
+
+    def _check_weight_transfer_engine(self) -> None:
+        if self.weight_transfer_engine is None:
+            raise RuntimeError(
+                "Weight transfer not configured. "
+                "Please set weight_transfer_config to enable weight transfer."
+            )
+
+    def init_weight_transfer_engine(self, init_info: dict) -> None:
+        """Initialize weight transfer mechanism for HCCL backend.
+
+        This creates a stateless process group with the trainer process
+        for HCCL weight broadcasting.
+
+        Args:
+            init_info: Dictionary containing backend-specific initialization info
+                (master_address, master_port, rank_offset, world_size)
+        """
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
+        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+    def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
+        """Start a new weight update.
+
+        Prepares the model for receiving weights. For checkpoint format,
+        this initializes state for layerwise processing. For kernel format,
+        this is a no-op but must still be called for consistency.
+
+        Args:
+            is_checkpoint_format: Whether incoming weights are in checkpoint
+                format (need layerwise processing) or kernel format (direct
+                copy). Stored as state for finish_weight_update.
+        """
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is not supported for weight update. "
+                "Please set VLLM_ASCEND_ENABLE_NZ=0."
+            )
+        self._check_weight_transfer_engine()
+
+        if self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update called while a weight update is "
+                "already active. Call finish_weight_update first."
+            )
+
+        if is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import (
+                initialize_layerwise_reload,
+            )
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                initialize_layerwise_reload(model)
+
+        self._is_checkpoint_format = is_checkpoint_format
+        self._weight_update_active = True
+
+    def update_weights(self, update_info: dict) -> None:
+        """Receive weights from the trainer (one or more chunks).
+
+        start_weight_update must be called before update_weights and
+        finish_weight_update must be called after.
+
+        Args:
+            update_info: Dictionary containing backend-specific update info
+                (names, dtype_names, shapes, packed, etc.)
+        """
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update must be called before update_weights."
+            )
+
+        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
+
+        model = self.model_runner.model
+
+        with torch.device(self.device):
+            if self._is_checkpoint_format:
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=model.load_weights,
+                )
+            else:
+                def load_weights_direct(
+                    weights: list[tuple[str, torch.Tensor]],
+                ) -> None:
+                    for name, weight in weights:
+                        param = model.get_parameter(name)
+                        param.copy_(weight)
+
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=load_weights_direct,
+                )
+
+        # HCCL broadcast/packed path are asynchronous.
+        # Sync here so the next step uses the new weights.
+        torch.npu.synchronize()
+
+    def finish_weight_update(self) -> None:
+        """Finish the current weight update.
+
+        For checkpoint format, this runs layerwise postprocessing.
+        Uses the is_checkpoint_format state stored by start_weight_update.
+        """
+        self._check_weight_transfer_engine()
+
+        if not self._weight_update_active:
+            raise RuntimeError(
+                "start_weight_update must be called before finish_weight_update."
+            )
+
+        is_checkpoint_format = self._is_checkpoint_format
+
+        if is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+            )
+
+            model = self.model_runner.model
+            with torch.device(self.device):
+                finalize_layerwise_reload(model, self.model_config)
+
+        # Reset state
+        self._weight_update_active = False
+        self._is_checkpoint_format = True
+
+    def shutdown(self) -> None:
+        if weight_transfer_engine := getattr(self, "weight_transfer_engine", None):
+            weight_transfer_engine.shutdown()
 
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -295,8 +295,20 @@ class NPUWorker(WorkerBase):
         typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
+    def _check_nz_disabled(self) -> None:
+        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+            raise ValueError(
+                "FRACTAL_NZ mode is enabled. This may cause model parameter "
+                "precision issues in the RL scenarios. Please set "
+                "VLLM_ASCEND_ENABLE_NZ=0."
+            )
+
     def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
-        """Begin a new weight update; prepares the model for layerwise reload."""
+        """Begin a new weight update; prepares the model for layerwise reload.
+
+        Only invoked on vLLM main. v0.20.2 has no /start_weight_update endpoint
+        and folds init/finalize layerwise reload into update_weights itself.
+        """
         self._check_weight_transfer_engine()
 
         if self._weight_update_active:
@@ -304,12 +316,7 @@ class NPUWorker(WorkerBase):
                 "start_weight_update called while a weight update is already active. Call finish_weight_update first."
             )
 
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
-            raise ValueError(
-                "FRACTAL_NZ mode is enabled. This may cause model parameter "
-                "precision issues in the RL scenarios. Please set "
-                "VLLM_ASCEND_ENABLE_NZ=0."
-            )
+        self._check_nz_disabled()
 
         if is_checkpoint_format:
             from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
@@ -326,36 +333,73 @@ class NPUWorker(WorkerBase):
         self._check_weight_transfer_engine()
         assert self.weight_transfer_engine is not None
 
-        if not self._weight_update_active:
-            raise RuntimeError("start_weight_update must be called before update_weights.")
-
         typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
         model = self.model_runner.model
 
-        with torch.device(self.device):
-            if self._is_checkpoint_format:
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=model.load_weights,
-                )
-            else:
+        if vllm_version_is("0.20.2"):
+            # v0.20.2 lifecycle: update_weights is self-contained — it runs
+            # initialize_layerwise_reload before receive_weights and
+            # finalize_layerwise_reload after, reading is_checkpoint_format
+            # off the update_info payload (no start/finish endpoints).
+            self._check_nz_disabled()
+            is_checkpoint_format = typed_update_info.is_checkpoint_format
+            with torch.device(self.device):
+                if is_checkpoint_format:
+                    from vllm.model_executor.model_loader.reload import (
+                        finalize_layerwise_reload,
+                        initialize_layerwise_reload,
+                    )
 
-                def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
-                    for name, weight in weights:
-                        param = model.get_parameter(name)
-                        param.copy_(weight)
+                    initialize_layerwise_reload(model)
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=model.load_weights,
+                    )
+                    finalize_layerwise_reload(model, self.model_config)
+                else:
 
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=load_weights_direct,
-                )
+                    def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
+                        for name, weight in weights:
+                            param = model.get_parameter(name)
+                            param.copy_(weight)
+
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=load_weights_direct,
+                    )
+        else:
+            # main lifecycle: state machine driven by start/finish.
+            if not self._weight_update_active:
+                raise RuntimeError("start_weight_update must be called before update_weights.")
+
+            with torch.device(self.device):
+                if self._is_checkpoint_format:
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=model.load_weights,
+                    )
+                else:
+
+                    def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
+                        for name, weight in weights:
+                            param = model.get_parameter(name)
+                            param.copy_(weight)
+
+                    self.weight_transfer_engine.receive_weights(
+                        typed_update_info,
+                        load_weights=load_weights_direct,
+                    )
 
         # HCCL broadcast / packed paths are asynchronous.
         # Sync so the next step uses the new weights.
         torch.npu.synchronize()
 
     def finish_weight_update(self) -> None:
-        """Finish the current weight update; runs layerwise postprocessing."""
+        """Finish the current weight update; runs layerwise postprocessing.
+
+        Only invoked on vLLM main. v0.20.2 has no /finish_weight_update endpoint
+        and folds layerwise finalization into update_weights itself.
+        """
         self._check_weight_transfer_engine()
 
         if not self._weight_update_active:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -119,6 +119,21 @@ class NPUWorker(WorkerBase):
             is_driver_worker=is_driver_worker,
         )
 
+        # Weight transfer engine for RLHF.  On Ascend the factory "nccl"
+        # entry is patched to return HCCLWeightTransferEngine, so
+        # backend="nccl" in weight_transfer_config actually loads HCCL.
+        from vllm.distributed.weight_transfer.factory import (
+            WeightTransferEngineFactory,
+        )
+
+        self.weight_transfer_engine = (
+            WeightTransferEngineFactory.create_engine(
+                self.vllm_config.weight_transfer_config,
+                self.vllm_config.parallel_config,
+            )
+            if self.vllm_config.weight_transfer_config is not None
+            else None
+        )
         if self.cache_config.cache_dtype == "auto":
             self.cache_dtype = self.model_config.dtype
         else:
@@ -755,6 +770,57 @@ class NPUWorker(WorkerBase):
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()
+
+    def _check_weight_transfer_engine(self) -> None:
+        if self.weight_transfer_engine is None:
+            raise RuntimeError(
+                "Weight transfer not configured. "
+                "Please set weight_transfer_config to enable weight transfer."
+            )
+
+    def init_weight_transfer_engine(self, init_info: dict) -> None:
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+        typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
+        self.weight_transfer_engine.init_transfer_engine(typed_init_info)
+
+    def update_weights(self, update_info: dict) -> None:
+        self._check_weight_transfer_engine()
+        assert self.weight_transfer_engine is not None
+
+        typed_update_info = self.weight_transfer_engine.parse_update_info(
+            update_info
+        )
+
+        model = self.model_runner.model
+
+        if typed_update_info.is_checkpoint_format:
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+                initialize_layerwise_reload,
+            )
+
+            with torch.device(self.device):
+                initialize_layerwise_reload(model)
+                self.weight_transfer_engine.receive_weights(
+                    typed_update_info,
+                    load_weights=model.load_weights,
+                )
+                finalize_layerwise_reload(model, self.model_config)
+        else:
+            def load_weights_direct(
+                weights: list[tuple[str, torch.Tensor]],
+            ) -> None:
+                for name, weight in weights:
+                    param = model.get_parameter(name)
+                    param.copy_(weight)
+
+            self.weight_transfer_engine.receive_weights(
+                typed_update_info,
+                load_weights=load_weights_direct,
+            )
+
+        torch.accelerator.synchronize()
 
     def check_health(self) -> None:
         import subprocess

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -359,9 +359,10 @@ class NPUWorker(WorkerBase):
                 else:
 
                     def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
-                        for name, weight in weights:
-                            param = model.get_parameter(name)
-                            param.copy_(weight)
+                        with torch.no_grad():
+                            for name, weight in weights:
+                                param = model.get_parameter(name)
+                                param.copy_(weight)
 
                     self.weight_transfer_engine.receive_weights(
                         typed_update_info,
@@ -381,9 +382,10 @@ class NPUWorker(WorkerBase):
                 else:
 
                     def load_weights_direct(weights: list[tuple[str, torch.Tensor]]) -> None:
-                        for name, weight in weights:
-                            param = model.get_parameter(name)
-                            param.copy_(weight)
+                        with torch.no_grad():
+                            for name, weight in weights:
+                                param = model.get_parameter(name)
+                                param.copy_(weight)
 
                     self.weight_transfer_engine.receive_weights(
                         typed_update_info,


### PR DESCRIPTION
### What this PR does / why we need it?

See  #9152 
See #9406 

- Add NPU IPC weight transfer engine (`NPUIPCWeightTransferEngine`) for Ascend NPU, enabling zero-copy weight synchronization from trainer to inference workers via shared memory
- Map the "ipc" backend to `NPUIPCWeightTransferEngine` using the factory swap strategy, so users pass the already-accepted "ipc" string without needing upstream pydantic schema changes
- Add `rlhf_http_npu_ipc.py` example script demonstrating the full RLHF workflow with NPU IPC weight sync over HTTP

#### Key Changes

vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py (new)

- NPUIPCWeightTransferEngine: Full implementation of the WeightTransferEngine interface — init_transfer_engine (no-op), receive_weights (rebuilds NPU tensors from IPC handles), and trainer_send_weights (creates IPC handles and sends them via Ray RPC or HTTP POST)
- NPUIPCWeightTransferUpdateInfo: Supports two transport modes — ipc_handles (direct Ray) and ipc_handles_pickled (HTTP via base64+pickle), with `VLLM_ALLOW_INSECURE_SERIALIZATION `safety gate
- npu_generate_uuid: Resolves the logical device index to a physical chip ID using `ASCEND_RT_VISIBLE_DEVICES`, producing a **{host_ip}-{physical_chip_id}** UUID for IPC handle matching between trainer and worker processes
- receive_weights: Matches IPC handles by UUID, rebuilds tensors via torch's `rebuild_npu_tensor`, and loads them into the model

vllm_ascend/patch/platform/patch_weight_transfer_engine.py (modified)

- Extend factory swap: add "ipc" → `NPUIPCWeightTransferEngine` mapping alongside the existing "nccl" → `HCCLWeightTransferEngine` mapping

vllm_ascend/distributed/weight_transfer/__init__.py (modified)

- Register the npu_ipc engine with `WeightTransferEngineFactory`

#### How It Works

```shell
  Trainer (Python process)              vLLM Worker
        |                                     |
        |-- reduce_tensor(weight) --> IPC handle
        |-- POST /update_weights -------->    |
        |   {names, shapes,                  |
        |    ipc_handles_pickled}            |
        |                              unpickle → rebuild_npu_tensor(handle)
        |                                     |
        |                              load_weights(weights)
```

Unlike the HCCL backend, NPU IPC requires the training model and vLLM server to be **co-located** on the same physical NPU. The `ASCEND_RT_VISIBLE_DEVICES` mapping ensures both sides produce matching UUIDs for IPC handle lookup.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

`examples/rl/rlhf_http_npu_ipc.py`

End-to-end RLHF example: load training model → generate nonsense text → init weight transfer → pause generation → sync weights via NPU IPC → resume generation → verify coherent output

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
