### PR TITLE
[Misc] Use logger.info_once for enable_npugraph_ex log

### DIFF
--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -204,7 +204,10 @@ class AscendCompiler(CompilerInterface):
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex:
-            logger.info("enable_npugraph_ex is enabled, which will bring graph compilation optimization.")
+            logger.info_once(
+                "enable_npugraph_ex is enabled, which will bring graph compilation optimization.",
+                scope="global",
+            )
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(
                 graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key


### PR DESCRIPTION
### What this PR does / why we need it?

Replaces `logger.info` with `logger.info_once(scope="global")` for the `enable_npugraph_ex` log in `compiler_interface.py` to avoid repeated log spam during graph compilation, consistent with the existing `enable_static_kernel` pattern.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI passed with existing tests.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
