### PR TITLE
[BugFix][310P] Repair 310P Qwen3.5 aclgraph precision

### DIFF
--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -88,6 +88,19 @@ class NPUModelRunner310(NPUModelRunner):
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.
             self.cudagraph_dispatcher.uniform_decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
 
+    def _update_states(self, scheduler_output: SchedulerOutput):
+        deferred = super()._update_states(scheduler_output)
+        if scheduler_output.finished_req_ids:
+            # condense() rewrites block_table.np (move_row). Drain the previous
+            # step's ACL graph replay on the NPU stream before the condensed
+            # CPU layout is uploaded and read as attn_metadata.block_tables.
+            # Main-line Ascend relies on the end-of-_prepare_inputs Triton
+            # slot-mapping kernel (reads block_table.gpu) for stream ordering;
+            # 310P uses CPU NumPy for slot_mapping and needs this barrier on
+            # layout-change steps only.
+            torch.npu.current_stream().synchronize()
+        return deferred
+
     @contextmanager
     def temporary_modify_uniform_decode_query_len(self):
         # This is only needed for the 310P ngram path where dispatcher uses q_len=1


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes incorrect outputs (garbled text) on Ascend 310P when running FULL_DECODE_ONLY ACL graph decode, typically at the first request finish + batch condense step

Root cause: 310P computes slot_mapping from CPU block_table.np (_310p/block_table.py), while paged-attention metadata reads block_table.gpu via get_device_tensor(). Main-line Ascend avoids this desync because the Triton slot-mapping kernel at the end of _prepare_inputs reads block_table.gpu on the same NPU stream after async H2D from commit_block_table(), establishing implicit ordering before metadata build. 310P has no equivalent GPU consumer.

When a request finishes, condense() rewrites CPU block_table rows (move_row), but the previous step’s ACL graph replay may still be in flight and/or GPU block_table may not reflect the condensed layout when PA metadata is built—leading to seq_lens and block_tables pointing at different batch layouts.

Fix: Override _update_states() in NPUModelRunner310 to call torch.npu.current_stream().synchronize() only when finished_req_ids is non-empty (layout-change steps). This drains in-flight graph replay after condense() and before the condensed CPU block table is uploaded and consumed by PA metadata.
RFC #9730
RFC #9711 
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
