### PR TITLE
[Feature] Implement DP Sharding for Rejection Sampling in Speculative Decoding

### DIFF
--- a/tests/ut/sample/test_rejection_sampler_dp_sharding.py
+++ b/tests/ut/sample/test_rejection_sampler_dp_sharding.py
@@ -1,0 +1,367 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from tests.ut.base import TestBase
+
+PLACEHOLDER_TOKEN_ID = -1
+GREEDY_TEMPERATURE = 0.0
+
+
+def mock_pin_memory(original_func):
+    def func_wo_pin_memory(*args, **kwargs):
+        if kwargs.get("pin_memory", False):
+            kwargs["pin_memory"] = False
+        return original_func(*args, **kwargs)
+
+    return func_wo_pin_memory
+
+
+def _mock_ascend_config():
+    mock_config = MagicMock()
+    mock_config.enable_reduce_sample = False
+    return mock_config
+
+
+def _make_sampling_metadata(
+    batch_size: int,
+    all_greedy: bool = True,
+    temperature: float | None = None,
+    top_p: torch.Tensor | None = None,
+    top_k: torch.Tensor | None = None,
+    generators: dict | None = None,
+    no_penalties: bool = True,
+    prompt_token_ids: torch.Tensor | None = None,
+    output_token_ids: list[list[int]] | None = None,
+    frequency_penalties: torch.Tensor | None = None,
+    presence_penalties: torch.Tensor | None = None,
+    repetition_penalties: torch.Tensor | None = None,
+):
+    from dataclasses import fields
+
+    from vllm.v1.sample.logits_processor import LogitsProcessors
+    from vllm.v1.sample.metadata import SamplingMetadata
+
+    if temperature is None:
+        temperature_val = GREEDY_TEMPERATURE if all_greedy else 1.0
+        temperature = torch.full((batch_size,), temperature_val, dtype=torch.float32)
+    if generators is None:
+        generators = {}
+    if output_token_ids is None:
+        output_token_ids = [[] for _ in range(batch_size)]
+    if frequency_penalties is None:
+        frequency_penalties = torch.zeros(batch_size, dtype=torch.float32)
+    if presence_penalties is None:
+        presence_penalties = torch.zeros(batch_size, dtype=torch.float32)
+    if repetition_penalties is None:
+        repetition_penalties = torch.ones(batch_size, dtype=torch.float32)
+
+    kwargs = {
+        "temperature": temperature,
+        "all_greedy": all_greedy,
+        "all_random": not all_greedy,
+        "top_p": top_p,
+        "top_k": top_k,
+        "generators": generators,
+        "max_num_logprobs": None,
+        "no_penalties": no_penalties,
+        "prompt_token_ids": prompt_token_ids,
+        "frequency_penalties": frequency_penalties,
+        "presence_penalties": presence_penalties,
+        "repetition_penalties": repetition_penalties,
+        "output_token_ids": output_token_ids,
+        "allowed_token_ids_mask": None,
+        "bad_words_token_ids": {},
+        "logitsprocs": LogitsProcessors([]),
+        "logprob_token_ids": None,
+        "spec_token_ids": None,
+    }
+
+    field_names = {f.name for f in fields(SamplingMetadata)}
+    if "thinking_budget_state_holder" in field_names:
+        kwargs["thinking_budget_state_holder"] = None
+
+    return SamplingMetadata(**kwargs)
+
+
+def _make_spec_decode_metadata(
+    num_draft_tokens: list[int],
+    draft_token_ids: torch.Tensor,
+):
+    import numpy as np
+    from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+
+    batch_size = len(num_draft_tokens)
+    num_tokens = len(draft_token_ids)
+    num_sampled = [n + 1 for n in num_draft_tokens]
+
+    cu_num_draft = np.cumsum(num_draft_tokens, dtype=np.int32)
+    cu_num_draft_tensor = torch.from_numpy(cu_num_draft)
+    cu_num_sampled = np.cumsum(num_sampled, dtype=np.int32)
+    cu_num_sampled_tensor = torch.from_numpy(cu_num_sampled)
+
+    target_logits_indices = torch.zeros(num_tokens, dtype=torch.int32)
+    bonus_logits_indices = torch.zeros(batch_size, dtype=torch.int32)
+    logits_indices = torch.zeros(num_tokens + batch_size, dtype=torch.int32)
+
+    return SpecDecodeMetadata(
+        draft_token_ids=draft_token_ids,
+        num_draft_tokens=num_draft_tokens,
+        cu_num_draft_tokens=cu_num_draft_tensor,
+        cu_num_sampled_tokens=cu_num_sampled_tensor,
+        target_logits_indices=target_logits_indices,
+        bonus_logits_indices=bonus_logits_indices,
+        logits_indices=logits_indices,
+    )
+
+
+class TestRejectionSamplerDPSharding(TestBase):
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    @patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False)
+    @patch("vllm_ascend.sample.rejection_sampler.get_ascend_config", side_effect=_mock_ascend_config)
+    @patch("vllm_ascend.sample.rejection_sampler.get_tp_group")
+    def test_dp_sharding_empty_local_batch(self, mock_get_tp_group, mock_get_ascend_config):
+        from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
+
+        mock_sampler = MagicMock()
+        rejection_sampler = AscendRejectionSampler(mock_sampler)
+        rejection_sampler.synthetic_mode = False
+        rejection_sampler.synthetic_conditional_rates = None
+        rejection_sampler.is_processed_logprobs_mode = False
+
+        mock_tp_group = MagicMock()
+        mock_tp_group.world_size = 4
+        mock_tp_group.rank_in_group = 3
+
+        def all_gather_impl(tensor, dim=0):
+            return tensor.repeat(4, *([1] * (tensor.ndim - 1)))
+
+        mock_tp_group.all_gather.side_effect = all_gather_impl
+        mock_get_tp_group.return_value = mock_tp_group
+
+        num_draft_tokens = [2, 3]
+        batch_size = len(num_draft_tokens)
+        max_spec_len = 3
+        chunk_size = (batch_size + 4 - 1) // 4
+
+        draft_token_ids = torch.tensor([10, 11, 20, 21, 22], dtype=torch.int32)
+        metadata = _make_spec_decode_metadata(num_draft_tokens, draft_token_ids)
+
+        vocab_size = 100
+        num_tokens_total = len(draft_token_ids)
+        target_logits = torch.randn(num_tokens_total, vocab_size, dtype=torch.float32)
+        bonus_token_ids = torch.tensor([[99], [98]], dtype=torch.int32)
+        sampling_metadata = _make_sampling_metadata(batch_size, all_greedy=True)
+
+        start_batch = 3 * chunk_size
+        end_batch = min(start_batch + chunk_size, batch_size)
+
+        result = rejection_sampler._rejection_sample_with_dp_sharding(
+            metadata=metadata,
+            target_logits=target_logits,
+            bonus_token_ids=bonus_token_ids,
+            sampling_metadata=sampling_metadata,
+            start_batch=start_batch,
+            end_batch=end_batch,
+            chunk_size=chunk_size,
+            skip_target_logits_sampling=False,
+        )
+
+        assert result.shape == (batch_size, max_spec_len + 1)
+        assert (result == PLACEHOLDER_TOKEN_ID).all()
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    @patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False)
+    @patch("vllm_ascend.sample.rejection_sampler.get_ascend_config", side_effect=_mock_ascend_config)
+    @patch("vllm_ascend.sample.sampler.get_ascend_config", side_effect=_mock_ascend_config)
+    @patch("vllm_ascend.sample.rejection_sampler.get_tp_group")
+    def test_dp_sharding_vs_non_dp_greedy(self, mock_get_tp_group, mock_sampler_config, mock_rejection_config):
+        from vllm_ascend.sample.rejection_sampler import (
+            AscendRejectionSampler,
+            apply_sampling_constraints,
+            rejection_sample,
+        )
+
+        torch.manual_seed(42)
+
+        mock_sampler = MagicMock()
+        rejection_sampler = AscendRejectionSampler(mock_sampler)
+        rejection_sampler.synthetic_mode = False
+        rejection_sampler.synthetic_conditional_rates = None
+        rejection_sampler.is_processed_logprobs_mode = False
+
+        mock_tp_group = MagicMock()
+        mock_tp_group.world_size = 2
+        mock_tp_group.rank_in_group = 0
+
+        def all_gather_impl(tensor, dim=0):
+            return tensor.repeat(2, *([1] * (tensor.ndim - 1)))
+
+        mock_tp_group.all_gather.side_effect = all_gather_impl
+        mock_get_tp_group.return_value = mock_tp_group
+
+        num_draft_tokens = [2, 3, 1, 2]
+        batch_size = len(num_draft_tokens)
+        vocab_size = 100
+
+        draft_token_ids = torch.randint(0, vocab_size, (sum(num_draft_tokens),), dtype=torch.int32)
+        metadata = _make_spec_decode_metadata(num_draft_tokens, draft_token_ids)
+
+        target_logits = torch.randn(sum(num_draft_tokens), vocab_size, dtype=torch.float32)
+        bonus_token_ids = torch.randint(0, vocab_size, (batch_size, 1), dtype=torch.int32)
+        sampling_metadata = _make_sampling_metadata(batch_size, all_greedy=True)
+
+        chunk_size = (batch_size + 2 - 1) // 2
+
+        result_dp_rank0 = rejection_sampler._rejection_sample_with_dp_sharding(
+            metadata=metadata,
+            target_logits=target_logits.clone(),
+            bonus_token_ids=bonus_token_ids,
+            sampling_metadata=sampling_metadata,
+            start_batch=0,
+            end_batch=chunk_size,
+            chunk_size=chunk_size,
+            skip_target_logits_sampling=False,
+        )
+
+        mock_tp_group.rank_in_group = 1
+        result_dp_rank1 = rejection_sampler._rejection_sample_with_dp_sharding(
+            metadata=metadata,
+            target_logits=target_logits.clone(),
+            bonus_token_ids=bonus_token_ids,
+            sampling_metadata=sampling_metadata,
+            start_batch=chunk_size,
+            end_batch=batch_size,
+            chunk_size=chunk_size,
+            skip_target_logits_sampling=False,
+        )
+
+        result_dp = torch.cat([result_dp_rank0[:chunk_size], result_dp_rank1[: batch_size - chunk_size]], dim=0)
+
+        processed_logits = rejection_sampler.apply_logits_processors(target_logits.clone(), sampling_metadata, metadata)
+        processed_logits = apply_sampling_constraints(
+            processed_logits, metadata.cu_num_draft_tokens, sampling_metadata, rejection_sampler.top_k
+        )
+        result_non_dp = rejection_sample(
+            metadata.draft_token_ids,
+            metadata.num_draft_tokens,
+            metadata.max_spec_len,
+            metadata.cu_num_draft_tokens,
+            None,
+            processed_logits,
+            bonus_token_ids,
+            sampling_metadata,
+        )
+
+        assert result_dp.shape == result_non_dp.shape
+        assert torch.equal(result_dp, result_non_dp)
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    @patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False)
+    @patch("vllm_ascend.sample.rejection_sampler.get_ascend_config", side_effect=_mock_ascend_config)
+    @patch("vllm_ascend.sample.sampler.get_ascend_config", side_effect=_mock_ascend_config)
+    @patch("vllm_ascend.sample.rejection_sampler.get_tp_group")
+    def test_dp_sharding_vs_non_dp_penalties(self, mock_get_tp_group, mock_sampler_config, mock_rejection_config):
+        from vllm_ascend.sample.rejection_sampler import (
+            AscendRejectionSampler,
+            apply_sampling_constraints,
+            rejection_sample,
+        )
+
+        torch.manual_seed(42)
+
+        mock_sampler = MagicMock()
+        rejection_sampler = AscendRejectionSampler(mock_sampler)
+        rejection_sampler.synthetic_mode = False
+        rejection_sampler.synthetic_conditional_rates = None
+        rejection_sampler.is_processed_logprobs_mode = False
+
+        mock_tp_group = MagicMock()
+        mock_tp_group.world_size = 2
+        mock_tp_group.rank_in_group = 0
+
+        def all_gather_impl(tensor, dim=0):
+            return tensor.repeat(2, *([1] * (tensor.ndim - 1)))
+
+        mock_tp_group.all_gather.side_effect = all_gather_impl
+        mock_get_tp_group.return_value = mock_tp_group
+
+        num_draft_tokens = [2, 3, 1, 2]
+        batch_size = len(num_draft_tokens)
+        vocab_size = 100
+
+        draft_token_ids = torch.randint(0, vocab_size, (sum(num_draft_tokens),), dtype=torch.int32)
+        metadata = _make_spec_decode_metadata(num_draft_tokens, draft_token_ids)
+
+        target_logits = torch.randn(sum(num_draft_tokens), vocab_size, dtype=torch.float32)
+        bonus_token_ids = torch.randint(0, vocab_size, (batch_size, 1), dtype=torch.int32)
+
+        prompt_token_ids = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
+        output_token_ids = [[10, 20], [30], [40, 50, 60], [70]]
+
+        generators = {i: torch.Generator().manual_seed(42 + i) for i in range(batch_size)}
+        sampling_metadata = _make_sampling_metadata(
+            batch_size,
+            all_greedy=True,
+            no_penalties=False,
+            prompt_token_ids=prompt_token_ids,
+            output_token_ids=output_token_ids,
+            frequency_penalties=torch.tensor([0.1, 0.2, 0.0, 0.3]),
+            presence_penalties=torch.tensor([0.0, 0.1, 0.2, 0.0]),
+            repetition_penalties=torch.tensor([1.0, 1.1, 1.2, 1.0]),
+            generators=generators,
+        )
+
+        chunk_size = (batch_size + 2 - 1) // 2
+
+        result_dp_rank0 = rejection_sampler._rejection_sample_with_dp_sharding(
+            metadata=metadata,
+            target_logits=target_logits.clone(),
+            bonus_token_ids=bonus_token_ids,
+            sampling_metadata=sampling_metadata,
+            start_batch=0,
+            end_batch=chunk_size,
+            chunk_size=chunk_size,
+            skip_target_logits_sampling=False,
+        )
+
+        mock_tp_group.rank_in_group = 1
+        result_dp_rank1 = rejection_sampler._rejection_sample_with_dp_sharding(
+            metadata=metadata,
+            target_logits=target_logits.clone(),
+            bonus_token_ids=bonus_token_ids,
+            sampling_metadata=sampling_metadata,
+            start_batch=chunk_size,
+            end_batch=batch_size,
+            chunk_size=chunk_size,
+            skip_target_logits_sampling=False,
+        )
+
+        result_dp = torch.cat([result_dp_rank0[:chunk_size], result_dp_rank1[: batch_size - chunk_size]], dim=0)
+
+        processed_logits = rejection_sampler.apply_logits_processors(target_logits.clone(), sampling_metadata, metadata)
+        processed_logits = apply_sampling_constraints(
+            processed_logits, metadata.cu_num_draft_tokens, sampling_metadata, rejection_sampler.top_k
+        )
+        result_non_dp = rejection_sample(
+            metadata.draft_token_ids,
+            metadata.num_draft_tokens,
+            metadata.max_spec_len,
+            metadata.cu_num_draft_tokens,
+            None,
+            processed_logits,
+            bonus_token_ids,
+            sampling_metadata,
+        )
+
+        assert result_dp.shape == result_non_dp.shape
+        assert torch.equal(result_dp, result_non_dp)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import json
 import os
 from typing import TYPE_CHECKING, Any
