### PR TITLE
[Ops][Feature] Add memfabric transfer engine backend for Mooncake KV pool

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -76,7 +76,8 @@ class MooncakeBackend(Backend):
                 self.config.local_buffer_size,
                 self.config.protocol,
                 self.config.device_name,
-                self.config.master_server_address)
+                self.config.master_server_address,
+            )
             if ret != 0:
                 msg = "Failed to initialize MemFabric UB protocol for Mooncake."
                 logger.error(msg)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -65,6 +65,22 @@ class MooncakeBackend(Backend):
                 msg = "Initialize mooncake failed."
                 logger.error(msg)
                 raise RuntimeError(msg)
+        elif self.config.protocol == "ub":
+            local_hostname = get_ip()
+            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
+            self.local_seg = ""
+            ret = self.store.setup(
+                local_hostname,
+                self.config.metadata_server,
+                self.config.global_segment_size,
+                self.config.local_buffer_size,
+                self.config.protocol,
+                self.config.device_name,
+                self.config.master_server_address)
+            if ret != 0:
+                msg = "Initialize memfabric ub protocol mooncake failed."
+                logger.error(msg)
+                raise RuntimeError(msg)
         else:
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -78,7 +78,7 @@ class MooncakeBackend(Backend):
                 self.config.device_name,
                 self.config.master_server_address)
             if ret != 0:
-                msg = "Initialize memfabric ub protocol mooncake failed."
+                msg = "Failed to initialize MemFabric UB protocol for Mooncake."
                 logger.error(msg)
                 raise RuntimeError(msg)
         else:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR integrates the **MemFabric transfer engine** into vLLM Ascend as an entry point for utilizing the Mooncake KV pool. It acts as the integration layer that allows vLLM Ascend to invoke Mooncake with MemFabric enabled, rather than implementing the underlying MemFabric-Mooncake adaptation logic itself.

### Does this PR introduce _any_ user-facing change?

Yes. Users running vLLM Ascend on NPUs can now configure the system to use `memfabric` as the transfer engine when initializing the Mooncake KV pool.

### How was this patch tested?

- Verified that vLLM Ascend successfully initializes the Mooncake KV pool with the MemFabric backend.
- Confirmed that the integration entry correctly passes parameters and triggers Mooncake operations without errors.
- Tested distributed serving scenarios on NPU hardware to ensure KV cache transfers are functioning as expected.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
