### PR TITLE
[BugFix] Update DeepSeek V4 tool-call and thinking patches

### DIFF
--- a/tests/ut/patch/platform/test_patch_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v4_thinking.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.tokenizers import deepseek_v4
+
+from vllm_ascend.patch.platform import patch_deepseek_v4_thinking  # noqa: F401
+
+
+class FakeTokenizer:
+    vocab_size = 1
+
+    def get_added_vocab(self):
+        return {}
+
+    def encode(self, text, add_special_tokens=False, **kwargs):
+        return text
+
+
+def test_deepseek_v4_reasoning_effort_accepts_latest_values():
+    for reasoning_effort in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
+        request = ChatCompletionRequest(
+            model="deepseek-v4",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort=reasoning_effort,
+        )
+        assert request.reasoning_effort == reasoning_effort
+
+
+def test_reasoning_effort_enables_thinking_unless_user_overrides():
+    request = ChatCompletionRequest(
+        model="deepseek-v4",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="high",
+    )
+    params = request.build_chat_params(None, "auto")
+    assert params.chat_template_kwargs["enable_thinking"] is True
+
+    request = ChatCompletionRequest(
+        model="deepseek-v4",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="none",
+    )
+    params = request.build_chat_params(None, "auto")
+    assert params.chat_template_kwargs["enable_thinking"] is False
+
+    request = ChatCompletionRequest(
+        model="deepseek-v4",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="high",
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    params = request.build_chat_params(None, "auto")
+    assert params.chat_template_kwargs["enable_thinking"] is False
+
+
+def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
+    captured_kwargs = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_kwargs.append(kwargs)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+
+    cases = [
+        ("none", "chat", None),
+        ("minimal", "thinking", "high"),
+        ("low", "thinking", "high"),
+        ("medium", "thinking", "high"),
+        ("high", "thinking", "high"),
+        ("xhigh", "thinking", "max"),
+        ("max", "thinking", "max"),
+        ("unexpected", "thinking", "high"),
+    ]
+    for reasoning_effort, expected_mode, expected_effort in cases:
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "hi"}],
+            tokenize=False,
+            enable_thinking=True,
+            reasoning_effort=reasoning_effort,
+        )
+        assert captured_kwargs[-1]["thinking_mode"] == expected_mode
+        assert captured_kwargs[-1]["reasoning_effort"] == expected_effort

--- a/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
@@ -47,6 +47,7 @@ def _stream(
     parser: DeepSeekV4ToolParser,
     full_text: str,
     chunk_size: int = 5,
+    tools=None,
 ):
     deltas = []
     previous_text = ""
@@ -63,7 +64,7 @@ def _stream(
             request=ChatCompletionRequest(
                 model="deepseek-ai/DeepSeek-V2-Chat",
                 messages=[],
-                tools=[_tools()],
+                tools=tools or [_tools()],
             ),
         )
         previous_text = current_text
@@ -227,6 +228,118 @@ def test_streaming_full_tool_call_single_chunk_drains_all_deltas():
         "flexible": False,
         "cities": ["Beijing", "Shanghai"],
         "notes": "靠窗座位",
