### PR TITLE
[BugFix][SpecDecode] Keep draft lm_head for DFlash with reduced (d2t) vocab

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -334,13 +334,30 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
         if self.method in ("eagle", "dflash"):
-            logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
-            if hasattr(model, "lm_head"):
-                self.model.lm_head = model.lm_head
-            elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
-                self.model.lm_head = model.get_language_model().lm_head
+            # For DFlash drafters trained with a reduced draft vocabulary, the
+            # draft model ships its own lm_head of shape [draft_vocab_size,
+            # hidden] whose rows map to a trained subset of the target vocab via
+            # the draft_id_to_target_id (d2t) buffer. Overwriting it with the
+            # target lm_head ([target_vocab_size, hidden]) makes the draft emit
+            # logits over the wrong vocabulary, so the verifier rejects almost
+            # every speculative token. Keep the draft's own lm_head in that case.
+            draft_has_own_lm_head = (
+                self.method == "dflash"
+                and getattr(self.model, "draft_id_to_target_id", None) is not None
+            )
+            if draft_has_own_lm_head:
+                logger.info(
+                    "DFlash draft uses d2t vocab remapping; keeping the draft's "
+                    "own lm_head instead of sharing the target lm_head."
+                )
             else:
-                logger.warning("Target model has no accessible lm_head for sharing.")
+                logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
+                if hasattr(model, "lm_head"):
+                    self.model.lm_head = model.lm_head
+                elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
+                    self.model.lm_head = model.get_language_model().lm_head
+                else:
+                    logger.warning("Target model has no accessible lm_head for sharing.")
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():


### PR DESCRIPTION
### What this PR does / why we need it?

`AscendSpecDecodeBaseProposer._maybe_share_lm_head` (`vllm_ascend/spec_decode/llm_base_proposer.py`) unconditionally replaced the draft model's `lm_head` with the **target** model's `lm_head` for `method in ("eagle", "dflash")`.

DFlash speculators trained with a **reduced draft vocabulary** ship their own `lm_head` of shape `[draft_vocab_size, hidden]` whose rows map to a trained subset of the target vocabulary via the `draft_id_to_target_id` (d2t) buffer. Example: `RedHatAI/Qwen3-8B-speculator.dflash` has `draft_vocab_size=32000` vs target `vocab_size=151936`.

Overwriting that head with the target `lm_head` (`[151936, hidden]`) made the draft produce logits over the **wrong vocabulary**. After `Qwen3DFlashForCausalLM.compute_logits` applies the d2t scatter, the token ids no longer correspond to the draft's trained vocab, so the verifier rejected almost every speculative token and draft acceptance collapsed to ~1%.

The fix gates the share on the presence of a d2t mapping: when a `dflash` draft exposes a non-`None` `draft_id_to_target_id`, keep its own `lm_head`; otherwise share the target `lm_head` exactly as before.

EAGLE / EAGLE3 / MTP / full-vocab DFlash drafters (where `draft_id_to_target_id` is `None`) are unaffected — they hit the unchanged share path.

Related: #9681 recently skipped `test_dflash_acceptance` as "broken by vllm main". This addresses the reduced-vocab DFlash acceptance collapse.

### Does this PR introduce _any_ user-facing change?

No API change. Behavior change is limited to reduced-vocab DFlash drafters: they now retain their own `lm_head` (one extra `[draft_vocab_size, hidden]` tensor kept, ~250 MB for the 32k RedHat head) instead of having it overwritten. An additional `logger.info` line is emitted on that path. All other speculative methods are byte-for-byte unchanged.

### How was this patch tested?

Manual validation on Ascend 910B4-1 (single card, TP=1, `enforce_eager=True`, `temperature=0`, `num_speculative_tokens=7`) with `RedHatAI/Qwen3-8B-speculator.dflash` drafting for a `Qwen3-8B` verifier.

**Bug impact** — without the fix, reduced-vocab DFlash draft acceptance collapses to **~1%** (near-zero speculative benefit). With the fix it returns to healthy acceptance.

**Parity vs the published H100 reference** — RedHat's model-card numbers were measured with reasoning enabled, so the comparison below uses the **same harness** (Qwen3 chat template, `enable_thinking=True`, greedy). Per-position draft acceptance, NPU (910B) vs the H100 model-card numbers:

| Dataset | Metric | NPU 910B (this fix) | H100 (model card) | NPU / H100 |
|---|---|---|---|---|
| HumanEval | Pos1 acceptance | 0.800 | 0.799 | **100%** |
| HumanEval | mean accept length | 3.30 | 3.41 | 97% |
| GSM8K (math) | Pos1 acceptance | 0.841 | 0.822 | **102%** |
| GSM8K (math) | mean accept length | 3.82 | 3.74 | **102%** |

On GSM8K, NPU per-position acceptance is within 102–104% of the H100 reference at every one of the 7 positions; on HumanEval Pos1 matches exactly. Outputs are coherent (no NaN; zero empty completions).

The fix was validated on **two** vllm-ascend layouts with statistically identical acceptance (≤0.5pp per position): the installed `49b6396c` (where `_maybe_share_lm_head` lives in `eagle_proposer.py`) and the exact `fac8784` / `llm_base_proposer.py` layout this PR targets (HumanEval aggregate 25.6% vs 25.6%, math 34.0% vs 34.3% under a fixed greedy harness).

AI assistance (Claude) was used in producing this change; the diff and validation were reviewed line-by-line.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
