### PR TITLE
[Feature]Add NZ layout support for C8 quantization

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -728,10 +728,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             }
 
             # change key/value shape
-            if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
-                _, block_size, _, _ = self.key_cache.shape  # type: ignore
-                key = self._nz_5d_view(self.key_cache, block_size)
-                value = self._nz_5d_view(self.value_cache, block_size)
+            _, block_size, _, _ = self.key_cache.shape  # type: ignore
+            key = self._nz_5d_view(self.key_cache, block_size)
+            value = self._nz_5d_view(self.value_cache, block_size)
 
             # TODO: change layerout from BNSD to TND.
             input_layout = "BNSD"
@@ -1439,7 +1438,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                     return output
                 elif attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
                     return self._forward_c8_decode(query, attn_metadata, output, layer)
-                
+
     def _nz_5d_view(self, cache: torch.Tensor, block_size: int) -> torch.Tensor:
         """View a KV cache tensor in NZ 5D layout: (num_blocks, num_kv_heads, head_size//nz, block_size, nz)."""
         NZ_FMT_LAST_DIM = 32
@@ -1492,7 +1491,6 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         """Gather paged INT8 KV blocks and dequantize."""
         batch_size = block_table.shape[0]
         max_blocks_per_seq = block_table.shape[1]
-        num_blocks = key.shape[0]
 
         # NZ 5D view: (num_blocks, num_kv_heads, head_size//nz, block_size, nz)
         block_size = key.shape[3]
@@ -1506,11 +1504,16 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         gathered_k = key_nz[flat_ids]
         gathered_v = value_nz[flat_ids]
         # NZ→ND conversion: permute (S, H, D//nz, nz) → reshape (S, H, D)