+    }
+
+
+def test_streaming_matches_non_streaming_conversion_fallbacks():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "coerce",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "union_value": {"type": ["null", "string"]},
+                        "bad_int": {"type": "integer"},
+                        "nullable_string": {"type": ["null", "string"]},
+                        "null_string": {"type": "string"},
+                        "whole_number": {"type": "number"},
+                    },
+                },
+            },
+        }
+    ]
+    full_text = (
+        f"{TC_START}\n"
+        f'{INV_START}coerce">\n'
+        f'{PARAM_START}union_value" string="false">hello{PARAM_END}\n'
+        f'{PARAM_START}bad_int" string="false">abc{PARAM_END}\n'
+        f'{PARAM_START}nullable_string" string="false">null{PARAM_END}\n'
+        f'{PARAM_START}null_string" string="false">null{PARAM_END}\n'
+        f'{PARAM_START}whole_number" string="false">3.0{PARAM_END}\n'
+        f"{INV_END}\n"
+        f"{TC_END}"
+    )
+    request = ChatCompletionRequest(
+        model="deepseek-ai/DeepSeek-V2-Chat",
+        messages=[],
+        tools=tools,
+    )
+
+    non_streaming = DeepSeekV4ToolParser(MOCK_TOKENIZER).extract_tool_calls(full_text, request)
+    deltas = _stream(DeepSeekV4ToolParser(MOCK_TOKENIZER), full_text, chunk_size=4, tools=tools)
+
+    stream_args = json.loads(
+        "".join(
+            tc.function.arguments
+            for delta in deltas
+            for tc in delta.tool_calls or []
+            if tc.index == 0 and tc.function and tc.function.arguments is not None
+        )
+    )
+    expected = {
+        "union_value": "hello",
+        "bad_int": "abc",
+        "nullable_string": None,
+        "null_string": "null",
+        "whole_number": 3,
+    }
+    assert stream_args == expected
+    assert json.loads(non_streaming.tool_calls[0].function.arguments) == expected
+
+
+def test_composed_schema_conversion_in_streaming():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "set_timer",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "wait": {
+                            "anyOf": [
+                                {"type": "object"},
+                                {"type": "null"},
+                            ],
+                        },
+                        "patches": {
+                            "allOf": [
+                                {"type": "array", "items": {"type": "object"}},
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+    ]
+    full_text = (
+        f"{TC_START}\n"
+        f'{INV_START}set_timer">\n'
+        f'{PARAM_START}wait" string="false">'
+        f'{{"type":"for","minutes":2880}}'
+        f"{PARAM_END}\n"
+        f'{PARAM_START}patches" string="false">'
+        f'[{{"op":"replace","path":"/schedule","value":"quiet"}}]'
+        f"{PARAM_END}\n"
+        f"{INV_END}\n"
+        f"{TC_END}"
+    )
+
+    deltas = _stream(DeepSeekV4ToolParser(MOCK_TOKENIZER), full_text, chunk_size=5, tools=tools)
+    args = json.loads(
+        "".join(
+            tc.function.arguments
+            for delta in deltas
+            for tc in delta.tool_calls or []
+            if tc.index == 0 and tc.function and tc.function.arguments is not None
+        )
+    )
+
+    assert args == {
+        "wait": {"type": "for", "minutes": 2880},
+        "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
     }
 
 

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -267,6 +267,26 @@
 #       Remove this patch if upstream streaming behavior is updated to satisfy the
 #       same DeepSeek DSML incrementality contract.
 #
+# ** 12a. File: platform/patch_deepseek_v4_thinking.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionRequest`
+#      `vllm.tokenizers.deepseek_v4`
+#    Why:
+#       Supported vLLM v0.20.2 predates newer DeepSeek V4 reasoning-effort
+#       handling: `minimal`, `xhigh`, and `max` are rejected at request
+#       validation time, reasoning effort does not automatically enable
+#       thinking, and `reasoning_effort="none"` does not force chat mode in
+#       the DeepSeek V4 tokenizer.
+#    How:
+#       Extend the request field validation to the newer accepted values,
+#       backport the newer `build_chat_params` enable_thinking behavior, and
+#       monkey-patch the DeepSeek V4 tokenizer reasoning-effort mapping.
+#    Related PR (if no, explain why):
+#       Upstream vLLM main behavior after v0.20.2.
+#    Future Plan:
+#       Remove this patch once vllm-ascend upgrades to a vLLM version with the
+#       same DeepSeek V4 thinking behavior.
+#
 # ** 13. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.is_cumem_allocator_available`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -31,6 +31,7 @@ else:
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -1,0 +1,153 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# DeepSeek V4 thinking compatibility with newer vLLM request/tokenizer behavior.
+#
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Literal
+
+from transformers import PreTrainedTokenizerFast
+from vllm.entrypoints.openai.chat_completion import protocol as chat_protocol
+from vllm.renderers.params import ChatParams
+from vllm.tokenizers import deepseek_v4 as deepseek_v4_tokenizer
+
+DeepSeekV4ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"] | None
+
+
+def _rebuild_model_field(model_cls, field_name: str, annotation) -> None:
+    model_cls.__annotations__[field_name] = annotation
+    model_cls.model_fields[field_name].annotation = annotation
+    model_cls.model_rebuild(force=True)
+
+
+_rebuild_model_field(
+    chat_protocol.ChatCompletionRequest,
+    "reasoning_effort",
+    DeepSeekV4ReasoningEffort,
+)
+
+_original_build_chat_params = chat_protocol.ChatCompletionRequest.build_chat_params
+
+
+def _patched_build_chat_params(
+    self: chat_protocol.ChatCompletionRequest,
+    default_template: str | None,
+    default_template_content_format,
+) -> ChatParams:
+    params = _original_build_chat_params(
+        self,
+        default_template,
+        default_template_content_format,
+    )
+    user_kwargs = self.chat_template_kwargs or {}
+    if self.reasoning_effort is None or "enable_thinking" in user_kwargs:
+        return params
+
+    chat_template_kwargs = dict(params.chat_template_kwargs)
+    chat_template_kwargs["enable_thinking"] = self.reasoning_effort != "none"
+    return ChatParams(
+        chat_template=params.chat_template,
+        chat_template_content_format=params.chat_template_content_format,
+        chat_template_kwargs=chat_template_kwargs,
+        media_io_kwargs=params.media_io_kwargs,
+        mm_processor_kwargs=params.mm_processor_kwargs,
+    )
+
+
+chat_protocol.ChatCompletionRequest.build_chat_params = _patched_build_chat_params
+
+
+def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4_tokenizer.HfTokenizer):
+    dsv4_tokenizer = copy.copy(tokenizer)
+
+    added_vocab = tokenizer.get_added_vocab()
+    added_vocab_size = len(added_vocab)
+    tokenizer_vocab_size = tokenizer.vocab_size
+
+    class _DeepseekV4Tokenizer(tokenizer.__class__):  # type: ignore
+        def apply_chat_template(
+            self,
+            messages: list[chat_protocol.ChatCompletionMessageParam],
+            tools: list[dict[str, Any]] | None = None,
+            **kwargs,
+        ) -> str | list[int]:
+            thinking = kwargs.get("thinking", False)
+            enable_thinking = kwargs.get("enable_thinking", False)
+            thinking = thinking or enable_thinking
+            thinking_mode = "thinking" if thinking else "chat"
+
+            conversation = kwargs.get("conversation", messages)
+            messages = conversation.copy()
+            if tools is not None and len(tools) > 0:
+                messages.insert(0, {"role": "system"})
+                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+
+            reasoning_effort = kwargs.get("reasoning_effort")
+            if not isinstance(reasoning_effort, str):
+                reasoning_effort = None
+            elif reasoning_effort == "none":
+                thinking_mode = "chat"
+                reasoning_effort = None
+            elif reasoning_effort in ("max", "xhigh"):
+                reasoning_effort = "max"
+            else:
+                reasoning_effort = "high"
+
+            prompt_str = deepseek_v4_tokenizer.encode_messages(
+                messages,
+                thinking_mode=thinking_mode,
+                drop_thinking=kwargs.get("drop_thinking", True),
+                reasoning_effort=reasoning_effort,
+            )
+
+            if kwargs.get("tokenize", True):
+                tokenizer_kwargs = {k: kwargs[k] for k in ("truncation", "max_length") if k in kwargs}
+                return self.encode(
+                    prompt_str,
+                    add_special_tokens=False,
+                    **tokenizer_kwargs,
+                )
+
+            return prompt_str
+
+        def num_special_tokens_to_add(self) -> int:
+            return len(self.encode(""))
+
+        def __len__(self) -> int:
+            return tokenizer_vocab_size + added_vocab_size
+
+        def get_added_vocab(self) -> dict[str, int]:
+            return added_vocab.copy()
+
+        def __reduce__(self):
+            return _patched_get_deepseek_v4_tokenizer, (tokenizer,)
+
+    _DeepseekV4Tokenizer.__name__ = f"DSV4{tokenizer.__class__.__name__}"
+
+    dsv4_tokenizer.__class__ = _DeepseekV4Tokenizer
+    return dsv4_tokenizer
+
+
+def _patched_deepseek_v4_from_pretrained(cls, *args, **kwargs):
+    tokenizer = PreTrainedTokenizerFast.from_pretrained(*args, **kwargs)
+    return deepseek_v4_tokenizer.get_cached_tokenizer(_patched_get_deepseek_v4_tokenizer(tokenizer))
+
+
+deepseek_v4_tokenizer.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer
+deepseek_v4_tokenizer.DeepseekV4Tokenizer.from_pretrained = classmethod(_patched_deepseek_v4_from_pretrained)

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py
@@ -31,10 +31,30 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
 )
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
 
 ESCAPED_ARGUMENTS_PARAM_NAME = "__vllm_param_arguments__"