@@ -29,7 +31,7 @@ class AscendConfig:
     Configuration Object for additional_config from vllm.configs.
     """
 
-    def __init__(self, vllm_config: "VllmConfig"):
+    def __init__(self, vllm_config: VllmConfig):
         self.vllm_config = vllm_config
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
 
@@ -230,6 +232,15 @@ class AscendConfig:
         self.enable_async_exponential = (
             bool(additional_config.get("enable_async_exponential", False)) and not envs.VLLM_BATCH_INVARIANT
         )
+
+        rejection_sampling_config = additional_config.get("rejection_sampling_config", {})
+        self.rejection_sampling_config = RejectionSamplingConfig(rejection_sampling_config, vllm_config)
+
+        if self.rejection_sampling_config.enable_sampling_dp and self.enable_async_exponential:
+            logger.warning(
+                "enable_sampling_dp is incompatible with enable_async_exponential. Disabling enable_async_exponential."
+            )
+            self.enable_async_exponential = False
 
         use_sparse = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
             vllm_config.model_config.hf_text_config, "index_topk"
@@ -687,6 +698,38 @@ class EplbConfig:
 
         logger.info("Dynamic EPLB is %s", self.config["dynamic_eplb"])
         logger.info("The number of redundant experts is %s", self.config["num_redundant_experts"])
+
+
+class RejectionSamplingConfig:
+    """Configuration for rejection sampling optimizations in speculative decoding.
+
+    Usage::
+
+        vllm serve <model> --additional-config '{
+            "rejection_sampling_config": {
+                "enable_sampling_dp": true,
+                "skip_target_logits_sampling": false,
+                "acceleration_method": "default"
+            }
+        }'
+    """
+
+    def __init__(self, config: dict | None = None, vllm_config: VllmConfig | None = None):
+        if config is None:
+            config = {}
+
+        import vllm.envs as envs
+
+        self.enable_sampling_dp: bool = (
+            bool(config.get("enable_sampling_dp", False))
+            and vllm_config is not None
+            and vllm_config.parallel_config.tensor_parallel_size > 1
+            and not envs.VLLM_BATCH_INVARIANT
+        )
+
+        self.skip_target_logits_sampling: bool = config.get("skip_target_logits_sampling", False)
+
+        self.acceleration_method: str = config.get("acceleration_method", "default")
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/ops/triton/bincount.py
+++ b/vllm_ascend/ops/triton/bincount.py
@@ -109,8 +109,12 @@ def get_token_bin_counts_and_mask_triton(
         assert n_rows == num_seqs, f"tokens rows must match num_seqs: tokens.shape[0]={n_rows}, num_seqs={num_seqs}"
     n_rows = num_seqs if num_seqs is not None else n_rows
 
-    # seq_len == 0 is valid for empty decode history; return directly.
-    if n_cols == 0:
+    # Guard against empty input tensors to avoid division by zero in grid calculation.
+    # This can happen in DP sharding scenarios where a rank may receive no draft tokens
+    # (e.g., when sum(local_num_draft_tokens) == 0 but local_batch > 0).
+    # n_rows == 0: empty batch (no tokens to count)
+    # n_cols == 0: empty sequence (valid for empty decode history)
+    if n_rows == 0 or n_cols == 0:
         bin_counts = torch.zeros((n_rows, vocab_size), dtype=torch.int32, device=tokens.device)
         return bin_counts, bin_counts > 0
 

--- a/vllm_ascend/ops/triton/penalty.py
+++ b/vllm_ascend/ops/triton/penalty.py
@@ -134,6 +134,13 @@ def _apply_all_penalties_triton(
 ) -> None:
     """Apply all penalties given precomputed bin counts and masks."""
     num_seqs, vocab_size = logits.shape
+    # Guard against empty logits to avoid kernel launch failure with grid=(0,1,1).
+    # Triton-Ascend backend does not support launching kernels with coreDim=0.
+    # This can happen when get_token_bin_counts_and_mask_triton returns empty tensors
+    # in DP sharding scenarios (see bincount.py for details).
+    if num_seqs == 0:
+        return
+
     grid = (min(num_seqs, get_vectorcore_num()), 1, 1)
 
     apply_all_penalties_kernel[grid](

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.triton_utils import HAS_TRITON
+from vllm.utils.math_utils import cdiv
 from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
@@ -14,7 +15,6 @@ from vllm.v1.sample.rejection_sampler import (
     RejectionSampler,
     generate_uniform_probs,
 )
-from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -51,15 +51,24 @@ class AscendRejectionSampler(RejectionSampler):
         if sampling_metadata.no_penalties:
             return logits
 
-        """Use Triton-Ascend penalties on NPU when Triton is available; else vLLM default."""
-        if not HAS_TRITON:
-            return Sampler.apply_penalties(logits, sampling_metadata, output_token_ids)
-
         assert sampling_metadata.prompt_token_ids is not None
         prompt_token_ids = sampling_metadata.prompt_token_ids[repeat_indices]
         presence_penalties = sampling_metadata.presence_penalties[repeat_indices]
         frequency_penalties = sampling_metadata.frequency_penalties[repeat_indices]
         repetition_penalties = sampling_metadata.repetition_penalties[repeat_indices]
+
+        if not HAS_TRITON:
+            from vllm.v1.sample.ops.penalties import apply_all_penalties as vllm_apply_all_penalties
+
+            return vllm_apply_all_penalties(
+                logits,
+                prompt_token_ids,
+                presence_penalties,
+                frequency_penalties,
+                repetition_penalties,
+                output_token_ids,
+            )
+
         return apply_all_penalties(
             logits,
             prompt_token_ids,
@@ -113,6 +122,12 @@ class AscendRejectionSampler(RejectionSampler):
                 requested.
         """
         assert metadata.max_spec_len <= MAX_SPEC_LEN
