### PR TITLE
[Ops][Misc] Remove VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL

### DIFF
--- a/docs/source/tutorials/features/long_sequence_context_parallel_multi_node.md
+++ b/docs/source/tutorials/features/long_sequence_context_parallel_multi_node.md
@@ -91,7 +91,6 @@ We can run the following scripts to launch a server on the prefiller/decoder nod
     export HCCL_OP_EXPANSION_MODE="AIV"
     export VLLM_USE_V1=1
     export TASK_QUEUE_ENABLE=1
-    export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 
     vllm serve /path_to_weight/DeepSeek-V3.1_w8a8mix_mtp \
       --host 0.0.0.0 \
@@ -158,7 +157,6 @@ We can run the following scripts to launch a server on the prefiller/decoder nod
     export HCCL_OP_EXPANSION_MODE="AIV"
     export VLLM_USE_V1=1
     export TASK_QUEUE_ENABLE=1
-    export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 
     vllm serve /path_to_weight/DeepSeek-V3.1_w8a8mix_mtp \
       --host 0.0.0.0 \
@@ -224,7 +222,6 @@ We can run the following scripts to launch a server on the prefiller/decoder nod
     export HCCL_OP_EXPANSION_MODE="AIV"
     export VLLM_USE_V1=1
     export TASK_QUEUE_ENABLE=1
-    export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1
 
     vllm serve /path_to_weight/DeepSeek-V3.1_w8a8mix_mtp \
       --host 0.0.0.0 \
@@ -318,7 +315,6 @@ The parameters are explained as follows:
 "cudagraph_mode": represents the specific graph mode. Currently, "PIECEWISE" and "FULL_DECODE_ONLY" are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, "FULL_DECODE_ONLY" is recommended.
 - "cudagraph_capture_sizes": represents different levels of graph modes. The default value is [1, 2, 4, 8, 16, 24, 32, 40,..., `--max-num-seqs`]. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance.
 - `export VLLM_ASCEND_ENABLE_FLASHCOMM1=1` indicates that Flashcomm1 optimization is enabled. Currently, this optimization is only supported for MoE in scenarios where tensor-parallel-size > 1.
-- `export VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL=1` indicates that context parallel is enabled. This environment variable is required in the PD architecture but not needed in the PD co-locate deployment scenario. It will be removed in the future.
 
 **Notice:**
 

--- a/examples/offline_inference_npu_long_seq.py
+++ b/examples/offline_inference_npu_long_seq.py
@@ -5,7 +5,6 @@ import time
 from vllm import LLM, SamplingParams
 
 os.environ["VLLM_USE_MODELSCOPE"] = "True"
-os.environ["VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL"] = "1"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 if __name__ == "__main__":

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
@@ -31,7 +31,6 @@ _FEATURE_ENVS: dict[str, str] = {
     "VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE": "topk_optimize",
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "matmul_allreduce",
     "VLLM_ASCEND_ENABLE_MLAPO": "mlapo",
-    "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": "context_parallel",
     "VLLM_ASCEND_ENABLE_FUSED_MC2": "fused_mc2",
 }
 

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -190,7 +190,6 @@ _FEATURE_ENVS: dict[str, str] = {
     "VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE": "topk_optimize",
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "matmul_allreduce",
     "VLLM_ASCEND_ENABLE_MLAPO": "mlapo",
-    "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": "context_parallel",
     "VLLM_ASCEND_ENABLE_FUSED_MC2": "fused_mc2",
 }
 

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -32,6 +32,7 @@ class TestMoECommMethod(TestBase):
         self.moe_config.tp_group.device_group = MagicMock()
         self.moe_config.dp_size = 1
         self.moe_config.tp_size = 1
+        self.moe_config.pcp_size = 1
         self.moe_config.ep_size = 1
         self.moe_config.dp_group = MagicMock()
         self.moe_config.global_redundant_expert_num = 0

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -35,6 +35,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         self.moe_config.tp_group.device_group = MagicMock()
         self.moe_config.dp_size = 1
         self.moe_config.tp_size = 1
+        self.moe_config.pcp_size = 1
         self.moe_config.ep_size = 1
         self.moe_config.dp_group = MagicMock()
         self.moe_config.original_num_experts = 8
@@ -183,6 +184,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
 
         self.moe_config.dp_size = 2
         self.moe_config.tp_size = 1
