### PR TITLE
[BugFix] Fix quant_description not loading per-layer data from json

### DIFF
--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -670,9 +670,12 @@ class AscendModelSlimConfig(QuantizationConfig):
         """
         from vllm_ascend.quantization.utils import get_model_file
 
-        # If quant_description is already populated (e.g. from from_config()),
-        # there is nothing to do.
-        if self.quant_description:
+        # If quant_description is already populated with per-layer data
+        # (e.g. from from_config()), there is nothing to do.
+        # But if it only has top-level config keys (quant_method, bits, etc.),
+        # we still need to load per-layer data from quant_model_description.json
+        has_per_layer_data = any(k.endswith(".weight") for k in self.quant_description)
+        if has_per_layer_data:
             return
 
         # Try to get the config file (local or remote)


### PR DESCRIPTION
  What this PR does / why we need it?

  When a model's config.json contains a quantization_config field (e.g. minimax-m2.5), the vLLM loading pipeline calls
  AscendModelSlimConfig.from_config(hf_quant_config), which populates self.quant_description with top-level config keys such as quant_method, bits,
  group_size, etc.

  Later, maybe_update_config() is supposed to load per-layer quantization data from quant_model_description.json. However, the existing guard
  condition:

  if self.quant_description:
      return  # skip loading json

  evaluates to True because quant_description is non-empty (it has top-level keys), even though it contains no per-layer data (no keys ending with
  .weight). This causes the json file to be incorrectly skipped.

  As a result, quant_description lacks per-layer quantization types. When get_quant_method() is called for each layer, it cannot determine the
  quantization scheme, causing all layers to fall back to unquantized (bf16) loading. This doubles weight memory from ~27GB to ~54GB per shard and
  triggers OOM on models like minimax-m2.5-w8a8-quarot.

  Fix (3 parts):

  1. Core fix: Replace if self.quant_description: with any(k.endswith(".weight") for k in self.quant_description) to only skip json loading when
  actual per-layer data is already present.
  2. Allow create_scheme_for_layer to return None: Layers not present in quant_description (e.g. embed_tokens, lm_head) are expected to be
  unquantized. Previously this raised ValueError; now it returns None gracefully.
  3. Defensive fallback in get_quant_method: When create_scheme_for_layer returns None for LinearBase or VocabParallelEmbedding, fall back to
  AscendUnquantizedLinearMethod / UnquantizedEmbeddingMethod respectively.

  Does this PR introduce any user-facing change?

  No. This is a bug fix. Models where config.json lacks quantization_config (so quant_description starts empty) are unaffected — the original code
  path works correctly for them. Models where config.json has quantization_config will now correctly load per-layer data from
  quant_model_description.json instead of falling back to bf16.

  How was this patch tested?

  Tested with minimax-m2.5-w8a8-quarot on Ascend NPU:

  - Before fix: Service fails to start with OOM (~54GB weight memory per shard due to bf16 fallback).
  - After fix: Service starts successfully with ~27GB weight memory per shard, matching expected int8 quantized memory footprint.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