+
+        ascend_config = get_ascend_config()
+        rejection_config = ascend_config.rejection_sampling_config
+        enable_sampling_dp = rejection_config.enable_sampling_dp
+        skip_target_logits_sampling = rejection_config.skip_target_logits_sampling
+
         bonus_logits_indices = metadata.bonus_logits_indices
         target_logits_indices = metadata.target_logits_indices
 
@@ -147,24 +162,60 @@ class AscendRejectionSampler(RejectionSampler):
             # the original raw logits for logprobs computation, since
             # apply_logits_processors modifies the tensor in-place.
             target_logits = target_logits.clone()
-        target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
-        # [num_tokens, vocab_size]
-        # NOTE(woosuk): `target_logits` can be updated in place inside the
-        # `apply_sampling_constraints` function.
-        target_logits = apply_sampling_constraints(
-            target_logits, metadata.cu_num_draft_tokens, sampling_metadata, self.top_k
+
+        # Check whether to use DP sharding path.
+        # DP sharding is only applicable when:
+        # - enable_sampling_dp is True
+        # - draft_probs is None (ngram/suffix spec decode, no draft probs to distribute)
+        # - thinking budget state holder is not active
+        use_dp_sharding = (
+            enable_sampling_dp
+            and draft_probs is None
+            and not (
+                sampling_metadata.thinking_budget_state_holder is not None
+                and sampling_metadata.thinking_budget_state_holder.has_tracked_requests()
+            )
         )
 
-        output_token_ids = rejection_sample(
-            metadata.draft_token_ids,
-            metadata.num_draft_tokens,
-            metadata.max_spec_len,
-            metadata.cu_num_draft_tokens,
-            draft_probs,
-            target_logits,
-            bonus_token_ids,
-            sampling_metadata,
-        )
+        if use_dp_sharding:
+            tp_group = get_tp_group()
+            tp_size = tp_group.world_size
+            tp_rank = tp_group.rank_in_group
+
+            batch_size = len(metadata.num_draft_tokens)
+            chunk_size = cdiv(batch_size, tp_size)
+            start_batch = tp_rank * chunk_size
+            end_batch = min(start_batch + chunk_size, batch_size)
+
+            output_token_ids = self._rejection_sample_with_dp_sharding(
+                metadata,
+                target_logits,
+                bonus_token_ids,
+                sampling_metadata,
+                start_batch,
+                end_batch,
+                chunk_size,
+                skip_target_logits_sampling,
+            )
+        else:
+            # [num_tokens, vocab_size]
+            # NOTE(woosuk): `target_logits` can be updated in place inside the
+            # `apply_sampling_constraints` function.
+            target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
+            target_logits = apply_sampling_constraints(
+                target_logits, metadata.cu_num_draft_tokens, sampling_metadata, self.top_k
+            )
+
+            output_token_ids = rejection_sample(
+                metadata.draft_token_ids,
+                metadata.num_draft_tokens,
+                metadata.max_spec_len,
+                metadata.cu_num_draft_tokens,
+                draft_probs,
+                target_logits,
+                bonus_token_ids,
+                sampling_metadata,
+            )
 
         logprobs_tensors = None
         if sampling_metadata.max_num_logprobs is not None:
@@ -181,6 +232,109 @@ class AscendRejectionSampler(RejectionSampler):
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
         )
