### PR TITLE
[BugFix][MoE] Remove redundant renormalization operations

### DIFF
--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -280,7 +280,7 @@ def _select_experts_with_fusion_ops(
             tid2eid=tid2eid_ones,
             k_group=topk_group,
             group_count=num_expert_group,
-            routed_scaling_factor=1.0,
+            routed_scaling_factor=routed_scaling_factor,
             eps=1e-20,
             group_select_mode=1,
             # The hash custom op currently rejects renorm != 0. Apply
@@ -289,11 +289,6 @@ def _select_experts_with_fusion_ops(
             norm_type=2,
             out_flag=False,
         )
-        # Match DeepSeek V4 routing: normalize sqrtsoftplus top-k weights
-        # before applying the routed scale. DSV4 non-AITER callers pass 1.0
-        # here and scale the routed output later with muls_add_triton.
-        topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
-        topk_weights = topk_weights * routed_scaling_factor
         return topk_weights, topk_ids
     norm_type = 0 if scoring_func == "softmax" else 1
     if e_score_correction_bias is not None and e_score_correction_bias.dtype != router_logits.dtype:


### PR DESCRIPTION
This pull request refines the expert selection logic within the MoE implementation by eliminating redundant manual weight renormalization and scaling. By correctly passing the scaling factor into the fusion operation, the code becomes more efficient and maintains consistency with the intended routing behavior.

Highlights
Dynamic Scaling Factor: Updated the expert selection function to utilize the provided routed_scaling_factor instead of a hardcoded 1.0 value.
Removal of Redundant Operations: Removed manual renormalization and post-fusion scaling steps, as these operations are now handled appropriately within the fused operation flow.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
