### PR TITLE
[Feature] Adapt load balance proxy example to shared scheduler workers

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -188,6 +188,19 @@ def setup_logging(log_level: str) -> None:
     )
 
 
+def next_req_id() -> str:
+    return str(uuid.uuid4())
+
+
+def calculate_prefill_score(request_length: int) -> float:
+    length_score = request_length / 4.0
+    return length_score * 0.0345 + 120.0745
+
+
+def calculate_decode_score(request_length: int) -> float:
+    return request_length
+
+
 def normalize_host(host: str) -> str:
     return host.replace("localhost", "0.0.0.0").replace("127.0.0.1", "0.0.0.0")
 
@@ -311,15 +324,11 @@ class SharedProxyScheduler:
         with self._lock:
             self.request_num = max(0, self.request_num - 1)
 
-    def next_req_id(self) -> str:
-        return str(uuid.uuid4())
-
-    def calculate_prefill_scores(self, request_length: int) -> float:
-        length_score = request_length / 4.0
-        return length_score * 0.0345 + 120.0745
-
-    def calculate_decode_scores(self, request_length: int) -> float:
-        return request_length
+    def start_request_and_reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
+        with self._lock:
+            prefiller = self._reserve_prefiller_kv_no_lock(token_count)
+            self.request_num += 1
+            return prefiller
 
     def select_prefiller(self, token_count: float) -> dict[str, Any]:
         with self._lock:
@@ -335,6 +344,28 @@ class SharedProxyScheduler:
             )
             return {"key": key, "host": state["host"], "port": state["port"]}
 
+    def _reserve_prefiller_kv_no_lock(self, token_count: float) -> dict[str, Any]:
+        if not self.prefiller_heap:
+            raise RuntimeError("No prefiller servers available")
+        _, _, key = heapq.heappop(self.prefiller_heap)
+        state = self.prefillers[key]
+        state["active_kv_cache"] += token_count
+        heapq.heappush(
+            self.prefiller_heap,
+            (self._priority_no_lock(InstanceType.PREFILL, key), state["ordinal"], key),
+        )
+        return {"key": key, "host": state["host"], "port": state["port"]}
+
+    def reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
+        """Select a prefiller and reserve only its KV pressure.
+
+        The request hot path releases prefiller active tokens immediately after
+        remote prefill finishes. Tracking only the net KV reservation avoids a
+        second manager RPC per request while keeping decode-time KV balancing.
+        """
+        with self._lock:
+            return self._reserve_prefiller_kv_no_lock(token_count)
+
     def release_prefiller(self, key: str, token_count: float) -> None:
         with self._lock:
             if key not in self.prefillers:
@@ -344,24 +375,30 @@ class SharedProxyScheduler:
 
     def release_prefiller_kv(self, key: str, token_count: float) -> None:
         with self._lock:
-            if key not in self.prefillers:
-                return
-            state = self.prefillers[key]
-            state["active_kv_cache"] = max(0.0, float(state["active_kv_cache"]) - token_count)
-            self._rebuild_heap_no_lock(InstanceType.PREFILL)
+            self._release_prefiller_kv_no_lock(key, token_count)
+
+    def _release_prefiller_kv_no_lock(self, key: str, token_count: float) -> None:
+        if key not in self.prefillers:
+            return
+        state = self.prefillers[key]
+        state["active_kv_cache"] = max(0.0, float(state["active_kv_cache"]) - token_count)
+        self._rebuild_heap_no_lock(InstanceType.PREFILL)
 
     def select_decoder(self, token_count: float) -> dict[str, Any]:
         with self._lock:
-            if not self.decoder_heap:
-                raise RuntimeError("No decoder servers available")
-            _, _, key = heapq.heappop(self.decoder_heap)
-            state = self.decoders[key]
-            state["active_tokens"] += token_count
-            heapq.heappush(
-                self.decoder_heap,
-                (self._priority_no_lock(InstanceType.DECODE, key), state["ordinal"], key),
-            )
-            return {"key": key, "host": state["host"], "port": state["port"]}
+            return self._select_decoder_no_lock(token_count)
+
+    def _select_decoder_no_lock(self, token_count: float) -> dict[str, Any]:
+        if not self.decoder_heap:
+            raise RuntimeError("No decoder servers available")
+        _, _, key = heapq.heappop(self.decoder_heap)
+        state = self.decoders[key]
+        state["active_tokens"] += token_count
+        heapq.heappush(
+            self.decoder_heap,
+            (self._priority_no_lock(InstanceType.DECODE, key), state["ordinal"], key),
+        )
+        return {"key": key, "host": state["host"], "port": state["port"]}
 
     def release_decoder(self, key: str, token_count: float) -> None:
         with self._lock:
@@ -369,6 +406,27 @@ class SharedProxyScheduler:
                 return
             self.decoders[key]["active_tokens"] -= token_count
             self._rebuild_heap_no_lock(InstanceType.DECODE)
+
+    def finish_request(
+        self,
+        prefiller_key: str | None,
+        prefiller_token_count: float,
+        decoder_key: str | None,
+        decoder_token_count: float,
+        release_prefiller_kv: bool,
+    ) -> None:
+        with self._lock:
+            if release_prefiller_kv and prefiller_key in self.prefillers:
+                prefiller = self.prefillers[prefiller_key]
+                prefiller["active_kv_cache"] = max(
+                    0.0,
+                    float(prefiller["active_kv_cache"]) - prefiller_token_count,
+                )
+                self._rebuild_heap_no_lock(InstanceType.PREFILL)
+            if decoder_key in self.decoders:
+                self.decoders[decoder_key]["active_tokens"] -= decoder_token_count
+                self._rebuild_heap_no_lock(InstanceType.DECODE)
+            self.request_num = max(0, self.request_num - 1)
 
     def get_waiting_nodes(self) -> dict[str, tuple[str, tuple[str, int], int]]:
         with self._lock:
@@ -528,6 +586,22 @@ class WorkerRuntime:
             await client.aclose()
         self.prefiller_clients.clear()
         self.decoder_clients.clear()
+
+
+async def get_prefiller_client(key: str) -> httpx.AsyncClient:
+    try:
+        return runtime.get_prefiller_client(key)
+    except KeyError:
+        await runtime.sync_clients()
+        return runtime.get_prefiller_client(key)
+
+
+async def get_decoder_client(key: str) -> httpx.AsyncClient:
+    try:
+        return runtime.get_decoder_client(key)
+    except KeyError:
+        await runtime.sync_clients()
+        return runtime.get_decoder_client(key)
 
 
 class NodeListener:
@@ -801,17 +875,26 @@ async def stream_service_response_with_retry(
                 raise exc
 
 
-async def handle_select_instance(api: str, req_data: Any, request_length: int) -> InstanceInfo:
-    await runtime.sync_clients()
+async def handle_select_instance(
+    api: str,
+    req_data: Any,
+    request_length: int,
+    start_request: bool,
+) -> InstanceInfo:
     scheduler = runtime.scheduler
-    prefiller_score = scheduler.calculate_prefill_scores(request_length)
-    request_id = scheduler.next_req_id()
-    prefiller = scheduler.select_prefiller(prefiller_score)
+    prefiller_score = calculate_prefill_score(request_length)
+    decoder_score = calculate_decode_score(request_length)
+    request_id = next_req_id()
+    if start_request:
+        prefiller = scheduler.start_request_and_reserve_prefiller_kv(prefiller_score)
+    else:
+        prefiller = scheduler.reserve_prefiller_kv(prefiller_score)
     prefiller_key = prefiller["key"]
+    prefiller_client = await get_prefiller_client(prefiller_key)
 
     try:
         response = await send_request_to_service(
-            runtime.get_prefiller_client(prefiller_key),
+            prefiller_client,
             prefiller_key,
             api,
             req_data,
@@ -819,21 +902,33 @@ async def handle_select_instance(api: str, req_data: Any, request_length: int) -
             max_retries=global_args.max_retries,
             base_delay=global_args.retry_delay,
         )
-    finally:
-        scheduler.release_prefiller(prefiller_key, prefiller_score)
+    except Exception:
+        if start_request:
+            scheduler.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
+        else:
+            scheduler.release_prefiller_kv(prefiller_key, prefiller_score)
+        raise
 
     response_json = response.json()
     kv_transfer_params = response_json.get("kv_transfer_params", {})
     if kv_transfer_params:
         req_data["kv_transfer_params"] = kv_transfer_params
 
-    decoder_score = scheduler.calculate_decode_scores(request_length)
-    decoder = scheduler.select_decoder(decoder_score)
+    try:
+        decoder = scheduler.select_decoder(decoder_score)
+    except Exception:
+        if start_request:
+            scheduler.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
+        else:
+            scheduler.release_prefiller_kv(prefiller_key, prefiller_score)
+        raise
     decoder_key = decoder["key"]
+    decoder_client = await get_decoder_client(decoder_key)
+
     logger.debug(
         "Using %s %s",
-        runtime.get_prefiller_client(prefiller_key).base_url,
-        runtime.get_decoder_client(decoder_key).base_url,
+        prefiller_client.base_url,
+        decoder_client.base_url,
     )
     return InstanceInfo(
         request_id=request_id,
@@ -853,19 +948,19 @@ async def select_recompute_instance(
     previous_instance: InstanceInfo,
 ) -> InstanceInfo:
     """Release the old decoder before assigning a new instance for recompute."""
+    runtime.scheduler.release_prefiller_kv(previous_instance.prefiller_key, previous_instance.prefiller_score)
     runtime.scheduler.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
-    return await handle_select_instance(api, req_data, request_length)
+    return await handle_select_instance(api, req_data, request_length, start_request=False)
 
 
 async def handle_completions_impl(api: str, request: Request):
     scheduler = runtime.scheduler
-    scheduler.request_started()
     request_released = False
     try:
         req_data = await request.json()
         req_body = await request.body()
         request_length = len(req_body)
-        instance_info = await handle_select_instance(api, req_data, request_length)
+        instance_info = await handle_select_instance(api, req_data, request_length, start_request=True)
         stream_flag = bool(req_data.get("stream", False))
         chat_flag = "messages" in req_data
 
@@ -886,20 +981,27 @@ async def handle_completions_impl(api: str, request: Request):
             retry_count = 0
             retry = True
             completion_tokens = 0
+
+            def release_prefiller_kv_once() -> None:
+                nonlocal released_kv
+                if not released_kv:
+                    scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
+                    released_kv = True
+
             try:
                 while retry:
                     retry = False
+                    decoder_client = await get_decoder_client(instance_info.decoder_key)
                     async for chunk in stream_service_response_with_retry(
-                        runtime.get_decoder_client(instance_info.decoder_key),
+                        decoder_client,
                         api,
                         req_data,
                         request_id=instance_info.request_id,
                         max_retries=global_args.max_retries,
                         base_delay=global_args.retry_delay,
                     ):
-                        if not released_kv and chunk:
-                            scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
-                            released_kv = True
+                        if chunk:
+                            release_prefiller_kv_once()
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
@@ -949,6 +1051,7 @@ async def handle_completions_impl(api: str, request: Request):
                                 tmp_request_length,
                                 instance_info,
                             )
+                            released_kv = False
                             break
                         if retry_count > 0 and not stream_flag:
                             if chat_flag:
@@ -964,21 +1067,24 @@ async def handle_completions_impl(api: str, request: Request):
                     instance_info.decoder["port"],
                     instance_info.request_id,
                 )
-                scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
                 raise
             except Exception as exc:
                 logger.error(
-                    "Error during streaming from decoder %s:%s: %s "
-                    "while handling request %s; releasing prefiller KV",
+                    "Error during streaming from decoder %s:%s: %s while handling request %s; releasing prefiller KV",
                     instance_info.decoder["host"],
                     instance_info.decoder["port"],
                     exc,
                     instance_info.request_id,
                 )
-                scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
             finally:
-                scheduler.release_decoder(instance_info.decoder_key, instance_info.decoder_score)
-                scheduler.request_finished()
+                scheduler.finish_request(
+                    instance_info.prefiller_key,
+                    instance_info.prefiller_score,
+                    instance_info.decoder_key,
+                    instance_info.decoder_score,
+                    release_prefiller_kv=not released_kv,
+                )
+                released_kv = True
                 request_released = True
 
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
@@ -989,10 +1095,16 @@ async def handle_completions_impl(api: str, request: Request):
         exc_info = sys.exc_info()
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print("".join(traceback.format_exception(*exc_info)))
+        if not request_released and "instance_info" in locals():
+            scheduler.finish_request(
+                instance_info.prefiller_key,
+                instance_info.prefiller_score,
+                instance_info.decoder_key,
+                instance_info.decoder_score,
+                release_prefiller_kv=True,
+            )
+            request_released = True
         raise
-    finally:
-        if not request_released:
-            scheduler.request_finished()
 
 
 async def adjust_instances_impl(adjust_mode: str, request: Request):

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -36,7 +36,7 @@
 # Run the proxy server, specifying the host/port for each prefiller and decoder:
 #
 #   python load_balance_proxy_server_example.py \
-#     --host 0.0.0.0 --port 9000 \
+#     --host 0.0.0.0 --port 9000 --workers 8 \
 #     --prefiller-hosts 127.0.0.1 127.0.0.1 \
 #     --prefiller-ports 8100 8101 \
 #     --decoder-hosts 127.0.0.1 127.0.0.1 \
@@ -114,10 +114,12 @@
 
 import argparse
 import asyncio
+import base64
 import functools
 import heapq
 import ipaddress
 import json
+import logging
 import os
 import sys
 import threading
@@ -125,22 +127,16 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from multiprocessing.managers import BaseManager
+from pathlib import Path
 from typing import Any
 
 import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
 
-try:
-    from vllm.logger import init_logger
+logger = logging.getLogger(__name__)
 
-    logger = init_logger(__name__)
-except ImportError:
-    import logging
-
-    logger = logging.getLogger(__name__)
-
-# Add uvloop for faster event loop if available
 try:
     import uvloop
 
@@ -155,352 +151,444 @@ class InstanceType:
     DECODE: str = "decode"
 
 
-TAINT_PRIORITY = 1e15
-
-
+@dataclass(frozen=True)
 class ServerState:
-    def __init__(self, host, port):
-        self.host = host
-        self.port = port
-        self.url = f"http://{host}:{port}/v1"
-        try:
-            ip = ipaddress.ip_address(self.host)
-            if isinstance(ip, ipaddress.IPv6Address):
-                self.url = f"http://[{host}]:{port}/v1"
-        except Exception:
-            pass
-        self.client = httpx.AsyncClient(
-            timeout=None,
-            base_url=self.url,
-            limits=httpx.Limits(max_connections=100000, max_keepalive_connections=100000),
-        )
-        self.active_tokens = 0
-        self.active_kv_cache = 0  # Only for prefiller
-        self.active_requests = 0  # Number of active requests
-        self.aborted_requests = set()  # Track aborted requests
-        # Removed individual server lock - will use global locks instead
+    host: str
+    port: int
 
-    def __eq__(self, other):
-        self_host = self.host.replace("localhost", "0.0.0.0").replace("127.0.0.1", "0.0.0.0")
-        other_host = other.host.replace("localhost", "0.0.0.0").replace("127.0.0.1", "0.0.0.0")
-        return self_host == other_host and str(self.port) == str(other.port)
-
-    def __hash__(self):
-        self_host = self.host.replace("localhost", "0.0.0.0").replace("127.0.0.1", "0.0.0.0")
-        return hash((self_host, str(self.port)))
-
-    def __repr__(self):
+    def __str__(self) -> str:
         return f"{self.host}:{self.port}"
 
 
-class ProxyState:
+@dataclass
+class InstanceInfo:
+    request_id: str
+    prefiller_key: str
+    prefiller_score: float
+    prefiller: dict[str, Any]
+    decoder_key: str
+    decoder_score: float
+    decoder: dict[str, Any]
+
+
+TAINT_PRIORITY = 1e15
+MANAGER_CONFIG_ENV = "LB_PROXY_MANAGER_CONFIG"
+ARGS_CONFIG_ENV = "LB_PROXY_ARGS"
+
+global_args = None
+shared_scheduler = None
+runtime = None
+
+
+def setup_logging(log_level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper()),
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        force=True,
+    )
+
+
+def normalize_host(host: str) -> str:
+    return host.replace("localhost", "0.0.0.0").replace("127.0.0.1", "0.0.0.0")
+
+
+def server_key(host: str, port: int) -> str:
+    return f"{normalize_host(host)}:{int(port)}"
+
+
+def build_base_url(host: str, port: int) -> str:
+    url = f"http://{host}:{port}/v1"
+    try:
+        ip = ipaddress.ip_address(host)
+        if isinstance(ip, ipaddress.IPv6Address):
+            url = f"http://[{host}]:{port}/v1"
+    except Exception:
+        pass
+    return url
+
+
+class SharedProxyScheduler:
+    """Centralized mutable scheduling state shared by all uvicorn workers."""
+
     def __init__(self, prefiller_instances, decoder_instances):
+        self._lock = threading.RLock()
         self.request_num = 0
-        self.tainted_prefillers: list[ServerState] = []
-        self.tainted_decoders: list[ServerState] = []
-        self.node_listener = NodeListener(self)
+        self.waiting_nodes: dict[str, tuple[str, tuple[str, int], int]] = {}
+        self.tainted_prefillers: set[str] = set()
+        self.tainted_decoders: set[str] = set()
+        self.prefillers: dict[str, dict[str, Any]] = {}
+        self.decoders: dict[str, dict[str, Any]] = {}
+        self.prefiller_heap: list[tuple[float, int, str]] = []
+        self.decoder_heap: list[tuple[float, int, str]] = []
+        self._ordinal = 0
 
-        self.prefillers: list[ServerState] = [ServerState(h, p) for h, p in prefiller_instances]
-        self.decoders: list[ServerState] = [ServerState(h, p) for h, p in decoder_instances]
-        self.req_to_prefiller = {}
-        self.req_id_lock = asyncio.Lock()
-        # Removed selection locks - no longer needed for synchronous methods
+        for host, port in prefiller_instances:
+            self._add_server_no_lock(InstanceType.PREFILL, host, port)
+        for host, port in decoder_instances:
+            self._add_server_no_lock(InstanceType.DECODE, host, port)
 
-        # Initialize priority queues for efficient server selection
-        # Each entry is (priority_score, server_index, server_reference)
-        # Lower priority score = higher priority (less loaded)
-        self.prefiller_heap = [(0.0, i, server) for i, server in enumerate(self.prefillers)]
-        self.decoder_heap = [(0.0, i, server) for i, server in enumerate(self.decoders)]
-        heapq.heapify(self.prefiller_heap)
-        heapq.heapify(self.decoder_heap)
+    def _server_map(self, instance_type: str) -> dict[str, dict[str, Any]]:
+        return self.prefillers if instance_type == InstanceType.PREFILL else self.decoders
 
-    def _update_prefiller_priority(self, server_idx: int):
-        """Update the priority of a prefiller server in the heap."""
-        server = self.prefillers[server_idx]
-        # Priority based on active_tokens and active_kv_cache
-        priority = server.active_tokens + server.active_kv_cache * 0.3
-        # Remove old entry and add new one
-        self.prefiller_heap = [(p, i, s) for p, i, s in self.prefiller_heap if i != server_idx]
-        heapq.heappush(self.prefiller_heap, (priority, server_idx, server))
+    def _heap(self, instance_type: str) -> list[tuple[float, int, str]]:
+        return self.prefiller_heap if instance_type == InstanceType.PREFILL else self.decoder_heap
 
