### PR TITLE
[BugFix]fix hybrid block table out of range bug when pcp or dcp

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1_with_device.py
+++ b/tests/ut/worker/a2/test_model_runner_v1_with_device.py
@@ -1,8 +1,8 @@
 import os
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from unittest.mock import MagicMock, patch
 from vllm.config import (
     CacheConfig,
     CUDAGraphMode,
@@ -98,7 +98,7 @@ def model_runner():
     with (
         set_current_vllm_config(vllm_config),
         patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group,
-        patch("vllm_ascend.worker.block_table.get_pcp_group") as mock_get_pcp_group
+        patch("vllm_ascend.worker.block_table.get_pcp_group") as mock_get_pcp_group,
     ):
         mock_dcp_group = MagicMock(spec=GroupCoordinator)
         mock_dcp_group.world_size = 1

--- a/tests/ut/worker/a2/test_model_runner_v1_with_device.py
+++ b/tests/ut/worker/a2/test_model_runner_v1_with_device.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pytest
+from unittest.mock import MagicMock, patch
 from vllm.config import (
     CacheConfig,
     CUDAGraphMode,
@@ -11,6 +12,7 @@ from vllm.config import (
     VllmConfig,
     set_current_vllm_config,
 )
+from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.model_executor.layers.attention import Attention
 from vllm.platforms import current_platform
 from vllm.v1.kv_cache_interface import (
@@ -93,7 +95,20 @@ def get_vllm_config():
 @pytest.fixture
 def model_runner():
     vllm_config = get_vllm_config()
-    with set_current_vllm_config(vllm_config):
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group,
+        patch("vllm_ascend.worker.block_table.get_pcp_group") as mock_get_pcp_group
+    ):
+        mock_dcp_group = MagicMock(spec=GroupCoordinator)
+        mock_dcp_group.world_size = 1
+        mock_dcp_group.rank_in_group = 0
+        mock_get_dcp_group.return_value = mock_dcp_group
+        mock_pcp_group = MagicMock(spec=GroupCoordinator)
+        mock_pcp_group.world_size = 1
+        mock_pcp_group.rank_in_group = 0
+        mock_get_pcp_group.return_value = mock_pcp_group
+
         model_config = vllm_config.model_config
         num_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
         head_size = model_config.get_head_size()

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -3,7 +3,7 @@ import torch
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec
+from vllm.v1.kv_cache_interface import KVCacheGroupSpec, MambaSpec
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.block_table import _compute_slot_mapping_kernel
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
@@ -24,20 +24,6 @@ class BlockTable:
         kv_cache_group: KVCacheGroupSpec = None,
     ):
         self.max_num_reqs = max_num_reqs
-        compress_ratio = 1
-        if (
-            kv_cache_group is not None
-            and hasattr(kv_cache_group, "kv_cache_spec")
-            and hasattr(kv_cache_group.kv_cache_spec, "compress_ratio")
-        ):
-            compress_ratio = kv_cache_group.kv_cache_spec.compress_ratio
-        max_num_blocks_per_req = max(cdiv(max_num_blocks_per_req, compress_ratio), 1)
-        self.max_num_blocks_per_req = max_num_blocks_per_req
-        self.max_num_batched_tokens = max_num_batched_tokens
-        self.pin_memory = pin_memory
-        self.device = device
-        self.physical_block_size = block_size
-
         try:
             self.pcp_world_size = get_pcp_group().world_size
             self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_world_size > 1 else 0
@@ -49,6 +35,26 @@ class BlockTable:
             self.dcp_rank = 0
             self.pcp_world_size = 1
             self.pcp_rank = 0
+        compress_ratio = 1
+        if (
+            kv_cache_group is not None
+            and hasattr(kv_cache_group, "kv_cache_spec")
+            and hasattr(kv_cache_group.kv_cache_spec, "compress_ratio")
+        ):
+            compress_ratio = kv_cache_group.kv_cache_spec.compress_ratio
+        if (
+            kv_cache_group is not None
+            and hasattr(kv_cache_group, "kv_cache_spec")
+            and (self.pcp_world_size * self.dcp_world_size > 1)
+            and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
+        ):
+            max_num_blocks_per_req = max_num_blocks_per_req * self.pcp_world_size * self.dcp_world_size
+        max_num_blocks_per_req = max(cdiv(max_num_blocks_per_req, compress_ratio), 1)
+        self.max_num_blocks_per_req = max_num_blocks_per_req
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.pin_memory = pin_memory
+        self.device = device
+        self.physical_block_size = block_size
 
         # If kernel_sizes is None or [0], use physical block size (no splitting)
         if kernel_sizes is None or kernel_sizes == [0]:

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -24,17 +24,10 @@ class BlockTable:
         kv_cache_group: KVCacheGroupSpec = None,
     ):
         self.max_num_reqs = max_num_reqs
-        try:
-            self.pcp_world_size = get_pcp_group().world_size
-            self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_world_size > 1 else 0
-            self.dcp_world_size = get_dcp_group().world_size
-            self.dcp_rank = get_dcp_group().rank_in_group
-        except AssertionError:
-            # DCP might not be initialized in testing
-            self.dcp_world_size = 1
-            self.dcp_rank = 0
-            self.pcp_world_size = 1
-            self.pcp_rank = 0
+        self.pcp_world_size = get_pcp_group().world_size
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_world_size > 1 else 0
+        self.dcp_world_size = get_dcp_group().world_size
+        self.dcp_rank = get_dcp_group().rank_in_group
         compress_ratio = 1
         if (
             kv_cache_group is not None


### PR DESCRIPTION
### What this PR does / why we need it?
Fix the block table out-of-bounds issue in scenarios where PCP or DCP hybrid linear encoding is applied.

In the PCP or DCP mixed linear scenario, the kv cache of full attention is partitioned, while the Mamba layer remains intact. Therefore, when applying for blocks, the Mamba does not need to divide by pcp_size/dcp_size.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
