### PR TITLE
[CI]fix dflash test

### DIFF
--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -13,6 +13,7 @@ from vllm.tokenizers.registry import resolve_tokenizer_args
 from vllm.v1.metrics.reader import Counter, Vector
 
 from tests.e2e.conftest import VllmRunner
+from vllm_ascend.utils import vllm_version_is
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
@@ -43,7 +44,11 @@ BASELINES = {
     "eagle": [0.74, 0.44, 0.29],
     "eagle3": [0.68, 0.40, 0.18],
     "draft_parallel": [0.83, 0.50, 0.33, 0.17, 0.17, 0.17, 0.17, 0.00],
-    "dflash": [0.67, 0.67, 0.44, 0.33, 0.11, 0.00, 0.00, 0.00],
+    "dflash": (
+        [0.67, 0.67, 0.44, 0.33, 0.11, 0.00, 0.00, 0.00]
+        if vllm_version_is("0.20.2")
+        else [0.60, 0.50, 0.30, 0.20, 0.20, 0.10, 0.00, 0.00]
+    ),
 }
 
 
@@ -480,7 +485,6 @@ def test_parallel_drafting_acceptance(
 
 @pytest.mark.parametrize("method", DFLASH.keys())
 @pytest.mark.parametrize("num_speculative_tokens", [8])
-@pytest.mark.skip(reason="DFlash acceptance is currently broken by vllm main(39910f2b25aacc09f5e7f166cdf0030b19f8b9e8)")
 def test_dflash_acceptance(
     method: str,
     num_speculative_tokens: int,


### PR DESCRIPTION
### What this PR does / why we need it?
The upstream PR of vllm https://github.com/vllm-project/vllm/pull/40727 fixed the dflash acceptance rate issue, which caused inconsistency between the acceptance rate and the use case. This PR modified the use case baseline.

### Does this PR introduce _any_ user-facing change?
None
### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