-        gathered_k = gathered_k.permute(0, 3, 1, 2, 4).contiguous().view(
-            batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
-        gathered_v = gathered_v.permute(0, 3, 1, 2, 4).contiguous().view(
-            batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
-
+        gathered_k = (
+            gathered_k.permute(0, 3, 1, 2, 4)
+            .contiguous()
+            .view(batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
+        )
+        gathered_v = (
+            gathered_v.permute(0, 3, 1, 2, 4)
+            .contiguous()
+            .view(batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
+        )
 
         seq_lens_t = torch.tensor(seq_lens, dtype=torch.long, device=key.device)
         positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key.device)
@@ -1654,7 +1657,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 num_block, blk_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
                 paged_k = self._nz_5d_view(self.key_cache, blk_size)
                 paged_v = self._nz_5d_view(self.value_cache, blk_size)
-                
+
                 prefill_bt = attn_metadata.block_tables[num_decodes:]
                 prefill_sl = attn_metadata.seq_lens_list[num_decodes:]
                 prefill_k, prefill_v = self._dequant_paged_kv_to_dense(

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -696,7 +696,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.layerIndex, attn_metadata.kvcomp_metadata, query, passed_key, block_table, actual_seq_lengths_kv
             )
 
-        num_tokens = attn_metadata.num_actual_tokens
+        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
         if _EXTRA_CTX.is_draft_model:
             if _EXTRA_CTX.is_draft_model_prefill:
                 graph_params = get_draft_graph_prefill_params()
@@ -732,15 +732,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 _, block_size, _, _ = self.key_cache.shape  # type: ignore
                 key = self._nz_5d_view(self.key_cache, block_size)
                 value = self._nz_5d_view(self.value_cache, block_size)
-                block_table = attn_metadata.block_tables
-                actual_seq_lengths_kv = attn_metadata.seq_lens_list
-            # chunked prefill.
-            else:
-                _, block_size, _, _ = self.key_cache.shape  # type: ignore
-                key = self._nz_5d_view(self.key_cache, block_size)
-                value = self._nz_5d_view(self.value_cache, block_size)
-                block_table = attn_metadata.block_tables
-                actual_seq_lengths_kv = attn_metadata.seq_lens_list
 
             # TODO: change layerout from BNSD to TND.
             input_layout = "BNSD"
@@ -1576,13 +1567,13 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         assert block_size % 32 == 0, f"C8 INT8 KV cache requires block_size to be a multiple of 32, got {block_size}"
         batch_size = len(attn_metadata.seq_lens_list)
 
-        key_5d = self._nz_5d_view(self.key_cache, block_size)
-        value_5d = self._nz_5d_view(self.value_cache, block_size)
+        key = self._nz_5d_view(self.key_cache, block_size)
+        value = self._nz_5d_view(self.value_cache, block_size)
 
         attn_output, _ = torch_npu.npu_fused_infer_attention_score(
             query[:batch_size].unsqueeze(2),
-            key_5d,
-            value_5d,
+            key,
+            value,
             key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
             value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
             block_table=attn_metadata.block_tables,
@@ -1617,12 +1608,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_decodes = attn_metadata.num_decodes
         actual_seq_qlen = attn_metadata.actual_seq_lengths_q
-        num_tokens = attn_metadata.num_actual_tokens
-        num_prefills = attn_metadata.num_prefills
-        actual_prefill_end = num_decodes + num_prefills
-
-        if actual_prefill_end > num_decodes and actual_seq_qlen[actual_prefill_end - 1] > num_tokens:
-            actual_prefill_end -= 1
+        num_tokens = int(actual_seq_qlen[-1])  # type: ignore[index]
 
         if num_decode_tokens > 0:
             num_block, block_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
@@ -1653,15 +1639,15 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             )
             output[:num_decode_tokens] = attn_out.squeeze(2)
 
-        if attn_metadata.num_prefills > num_decodes:
+        if attn_metadata.num_prefills > 0:
             prefill_q = query[num_decode_tokens:num_tokens]
 
             prefill_seq_qlen = [
-                actual_seq_qlen[i] - num_decode_tokens for i in range(num_decodes, actual_prefill_end)
+                actual_seq_qlen[i] - num_decode_tokens for i in range(num_decodes, len(actual_seq_qlen))
             ]
 
             all_new_prefill = True
-            for i in range(num_decodes, actual_prefill_end):
+            for i in range(num_decodes, len(attn_metadata.seq_lens_list)):
                 q_start = actual_seq_qlen[i - 1] if i > 0 else 0
                 qlen_i = actual_seq_qlen[i] - q_start
                 if attn_metadata.seq_lens_list[i] > qlen_i:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -642,11 +642,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     if c8_k_aq_scale is not None:
                         extra_args = {
                             "key_antiquant_scale": c8_k_aq_scale,
-                            "key_antiquant_offset": c8_k_aq_offset,
                             "value_antiquant_scale": c8_v_aq_scale,
-                            "value_antiquant_offset": c8_v_aq_offset,
                             "key_antiquant_mode": 0,
                             "value_antiquant_mode": 0,
+                            "inner_precise": 1,
                         }
                         input_layout = "BNSD"
                         sparse_mode = 0
@@ -697,7 +696,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.layerIndex, attn_metadata.kvcomp_metadata, query, passed_key, block_table, actual_seq_lengths_kv
             )
 
-        num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+        num_tokens = attn_metadata.num_actual_tokens
         if _EXTRA_CTX.is_draft_model:
             if _EXTRA_CTX.is_draft_model_prefill:
                 graph_params = get_draft_graph_prefill_params()
@@ -721,14 +720,29 @@ class AscendAttentionBackendImpl(AttentionImpl):
         extra_args = {}
         if self.enable_c8_quant:
             extra_args = {
-                "key_antiquant_scale": layer._c8_k_aq_scale,
-                "key_antiquant_offset": layer._c8_k_aq_offset,
-                "value_antiquant_scale": layer._c8_v_aq_scale,
-                "value_antiquant_offset": layer._c8_v_aq_offset,
+                "key_antiquant_scale": layer._c8_k_aq_scale_nz_bnsd,
+                "value_antiquant_scale": layer._c8_v_aq_scale_nz_bnsd,
                 "key_antiquant_mode": 0,
                 "value_antiquant_mode": 0,
+                "inner_precise": 1,
             }
-            # TODO: Convert kvcache to NZ, and change layerout from BNSD to TND.
+
+            # change key/value shape
+            if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
+                _, block_size, _, _ = self.key_cache.shape  # type: ignore
+                key = self._nz_5d_view(self.key_cache, block_size)
+                value = self._nz_5d_view(self.value_cache, block_size)
+                block_table = attn_metadata.block_tables
+                actual_seq_lengths_kv = attn_metadata.seq_lens_list
+            # chunked prefill.
+            else:
+                _, block_size, _, _ = self.key_cache.shape  # type: ignore
+                key = self._nz_5d_view(self.key_cache, block_size)
+                value = self._nz_5d_view(self.value_cache, block_size)
+                block_table = attn_metadata.block_tables
+                actual_seq_lengths_kv = attn_metadata.seq_lens_list
+
+            # TODO: change layerout from BNSD to TND.
             input_layout = "BNSD"
             query = query.unsqueeze(2)
             output = output.unsqueeze(2)
@@ -785,10 +799,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         )
         if self.enable_c8_quant:
             attn_params = attn_params + (
-                weak_ref_tensors(layer._c8_k_aq_scale),
-                weak_ref_tensors(layer._c8_k_aq_offset),
-                weak_ref_tensors(layer._c8_v_aq_scale),
-                weak_ref_tensors(layer._c8_v_aq_offset),
+                weak_ref_tensors(layer._c8_k_aq_scale_nz_bnsd),
+                None,
+                weak_ref_tensors(layer._c8_v_aq_scale_nz_bnsd),
+                None,
             )  # type: ignore
         else:
             attn_params = attn_params + (None, None, None, None)  # type: ignore
@@ -1377,7 +1391,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 if attn_metadata.attn_state != AscendAttentionState.DecodeOnly:
                     float_key, float_value = key, value
                 key, value = self._quantize_kv_to_int8(key, value, layer, attn_metadata.num_actual_tokens)
-                query, key, value, _ = self.reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
+                query, key, value, _ = self._reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
             # pooling model branch
             if attn_metadata.model_runner_type == "pooling":
                 attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
@@ -1422,7 +1436,7 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             elif not self.is_kv_producer:
                 if key is not None and value is not None:
                     key, value = self._quantize_kv_to_int8(key, value, layer, attn_metadata.num_actual_tokens)
-                    query, key, value, _ = self.reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
+                    query, key, value, _ = self._reshape_and_cache(query, key, value, kv_cache, attn_metadata, output)
                 # pooling model branch
                 if attn_metadata.model_runner_type == "pooling":
                     attn_output = self._forward_encoder_attention(query, key, value, attn_metadata, output)
@@ -1434,6 +1448,11 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                     return output
                 elif attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
                     return self._forward_c8_decode(query, attn_metadata, output, layer)
+                
+    def _nz_5d_view(self, cache: torch.Tensor, block_size: int) -> torch.Tensor:
+        """View a KV cache tensor in NZ 5D layout: (num_blocks, num_kv_heads, head_size//nz, block_size, nz)."""
+        NZ_FMT_LAST_DIM = 32
+        return cache.view(-1, self.num_kv_heads, self.head_size // NZ_FMT_LAST_DIM, block_size, NZ_FMT_LAST_DIM)
 
     def _prepare_c8_scales(self, layer: AttentionLayer, device: torch.device) -> None:
         """Shard per-channel C8 scales/offsets to this TP rank and pre-compute
@@ -1461,14 +1480,20 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         layer._c8_v_scale = _shard_and_reshape(layer.v_cache_scale.data)
         layer._c8_v_offset = _shard_and_reshape(layer.v_cache_offset.data)
 
-        bnsd = (1, self.num_kv_heads, 1, self.head_size)
-        layer._c8_k_aq_scale = layer._c8_k_scale.view(bnsd).contiguous()
-        layer._c8_k_aq_offset = layer._c8_k_offset.view(bnsd).contiguous()
-        layer._c8_v_aq_scale = layer._c8_v_scale.view(bnsd).contiguous()
-        layer._c8_v_aq_offset = layer._c8_v_offset.view(bnsd).contiguous()
-
         layer._c8_k_inv_scale = 1.0 / layer._c8_k_scale
         layer._c8_v_inv_scale = 1.0 / layer._c8_v_scale
+
+        nz_bnsd = (self.num_kv_heads, 1, self.head_size)
+        layer._c8_k_aq_scale_nz_bnsd = layer._c8_k_scale.view(nz_bnsd).contiguous()
+        layer._c8_v_aq_scale_nz_bnsd = layer._c8_v_scale.view(nz_bnsd).contiguous()
+
+        # NZ is the default KV cache layout. Validate hardware constraints.
+        cache_config = self.vllm_config.cache_config
+        block_size_val = cache_config.block_size
+        assert self.head_size == 128, \
+            f"C8 NZ KV cache requires head_size==128, got {self.head_size}"
+        assert block_size_val in (128, 512), \
+            f"C8 NZ KV cache requires block_size in (128, 512), got {block_size_val}"
 
         layer._c8_scales_prepared = True
 
@@ -1483,26 +1508,37 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Gather paged INT8 KV blocks and dequantize."""
         batch_size = block_table.shape[0]
-        block_size = key.shape[1]
-        H = key.shape[2]
         max_blocks_per_seq = block_table.shape[1]
+        num_blocks = key.shape[0]
+
+        # NZ 5D view: (num_blocks, num_kv_heads, head_size//nz, block_size, nz)
+        block_size = key.shape[3]
         max_tokens_padded = max_blocks_per_seq * block_size
 
         flat_ids = block_table.reshape(-1)
-        gathered_k = key[flat_ids].view(batch_size, max_tokens_padded, H)
-        gathered_v = value[flat_ids].view(batch_size, max_tokens_padded, H)
+        key_nz = self._nz_5d_view(key, block_size)
+        value_nz = self._nz_5d_view(value, block_size)
+
+        # Gather: (batch*max_blocks, H, D//nz, S, nz)
+        gathered_k = key_nz[flat_ids]
+        gathered_v = value_nz[flat_ids]
+        # NZ→ND conversion: permute (S, H, D//nz, nz) → reshape (S, H, D)
+        gathered_k = gathered_k.permute(0, 3, 1, 2, 4).contiguous().view(
+            batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
+        gathered_v = gathered_v.permute(0, 3, 1, 2, 4).contiguous().view(
+            batch_size, max_tokens_padded, self.num_kv_heads, self.head_size)
+
 
         seq_lens_t = torch.tensor(seq_lens, dtype=torch.long, device=key.device)
         positions = torch.arange(max_tokens_padded, dtype=torch.long, device=key.device)
         valid_mask = (positions.unsqueeze(0) < seq_lens_t.unsqueeze(1)).view(-1)
 
-        dense_k = gathered_k.view(-1, H)[valid_mask]
-        dense_v = gathered_v.view(-1, H)[valid_mask]
+        dense_k = gathered_k.view(-1, self.num_kv_heads, self.head_size)[valid_mask]
+        dense_v = gathered_v.view(-1, self.num_kv_heads, self.head_size)[valid_mask]
 
-        dense_k = dense_k.view(-1, self.num_kv_heads, self.head_size)
-        dense_v = dense_v.view(-1, self.num_kv_heads, self.head_size)
-        dense_k = (dense_k.to(target_dtype) - layer._c8_k_offset) * layer._c8_k_scale
-        dense_v = (dense_v.to(target_dtype) - layer._c8_v_offset) * layer._c8_v_scale
+        # Scale-only dequant for NZ (symmetric)
+        dense_k = dense_k.to(target_dtype) * layer._c8_k_scale
+        dense_v = dense_v.to(target_dtype) * layer._c8_v_scale
         return dense_k, dense_v
 
     def _quantize_kv_to_int8(
@@ -1538,18 +1574,17 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         """C8 decode via FIA V1 BNSD with native paged INT8 KV + perchannel antiquant."""
         num_block, block_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
         assert block_size % 32 == 0, f"C8 INT8 KV cache requires block_size to be a multiple of 32, got {block_size}"
-        key = self.key_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
-        value = self.value_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
         batch_size = len(attn_metadata.seq_lens_list)
+
+        key_5d = self._nz_5d_view(self.key_cache, block_size)
+        value_5d = self._nz_5d_view(self.value_cache, block_size)
 
         attn_output, _ = torch_npu.npu_fused_infer_attention_score(
             query[:batch_size].unsqueeze(2),
-            key,
-            value,
-            key_antiquant_scale=layer._c8_k_aq_scale,
-            key_antiquant_offset=layer._c8_k_aq_offset,
-            value_antiquant_scale=layer._c8_v_aq_scale,
-            value_antiquant_offset=layer._c8_v_aq_offset,
+            key_5d,
+            value_5d,
+            key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
+            value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
             block_table=attn_metadata.block_tables,
             actual_seq_lengths_kv=attn_metadata.seq_lens_list,
             num_heads=self.num_heads,
@@ -1557,8 +1592,10 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             input_layout="BNSD",
             scale=self.scale,
             block_size=block_size,
+            antiquant_mode=0,
             key_antiquant_mode=0,
             value_antiquant_mode=0,
+            inner_precise=1,
             sparse_mode=0,
         )
         attn_output = attn_output.squeeze(2)
@@ -1580,24 +1617,27 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_decodes = attn_metadata.num_decodes
         actual_seq_qlen = attn_metadata.actual_seq_lengths_q
-        num_tokens = int(actual_seq_qlen[-1])  # type: ignore[index]
+        num_tokens = attn_metadata.num_actual_tokens
+        num_prefills = attn_metadata.num_prefills
+        actual_prefill_end = num_decodes + num_prefills
+
+        if actual_prefill_end > num_decodes and actual_seq_qlen[actual_prefill_end - 1] > num_tokens:
+            actual_prefill_end -= 1
 
         if num_decode_tokens > 0:
             num_block, block_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
             assert block_size % 32 == 0, (
                 f"C8 INT8 KV cache requires block_size to be a multiple of 32, got {block_size}"
             )
-            kv_k = self.key_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
-            kv_v = self.value_cache.view(num_block, block_size, -1)  # type: ignore[attr-defined]
+            kv_k = self._nz_5d_view(self.key_cache, block_size)
+            kv_v = self._nz_5d_view(self.value_cache, block_size)
 
             attn_out, _ = torch_npu.npu_fused_infer_attention_score(
                 query[:num_decode_tokens].unsqueeze(2),
                 kv_k,
                 kv_v,
-                key_antiquant_scale=layer._c8_k_aq_scale,
-                key_antiquant_offset=layer._c8_k_aq_offset,
-                value_antiquant_scale=layer._c8_v_aq_scale,
-                value_antiquant_offset=layer._c8_v_aq_offset,
+                key_antiquant_scale=layer._c8_k_aq_scale_nz_bnsd,
+                value_antiquant_scale=layer._c8_v_aq_scale_nz_bnsd,
                 block_table=attn_metadata.block_tables[:num_decodes],
                 actual_seq_lengths_kv=attn_metadata.seq_lens_list[:num_decodes],
                 num_heads=self.num_heads,
@@ -1605,21 +1645,23 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 input_layout="BNSD",
                 scale=self.scale,
                 block_size=block_size,
+                antiquant_mode=0,
                 key_antiquant_mode=0,
                 value_antiquant_mode=0,
+                inner_precise=1,
                 sparse_mode=0,
             )
             output[:num_decode_tokens] = attn_out.squeeze(2)
 
-        if attn_metadata.num_prefills > 0:
+        if attn_metadata.num_prefills > num_decodes:
             prefill_q = query[num_decode_tokens:num_tokens]
 
             prefill_seq_qlen = [
-                actual_seq_qlen[i] - num_decode_tokens for i in range(num_decodes, len(actual_seq_qlen))
+                actual_seq_qlen[i] - num_decode_tokens for i in range(num_decodes, actual_prefill_end)
             ]
 
             all_new_prefill = True
-            for i in range(num_decodes, len(attn_metadata.seq_lens_list)):
+            for i in range(num_decodes, actual_prefill_end):
                 q_start = actual_seq_qlen[i - 1] if i > 0 else 0
                 qlen_i = actual_seq_qlen[i] - q_start
                 if attn_metadata.seq_lens_list[i] > qlen_i:
@@ -1632,10 +1674,11 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 prefill_seq_kvlen = prefill_seq_qlen
             else:
                 num_block, blk_size, _, _ = self.key_cache.shape  # type: ignore[attr-defined]
-                paged_k = self.key_cache.view(num_block, blk_size, -1)  # type: ignore[attr-defined]
-                paged_v = self.value_cache.view(num_block, blk_size, -1)  # type: ignore[attr-defined]
-                prefill_bt = attn_metadata.block_tables[num_decodes:]
-                prefill_sl = attn_metadata.seq_lens_list[num_decodes:]
+                paged_k = self._nz_5d_view(self.key_cache, blk_size)
+                paged_v = self._nz_5d_view(self.value_cache, blk_size)
+                # Exclude SP dummy from block_table and seq_lens slices.
+                prefill_bt = attn_metadata.block_tables[num_decodes:actual_prefill_end]
+                prefill_sl = attn_metadata.seq_lens_list[num_decodes:actual_prefill_end]
                 prefill_k, prefill_v = self._dequant_paged_kv_to_dense(
                     paged_k, paged_v, prefill_bt, prefill_sl, query.dtype, layer
                 )
@@ -1723,3 +1766,38 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
         output[:num_tokens] = attn_output
         return output
+
+    def _reshape_and_cache(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: tuple[torch.Tensor],
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ):
+        if len(kv_cache) > 1:
+            if self.is_kv_producer:
+                attn_metadata.reshape_cache_event = torch.npu.Event()
+            if self.key_cache is None:
+                self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
+            slots = attn_metadata.slot_mapping
+
+            encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
+
+            # NZ write path: 5D view + npu_scatter_pa_kv_cache
+            block_size = self.vllm_config.cache_config.block_size
+            k_cache_layer = self._nz_5d_view(self.key_cache, block_size)
+            v_cache_layer = self._nz_5d_view(self.value_cache, block_size)
+
+            torch_npu.npu_scatter_pa_kv_cache(
+                key=key[: attn_metadata.num_actual_tokens] if not encoder_decoder else key,
+                value=value[: attn_metadata.num_actual_tokens] if not encoder_decoder else value,
+                key_cache=k_cache_layer,
+                value_cache=v_cache_layer,
+                slot_mapping=slots,
+            )
+
+            if self.is_kv_producer:
+                attn_metadata.reshape_cache_event.record()
+        return query, key, value, output

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -718,7 +718,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX
 
         extra_args = {}
-        if self.enable_c8_quant:
+        if self.enable_c8_quant and layer is not None:
             extra_args = {
                 "key_antiquant_scale": layer._c8_k_aq_scale_nz_bnsd,
                 "value_antiquant_scale": layer._c8_v_aq_scale_nz_bnsd,
@@ -788,7 +788,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             pre_tokens,
             next_tokens,
         )
-        if self.enable_c8_quant:
+        if self.enable_c8_quant and layer is not None:
             attn_params = attn_params + (
                 weak_ref_tensors(layer._c8_k_aq_scale_nz_bnsd),
                 None,
@@ -1477,14 +1477,6 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
         nz_bnsd = (self.num_kv_heads, 1, self.head_size)
         layer._c8_k_aq_scale_nz_bnsd = layer._c8_k_scale.view(nz_bnsd).contiguous()
         layer._c8_v_aq_scale_nz_bnsd = layer._c8_v_scale.view(nz_bnsd).contiguous()
-
-        # NZ is the default KV cache layout. Validate hardware constraints.
-        cache_config = self.vllm_config.cache_config
-        block_size_val = cache_config.block_size
-        assert self.head_size == 128, \
-            f"C8 NZ KV cache requires head_size==128, got {self.head_size}"
-        assert block_size_val in (128, 512), \
-            f"C8 NZ KV cache requires block_size in (128, 512), got {block_size_val}"
 
         layer._c8_scales_prepared = True
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1663,8 +1663,8 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
                 paged_k = self._nz_5d_view(self.key_cache, blk_size)
                 paged_v = self._nz_5d_view(self.value_cache, blk_size)
                 # Exclude SP dummy from block_table and seq_lens slices.
-                prefill_bt = attn_metadata.block_tables[num_decodes:actual_prefill_end]
-                prefill_sl = attn_metadata.seq_lens_list[num_decodes:actual_prefill_end]
+                prefill_bt = attn_metadata.block_tables[num_decodes:]
+                prefill_sl = attn_metadata.seq_lens_list[num_decodes:]
                 prefill_k, prefill_v = self._dequant_paged_kv_to_dense(
                     paged_k, paged_v, prefill_bt, prefill_sl, query.dtype, layer
                 )

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -1629,7 +1629,7 @@ class MooncakeLayerwiseConnectorWorker:
                     and (isinstance(self.kv_cache_specs[layer_group_idx], (FullAttentionSpec, SlidingWindowSpec)))
                     and send_task.group_num_blocks[layer_group_idx] > 0
                 )
-                or self.enable_c8_quant
+                or (self.enable_c8_quant and self.current_layer in self.vllm_config.quant_config.c8_quant_layers)
                 or (self.enable_kv_quant and self.current_layer in self.vllm_config.quant_config.kvcache_quant_layers)
             ):
                 assert self.resharding_stream is not None
@@ -1691,6 +1691,8 @@ class MooncakeLayerwiseConnectorWorker:
                             -128,
                             127,
                         ).to(torch.int8)
+                        quant_keys = self.get_nz_cache(keys, layer_group_idx)
+                        quant_values = self.get_nz_cache(values, layer_group_idx)
                     if (
                         self.enable_kv_quant
                         and self.current_layer in self.vllm_config.quant_config.kvcache_quant_layers

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -549,7 +549,7 @@ class AscendModelSlimConfig(QuantizationConfig):
             scheme = create_scheme_for_layer(self.quant_description, prefix, "attention", self.packed_modules_mapping)
             logger.debug("Select AscendKVCacheMethod for %s (layer=%s)", prefix, "AttentionLayerBase[fa/indexer]")
             return AscendKVCacheMethod(scheme)
-        elif isinstance(layer, AttentionLayerBase) and self.is_c8_quant_layer(prefix): 
+        elif isinstance(layer, AttentionLayerBase) and self.is_c8_quant_layer(prefix):
             from .methods.kv_c8 import AscendC8KVCacheAttentionMethod
 
             logger.debug("Select AscendKVCacheMethod(C8) for %s (layer=%s)", prefix, "AttentionLayerBase[C8]")

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -811,13 +811,13 @@ class AscendModelSlimConfig(QuantizationConfig):
 
     def _add_kvcache_quant_metadata(self):
         fa_quant_type = self.quant_description.get("fa_quant_type", "")
-        self.enable_fa_quant = fa_quant_type != "C8"
+        self.enable_fa_quant = fa_quant_type != ""
         self.kvcache_quant_layers = []
         indexer_quant_type = self.quant_description.get("indexer_quant_type", "")
         self.enable_indexer_quant = indexer_quant_type != ""
         self.indexer_quant_layers = []
         kv_quant_type = self.quant_description.get("kv_cache_type", "")
-        self.enable_c8_quant = kv_quant_type != ""
+        self.enable_c8_quant = kv_quant_type == "C8"
         self.c8_quant_layers = []
         if self.enable_fa_quant or self.enable_indexer_quant or self.enable_c8_quant:
             for key in self.quant_description:

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -811,7 +811,7 @@ class AscendModelSlimConfig(QuantizationConfig):
 
     def _add_kvcache_quant_metadata(self):
         fa_quant_type = self.quant_description.get("fa_quant_type", "")
-        self.enable_fa_quant = fa_quant_type != ""
+        self.enable_fa_quant = fa_quant_type != "C8"
         self.kvcache_quant_layers = []
         indexer_quant_type = self.quant_description.get("indexer_quant_type", "")
         self.enable_indexer_quant = indexer_quant_type != ""

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -549,7 +549,7 @@ class AscendModelSlimConfig(QuantizationConfig):
             scheme = create_scheme_for_layer(self.quant_description, prefix, "attention", self.packed_modules_mapping)
             logger.debug("Select AscendKVCacheMethod for %s (layer=%s)", prefix, "AttentionLayerBase[fa/indexer]")
             return AscendKVCacheMethod(scheme)
-        elif isinstance(layer, AttentionLayerBase) and self.quant_description.get("kv_cache_type") == "C8":
+        elif isinstance(layer, AttentionLayerBase) and self.is_c8_quant_layer(prefix): 
             from .methods.kv_c8 import AscendC8KVCacheAttentionMethod
 
             logger.debug("Select AscendKVCacheMethod(C8) for %s (layer=%s)", prefix, "AttentionLayerBase[C8]")
@@ -622,6 +622,13 @@ class AscendModelSlimConfig(QuantizationConfig):
         if self.enable_indexer_quant:
             layer_id_str = "".join(re.findall(r"\.(\d+)\.", prefix))
             if layer_id_str.isdigit() and int(layer_id_str) in self.indexer_quant_layers:
+                return True
+        return False
+
+    def is_c8_quant_layer(self, prefix):
+        if self.enable_c8_quant:
+            layer_id_str = "".join(re.findall(r"\.(\d+)\.", prefix))
+            if layer_id_str.isdigit() and int(layer_id_str) in self.c8_quant_layers:
                 return True
         return False
 
@@ -811,10 +818,13 @@ class AscendModelSlimConfig(QuantizationConfig):
         self.indexer_quant_layers = []
         kv_quant_type = self.quant_description.get("kv_cache_type", "")
         self.enable_c8_quant = kv_quant_type != ""
-        if self.enable_fa_quant or self.enable_indexer_quant:
+        self.c8_quant_layers = []
+        if self.enable_fa_quant or self.enable_indexer_quant or self.enable_c8_quant:
             for key in self.quant_description:
                 _id = "".join(re.findall(r"\.(\d+)\.", key))
                 if "fa_k.scale" in key:
                     self.kvcache_quant_layers.append(int(_id))
                 if "indexer.quant_type" in key:
                     self.indexer_quant_layers.append(int(_id))
+                if "k_proj.kv_cache_scale" in key:
+                    self.c8_quant_layers.append(int(_id))


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds NZ layout support for C8 quantization of KV cache. It enables converting the KV cache from the original ND layout to NZ layout during C8 quantization, improving memory access efficiency and computational performance for attention operations.
**The test results are as follows(Qwen3-32B-w8a8c8/910B3*4):**
**Accuracy:**
python3 aisbench_test.py --dataset "/workspace/aisbench_auto_tools_prefix/GSM8K.jsonl" --concurrency 64 --request_rate 1 --test_accuracy --output_len 32768 --test_type text
<img width="1583" height="644" alt="image" src="https://github.com/user-attachments/assets/85eefce9-a86e-40a2-bb51-830cbd8ab87b" />

**Performance:**
python3 aisbench_test.py --input_len 30720 --output_len 1024 --data_num 256 --concurrency 64 --request_rate 1 --repeat_rate 0.9 --dataset_type prefix_cache --seed 1024
<img width="1447" height="804" alt="image" src="https://github.com/user-attachments/assets/aa3c0179-0921-4a38-96f6-29e2ef5c508a" />

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