+        self.moe_config.pcp_size = 1
         self.moe_config.ep_size = 1
         self.moe_config.dp_group = mock_dp_group
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -111,7 +111,6 @@ class TestAscendConfig(TestBase):
         ):
             ascend_config = init_ascend_config(test_vllm_config)
 
-        self.assertTrue(ascend_config.enable_context_parallel)
         self.assertTrue(ascend_config.enable_matmul_allreduce)
         self.assertEqual(ascend_config.enable_fused_mc2, 2)
         self.assertFalse(ascend_config.enable_mlapo)
@@ -152,7 +151,6 @@ class TestAscendConfig(TestBase):
     def test_migrated_config_overrides_envs(self, mock_fix_incompatible_config, mock_info_once):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
-            "enable_context_parallel": False,
             "enable_matmul_allreduce": False,
             "enable_fused_mc2": 0,
             "enable_mlapo": True,
@@ -177,7 +175,6 @@ class TestAscendConfig(TestBase):
         ):
             ascend_config = init_ascend_config(test_vllm_config)
 
-        self.assertFalse(ascend_config.enable_context_parallel)
         self.assertFalse(ascend_config.enable_matmul_allreduce)
         self.assertEqual(ascend_config.enable_fused_mc2, 0)
         self.assertTrue(ascend_config.enable_mlapo)

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -99,7 +99,6 @@ class TestAscendConfig(TestBase):
         with patch.dict(
             os.environ,
             {
-                "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": "1",
                 "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
                 "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
@@ -166,7 +165,6 @@ class TestAscendConfig(TestBase):
         with patch.dict(
             os.environ,
             {
-                "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": "1",
                 "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "1",
                 "VLLM_ASCEND_ENABLE_FUSED_MC2": "2",
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -137,12 +137,6 @@ class AscendConfig:
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", False)
         self.prefill_comm_compute_overlap = additional_config.get("prefill_comm_compute_overlap", False)
 
-        self.enable_context_parallel = self._get_config_value(
-            additional_config,
-            "enable_context_parallel",
-            "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL",
-            ascend_envs.VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL,
-        )
         self.enable_matmul_allreduce = self._get_config_value(
             additional_config,
             "enable_matmul_allreduce",

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -90,8 +90,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # 1: only quant case enable nz;
     # 2: enable nz as long as possible.
     "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
-    # Decide whether we should enable CP parallelism.
-    "VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL", "0"))),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
     # Whether to enable fused MC2 (`dispatch_gmm_combine_decode` / `dispatch_ffn_combine`).

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -34,7 +34,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.distributed.utils import fc3_all_gather_and_maybe_unpad_impl
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEPrepareOutput
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import enable_sp, enable_sp_by_pass, npu_stream_switch, prefill_context_parallel_enable
+from vllm_ascend.utils import enable_sp, enable_sp_by_pass, npu_stream_switch
 
 
 class PrepareAndFinalize(ABC):
@@ -431,7 +431,7 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             hidden_states = self.moe_config.dp_group.all_gather(hidden_states, 0)
             router_logits = self.moe_config.dp_group.all_gather(router_logits, 0)
 
-        if prefill_context_parallel_enable() and self.moe_config.pcp_size > 1:
+        if self.moe_config.pcp_size > 1:
             max_tokens_across_pcp = _EXTRA_CTX.max_tokens_across_pcp
 
             self.num_tokens_pcp = hidden_states.shape[0]
@@ -513,6 +513,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             hidden_states = get_dp_group().reduce_scatter(hidden_states, 0)
             hidden_states = hidden_states[: self.num_tokens]
 
-        if prefill_context_parallel_enable() and self.moe_config.pcp_size > 1:
+        if self.moe_config.pcp_size > 1:
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
         return hidden_states

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -925,10 +925,6 @@ def shared_expert_dp_enabled() -> bool:
     return get_ascend_config().enable_shared_expert_dp or enable_sp() or enable_sp_by_pass()
 
 
-def prefill_context_parallel_enable() -> bool:
-    return get_ascend_config().enable_context_parallel
-
-
 def is_moe_model(vllm_config: VllmConfig):
     """Checks if the model is a MoE model by config"""
     global _IS_MOE_MODEL


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes the environment variable `VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL` and its associated configuration `enable_context_parallel` from `AscendConfig`. This environment variable was previously used for PCP+EP in A2, but is no longer needed since `moe_config` now contains `pcp_size` (after PR https://github.com/vllm-project/vllm/pull/31003 was merged).

### Does this PR introduce _any_ user-facing change?

Yes, users running on Ascend no longer need to set the `VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL` environment variable.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
