### PR TITLE
[Feature][core] add group_name param when create hccl_config

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1072,9 +1072,9 @@ def npu_stream_switch(target_stream: torch.npu.Stream, *, enabled: bool = True):
 
 def create_hccl_pg_options(group_name: str):
     options = torch_npu._C._distributed_c10d.ProcessGroupHCCL.Options()
-    hccl_config = get_hccl_config_for_pg_options(group_name)
-    if hccl_config is not None:
-        options.hccl_config = hccl_config
+    hccl_config = get_hccl_config_for_pg_options(group_name) or {}
+    hccl_config["group_name"] = group_name
+    options.hccl_config = hccl_config
     return options
 
 


### PR DESCRIPTION

### What this PR does / why we need it?
Profiler tool need save parallel info for user to analyze model communication problems.
So we add "group_name": group_name in hccl_config, then profiler can get parallel info by using torch_npu apis and save it to profiler data file([_add_group_info_to_metadata](https://github.com/Ascend/pytorch/blob/master/torch_npu/profiler/profiler_interface.py )).
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Use profiler tool to collect vllm-ascend model data, then check if there is parallel info in profiler data file


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
