### PR TITLE
[Ascend950][Feature]Support MXFP8 FlashcommV3 on 950

### DIFF
--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -288,6 +288,9 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
                 tid2eid=tid2eid,
             )
 
+        if topk_weights is None or topk_ids is None:
+            raise RuntimeError("topk_weights and topk_ids must be set before fused MoE execution.")
+
         # this is a naive implementation for experts load balance so as
         # to avoid accumulating too much tokens on a single rank.
         # currently it is only activated when doing profile runs.

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -32,6 +32,7 @@ from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp8_linear_available,
     ensure_mxfp8_moe_available,
 )
+from vllm_ascend.flash_common3_context import get_flash_common3_context
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
@@ -201,6 +202,7 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
             and not vllm_config.model_config.enforce_eager
         )
         self.dynamic_eplb = ascend_config.eplb_config.dynamic_eplb
+        self.multistream_overlap_gate = ascend_config.multistream_overlap_gate
 
     @staticmethod
     def get_weight(
@@ -264,21 +266,27 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
             num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
+        if self.multistream_overlap_gate:
+            fc3_context = get_flash_common3_context()
+            assert fc3_context is not None
+            topk_weights = fc3_context.topk_weights
+            topk_ids = fc3_context.topk_ids
+        else:
+            topk_weights, topk_ids = select_experts(
+                hidden_states=x,
+                router_logits=router_logits,
+                top_k=top_k,
+                use_grouped_topk=use_grouped_topk,
+                renormalize=renormalize,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                routed_scaling_factor=routed_scaling_factor,
+                e_score_correction_bias=e_score_correction_bias,
+                num_experts=num_logical_experts,
+                tid2eid=tid2eid,
+            )
 
         # this is a naive implementation for experts load balance so as
         # to avoid accumulating too much tokens on a single rank.


### PR DESCRIPTION
What this PR does / why we need it?

This PR adds support for MXFP8 FlashCommV3 on Ascend 950.

Specifically, it updates the W8A8_MXFP8 MoE path to reuse `topk_weights` and `topk_ids` from `FlashCommon3Context` when `multistream_overlap_gate` is enabled, instead of calling `select_experts` again. The original `select_experts` path is kept for non-overlap scenarios.

This is needed to make the MXFP8 fused MoE path compatible with FlashCommV3 multistream overlap on Ascend 950, avoid duplicated gating computation, and ensure that MoE execution uses the routing results generated by the FlashCommV3 overlap path.

Performance on Ascend 950 with DeepSeek V3.1 prefill scenario using variable-length input data from 0 to 16K:

| Scenario | FlashCommV3 | Input Length | QPS |
| --- | --- | --- | --- |
| DeepSeek V3.1 Prefill | Disabled | 0-16K variable length | 0.62 |
| DeepSeek V3.1 Prefill | Enabled | 0-16K variable length | 0.64 |

This shows that enabling FlashCommV3 improves QPS from 0.62 to 0.64 in the DeepSeek V3.1 prefill scenario on Ascend 950.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/1ac10f159a09897baada01b14b6a0dd6442aefd6