-    def _update_decoder_priority(self, server_idx: int):
-        """Update the priority of a decoder server in the heap."""
-        server = self.decoders[server_idx]
-        priority = server.active_tokens
-        # Remove old entry and add new one
-        self.decoder_heap = [(p, i, s) for p, i, s in self.decoder_heap if i != server_idx]
-        heapq.heappush(self.decoder_heap, (priority, server_idx, server))
+    def _next_ordinal(self) -> int:
+        ordinal = self._ordinal
+        self._ordinal += 1
+        return ordinal
 
-    def abort_prefiller_request(self, server_idx: int, request_id):  # Changed to synchronous
-        """
-        Mark a request as aborted. This will helps to release kv cache in
-        prefiller node.
-        """
-        # No lock needed - atomic operation
-        if server_idx >= len(self.prefillers):
-            return
-        self.prefillers[server_idx].aborted_requests.add(request_id)
+    def _priority_no_lock(self, instance_type: str, key: str) -> float:
+        server = self._server_map(instance_type)[key]
+        if instance_type == InstanceType.PREFILL:
+            if key in self.tainted_prefillers:
+                return TAINT_PRIORITY
+            return float(server["active_tokens"]) + float(server["active_kv_cache"]) * 0.3
+        if key in self.tainted_decoders:
+            return TAINT_PRIORITY
+        return float(server["active_tokens"])
 
-    def acquire_aborted_prefiller_requests(self, server_idx: int):  # Changed to synchronous
-        """
-        Get the set of aborted requests and clear it.
-        This is used to release kv cache in prefiller node.
-        """
-        # No lock needed - atomic operation
-        if server_idx >= len(self.prefillers):
-            return set()
-        aborted_requests = self.prefillers[server_idx].aborted_requests.copy()
-        self.prefillers[server_idx].aborted_requests.clear()
-        return aborted_requests
+    def _rebuild_heap_no_lock(self, instance_type: str) -> None:
+        heap = []
+        for key, state in self._server_map(instance_type).items():
+            heap.append((self._priority_no_lock(instance_type, key), state["ordinal"], key))
+        heapq.heapify(heap)
+        if instance_type == InstanceType.PREFILL:
+            self.prefiller_heap = heap
+        else:
+            self.decoder_heap = heap
 
-    async def next_req_id(self):
-        async with self.req_id_lock:
-            return str(uuid.uuid4())
+    def _add_server_no_lock(self, instance_type: str, host: str, port: int) -> bool:
+        key = server_key(host, port)
+        servers = self._server_map(instance_type)
+        if key in servers:
+            return False
+        servers[key] = {
+            "host": host,
+            "port": int(port),
+            "active_tokens": 0.0,
+            "active_kv_cache": 0.0,
+            "ordinal": self._next_ordinal(),
+        }
+        heapq.heappush(self._heap(instance_type), (0.0, servers[key]["ordinal"], key))
+        return True
 
-    def select_prefiller(self, token_count):  # Changed to synchronous
-        # No lock needed - entire function is atomic
-        if not self.prefiller_heap:
-            raise RuntimeError("No prefiller servers available")
+    def get_snapshot(self) -> dict[str, list[dict[str, Any]]]:
+        with self._lock:
+            return {
+                "prefill_instances": [
+                    {"host": state["host"], "port": state["port"]}
+                    for _, state in sorted(self.prefillers.items(), key=lambda item: item[1]["ordinal"])
+                ],
+                "decode_instances": [
+                    {"host": state["host"], "port": state["port"]}
+                    for _, state in sorted(self.decoders.items(), key=lambda item: item[1]["ordinal"])
+                ],
+            }
 
-        priority, chosen, server = heapq.heappop(self.prefiller_heap)
+    def print_status(self, msg: str) -> None:
+        snapshot = self.get_snapshot()
+        status = {
+            "prefill_instances": [f"{s['host']}:{s['port']}" for s in snapshot["prefill_instances"]],
+            "decode_instances": [f"{s['host']}:{s['port']}" for s in snapshot["decode_instances"]],
+        }
+        print(f"{msg} Status: {status}")
 
-        # Update the chosen server atomically
-        self.prefillers[chosen].active_tokens += token_count
-        self.prefillers[chosen].active_kv_cache += token_count
+    def healthcheck(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "status": "ok",
+                "prefill_instances": len(self.prefillers),
+                "decode_instances": len(self.decoders),
+                "request_num": self.request_num,
+            }
 
-        # Update priority and re-add to heap
-        self._update_prefiller_priority(chosen)
+    def request_started(self) -> None:
+        with self._lock:
+            self.request_num += 1
 
-        return chosen
+    def request_finished(self) -> None:
+        with self._lock:
+            self.request_num = max(0, self.request_num - 1)
 
-    def release_prefiller(self, idx, token_count):  # Changed to synchronous
-        # No lock needed - atomic operation
-        if idx >= len(self.prefillers):
-            return
-        self.prefillers[idx].active_tokens -= token_count
-        # Update priority queue after releasing
-        self._update_prefiller_priority(idx)
+    def next_req_id(self) -> str:
+        return str(uuid.uuid4())
 
-    def release_prefiller_kv(self, idx, token_count):  # Changed to synchronous
-        # No lock needed - atomic operation
-        if idx >= len(self.prefillers):
-            return
-        if self.prefillers[idx].active_kv_cache > 0:
-            self.prefillers[idx].active_kv_cache -= token_count
-        # Update priority queue after releasing
-        self._update_prefiller_priority(idx)
-
-    def select_decoder(self, token_count):  # Changed to synchronous
-        # No lock needed - entire function is atomic
-        if not self.decoder_heap:
-            raise RuntimeError("No decoder servers available")
-
-        priority, chosen, server = heapq.heappop(self.decoder_heap)
-
-        # Update the chosen server atomically
-        self.decoders[chosen].active_tokens += token_count
-
-        # Update priority and re-add to heap
-        self._update_decoder_priority(chosen)
-
-        return chosen
-
-    def release_decoder(self, idx, token_count):  # Changed to synchronous
-        # No lock needed - atomic operation
-        if idx >= len(self.decoders):
-            return
-        self.decoders[idx].active_tokens -= token_count
-        # Update priority queue after releasing
-        self._update_decoder_priority(idx)
-
-    # Omni_infer's calculate_input_scores function
     def calculate_prefill_scores(self, request_length: int) -> float:
         length_score = request_length / 4.0
-        input_score = length_score * 0.0345 + 120.0745
-        return input_score
+        return length_score * 0.0345 + 120.0745
 
     def calculate_decode_scores(self, request_length: int) -> float:
         return request_length
 
-    async def add_instances(self, instance_type: str, instances: list[ServerState]) -> tuple[list[str], list[str]]:
-        added_nodes, waiting_nodes = [], []
-        for server in instances:
-            is_valid = await self.node_listener.check_instance_status(server.client)
-            if is_valid and instance_type == InstanceType.PREFILL:
-                self.add_prefillers([server])
-                added_nodes.append(str(server))
-            elif is_valid and instance_type == InstanceType.DECODE:
-                self.add_decoders([server])
-                added_nodes.append(str(server))
-            else:
-                node = str(server)
-                self.node_listener.waiting_nodes[node] = (instance_type, server, 0)
-                waiting_nodes.append(node)
+    def select_prefiller(self, token_count: float) -> dict[str, Any]:
+        with self._lock:
+            if not self.prefiller_heap:
+                raise RuntimeError("No prefiller servers available")
+            _, _, key = heapq.heappop(self.prefiller_heap)
+            state = self.prefillers[key]
+            state["active_tokens"] += token_count
+            state["active_kv_cache"] += token_count
+            heapq.heappush(
+                self.prefiller_heap,
+                (self._priority_no_lock(InstanceType.PREFILL, key), state["ordinal"], key),
+            )
+            return {"key": key, "host": state["host"], "port": state["port"]}
+
+    def release_prefiller(self, key: str, token_count: float) -> None:
+        with self._lock:
+            if key not in self.prefillers:
+                return
+            self.prefillers[key]["active_tokens"] -= token_count
+            self._rebuild_heap_no_lock(InstanceType.PREFILL)
+
+    def release_prefiller_kv(self, key: str, token_count: float) -> None:
+        with self._lock:
+            if key not in self.prefillers:
+                return
+            state = self.prefillers[key]
+            state["active_kv_cache"] = max(0.0, float(state["active_kv_cache"]) - token_count)
+            self._rebuild_heap_no_lock(InstanceType.PREFILL)
+
+    def select_decoder(self, token_count: float) -> dict[str, Any]:
+        with self._lock:
+            if not self.decoder_heap:
+                raise RuntimeError("No decoder servers available")
+            _, _, key = heapq.heappop(self.decoder_heap)
+            state = self.decoders[key]
+            state["active_tokens"] += token_count
+            heapq.heappush(
+                self.decoder_heap,
+                (self._priority_no_lock(InstanceType.DECODE, key), state["ordinal"], key),
+            )
+            return {"key": key, "host": state["host"], "port": state["port"]}
+
+    def release_decoder(self, key: str, token_count: float) -> None:
+        with self._lock:
+            if key not in self.decoders:
+                return
+            self.decoders[key]["active_tokens"] -= token_count
+            self._rebuild_heap_no_lock(InstanceType.DECODE)
+
+    def get_waiting_nodes(self) -> dict[str, tuple[str, tuple[str, int], int]]:
+        with self._lock:
+            return dict(self.waiting_nodes)
+
+    def add_instances(self, instance_type: str, instances: list[tuple[str, int]]) -> tuple[list[str], list[str]]:
+        added_nodes: list[str] = []
+        waiting_nodes: list[str] = []
+        with self._lock:
+            servers = self._server_map(instance_type)
+            for host, port in instances:
+                key = server_key(host, port)
+                if key in servers or key in self.waiting_nodes:
+                    continue
+                self.waiting_nodes[key] = (instance_type, (host, int(port)), 0)
+                waiting_nodes.append(f"{host}:{port}")
         return added_nodes, waiting_nodes
 
-    def add_prefillers(self, instances: list[ServerState]) -> None:
-        for server in instances:
-            if server in self.tainted_prefillers:
-                self.tainted_prefillers.remove(server)
-                self.prefiller_heap = [
-                    (0, idx, server) if srv == server else (priority, idx, srv)
-                    for priority, idx, srv in self.prefiller_heap
-                ]
-                heapq.heapify(self.prefiller_heap)
-            elif server not in self.prefillers:
-                self.prefillers.append(server)
-                # prefiller_heap: [(priority_0, 0, server_0)] -> [(priority_0, 0, server_0), (0, 1, server_1)]
-                heapq.heappush(self.prefiller_heap, (0, len(self.prefillers) - 1, server))
-        self.print_status(f"Add prefiller instances: {instances}.")
+    def mark_waiting_retry(self, key: str, retry_count: int) -> None:
+        with self._lock:
+            if key not in self.waiting_nodes:
+                return
+            instance_type, server, _ = self.waiting_nodes[key]
+            self.waiting_nodes[key] = (instance_type, server, retry_count)
 
-    def add_decoders(self, instances: list[ServerState]) -> None:
-        for server in instances:
-            if server in self.tainted_decoders:
-                self.tainted_decoders.remove(server)
-                self.decoder_heap = [
-                    (0, idx, server) if srv == server else (priority, idx, srv)
-                    for priority, idx, srv in self.decoder_heap
-                ]
-                heapq.heapify(self.decoder_heap)
-            elif server not in self.decoders:
-                self.decoders.append(server)
-                # decoder_heap: [(priority_0, 0, server_0)] -> [(priority_0, 0, server_0), (0, 1, server_1)]
-                heapq.heappush(self.decoder_heap, (0, len(self.decoders) - 1, server))
-        self.print_status(f"Add decoder instances: {instances}.")
+    def activate_waiting_instance(self, instance_type: str, host: str, port: int) -> None:
+        with self._lock:
+            key = server_key(host, port)
+            self.waiting_nodes.pop(key, None)
+            if instance_type == InstanceType.PREFILL and key in self.tainted_prefillers:
+                self.tainted_prefillers.discard(key)
+                self._rebuild_heap_no_lock(InstanceType.PREFILL)
+                return
+            if instance_type == InstanceType.DECODE and key in self.tainted_decoders:
+                self.tainted_decoders.discard(key)
+                self._rebuild_heap_no_lock(InstanceType.DECODE)
+                return
+            if self._add_server_no_lock(instance_type, host, port):
+                self.print_status(f"Add {instance_type} instance: {host}:{port}.")
 
-    def remove_prefillers(self, instances: list[ServerState]) -> bool:
+    def drop_waiting_instance(self, key: str) -> None:
+        with self._lock:
+            self.waiting_nodes.pop(key, None)
+
+    def remove_prefillers(self, instances: list[tuple[str, int]]) -> bool:
+        return self._remove_instances(InstanceType.PREFILL, instances)
+
+    def remove_decoders(self, instances: list[tuple[str, int]]) -> bool:
+        return self._remove_instances(InstanceType.DECODE, instances)
+
+    def _remove_instances(self, instance_type: str, instances: list[tuple[str, int]]) -> bool:
         if not instances:
             return False
+        keys = {server_key(host, port) for host, port in instances}
+        with self._lock:
+            if self.request_num > 0:
+                if instance_type == InstanceType.PREFILL:
+                    self.tainted_prefillers.update(keys)
+                else:
+                    self.tainted_decoders.update(keys)
+                self._rebuild_heap_no_lock(instance_type)
+                logger.warning("Start to taint %s instances %s.", instance_type, sorted(keys))
+                return True
 
-        if self.request_num > 0:
-            logger.warning("Start to taint prefill instances %s.", instances)
-            self._taint_prefillers(instances)
-            return True
-
-        instances_to_remove = set(instances)
-        self.prefillers = [server for server in self.prefillers if server not in instances_to_remove]
-        prefiller_heap_copy = self.prefiller_heap.copy()
-        prefiller_heap_copy.sort(key=lambda x: x[1])  # sorted by key: prefiller_idx
-        prefiller_heap = []
-        idx = 0
-        for priority, _, server in prefiller_heap_copy:
-            if server not in instances_to_remove:
-                prefiller_heap.append((priority, idx, server))
-                idx += 1
-
-        # prefiller_heap: [(priority_0, 0, server_0), (priority_1, 1, server_1)] -> [(priority_1, 0, server_1)]
-        self.prefiller_heap = prefiller_heap
-        heapq.heapify(self.prefiller_heap)
-        self.print_status(f"Remove prefiller instances: {instances}.")
-        return False
-
-    def remove_decoders(self, instances: list[ServerState]) -> bool:
-        if not instances:
+            removed = False
+            servers = self._server_map(instance_type)
+            for key in keys:
+                removed = servers.pop(key, None) is not None or removed
+                self.waiting_nodes.pop(key, None)
+                if instance_type == InstanceType.PREFILL:
+                    self.tainted_prefillers.discard(key)
+                else:
+                    self.tainted_decoders.discard(key)
+            if removed:
+                self._rebuild_heap_no_lock(instance_type)
+                self.print_status(f"Remove {instance_type} instances: {sorted(keys)}.")
             return False
 
-        if self.request_num > 0:
-            logger.warning("Start to taint decode instances %s.", instances)
-            self._taint_decoders(instances)
-            return True
+    def finalize_tainted_instances(self) -> None:
+        with self._lock:
+            if self.request_num != 0:
+                return
+            if self.tainted_prefillers:
+                keys = list(self.tainted_prefillers)
+                for key in keys:
+                    self.prefillers.pop(key, None)
+                self.tainted_prefillers.clear()
+                self._rebuild_heap_no_lock(InstanceType.PREFILL)
+                self.print_status(f"Remove prefiller instances after drain: {keys}.")
+            if self.tainted_decoders:
+                keys = list(self.tainted_decoders)
+                for key in keys:
+                    self.decoders.pop(key, None)
+                self.tainted_decoders.clear()
+                self._rebuild_heap_no_lock(InstanceType.DECODE)
+                self.print_status(f"Remove decoder instances after drain: {keys}.")
 
-        instances_to_remove = set(instances)
-        self.decoders = [server for server in self.decoders if server not in instances_to_remove]
-        decoder_heap_copy = self.decoder_heap.copy()
-        decoder_heap_copy.sort(key=lambda x: x[1])  # sorted by key: decoder_idx
-        decoder_heap = []
-        idx = 0
-        for priority, _, server in decoder_heap_copy:
-            if server not in instances_to_remove:
-                decoder_heap.append((priority, idx, server))
-                idx += 1
 
-        # decoder_heap: [(priority_0, 0, server_0), (priority_1, 1, server_1)] -> [(priority_1, 0, server_1)]
-        self.decoder_heap = decoder_heap
-        heapq.heapify(self.decoder_heap)
-        self.print_status(f"Remove decoder instances: {instances}.")
-        return False
+class SchedulerManager(BaseManager):
+    pass
 
-    def _taint_prefillers(self, instances: list[ServerState]) -> None:
-        instances_to_taint = set(instances)
-        for server in self.prefillers:
-            if server in instances_to_taint and server not in self.tainted_prefillers:
-                self.tainted_prefillers.append(server)
 
-        self.prefiller_heap = [
-            (TAINT_PRIORITY, idx, srv) if srv in instances_to_taint else (priority, idx, srv)
-            for priority, idx, srv in self.prefiller_heap
-        ]
-        heapq.heapify(self.prefiller_heap)
+def get_shared_scheduler():
+    if shared_scheduler is None:
+        raise RuntimeError("shared scheduler is not initialized")
+    return shared_scheduler
 
-    def _taint_decoders(self, instances: list[ServerState]) -> None:
-        instances_to_taint = set(instances)
-        for server in self.decoders:
-            if server in instances_to_taint and server not in self.tainted_decoders:
-                self.tainted_decoders.append(server)
 
-        self.decoder_heap = [
-            (TAINT_PRIORITY, idx, srv) if srv in instances_to_taint else (priority, idx, srv)
-            for priority, idx, srv in self.decoder_heap
-        ]
-        heapq.heapify(self.decoder_heap)
+SchedulerManager.register("get_scheduler", callable=get_shared_scheduler)
 
