### PR TITLE
[Worker][Doc] Add A5 server disaggregated PD endpoint configuration

### DIFF
--- a/examples/disaggregated_prefill_a5_adaption/README.md
+++ b/examples/disaggregated_prefill_a5_adaption/README.md
@@ -13,6 +13,8 @@ Both scripts are located in this directory.
 
 ## Prerequisites
 
+Check if `/etc/hccl_rootinfo.json` exists. If not existed or current one is not ok (task failed), follow instructions below to generate one.
+
 ### 1. Install the dependency tool
 
 ```bash

--- a/examples/disaggregated_prefill_a5_adaption/README.md
+++ b/examples/disaggregated_prefill_a5_adaption/README.md
@@ -1,0 +1,107 @@
+# A5 Server Disaggregated Prefill-Deploy (PD) Adaptation Guide
+
+This guide describes the steps to configure an A5 server for vLLM disaggregated prefill (PD) deployment with NPU endpoint routing.
+
+## Overview
+
+Disaggregated prefill requires proper NPU endpoint configuration so that HCCL communication layers correctly match the hardware topology. The setup involves two scripts that must be run sequentially:
+
+1. **`gen_route.sh`** — reads NPU device topology from `/proc` and generates a route configuration file.
+2. **`generate_ep.py`** — consumes the route file, the HCCL topology, and rootinfo to produce per-NPU endpoint JSON files.
+
+Both scripts are located in this directory.
+
+## Prerequisites
+
+### 1. Install the dependency tool
+
+```bash
+python3 -m pip install unofficial-ascend-tools==0.0.7rc4
+```
+
+### 2. Generate `/etc/hccl_rootinfo.json`
+
+Use the installed tool to generate the rootinfo file and copy and rename it to `/etc/hccl_rootinfo.json`:
+
+```bash
+mindcluster-tools rootinfo --product_type server
+# The output filename (e.g. new_hccl_rootinfo.json) may vary by machine or tool version.
+# Check the actual generated file and copy it accordingly.
+cp new_hccl_rootinfo.json /etc/hccl_rootinfo.json
+```
+
+> **Note:** This file is required by `generate_ep.py` and describes the HCCL rank list, device IDs, EIDs, and topology file path.
+
+## Step 1 — Generate Route Configuration
+
+Run `gen_route.sh` to produce the route configuration file (`/lib/route.conf`). This script:
+
+- Detects davinci/NPU devices via `/proc/ascend_ub` (or `/proc/asdrv_ub`).
+- Extracts device ID and EID (local/remote) mappings from the kernel pair_info interface.
+- Writes the route.conf file consumed by the next step.
+
+```bash
+bash gen_route.sh
+```
+
+On success, the script prints the number of devices found and the contents of the generated `/lib/route.conf`.
+
+> **Tip:** If `/lib/route.conf` already exists, the script backs it up as `/lib/route.conf.bak` before regenerating.
+
+## Step 2 — Generate Endpoint Configuration Files
+
+Run `generate_ep.py` to produce per-NPU endpoint JSON files under `/etc/hixlep/`.
+
+| Scenario       | Flag | Description                                       |
+|----------------|------|---------------------------------------------------|
+| A5 Server      | `-s` | 0+8 server topology (tested, recommended for A5)  |
+| POD            | `-p` | 1D PoD topology (untested)                        |
+
+**For A5 server (recommended):**
+
+```bash
+python generate_ep.py -s
+```
+
+**For POD (not yet tested):**
+
+```bash
+python generate_ep.py -p
+```
+
+## Output
+
+After both scripts run successfully, the following files are produced:
+
+| Path                               | Description                                   |
+|------------------------------------|-----------------------------------------------|
+| `/lib/route.conf`                  | Route configuration (device-to-EID mappings)  |
+| `/etc/hixlep/ub_endpoint_npu_*.json` | One endpoint file per NPU device              |
+
+## Post-Configuration — vLLM Environment Variable
+
+With the updated worker code in `vllm_ascend/worker/worker.py`, you must set the following environment variable when launching vLLM:
+
+```bash
+export ASCEND_LOCAL_COMM_RES_PATH=/etc/hixlep
+```
+
+This tells the PD-adapted worker where to find the NPU endpoint configuration files.
+
+## Full Command Summary
+
+```bash
+# 0. Prerequisites (one-time setup)
+python3 -m pip install unofficial-ascend-tools==0.0.7rc4
+mindcluster-tools rootinfo --product_type server
+cp new_hccl_rootinfo.json /etc/hccl_rootinfo.json  # actual filename may vary
+
+# 1. Generate route config
+bash gen_route.sh
+
+# 2. Generate endpoint configs (A5 server)
+python generate_ep.py -s
+
+# 3. Set vLLM environment variable
+export ASCEND_LOCAL_COMM_RES_PATH=/etc/hixlep
+```

--- a/examples/disaggregated_prefill_a5_adaption/gen_route.sh
+++ b/examples/disaggregated_prefill_a5_adaption/gen_route.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+if [ -d "/proc/ascend_ub" ]; then
+    cd /proc/ascend_ub
+else
+    cd /proc/asdrv_ub
+fi
+
+ls dev_id
+
+# 定义输出文件
+OUTPUT_FILE="/lib/route.conf"
+
+# 动态获取davinci设备编号（排除davinci_manager）
+DEVICES=($(awk '/^ns_id/ {ns_count++} ns_count==1 && /^[[:space:]]*[0-9]+/{print $2}' /proc/uda/namespace_node | sort -n))
+
+# 检查是否找到设备
+if [[ ${#DEVICES[@]} -eq 0 ]]; then
+    echo "错误: 未找到任何davinci设备"
+    exit 1
+fi
+
+if [ ! -e "/lib/route.conf.bak" ]; then
+    cp -r "$OUTPUT_FILE" "/lib/route.conf.bak"
+fi
+
+# 判断输出文件是否存在，如果存在就退出
+if [ -e "$OUTPUT_FILE" ]; then
+    rm -f $OUTPUT_FILE
+    echo "已删除旧配置文件:  $OUTPUT_FILE 已存在，准备重新生成"
+    # exit 1
+fi
+
+# 清空或创建输出文件
+> "$OUTPUT_FILE"
+
+# 写入pair_device_num
+echo "pair_device_num=${#DEVICES[@]}" >> "$OUTPUT_FILE"
+echo "找到 ${#DEVICES[@]} 个davinci设备: ${DEVICES[@]}"
+
+# if [ -e "/home/source_dest_ips.txt" ]; then
+#     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#     python3 $SCRIPT_DIR/get_route_eid.py
+#     exit 0
+# fi
+
+# 检查必要的文件是否存在
+if [[ ! -f "dev_id" ]]; then
+    echo "错误: dev_id 文件不存在"
+    exit 1
+fi
+
+if [[ ! -f "pair_info" ]]; then
+    echo "错误: pair_info 文件不存在"
+    exit 1
+fi
+
+INDEX=0
+
+echo "开始处理设备..."
+
+# 分析设备ID的范围和分组
+MIN_DEVICE=${DEVICES[0]}
+MAX_DEVICE=${DEVICES[${#DEVICES[@]}-1]}
+echo "设备ID范围: $MIN_DEVICE - $MAX_DEVICE"
+
+# 计算每个设备的组内索引（相对于8的倍数）
+for i in "${!DEVICES[@]}"; do
+    num=${DEVICES[i]}
+    
+    # 计算当前设备在8个一组中的位置
+    GROUP_OFFSET=$((num % 8))
+    
+    # 根据在组内的位置决定使用哪组eid
+    # 前4个设备（0-3）使用第一组eid，后4个设备（4-7）使用第二组eid
+    if [ $GROUP_OFFSET -lt 4 ]; then
+        EID_SELECTOR="head -1"
+        EID_GROUP="第一组(组内位置: $GROUP_OFFSET)"
+    else
+        EID_SELECTOR="tail -1" 
+        EID_GROUP="第二组(组内位置: $GROUP_OFFSET)"
+    fi
+    
+    echo "正在处理设备 davinci$num (全局索引: $i, 组内位置: $GROUP_OFFSET, 使用: $EID_GROUP)..."
+    
+    # 将设备编号写入dev_id
+    echo "$num" > dev_id
+    
+    # 检查写入是否成功
+    if [[ $? -ne 0 ]]; then
+        echo "错误: 无法写入 dev_id 文件"
+        continue
+    fi
+    
+    # 等待一下确保信息更新
+    sleep 0.1
+    
+    # 获取pair_info内容
+    PAIR_INFO=$(cat pair_info 2>/dev/null)
+    if [[ $? -ne 0 ]]; then
+        echo "错误: 无法读取 pair_info 文件"
+        continue
+    fi
+    
+    # 提取slot_id（从pair_info中解析）
+    SLOT_ID=$(echo "$PAIR_INFO" | grep "dev_id=$num" | sed -n 's/.*slot_id=\([0-9]*\).*/\1/p')
+    if [[ -z "$SLOT_ID" ]]; then
+        echo "警告: 无法从pair_info中提取slot_id，使用设备编号 $num 作为slot_id"
+        SLOT_ID=$num
+    fi
+    
+    # 根据组内位置选择对应的eid组
+    LOCAL_EID=$(echo "$PAIR_INFO" | grep "local_eid:" | $EID_SELECTOR | awk '{print $2}' | sed 's/://g')
+    REMOTE_EID=$(echo "$PAIR_INFO" | grep "remote_eid:" | $EID_SELECTOR | awk '{print $2}' | sed 's/://g')
+    
+    # 检查是否成功提取到EID
+    if [[ -z "$LOCAL_EID" || -z "$REMOTE_EID" ]]; then
+        echo "警告: 无法从pair_info中提取$EID_GROUP EID信息，尝试使用备选方案..."
+        
+        # 如果当前选择的eid组不存在，尝试使用另一组
+        if [ $GROUP_OFFSET -lt 4 ]; then
+            # 原本应该用第一组，但不存在，尝试第二组
+            LOCAL_EID=$(echo "$PAIR_INFO" | grep "local_eid:" | tail -1 | awk '{print $2}' | sed 's/://g')
+            REMOTE_EID=$(echo "$PAIR_INFO" | grep "remote_eid:" | tail -1 | awk '{print $2}' | sed 's/://g')
+            EID_GROUP="第二组(备选)"
+        else
+            # 原本应该用第二组，但不存在，尝试第一组
+            LOCAL_EID=$(echo "$PAIR_INFO" | grep "local_eid:" | head -1 | awk '{print $2}' | sed 's/://g')
+            REMOTE_EID=$(echo "$PAIR_INFO" | grep "remote_eid:" | head -1 | awk '{print $2}' | sed 's/://g')
+            EID_GROUP="第一组(备选)"
+        fi
+        
+        # 再次检查
+        if [[ -z "$LOCAL_EID" || -z "$REMOTE_EID" ]]; then
+            echo "错误: 无法提取任何EID信息，跳过设备 $num"
+            continue
+        fi
+    fi
+    
+    # 格式化EID，确保长度正确并添加0x前缀
+    LOCAL_EID="0x$(printf "%032s" "$LOCAL_EID" | sed 's/ /0/g')"
+    REMOTE_EID="0x$(printf "%032s" "$REMOTE_EID" | sed 's/ /0/g')"
+    
+    # 写入route.conf文件
+    echo "pair${INDEX}_dev_id=$((num % 8))" >> "$OUTPUT_FILE"
+    echo "pair${INDEX}_slot_id=$SLOT_ID" >> "$OUTPUT_FILE"
+    echo "pair${INDEX}_chan_num=1" >> "$OUTPUT_FILE"
+    echo "pair${INDEX}_chan0_local_eid=$LOCAL_EID" >> "$OUTPUT_FILE"
+    echo "pair${INDEX}_chan0_remote_eid=$REMOTE_EID" >> "$OUTPUT_FILE"
+    echo "pair${INDEX}_chan0_flag=1" >> "$OUTPUT_FILE"
+    
+    echo "设备 davinci$num 处理完成 -> pair$INDEX ($EID_GROUP)"
+    
+    # 索引递增
+    ((INDEX++))
+    
+    # 添加空行分隔（可选）
+    if [[ $INDEX -lt ${#DEVICES[@]} ]]; then
+        echo "" >> "$OUTPUT_FILE"
+    fi
+done
+
+echo "路由配置文件生成完成: $OUTPUT_FILE"
+echo "共处理了 $INDEX 个设备"
+
+# 显示生成的文件内容
+echo -e "\n生成的route.conf文件内容:"
+echo "=========================================="
+cat "$OUTPUT_FILE"
+echo "=========================================="

--- a/examples/disaggregated_prefill_a5_adaption/generate_ep.py
+++ b/examples/disaggregated_prefill_a5_adaption/generate_ep.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026. Huawei Technologies Co.,Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Generate endpoint configuration files from HCCL topology, rootinfo, and route.conf.
+
+Input files (supports POD and SERVER topologies):
+- hccl_rootinfo.json (contains topo_file_path reference)
+- atlas_xxx.json (topology file)
+- route.conf (CPU-device pair EID mappings)
+
+Output files: ub_endpoint_npu_*.json (one file per NPU device_id)
+
+CLI Arguments:
+- --local, -l: Use local testing paths (default, supports --pod or --server modes)
+- --pod, -p: POD mode: 1D PoD topology
+- --server, -s: Server mode: 0+8 server topology or 2+4 server topology
+- --dry-run, -n: Parse files but do not write output
+- --rootinfo-path: Path to hccl_rootinfo.json file (only valid with --local)
+- --topo-path: Path to topology JSON file (only valid with --local)
+- --route-path: Path to route.conf file (only valid with --local)
+
+Example topologies:
+- POD mode: 1D PoD topology with devices 8-15
+- SERVER mode: 0+8 server topology with devices 0-7
+
+Example usage:
+python generate_endpoint_configs.py --local --pod
+python generate_endpoint_configs.py --local --server
+python generate_endpoint_configs.py --local --pod --rootinfo-path pod06_cpu5/hccl_rootinfo.json
+     --topo-path pod06_cpu5/atlas_950_1.json --route-path pod06_cpu5/route.conf
+python generate_endpoint_configs.py --local --server --rootinfo-path server/hccl_rootinfo_08server.json
+     --topo-path server/atlas_850_1.json --route-path server/route.conf
+"""
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+def parse_route_conf(route_conf_path: Path) -> Dict[int, Dict[str, str]]:
+    """
+    Parse route.conf file to extract device-to-EID mappings.
+
+    Returns: {device_id: {'local_eid': '...', 'remote_eid': '...'}}
+    """
+    pairs = {}
+    current_device_id = None
+    current_pair = {}
+
+    with open(route_conf_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+
+            if '_dev_id=' in line:
+                # Extract device_id: pairX_dev_id=32 -> device_id=32
+                parts = line.split('=')
+                current_device_id = int(parts[1])
+                current_pair = {'dev_id': current_device_id, 'local_eid': None, 'remote_eid': None}
+                pairs[current_device_id] = current_pair
+                print(f"current_device_local_id: {current_device_id}")
+            elif '_local_eid=' in line:
+                # Extract local EID: pairX_chan0_local_eid=0x...
+                eid = line.split('=')[1].strip().replace('0x', '')
+                if current_device_id is not None:
+                    current_pair['local_eid'] = eid
+            elif '_remote_eid=' in line:
+                # Extract remote EID: pairX_chan0_remote_eid=0x...
+                eid = line.split('=')[1].strip().replace('0x', '')
+                if current_device_id is not None:
+                    current_pair['remote_eid'] = eid
+
+    return pairs
+
+
+def build_eid_to_device_map(hccl_rootinfo: Dict) -> Dict[str, int]:
+    """
+    Build a mapping from EID to device_id using hccl_rootinfo.
+
+    Returns: {eid: device_id}
+    """
+    eid_to_device = {}
+    for rank in hccl_rootinfo.get('rank_list', []):
+        device_id = rank['device_id']
+        for level in rank.get('level_list', []):
+            for addr in level.get('rank_addr_list', []):
+                eid = addr['addr']
+                eid_to_device[eid] = device_id
+    return eid_to_device
+
+
+def build_device_id_to_local_id_map(hccl_rootinfo: Dict) -> Dict[int, int]:
+    """
+    Build mapping from device_id to local_id using hccl_rootinfo.
+
+    Returns: {device_id: local_id}
+    """
+    return {rank['device_id']: rank['local_id'] for rank in hccl_rootinfo.get('rank_list', [])}
+
+
+def build_local_id_to_device_id_map(hccl_rootinfo: Dict) -> Dict[int, int]:
+    """
+    Build mapping from local_id to device_id using hccl_rootinfo.
+
+    Returns: {local_id: device_id}
+    """
+    return {rank['local_id']: rank['device_id'] for rank in hccl_rootinfo.get('rank_list', [])}
+
+
+def find_peer_eid_from_1dmesh(
+    local_id: int,
+    device_local_id: int,
+    device_eid: str,
+    device_eid_ports: List[str],
+    topo_data: Dict,
+    rootinfo: Dict
+) -> str:
+    """
+    Find the connected peer's EID for a given device from 1DM mesh topology.
+
+    For PEER2PEER (direct connections) in net_layer 0.
+
+    Returns: peer EID string, or empty string if not found.
+    """
+    # Get all 1DM mesh PEER2PEER edges
+    p2p_edges = [
+        edge for edge in topo_data.get('edge_list', [])
+        if edge.get('topo_type') == '1DMESH'
+        and edge.get('link_type') == 'PEER2PEER'
+        and edge.get('net_layer') == 0
+    ]
+
+    # Build EID+port to device_id mapping from rootinfo
+    eid_port_to_device = {}
+    for rank in rootinfo.get('rank_list', []):
+        dev_id = rank['device_id']
+        for level in rank.get('level_list', []):
+            if level.get('net_layer') != 0:
+                continue
+            for addr in level.get('rank_addr_list', []):
+                eid = addr['addr']
+                ports = addr.get('ports', [])
+                for port in ports:
+                    eid_port_to_device[(eid, port)] = dev_id
+
+    # Use local_id for topology edge matching (topo file uses local_id, not device_id)
+    topo_my_index = local_id
+
+
+    # Find edges involving our device and identify the peer
+    for edge in p2p_edges:
+        local_a = edge['local_a']
+        local_b = edge['local_b']
+        local_a_ports = edge.get('local_a_ports', [])
+        local_b_ports = edge.get('local_b_ports', [])
+
+        # Determine which end is our device and which is the peer
+        if local_a == topo_my_index:
+            my_ports = local_a_ports
+            peer_ports = local_b_ports
+            peer_topo_index = local_b
+        elif local_b == topo_my_index:
+            my_ports = local_b_ports
+            peer_ports = local_a_ports
+            peer_topo_index = local_a
+        else:
+            continue
+
+        # Find intersection of our EID's ports and the connected ports
+        for my_port in device_eid_ports:
+            if my_port in my_ports:
+                # Find which peer device connects through this port
+                # The peer port is the corresponding one on the other side
+                # For ring topology there's typically a 1:1 port mapping
+                for peer_port in peer_ports:
+                    # Look up EID for the peer device using local_id (peer_topo_index)
+                    # Topology uses local_id, so we need to find the rank where local_id matches
+                    for rank in rootinfo.get('rank_list', []):
+                        if rank['local_id'] != peer_topo_index:
+                            continue
+                        for level in rank.get('level_list', []):
+                            if level.get('net_layer') != 0:
+                                continue
+                            for addr in level.get('rank_addr_list', []):
+                                if peer_port in addr.get('ports', []):
+                                    return addr['addr']
+
+    return ""
+
+
+def get_protocol_from_eid(
+    eid: str,
+    net_layer: int,
+    topo_data: Dict,
+    device_local_id: int,
+    device_eid_ports: List[str]
+) -> str:
+    """
+    Determine protocol for an EID based on topology and net layer.
+
+    Returns: 'ub_ctp' or 'ub_tp'.
+
+    todo: 'roce', 'uboe'
+    """
+    # For net_layer 0 (1DMESH), always use ub_ctp
+    if net_layer == 0:
+        return 'ub_ctp'
+
+    # For CLOS layer (net_layer 1+), check topology
+    if net_layer >= 1:
+        for edge in topo_data.get('edge_list', []):
+            if edge.get('topo_type') == 'CLOS' and edge.get('net_layer') == net_layer:
+                protocols = edge.get('protocols', [])
+                # Check if any of the device's EID ports match this edge's ports
+                edge_a_ports = edge.get('local_a_ports', [])
+                edge_b_ports = edge.get('local_b_ports', [])
+                all_edge_ports = set(edge_a_ports) | set(edge_b_ports)
+                device_port_set = set(device_eid_ports)
+
+                # If there's any port overlap, this edge applies to this device
+                if all_edge_ports & device_port_set:
+                    if 'UB_CTP' in protocols:
+                        return 'ub_ctp'
+                    elif 'UB_TP' in protocols:
+                        return 'ub_tp'
+
+    return 'ub_ctp'
+
+
+def get_h2d_plane_id(device_id: int, rootinfo: Dict, mode: str) -> str:
+    """
+    Find the host endpoint and return its plane_id.
+
+    POD mode: H2D has 6 ports (1DPoD topology)
+    SERVER mode: H2D has 8 ports (0+8 server topology) or 4 ports (2+4 topo)
+
+    Args:
+        device_id: The NPU device ID (e.g., 32, 33, 34, etc.)
+        rootinfo: Parsed hccl_rootinfo.json data
+        mode: Topology mode ('pod' or 'server')
+
+    Returns:
+        The plane_id from the H2D endpoint, or 'plane_x' if not found
+    """
+    port_count = 4 if mode == 'server' else 6
+    for rank in rootinfo.get('rank_list', []):
+        if rank['device_id'] == device_id:
+            for level in rank.get('level_list', []):
+                if level.get('net_layer') == 1:  # CLOS layer
+                    for addr_entry in level.get('rank_addr_list', []):
+                        if len(addr_entry.get('ports', [])) >= port_count:
+                            return addr_entry.get('plane_id', 'plane_x')
+    return 'plane_x'
+
+
+def generate_endpoint_list(
+    local_id: int,
+    device_info: Dict,
+    topo_data: Dict,
+    rootinfo: Dict
+) -> List[Dict]:
+    """
+    Generate endpoint list for a single NPU device.
+
+    Args:
+        local_id: The logical device index (used for topology edge lookups)
+        device_info: The device info from hccl_rootinfo (contains device_id, local_id, level_list)
+        topo_data: Topology data from atlas_*.json
+        rootinfo: HCCL rootinfo data
+
+    Returns:
+        List of endpoint configurations
+    """
+    endpoint_list = []
+    device_local_id = device_info['local_id']
+    seen_eids = set()  # Track unique EIDs
+
+    # Iterate through all layers in level_list
+    for level in device_info['level_list']:
+        net_layer = level['net_layer']
+        net_type = level['net_type']
+
+        for addr_entry in level['rank_addr_list']:
+            eid = addr_entry['addr']
+            device_eid_ports = addr_entry.get('ports', [])
+            plane_id = addr_entry.get('plane_id', 'plane_0')
+
+            # Skip duplicate EIDs
+            if eid in seen_eids:
+                continue
+            seen_eids.add(eid)
+
+            # Determine protocol
+            protocol = get_protocol_from_eid(eid, net_layer, topo_data, device_local_id, device_eid_ports)
+
+            # Create endpoint
+            endpoint = {
+                "protocol": protocol,
+                "comm_id": eid,
+                "placement": "device"
+            }
+
+            # Add plane field for ub_tp protocol or for net_layer >= 1 (CLOS/P2N)
+            # P2P (net_layer 0) direct connections should NOT have plane field
+            if (net_layer >= 1 or protocol == 'ub_tp') and plane_id:
+                endpoint["plane"] = plane_id
+
+            # Add dst_eid for 1DMESH (net_layer 0) direct connections
+            if net_layer == 0:
+                peer_eid = find_peer_eid_from_1dmesh(
+                    local_id, device_local_id, eid, device_eid_ports, topo_data, rootinfo
+                )
+                if peer_eid:
+                    endpoint["dst_eid"] = peer_eid
+
+            endpoint_list.append(endpoint)
+
+    return endpoint_list
+
+
+if __name__ == "__main__":
+    """Main entry point for endpoint config generation."""
+    parser = argparse.ArgumentParser(
+        description="Generate NPU endpoint configuration files from HCCL topology and route.conf."
+    )
+    parser.add_argument("--local", "-l", action="store_true", default=False,
+                       help="Use local testing paths (supports --pod or --server modes)")
+    parser.add_argument("--pod", "-p", action="store_true",
+                       help="POD mode: 1D PoD topology")
+    parser.add_argument("--server", "-s", action="store_true",
+                       help="Server mode: 0+8 server topology")
+    parser.add_argument("--dry-run", "-n", action="store_true",
+                       help="Parse files but do not write output")
+    parser.add_argument("--rootinfo-path", type=str, default=None,
+                       help="Path to hccl_rootinfo.json file (only valid with --local)")
+    parser.add_argument("--topo-path", type=str, default=None,
+                       help="Path to topology JSON file (only valid with --local)")
+    parser.add_argument("--route-path", type=str, default=None,
+                       help="Path to route.conf file (only valid with --local)")
+
+    args = parser.parse_args()
+
+    # Determine mode: pod or server (server takes priority if both specified)
+    use_local = args.local  # local testing mode or production mode
+    mode = 'server' if args.server else 'pod' if args.pod else 'pod'
+
+    # Set default paths for local mode
+    if use_local and not args.rootinfo_path:
+        if mode == 'pod':
+            args.rootinfo_path = "./pod/hccl_rootinfo.json"
+            args.topo_path = "./pod/atlas_950_1.json"
+            args.route_path = "./pod/route.conf"
+        else:  # server mode
+            args.rootinfo_path = "./server/hccl_rootinfo_08server.json"
+            args.topo_path = "./server/atlas_850_1.json"
+            args.route_path = "./server/route.conf"
+
+    mode_str = f"local {mode}" if use_local else "production"
+    print(f"Running in {mode_str} mode")
+    
+    # Production mode: use /etc and /lib paths (same for both modes)
+    if not use_local:
+        args.rootinfo_path = "/etc/hccl_rootinfo.json"
+        args.route_path = "/lib/route.conf"
+
+    if args.dry_run:
+        print("Dry run mode: parsing only, no output files will be written")
+
+    # Parse route.conf
+    print(f"Loading: {args.route_path}")
+    route_pairs = parse_route_conf(args.route_path)
+    print(f"Found {len(route_pairs)} device pairs (local_id: {sorted(route_pairs.keys())})")
+
+    # Load hccl_rootinfo.json
+    print(f"Loading: {args.rootinfo_path}")
+    with open(args.rootinfo_path) as f:
+        hccl_rootinfo = json.load(f)
+
+    if not use_local:
+        args.topo_path = Path(hccl_rootinfo['topo_file_path'])
+
+    # Load topology file
+    print(f"Loading topology: {args.topo_path}")
+    with open(args.topo_path) as f:
+        topo_data = json.load(f)
+
+    # Build local_id to device_id mapping (route.conf uses local_id, hccl_rootinfo uses device_id)
+    local_id_to_device_id = build_local_id_to_device_id_map(hccl_rootinfo)
+    print(f"Built local_id to device_id mapping: {local_id_to_device_id}")
+
+    # Generate endpoint files for each device
+    print(f"Generating endpoints for {len(route_pairs)} NPUs...")
+    for local_id, route_pair_info in route_pairs.items():
+        # route.conf uses local_id (named dev_id), convert to device_id for hccl_rootinfo lookup
+        device_id = local_id_to_device_id.get(local_id)
+        if device_id is None:
+            print(f"Warning: device_id not found for local_id {local_id}")
+            continue
+
+        # Find device info in hccl_rootinfo by device_id
+        device_info = None
+        for rank in hccl_rootinfo.get('rank_list', []):
+            if rank['device_id'] == device_id:
+                device_info = rank
+                break
+
+        if not device_info:
+            print(f"Warning: device_id {device_id} not found in hccl_rootinfo")
+            continue
+
+        # Generate endpoint list using local_id for topology edge lookups
+        endpoint_list = generate_endpoint_list(
+            local_id, device_info, topo_data, hccl_rootinfo
+        )
+
+        # Add CPU host endpoint from route.conf
+        if 'local_eid' in route_pair_info:
+            h2d_plane_id = get_h2d_plane_id(device_id, hccl_rootinfo, mode)
+            h2d_device_eid = route_pair_info['remote_eid']
+            if h2d_plane_id == 'plane_x':
+                print(f"Warning: host plane not found in hccl_rootinfo")
+                ub_host_endpoint = {
+                    "protocol": "ub_ctp",
+                    "comm_id": route_pair_info['local_eid'],
+                    "placement": "host",
+                    "dst_eid": "None"
+                }
+            else:
+                ub_host_endpoint = {
+                    "protocol": "ub_ctp",
+                    "comm_id": route_pair_info['local_eid'],
+                    "placement": "host",
+                    "plane": h2d_plane_id
+                }
+            ub_host_endpoint_d = {
+                "protocol": "ub_ctp",
+                "comm_id": route_pair_info['local_eid'],
+                "placement": "host",
+                "dst_eid": h2d_device_eid
+            }
+            # Insert host endpoint at the end
+            # endpoint_list.append(ub_host_endpoint_d)
+            # endpoint_list.append(ub_host_endpoint)
+
+        net_instance_id = next(
+            (item.get('net_instance_id')
+            for item in device_info.get('level_list', [])
+            if item.get('net_layer') == 1),
+            None  # 默认值：没找到就返回 None
+        )
+        output = {
+            "version": "1.3",
+            "net_instance_id": net_instance_id,
+            "endpoint_list": endpoint_list
+        }
+
+        if use_local:
+            output_path = Path(f"./hixlep/ub_endpoint_npu_{local_id}.json")
+        else:
+            output_path = Path(f"/etc/hixlep/ub_endpoint_npu_{local_id}.json")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not args.dry_run:
+            with open(output_path, "w", encoding='utf-8') as f:
+                json.dump(output, f, indent=2)
+            print(f"Generated: {output_path}")
+        else:
+            print(f"[Dry run] Would generate: {output_path}")
+
+    print(f"{'Dry run: Would generate' if args.dry_run else 'Generated'} {len(route_pairs)} endpoint configuration files.")

--- a/examples/disaggregated_prefill_a5_adaption/generate_ep.py
+++ b/examples/disaggregated_prefill_a5_adaption/generate_ep.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright 2026. Huawei Technologies Co.,Ltd. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,13 +45,13 @@ python generate_endpoint_configs.py --local --pod --rootinfo-path pod06_cpu5/hcc
 python generate_endpoint_configs.py --local --server --rootinfo-path server/hccl_rootinfo_08server.json
      --topo-path server/atlas_850_1.json --route-path server/route.conf
 """
+
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 
-def parse_route_conf(route_conf_path: Path) -> Dict[int, Dict[str, str]]:
+def parse_route_conf(route_conf_path: Path) -> dict[int, dict[str, str]]:
     """
     Parse route.conf file to extract device-to-EID mappings.
 
@@ -65,71 +64,66 @@ def parse_route_conf(route_conf_path: Path) -> Dict[int, Dict[str, str]]:
     with open(route_conf_path) as f:
         for line in f:
             line = line.strip()
-            if not line or line.startswith('#'):
+            if not line or line.startswith("#"):
                 continue
 
-            if '_dev_id=' in line:
+            if "_dev_id=" in line:
                 # Extract device_id: pairX_dev_id=32 -> device_id=32
-                parts = line.split('=')
+                parts = line.split("=")
                 current_device_id = int(parts[1])
-                current_pair = {'dev_id': current_device_id, 'local_eid': None, 'remote_eid': None}
+                current_pair = {"dev_id": current_device_id, "local_eid": None, "remote_eid": None}
                 pairs[current_device_id] = current_pair
                 print(f"current_device_local_id: {current_device_id}")
-            elif '_local_eid=' in line:
+            elif "_local_eid=" in line:
                 # Extract local EID: pairX_chan0_local_eid=0x...
-                eid = line.split('=')[1].strip().replace('0x', '')
+                eid = line.split("=")[1].strip().replace("0x", "")
                 if current_device_id is not None:
-                    current_pair['local_eid'] = eid
-            elif '_remote_eid=' in line:
+                    current_pair["local_eid"] = eid
+            elif "_remote_eid=" in line:
                 # Extract remote EID: pairX_chan0_remote_eid=0x...
-                eid = line.split('=')[1].strip().replace('0x', '')
+                eid = line.split("=")[1].strip().replace("0x", "")
                 if current_device_id is not None:
-                    current_pair['remote_eid'] = eid
+                    current_pair["remote_eid"] = eid
 
     return pairs
 
 
-def build_eid_to_device_map(hccl_rootinfo: Dict) -> Dict[str, int]:
+def build_eid_to_device_map(hccl_rootinfo: dict) -> dict[str, int]:
     """
     Build a mapping from EID to device_id using hccl_rootinfo.
 
     Returns: {eid: device_id}
     """
     eid_to_device = {}
-    for rank in hccl_rootinfo.get('rank_list', []):
-        device_id = rank['device_id']
-        for level in rank.get('level_list', []):
-            for addr in level.get('rank_addr_list', []):
-                eid = addr['addr']
+    for rank in hccl_rootinfo.get("rank_list", []):
+        device_id = rank["device_id"]
+        for level in rank.get("level_list", []):
+            for addr in level.get("rank_addr_list", []):
+                eid = addr["addr"]
                 eid_to_device[eid] = device_id
     return eid_to_device
 
 
-def build_device_id_to_local_id_map(hccl_rootinfo: Dict) -> Dict[int, int]:
+def build_device_id_to_local_id_map(hccl_rootinfo: dict) -> dict[int, int]:
     """
     Build mapping from device_id to local_id using hccl_rootinfo.
 
     Returns: {device_id: local_id}
     """
-    return {rank['device_id']: rank['local_id'] for rank in hccl_rootinfo.get('rank_list', [])}
+    return {rank["device_id"]: rank["local_id"] for rank in hccl_rootinfo.get("rank_list", [])}
 
 
-def build_local_id_to_device_id_map(hccl_rootinfo: Dict) -> Dict[int, int]:
+def build_local_id_to_device_id_map(hccl_rootinfo: dict) -> dict[int, int]:
     """
     Build mapping from local_id to device_id using hccl_rootinfo.
 
     Returns: {local_id: device_id}
     """
-    return {rank['local_id']: rank['device_id'] for rank in hccl_rootinfo.get('rank_list', [])}
+    return {rank["local_id"]: rank["device_id"] for rank in hccl_rootinfo.get("rank_list", [])}
 
 
 def find_peer_eid_from_1dmesh(
-    local_id: int,
-    device_local_id: int,
-    device_eid: str,
-    device_eid_ports: List[str],
-    topo_data: Dict,
-    rootinfo: Dict
+    local_id: int, device_local_id: int, device_eid: str, device_eid_ports: list[str], topo_data: dict, rootinfo: dict
 ) -> str:
     """
     Find the connected peer's EID for a given device from 1DM mesh topology.
@@ -140,35 +134,33 @@ def find_peer_eid_from_1dmesh(
     """
     # Get all 1DM mesh PEER2PEER edges
     p2p_edges = [
-        edge for edge in topo_data.get('edge_list', [])
-        if edge.get('topo_type') == '1DMESH'
-        and edge.get('link_type') == 'PEER2PEER'
-        and edge.get('net_layer') == 0
+        edge
+        for edge in topo_data.get("edge_list", [])
+        if edge.get("topo_type") == "1DMESH" and edge.get("link_type") == "PEER2PEER" and edge.get("net_layer") == 0
     ]
 
     # Build EID+port to device_id mapping from rootinfo
     eid_port_to_device = {}
-    for rank in rootinfo.get('rank_list', []):
-        dev_id = rank['device_id']
-        for level in rank.get('level_list', []):
-            if level.get('net_layer') != 0:
+    for rank in rootinfo.get("rank_list", []):
+        dev_id = rank["device_id"]
+        for level in rank.get("level_list", []):
+            if level.get("net_layer") != 0:
                 continue
-            for addr in level.get('rank_addr_list', []):
-                eid = addr['addr']
-                ports = addr.get('ports', [])
+            for addr in level.get("rank_addr_list", []):
+                eid = addr["addr"]
+                ports = addr.get("ports", [])
                 for port in ports:
                     eid_port_to_device[(eid, port)] = dev_id
 
     # Use local_id for topology edge matching (topo file uses local_id, not device_id)
     topo_my_index = local_id
 
-
     # Find edges involving our device and identify the peer
     for edge in p2p_edges:
-        local_a = edge['local_a']
-        local_b = edge['local_b']
-        local_a_ports = edge.get('local_a_ports', [])
-        local_b_ports = edge.get('local_b_ports', [])
+        local_a = edge["local_a"]
+        local_b = edge["local_b"]
+        local_a_ports = edge.get("local_a_ports", [])
+        local_b_ports = edge.get("local_b_ports", [])
 
         # Determine which end is our device and which is the peer
         if local_a == topo_my_index:
@@ -191,25 +183,21 @@ def find_peer_eid_from_1dmesh(
                 for peer_port in peer_ports:
                     # Look up EID for the peer device using local_id (peer_topo_index)
                     # Topology uses local_id, so we need to find the rank where local_id matches
-                    for rank in rootinfo.get('rank_list', []):
-                        if rank['local_id'] != peer_topo_index:
+                    for rank in rootinfo.get("rank_list", []):
+                        if rank["local_id"] != peer_topo_index:
                             continue
-                        for level in rank.get('level_list', []):
-                            if level.get('net_layer') != 0:
+                        for level in rank.get("level_list", []):
+                            if level.get("net_layer") != 0:
                                 continue
-                            for addr in level.get('rank_addr_list', []):
-                                if peer_port in addr.get('ports', []):
-                                    return addr['addr']
+                            for addr in level.get("rank_addr_list", []):
+                                if peer_port in addr.get("ports", []):
+                                    return addr["addr"]
 
     return ""
 
 
 def get_protocol_from_eid(
-    eid: str,
-    net_layer: int,
-    topo_data: Dict,
-    device_local_id: int,
-    device_eid_ports: List[str]
+    eid: str, net_layer: int, topo_data: dict, device_local_id: int, device_eid_ports: list[str]
 ) -> str:
     """
     Determine protocol for an EID based on topology and net layer.
@@ -220,30 +208,30 @@ def get_protocol_from_eid(
     """
     # For net_layer 0 (1DMESH), always use ub_ctp
     if net_layer == 0:
-        return 'ub_ctp'
+        return "ub_ctp"
 
     # For CLOS layer (net_layer 1+), check topology
     if net_layer >= 1:
-        for edge in topo_data.get('edge_list', []):
-            if edge.get('topo_type') == 'CLOS' and edge.get('net_layer') == net_layer:
-                protocols = edge.get('protocols', [])
+        for edge in topo_data.get("edge_list", []):
+            if edge.get("topo_type") == "CLOS" and edge.get("net_layer") == net_layer:
+                protocols = edge.get("protocols", [])
                 # Check if any of the device's EID ports match this edge's ports
-                edge_a_ports = edge.get('local_a_ports', [])
-                edge_b_ports = edge.get('local_b_ports', [])
+                edge_a_ports = edge.get("local_a_ports", [])
+                edge_b_ports = edge.get("local_b_ports", [])
                 all_edge_ports = set(edge_a_ports) | set(edge_b_ports)
                 device_port_set = set(device_eid_ports)
 
                 # If there's any port overlap, this edge applies to this device
                 if all_edge_ports & device_port_set:
-                    if 'UB_CTP' in protocols:
-                        return 'ub_ctp'
-                    elif 'UB_TP' in protocols:
-                        return 'ub_tp'
+                    if "UB_CTP" in protocols:
+                        return "ub_ctp"
+                    elif "UB_TP" in protocols:
+                        return "ub_tp"
 
-    return 'ub_ctp'
+    return "ub_ctp"
 
 
-def get_h2d_plane_id(device_id: int, rootinfo: Dict, mode: str) -> str:
+def get_h2d_plane_id(device_id: int, rootinfo: dict, mode: str) -> str:
     """
     Find the host endpoint and return its plane_id.
 
@@ -258,23 +246,18 @@ def get_h2d_plane_id(device_id: int, rootinfo: Dict, mode: str) -> str:
     Returns:
         The plane_id from the H2D endpoint, or 'plane_x' if not found
     """
-    port_count = 4 if mode == 'server' else 6
-    for rank in rootinfo.get('rank_list', []):
-        if rank['device_id'] == device_id:
-            for level in rank.get('level_list', []):
-                if level.get('net_layer') == 1:  # CLOS layer
-                    for addr_entry in level.get('rank_addr_list', []):
-                        if len(addr_entry.get('ports', [])) >= port_count:
-                            return addr_entry.get('plane_id', 'plane_x')
-    return 'plane_x'
+    port_count = 4 if mode == "server" else 6
+    for rank in rootinfo.get("rank_list", []):
+        if rank["device_id"] == device_id:
+            for level in rank.get("level_list", []):
+                if level.get("net_layer") == 1:  # CLOS layer
+                    for addr_entry in level.get("rank_addr_list", []):
+                        if len(addr_entry.get("ports", [])) >= port_count:
+                            return addr_entry.get("plane_id", "plane_x")
+    return "plane_x"
 
 
-def generate_endpoint_list(
-    local_id: int,
-    device_info: Dict,
-    topo_data: Dict,
-    rootinfo: Dict
-) -> List[Dict]:
+def generate_endpoint_list(local_id: int, device_info: dict, topo_data: dict, rootinfo: dict) -> list[dict]:
     """
     Generate endpoint list for a single NPU device.
 
@@ -288,18 +271,17 @@ def generate_endpoint_list(
         List of endpoint configurations
     """
     endpoint_list = []
-    device_local_id = device_info['local_id']
+    device_local_id = device_info["local_id"]
     seen_eids = set()  # Track unique EIDs
 
     # Iterate through all layers in level_list
-    for level in device_info['level_list']:
-        net_layer = level['net_layer']
-        net_type = level['net_type']
+    for level in device_info["level_list"]:
+        net_layer = level["net_layer"]
 
-        for addr_entry in level['rank_addr_list']:
-            eid = addr_entry['addr']
-            device_eid_ports = addr_entry.get('ports', [])
-            plane_id = addr_entry.get('plane_id', 'plane_0')
+        for addr_entry in level["rank_addr_list"]:
+            eid = addr_entry["addr"]
+            device_eid_ports = addr_entry.get("ports", [])
+            plane_id = addr_entry.get("plane_id", "plane_0")
 
             # Skip duplicate EIDs
             if eid in seen_eids:
@@ -310,15 +292,11 @@ def generate_endpoint_list(
             protocol = get_protocol_from_eid(eid, net_layer, topo_data, device_local_id, device_eid_ports)
 
             # Create endpoint
-            endpoint = {
-                "protocol": protocol,
-                "comm_id": eid,
-                "placement": "device"
-            }
+            endpoint = {"protocol": protocol, "comm_id": eid, "placement": "device"}
 
             # Add plane field for ub_tp protocol or for net_layer >= 1 (CLOS/P2N)
             # P2P (net_layer 0) direct connections should NOT have plane field
-            if (net_layer >= 1 or protocol == 'ub_tp') and plane_id:
+            if (net_layer >= 1 or protocol == "ub_tp") and plane_id:
                 endpoint["plane"] = plane_id
 
             # Add dst_eid for 1DMESH (net_layer 0) direct connections
@@ -339,30 +317,35 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate NPU endpoint configuration files from HCCL topology and route.conf."
     )
-    parser.add_argument("--local", "-l", action="store_true", default=False,
-                       help="Use local testing paths (supports --pod or --server modes)")
-    parser.add_argument("--pod", "-p", action="store_true",
-                       help="POD mode: 1D PoD topology")
-    parser.add_argument("--server", "-s", action="store_true",
-                       help="Server mode: 0+8 server topology")
-    parser.add_argument("--dry-run", "-n", action="store_true",
-                       help="Parse files but do not write output")
-    parser.add_argument("--rootinfo-path", type=str, default=None,
-                       help="Path to hccl_rootinfo.json file (only valid with --local)")
-    parser.add_argument("--topo-path", type=str, default=None,
-                       help="Path to topology JSON file (only valid with --local)")
-    parser.add_argument("--route-path", type=str, default=None,
-                       help="Path to route.conf file (only valid with --local)")
+    parser.add_argument(
+        "--local",
+        "-l",
+        action="store_true",
+        default=False,
+        help="Use local testing paths (supports --pod or --server modes)",
+    )
+    parser.add_argument("--pod", "-p", action="store_true", help="POD mode: 1D PoD topology")
+    parser.add_argument("--server", "-s", action="store_true", help="Server mode: 0+8 server topology")
+    parser.add_argument("--dry-run", "-n", action="store_true", help="Parse files but do not write output")
+    parser.add_argument(
+        "--rootinfo-path", type=str, default=None, help="Path to hccl_rootinfo.json file (only valid with --local)"
+    )
+    parser.add_argument(
+        "--topo-path", type=str, default=None, help="Path to topology JSON file (only valid with --local)"
+    )
+    parser.add_argument(
+        "--route-path", type=str, default=None, help="Path to route.conf file (only valid with --local)"
+    )
 
     args = parser.parse_args()
 
     # Determine mode: pod or server (server takes priority if both specified)
     use_local = args.local  # local testing mode or production mode
-    mode = 'server' if args.server else 'pod' if args.pod else 'pod'
+    mode = "server" if args.server else "pod" if args.pod else "pod"
 
     # Set default paths for local mode
     if use_local and not args.rootinfo_path:
-        if mode == 'pod':
+        if mode == "pod":
             args.rootinfo_path = "./pod/hccl_rootinfo.json"
             args.topo_path = "./pod/atlas_950_1.json"
             args.route_path = "./pod/route.conf"
@@ -373,7 +356,7 @@ if __name__ == "__main__":
 
     mode_str = f"local {mode}" if use_local else "production"
     print(f"Running in {mode_str} mode")
-    
+
     # Production mode: use /etc and /lib paths (same for both modes)
     if not use_local:
         args.rootinfo_path = "/etc/hccl_rootinfo.json"
@@ -393,7 +376,7 @@ if __name__ == "__main__":
         hccl_rootinfo = json.load(f)
 
     if not use_local:
-        args.topo_path = Path(hccl_rootinfo['topo_file_path'])
+        args.topo_path = Path(hccl_rootinfo["topo_file_path"])
 
     # Load topology file
     print(f"Loading topology: {args.topo_path}")
@@ -415,8 +398,8 @@ if __name__ == "__main__":
 
         # Find device info in hccl_rootinfo by device_id
         device_info = None
-        for rank in hccl_rootinfo.get('rank_list', []):
-            if rank['device_id'] == device_id:
+        for rank in hccl_rootinfo.get("rank_list", []):
+            if rank["device_id"] == device_id:
                 device_info = rank
                 break
 
@@ -425,50 +408,42 @@ if __name__ == "__main__":
             continue
 
         # Generate endpoint list using local_id for topology edge lookups
-        endpoint_list = generate_endpoint_list(
-            local_id, device_info, topo_data, hccl_rootinfo
-        )
+        endpoint_list = generate_endpoint_list(local_id, device_info, topo_data, hccl_rootinfo)
 
         # Add CPU host endpoint from route.conf
-        if 'local_eid' in route_pair_info:
+        if "local_eid" in route_pair_info:
             h2d_plane_id = get_h2d_plane_id(device_id, hccl_rootinfo, mode)
-            h2d_device_eid = route_pair_info['remote_eid']
-            if h2d_plane_id == 'plane_x':
-                print(f"Warning: host plane not found in hccl_rootinfo")
+            h2d_device_eid = route_pair_info["remote_eid"]
+            if h2d_plane_id == "plane_x":
+                print("Warning: host plane not found in hccl_rootinfo")
                 ub_host_endpoint = {
                     "protocol": "ub_ctp",
-                    "comm_id": route_pair_info['local_eid'],
+                    "comm_id": route_pair_info["local_eid"],
                     "placement": "host",
-                    "dst_eid": "None"
+                    "dst_eid": "None",
                 }
             else:
                 ub_host_endpoint = {
                     "protocol": "ub_ctp",
-                    "comm_id": route_pair_info['local_eid'],
+                    "comm_id": route_pair_info["local_eid"],
                     "placement": "host",
-                    "plane": h2d_plane_id
+                    "plane": h2d_plane_id,
                 }
             ub_host_endpoint_d = {
                 "protocol": "ub_ctp",
-                "comm_id": route_pair_info['local_eid'],
+                "comm_id": route_pair_info["local_eid"],
                 "placement": "host",
-                "dst_eid": h2d_device_eid
+                "dst_eid": h2d_device_eid,
             }
             # Insert host endpoint at the end
             # endpoint_list.append(ub_host_endpoint_d)
             # endpoint_list.append(ub_host_endpoint)
 
         net_instance_id = next(
-            (item.get('net_instance_id')
-            for item in device_info.get('level_list', [])
-            if item.get('net_layer') == 1),
-            None  # 默认值：没找到就返回 None
+            (item.get("net_instance_id") for item in device_info.get("level_list", []) if item.get("net_layer") == 1),
+            None,  # 默认值：没找到就返回 None
         )
-        output = {
-            "version": "1.3",
-            "net_instance_id": net_instance_id,
-            "endpoint_list": endpoint_list
-        }
+        output = {"version": "1.3", "net_instance_id": net_instance_id, "endpoint_list": endpoint_list}
 
         if use_local:
             output_path = Path(f"./hixlep/ub_endpoint_npu_{local_id}.json")
@@ -478,10 +453,12 @@ if __name__ == "__main__":
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         if not args.dry_run:
-            with open(output_path, "w", encoding='utf-8') as f:
+            with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(output, f, indent=2)
             print(f"Generated: {output_path}")
         else:
             print(f"[Dry run] Would generate: {output_path}")
 
-    print(f"{'Dry run: Would generate' if args.dry_run else 'Generated'} {len(route_pairs)} endpoint configuration files.")
+    print(
+        f"{'Dry run: Would generate' if args.dry_run else 'Generated'} {len(route_pairs)} endpoint configuration files."
+    )

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -274,9 +274,9 @@ class NPUWorker(WorkerBase):
         if get_ascend_device_type() == AscendDeviceType.A5:
             visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
             if visible_devices is None:
-                devices = sorted(list(DeviceInfo.get_npu_map_info().keys()))
+                devices = sorted([int(x) for x in DeviceInfo.get_npu_map_info().keys()])
             else:
-                devices = [int(x) for x in visible_devices.split(",")]
+                devices = [int(x) for x in visible_devices.split(",") if x.strip()]
             local_comm_res_path = os.getenv("ASCEND_LOCAL_COMM_RES_PATH")
 
             if local_comm_res_path:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -19,7 +19,9 @@
 
 import copy
 import gc
+import json
 import logging
+import os
 from types import NoneType
 
 import torch
@@ -50,7 +52,7 @@ from vllm.v1.worker.workspace import init_workspace_manager
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
-from vllm_ascend.cpu_binding import bind_cpus
+from vllm_ascend.cpu_binding import bind_cpus, DeviceInfo
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
@@ -268,6 +270,32 @@ class NPUWorker(WorkerBase):
 
         gc.collect()
         torch.npu.empty_cache()
+
+        if get_ascend_device_type() == AscendDeviceType.A5:
+            visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
+            if visible_devices is None:
+                devices = sorted(list(DeviceInfo.get_npu_map_info().keys()))
+            else:
+                devices = [int(x) for x in visible_devices.split(",")]
+            local_comm_res_path = os.getenv("ASCEND_LOCAL_COMM_RES_PATH")
+
+            if local_comm_res_path:
+                local_comm_res_file = os.path.join(local_comm_res_path, f"ub_endpoint_npu_{devices[self.local_rank]}.json")
+                try:
+                    with open(local_comm_res_file, "r") as f:
+                        data = json.load(f)
+                except FileNotFoundError:
+                    raise FileNotFoundError(
+                        f"Endpoint config file not found: {local_comm_res_file}. "
+                        "Please run generate_ep.py first to generate the endpoint configurations."
+                    )
+                except json.JSONDecodeError as e:
+                    raise ValueError(
+                        f"Failed to parse endpoint config file: {local_comm_res_file}"
+                    ) from e
+
+                local_comm_res_str = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+                os.environ["ASCEND_LOCAL_COMM_RES"] = local_comm_res_str
 
         # take current memory snapshot
         self.init_snapshot = MemorySnapshot()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -52,7 +52,7 @@ from vllm.v1.worker.workspace import init_workspace_manager
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
-from vllm_ascend.cpu_binding import bind_cpus, DeviceInfo
+from vllm_ascend.cpu_binding import DeviceInfo, bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
@@ -274,15 +274,17 @@ class NPUWorker(WorkerBase):
         if get_ascend_device_type() == AscendDeviceType.A5:
             visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
             if visible_devices is None:
-                devices = sorted([int(x) for x in DeviceInfo.get_npu_map_info().keys()])
+                devices = sorted([int(x) for x in DeviceInfo.get_npu_map_info()])
             else:
                 devices = [int(x) for x in visible_devices.split(",") if x.strip()]
             local_comm_res_path = os.getenv("ASCEND_LOCAL_COMM_RES_PATH")
 
             if local_comm_res_path:
-                local_comm_res_file = os.path.join(local_comm_res_path, f"ub_endpoint_npu_{devices[self.local_rank]}.json")
+                local_comm_res_file = os.path.join(
+                    local_comm_res_path, f"ub_endpoint_npu_{devices[self.local_rank]}.json"
+                )
                 try:
-                    with open(local_comm_res_file, "r") as f:
+                    with open(local_comm_res_file) as f:
                         data = json.load(f)
                 except FileNotFoundError:
                     raise FileNotFoundError(
@@ -290,9 +292,7 @@ class NPUWorker(WorkerBase):
                         "Please run generate_ep.py first to generate the endpoint configurations."
                     )
                 except json.JSONDecodeError as e:
-                    raise ValueError(
-                        f"Failed to parse endpoint config file: {local_comm_res_file}"
-                    ) from e
+                    raise ValueError(f"Failed to parse endpoint config file: {local_comm_res_file}") from e
 
                 local_comm_res_str = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
                 os.environ["ASCEND_LOCAL_COMM_RES"] = local_comm_res_str


### PR DESCRIPTION
### What this PR does / why we need it?

Add A5 server disaggregated prefill-decode (PD) endpoint configuration support. On A5 hardware, disaggregated PD requires per-device NPU endpoint JSON files to be loaded at worker initialization so that HCCL communication layers can correctly match the hardware topology.

Changes:
- `vllm_ascend/worker/worker.py`: In `init_device()`, when running on A5,
  read the per-device endpoint config from `ASCEND_LOCAL_COMM_RES_PATH` and
  set `ASCEND_LOCAL_COMM_RES` for HCCL.
- `examples/disaggregated_prefill_a5_adaption/`: Scripts (`gen_route.sh`,
  `generate_ep.py`) and a README guide for generating the required endpoint
  config files on A5 servers.

### Does this PR introduce _any_ user-facing change?

Yes. Users running disaggregated PD on A5 servers need to:
1. Run the setup scripts (gen_route.sh, generate_ep.py -s) once to generate
   /etc/hixlep/ub_endpoint_npu_*.json
2. Set the environment variable: export ASCEND_LOCAL_COMM_RES_PATH=/etc/hixlep
   before launching vLLM.

### How was this patch tested?

Tested manually on an A5 server:
1. Ran gen_route.sh → verified /lib/route.conf generated correctly
2. Ran generate_ep.py -s → verified /etc/hixlep/ub_endpoint_npu_*.json
   generated for all NPU devices
3. Launched vLLM with ASCEND_LOCAL_COMM_RES_PATH=/etc/hixlep → confirmed
   ASCEND_LOCAL_COMM_RES is set correctly in each worker process
4. Non-A5 device path: not yet tested (pending)

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
