### PR TITLE
add OTP (O-matrix Tensor Parallelism) support for general DP scenarios

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -436,13 +436,15 @@ class FinegrainedTPConfig:
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
-            # dummy_run does not run the entire attention module in eager mode,
-            # so the o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config.enforce_eager:
-                raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
-            if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
+            # OTP is only supported in pure DP scenarios (data_parallel_size > 1 with no regular TP).
+            is_pure_dp = (
+                vllm_config.parallel_config.data_parallel_size > 1
+                and vllm_config.parallel_config.tensor_parallel_size == 1
+            )
+            if not is_pure_dp:
                 raise AssertionError(
-                    "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
+                    "oproj_tensor_parallel_size (OTP) is only supported in pure DP scenarios "
+                    "(data_parallel_size > 1 and tensor_parallel_size == 1)"
                 )
         if self.olora_tensor_parallel_size > 0:
             enabled_configs.append(f"olora_tensor_parallel_size={self.olora_tensor_parallel_size}")

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -28,6 +28,7 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,
+    oproj_tp_enable,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
@@ -1440,6 +1441,23 @@ class AscendDSAImpl(DSAAttentionImpl):
             "use_index_cache",
             False,
         )
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype):
+        if oproj_tp_enable():
+            from vllm_ascend.distributed.parallel_state import get_otp_group
+
+            otp_group = get_otp_group()
+            otp_size = otp_group.world_size
+            otp_rank = otp_group.rank_in_group
+
+            # Only OTP row-slice wo_b (wo_a keeps ColumnParallelLinear with
+            # batch matmul — group dimension must be preserved for correctness)
+            wo_b_weight = self.wo_b.weight.data
+            wo_b_rows_per_otp = wo_b_weight.shape[0] // otp_size
+            wo_b_shard = wo_b_weight[
+                otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
+            ].clone()
+            self.wo_b.weight = torch.nn.Parameter(wo_b_shard, requires_grad=False)
 
     def _get_indexcache_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
         if self.topk_indices_buffer is None:

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -81,6 +81,7 @@ from vllm_ascend.utils import (
     extract_dsv4_layer_index,
     get_ascend_device_type,
     get_dsv4_compress_ratio,
+    oproj_tp_enable,
 )
 
 
@@ -1078,6 +1079,16 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 self.moe_layers.append(layer.mlp.experts)
 
         self.extract_moe_parameters(example_moe)
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype):
+        if oproj_tp_enable():
+            for layer in self.model.layers:
+                if isinstance(layer, PPMissingLayer):
+                    continue
+                # DeepseekV4Attention -> dsa_attn (AscendDeepseekSparseAttention)
+                # -> dsa_attn (DSAAttention) -> impl (AscendDSAImpl)
+                attn = layer.self_attn
+                attn.dsa_attn.dsa_attn.impl.process_weights_after_loading(act_dtype)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -232,6 +232,18 @@ class OProjRowParallelOp(CustomRowParallelOp):
         self,
         input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        # Pure DP OTP: weight is row-sliced along the output dimension.
+        # Each OTP rank computes a partial output slice and all-gathers
+        # along the feature dimension to reconstruct the full output.
+        if get_tp_group().world_size == 1:
+            assert self.quant_method is not None
+            bias_ = None if (self.comm_group.rank_in_group > 0 or self.skip_bias_add) else self.bias
+            output_parallel = self.quant_method.apply(self.layer, input_, bias=bias_)
+            output = self.comm_group.all_gather(output_parallel, dim=-1)
+            output_bias = self.bias if self.skip_bias_add else None
+            return output, output_bias
+
+        # PD scenario: all-to-all + matmul + reduce-scatter
         input_parallel = self.get_input_parallel(input_)
 
         # Prepare tensors for all-to-all communication
@@ -666,7 +678,7 @@ def _get_row_parallel_op(
         return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPRowParallelOp(layer)
-    if "o_proj" in prefix and oproj_tp_enable():
+    if ("o_proj" in prefix or "wo_b" in prefix) and oproj_tp_enable():
         return OProjRowParallelOp(layer)
     if matmul_allreduce_enable():
         return MatmulAllreduceRowParallelOp(layer)
@@ -717,6 +729,12 @@ def get_parallel_op(disable_tp, prefix, layer, direct):
         custom_op = _get_column_parallel_op(prefix, layer)
 
     if custom_op is not None:
+        # For wo_b in pure DP OTP mode, the weight is row-sliced along the output
+        # dimension (not column-sliced along the input dimension).  Keep the
+        # original TP size so that input_size_per_partition stays at the full
+        # input size and the RowParallelLinear weight is loaded unsplit.
+        if isinstance(custom_op, OProjRowParallelOp) and "wo_b" in prefix:
+            return custom_op, 0, 1
         return custom_op, custom_op.tp_rank, custom_op.tp_size
 
     return None, get_tp_group().rank_in_group, get_tp_group().world_size

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -232,10 +232,10 @@ class OProjRowParallelOp(CustomRowParallelOp):
         self,
         input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
-        # Pure DP OTP: weight is row-sliced along the output dimension.
-        # Each OTP rank computes a partial output slice and all-gathers
-        # along the feature dimension to reconstruct the full output.
-        if get_tp_group().world_size == 1:
+        # Single-operator (eager) mode: use simple matmul + all_gather path.
+        # In graph mode (capturing=True), the PD path (all-to-all + reduce-scatter)
+        # is used because it can be captured into an NPU graph.
+        if not _EXTRA_CTX.capturing:
             assert self.quant_method is not None
             bias_ = None if (self.comm_group.rank_in_group > 0 or self.skip_bias_add) else self.bias
             output_parallel = self.quant_method.apply(self.layer, input_, bias=bias_)
@@ -243,7 +243,7 @@ class OProjRowParallelOp(CustomRowParallelOp):
             output_bias = self.bias if self.skip_bias_add else None
             return output, output_bias
 
-        # PD scenario: all-to-all + matmul + reduce-scatter
+        # Graph mode (PD scenario): all-to-all + matmul + reduce-scatter
         input_parallel = self.get_input_parallel(input_)
 
         # Prepare tensors for all-to-all communication
@@ -678,7 +678,7 @@ def _get_row_parallel_op(
         return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPRowParallelOp(layer)
-    if ("o_proj" in prefix or "wo_b" in prefix) and oproj_tp_enable():
+    if ("o_proj" in prefix or re.search(r'\.wo_b$', prefix)) and oproj_tp_enable():
         return OProjRowParallelOp(layer)
     if matmul_allreduce_enable():
         return MatmulAllreduceRowParallelOp(layer)
@@ -733,7 +733,7 @@ def get_parallel_op(disable_tp, prefix, layer, direct):
         # dimension (not column-sliced along the input dimension).  Keep the
         # original TP size so that input_size_per_partition stays at the full
         # input size and the RowParallelLinear weight is loaded unsplit.
-        if isinstance(custom_op, OProjRowParallelOp) and "wo_b" in prefix:
+        if isinstance(custom_op, OProjRowParallelOp) and re.search(r'\.wo_b$', prefix):
             return custom_op, 0, 1
         return custom_op, custom_op.tp_rank, custom_op.tp_size
 


### PR DESCRIPTION
### What this PR does / why we need it?
OTP mode: each DP rank holds full wo_a/wo_b weights (via ReplicatedLinear),
    performs row-sliced matmul within OTP group, then reduce-scatters results.
Extend OTP (oproj_tensor_parallel_size) support beyond PD D node to general DP scenarios including mix_placement.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
