### PR TITLE
fix: use logger.info_once for enable_npugraph_ex log

### DIFF
--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -204,7 +204,10 @@ class AscendCompiler(CompilerInterface):
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex:
-            logger.info("enable_npugraph_ex is enabled, which will bring graph compilation optimization.")
+            logger.info_once(
+                "enable_npugraph_ex is enabled, which will bring graph compilation optimization.",
+                scope="global",
+            )
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(
                 graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key


### PR DESCRIPTION
Replace logger.info with logger.info_once(scope='global') for the enable_npugraph_ex compilation log to avoid repeated log spam during graph compilation, consistent with the existing enable_static_kernel pattern.

### What this PR does / why we need it?

This PR changes the `enable_npugraph_ex` compilation log from `logger.info` to `logger.info_once(scope='global')`.

During graph compilation, the same log message may be printed repeatedly, causing unnecessary log spam and reducing log readability. This behavior is inconsistent with the existing `enable_static_kernel` logging pattern, which already uses `logger.info_once`.

This change aligns the logging behavior between the two features and keeps compilation logs cleaner.

### Does this PR introduce _any_ user-facing change?

No. This change only affects internal logging behavior by reducing duplicated log messages.

### How was this patch tested?

Verified by enabling `enable_npugraph_ex` and checking runtime logs during graph compilation.

Before this change, the same compilation log was printed repeatedly.
After this change, the log is printed only once globally as expected.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
