### PR TITLE
[BugFix][SpecDecode] Fix MLA shape mismatch with Eagle3 and add   DeepSeek V2 Eagle3 support

### DIFF
--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -159,7 +159,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         kv_cache: torch.Tensor | None = None,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        hidden_dim = hidden_states.shape[-1]
+        hidden_dim = self.hidden_size
 
         if _EXTRA_CTX.flash_comm_v1_enabled and self.tp_size > 1 and self.is_vl_first_layer:
             need_gather_q_kv = False
@@ -167,7 +167,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             output = torch.empty((n_out, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device)
         else:
             need_gather_q_kv = _EXTRA_CTX.flash_comm_v1_enabled
-            output = torch.empty(hidden_states.shape, dtype=hidden_states.dtype, device=hidden_states.device)
+            output = torch.empty((hidden_states.shape[0], hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device)
 
         torch.ops.vllm.mla_forward(hidden_states, need_gather_q_kv, output, self.prefix)
         output = output.view(-1, hidden_dim)

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -167,7 +167,9 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             output = torch.empty((n_out, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device)
         else:
             need_gather_q_kv = _EXTRA_CTX.flash_comm_v1_enabled
-            output = torch.empty((hidden_states.shape[0], hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device)
+            output = torch.empty(
+                (hidden_states.shape[0], hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+            )
 
         torch.ops.vllm.mla_forward(hidden_states, need_gather_q_kv, output, self.prefix)
         output = output.view(-1, hidden_dim)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+from vllm.model_executor.models.deepseek_eagle3 import Eagle3DeepseekV2ForCausalLM
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.triton_utils import HAS_TRITON, triton
@@ -567,7 +568,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 
         if self.method in ("eagle3", "dflash"):
-            assert isinstance(self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM))
+            assert isinstance(self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM))
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -23,8 +23,8 @@ from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
-from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.deepseek_eagle3 import Eagle3DeepseekV2ForCausalLM
+from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.triton_utils import HAS_TRITON, triton
@@ -568,7 +568,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 
         if self.method in ("eagle3", "dflash"):
-            assert isinstance(self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM))
+            assert isinstance(
+                self.get_model(), (Eagle3LlamaForCausalLM, DFlashQwen3ForCausalLM, Eagle3DeepseekV2ForCausalLM)
+            )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
             assert target_hidden_states.shape[-1] == self.hidden_size
 


### PR DESCRIPTION
### What this PR does / why we need it?

  1. **Fix MLA `hidden_dim` shape mismatch with Eagle3 speculative
  decoding**

     In `AscendMultiHeadLatentAttention`, `hidden_dim` was derived from `hidden_states.shape[-1]`, which does not always equal `self.hidden_size`. When Eagle3 calls `combine_hidden_states`, the resulting tensor dimension differs from `self.hidden_size`, causing a shape mismatch. Fix by using `self.hidden_size` directly and explicitly constructing output shape as `(batch, hidden_dim)`.

  2. **Add `Eagle3DeepseekV2ForCausalLM` support in Eagle3 speculative
  decoding**

     The `isinstance` assertion in `AscendSpecDecodeBaseProposer` only allowed `Eagle3LlamaForCausalLM` and `DFlashQwen3ForCausalLM`, causing an `AssertionError` when running Eagle3 with DeepSeek V2 models. Add `Eagle3DeepseekV2ForCausalLM` (defined in upstream `vllm/model_executor/models/deepseek_eagle3.py`) to the check.

  ### Does this PR introduce _any_ user-facing change?

  No.

  ### How was this patch tested?

  Tested Eagle3 speculative decoding with [Kimi-K2.5-Thinking-Eagle3](https:
  //www.modelscope.cn/models/nv-community/Kimi-K2.5-Thinking-Eagle3) on 2×A3
   (16 NPU each), DP=32, TP=1, EP=32, W4A8 quantization. Launch script:

  ```bash
  #!/bin/bash

  current_dir=$(dirname "$0")

  if [ "$#" -ne 1 ]; then
      echo "Usage: $0 <node_rank>"
      echo "<node_rank> should start from 0 for both prefill and decode."
      exit 1
  fi

  NODE_RANK=$1

  # parallel_sizes
  export DATA_PARALLEL_SIZE=32
  export TENSOR_PARALLEL_SIZE=1
  export DATA_PARALLEL_SIZE_LOCAL=$((DATA_PARALLEL_SIZE / 2))
  export DATA_PARALLEL_START_RANK=$((NODE_RANK * DATA_PARALLEL_SIZE_LOCAL))

  #MLAPO
  export VLLM_ASCEND_ENABLE_MLAPO=1

  # bf16设置为2，量化权重设置为1
  export VLLM_ASCEND_ENABLE_NZ=1

  export NET_CARD_NAME="eth0"
  export MODEL_PATH="/a3_inference/itask/workdir/models/kimi-k2.5-w4a8-20260
  212091441"
  export
  DATA_PARALLEL_HEAD_ADDRESS=${DATA_PARALLEL_HEAD_ADDRESS:-"10.236.252.5"} #
   Set with the IP of node 0

  source "$(dirname $0)/../../common.sh"

  # Basic
  export TASK_QUEUE_ENABLE=0
  export OMP_NUM_THREADS=6

  # Ascend
  export GLOO_SOCKET_IFNAME=${NET_CARD_NAME}
  export TP_SOCKET_IFNAME=${NET_CARD_NAME}
  export HCCL_SOCKET_IFNAME=${NET_CARD_NAME}
  export HCCL_IF_BASE_PORT=50000

  # MoonCake
  export VLLM_BASE_PORT=9200
  export MC_LOG_LEVEL=INFO
  export MC_LOG_DIR=/home/admin/logs/mooncake
  export GLOG_alsologtostderr=1

  export ASCEND_CONNECT_TIMEOUT=60000
  export ASCEND_TRANSFER_TIMEOUT=60000

  # kv pool
  export HCCL_BUFFSIZE=650

  # Additional parameters required for cross-machine data parallelism
  if [ $NODE_RANK -ne 0 ]; then
      extra_params="--headless"
  else
      extra_params="--api-server-count 1"
  fi

  ulimit -n 65536
  nohup vllm serve ${MODEL_PATH} \
      ${extra_params} \
      --port 8200 \
      $COMMON_ARGS \
      --max-num-seqs 18 \
      --max-model-len 120000 \
      --max-num-batched-tokens 8192 \
      --block-size 128 \
      --gpu-memory-utilization 0.90 \
      --no-async-scheduling \
      --no-enable-prefix-caching \
      --data-parallel-size ${DATA_PARALLEL_SIZE} \
      --data-parallel-size-local ${DATA_PARALLEL_SIZE_LOCAL} \
      --data-parallel-address ${DATA_PARALLEL_HEAD_ADDRESS} \
      --data-parallel-rpc-port 14479 \
      --data-parallel-start-rank ${DATA_PARALLEL_START_RANK} \
      --tensor-parallel-size ${TENSOR_PARALLEL_SIZE} \
      --enable-expert-parallel \
      --quantization ascend \
      --additional-config '{"multistream_overlap_shared_expert":true}' \
      --compilation-config
  '{"cudagraph_capture_sizes":[3,6,9],"cudagraph_mode":"FULL_DECODE_ONLY"}'
  \
      --speculative-config '{"model": "/a3_inference/itask/workdir/models/ki
  mi-k2-5-thinking-eagle3/","method":"eagle3","num_speculative_tokens":
  2,"enforce_eager": true}' &> log_decode_${NODE_RANK}.log &
```
  Startup and inference results:
<img width="910" height="742" alt="image" src="https://github.com/user-attachments/assets/87a521a2-61a8-407d-98eb-7362855c0b84" />
<img width="1886" height="191" alt="image" src="https://github.com/user-attachments/assets/784eac56-1d37-430e-bed4-bee48b63f4ff" />


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
