### PR TITLE
[Performance] Optimize NGRAM with padding for full_decode_only dispatch

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1786,6 +1786,49 @@ class NPUModelRunner(GPUModelRunner):
                 num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
                 max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
 
+                # For ngram_gpu with full cudagraph: pad num_scheduled_tokens_np
+                # to uniform_decode_query_len so FULL dispatch has enough
+                # request slots. Skip padding in PIECEWISE / NONE (eager) modes
+                # since there is no FULL dispatch to benefit from.
+                if (
+                    self.speculative_config is not None
+                    and self.speculative_config.use_ngram_gpu()
+                    and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+                    and max_num_scheduled_tokens >= 1
+                    and max_num_scheduled_tokens <= self.uniform_decode_query_len
+                    and not np.all(num_scheduled_tokens_np == self.uniform_decode_query_len)
+                ):
+                    target_ql = self.uniform_decode_query_len
+                    num_padding_tokens: dict[str, int] = {}
+                    for i in range(num_reqs):
+                        if num_scheduled_tokens_np[i] < target_ql:
+                            pad_count = target_ql - int(num_scheduled_tokens_np[i])
+                            req_id = req_ids[i]
+                            last_token = int(self.input_batch.token_ids_cpu[
+                                i,
+                                self.input_batch.num_computed_tokens_cpu[i]
+                                + int(num_scheduled_tokens_np[i]) - 1
+                            ])
+                            dummy_draft = [last_token] * pad_count
+                            if req_id in scheduler_output.scheduled_spec_decode_tokens:
+                                scheduler_output.scheduled_spec_decode_tokens[req_id].extend(dummy_draft)
+                            else:
+                                scheduler_output.scheduled_spec_decode_tokens[req_id] = dummy_draft
+                            num_padding_tokens[req_id] = pad_count
+                            num_scheduled_tokens_np[i] = target_ql
+                    scheduler_output.total_num_scheduled_tokens = int(num_scheduled_tokens_np.sum())
+                    max_num_scheduled_tokens = target_ql
+
+                    # Record padding counts so scheduler can exclude dummy
+                    # drafts from acceptance rate statistics.
+                    if num_padding_tokens:
+                        if scheduler_output.num_invalid_spec_tokens is None:
+                            scheduler_output.num_invalid_spec_tokens = {}
+                        for rid, cnt in num_padding_tokens.items():
+                            scheduler_output.num_invalid_spec_tokens[rid] = (
+                                scheduler_output.num_invalid_spec_tokens.get(rid, 0) + cnt
+                            )
+
                 (
                     logits_indices,
                     spec_decode_metadata,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1816,6 +1816,7 @@ class NPUModelRunner(GPUModelRunner):
                                 scheduler_output.scheduled_spec_decode_tokens[req_id] = dummy_draft
                             num_padding_tokens[req_id] = pad_count
                             num_scheduled_tokens_np[i] = target_ql
+                            scheduler_output.num_scheduled_tokens[req_id] = target_ql
                     scheduler_output.total_num_scheduled_tokens = int(num_scheduled_tokens_np.sum())
                     max_num_scheduled_tokens = target_ql
 


### PR DESCRIPTION
### What this PR does / why we need it?

When ngram_gpu speculation is used together with full-decode-only graphs,
requests with varying scheduled token counts prevent the FULL dispatch
path from being utilized, falling back to less efficient PIECEWISE or
NONE (eager) modes.

This change pads `num_scheduled_tokens_np` to `uniform_decode_query_len`
so that every decode step can dispatch through the full cudagraph path.
Under-filled requests are padded with repeated `[last_token]` as dummy
drafts, and the padding count is recorded in
`num_invalid_spec_tokens` so the scheduler can exclude them from
acceptance rate statistics.

**Before — Mean TPOT (ms): 48.94**
**After  — Mean TPOT (ms): 25.17**

This yields a ~48% latency reduction on Ascend NPU for ngram_gpu
speculative decoding with full cudagraphs enabled.

### Does this PR introduce _any_ user-facing change?

No, this is an internal optimization with no user-facing changes.

### How was this patch tested?

Startup command:

```bash
vllm serve /data/models/Qwen/Qwen3-8B \
    --host 0.0.0.0 --port 8402 \
    --trust-remote-code \
    --tensor-parallel-size 1 --data-parallel-size 1 \
    --seed 42 \
    --max_num_seqs 32 \
    --max_model_len 40960 --max_num_batched_tokens 16384 \
    --gpu-memory-utilization 0.92 \
    --speculative-config '{"method": "ngram_gpu", "num_speculative_tokens": 3}' \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
Benchmark command:

vllm bench serve \
    --host "0.0.0.0" --port 8402 \
    --model /data/models/Qwen/Qwen3-8B \
    --dataset-name spec_bench \
    --max-concurrency 10 \
    --dataset-path /data/code/SpecEval/datasets/spec_bench/question.jsonl \
    --trust-remote-code \
    --num-prompts 200 \
    --temperature 0.0
Results show Mean TPOT improved from 48.94 ms to 25.17 ms (48% reduction).

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