-    def print_status(self, msg: str) -> None:
-        status = {
-            "prefill_instances": [str(server) for server in self.prefillers],
-            "decode_instances": [str(server) for server in self.decoders],
+
+class WorkerRuntime:
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        self.prefiller_clients: dict[str, httpx.AsyncClient] = {}
+        self.decoder_clients: dict[str, httpx.AsyncClient] = {}
+
+    async def sync_clients(self) -> None:
+        snapshot = self.scheduler.get_snapshot()
+        prefiller_targets = {
+            server_key(s["host"], s["port"]): (s["host"], s["port"]) for s in snapshot["prefill_instances"]
         }
-        print(f"{msg} Status: {status}")
+        decoder_targets = {
+            server_key(s["host"], s["port"]): (s["host"], s["port"]) for s in snapshot["decode_instances"]
+        }
+        await self._sync_group(self.prefiller_clients, prefiller_targets)
+        await self._sync_group(self.decoder_clients, decoder_targets)
 
+    async def _sync_group(
+        self,
+        client_group: dict[str, httpx.AsyncClient],
+        targets: dict[str, tuple[str, int]],
+    ) -> None:
+        stale = [key for key in client_group if key not in targets]
+        for key in stale:
+            client = client_group.pop(key)
+            await client.aclose()
+        for key, (host, port) in targets.items():
+            if key in client_group:
+                continue
+            client_group[key] = httpx.AsyncClient(
+                timeout=None,
+                base_url=build_base_url(host, port),
+                limits=httpx.Limits(max_connections=100000, max_keepalive_connections=100000),
+            )
 
-proxy_state = None
+    def get_prefiller_client(self, key: str) -> httpx.AsyncClient:
+        return self.prefiller_clients[key]
+
+    def get_decoder_client(self, key: str) -> httpx.AsyncClient:
+        return self.decoder_clients[key]
+
+    async def close(self) -> None:
+        for client in list(self.prefiller_clients.values()):
+            await client.aclose()
+        for client in list(self.decoder_clients.values()):
+            await client.aclose()
+        self.prefiller_clients.clear()
+        self.decoder_clients.clear()
 
 
 class NodeListener:
-    def __init__(self, proxy):
-        self.proxy_state = proxy
-        self.waiting_nodes: dict[str, tuple[str, Any, int]] = {}
-        self.listening_thread = threading.Thread(target=self._node_listener, daemon=True)
-        self.listening_thread.start()
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
 
-    def _node_listener(self) -> None:
+    def _run(self) -> None:
         while True:
-            for node, (instance_type, server, check_times) in list(self.waiting_nodes.items()):
-                is_valid = asyncio.run(self.check_instance_status(server.client))
-                print(f"Checking instance {node}...")
-                check_times += 1
+            for key, (instance_type, server, retries) in list(self.scheduler.get_waiting_nodes().items()):
+                host, port = server
+                is_valid = asyncio.run(self.check_instance_status(host, port))
+                print(f"Checking instance {key}...")
+                retries += 1
                 if is_valid:
-                    if instance_type == InstanceType.PREFILL:
-                        self.proxy_state.add_prefillers([server])
-                    else:
-                        self.proxy_state.add_decoders([server])
-                    self.waiting_nodes.pop(node)
-                elif check_times == global_args.max_waiting_retries:
-                    print(f"Instance {node} was not added to the proxy.")
-                    self.waiting_nodes.pop(node)
+                    self.scheduler.activate_waiting_instance(instance_type, host, port)
+                elif retries >= global_args.max_waiting_retries:
+                    print(f"Instance {key} was not added to the proxy.")
+                    self.scheduler.drop_waiting_instance(key)
                 else:
-                    self.waiting_nodes[node] = (instance_type, server, check_times)
+                    self.scheduler.mark_waiting_retry(key, retries)
 
-            if self.proxy_state.tainted_prefillers and not self.proxy_state.request_num:
-                need_waiting = self.proxy_state.remove_prefillers(self.proxy_state.tainted_prefillers)
-                if not need_waiting:
-                    self.proxy_state.tainted_prefillers.clear()
-
-            if self.proxy_state.tainted_decoders and not self.proxy_state.request_num:
-                need_waiting = self.proxy_state.remove_decoders(self.proxy_state.tainted_decoders)
-                if not need_waiting:
-                    self.proxy_state.tainted_decoders.clear()
+            self.scheduler.finalize_tainted_instances()
             time.sleep(global_args.waiting_retry_interval)
 
     @staticmethod
-    async def check_instance_status(client: httpx.AsyncClient) -> bool:
+    async def check_instance_status(host: str, port: int) -> bool:
         endpoint = "/models"
         headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
         try:
-            response = await client.get(endpoint, headers=headers)
-            response.raise_for_status()
-            return True
+            async with httpx.AsyncClient(timeout=5.0, base_url=build_base_url(host, port)) as client:
+                response = await client.get(endpoint, headers=headers)
+                response.raise_for_status()
+                return True
         except (httpx.RequestError, httpx.HTTPStatusError):
             return False
+
+
+def serialize_args(args) -> dict[str, Any]:
+    return {
+        "port": args.port,
+        "host": args.host,
+        "prefiller_hosts": args.prefiller_hosts,
+        "prefiller_ports": args.prefiller_ports,
+        "decoder_hosts": args.decoder_hosts,
+        "decoder_ports": args.decoder_ports,
+        "max_retries": args.max_retries,
+        "retry_delay": args.retry_delay,
+        "max_waiting_retries": args.max_waiting_retries,
+        "waiting_retry_interval": args.waiting_retry_interval,
+        "workers": args.workers,
+        "log_level": args.log_level,
+    }
+
+
+def deserialize_args(raw_args: dict[str, Any]):
+    args = argparse.Namespace(**raw_args)
+    args.prefiller_instances = list(zip(args.prefiller_hosts, args.prefiller_ports))
+    args.decoder_instances = list(zip(args.decoder_hosts, args.decoder_ports))
+    return args
 
 
 def parse_args():
@@ -524,6 +612,19 @@ def parse_args():
         default=10,
         help="Check interval (seconds) for waiting nodes to be started",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of uvicorn worker processes. Scheduling state is shared across workers.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Log level for the proxy server.",
+    )
     args = parser.parse_args()
     if len(args.prefiller_hosts) != len(args.prefiller_ports):
         raise ValueError("Number of prefiller hosts must match number of prefiller ports")
@@ -534,20 +635,71 @@ def parse_args():
     return args
 
 
+def load_global_args_from_env():
+    global global_args
+    if global_args is None:
+        raw = os.environ.get(ARGS_CONFIG_ENV)
+        if raw is None:
+            raise RuntimeError(f"{ARGS_CONFIG_ENV} is not set")
+        global_args = deserialize_args(json.loads(raw))
+    return global_args
+
+
+def connect_shared_scheduler():
+    config = os.environ.get(MANAGER_CONFIG_ENV)
+    if config is None:
+        raise RuntimeError(f"{MANAGER_CONFIG_ENV} is not set")
+    manager_cfg = json.loads(config)
+    manager = SchedulerManager(
+        address=(manager_cfg["host"], manager_cfg["port"]),
+        authkey=base64.b64decode(manager_cfg["authkey"]),
+    )
+    manager.connect()
+    return manager.get_scheduler()
+
+
+def start_shared_scheduler(args) -> None:
+    global shared_scheduler
+    shared_scheduler = SharedProxyScheduler(args.prefiller_instances, args.decoder_instances)
+    NodeListener(shared_scheduler)
+    authkey = os.urandom(16)
+    manager = SchedulerManager(address=("127.0.0.1", 0), authkey=authkey)
+    server = manager.get_server()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.address
+    os.environ[MANAGER_CONFIG_ENV] = json.dumps(
+        {"host": host, "port": port, "authkey": base64.b64encode(authkey).decode("ascii")}
+    )
+    os.environ[ARGS_CONFIG_ENV] = json.dumps(serialize_args(args))
+
+
 @asynccontextmanager
-async def lifespan(app: FastAPI):
-    global proxy_state
-    proxy_state = ProxyState(global_args.prefiller_instances, global_args.decoder_instances)
-    print(f"Initialized {len(proxy_state.prefillers)} prefill clients and {len(proxy_state.decoders)} decode clients.")
+async def lifespan(_app: FastAPI):
+    global runtime
+    scheduler = connect_shared_scheduler()
+    runtime = WorkerRuntime(scheduler)
+    await runtime.sync_clients()
+    snapshot = scheduler.get_snapshot()
+    print(
+        f"Initialized {len(snapshot['prefill_instances'])} prefill clients and "
+        f"{len(snapshot['decode_instances'])} decode clients in worker {os.getpid()}."
+    )
     yield
-    for p in proxy_state.prefillers:
-        await p.client.aclose()
-    for d in proxy_state.decoders:
-        await d.client.aclose()
+    await runtime.close()
+    runtime = None
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+def create_app():
+    args = load_global_args_from_env()
+    setup_logging(args.log_level)
+    return app
 
 
 async def listen_for_disconnect(request: Request) -> None:
-    """Return if a disconnect message is received"""
     while True:
         message = await request.receive()
         if message["type"] == "http.disconnect":
@@ -570,19 +722,15 @@ def with_cancellation(handler_func):
     return wrapper
 
 
-app = FastAPI(lifespan=lifespan)
-
-
 async def send_request_to_service(
     client: httpx.AsyncClient,
-    prefiller_id: int,
+    prefiller_key: str,
     endpoint: str,
     req_data: dict,
     request_id: str,
     max_retries: int = 3,
     base_delay: float = 0.2,
 ):