+
+
+def _ensure_parser_regexes(self: DeepSeekV4ToolParser) -> None:
+    self.tool_call_complete_regex = re.compile(
+        re.escape(self.tool_call_start_token) + r"(.*?)" + re.escape(self.tool_call_end_token),
+        re.DOTALL,
+    )
+    self.invoke_complete_regex = re.compile(
+        r'<｜DSML｜invoke\s+name="([^"]+)"\s*>(.*?)</｜DSML｜invoke>',
+        re.DOTALL,
+    )
+    self.parameter_complete_regex = re.compile(
+        r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)"\s*>(.*?)</｜DSML｜parameter>',
+        re.DOTALL,
+    )
+    self.parameter_start_regex = re.compile(r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)"\s*>')
+    self.invoke_start_regex = re.compile(r'<｜DSML｜invoke\s+name="([^"]+)"\s*>')
 
 
 def _partial_tag_overlap(text: str, tag: str) -> int:
@@ -65,25 +85,7 @@ def _ensure_streaming_attrs(self: DeepSeekV4ToolParser) -> None:
     if not hasattr(self, "_pending_delta_messages"):
         self._pending_delta_messages = deque()
 
-    if not hasattr(self, "tool_call_complete_regex"):
-        self.tool_call_complete_regex = re.compile(
-            re.escape(self.tool_call_start_token) + r"(.*?)" + re.escape(self.tool_call_end_token),
-            re.DOTALL,
-        )
-    if not hasattr(self, "invoke_complete_regex"):
-        self.invoke_complete_regex = re.compile(
-            r'<｜DSML｜invoke\s+name="([^"]+)"\s*>(.*?)</｜DSML｜invoke>',
-            re.DOTALL,
-        )
-    if not hasattr(self, "parameter_complete_regex"):
-        self.parameter_complete_regex = re.compile(
-            r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)"\s*>(.*?)</｜DSML｜parameter>',
-            re.DOTALL,
-        )
-    if not hasattr(self, "parameter_start_regex"):
-        self.parameter_start_regex = re.compile(r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)"\s*>')
-    if not hasattr(self, "invoke_start_regex"):
-        self.invoke_start_regex = re.compile(r'<｜DSML｜invoke\s+name="([^"]+)"\s*>')
+    _ensure_parser_regexes(self)
 
     if not hasattr(self, "current_tool_index"):
         self.current_tool_index = 0
