### PR TITLE
[BugFix][Model] Recompute DeepSeek V4 hash routing weights

### DIFF
--- a/tests/ut/ops/test_moe_hash_routing_input_ids.py
+++ b/tests/ut/ops/test_moe_hash_routing_input_ids.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ops.fused_moe import experts_selector as experts_selector_module
+
+
+@pytest.mark.parametrize(
+    "moe_comm_type",
+    [
+        MoECommType.ALLGATHER,
+        MoECommType.MC2,
+        MoECommType.ALLTOALL,
+        MoECommType.FUSED_MC2,
+    ],
+)
+def test_hash_routing_uses_comm_aligned_input_ids(monkeypatch, moe_comm_type):
+    raw_input_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+    aligned_input_ids = torch.tensor([9, -1, 7], dtype=torch.int64)
+    tid2eid = torch.arange(64, dtype=torch.int64).view(16, 4)
+    captured = {}
+
+    def fake_hash_gate(**kwargs):
+        captured.update(kwargs)
+        return (
+            torch.ones(3, 2, dtype=torch.float32),
+            torch.zeros(3, 2, dtype=torch.int32),
+            torch.arange(3, dtype=torch.int32),
+        )
+
+    monkeypatch.setattr(torch.ops._C_ascend, "moe_gating_top_k_hash", fake_hash_gate, raising=False)
+
+    if moe_comm_type == MoECommType.ALLGATHER:
+        prepare_finalize = SimpleNamespace(all_gather_input_id_with_dp_group=MagicMock(return_value=aligned_input_ids))
+        moe_comm_method = SimpleNamespace(prepare_finalize=prepare_finalize)
+    else:
+        prepare_finalize = None
+        moe_comm_method = SimpleNamespace(pad_and_split_input_ids=MagicMock(return_value=aligned_input_ids))
+
+    forward_context = SimpleNamespace(
+        input_ids=raw_input_ids,
+        moe_comm_type=moe_comm_type,
+        moe_comm_method=moe_comm_method,
+        flash_comm_v1_enabled=False,
+    )
+    monkeypatch.setattr(experts_selector_module, "get_forward_context", lambda: forward_context)
+
+    experts_selector_module._select_experts_with_fusion_ops(
+        hidden_states=torch.randn(3, 32),
+        router_logits=torch.randn(3, 16),
+        top_k=2,
+        use_grouped_topk=True,
+        renormalize=False,
+        e_score_correction_bias=None,
+        topk_group=2,
+        num_expert_group=4,
+        scoring_func="sqrtsoftplus",
+        tid2eid=tid2eid,
+    )
+
+    if moe_comm_type == MoECommType.ALLGATHER:
+        assert prepare_finalize is not None
+        prepare_finalize.all_gather_input_id_with_dp_group.assert_called_once_with(raw_input_ids)
+    else:
+        moe_comm_method.pad_and_split_input_ids.assert_called_once_with(raw_input_ids)
+
+    expected_input_ids = torch.tensor([9, 0, 7], dtype=torch.int64)
+    assert torch.equal(captured["input_ids"], expected_input_ids)
+    assert torch.equal(captured["tid2eid"], tid2eid.to(torch.int32))
+
+
+def test_hash_route_recomputes_weights_from_router_logits(monkeypatch):
+    raw_input_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+    aligned_input_ids = torch.tensor([9, -1], dtype=torch.int64)
+    tid2eid = torch.arange(16, dtype=torch.int64).view(4, 4)
+    router_logits = torch.tensor(
+        [[-4.0, -1.0, 0.5, 2.0], [3.0, -2.0, 1.0, -0.5]],
+        dtype=torch.float32,
+    )
+    topk_ids = torch.tensor([[0, 2], [1, 3]], dtype=torch.int32)
+
+    def fake_hash_gate(**kwargs):
+        bad_weights = torch.full((2, 2), float("nan"), dtype=torch.float32)
+        return bad_weights, topk_ids, torch.arange(2, dtype=torch.int32)
+
+    monkeypatch.setattr(torch.ops._C_ascend, "moe_gating_top_k_hash", fake_hash_gate, raising=False)
+
+    moe_comm_method = SimpleNamespace(pad_and_split_input_ids=MagicMock(return_value=aligned_input_ids))
+    forward_context = SimpleNamespace(
+        input_ids=raw_input_ids,
+        moe_comm_type=MoECommType.MC2,
+        moe_comm_method=moe_comm_method,
+        flash_comm_v1_enabled=False,
+    )
+    monkeypatch.setattr(experts_selector_module, "get_forward_context", lambda: forward_context)
+
+    topk_weights, actual_topk_ids = experts_selector_module._select_experts_with_fusion_ops(
+        hidden_states=torch.randn(2, 32),
+        router_logits=router_logits,
+        top_k=2,
+        use_grouped_topk=True,
+        renormalize=True,
+        e_score_correction_bias=None,
+        topk_group=1,
+        num_expert_group=1,
+        scoring_func="sqrtsoftplus",
+        routed_scaling_factor=2.5,
+        tid2eid=tid2eid,
+    )
+
+    expected = torch.nn.functional.softplus(router_logits).sqrt().gather(1, topk_ids.to(torch.int64))
+    expected = expected / expected.sum(dim=-1, keepdim=True)
+    expected = expected * 2.5
+    assert torch.equal(actual_topk_ids, topk_ids)
+    assert torch.isfinite(topk_weights).all()
+    torch.testing.assert_close(topk_weights, expected)

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -272,7 +272,7 @@ def _select_experts_with_fusion_ops(
         else:
             input_ids = None
             tid2eid_ones = None
-        topk_weights, topk_ids, _ = torch.ops._C_ascend.moe_gating_top_k_hash(
+        _, topk_ids, _ = torch.ops._C_ascend.moe_gating_top_k_hash(
             x=router_logits,
             k=top_k,
             bias=e_score_correction_bias,
@@ -292,6 +292,7 @@ def _select_experts_with_fusion_ops(
         # Match DeepSeek V4 routing: normalize sqrtsoftplus top-k weights
         # before applying the routed scale. DSV4 non-AITER callers pass 1.0
         # here and scale the routed output later with muls_add_triton.
+        topk_weights = F.softplus(router_logits.to(torch.float32)).sqrt().gather(1, topk_ids.to(torch.int64))
         topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
         topk_weights = topk_weights * routed_scaling_factor
         return topk_weights, topk_ids

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -386,7 +386,9 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
-        topk_weights = topk_weights.to(x.dtype)
+        # Keep router weights in FP32 for expert scaling. Casting to BF16 here
+        # loses precision before MC2/ALLTOALL combine can promote them again.
+        topk_weights = topk_weights.to(torch.float32)
 
         if self.dynamic_eplb:
             w1 = layer.w13_weight_list


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 W4A8 can hit NaN router weights in the `sqrtsoftplus + tid2eid/hash routing` path. The hash-routing custom op still returns finite `topk_ids`, but its returned `topk_weights` can become NaN and then propagate into MoE output for long generations.

This PR keeps using `moe_gating_top_k_hash` for selected expert ids, but recomputes the corresponding weights from `router_logits` in FP32:

```python
sqrt(softplus(router_logits)).gather(topk_ids)
```

The recomputed weights are then renormalized and scaled exactly like the existing DeepSeek V4 path. The W4A8 MoE path also keeps `topk_weights` in FP32 before expert scaling to avoid losing precision before MC2/ALLTOALL combine can promote them again.

The branch was created from `main@b26970e597222029d624261a8738a40f2d33ad17`.

### Does this PR introduce _any_ user-facing change?

No. This is an internal accuracy fix for DeepSeek V4 W4A8 MoE routing on Ascend.

### How was this patch tested?

- `python -m py_compile vllm_ascend/ops/fused_moe/experts_selector.py vllm_ascend/quantization/methods/w4a8.py tests/ut/ops/test_moe_hash_routing_input_ids.py`
- `ruff check vllm_ascend/ops/fused_moe/experts_selector.py vllm_ascend/quantization/methods/w4a8.py tests/ut/ops/test_moe_hash_routing_input_ids.py`
- `pytest -q tests/ut/ops/test_moe_hash_routing_input_ids.py tests/ut/quantization/methods/test_w4a8.py::TestAscendW4A8DynamicFusedMoEMethod::test_apply_comprehensive`

The new unit tests cover comm-aligned input ids for hash routing and the regression case where the custom op returns NaN weights while `topk_ids` and `router_logits` remain finite.

Manual validation was also run on DeepSeek-V4-Pro W4A8 with TP16DP1EP, eager mode, prefix cache disabled, FlashComm/FUSED_MC2 disabled, `HCCL_DETERMINISTIC=true`, and `HCCL_BUFFSIZE=512`. A long deterministic completion that previously produced abnormal tokens no longer propagated non-finite values through the effective MoE/hidden/logits path after this fix.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