-    aborted_requests = proxy_state.acquire_aborted_prefiller_requests(prefiller_id)
     req_data = req_data.copy()
     req_data["kv_transfer_params"] = {
         "do_remote_decode": True,
@@ -591,7 +739,6 @@ async def send_request_to_service(
         "remote_block_ids": None,
         "remote_host": None,
         "remote_port": None,
-        "aborted_request": list(aborted_requests),
     }
     req_data["stream"] = False
     req_data["max_tokens"] = 1
@@ -607,9 +754,9 @@ async def send_request_to_service(
             response = await client.post(endpoint, json=req_data, headers=headers)
             response.raise_for_status()
             return response
-        except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
-            last_exc = e
+        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, exc)
+            last_exc = exc
             if attempt < max_retries:
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
@@ -634,86 +781,91 @@ async def stream_service_response_with_retry(
                 async for chunk in response.aiter_bytes():
                     first_chunk_sent = True
                     yield chunk
-                return  # Success, exit after streaming
-        except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                return
+        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
             if attempt < max_retries:
-                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
                 logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
-                raise e
-        except Exception as e:
-            # If any chunk has been sent, do not retry, just log and drop
+                raise exc
+        except Exception as exc:
             if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error("Streaming to client interrupted after response started: %s", e)
+                logger.error("Streaming to client interrupted after response started: %s", exc)
                 return
+            if attempt < max_retries:
+                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
+                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
-                if attempt < max_retries:
-                    logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
-                    await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-                else:
-                    logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
-                    raise e
+                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
+                raise exc
 
 
-async def _handle_select_instance(api: str, req_data: Any, request_length: int):
-    prefiller_score = proxy_state.calculate_prefill_scores(request_length)
-    logger.debug("Request length: %s, Prefiller score: %s", request_length, prefiller_score)
-    request_id = await proxy_state.next_req_id()
-    # Select prefiller
-    prefiller_idx = proxy_state.select_prefiller(prefiller_score)
-    prefiller = proxy_state.prefillers[prefiller_idx]
-    # Send request to prefiller
-    response = await send_request_to_service(
-        prefiller.client,
-        prefiller_idx,
-        api,
-        req_data,
-        request_id,
-        max_retries=global_args.max_retries,
-        base_delay=global_args.retry_delay,
-    )
-    proxy_state.release_prefiller(prefiller_idx, prefiller_score)
+async def handle_select_instance(api: str, req_data: Any, request_length: int) -> InstanceInfo:
+    await runtime.sync_clients()
+    scheduler = runtime.scheduler
+    prefiller_score = scheduler.calculate_prefill_scores(request_length)
+    request_id = scheduler.next_req_id()
+    prefiller = scheduler.select_prefiller(prefiller_score)
+    prefiller_key = prefiller["key"]
+
+    try:
+        response = await send_request_to_service(
+            runtime.get_prefiller_client(prefiller_key),
+            prefiller_key,
+            api,
+            req_data,
+            request_id,
+            max_retries=global_args.max_retries,
+            base_delay=global_args.retry_delay,
+        )
+    finally:
+        scheduler.release_prefiller(prefiller_key, prefiller_score)
+
     response_json = response.json()
     kv_transfer_params = response_json.get("kv_transfer_params", {})
     if kv_transfer_params:
         req_data["kv_transfer_params"] = kv_transfer_params
-    # Select decoder
-    decoder_score = proxy_state.calculate_decode_scores(request_length)
-    logger.debug("Decoder score: %f", decoder_score)
-    # Use the prefiller's kv_transfer_params to select decoder
-    decoder_idx = proxy_state.select_decoder(decoder_score)
-    decoder = proxy_state.decoders[decoder_idx]
-    logger.debug("Using %s %s", prefiller.url, decoder.url)
+
+    decoder_score = scheduler.calculate_decode_scores(request_length)
+    decoder = scheduler.select_decoder(decoder_score)
+    decoder_key = decoder["key"]
+    logger.debug(
+        "Using %s %s",
+        runtime.get_prefiller_client(prefiller_key).base_url,
+        runtime.get_decoder_client(decoder_key).base_url,
+    )
     return InstanceInfo(
         request_id=request_id,
-        prefiller_idx=prefiller_idx,
+        prefiller_key=prefiller_key,
         prefiller_score=prefiller_score,
         prefiller=prefiller,
-        decoder=decoder,
-        decoder_idx=decoder_idx,
+        decoder_key=decoder_key,
         decoder_score=decoder_score,
+        decoder=decoder,
     )
 
 
-@dataclass
-class InstanceInfo:
-    request_id: str
-    prefiller_idx: int
-    prefiller_score: float
-    prefiller: ServerState
-    decoder_idx: int
-    decoder_score: float
-    decoder: ServerState
+async def select_recompute_instance(
+    api: str,
+    req_data: Any,
+    request_length: int,
+    previous_instance: InstanceInfo,
+) -> InstanceInfo:
+    """Release the old decoder before assigning a new instance for recompute."""
+    runtime.scheduler.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
+    return await handle_select_instance(api, req_data, request_length)
 
 
-async def _handle_completions(api: str, request: Request):
+async def handle_completions_impl(api: str, request: Request):
+    scheduler = runtime.scheduler
+    scheduler.request_started()
+    request_released = False
     try:
-        proxy_state.request_num += 1
         req_data = await request.json()
         req_body = await request.body()
         request_length = len(req_body)
-        instance_info = await _handle_select_instance(api, req_data, request_length)
+        instance_info = await handle_select_instance(api, req_data, request_length)
         stream_flag = bool(req_data.get("stream", False))
         chat_flag = "messages" in req_data
 
@@ -724,29 +876,21 @@ async def _handle_completions(api: str, request: Request):
             origin_prompt = messages[0].get("content", "")
         else:
             origin_prompt = ""
-        # refer to vLLM sampling_params: max_token default value
         origin_max_tokens = req_data.get("max_tokens", 16)
 
         async def generate_stream():
             nonlocal instance_info
+            nonlocal request_released
             generated_token = ""
             released_kv = False
             retry_count = 0
             retry = True
             completion_tokens = 0
-
-            def release_prefiller_kv_once():
-                nonlocal released_kv
-                if not released_kv:
-                    proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
-                    released_kv = True
-
-            # Only one await per chunk, minimal logic in loop
             try:
                 while retry:
                     retry = False
                     async for chunk in stream_service_response_with_retry(
-                        instance_info.decoder.client,
+                        runtime.get_decoder_client(instance_info.decoder_key),
                         api,
                         req_data,
                         request_id=instance_info.request_id,
@@ -754,7 +898,8 @@ async def _handle_completions(api: str, request: Request):
                         base_delay=global_args.retry_delay,
                     ):
                         if not released_kv and chunk:
-                            release_prefiller_kv_once()
+                            scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
+                            released_kv = True
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
@@ -768,7 +913,6 @@ async def _handle_completions(api: str, request: Request):
                         try:
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
-                            # if chunk is [done], skip it.
                             logger.debug("Skipping chunk: %s", chunk_str)
                             yield chunk
                             continue
@@ -788,7 +932,7 @@ async def _handle_completions(api: str, request: Request):
                         completion_tokens = (
                             (completion_tokens + 1)
                             if stream_flag
-                            else (completion_tokens + usage.get("completion_tokens"))
+                            else (completion_tokens + usage.get("completion_tokens", 0))
                         )
                         if stop_reason == "recomputed":
                             retry = True
@@ -799,7 +943,12 @@ async def _handle_completions(api: str, request: Request):
                                 req_data["prompt"] = origin_prompt + generated_token
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await _handle_select_instance(api, req_data, tmp_request_length)
+                            instance_info = await select_recompute_instance(
+                                api,
+                                req_data,
+                                tmp_request_length,
+                                instance_info,
+                            )
                             break
                         if retry_count > 0 and not stream_flag:
                             if chat_flag:
@@ -809,96 +958,102 @@ async def _handle_completions(api: str, request: Request):
                             chunk = json.dumps(chunk_json).encode("utf-8")
                         yield chunk
             except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.error(
-                    "Error during streaming from decoder %s: %s the aborted request %s "
-                    "will be routing to the target prefiller when new request is ready to dispatch to it",
-                    instance_info.decoder.url,
-                    e,
+                logger.warning(
+                    "Streaming from decoder %s:%s was cancelled; releasing request %s resources",
+                    instance_info.decoder["host"],
+                    instance_info.decoder["port"],
                     instance_info.request_id,
                 )
-                proxy_state.abort_prefiller_request(instance_info.prefiller_idx, instance_info.request_id)
-                release_prefiller_kv_once()
+                scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
+                raise
+            except Exception as exc:
+                logger.error(
+                    "Error during streaming from decoder %s:%s: %s "
+                    "while handling request %s; releasing prefiller KV",
+                    instance_info.decoder["host"],
+                    instance_info.decoder["port"],
+                    exc,
+                    instance_info.request_id,
+                )
+                scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
             finally:
-                # After streaming is done or cancelled, release tokens.
-                release_prefiller_kv_once()
-                proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
-                proxy_state.request_num -= 1
+                scheduler.release_decoder(instance_info.decoder_key, instance_info.decoder_score)
+                scheduler.request_finished()
+                request_released = True
 
-        # Determine the correct media type based on stream flag
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
         return StreamingResponse(generate_stream(), media_type=media_type)
-    except Exception as e:
+    except Exception:
         import traceback
 
         exc_info = sys.exc_info()
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
-        print(e)
         print("".join(traceback.format_exception(*exc_info)))
-        proxy_state.request_num -= 1
         raise
+    finally:
+        if not request_released:
+            scheduler.request_finished()
 
 
-async def _handle_adjust_instances(adjust_mode: str, request: Request):
-    try:
-        req_data = await request.json()
-        instance_type = req_data.get("type", "")
-        instances = req_data.get("instances", [])
-        if isinstance(instances, str):
-            instances = [instances]
-        instances = trans_instances(instances)
-        all_msg = f"{adjust_mode} {instance_type} instances: {[str(server) for server in instances]}."
+async def adjust_instances_impl(adjust_mode: str, request: Request):
+    req_data = await request.json()
+    instance_type = req_data.get("type", "")
+    instances = req_data.get("instances", [])
+    if isinstance(instances, str):
+        instances = [instances]
+    instances = trans_instances(instances)
+    all_msg = f"{adjust_mode} {instance_type} instances: {[str(server) for server in instances]}."
 
-        if instance_type not in [InstanceType.PREFILL, InstanceType.DECODE]:
-            return {
-                "error": f"Instance type {instance_type} is not supported. "
-                f"Only support '{InstanceType.PREFILL}' and '{InstanceType.DECODE}'."
-            }
-
-        if adjust_mode == "add":
-            added_nodes, waiting_nodes = await proxy_state.add_instances(instance_type, instances)
-            if waiting_nodes:
-                all_msg = (
-                    f"{adjust_mode} {instance_type} instances: {added_nodes}. "
-                    f"Instances {waiting_nodes} are waiting to be added."
-                )
-        elif adjust_mode == "remove":
-            if instance_type == InstanceType.PREFILL:
-                need_waiting = proxy_state.remove_prefillers(instances)
-            else:
-                need_waiting = proxy_state.remove_decoders(instances)
-
-            if need_waiting:
-                all_msg = f"Instances {instances} are isolated and waiting to be removed."
+    if instance_type not in [InstanceType.PREFILL, InstanceType.DECODE]:
         return {
-            "message": all_msg,
-            "current_prefill_instances": [str(prefiller) for prefiller in proxy_state.prefillers],
-            "current_decode_instances": [str(decoder) for decoder in proxy_state.decoders],
+            "error": f"Instance type {instance_type} is not supported. "
+            f"Only support '{InstanceType.PREFILL}' and '{InstanceType.DECODE}'."
         }
-    except Exception as e:
-        logger.error("Failed to %s instances: %s", adjust_mode, e)
-        raise e
+
+    raw_instances = [(server.host, server.port) for server in instances]
+    scheduler = runtime.scheduler
+
+    if adjust_mode == "add":
+        added_nodes, waiting_nodes = scheduler.add_instances(instance_type, raw_instances)
+        if waiting_nodes:
+            all_msg = (
+                f"{adjust_mode} {instance_type} instances: {added_nodes}. "
+                f"Instances {waiting_nodes} are waiting to be added."
+            )
+    elif adjust_mode == "remove":
+        if instance_type == InstanceType.PREFILL:
+            need_waiting = scheduler.remove_prefillers(raw_instances)
+        else:
+            need_waiting = scheduler.remove_decoders(raw_instances)
+        if need_waiting:
+            all_msg = f"Instances {[str(server) for server in instances]} are isolated and waiting to be removed."
+
+    snapshot = scheduler.get_snapshot()
+    return {
+        "message": all_msg,
+        "current_prefill_instances": [f"{server['host']}:{server['port']}" for server in snapshot["prefill_instances"]],
+        "current_decode_instances": [f"{server['host']}:{server['port']}" for server in snapshot["decode_instances"]],
+    }
 
 
 def trans_instances(instances: list[str]) -> list[ServerState]:
-    server_list = []
+    result = []
     for instance in instances:
-        h, p = instance.split(":")
-        server_list.append(ServerState(h, int(p)))
-    return server_list
+        host, port = instance.split(":")
+        result.append(ServerState(host, int(port)))
+    return result
 
 
 @app.post("/v1/completions")
 @with_cancellation
 async def handle_completions(request: Request):
-    return await _handle_completions("/completions", request)
+    return await handle_completions_impl("/completions", request)
 
 
 @app.post("/v1/chat/completions")
 @with_cancellation
 async def handle_chat_completions(request: Request):
-    return await _handle_completions("/chat/completions", request)
+    return await handle_completions_impl("/chat/completions", request)
 
 
 @app.post("/reset_prefix_cache")
@@ -925,26 +1080,31 @@ async def reset_prefix_cache(request: Request):
 
 @app.get("/healthcheck")
 async def healthcheck():
-    return {
-        "status": "ok",
-        "prefill_instances": len(proxy_state.prefillers),
-        "decode_instances": len(proxy_state.decoders),
-    }
+    return runtime.scheduler.healthcheck()
 
 
 @app.post("/instances/add")
 async def handle_add_instances(request: Request):
-    return await _handle_adjust_instances("add", request)
+    return await adjust_instances_impl("add", request)
 
 
 @app.post("/instances/remove")
 async def handle_remove_instances(request: Request):
-    return await _handle_adjust_instances("remove", request)
+    return await adjust_instances_impl("remove", request)
 
 
 if __name__ == "__main__":
-    global global_args
     global_args = parse_args()
+    setup_logging(global_args.log_level)
+    start_shared_scheduler(global_args)
     import uvicorn
 
-    uvicorn.run(app, host=global_args.host, port=global_args.port)
+    module_name = Path(__file__).stem
+    uvicorn.run(
+        f"{module_name}:create_app",
+        host=global_args.host,
+        port=global_args.port,
+        workers=global_args.workers,
+        factory=True,
+        app_dir=str(Path(__file__).resolve().parent),
+    )

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -122,11 +122,13 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import threading
 import time
 import uuid
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from multiprocessing.managers import BaseManager
 from pathlib import Path
 from typing import Any, cast
@@ -145,19 +147,9 @@ except ImportError:
     pass
 
 
-@dataclass
-class InstanceType:
-    PREFILL: str = "prefill"
-    DECODE: str = "decode"
-
-
-@dataclass(frozen=True)
-class ServerState:
-    host: str
-    port: int
-
-    def __str__(self) -> str:
-        return f"{self.host}:{self.port}"
+class ServerRole(str, Enum):
+    PREFILL = "prefill"
+    DECODE = "decode"
 
 
 @dataclass
@@ -165,33 +157,36 @@ class InstanceInfo:
     request_id: str
     prefiller_key: str
     prefiller_score: float
-    prefiller: dict[str, Any]
     decoder_key: str
     decoder_score: float
-    decoder: dict[str, Any]
+    decoder_host: str
+    decoder_port: int
 
 
 TAINT_PRIORITY = 1e15
-_IS_PREFILL = True
-_IS_DECODE = False
-MANAGER_CONFIG_ENV = "LB_PROXY_MANAGER_CONFIG"
-ARGS_CONFIG_ENV = "LB_PROXY_ARGS"
 
 global_args: argparse.Namespace | None = None
 shared_scheduler: "SharedProxyScheduler | None" = None
 runtime: "WorkerRuntime | None" = None
 
 
-class _ServerEntry:
-    __slots__ = ("host", "port", "active_tokens", "active_kv_cache", "ordinal", "heap_seq")
+@dataclass
+class BackendServer:
+    host: str
+    port: int
+    ordinal: int
+    active_tokens: float = 0.0
+    active_kv_cache: float = 0.0
+    heap_seq: int = 0
 
-    def __init__(self, host: str, port: int, ordinal: int):
-        self.host = host
-        self.port = port
-        self.active_tokens: float = 0.0
-        self.active_kv_cache: float = 0.0
-        self.ordinal: int = ordinal
-        self.heap_seq: int = 0
+
+@dataclass
+class RolePools:
+    """Per-role scheduling state: live servers, priority heap, and drain-isolated keys."""
+
+    servers: dict[str, BackendServer] = field(default_factory=dict)
+    heap: list[tuple[float, int, int, str]] = field(default_factory=list)
+    tainted: set[str] = field(default_factory=set)
 
 
 def setup_logging(log_level: str) -> None:
@@ -240,99 +235,83 @@ class SharedProxyScheduler:
 
     Uses lazy-deletion min-heap: on priority change, push a new entry and
     bump the server's ``heap_seq`` counter; stale entries (whose seq does
-    not match) are skipped on pop.  This avoids the O(n) list-comp filter
-    that the previous _incremental_update_heap incurred on every hot-path
-    operation.
+    not match) are skipped on pop.
     """
 
     def __init__(self, prefiller_instances, decoder_instances):
         self._lock = threading.RLock()
         self.request_num = 0
         self.waiting_nodes: dict[str, tuple[str, tuple[str, int], int]] = {}
-        self.tainted_prefillers: set[str] = set()
-        self.tainted_decoders: set[str] = set()
-        self.prefillers: dict[str, _ServerEntry] = {}
-        self.decoders: dict[str, _ServerEntry] = {}
-        self.prefiller_heap: list[tuple[float, int, int, str]] = []
-        self.decoder_heap: list[tuple[float, int, int, str]] = []
+        self._pools: dict[ServerRole, RolePools] = {
+            ServerRole.PREFILL: RolePools(),
+            ServerRole.DECODE: RolePools(),
+        }
         self._ordinal = 0
 
         for host, port in prefiller_instances:
-            self._add_server_no_lock(_IS_PREFILL, host, port)
+            self._add_server_no_lock(ServerRole.PREFILL, host, port)
         for host, port in decoder_instances:
-            self._add_server_no_lock(_IS_DECODE, host, port)
+            self._add_server_no_lock(ServerRole.DECODE, host, port)
 
-    def _server_map(self, is_prefill: bool) -> dict[str, _ServerEntry]:
-        return self.prefillers if is_prefill else self.decoders
+    def _pool(self, role: ServerRole) -> RolePools:
+        return self._pools[role]
 
-    def _heap_ref(self, is_prefill: bool) -> list[tuple[float, int, int, str]]:
-        return self.prefiller_heap if is_prefill else self.decoder_heap
+    @property
+    def prefillers(self) -> dict[str, BackendServer]:
+        return self._pool(ServerRole.PREFILL).servers
 
-    def _tainted_ref(self, is_prefill: bool) -> set[str]:
-        return self.tainted_prefillers if is_prefill else self.tainted_decoders
+    @property
+    def decoders(self) -> dict[str, BackendServer]:
+        return self._pool(ServerRole.DECODE).servers
 
     def _next_ordinal(self) -> int:
         ordinal = self._ordinal
         self._ordinal += 1
         return ordinal
 
-    def _priority(self, is_prefill: bool, entry: _ServerEntry, key: str) -> float:
-        if key in (self.tainted_prefillers if is_prefill else self.tainted_decoders):
+    def _priority(self, role: ServerRole, entry: BackendServer, key: str) -> float:
+        if key in self._pool(role).tainted:
             return TAINT_PRIORITY
-        if is_prefill:
+        if role is ServerRole.PREFILL:
             return entry.active_tokens + entry.active_kv_cache * 0.3
         return entry.active_tokens
 
-    def _push_heap(self, is_prefill: bool, key: str) -> None:
-        entry = self._server_map(is_prefill)[key]
+    def _push_heap(self, role: ServerRole, key: str) -> None:
+        pool = self._pool(role)
+        entry = pool.servers[key]
         entry.heap_seq += 1
-        heap = self._heap_ref(is_prefill)
-        heapq.heappush(heap, (self._priority(is_prefill, entry, key), entry.ordinal, entry.heap_seq, key))
-        if len(heap) > 2 * len(self._server_map(is_prefill)):
-            self._compact_heap_no_lock(is_prefill)
+        heapq.heappush(pool.heap, (self._priority(role, entry, key), entry.ordinal, entry.heap_seq, key))
+        if len(pool.heap) > 2 * len(pool.servers):
+            self._reset_heap(role)
 
-    def _pop_valid(self, is_prefill: bool) -> str:
-        servers = self._server_map(is_prefill)
-        heap = self._heap_ref(is_prefill)
-        while heap:
-            _, _, seq, key = heapq.heappop(heap)
-            if key not in servers:
+    def _pop_valid(self, role: ServerRole) -> str:
+        pool = self._pool(role)
+        while pool.heap:
+            _, _, seq, key = heapq.heappop(pool.heap)
+            if key not in pool.servers:
                 continue
-            entry = servers[key]
+            entry = pool.servers[key]
             if entry.heap_seq == seq:
                 return key
-        raise RuntimeError("No available servers")
+        raise RuntimeError(f"No available {role.value} servers")
 
-    def _rebuild_heap_no_lock(self, is_prefill: bool) -> None:
+    def _reset_heap(self, role: ServerRole, *, bump_seq: bool = False) -> None:
+        pool = self._pool(role)
         heap = []
-        for key, entry in self._server_map(is_prefill).items():
-            entry.heap_seq += 1
-            heap.append((self._priority(is_prefill, entry, key), entry.ordinal, entry.heap_seq, key))
+        for key, entry in pool.servers.items():
+            if bump_seq:
+                entry.heap_seq += 1
+            heap.append((self._priority(role, entry, key), entry.ordinal, entry.heap_seq, key))
         heapq.heapify(heap)
-        if is_prefill:
-            self.prefiller_heap = heap
-        else:
-            self.decoder_heap = heap
+        pool.heap = heap
 
-    def _compact_heap_no_lock(self, is_prefill: bool) -> None:
-        servers = self._server_map(is_prefill)
-        heap = []
-        for key, entry in servers.items():
-            heap.append((self._priority(is_prefill, entry, key), entry.ordinal, entry.heap_seq, key))
-        heapq.heapify(heap)
-        if is_prefill:
-            self.prefiller_heap = heap
-        else:
-            self.decoder_heap = heap
-
-    def _add_server_no_lock(self, is_prefill: bool, host: str, port: int) -> bool:
+    def _add_server_no_lock(self, role: ServerRole, host: str, port: int) -> bool:
         key = server_key(host, port)
-        servers = self._server_map(is_prefill)
-        if key in servers:
+        pool = self._pool(role)
+        if key in pool.servers:
             return False
-        ordinal = self._next_ordinal()
-        servers[key] = _ServerEntry(host, int(port), ordinal)
-        self._push_heap(is_prefill, key)
+        pool.servers[key] = BackendServer(host, int(port), self._next_ordinal())
+        self._push_heap(role, key)
         return True
 
     def get_snapshot(self) -> dict[str, list[dict[str, Any]]]:
@@ -348,13 +327,14 @@ class SharedProxyScheduler:
                 ],
             }
 
-    def print_status(self, msg: str) -> None:
+    def log_status(self, msg: str) -> None:
         snapshot = self.get_snapshot()
-        status = {
-            "prefill_instances": [f"{s['host']}:{s['port']}" for s in snapshot["prefill_instances"]],
-            "decode_instances": [f"{s['host']}:{s['port']}" for s in snapshot["decode_instances"]],
-        }
-        print(f"{msg} Status: {status}")
+        logger.info(
+            "%s prefill=%s decode=%s",
+            msg,
+            [f"{s['host']}:{s['port']}" for s in snapshot["prefill_instances"]],
+            [f"{s['host']}:{s['port']}" for s in snapshot["decode_instances"]],
+        )
 
     def healthcheck(self) -> dict[str, Any]:
         with self._lock:
@@ -365,120 +345,94 @@ class SharedProxyScheduler:
                 "request_num": self.request_num,
             }
 
-    def request_started(self) -> None:
-        with self._lock:
-            self.request_num += 1
-
-    def request_finished(self) -> None:
-        with self._lock:
-            self.request_num = max(0, self.request_num - 1)
-
-    def start_request_and_reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
-        with self._lock:
-            key = self._pop_valid(_IS_PREFILL)
-            entry = self.prefillers[key]
-            entry.active_kv_cache += token_count
-            self._push_heap(_IS_PREFILL, key)
-            self.request_num += 1
-            return {"key": key, "host": entry.host, "port": entry.port}
-
-    def select_prefiller(self, token_count: float) -> dict[str, Any]:
-        with self._lock:
-            key = self._pop_valid(_IS_PREFILL)
-            entry = self.prefillers[key]
-            entry.active_tokens += token_count
-            entry.active_kv_cache += token_count
-            self._push_heap(_IS_PREFILL, key)
-            return {"key": key, "host": entry.host, "port": entry.port}
-
-    def _reserve_prefiller_kv_no_lock(self, token_count: float) -> dict[str, Any]:
-        key = self._pop_valid(_IS_PREFILL)
-        entry = self.prefillers[key]
-        entry.active_kv_cache += token_count
-        self._push_heap(_IS_PREFILL, key)
+    def _pick_server(
+        self,
+        role: ServerRole,
+        load: float,
+        *,
+        active_tokens: bool = False,
+        kv_cache: bool = False,
+    ) -> dict[str, Any]:
+        key = self._pop_valid(role)
+        entry = self._pool(role).servers[key]
+        if active_tokens:
+            entry.active_tokens += load
+        if kv_cache:
+            entry.active_kv_cache += load
+        self._push_heap(role, key)
         return {"key": key, "host": entry.host, "port": entry.port}
 
-    def reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
-        """Select a prefiller and reserve only its KV pressure.
-
-        The request hot path releases prefiller active tokens immediately after
-        remote prefill finishes. Tracking only the net KV reservation avoids a
-        second manager RPC per request while keeping decode-time KV balancing.
-        """
-        with self._lock:
-            return self._reserve_prefiller_kv_no_lock(token_count)
-
-    def release_prefiller(self, key: str, token_count: float) -> None:
-        with self._lock:
-            if key not in self.prefillers:
-                return
-            self.prefillers[key].active_tokens -= token_count
-            self._push_heap(_IS_PREFILL, key)
-
-    def release_prefiller_kv(self, key: str, token_count: float) -> None:
-        with self._lock:
-            self._release_prefiller_kv_no_lock(key, token_count)
-
-    def _release_prefiller_kv_no_lock(self, key: str, token_count: float) -> None:
-        if key not in self.prefillers:
+    def _release_load(
+        self,
+        role: ServerRole,
+        key: str | None,
+        load: float,
+        *,
+        active_tokens: bool = False,
+        kv_cache: bool = False,
+    ) -> None:
+        if not key or key not in self._pool(role).servers:
             return
-        entry = self.prefillers[key]
-        entry.active_kv_cache = max(0.0, entry.active_kv_cache - token_count)
-        self._push_heap(_IS_PREFILL, key)
+        entry = self._pool(role).servers[key]
+        if active_tokens:
+            entry.active_tokens -= load
+        if kv_cache:
+            entry.active_kv_cache = max(0.0, entry.active_kv_cache - load)
+        self._push_heap(role, key)
 
-    def select_decoder(self, token_count: float) -> dict[str, Any]:
+    def begin_request(self, load: float) -> dict[str, Any]:
+        """Pick a prefiller, reserve KV pressure, and count this as an active request."""
         with self._lock:
-            return self._select_decoder_no_lock(token_count)
+            picked = self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
+            self.request_num += 1
+            return picked
 
-    def _select_decoder_no_lock(self, token_count: float) -> dict[str, Any]:
-        key = self._pop_valid(_IS_DECODE)
-        entry = self.decoders[key]
-        entry.active_tokens += token_count
-        self._push_heap(_IS_DECODE, key)
-        return {"key": key, "host": entry.host, "port": entry.port}
-
-    def release_decoder(self, key: str, token_count: float) -> None:
+    def reserve_prefill_kv(self, load: float) -> dict[str, Any]:
+        """Pick a prefiller for recompute without bumping the active request count."""
         with self._lock:
-            if key not in self.decoders:
-                return
-            self.decoders[key].active_tokens -= token_count
-            self._push_heap(_IS_DECODE, key)
+            return self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
+
+    def pick_decoder(self, load: float) -> dict[str, Any]:
+        with self._lock:
+            return self._pick_server(ServerRole.DECODE, load, active_tokens=True)
+
+    def release_prefill_kv(self, key: str, load: float) -> None:
+        with self._lock:
+            self._release_load(ServerRole.PREFILL, key, load, kv_cache=True)
+
+    def release_decoder(self, key: str, load: float) -> None:
+        with self._lock:
+            self._release_load(ServerRole.DECODE, key, load, active_tokens=True)
 
     def finish_request(
         self,
         prefiller_key: str | None,
-        prefiller_token_count: float,
+        prefiller_load: float,
         decoder_key: str | None,
-        decoder_token_count: float,
-        release_prefiller_kv: bool,
+        decoder_load: float,
+        release_prefill_kv: bool,
     ) -> None:
         with self._lock:
-            if release_prefiller_kv and prefiller_key in self.prefillers:
-                entry = self.prefillers[prefiller_key]
-                entry.active_kv_cache = max(0.0, entry.active_kv_cache - prefiller_token_count)
-                self._push_heap(_IS_PREFILL, prefiller_key)
-            if decoder_key in self.decoders:
-                self.decoders[decoder_key].active_tokens -= decoder_token_count
-                self._push_heap(_IS_DECODE, decoder_key)
+            if release_prefill_kv:
+                self._release_load(ServerRole.PREFILL, prefiller_key, prefiller_load, kv_cache=True)
+            self._release_load(ServerRole.DECODE, decoder_key, decoder_load, active_tokens=True)
             self.request_num = max(0, self.request_num - 1)
 
     def get_waiting_nodes(self) -> dict[str, tuple[str, tuple[str, int], int]]:
         with self._lock:
             return dict(self.waiting_nodes)
 
-    def add_instances(self, instance_type: str, instances: list[tuple[str, int]]) -> tuple[list[str], list[str]]:
-        is_prefill = instance_type == InstanceType.PREFILL
-        added_nodes: list[str] = []
+    def add_instances(self, role: ServerRole, instances: list[tuple[str, int]]) -> list[str]:
         waiting_nodes: list[str] = []
         with self._lock:
-            servers = self._server_map(is_prefill)
+            servers = self._pool(role).servers
             for host, port in instances:
                 key = server_key(host, port)
                 if key in servers or key in self.waiting_nodes:
                     continue
-                self.waiting_nodes[key] = (instance_type, (host, int(port)), 0)
+                self.waiting_nodes[key] = (role.value, (host, int(port)), 0)
                 waiting_nodes.append(f"{host}:{port}")
-        return added_nodes, waiting_nodes
+        return waiting_nodes
 
     def mark_waiting_retry(self, key: str, retry_count: int) -> None:
         with self._lock:
@@ -487,188 +441,131 @@ class SharedProxyScheduler:
             instance_type, server, _ = self.waiting_nodes[key]
             self.waiting_nodes[key] = (instance_type, server, retry_count)
 
-    def activate_waiting_instance(self, instance_type: str, host: str, port: int) -> None:
-        is_prefill = instance_type == InstanceType.PREFILL
+    def activate_waiting_instance(self, role: ServerRole, host: str, port: int) -> None:
         with self._lock:
             key = server_key(host, port)
             self.waiting_nodes.pop(key, None)
-            tainted = self._tainted_ref(is_prefill)
-            if key in tainted:
-                tainted.discard(key)
-                self._push_heap(is_prefill, key)
+            pool = self._pool(role)
+            if key in pool.tainted:
+                pool.tainted.discard(key)
+                self._push_heap(role, key)
                 return
-            if self._add_server_no_lock(is_prefill, host, port):
-                self.print_status(f"Add {instance_type} instance: {host}:{port}.")
+            if self._add_server_no_lock(role, host, port):
+                self.log_status(f"Add {role.value} instance: {host}:{port}.")
 
     def drop_waiting_instance(self, key: str) -> None:
         with self._lock:
             self.waiting_nodes.pop(key, None)
 
-    def remove_prefillers(self, instances: list[tuple[str, int]]) -> bool:
-        return self._remove_instances(_IS_PREFILL, instances)
-
-    def remove_decoders(self, instances: list[tuple[str, int]]) -> bool:
-        return self._remove_instances(_IS_DECODE, instances)
-
-    def _remove_instances(self, is_prefill: bool, instances: list[tuple[str, int]]) -> bool:
+    def remove_instances(self, role: ServerRole, instances: list[tuple[str, int]]) -> bool:
         if not instances:
             return False
         keys = {server_key(host, port) for host, port in instances}
         with self._lock:
+            pool = self._pool(role)
             if self.request_num > 0:
-                tainted = self._tainted_ref(is_prefill)
-                tainted.update(keys)
-                self._rebuild_heap_no_lock(is_prefill)
-                logger.warning("Start to taint %s instances %s.", "prefill" if is_prefill else "decode", sorted(keys))
+                pool.tainted.update(keys)
+                self._reset_heap(role, bump_seq=True)
+                logger.warning("Start to taint %s instances %s.", role.value, sorted(keys))
                 return True
 
             removed = False
-            servers = self._server_map(is_prefill)
             for key in keys:
-                removed = servers.pop(key, None) is not None or removed
+                removed = pool.servers.pop(key, None) is not None or removed
                 self.waiting_nodes.pop(key, None)
-            self._tainted_ref(is_prefill).difference_update(keys)
+            pool.tainted.difference_update(keys)
             if removed:
-                self._rebuild_heap_no_lock(is_prefill)
-                self.print_status(f"Remove {'prefill' if is_prefill else 'decode'} instances: {sorted(keys)}.")
+                self._reset_heap(role, bump_seq=True)
+                self.log_status(f"Remove {role.value} instances: {sorted(keys)}.")
             return False
 
     def finalize_tainted_instances(self) -> None:
         with self._lock:
             if self.request_num != 0:
                 return
-            for is_prefill in (_IS_PREFILL, _IS_DECODE):
-                tainted = self._tainted_ref(is_prefill)
-                if not tainted:
+            for role in ServerRole:
+                pool = self._pool(role)
+                if not pool.tainted:
                     continue
-                keys = list(tainted)
-                servers = self._server_map(is_prefill)
+                keys = list(pool.tainted)
                 for key in keys:
-                    servers.pop(key, None)
-                tainted.clear()
-                self._rebuild_heap_no_lock(is_prefill)
-                self.print_status(f"Remove {'prefiller' if is_prefill else 'decoder'} instances after drain: {keys}.")
+                    pool.servers.pop(key, None)
+                pool.tainted.clear()
+                self._reset_heap(role, bump_seq=True)
+                self.log_status(f"Remove {role.value} instances after drain: {keys}.")
 
 
 class SchedulerManager(BaseManager):
-    pass
+    """Multiprocessing RPC bridge; body is empty but required by BaseManager."""
 
 
-def get_shared_scheduler() -> "SharedProxyScheduler":
+def _shared_scheduler_proxy() -> "SharedProxyScheduler":
     if shared_scheduler is None:
         raise RuntimeError("shared scheduler is not initialized")
     return shared_scheduler
 
 
-SchedulerManager.register("get_scheduler", callable=get_shared_scheduler)
+SchedulerManager.register("get_scheduler", callable=_shared_scheduler_proxy)
 
 
 class WorkerRuntime:
     def __init__(self, scheduler: Any):
         self.scheduler = scheduler
-        self.prefiller_clients: dict[str, httpx.AsyncClient] = {}
-        self.decoder_clients: dict[str, httpx.AsyncClient] = {}
+        self._clients: dict[ServerRole, dict[str, httpx.AsyncClient]] = {
+            ServerRole.PREFILL: {},
+            ServerRole.DECODE: {},
+        }
         self._async_lock = asyncio.Lock()
 
-    async def start_request_and_reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
+    async def schedule(self, method: str, /, *args, **kwargs) -> Any:
         async with self._async_lock:
-            return self.scheduler.start_request_and_reserve_prefiller_kv(token_count)
+            return getattr(self.scheduler, method)(*args, **kwargs)
 
-    async def reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
-        async with self._async_lock:
-            return self.scheduler.reserve_prefiller_kv(token_count)
-
-    async def release_prefiller_kv(self, key: str, token_count: float) -> None:
-        async with self._async_lock:
-            self.scheduler.release_prefiller_kv(key, token_count)
-
-    async def select_decoder(self, token_count: float) -> dict[str, Any]:
-        async with self._async_lock:
-            return self.scheduler.select_decoder(token_count)
-
-    async def release_decoder(self, key: str, token_count: float) -> None:
-        async with self._async_lock:
-            self.scheduler.release_decoder(key, token_count)
-
-    async def finish_request(
-        self,
-        prefiller_key: str | None,
-        prefiller_token_count: float,
-        decoder_key: str | None,
-        decoder_token_count: float,
-        release_prefiller_kv: bool,
-    ) -> None:
-        async with self._async_lock:
-            self.scheduler.finish_request(
-                prefiller_key, prefiller_token_count, decoder_key, decoder_token_count, release_prefiller_kv
-            )
+    async def get_client(self, role: ServerRole, key: str) -> httpx.AsyncClient:
+        clients = self._clients[role]
+        if key not in clients:
+            await self.sync_clients()
+        return clients[key]
 
     async def sync_clients(self) -> None:
         snapshot = self.scheduler.get_snapshot()
-        prefiller_targets = {
-            server_key(s["host"], s["port"]): (s["host"], s["port"]) for s in snapshot["prefill_instances"]
+        role_targets = {
+            ServerRole.PREFILL: {
+                server_key(s["host"], s["port"]): (s["host"], s["port"])
+                for s in snapshot["prefill_instances"]
+            },
+            ServerRole.DECODE: {
+                server_key(s["host"], s["port"]): (s["host"], s["port"])
+                for s in snapshot["decode_instances"]
+            },
         }
-        decoder_targets = {
-            server_key(s["host"], s["port"]): (s["host"], s["port"]) for s in snapshot["decode_instances"]
-        }
-        await self._sync_group(self.prefiller_clients, prefiller_targets)
-        await self._sync_group(self.decoder_clients, decoder_targets)
+        for role, targets in role_targets.items():
+            await self._sync_clients(role, targets)
 
-    async def _sync_group(
-        self,
-        client_group: dict[str, httpx.AsyncClient],
-        targets: dict[str, tuple[str, int]],
-    ) -> None:
-        stale = [key for key in client_group if key not in targets]
-        for key in stale:
-            client = client_group.pop(key)
-            await client.aclose()
+    async def _sync_clients(self, role: ServerRole, targets: dict[str, tuple[str, int]]) -> None:
+        clients = self._clients[role]
+        for key in [key for key in clients if key not in targets]:
+            await clients.pop(key).aclose()
         for key, (host, port) in targets.items():
-            if key in client_group:
+            if key in clients:
                 continue
-            client_group[key] = httpx.AsyncClient(
+            clients[key] = httpx.AsyncClient(
                 timeout=None,
                 base_url=build_base_url(host, port),
                 limits=httpx.Limits(max_connections=100000, max_keepalive_connections=100000),
             )
 
-    def get_prefiller_client(self, key: str) -> httpx.AsyncClient:
-        return self.prefiller_clients[key]
-
-    def get_decoder_client(self, key: str) -> httpx.AsyncClient:
-        return self.decoder_clients[key]
-
     async def close(self) -> None:
-        for client in list(self.prefiller_clients.values()):
-            await client.aclose()
-        for client in list(self.decoder_clients.values()):
-            await client.aclose()
-        self.prefiller_clients.clear()
-        self.decoder_clients.clear()
+        for role in ServerRole:
+            for client in list(self._clients[role].values()):
+                await client.aclose()
+            self._clients[role].clear()
 
 
 def get_runtime() -> WorkerRuntime:
     if runtime is None:
         raise RuntimeError("worker runtime is not initialized")
     return runtime
-
-
-async def get_prefiller_client(key: str) -> httpx.AsyncClient:
-    worker_runtime = get_runtime()
-    try:
-        return worker_runtime.get_prefiller_client(key)
-    except KeyError:
-        await worker_runtime.sync_clients()
-        return worker_runtime.get_prefiller_client(key)
-
-
-async def get_decoder_client(key: str) -> httpx.AsyncClient:
-    worker_runtime = get_runtime()
-    try:
-        return worker_runtime.get_decoder_client(key)
-    except KeyError:
-        await worker_runtime.sync_clients()
-        return worker_runtime.get_decoder_client(key)
 
 
 class NodeListener:
@@ -686,7 +583,7 @@ class NodeListener:
                 print(f"Checking instance {key}...")
                 retries += 1
                 if is_valid:
-                    self.scheduler.activate_waiting_instance(instance_type, host, port)
+                    self.scheduler.activate_waiting_instance(ServerRole(instance_type), host, port)
                 elif retries >= args.max_waiting_retries:
                     print(f"Instance {key} was not added to the proxy.")
                     self.scheduler.drop_waiting_instance(key)
@@ -709,28 +606,35 @@ class NodeListener:
             return False
 
 
-def serialize_args(args: argparse.Namespace) -> dict[str, Any]:
-    return {
-        "port": args.port,
-        "host": args.host,
-        "prefiller_hosts": args.prefiller_hosts,
-        "prefiller_ports": args.prefiller_ports,
-        "decoder_hosts": args.decoder_hosts,
-        "decoder_ports": args.decoder_ports,
-        "max_retries": args.max_retries,
-        "retry_delay": args.retry_delay,
-        "max_waiting_retries": args.max_waiting_retries,
-        "waiting_retry_interval": args.waiting_retry_interval,
-        "workers": args.workers,
-        "log_level": args.log_level,
-    }
+def manager_config_path(proxy_port: int) -> Path:
+    return Path(tempfile.gettempdir()) / f"vllm_lb_proxy_manager_{proxy_port}.json"
 
 
-def deserialize_args(raw_args: dict[str, Any]) -> argparse.Namespace:
-    args = argparse.Namespace(**raw_args)
-    args.prefiller_instances = list(zip(args.prefiller_hosts, args.prefiller_ports))
-    args.decoder_instances = list(zip(args.decoder_hosts, args.decoder_ports))
-    return args
+def write_manager_config(proxy_port: int, host: str, manager_port: int, authkey: bytes) -> None:
+    manager_config_path(proxy_port).write_text(
+        json.dumps(
+            {
+                "host": host,
+                "port": manager_port,
+                "authkey": base64.b64encode(authkey).decode("ascii"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def read_manager_config(proxy_port: int) -> dict[str, Any]:
+    path = manager_config_path(proxy_port)
+    if not path.is_file():
+        raise RuntimeError(
+            f"Manager config not found at {path}. "
+            "Start the proxy from __main__ with --workers > 1 before worker processes connect."
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def cleanup_manager_config(proxy_port: int) -> None:
+    manager_config_path(proxy_port).unlink(missing_ok=True)
 
 
 def parse_args() -> argparse.Namespace:
@@ -777,28 +681,15 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def load_global_args_from_env() -> argparse.Namespace:
+def get_global_args() -> argparse.Namespace:
     global global_args
     if global_args is None:
-        raw = os.environ.get(ARGS_CONFIG_ENV)
-        if raw is None:
-            raise RuntimeError(f"{ARGS_CONFIG_ENV} is not set")
-        global_args = deserialize_args(json.loads(raw))
+        global_args = parse_args()
     return global_args
 
 
-def get_global_args() -> argparse.Namespace:
-    args = load_global_args_from_env()
-    if args is None:
-        raise RuntimeError("global args are not initialized")
-    return args
-
-
-def connect_shared_scheduler():
-    config = os.environ.get(MANAGER_CONFIG_ENV)
-    if config is None:
-        raise RuntimeError(f"{MANAGER_CONFIG_ENV} is not set")
-    manager_cfg = json.loads(config)
+def connect_shared_scheduler(proxy_port: int):
+    manager_cfg = read_manager_config(proxy_port)
     manager = SchedulerManager(
         address=(manager_cfg["host"], manager_cfg["port"]),
         authkey=base64.b64decode(manager_cfg["authkey"]),
@@ -807,23 +698,22 @@ def connect_shared_scheduler():
     return manager.get_scheduler()  # type: ignore[attr-defined]
 
 
-def start_shared_scheduler(args) -> None:
+def bootstrap_parent_process(args: argparse.Namespace) -> None:
+    """Initialize cross-worker shared state in the parent process before uvicorn spawns workers."""
     global shared_scheduler
+    if args.workers <= 1:
+        return
+
     shared_scheduler = SharedProxyScheduler(args.prefiller_instances, args.decoder_instances)
     NodeListener(shared_scheduler)
-    os.environ[ARGS_CONFIG_ENV] = json.dumps(serialize_args(args))
-    if args.workers > 1:
-        authkey = os.urandom(16)
-        manager = SchedulerManager(address=("127.0.0.1", 0), authkey=authkey)
-        server = manager.get_server()
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        host, port = cast(tuple[str, int], server.address)
-        os.environ[MANAGER_CONFIG_ENV] = json.dumps(
-            {"host": host, "port": port, "authkey": base64.b64encode(authkey).decode("ascii")}
-        )
-    else:
-        os.environ.pop(MANAGER_CONFIG_ENV, None)
+
+    authkey = os.urandom(16)
+    manager = SchedulerManager(address=("127.0.0.1", 0), authkey=authkey)
+    server = manager.get_server()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = cast(tuple[str, int], server.address)
+    write_manager_config(args.port, host, port, authkey)
 
 
 def _ensure_scheduler(args) -> SharedProxyScheduler:
@@ -838,17 +728,19 @@ def _ensure_scheduler(args) -> SharedProxyScheduler:
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     global runtime
-    args = load_global_args_from_env()
+    args = get_global_args()
     if args.workers > 1:
-        scheduler = connect_shared_scheduler()
+        scheduler = connect_shared_scheduler(args.port)
     else:
         scheduler = _ensure_scheduler(args)
     runtime = WorkerRuntime(scheduler)
     await runtime.sync_clients()
     snapshot = scheduler.get_snapshot()
-    print(
-        f"Initialized {len(snapshot['prefill_instances'])} prefill clients and "
-        f"{len(snapshot['decode_instances'])} decode clients in worker {os.getpid()}."
+    logger.info(
+        "Initialized %s prefill clients and %s decode clients in worker %s.",
+        len(snapshot["prefill_instances"]),
+        len(snapshot["decode_instances"]),
+        os.getpid(),
     )
     yield
     await runtime.close()
@@ -859,8 +751,7 @@ app = FastAPI(lifespan=lifespan)
 
 
 def create_app():
-    args = load_global_args_from_env()
-    setup_logging(args.log_level)
+    setup_logging(get_global_args().log_level)
     return app
 
 
@@ -887,17 +778,16 @@ def with_cancellation(handler_func):
     return wrapper
 
 
-async def send_request_to_service(
-    client: httpx.AsyncClient,
-    prefiller_key: str,
-    endpoint: str,
-    req_data: dict,
-    request_id: str,
-    max_retries: int = 3,
-    base_delay: float = 0.2,
-):
-    req_data = req_data.copy()
-    req_data["kv_transfer_params"] = {
+def auth_headers(request_id: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+        "X-Request-Id": request_id,
+    }
+
+
+def build_prefill_request(req_data: dict) -> dict:
+    payload = req_data.copy()
+    payload["kv_transfer_params"] = {
         "do_remote_decode": True,
         "do_remote_prefill": False,
         "remote_engine_id": None,
@@ -905,14 +795,25 @@ async def send_request_to_service(
         "remote_host": None,
         "remote_port": None,
     }
-    req_data["stream"] = False
-    req_data["max_tokens"] = 1
-    req_data["min_tokens"] = 1
-    if "max_completion_tokens" in req_data:
-        req_data["max_completion_tokens"] = 1
-    if "stream_options" in req_data:
-        del req_data["stream_options"]
-    headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}", "X-Request-Id": request_id}
+    payload["stream"] = False
+    payload["max_tokens"] = 1
+    payload["min_tokens"] = 1
+    if "max_completion_tokens" in payload:
+        payload["max_completion_tokens"] = 1
+    payload.pop("stream_options", None)
+    return payload
+
+
+async def send_request_to_service(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    req_data: dict,
+    request_id: str,
+    max_retries: int = 3,
+    base_delay: float = 0.2,
+):
+    req_data = build_prefill_request(req_data)
+    headers = auth_headers(request_id)
     last_exc = None
     for attempt in range(1, max_retries + 1):
         try:
@@ -937,7 +838,7 @@ async def stream_service_response_with_retry(
     max_retries: int = 3,
     base_delay: float = 0.2,
 ):
-    headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}", "X-Request-Id": request_id}
+    headers = auth_headers(request_id)
     for attempt in range(1, max_retries + 1):
         try:
             async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
@@ -966,28 +867,51 @@ async def stream_service_response_with_retry(
                 raise exc
 
 
-async def handle_select_instance(
+async def _abort_prefill_selection(
+    runtime: WorkerRuntime,
+    prefiller_key: str,
+    prefiller_score: float,
+    *,
+    is_initial_request: bool,
+) -> None:
+    if is_initial_request:
+        await runtime.schedule(
+            "finish_request", prefiller_key, prefiller_score, None, 0.0, release_prefill_kv=True
+        )
+    else:
+        await runtime.schedule("release_prefill_kv", prefiller_key, prefiller_score)
+
+
+async def _finish_instance(runtime: WorkerRuntime, info: InstanceInfo, *, release_prefill_kv: bool) -> None:
+    await runtime.schedule(
+        "finish_request",
+        info.prefiller_key,
+        info.prefiller_score,
+        info.decoder_key,
+        info.decoder_score,
+        release_prefill_kv,
+    )
+
+
+async def assign_instances(
     api: str,
     req_data: Any,
     request_length: int,
-    start_request: bool,
+    *,
+    is_initial_request: bool,
 ) -> InstanceInfo:
-    worker_runtime = get_runtime()
+    runtime = get_runtime()
     args = get_global_args()
     prefiller_score = calculate_prefill_score(request_length)
     decoder_score = calculate_decode_score(request_length)
     request_id = next_req_id()
-    if start_request:
-        prefiller = await worker_runtime.start_request_and_reserve_prefiller_kv(prefiller_score)
-    else:
-        prefiller = await worker_runtime.reserve_prefiller_kv(prefiller_score)
+    pick_prefill = "begin_request" if is_initial_request else "reserve_prefill_kv"
+    prefiller = await runtime.schedule(pick_prefill, prefiller_score)
     prefiller_key = prefiller["key"]
-    prefiller_client = await get_prefiller_client(prefiller_key)
 
     try:
         response = await send_request_to_service(
-            prefiller_client,
-            prefiller_key,
+            await runtime.get_client(ServerRole.PREFILL, prefiller_key),
             api,
             req_data,
             request_id,
@@ -995,66 +919,54 @@ async def handle_select_instance(
             base_delay=args.retry_delay,
         )
     except Exception:
-        if start_request:
-            await worker_runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
-        else:
-            await worker_runtime.release_prefiller_kv(prefiller_key, prefiller_score)
+        await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
         raise
 
-    response_json = response.json()
-    kv_transfer_params = response_json.get("kv_transfer_params", {})
+    kv_transfer_params = response.json().get("kv_transfer_params", {})
     if kv_transfer_params:
         req_data["kv_transfer_params"] = kv_transfer_params
 
     try:
-        decoder = await worker_runtime.select_decoder(decoder_score)
+        decoder = await runtime.schedule("pick_decoder", decoder_score)
     except Exception:
-        if start_request:
-            await worker_runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
-        else:
-            await worker_runtime.release_prefiller_kv(prefiller_key, prefiller_score)
+        await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
         raise
-    decoder_key = decoder["key"]
-    decoder_client = await get_decoder_client(decoder_key)
 
-    logger.debug(
-        "Using %s %s",
-        prefiller_client.base_url,
-        decoder_client.base_url,
-    )
+    prefiller_client = await runtime.get_client(ServerRole.PREFILL, prefiller_key)
+    decoder_client = await runtime.get_client(ServerRole.DECODE, decoder["key"])
+    logger.debug("Using %s %s", prefiller_client.base_url, decoder_client.base_url)
     return InstanceInfo(
         request_id=request_id,
         prefiller_key=prefiller_key,
         prefiller_score=prefiller_score,
-        prefiller=prefiller,
-        decoder_key=decoder_key,
+        decoder_key=decoder["key"],
         decoder_score=decoder_score,
-        decoder=decoder,
+        decoder_host=decoder["host"],
+        decoder_port=decoder["port"],
     )
 
 
-async def select_recompute_instance(
+async def reassign_instances(
     api: str,
     req_data: Any,
     request_length: int,
     previous_instance: InstanceInfo,
 ) -> InstanceInfo:
-    """Release the old decoder before assigning a new instance for recompute."""
-    worker_runtime = get_runtime()
-    await worker_runtime.release_prefiller_kv(previous_instance.prefiller_key, previous_instance.prefiller_score)
-    await worker_runtime.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
-    return await handle_select_instance(api, req_data, request_length, start_request=False)
+    runtime = get_runtime()
+    await runtime.schedule("release_prefill_kv", previous_instance.prefiller_key, previous_instance.prefiller_score)
+    await runtime.schedule("release_decoder", previous_instance.decoder_key, previous_instance.decoder_score)
+    return await assign_instances(api, req_data, request_length, is_initial_request=False)
 
 
 async def handle_completions_impl(api: str, request: Request):
-    worker_runtime = get_runtime()
+    runtime = get_runtime()
     args = get_global_args()
     request_released = False
     try:
         req_data = await request.json()
         req_body = await request.body()
         request_length = len(req_body)
-        instance_info = await handle_select_instance(api, req_data, request_length, start_request=True)
+        instance_info = await assign_instances(api, req_data, request_length, is_initial_request=True)
         stream_flag = bool(req_data.get("stream", False))
         chat_flag = "messages" in req_data
 
@@ -1076,18 +988,18 @@ async def handle_completions_impl(api: str, request: Request):
             retry = True
             completion_tokens = 0
 
-            async def release_prefiller_kv_once() -> None:
+            async def release_prefill_kv_once() -> None:
                 nonlocal released_kv
                 if not released_kv:
-                    await worker_runtime.release_prefiller_kv(
-                        instance_info.prefiller_key, instance_info.prefiller_score
+                    await runtime.schedule(
+                        "release_prefill_kv", instance_info.prefiller_key, instance_info.prefiller_score
                     )
                     released_kv = True
 
             try:
                 while retry:
                     retry = False
-                    decoder_client = await get_decoder_client(instance_info.decoder_key)
+                    decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
                     async for chunk in stream_service_response_with_retry(
                         decoder_client,
                         api,
@@ -1097,7 +1009,7 @@ async def handle_completions_impl(api: str, request: Request):
                         base_delay=args.retry_delay,
                     ):
                         if not released_kv and chunk:
-                            await release_prefiller_kv_once()
+                            await release_prefill_kv_once()
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
@@ -1141,7 +1053,7 @@ async def handle_completions_impl(api: str, request: Request):
                                 req_data["prompt"] = origin_prompt + generated_token
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await select_recompute_instance(
+                            instance_info = await reassign_instances(
                                 api, req_data, tmp_request_length, instance_info
                             )
                             released_kv = False
@@ -1156,27 +1068,21 @@ async def handle_completions_impl(api: str, request: Request):
             except asyncio.CancelledError:
                 logger.warning(
                     "Streaming from decoder %s:%s was cancelled; releasing request %s resources",
-                    instance_info.decoder["host"],
-                    instance_info.decoder["port"],
+                    instance_info.decoder_host,
+                    instance_info.decoder_port,
                     instance_info.request_id,
                 )
                 raise
             except Exception as exc:
                 logger.error(
                     "Error during streaming from decoder %s:%s: %s while handling request %s; releasing prefiller KV",
-                    instance_info.decoder["host"],
-                    instance_info.decoder["port"],
+                    instance_info.decoder_host,
+                    instance_info.decoder_port,
                     exc,
                     instance_info.request_id,
                 )
             finally:
-                await worker_runtime.finish_request(
-                    instance_info.prefiller_key,
-                    instance_info.prefiller_score,
-                    instance_info.decoder_key,
-                    instance_info.decoder_score,
-                    release_prefiller_kv=not released_kv,
-                )
+                await _finish_instance(runtime, instance_info, release_prefill_kv=not released_kv)
                 released_kv = True
                 request_released = True
 
@@ -1189,13 +1095,7 @@ async def handle_completions_impl(api: str, request: Request):
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print("".join(traceback.format_exception(*exc_info)))
         if not request_released and "instance_info" in locals():
-            await worker_runtime.finish_request(
-                instance_info.prefiller_key,
-                instance_info.prefiller_score,
-                instance_info.decoder_key,
-                instance_info.decoder_score,
-                release_prefiller_kv=True,
-            )
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
             request_released = True
         raise
 
@@ -1206,32 +1106,32 @@ async def adjust_instances_impl(adjust_mode: str, request: Request):
     instances = req_data.get("instances", [])
     if isinstance(instances, str):
         instances = [instances]
-    instances = trans_instances(instances)
-    all_msg = f"{adjust_mode} {instance_type} instances: {[str(server) for server in instances]}."
+    parsed_instances = parse_server_addresses(instances)
+    all_msg = f"{adjust_mode} {instance_type} instances: {[f'{host}:{port}' for host, port in parsed_instances]}."
 
-    if instance_type not in [InstanceType.PREFILL, InstanceType.DECODE]:
+    try:
+        role = ServerRole(instance_type)
+    except ValueError:
         return {
-            "error": f"Instance type {instance_type} is not supported. "
-            f"Only support '{InstanceType.PREFILL}' and '{InstanceType.DECODE}'."
+            "error": (
+                f"Instance type {instance_type!r} is not supported. "
+                f"Only '{ServerRole.PREFILL.value}' and '{ServerRole.DECODE.value}' are allowed."
+            )
         }
 
-    raw_instances = [(server.host, server.port) for server in instances]
     scheduler = get_runtime().scheduler
 
     if adjust_mode == "add":
-        added_nodes, waiting_nodes = scheduler.add_instances(instance_type, raw_instances)
+        waiting_nodes = scheduler.add_instances(role, parsed_instances)
         if waiting_nodes:
-            all_msg = (
-                f"{adjust_mode} {instance_type} instances: {added_nodes}. "
-                f"Instances {waiting_nodes} are waiting to be added."
-            )
+            all_msg = f"Instances {waiting_nodes} are waiting to be added."
     elif adjust_mode == "remove":
-        if instance_type == InstanceType.PREFILL:
-            need_waiting = scheduler.remove_prefillers(raw_instances)
-        else:
-            need_waiting = scheduler.remove_decoders(raw_instances)
+        need_waiting = scheduler.remove_instances(role, parsed_instances)
         if need_waiting:
-            all_msg = f"Instances {[str(server) for server in instances]} are isolated and waiting to be removed."
+            all_msg = (
+                f"Instances {[f'{host}:{port}' for host, port in parsed_instances]} "
+                "are isolated and waiting to be removed."
+            )
 
     snapshot = scheduler.get_snapshot()
     return {
@@ -1241,12 +1141,8 @@ async def adjust_instances_impl(adjust_mode: str, request: Request):
     }
 
 
-def trans_instances(instances: list[str]) -> list[ServerState]:
-    result = []
-    for instance in instances:
-        host, port = instance.split(":")
-        result.append(ServerState(host, int(port)))
-    return result
+def parse_server_addresses(instances: list[str]) -> list[tuple[str, int]]:
+    return [(host, int(port)) for host, port in (instance.split(":") for instance in instances)]
 
 
 @app.post("/v1/completions")
@@ -1301,15 +1197,18 @@ async def handle_remove_instances(request: Request):
 if __name__ == "__main__":
     global_args = parse_args()
     setup_logging(global_args.log_level)
-    start_shared_scheduler(global_args)
+    bootstrap_parent_process(global_args)
     import uvicorn
 
     module_name = Path(__file__).stem
-    uvicorn.run(
-        f"{module_name}:create_app",
-        host=global_args.host,
-        port=global_args.port,
-        workers=global_args.workers,
-        factory=True,
-        app_dir=str(Path(__file__).resolve().parent),
-    )
+    try:
+        uvicorn.run(
+            f"{module_name}:create_app",
+            host=global_args.host,
+            port=global_args.port,
+            workers=global_args.workers,
+            factory=True,
+            app_dir=str(Path(__file__).resolve().parent),
+        )
+    finally:
+        cleanup_manager_config(global_args.port)

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -135,7 +135,7 @@ from typing import Any, cast
 
 import httpx
 from fastapi import FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 logger = logging.getLogger(__name__)
 
@@ -219,15 +219,19 @@ def server_key(host: str, port: int) -> str:
     return f"{normalize_host(host)}:{int(port)}"
 
 
-def build_base_url(host: str, port: int) -> str:
-    url = f"http://{host}:{port}/v1"
+def build_server_url(host: str, port: int) -> str:
+    url = f"http://{host}:{port}"
     try:
         ip = ipaddress.ip_address(host)
         if isinstance(ip, ipaddress.IPv6Address):
-            url = f"http://[{host}]:{port}/v1"
+            url = f"http://[{host}]:{port}"
     except Exception:
         pass
     return url
+
+
+def build_base_url(host: str, port: int) -> str:
+    return f"{build_server_url(host, port)}/v1"
 
 
 class SharedProxyScheduler:
@@ -531,12 +535,10 @@ class WorkerRuntime:
         snapshot = self.scheduler.get_snapshot()
         role_targets = {
             ServerRole.PREFILL: {
-                server_key(s["host"], s["port"]): (s["host"], s["port"])
-                for s in snapshot["prefill_instances"]
+                server_key(s["host"], s["port"]): (s["host"], s["port"]) for s in snapshot["prefill_instances"]
             },
             ServerRole.DECODE: {
-                server_key(s["host"], s["port"]): (s["host"], s["port"])
-                for s in snapshot["decode_instances"]
+                server_key(s["host"], s["port"]): (s["host"], s["port"]) for s in snapshot["decode_instances"]
             },
         }
         for role, targets in role_targets.items():
@@ -875,9 +877,7 @@ async def _abort_prefill_selection(
     is_initial_request: bool,
 ) -> None:
     if is_initial_request:
-        await runtime.schedule(
-            "finish_request", prefiller_key, prefiller_score, None, 0.0, release_prefill_kv=True
-        )
+        await runtime.schedule("finish_request", prefiller_key, prefiller_score, None, 0.0, release_prefill_kv=True)
     else:
         await runtime.schedule("release_prefill_kv", prefiller_key, prefiller_score)
 
@@ -1053,9 +1053,7 @@ async def handle_completions_impl(api: str, request: Request):
                                 req_data["prompt"] = origin_prompt + generated_token
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await reassign_instances(
-                                api, req_data, tmp_request_length, instance_info
-                            )
+                            instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
                             released_kv = False
                             break
                         if retry_count > 0 and not stream_flag:
@@ -1160,23 +1158,25 @@ async def handle_chat_completions(request: Request):
 @app.post("/reset_prefix_cache")
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)
-    failures = []
-    for client, base_url in [
-        (s.client, f"http://{s.host}:{s.port}") for s in proxy_state.prefillers + proxy_state.decoders
-    ]:
+    runtime = get_runtime()
+    await runtime.sync_clients()
+    snapshot = runtime.scheduler.get_snapshot()
+    backend_instances = [(ServerRole.PREFILL, server) for server in snapshot["prefill_instances"]] + [
+        (ServerRole.DECODE, server) for server in snapshot["decode_instances"]
+    ]
+    failures: list[str] = []
+    for role, server in backend_instances:
+        base_url = build_server_url(server["host"], server["port"])
         try:
+            client = await runtime.get_client(role, server_key(server["host"], server["port"]))
             resp = await client.post(f"{base_url}/reset_prefix_cache", params=params)
             resp.raise_for_status()
         except Exception as e:
             logger.error("reset_prefix_cache failed for %s: %s", base_url, e)
             failures.append(base_url)
     if failures:
-        from fastapi.responses import JSONResponse
-
         return JSONResponse(status_code=500, content={"failed": failures})
-    from fastapi.responses import Response as FastAPIResponse
-
-    return FastAPIResponse(status_code=200)
+    return Response(status_code=200)
 
 
 @app.get("/healthcheck")

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -36,7 +36,7 @@
 # Run the proxy server, specifying the host/port for each prefiller and decoder:
 #
 #   python load_balance_proxy_server_example.py \
-#     --host 0.0.0.0 --port 9000 --workers 8 \
+#     --host 0.0.0.0 --port 9000 --workers 2 \
 #     --prefiller-hosts 127.0.0.1 127.0.0.1 \
 #     --prefiller-ports 8100 8101 \
 #     --decoder-hosts 127.0.0.1 127.0.0.1 \
@@ -129,7 +129,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from multiprocessing.managers import BaseManager
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from fastapi import FastAPI, Request
@@ -138,7 +138,7 @@ from fastapi.responses import StreamingResponse
 logger = logging.getLogger(__name__)
 
 try:
-    import uvloop
+    import uvloop  # type: ignore[import-not-found]
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 except ImportError:
@@ -177,9 +177,9 @@ _IS_DECODE = False
 MANAGER_CONFIG_ENV = "LB_PROXY_MANAGER_CONFIG"
 ARGS_CONFIG_ENV = "LB_PROXY_ARGS"
 
-global_args = None
-shared_scheduler = None
-runtime = None
+global_args: argparse.Namespace | None = None
+shared_scheduler: "SharedProxyScheduler | None" = None
+runtime: "WorkerRuntime | None" = None
 
 
 class _ServerEntry:
@@ -196,10 +196,11 @@ class _ServerEntry:
 
 def setup_logging(log_level: str) -> None:
     logging.basicConfig(
-        level=getattr(logging, log_level.upper()),
+        level=logging.WARNING,
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
         force=True,
     )
+    logger.setLevel(getattr(logging, log_level.upper()))
 
 
 def next_req_id() -> str:
@@ -553,7 +554,7 @@ class SchedulerManager(BaseManager):
     pass
 
 
-def get_shared_scheduler():
+def get_shared_scheduler() -> "SharedProxyScheduler":
     if shared_scheduler is None:
         raise RuntimeError("shared scheduler is not initialized")
     return shared_scheduler
@@ -563,7 +564,7 @@ SchedulerManager.register("get_scheduler", callable=get_shared_scheduler)
 
 
 class WorkerRuntime:
-    def __init__(self, scheduler):
+    def __init__(self, scheduler: Any):
         self.scheduler = scheduler
         self.prefiller_clients: dict[str, httpx.AsyncClient] = {}
         self.decoder_clients: dict[str, httpx.AsyncClient] = {}
@@ -646,20 +647,28 @@ class WorkerRuntime:
         self.decoder_clients.clear()
 
 
+def get_runtime() -> WorkerRuntime:
+    if runtime is None:
+        raise RuntimeError("worker runtime is not initialized")
+    return runtime
+
+
 async def get_prefiller_client(key: str) -> httpx.AsyncClient:
+    worker_runtime = get_runtime()
     try:
-        return runtime.get_prefiller_client(key)
+        return worker_runtime.get_prefiller_client(key)
     except KeyError:
-        await runtime.sync_clients()
-        return runtime.get_prefiller_client(key)
+        await worker_runtime.sync_clients()
+        return worker_runtime.get_prefiller_client(key)
 
 
 async def get_decoder_client(key: str) -> httpx.AsyncClient:
+    worker_runtime = get_runtime()
     try:
-        return runtime.get_decoder_client(key)
+        return worker_runtime.get_decoder_client(key)
     except KeyError:
-        await runtime.sync_clients()
-        return runtime.get_decoder_client(key)
+        await worker_runtime.sync_clients()
+        return worker_runtime.get_decoder_client(key)
 
 
 class NodeListener:
@@ -670,6 +679,7 @@ class NodeListener:
 
     def _run(self) -> None:
         while True:
+            args = get_global_args()
             for key, (instance_type, server, retries) in list(self.scheduler.get_waiting_nodes().items()):
                 host, port = server
                 is_valid = asyncio.run(self.check_instance_status(host, port))
@@ -677,14 +687,14 @@ class NodeListener:
                 retries += 1
                 if is_valid:
                     self.scheduler.activate_waiting_instance(instance_type, host, port)
-                elif retries >= global_args.max_waiting_retries:
+                elif retries >= args.max_waiting_retries:
                     print(f"Instance {key} was not added to the proxy.")
                     self.scheduler.drop_waiting_instance(key)
                 else:
                     self.scheduler.mark_waiting_retry(key, retries)
 
             self.scheduler.finalize_tainted_instances()
-            time.sleep(global_args.waiting_retry_interval)
+            time.sleep(args.waiting_retry_interval)
 
     @staticmethod
     async def check_instance_status(host: str, port: int) -> bool:
@@ -699,7 +709,7 @@ class NodeListener:
             return False
 
 
-def serialize_args(args) -> dict[str, Any]:
+def serialize_args(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "port": args.port,
         "host": args.host,
@@ -716,14 +726,14 @@ def serialize_args(args) -> dict[str, Any]:
     }
 
 
-def deserialize_args(raw_args: dict[str, Any]):
+def deserialize_args(raw_args: dict[str, Any]) -> argparse.Namespace:
     args = argparse.Namespace(**raw_args)
     args.prefiller_instances = list(zip(args.prefiller_hosts, args.prefiller_ports))
     args.decoder_instances = list(zip(args.decoder_hosts, args.decoder_ports))
     return args
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--host", type=str, default="localhost")
@@ -767,7 +777,7 @@ def parse_args():
     return args
 
 
-def load_global_args_from_env():
+def load_global_args_from_env() -> argparse.Namespace:
     global global_args
     if global_args is None:
         raw = os.environ.get(ARGS_CONFIG_ENV)
@@ -775,6 +785,13 @@ def load_global_args_from_env():
             raise RuntimeError(f"{ARGS_CONFIG_ENV} is not set")
         global_args = deserialize_args(json.loads(raw))
     return global_args
+
+
+def get_global_args() -> argparse.Namespace:
+    args = load_global_args_from_env()
+    if args is None:
+        raise RuntimeError("global args are not initialized")
+    return args
 
 
 def connect_shared_scheduler():
@@ -787,7 +804,7 @@ def connect_shared_scheduler():
         authkey=base64.b64decode(manager_cfg["authkey"]),
     )
     manager.connect()
-    return manager.get_scheduler()
+    return manager.get_scheduler()  # type: ignore[attr-defined]
 
 
 def start_shared_scheduler(args) -> None:
@@ -801,7 +818,7 @@ def start_shared_scheduler(args) -> None:
         server = manager.get_server()
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
-        host, port = server.address
+        host, port = cast(tuple[str, int], server.address)
         os.environ[MANAGER_CONFIG_ENV] = json.dumps(
             {"host": host, "port": port, "authkey": base64.b64encode(authkey).decode("ascii")}
         )
@@ -955,13 +972,15 @@ async def handle_select_instance(
     request_length: int,
     start_request: bool,
 ) -> InstanceInfo:
+    worker_runtime = get_runtime()
+    args = get_global_args()
     prefiller_score = calculate_prefill_score(request_length)
     decoder_score = calculate_decode_score(request_length)
     request_id = next_req_id()
     if start_request:
-        prefiller = await runtime.start_request_and_reserve_prefiller_kv(prefiller_score)
+        prefiller = await worker_runtime.start_request_and_reserve_prefiller_kv(prefiller_score)
     else:
-        prefiller = await runtime.reserve_prefiller_kv(prefiller_score)
+        prefiller = await worker_runtime.reserve_prefiller_kv(prefiller_score)
     prefiller_key = prefiller["key"]
     prefiller_client = await get_prefiller_client(prefiller_key)
 
@@ -972,14 +991,14 @@ async def handle_select_instance(
             api,
             req_data,
             request_id,
-            max_retries=global_args.max_retries,
-            base_delay=global_args.retry_delay,
+            max_retries=args.max_retries,
+            base_delay=args.retry_delay,
         )
     except Exception:
         if start_request:
-            await runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
+            await worker_runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
         else:
-            await runtime.release_prefiller_kv(prefiller_key, prefiller_score)
+            await worker_runtime.release_prefiller_kv(prefiller_key, prefiller_score)
         raise
 
     response_json = response.json()
@@ -988,12 +1007,12 @@ async def handle_select_instance(
         req_data["kv_transfer_params"] = kv_transfer_params
 
     try:
-        decoder = await runtime.select_decoder(decoder_score)
+        decoder = await worker_runtime.select_decoder(decoder_score)
     except Exception:
         if start_request:
-            await runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
+            await worker_runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
         else:
-            await runtime.release_prefiller_kv(prefiller_key, prefiller_score)
+            await worker_runtime.release_prefiller_kv(prefiller_key, prefiller_score)
         raise
     decoder_key = decoder["key"]
     decoder_client = await get_decoder_client(decoder_key)
@@ -1021,12 +1040,15 @@ async def select_recompute_instance(
     previous_instance: InstanceInfo,
 ) -> InstanceInfo:
     """Release the old decoder before assigning a new instance for recompute."""
-    await runtime.release_prefiller_kv(previous_instance.prefiller_key, previous_instance.prefiller_score)
-    await runtime.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
+    worker_runtime = get_runtime()
+    await worker_runtime.release_prefiller_kv(previous_instance.prefiller_key, previous_instance.prefiller_score)
+    await worker_runtime.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
     return await handle_select_instance(api, req_data, request_length, start_request=False)
 
 
 async def handle_completions_impl(api: str, request: Request):
+    worker_runtime = get_runtime()
+    args = get_global_args()
     request_released = False
     try:
         req_data = await request.json()
@@ -1057,7 +1079,9 @@ async def handle_completions_impl(api: str, request: Request):
             async def release_prefiller_kv_once() -> None:
                 nonlocal released_kv
                 if not released_kv:
-                    await runtime.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
+                    await worker_runtime.release_prefiller_kv(
+                        instance_info.prefiller_key, instance_info.prefiller_score
+                    )
                     released_kv = True
 
             try:
@@ -1069,8 +1093,8 @@ async def handle_completions_impl(api: str, request: Request):
                         api,
                         req_data,
                         request_id=instance_info.request_id,
-                        max_retries=global_args.max_retries,
-                        base_delay=global_args.retry_delay,
+                        max_retries=args.max_retries,
+                        base_delay=args.retry_delay,
                     ):
                         if not released_kv and chunk:
                             await release_prefiller_kv_once()
@@ -1083,7 +1107,7 @@ async def handle_completions_impl(api: str, request: Request):
                         if not chunk_str:
                             continue
                         if chunk_str.startswith("data: "):
-                            chunk_str = chunk_str[len("data: "):]
+                            chunk_str = chunk_str[len("data: ") :]
                         try:
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
@@ -1146,7 +1170,7 @@ async def handle_completions_impl(api: str, request: Request):
                     instance_info.request_id,
                 )
             finally:
-                await runtime.finish_request(
+                await worker_runtime.finish_request(
                     instance_info.prefiller_key,
                     instance_info.prefiller_score,
                     instance_info.decoder_key,
@@ -1165,7 +1189,7 @@ async def handle_completions_impl(api: str, request: Request):
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print("".join(traceback.format_exception(*exc_info)))
         if not request_released and "instance_info" in locals():
-            await runtime.finish_request(
+            await worker_runtime.finish_request(
                 instance_info.prefiller_key,
                 instance_info.prefiller_score,
                 instance_info.decoder_key,
@@ -1192,7 +1216,7 @@ async def adjust_instances_impl(adjust_mode: str, request: Request):
         }
 
     raw_instances = [(server.host, server.port) for server in instances]
-    scheduler = runtime.scheduler
+    scheduler = get_runtime().scheduler
 
     if adjust_mode == "add":
         added_nodes, waiting_nodes = scheduler.add_instances(instance_type, raw_instances)
@@ -1261,7 +1285,7 @@ async def reset_prefix_cache(request: Request):
 
 @app.get("/healthcheck")
 async def healthcheck():
-    return runtime.scheduler.healthcheck()
+    return get_runtime().scheduler.healthcheck()
 
 
 @app.post("/instances/add")

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -172,12 +172,26 @@ class InstanceInfo:
 
 
 TAINT_PRIORITY = 1e15
+_IS_PREFILL = True
+_IS_DECODE = False
 MANAGER_CONFIG_ENV = "LB_PROXY_MANAGER_CONFIG"
 ARGS_CONFIG_ENV = "LB_PROXY_ARGS"
 
 global_args = None
 shared_scheduler = None
 runtime = None
+
+
+class _ServerEntry:
+    __slots__ = ("host", "port", "active_tokens", "active_kv_cache", "ordinal", "heap_seq")
+
+    def __init__(self, host: str, port: int, ordinal: int):
+        self.host = host
+        self.port = port
+        self.active_tokens: float = 0.0
+        self.active_kv_cache: float = 0.0
+        self.ordinal: int = ordinal
+        self.heap_seq: int = 0
 
 
 def setup_logging(log_level: str) -> None:
@@ -221,7 +235,14 @@ def build_base_url(host: str, port: int) -> str:
 
 
 class SharedProxyScheduler:
-    """Centralized mutable scheduling state shared by all uvicorn workers."""
+    """Centralized mutable scheduling state shared by all uvicorn workers.
+
+    Uses lazy-deletion min-heap: on priority change, push a new entry and
+    bump the server's ``heap_seq`` counter; stale entries (whose seq does
+    not match) are skipped on pop.  This avoids the O(n) list-comp filter
+    that the previous _incremental_update_heap incurred on every hot-path
+    operation.
+    """
 
     def __init__(self, prefiller_instances, decoder_instances):
         self._lock = threading.RLock()
@@ -229,73 +250,100 @@ class SharedProxyScheduler:
         self.waiting_nodes: dict[str, tuple[str, tuple[str, int], int]] = {}
         self.tainted_prefillers: set[str] = set()
         self.tainted_decoders: set[str] = set()
-        self.prefillers: dict[str, dict[str, Any]] = {}
-        self.decoders: dict[str, dict[str, Any]] = {}
-        self.prefiller_heap: list[tuple[float, int, str]] = []
-        self.decoder_heap: list[tuple[float, int, str]] = []
+        self.prefillers: dict[str, _ServerEntry] = {}
+        self.decoders: dict[str, _ServerEntry] = {}
+        self.prefiller_heap: list[tuple[float, int, int, str]] = []
+        self.decoder_heap: list[tuple[float, int, int, str]] = []
         self._ordinal = 0
 
         for host, port in prefiller_instances:
-            self._add_server_no_lock(InstanceType.PREFILL, host, port)
+            self._add_server_no_lock(_IS_PREFILL, host, port)
         for host, port in decoder_instances:
-            self._add_server_no_lock(InstanceType.DECODE, host, port)
+            self._add_server_no_lock(_IS_DECODE, host, port)
 
-    def _server_map(self, instance_type: str) -> dict[str, dict[str, Any]]:
-        return self.prefillers if instance_type == InstanceType.PREFILL else self.decoders
+    def _server_map(self, is_prefill: bool) -> dict[str, _ServerEntry]:
+        return self.prefillers if is_prefill else self.decoders
 
-    def _heap(self, instance_type: str) -> list[tuple[float, int, str]]:
-        return self.prefiller_heap if instance_type == InstanceType.PREFILL else self.decoder_heap
+    def _heap_ref(self, is_prefill: bool) -> list[tuple[float, int, int, str]]:
+        return self.prefiller_heap if is_prefill else self.decoder_heap
+
+    def _tainted_ref(self, is_prefill: bool) -> set[str]:
+        return self.tainted_prefillers if is_prefill else self.tainted_decoders
 
     def _next_ordinal(self) -> int:
         ordinal = self._ordinal
         self._ordinal += 1
         return ordinal
 
-    def _priority_no_lock(self, instance_type: str, key: str) -> float:
-        server = self._server_map(instance_type)[key]
-        if instance_type == InstanceType.PREFILL:
-            if key in self.tainted_prefillers:
-                return TAINT_PRIORITY
-            return float(server["active_tokens"]) + float(server["active_kv_cache"]) * 0.3
-        if key in self.tainted_decoders:
+    def _priority(self, is_prefill: bool, entry: _ServerEntry, key: str) -> float:
+        if key in (self.tainted_prefillers if is_prefill else self.tainted_decoders):
             return TAINT_PRIORITY
-        return float(server["active_tokens"])
+        if is_prefill:
+            return entry.active_tokens + entry.active_kv_cache * 0.3
+        return entry.active_tokens
 
-    def _rebuild_heap_no_lock(self, instance_type: str) -> None:
+    def _push_heap(self, is_prefill: bool, key: str) -> None:
+        entry = self._server_map(is_prefill)[key]
+        entry.heap_seq += 1
+        heap = self._heap_ref(is_prefill)
+        heapq.heappush(heap, (self._priority(is_prefill, entry, key), entry.ordinal, entry.heap_seq, key))
+        if len(heap) > 2 * len(self._server_map(is_prefill)):
+            self._compact_heap_no_lock(is_prefill)
+
+    def _pop_valid(self, is_prefill: bool) -> str:
+        servers = self._server_map(is_prefill)
+        heap = self._heap_ref(is_prefill)
+        while heap:
+            _, _, seq, key = heapq.heappop(heap)
+            if key not in servers:
+                continue
+            entry = servers[key]
+            if entry.heap_seq == seq:
+                return key
+        raise RuntimeError("No available servers")
+
+    def _rebuild_heap_no_lock(self, is_prefill: bool) -> None:
         heap = []
-        for key, state in self._server_map(instance_type).items():
-            heap.append((self._priority_no_lock(instance_type, key), state["ordinal"], key))
+        for key, entry in self._server_map(is_prefill).items():
+            entry.heap_seq += 1
+            heap.append((self._priority(is_prefill, entry, key), entry.ordinal, entry.heap_seq, key))
         heapq.heapify(heap)
-        if instance_type == InstanceType.PREFILL:
+        if is_prefill:
             self.prefiller_heap = heap
         else:
             self.decoder_heap = heap
 
-    def _add_server_no_lock(self, instance_type: str, host: str, port: int) -> bool:
+    def _compact_heap_no_lock(self, is_prefill: bool) -> None:
+        servers = self._server_map(is_prefill)
+        heap = []
+        for key, entry in servers.items():
+            heap.append((self._priority(is_prefill, entry, key), entry.ordinal, entry.heap_seq, key))
+        heapq.heapify(heap)
+        if is_prefill:
+            self.prefiller_heap = heap
+        else:
+            self.decoder_heap = heap
+
+    def _add_server_no_lock(self, is_prefill: bool, host: str, port: int) -> bool:
         key = server_key(host, port)
-        servers = self._server_map(instance_type)
+        servers = self._server_map(is_prefill)
         if key in servers:
             return False
-        servers[key] = {
-            "host": host,
-            "port": int(port),
-            "active_tokens": 0.0,
-            "active_kv_cache": 0.0,
-            "ordinal": self._next_ordinal(),
-        }
-        heapq.heappush(self._heap(instance_type), (0.0, servers[key]["ordinal"], key))
+        ordinal = self._next_ordinal()
+        servers[key] = _ServerEntry(host, int(port), ordinal)
+        self._push_heap(is_prefill, key)
         return True
 
     def get_snapshot(self) -> dict[str, list[dict[str, Any]]]:
         with self._lock:
             return {
                 "prefill_instances": [
-                    {"host": state["host"], "port": state["port"]}
-                    for _, state in sorted(self.prefillers.items(), key=lambda item: item[1]["ordinal"])
+                    {"host": e.host, "port": e.port}
+                    for _, e in sorted(self.prefillers.items(), key=lambda item: item[1].ordinal)
                 ],
                 "decode_instances": [
-                    {"host": state["host"], "port": state["port"]}
-                    for _, state in sorted(self.decoders.items(), key=lambda item: item[1]["ordinal"])
+                    {"host": e.host, "port": e.port}
+                    for _, e in sorted(self.decoders.items(), key=lambda item: item[1].ordinal)
                 ],
             }
 
@@ -326,35 +374,28 @@ class SharedProxyScheduler:
 
     def start_request_and_reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
         with self._lock:
-            prefiller = self._reserve_prefiller_kv_no_lock(token_count)
+            key = self._pop_valid(_IS_PREFILL)
+            entry = self.prefillers[key]
+            entry.active_kv_cache += token_count
+            self._push_heap(_IS_PREFILL, key)
             self.request_num += 1
-            return prefiller
+            return {"key": key, "host": entry.host, "port": entry.port}
 
     def select_prefiller(self, token_count: float) -> dict[str, Any]:
         with self._lock:
-            if not self.prefiller_heap:
-                raise RuntimeError("No prefiller servers available")
-            _, _, key = heapq.heappop(self.prefiller_heap)
-            state = self.prefillers[key]
-            state["active_tokens"] += token_count
-            state["active_kv_cache"] += token_count
-            heapq.heappush(
-                self.prefiller_heap,
-                (self._priority_no_lock(InstanceType.PREFILL, key), state["ordinal"], key),
-            )
-            return {"key": key, "host": state["host"], "port": state["port"]}
+            key = self._pop_valid(_IS_PREFILL)
+            entry = self.prefillers[key]
+            entry.active_tokens += token_count
+            entry.active_kv_cache += token_count
+            self._push_heap(_IS_PREFILL, key)
+            return {"key": key, "host": entry.host, "port": entry.port}
 
     def _reserve_prefiller_kv_no_lock(self, token_count: float) -> dict[str, Any]:
-        if not self.prefiller_heap:
-            raise RuntimeError("No prefiller servers available")
-        _, _, key = heapq.heappop(self.prefiller_heap)
-        state = self.prefillers[key]
-        state["active_kv_cache"] += token_count
-        heapq.heappush(
-            self.prefiller_heap,
-            (self._priority_no_lock(InstanceType.PREFILL, key), state["ordinal"], key),
-        )
-        return {"key": key, "host": state["host"], "port": state["port"]}
+        key = self._pop_valid(_IS_PREFILL)
+        entry = self.prefillers[key]
+        entry.active_kv_cache += token_count
+        self._push_heap(_IS_PREFILL, key)
+        return {"key": key, "host": entry.host, "port": entry.port}
 
     def reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
         """Select a prefiller and reserve only its KV pressure.
