### PR TITLE
[CI] Upgrade 310P CANN image to 9.1.0-beta.1

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -16,7 +16,7 @@ on:
       image_310p:
         required: false
         type: string
-        default: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-310p-ubuntu22.04-py3.11
+        default: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.11
       type:
         required: true
         type: string

--- a/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
+++ b/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 ARG PY_VERSION=3.11
-FROM quay.io/ascend/manylinux:9.0.0-310p-manylinux_2_28-py${PY_VERSION}
+FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_28-py${PY_VERSION}
 
 ARG SOC_VERSION="ascend310p1"
 

--- a/.github/workflows/push_build_csrc_cache.yaml
+++ b/.github/workflows/push_build_csrc_cache.yaml
@@ -86,7 +86,7 @@ jobs:
             image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-ubuntu22.04-py3.11
           - os: ubuntu
             chip_type: 310p
-            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-310p-ubuntu22.04-py3.11
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.11
           - os: openeuler
             chip_type: a2
             image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-openeuler24.03-py3.11
@@ -95,7 +95,7 @@ jobs:
             image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-openeuler24.03-py3.11
           - os: openeuler
             chip_type: 310p
-            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-310p-openeuler24.03-py3.11
+            image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-beta.1-310p-openeuler24.03-py3.11
 
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/scripts/runner_label.json
+++ b/.github/workflows/scripts/runner_label.json
@@ -2,17 +2,17 @@
     "linux-aarch64-310p-1": {
         "chip": "310p",
         "npu_num": 1,
-        "image_tag": "9.0.0-310p-ubuntu22.04-py3.11"
+        "image_tag": "9.1.0-beta.1-310p-ubuntu22.04-py3.11"
     },
     "linux-aarch64-310p-2": {
         "chip": "310p",
         "npu_num": 2,
-        "image_tag": "9.0.0-310p-ubuntu22.04-py3.11"
+        "image_tag": "9.1.0-beta.1-310p-ubuntu22.04-py3.11"
     },
     "linux-aarch64-310p-4": {
         "chip": "310p",
         "npu_num": 4,
-        "image_tag": "9.0.0-310p-ubuntu22.04-py3.11"
+        "image_tag": "9.1.0-beta.1-310p-ubuntu22.04-py3.11"
     },
     "linux-aarch64-a3-2": {
         "chip": "a3",

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.0-310p-ubuntu22.04-py3.11
+FROM quay.io/ascend/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.0-310p-openeuler24.03-py3.11
+FROM quay.io/ascend/cann:9.1.0-beta.1-310p-openeuler24.03-py3.11
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 


### PR DESCRIPTION
### What this PR does

Upgrade the CANN image version used by 310P CI and Dockerfiles from `9.0.0-310p` to `9.1.0-beta.1-310p`.

Updated 310P image references in:
- CI E2E default image
- csrc cache build matrix images
- smart E2E runner image tags
- 310P wheel build image
- 310P Docker base images for Ubuntu and openEuler

### Verification

- Confirmed no `9.0.0-310p` references remain in the updated 310P image paths
- Validated `.github/workflows/scripts/runner_label.json` parses successfully
- Ran `git diff --check upstream/main..HEAD`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