+
+    def _rejection_sample_with_dp_sharding(
+        self,
+        metadata: SpecDecodeMetadata,
+        target_logits: torch.Tensor,
+        bonus_token_ids: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        start_batch: int,
+        end_batch: int,
+        chunk_size: int,
+        skip_target_logits_sampling: bool,
+    ) -> torch.Tensor:
+        tp_group = get_tp_group()
+        batch_size = len(metadata.num_draft_tokens)
+        max_spec_len = metadata.max_spec_len
+        local_batch = end_batch - start_batch
+
+        if local_batch <= 0:
+            padded_output = torch.full(
+                (chunk_size, max_spec_len + 1),
+                PLACEHOLDER_TOKEN_ID,
+                dtype=torch.int32,
+                device=target_logits.device,
+            )
+            gathered_output = tp_group.all_gather(padded_output, dim=0)
+            return gathered_output[:batch_size]
+
+        local_sampling_metadata = _split_sampling_metadata(sampling_metadata, start_batch, end_batch)
+
+        local_bonus_token_ids = bonus_token_ids[start_batch:end_batch]
+
+        cu_num_draft_tokens = metadata.cu_num_draft_tokens
+
+        local_num_draft_tokens = metadata.num_draft_tokens[start_batch:end_batch]
+        draft_start = sum(metadata.num_draft_tokens[:start_batch]) if start_batch > 0 else 0
+        draft_end = draft_start + sum(local_num_draft_tokens)
+        local_draft_token_ids = metadata.draft_token_ids[draft_start:draft_end]
+        local_target_logits = target_logits[draft_start:draft_end]
+
+        device = cu_num_draft_tokens.device
+        if start_batch > 0:
+            local_cu_num_draft = cu_num_draft_tokens[start_batch:end_batch] - cu_num_draft_tokens[start_batch - 1]
+        else:
+            local_cu_num_draft = cu_num_draft_tokens[start_batch:end_batch]
+        local_cu_num_sampled = local_cu_num_draft + torch.arange(1, local_batch + 1, device=device, dtype=torch.int32)
+
+        local_metadata = SpecDecodeMetadata(
+            draft_token_ids=local_draft_token_ids,
+            num_draft_tokens=local_num_draft_tokens,
+            cu_num_draft_tokens=local_cu_num_draft,
+            cu_num_sampled_tokens=local_cu_num_sampled,
+            target_logits_indices=torch.arange(len(local_draft_token_ids), dtype=torch.int32, device=device),
+            bonus_logits_indices=torch.arange(
+                len(local_draft_token_ids),
+                len(local_draft_token_ids) + len(local_num_draft_tokens),
+                dtype=torch.int32,
+                device=device,
+            ),
+            logits_indices=torch.arange(
+                len(local_draft_token_ids) + len(local_num_draft_tokens),
+                dtype=torch.int32,
+                device=device,
+            ),
+        )
+
+        if not skip_target_logits_sampling:
+            local_target_logits = self.apply_logits_processors(
+                local_target_logits,
+                local_sampling_metadata,
+                local_metadata,
+            )
+
+            local_target_logits = apply_sampling_constraints(
+                local_target_logits,
+                local_cu_num_draft,
+                local_sampling_metadata,
+                self.top_k,
+            )
+
+        local_output_token_ids = rejection_sample(
+            local_draft_token_ids,
+            local_num_draft_tokens,
+            max_spec_len,
+            local_cu_num_draft,
+            None,
+            local_target_logits,
+            local_bonus_token_ids,
+            local_sampling_metadata,
+            synthetic_mode=self.synthetic_mode,
+            synthetic_conditional_rates=self.synthetic_conditional_rates,
+        )
+
+        padded_output = torch.full(
+            (chunk_size, max_spec_len + 1),
+            PLACEHOLDER_TOKEN_ID,
+            dtype=torch.int32,
+            device=target_logits.device,
+        )
+        padded_output[:local_batch] = local_output_token_ids
+
+        gathered_output = tp_group.all_gather(padded_output, dim=0)
+
+        return gathered_output[:batch_size]
 
 
 def greedy_sample(logits: torch.Tensor) -> torch.Tensor:
@@ -1345,3 +1499,50 @@ def sample_recovered_tokens_blockwise_pytorch(
         output_token_ids[:] = target_indices[torch.arange(num_tokens, device=device), indices]
     else:
         output_token_ids[:] = torch.argmax(prob_over_q, dim=1)
+
+
+def _split_sampling_metadata(metadata: SamplingMetadata, start: int, end: int) -> SamplingMetadata:
+    local_temperature = metadata.temperature[start:end] if metadata.temperature is not None else None
+    local_top_p = metadata.top_p[start:end] if metadata.top_p is not None else None
+    local_top_k = metadata.top_k[start:end] if metadata.top_k is not None else None
+    local_frequency_penalties = metadata.frequency_penalties[start:end]
+    local_presence_penalties = metadata.presence_penalties[start:end]
+    local_repetition_penalties = metadata.repetition_penalties[start:end]
+
+    local_prompt_token_ids = metadata.prompt_token_ids[start:end] if metadata.prompt_token_ids is not None else None
+    local_allowed_mask = (
+        metadata.allowed_token_ids_mask[start:end] if metadata.allowed_token_ids_mask is not None else None
+    )
+
+    local_output_token_ids = metadata.output_token_ids[start:end]
+    local_spec_token_ids = metadata.spec_token_ids[start:end] if metadata.spec_token_ids is not None else None
+
+    local_generators = {i - start: gen for i, gen in metadata.generators.items() if start <= i < end}
+    local_bad_words = {i - start: words for i, words in metadata.bad_words_token_ids.items() if start <= i < end}
+    local_logprob_token_ids = (
+        {i - start: tids for i, tids in metadata.logprob_token_ids.items() if start <= i < end}
+        if metadata.logprob_token_ids is not None
+        else None
+    )
+
+    return SamplingMetadata(
+        temperature=local_temperature,
+        all_greedy=metadata.all_greedy,
+        all_random=metadata.all_random,
+        top_p=local_top_p,
+        top_k=local_top_k,
+        generators=local_generators,
+        max_num_logprobs=metadata.max_num_logprobs,
+        no_penalties=metadata.no_penalties,
+        prompt_token_ids=local_prompt_token_ids,
+        frequency_penalties=local_frequency_penalties,
+        presence_penalties=local_presence_penalties,
+        repetition_penalties=local_repetition_penalties,
+        output_token_ids=local_output_token_ids,
+        allowed_token_ids_mask=local_allowed_mask,
+        bad_words_token_ids=local_bad_words,
+        logitsprocs=metadata.logitsprocs,
+        logprob_token_ids=local_logprob_token_ids,
+        spec_token_ids=local_spec_token_ids,
+        thinking_budget_state_holder=None,
+    )


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request introduces Data Parallel (DP) sharding for rejection sampling in speculative decoding to optimize performance. It adds `_rejection_sample_with_dp_sharding` and helper `_split_sampling_metadata` in `rejection_sampler.py`, introduces `RejectionSamplingConfig` in `ascend_config.py`, and adds guards against empty tensors in `bincount.py` and `penalty.py` to support DP sharding scenarios.

### Does this PR introduce _any_ user-facing change?
Yes, it adds a new configuration option `rejection_sampling_config` under `--additional-config` to enable DP sampling, skip target logits sampling, and specify acceleration methods.

### How was this patch tested?
The patch includes unit tests in `tests/ut/sample/test_rejection_sampler_dp_sharding.py` covering basic greedy/random splitting, penalty preservation, and DP sharding behaviors.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