@@ -370,8 +411,8 @@ class SharedProxyScheduler:
         with self._lock:
             if key not in self.prefillers:
                 return
-            self.prefillers[key]["active_tokens"] -= token_count
-            self._rebuild_heap_no_lock(InstanceType.PREFILL)
+            self.prefillers[key].active_tokens -= token_count
+            self._push_heap(_IS_PREFILL, key)
 
     def release_prefiller_kv(self, key: str, token_count: float) -> None:
         with self._lock:
@@ -380,32 +421,27 @@ class SharedProxyScheduler:
     def _release_prefiller_kv_no_lock(self, key: str, token_count: float) -> None:
         if key not in self.prefillers:
             return
-        state = self.prefillers[key]
-        state["active_kv_cache"] = max(0.0, float(state["active_kv_cache"]) - token_count)
-        self._rebuild_heap_no_lock(InstanceType.PREFILL)
+        entry = self.prefillers[key]
+        entry.active_kv_cache = max(0.0, entry.active_kv_cache - token_count)
+        self._push_heap(_IS_PREFILL, key)
 
     def select_decoder(self, token_count: float) -> dict[str, Any]:
         with self._lock:
             return self._select_decoder_no_lock(token_count)
 
     def _select_decoder_no_lock(self, token_count: float) -> dict[str, Any]:
-        if not self.decoder_heap:
-            raise RuntimeError("No decoder servers available")
-        _, _, key = heapq.heappop(self.decoder_heap)
-        state = self.decoders[key]
-        state["active_tokens"] += token_count
-        heapq.heappush(
-            self.decoder_heap,
-            (self._priority_no_lock(InstanceType.DECODE, key), state["ordinal"], key),
-        )
-        return {"key": key, "host": state["host"], "port": state["port"]}
+        key = self._pop_valid(_IS_DECODE)
+        entry = self.decoders[key]
+        entry.active_tokens += token_count
+        self._push_heap(_IS_DECODE, key)
+        return {"key": key, "host": entry.host, "port": entry.port}
 
     def release_decoder(self, key: str, token_count: float) -> None:
         with self._lock:
             if key not in self.decoders:
                 return
-            self.decoders[key]["active_tokens"] -= token_count
-            self._rebuild_heap_no_lock(InstanceType.DECODE)
+            self.decoders[key].active_tokens -= token_count
+            self._push_heap(_IS_DECODE, key)
 
     def finish_request(
         self,
@@ -417,15 +453,12 @@ class SharedProxyScheduler:
     ) -> None:
         with self._lock:
             if release_prefiller_kv and prefiller_key in self.prefillers:
-                prefiller = self.prefillers[prefiller_key]
-                prefiller["active_kv_cache"] = max(
-                    0.0,
-                    float(prefiller["active_kv_cache"]) - prefiller_token_count,
-                )
-                self._rebuild_heap_no_lock(InstanceType.PREFILL)
+                entry = self.prefillers[prefiller_key]
+                entry.active_kv_cache = max(0.0, entry.active_kv_cache - prefiller_token_count)
+                self._push_heap(_IS_PREFILL, prefiller_key)
             if decoder_key in self.decoders:
-                self.decoders[decoder_key]["active_tokens"] -= decoder_token_count
-                self._rebuild_heap_no_lock(InstanceType.DECODE)
+                self.decoders[decoder_key].active_tokens -= decoder_token_count
+                self._push_heap(_IS_DECODE, decoder_key)
             self.request_num = max(0, self.request_num - 1)
 
     def get_waiting_nodes(self) -> dict[str, tuple[str, tuple[str, int], int]]:
@@ -433,10 +466,11 @@ class SharedProxyScheduler:
             return dict(self.waiting_nodes)
 
     def add_instances(self, instance_type: str, instances: list[tuple[str, int]]) -> tuple[list[str], list[str]]:
+        is_prefill = instance_type == InstanceType.PREFILL
         added_nodes: list[str] = []
         waiting_nodes: list[str] = []
         with self._lock:
-            servers = self._server_map(instance_type)
+            servers = self._server_map(is_prefill)
             for host, port in instances:
                 key = server_key(host, port)
                 if key in servers or key in self.waiting_nodes:
@@ -453,18 +487,16 @@ class SharedProxyScheduler:
             self.waiting_nodes[key] = (instance_type, server, retry_count)
 
     def activate_waiting_instance(self, instance_type: str, host: str, port: int) -> None:
+        is_prefill = instance_type == InstanceType.PREFILL
         with self._lock:
             key = server_key(host, port)
             self.waiting_nodes.pop(key, None)