@@ -109,6 +111,117 @@ def _function_parameters(tool):
             return function.get("parameters")
         return getattr(function, "parameters", None)
     return getattr(getattr(tool, "function", None), "parameters", None)
+
+
+def _extract_types_from_schema(schema: Any) -> list[str]:
+    if schema is None or not isinstance(schema, dict):
+        return ["string"]
+
+    types: set[str] = set()
+    type_value = schema.get("type")
+    if isinstance(type_value, str):
+        types.add(type_value)
+    elif isinstance(type_value, list):
+        types.update(t for t in type_value if isinstance(t, str))
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and enum_values:
+        for value in enum_values:
+            if value is None:
+                types.add("null")
+            elif isinstance(value, bool):
+                types.add("boolean")
+            elif isinstance(value, int):
+                types.add("integer")
+            elif isinstance(value, float):
+                types.add("number")
+            elif isinstance(value, str):
+                types.add("string")
+            elif isinstance(value, list):
+                types.add("array")
+            elif isinstance(value, dict):
+                types.add("object")
+
+    for choice_field in ("anyOf", "oneOf", "allOf"):
+        choices = schema.get(choice_field)
+        if isinstance(choices, list):
+            for choice in choices:
+                types.update(_extract_types_from_schema(choice))
+
+    return list(types) if types else ["string"]
+
+
+_TYPE_ALIASES: dict[str, str] = {
+    "str": "string",
+    "text": "string",
+    "varchar": "string",
+    "char": "string",
+    "enum": "string",
+    "int": "integer",
+    "int32": "integer",
+    "int64": "integer",
+    "uint": "integer",
+    "uint32": "integer",
+    "uint64": "integer",
+    "long": "integer",
+    "short": "integer",
+    "unsigned": "integer",
+    "float": "number",
+    "float32": "number",
+    "float64": "number",
+    "double": "number",
+    "bool": "boolean",
+    "dict": "object",
+    "arr": "array",
+    "list": "array",
+    "sequence": "array",
+}
+
+
+def _coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
+    if isinstance(schema_type, str):
+        schema_type = [schema_type]
+
+    normalized_types = {_TYPE_ALIASES.get(key, key) for t in schema_type for key in [t.strip().lower()]}
+
+    for candidate_type in ("null", "integer", "number", "boolean", "object", "array", "string"):
+        if candidate_type not in normalized_types:
+            continue
+
+        if candidate_type == "null":
+            if value.lower() == "null":
+                return None
+            continue
+        if candidate_type == "string":
+            return value
+        if candidate_type == "integer":
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+        if candidate_type == "number":
+            try:
+                val = float(value)
+                return val if val != int(val) else int(val)
+            except (TypeError, ValueError):
+                continue
+        if candidate_type == "boolean":
+            lower_val = value.lower().strip()
+            if lower_val in ("true", "1"):
+                return True
+            if lower_val in ("false", "0"):
+                return False
+            continue
+        if candidate_type in ("object", "array"):
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
 
 
 def _convert_param_value_checked(value: str, param_type: str) -> Any:
@@ -175,7 +288,7 @@ def _coerce_param_value(
     if string_attr == "true":
         return value
     if param_type:
-        return _convert_param_value(self, value, param_type)
+        return _coerce_to_schema_type(value, param_type)
     try:
         return json.loads(value)
     except json.JSONDecodeError:
@@ -207,6 +320,7 @@ def _parse_invoke_params(
     request: ChatCompletionRequest | None = None,
     function_name: str | None = None,
 ) -> dict:
+    _ensure_parser_regexes(self)
     param_config = _get_param_config(self, request, function_name)
     param_dict = {}
     for param_name, string_attr, param_val in self.parameter_complete_regex.findall(invoke_str):
@@ -214,9 +328,9 @@ def _parse_invoke_params(
         param_name = _extract_param_name(param_name)
         param_type = None
         if original_param_name == ESCAPED_ARGUMENTS_PARAM_NAME and "arguments" in param_config:
-            param_type = param_config["arguments"].get("type")
+            param_type = _extract_types_from_schema(param_config["arguments"])
         elif param_name in param_config and isinstance(param_config[param_name], dict):
-            param_type = param_config[param_name].get("type")
+            param_type = _extract_types_from_schema(param_config[param_name])
 
         param_dict[param_name] = _coerce_param_value(
             self,
@@ -226,6 +340,44 @@ def _parse_invoke_params(
         )
 
     return _repair_param_dict(param_dict, param_config)
+
+
+def _patched_extract_tool_calls(
+    self: DeepSeekV4ToolParser,
+    model_output: str,
+    request: ChatCompletionRequest,
+) -> ExtractedToolCallInformation:
+    if self.tool_call_start_token not in model_output:
+        return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=model_output)
+
+    try:
+        _ensure_parser_regexes(self)
+        tool_calls = []
+        for tool_call_match in self.tool_call_complete_regex.findall(model_output):
+            for invoke_name, invoke_content in self.invoke_complete_regex.findall(tool_call_match):
+                params = _parse_invoke_params(self, invoke_content, request, invoke_name)
+                tool_calls.append(
+                    ToolCall(
+                        type="function",
+                        function=FunctionCall(
+                            name=invoke_name,
+                            arguments=json.dumps(params, ensure_ascii=False),
+                        ),
+                    )
+                )
+
+        if not tool_calls:
+            return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=model_output)
+
+        first_tool_idx = model_output.find(self.tool_call_start_token)
+        content = model_output[:first_tool_idx] if first_tool_idx > 0 else None
+        return ExtractedToolCallInformation(
+            tools_called=True,
+            tool_calls=tool_calls,
+            content=content,
+        )
+    except Exception:
+        return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=model_output)
 
 
 def _reset_streaming_state(self: DeepSeekV4ToolParser) -> None:
@@ -372,6 +524,38 @@ def _append_raw_param_value(
     self._queue_delta_message(self._emit_tool_args_delta(index, frag))
 
 
+def _param_types_for_name(
+    self: DeepSeekV4ToolParser,
+    name: str,
+    request: ChatCompletionRequest | None,
+) -> list[str]:
+    param_config = _get_param_config(self, request, self._active_tool_name)
+    if name in param_config and isinstance(param_config[name], dict):
+        return _extract_types_from_schema(param_config[name])
+    return ["string"]
+
+
+def _can_stream_raw_param(param_types: list[str]) -> bool:
+    return set(param_types).issubset({"object", "array"})
+
+
+def _finish_buffered_param(
+    self: DeepSeekV4ToolParser,
+    index: int,
+    request: ChatCompletionRequest | None,
+) -> None:
+    key = self._streaming_param_key
+    if key is None:
+        return
+
+    raw_value = "".join(self._streaming_param_raw_parts)
+    param_types = _param_types_for_name(self, key, request)
+    value = _coerce_to_schema_type(raw_value, param_types)
+    _append_json_param_value(self, index, key, value)
+    self._streaming_param_key = None
+    self._streaming_param_raw_parts.clear()
+
+
 def _should_buffer_wrapper_param(self: DeepSeekV4ToolParser, key: str, request: ChatCompletionRequest | None) -> bool:
     if self._args_started[self._active_tool_index]:
         return False
@@ -495,6 +679,9 @@ def _process_streaming_buffer(self: DeepSeekV4ToolParser, request: ChatCompletio
                 if self._streaming_param_mode.startswith("wrapper_"):
                     self._streaming_param_raw_parts.append(raw_content)
                     _finish_buffered_wrapper_param(self, index, request)
+                elif self._streaming_param_mode == "buffered_json":
+                    self._streaming_param_raw_parts.append(raw_content)
+                    _finish_buffered_param(self, index, request)
                 elif self._streaming_param_mode == "string":
                     frag = _json_escape_string_content(raw_content) + '"'
                     self._queue_delta_message(self._emit_tool_args_delta(index, frag))
@@ -509,7 +696,7 @@ def _process_streaming_buffer(self: DeepSeekV4ToolParser, request: ChatCompletio
             if safe_len > 0:
                 raw_content = self._buffer[:safe_len]
                 self._buffer = self._buffer[safe_len:]
-                if self._streaming_param_mode.startswith("wrapper_"):
+                if self._streaming_param_mode.startswith("wrapper_") or self._streaming_param_mode == "buffered_json":
                     self._streaming_param_raw_parts.append(raw_content)
                 elif self._streaming_param_mode == "string":
                     frag = _json_escape_string_content(raw_content)
@@ -542,6 +729,14 @@ def _process_streaming_buffer(self: DeepSeekV4ToolParser, request: ChatCompletio
             self._streaming_param_raw_parts.clear()
             self._streaming_param_mode = "wrapper_string" if is_string else "wrapper_json"
             continue
+
+        if not is_string:
+            param_types = _param_types_for_name(self, key, request)
+            if not _can_stream_raw_param(param_types):
+                self._streaming_param_key = key
+                self._streaming_param_raw_parts.clear()
+                self._streaming_param_mode = "buffered_json"
+                continue
 
         _append_param_prefix(self, index, key, is_string=is_string)
         self._streaming_param_mode = "string" if is_string else "json"
@@ -584,6 +779,7 @@ DeepSeekV4ToolParser._get_param_config = _get_param_config
 DeepSeekV4ToolParser._coerce_param_value = _coerce_param_value
 DeepSeekV4ToolParser._repair_param_dict = _repair_param_dict
 DeepSeekV4ToolParser._parse_invoke_params = _parse_invoke_params
+DeepSeekV4ToolParser.extract_tool_calls = _patched_extract_tool_calls
 DeepSeekV4ToolParser._reset_streaming_state = _reset_streaming_state
 DeepSeekV4ToolParser._json_escape_string_content = _json_escape_string_content
 DeepSeekV4ToolParser.drain_pending_tool_call_deltas = _drain_pending_tool_call_deltas
@@ -595,6 +791,9 @@ DeepSeekV4ToolParser._begin_streaming_tool_call = _begin_streaming_tool_call
 DeepSeekV4ToolParser._append_param_prefix = _append_param_prefix
 DeepSeekV4ToolParser._append_json_param_value = _append_json_param_value
 DeepSeekV4ToolParser._append_raw_param_value = _append_raw_param_value
+DeepSeekV4ToolParser._param_types_for_name = _param_types_for_name
+DeepSeekV4ToolParser._can_stream_raw_param = _can_stream_raw_param
+DeepSeekV4ToolParser._finish_buffered_param = _finish_buffered_param
 DeepSeekV4ToolParser._should_buffer_wrapper_param = _should_buffer_wrapper_param
 DeepSeekV4ToolParser._finish_buffered_wrapper_param = _finish_buffered_wrapper_param
 DeepSeekV4ToolParser._close_streaming_tool_call = _close_streaming_tool_call


### PR DESCRIPTION
### What this PR does

This updates the existing vLLM Ascend DeepSeek V4 tool-call and thinking compatibility patches to align with latest upstream vLLM while staying compatible with the pinned vLLM v0.20.2 runtime.

Reference vLLM commit: vllm-project/vllm@1a096d82087bda7faaf4cad81d639419c4734869.

Changes include:
- keep `deepseek_v4` tool parser registration in the vLLM Ascend platform patch path;
- add local schema-type extraction/coercion logic needed because vLLM v0.20.2 does not expose the latest upstream helpers;
- align streaming and non-streaming DSML tool-call conversion fallback behavior, including scalar values such as `string="false"` for boolean parameters;
- preserve wrapper `arguments` repair behavior for DeepSeek V4 tool calls;
- update DeepSeek V4 thinking compatibility for latest `reasoning_effort` values (`minimal`, `xhigh`, `max`, etc.) and map them into tokenizer thinking mode.

Fixes #9732.
Related to #9266, #8997, and #8935.

### Testing

```bash
python3 -m pytest -q tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py tests/ut/patch/platform/test_patch_deepseek_v4_thinking.py
python3 -m ruff check tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py tests/ut/patch/platform/test_patch_deepseek_v4_thinking.py vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py
python3 -m ruff format --check tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py tests/ut/patch/platform/test_patch_deepseek_v4_thinking.py vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py
git diff --check
```

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
