### PR TITLE
[BugFix][MLA][Ascend950] Zero-init o_proj_input padding to prevent NaN propagation in quantization

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1667,7 +1667,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         # Inputs and outputs may be padded for CUDA graphs
         output_padded = output
         o_proj_input_shape = (_EXTRA_CTX.num_tokens, self.num_heads * self.v_head_dim)
-        o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+        o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
         # MLA Preprocess
         if self.fa_quant_layer or (


### PR DESCRIPTION

### What this PR does / why we need it?

The o_proj_input buffer is allocated with the graph-mode padded shape (_EXTRA_CTX.num_tokens) but only the [:num_actual_tokens] segment is written by the decode/prefill paths. The padding segment [num_actual_tokens:_EXTRA_CTX.num_tokens] contains uninitialized memory. When NaN values appear in the padding segment and propagate through downstream per-block quantization (e.g., w8a8_mxfp8), Kimi models exhibit precision degradation with spurious '!' token bursts.

Switching to torch.zeros makes the padding slots inert for quantization.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