-            if instance_type == InstanceType.PREFILL and key in self.tainted_prefillers:
-                self.tainted_prefillers.discard(key)
-                self._rebuild_heap_no_lock(InstanceType.PREFILL)
+            tainted = self._tainted_ref(is_prefill)
+            if key in tainted:
+                tainted.discard(key)
+                self._push_heap(is_prefill, key)
                 return
-            if instance_type == InstanceType.DECODE and key in self.tainted_decoders:
-                self.tainted_decoders.discard(key)
-                self._rebuild_heap_no_lock(InstanceType.DECODE)
-                return
-            if self._add_server_no_lock(instance_type, host, port):
+            if self._add_server_no_lock(is_prefill, host, port):
                 self.print_status(f"Add {instance_type} instance: {host}:{port}.")
 
     def drop_waiting_instance(self, key: str) -> None:
@@ -472,57 +504,49 @@ class SharedProxyScheduler:
             self.waiting_nodes.pop(key, None)
 
     def remove_prefillers(self, instances: list[tuple[str, int]]) -> bool:
-        return self._remove_instances(InstanceType.PREFILL, instances)
+        return self._remove_instances(_IS_PREFILL, instances)
 
     def remove_decoders(self, instances: list[tuple[str, int]]) -> bool:
-        return self._remove_instances(InstanceType.DECODE, instances)
+        return self._remove_instances(_IS_DECODE, instances)
 
-    def _remove_instances(self, instance_type: str, instances: list[tuple[str, int]]) -> bool:
+    def _remove_instances(self, is_prefill: bool, instances: list[tuple[str, int]]) -> bool:
         if not instances:
             return False
         keys = {server_key(host, port) for host, port in instances}
         with self._lock:
             if self.request_num > 0:
-                if instance_type == InstanceType.PREFILL:
-                    self.tainted_prefillers.update(keys)
-                else:
-                    self.tainted_decoders.update(keys)
-                self._rebuild_heap_no_lock(instance_type)
-                logger.warning("Start to taint %s instances %s.", instance_type, sorted(keys))
+                tainted = self._tainted_ref(is_prefill)
+                tainted.update(keys)
+                self._rebuild_heap_no_lock(is_prefill)
+                logger.warning("Start to taint %s instances %s.", "prefill" if is_prefill else "decode", sorted(keys))
                 return True
 
             removed = False
-            servers = self._server_map(instance_type)
+            servers = self._server_map(is_prefill)
             for key in keys:
                 removed = servers.pop(key, None) is not None or removed
                 self.waiting_nodes.pop(key, None)
-                if instance_type == InstanceType.PREFILL:
-                    self.tainted_prefillers.discard(key)
-                else:
-                    self.tainted_decoders.discard(key)
+            self._tainted_ref(is_prefill).difference_update(keys)
             if removed:
-                self._rebuild_heap_no_lock(instance_type)
-                self.print_status(f"Remove {instance_type} instances: {sorted(keys)}.")
+                self._rebuild_heap_no_lock(is_prefill)
+                self.print_status(f"Remove {'prefill' if is_prefill else 'decode'} instances: {sorted(keys)}.")
             return False
 
     def finalize_tainted_instances(self) -> None:
         with self._lock:
             if self.request_num != 0:
                 return
-            if self.tainted_prefillers:
-                keys = list(self.tainted_prefillers)
+            for is_prefill in (_IS_PREFILL, _IS_DECODE):
+                tainted = self._tainted_ref(is_prefill)
+                if not tainted:
+                    continue
+                keys = list(tainted)
+                servers = self._server_map(is_prefill)
                 for key in keys:
-                    self.prefillers.pop(key, None)
-                self.tainted_prefillers.clear()
-                self._rebuild_heap_no_lock(InstanceType.PREFILL)
-                self.print_status(f"Remove prefiller instances after drain: {keys}.")
-            if self.tainted_decoders:
-                keys = list(self.tainted_decoders)
-                for key in keys:
-                    self.decoders.pop(key, None)
-                self.tainted_decoders.clear()
-                self._rebuild_heap_no_lock(InstanceType.DECODE)
-                self.print_status(f"Remove decoder instances after drain: {keys}.")
+                    servers.pop(key, None)
+                tainted.clear()
+                self._rebuild_heap_no_lock(is_prefill)
+                self.print_status(f"Remove {'prefiller' if is_prefill else 'decoder'} instances after drain: {keys}.")
 
 
 class SchedulerManager(BaseManager):
@@ -543,6 +567,40 @@ class WorkerRuntime:
         self.scheduler = scheduler
         self.prefiller_clients: dict[str, httpx.AsyncClient] = {}
         self.decoder_clients: dict[str, httpx.AsyncClient] = {}
+        self._async_lock = asyncio.Lock()
+
+    async def start_request_and_reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
+        async with self._async_lock:
+            return self.scheduler.start_request_and_reserve_prefiller_kv(token_count)
+
+    async def reserve_prefiller_kv(self, token_count: float) -> dict[str, Any]:
+        async with self._async_lock:
+            return self.scheduler.reserve_prefiller_kv(token_count)
+
+    async def release_prefiller_kv(self, key: str, token_count: float) -> None:
+        async with self._async_lock:
+            self.scheduler.release_prefiller_kv(key, token_count)
+
+    async def select_decoder(self, token_count: float) -> dict[str, Any]:
+        async with self._async_lock:
+            return self.scheduler.select_decoder(token_count)
+
+    async def release_decoder(self, key: str, token_count: float) -> None:
+        async with self._async_lock:
+            self.scheduler.release_decoder(key, token_count)
+
+    async def finish_request(
+        self,
+        prefiller_key: str | None,
+        prefiller_token_count: float,
+        decoder_key: str | None,
+        decoder_token_count: float,
+        release_prefiller_kv: bool,
+    ) -> None:
+        async with self._async_lock:
+            self.scheduler.finish_request(
+                prefiller_key, prefiller_token_count, decoder_key, decoder_token_count, release_prefiller_kv
+            )
 
     async def sync_clients(self) -> None:
         snapshot = self.scheduler.get_snapshot()
@@ -736,22 +794,38 @@ def start_shared_scheduler(args) -> None:
     global shared_scheduler
     shared_scheduler = SharedProxyScheduler(args.prefiller_instances, args.decoder_instances)
     NodeListener(shared_scheduler)
-    authkey = os.urandom(16)
-    manager = SchedulerManager(address=("127.0.0.1", 0), authkey=authkey)
-    server = manager.get_server()
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    host, port = server.address
-    os.environ[MANAGER_CONFIG_ENV] = json.dumps(
-        {"host": host, "port": port, "authkey": base64.b64encode(authkey).decode("ascii")}
-    )
     os.environ[ARGS_CONFIG_ENV] = json.dumps(serialize_args(args))
+    if args.workers > 1:
+        authkey = os.urandom(16)
+        manager = SchedulerManager(address=("127.0.0.1", 0), authkey=authkey)
+        server = manager.get_server()
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        host, port = server.address
+        os.environ[MANAGER_CONFIG_ENV] = json.dumps(
+            {"host": host, "port": port, "authkey": base64.b64encode(authkey).decode("ascii")}
+        )
+    else:
+        os.environ.pop(MANAGER_CONFIG_ENV, None)
+
+
+def _ensure_scheduler(args) -> SharedProxyScheduler:
+    global shared_scheduler
+    if shared_scheduler is not None:
+        return shared_scheduler
+    shared_scheduler = SharedProxyScheduler(args.prefiller_instances, args.decoder_instances)
+    NodeListener(shared_scheduler)
+    return shared_scheduler
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     global runtime
-    scheduler = connect_shared_scheduler()
+    args = load_global_args_from_env()
+    if args.workers > 1:
+        scheduler = connect_shared_scheduler()
+    else:
+        scheduler = _ensure_scheduler(args)
     runtime = WorkerRuntime(scheduler)
     await runtime.sync_clients()
     snapshot = scheduler.get_snapshot()
@@ -881,14 +955,13 @@ async def handle_select_instance(
     request_length: int,
     start_request: bool,
 ) -> InstanceInfo:
-    scheduler = runtime.scheduler
     prefiller_score = calculate_prefill_score(request_length)
     decoder_score = calculate_decode_score(request_length)
     request_id = next_req_id()
     if start_request:
-        prefiller = scheduler.start_request_and_reserve_prefiller_kv(prefiller_score)
+        prefiller = await runtime.start_request_and_reserve_prefiller_kv(prefiller_score)
     else:
-        prefiller = scheduler.reserve_prefiller_kv(prefiller_score)
+        prefiller = await runtime.reserve_prefiller_kv(prefiller_score)
     prefiller_key = prefiller["key"]
     prefiller_client = await get_prefiller_client(prefiller_key)
 
@@ -904,9 +977,9 @@ async def handle_select_instance(
         )
     except Exception:
         if start_request:
-            scheduler.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
+            await runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
         else:
-            scheduler.release_prefiller_kv(prefiller_key, prefiller_score)
+            await runtime.release_prefiller_kv(prefiller_key, prefiller_score)
         raise
 
     response_json = response.json()
@@ -915,12 +988,12 @@ async def handle_select_instance(
         req_data["kv_transfer_params"] = kv_transfer_params
 
     try:
-        decoder = scheduler.select_decoder(decoder_score)
+        decoder = await runtime.select_decoder(decoder_score)
     except Exception:
         if start_request:
-            scheduler.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
+            await runtime.finish_request(prefiller_key, prefiller_score, None, 0.0, release_prefiller_kv=True)
         else:
-            scheduler.release_prefiller_kv(prefiller_key, prefiller_score)
+            await runtime.release_prefiller_kv(prefiller_key, prefiller_score)
         raise
     decoder_key = decoder["key"]
     decoder_client = await get_decoder_client(decoder_key)
@@ -948,13 +1021,12 @@ async def select_recompute_instance(
     previous_instance: InstanceInfo,
 ) -> InstanceInfo:
     """Release the old decoder before assigning a new instance for recompute."""
-    runtime.scheduler.release_prefiller_kv(previous_instance.prefiller_key, previous_instance.prefiller_score)
-    runtime.scheduler.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
+    await runtime.release_prefiller_kv(previous_instance.prefiller_key, previous_instance.prefiller_score)
+    await runtime.release_decoder(previous_instance.decoder_key, previous_instance.decoder_score)
     return await handle_select_instance(api, req_data, request_length, start_request=False)
 
 
 async def handle_completions_impl(api: str, request: Request):
-    scheduler = runtime.scheduler
     request_released = False
     try:
         req_data = await request.json()
@@ -982,10 +1054,10 @@ async def handle_completions_impl(api: str, request: Request):
             retry = True
             completion_tokens = 0
 
-            def release_prefiller_kv_once() -> None:
+            async def release_prefiller_kv_once() -> None:
                 nonlocal released_kv
                 if not released_kv:
-                    scheduler.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
+                    await runtime.release_prefiller_kv(instance_info.prefiller_key, instance_info.prefiller_score)
                     released_kv = True
 
             try:
@@ -1000,8 +1072,8 @@ async def handle_completions_impl(api: str, request: Request):
                         max_retries=global_args.max_retries,
                         base_delay=global_args.retry_delay,
                     ):
-                        if chunk:
-                            release_prefiller_kv_once()
+                        if not released_kv and chunk:
+                            await release_prefiller_kv_once()
                         try:
                             chunk_str = chunk.decode("utf-8").strip()
                         except UnicodeDecodeError:
@@ -1011,7 +1083,7 @@ async def handle_completions_impl(api: str, request: Request):
                         if not chunk_str:
                             continue
                         if chunk_str.startswith("data: "):
-                            chunk_str = chunk_str[len("data: ") :]
+                            chunk_str = chunk_str[len("data: "):]
                         try:
                             chunk_json = json.loads(chunk_str)
                         except json.JSONDecodeError:
@@ -1046,10 +1118,7 @@ async def handle_completions_impl(api: str, request: Request):
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
                             instance_info = await select_recompute_instance(
-                                api,
-                                req_data,
-                                tmp_request_length,
-                                instance_info,
+                                api, req_data, tmp_request_length, instance_info
                             )
                             released_kv = False
                             break
@@ -1077,7 +1146,7 @@ async def handle_completions_impl(api: str, request: Request):
                     instance_info.request_id,
                 )
             finally:
-                scheduler.finish_request(
+                await runtime.finish_request(
                     instance_info.prefiller_key,
                     instance_info.prefiller_score,
                     instance_info.decoder_key,
@@ -1096,7 +1165,7 @@ async def handle_completions_impl(api: str, request: Request):
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print("".join(traceback.format_exception(*exc_info)))
         if not request_released and "instance_info" in locals():
-            scheduler.finish_request(
+            await runtime.finish_request(
                 instance_info.prefiller_key,
                 instance_info.prefiller_score,
                 instance_info.decoder_key,


### PR DESCRIPTION
## What this PR does / why we need it?

This PR updates `examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py` to support a multi-worker load balance proxy for disaggregated prefill.

The previous proxy flow works well as a single process example, but when `uvicorn --workers > 1` is used, each worker process has its own memory space. If every worker keeps an independent scheduler, the proxy will no longer have a global view of backend pressure: different workers may select the same prefiller/decoder at the same time, active request counts become inaccurate, and dynamic add/remove behavior becomes inconsistent.

This PR introduces a shared scheduling architecture:

- one centralized scheduler owns the global mutable state
- every uvicorn worker keeps its own local HTTP client pool
- workers communicate with the scheduler through a multiprocessing manager
- backend selection, resource reservation, release, add/remove, and health state are coordinated through the shared scheduler

In short, the proxy now behaves like one logical load balancer even when it is served by multiple worker processes.

## Main design

### 1. Centralized scheduling state

`SharedProxyScheduler` is the single source of truth for backend state.

It tracks:

- prefiller instances
- decoder instances
- active request count
- prefiller KV pressure
- decoder token pressure

The scheduler uses a lock to protect cross-request updates and keeps separate min-heaps for prefill and decode selection. Each backend has a score, and the backend with the lowest pressure is selected first.

For prefill, the score includes both active token pressure and reserved KV cache pressure:

```text
prefill_score = active_tokens + active_kv_cache * 0.3
```

For decode, the score tracks active decode token pressure.

This keeps scheduling decisions close to the actual workload shape: prefill has KV cache impact, while decode mostly needs active token balancing.

### 2. Lazy-deletion heap for efficient updates

Backend pressure changes frequently: every request reserves resources, releases resources, or retries.

Instead of scanning and rebuilding the heap on every update, this PR uses a lazy-deletion heap pattern:

- every backend entry has a `heap_seq`
- when priority changes, a new heap record is pushed
- stale heap records are skipped when popped
- the heap is compacted only when it grows too large

This keeps the hot path cheap and avoids repeated O(n) heap filtering during high concurrency.

### 3. Multi-worker coordination through `BaseManager`

When `workers > 1`, the parent process starts a `SchedulerManager` server and stores its connection info in environment variables.

Each uvicorn worker then connects back to that manager during FastAPI lifespan initialization:

```text
parent process
  └── starts SharedProxyScheduler
  └── starts SchedulerManager server
  └── exports manager config via env

worker process
  └── reads manager config from env
  └── connects to SchedulerManager
  └── gets shared scheduler proxy
```

This is the key multi-process design point: workers do not copy scheduling state. They all operate on the same scheduler object through manager RPCs.

### 4. Worker-local HTTP clients

The scheduler is shared, but HTTP clients are intentionally not shared.

Each worker owns a `WorkerRuntime`, which maintains local `httpx.AsyncClient` pools for prefiller and decoder backends. This avoids sharing async network clients across processes, which is unsafe and difficult to reason about.

The split is:

```text
SharedProxyScheduler:
  global scheduling state

WorkerRuntime:
  per-worker async HTTP clients
  per-worker request forwarding
```

This keeps the network layer process-local while the scheduling layer remains globally consistent.

### 5. Request lifecycle

For each request, the proxy follows this flow:

1. calculate request pressure from request body length
2. reserve prefiller KV pressure in the shared scheduler
3. send a prefill request to the selected prefiller
4. read `kv_transfer_params` from the prefiller response
5. select a decoder from the shared scheduler
6. stream the decoder response back to the client
7. release scheduler resources in `finally`

The important part is that resource release is centralized and guarded, so cancellation, decoder errors, and client disconnects do not leave stale pressure in the scheduler.

### 6. Logging and typing cleanup

The proxy log level is scoped to the proxy module logger instead of changing the root logger for dependencies like `httpx`.

This PR also tightens mypy compatibility for the example file by adding explicit typing around global runtime/config state and manager dynamic methods.

## Does this PR introduce any user-facing change?

Yes.

Users can now run the example proxy with multiple uvicorn workers by setting `--workers`.

Example:

```bash
python load_balance_proxy_server_example.py \
  --host 0.0.0.0 \
  --port 9000 \
  --workers 2 \
  --prefiller-hosts 127.0.0.1 127.0.0.1 \
  --prefiller-ports 8100 8101 \
  --decoder-hosts 127.0.0.1 127.0.0.1 \
  --decoder-ports 8200 8201
```

The proxy will expose the same OpenAI-compatible endpoints, but scheduling state is now shared across all worker processes.

## How was this patch tested?

by nightly


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
