### PR TITLE
[Feature] Enable oproj_tensor_parallel_size for eager mode

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -436,10 +436,6 @@ class FinegrainedTPConfig:
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
-            # dummy_run does not run the entire attention module in eager mode,
-            # so the o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config.enforce_eager:
-                raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
             if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -436,9 +436,22 @@ class FinegrainedTPConfig:
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
-            if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
+            # OTP is supported in two scenarios:
+            # 1. Pure DP: data_parallel_size > 1 and tensor_parallel_size == 1
+            # 2. PD disaggregation: current node is KV consumer (D node)
+            is_pure_dp = (
+                vllm_config.parallel_config.data_parallel_size > 1
+                and vllm_config.parallel_config.tensor_parallel_size == 1
+            )
+            is_pd_d_node = (
+                vllm_config.kv_transfer_config is not None
+                and vllm_config.kv_transfer_config.is_kv_consumer
+            )
+            if not (is_pure_dp or is_pd_d_node):
                 raise AssertionError(
-                    "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
+                    "oproj_tensor_parallel_size (OTP) is only supported in pure DP scenarios "
+                    "(data_parallel_size > 1 and tensor_parallel_size == 1) "
+                    "or PD disaggregation scenarios (as KV consumer / D node)"
                 )
         if self.olora_tensor_parallel_size > 0:
             enabled_configs.append(f"olora_tensor_parallel_size={self.olora_tensor_parallel_size}")

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -28,7 +28,6 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,
-    oproj_tp_enable,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
@@ -1461,48 +1460,6 @@ class AscendDSAImpl(DSAAttentionImpl):
             assert topk_indices_to_cache.shape[1] == 1
             topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
         topk_indices_buffer.copy_(topk_indices_to_cache)
-
-    def process_weights_after_loading(self, act_dtype: torch.dtype):
-        if oproj_tp_enable():
-            from vllm_ascend.distributed.parallel_state import get_otp_group
-
-            otp_group = get_otp_group()
-            otp_size = otp_group.world_size
-            otp_rank = otp_group.rank_in_group
-
-            # Only OTP row-slice wo_b (wo_a keeps ColumnParallelLinear with
-            # batch matmul — group dimension must be preserved for correctness)
-            wo_b_weight = self.wo_b.weight.data
-            wo_b_rows_per_otp = wo_b_weight.shape[0] // otp_size
-            wo_b_shard = wo_b_weight[
-                otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
-            ].clone()
-            # Explicitly delete the old full-weight data before assigning the
-            # shard, so that the underlying storage is freed immediately rather
-            # than lingering until GC.  Without this, 60 layers × ~50 MiB of
-            # dead wo_b weight (~3 GiB total) remains on the device and causes
-            # KV-cache OOM.
-            del wo_b_weight
-            self.wo_b.weight = torch.nn.Parameter(wo_b_shard, requires_grad=False)
-
-            # Also shard the quantization scale/offset tensors that are tied to
-            # the row dimension of wo_b (RowParallelLinear output dim).
-            # For Ascend W8A8 quantization, weight_scale and weight_offset
-            # have shape [output_rows, ...] and must be sliced accordingly.
-            if hasattr(self.wo_b, 'weight_scale'):
-                ws = self.wo_b.weight_scale.data
-                ws_shard = ws[
-                    otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
-                ].clone()
-                del ws
-                self.wo_b.weight_scale = torch.nn.Parameter(ws_shard, requires_grad=False)
-            if hasattr(self.wo_b, 'weight_offset'):
-                wo = self.wo_b.weight_offset.data
-                wo_shard = wo[
-                    otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
-                ].clone()
-                del wo
-                self.wo_b.weight_offset = torch.nn.Parameter(wo_shard, requires_grad=False)
 
     # TODO: cast to bfloat16 to speed up
     def rope_single(self, x, cos, sin, inverse=False):

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -28,6 +28,7 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     npu_stream_switch,
     olora_tp_enable,
+    oproj_tp_enable,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
@@ -1462,7 +1463,46 @@ class AscendDSAImpl(DSAAttentionImpl):
         topk_indices_buffer.copy_(topk_indices_to_cache)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
-        pass
+        if oproj_tp_enable():
+            from vllm_ascend.distributed.parallel_state import get_otp_group
+
+            otp_group = get_otp_group()
+            otp_size = otp_group.world_size
+            otp_rank = otp_group.rank_in_group
+
+            # Only OTP row-slice wo_b (wo_a keeps ColumnParallelLinear with
+            # batch matmul — group dimension must be preserved for correctness)
+            wo_b_weight = self.wo_b.weight.data
+            wo_b_rows_per_otp = wo_b_weight.shape[0] // otp_size
+            wo_b_shard = wo_b_weight[
+                otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
+            ].clone()
+            # Explicitly delete the old full-weight data before assigning the
+            # shard, so that the underlying storage is freed immediately rather
+            # than lingering until GC.  Without this, 60 layers × ~50 MiB of
+            # dead wo_b weight (~3 GiB total) remains on the device and causes
+            # KV-cache OOM.
+            del wo_b_weight
+            self.wo_b.weight = torch.nn.Parameter(wo_b_shard, requires_grad=False)
+
+            # Also shard the quantization scale/offset tensors that are tied to
+            # the row dimension of wo_b (RowParallelLinear output dim).
+            # For Ascend W8A8 quantization, weight_scale and weight_offset
+            # have shape [output_rows, ...] and must be sliced accordingly.
+            if hasattr(self.wo_b, 'weight_scale'):
+                ws = self.wo_b.weight_scale.data
+                ws_shard = ws[
+                    otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
+                ].clone()
+                del ws
+                self.wo_b.weight_scale = torch.nn.Parameter(ws_shard, requires_grad=False)
+            if hasattr(self.wo_b, 'weight_offset'):
+                wo = self.wo_b.weight_offset.data
+                wo_shard = wo[
+                    otp_rank * wo_b_rows_per_otp : (otp_rank + 1) * wo_b_rows_per_otp, :
+                ].clone()
+                del wo
+                self.wo_b.weight_offset = torch.nn.Parameter(wo_shard, requires_grad=False)
 
     # TODO: cast to bfloat16 to speed up
     def rope_single(self, x, cos, sin, inverse=False):

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -81,6 +81,7 @@ from vllm_ascend.utils import (
     extract_dsv4_layer_index,
     get_ascend_device_type,
     get_dsv4_compress_ratio,
+    oproj_tp_enable,
 )
 
 
@@ -1078,6 +1079,16 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 self.moe_layers.append(layer.mlp.experts)
 
         self.extract_moe_parameters(example_moe)
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype):
+        if oproj_tp_enable():
+            for layer in self.model.layers:
+                if isinstance(layer, PPMissingLayer):
+                    continue
+                # DeepseekV4Attention -> dsa_attn (AscendDeepseekSparseAttention)
+                # -> dsa_attn (DSAAttention) -> impl (AscendDSAImpl)
+                attn = layer.self_attn
+                attn.dsa_attn.dsa_attn.impl.process_weights_after_loading(act_dtype)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -81,7 +81,6 @@ from vllm_ascend.utils import (
     extract_dsv4_layer_index,
     get_ascend_device_type,
     get_dsv4_compress_ratio,
-    oproj_tp_enable,
 )
 
 
@@ -1079,16 +1078,6 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 self.moe_layers.append(layer.mlp.experts)
 
         self.extract_moe_parameters(example_moe)
-
-    def process_weights_after_loading(self, act_dtype: torch.dtype):
-        if oproj_tp_enable():
-            for layer in self.model.layers:
-                if isinstance(layer, PPMissingLayer):
-                    continue
-                # DeepseekV4Attention -> dsa_attn (AscendDeepseekSparseAttention)
-                # -> dsa_attn (DSAAttention) -> impl (AscendDSAImpl)
-                attn = layer.self_attn
-                attn.dsa_attn.dsa_attn.impl.process_weights_after_loading(act_dtype)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -43,6 +43,7 @@ get_row_parallel_op.
 from functools import lru_cache
 from types import SimpleNamespace
 
+import numpy as np
 import regex as re
 import torch
 import torch.distributed as dist
@@ -56,7 +57,8 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
 )
-from vllm.distributed.parallel_state import get_tp_group
+from vllm.forward_context import get_forward_context
+from vllm.distributed.parallel_state import get_dp_group, get_tp_group
 from vllm.model_executor.models.utils import extract_layer_index
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -228,10 +230,21 @@ class OProjRowParallelOp(CustomRowParallelOp):
     def comm_group(self):
         return get_otp_group()
 
+    @property
+    def dp_rank(self):
+        return get_dp_group().rank_in_group
+
     def apply_impl(
         self,
         input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        # Single-operator (eager) mode: use simple matmul + all_gather path.
+        # In graph mode (capturing=True), the PD path (all-to-all + reduce-scatter)
+        # is used because it can be captured into an NPU graph.
+        if get_ascend_config().vllm_config.model_config.enforce_eager:
+            return self.eager_apply_impl(input_)
+
+        # Graph mode (PD scenario): all-to-all + matmul + reduce-scatter
         input_parallel = self.get_input_parallel(input_)
 
         # Prepare tensors for all-to-all communication
@@ -258,6 +271,85 @@ class OProjRowParallelOp(CustomRowParallelOp):
         # otp-specific: Combine partial results across devices
         output = self.comm_group.reduce_scatter(output_parallel, dim=0)
         output = output.view(input_.shape[0], self.layer.output_size)
+
+        # Handle bias return based on configuration
+        output_bias = self.bias if self.skip_bias_add else None
+        return output, output_bias
+
+    def eager_apply_impl(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            splitted_input = split_tensor_along_last_dim(
+                input_, num_partitions=self.tp_size)
+            input_parallel = splitted_input[self.tp_rank].contiguous()
+
+        forward_context = get_forward_context()
+
+        # Prepare tensors for all-to-all communication
+        local_batch_size = input_parallel.size(0)
+        chunk_size = self.input_size_per_partition
+
+        cu_tokens_across_dp_cpu = forward_context.dp_metadata.cu_tokens_across_dp_cpu
+        prefix_array = cu_tokens_across_dp_cpu.cpu().numpy()
+        global_batch_size = np.concatenate(
+            ([prefix_array[0]], np.diff(prefix_array)))
+        tp_group_id = self.dp_rank // self.tp_size
+        tp_group_batchsize = global_batch_size[tp_group_id *
+                                               self.tp_size:tp_group_id *
+                                               self.tp_size + self.tp_size]
+        total_batch_size = sum(tp_group_batchsize)
+
+        # Reshape for all-to-all communication
+        send_buf = (input_parallel.reshape(-1,
+                                           self.tp_size, chunk_size).transpose(
+                                               0, 1).contiguous().view(-1))
+        # Create receive buffer
+        recv_buf = torch.zeros(total_batch_size * chunk_size,
+                               dtype=input_parallel.dtype,
+                               device=input_parallel.device)
+
+        # Create split array
+        recv_splits = [size * chunk_size for size in tp_group_batchsize]
+        send_splits = [local_batch_size * chunk_size] * self.tp_size
+
+        # Perform all-to-all communication
+        dist.all_to_all_single(recv_buf,
+                               send_buf,
+                               recv_splits,
+                               send_splits,
+                               group=self.comm_group.device_group)
+
+        input_parallel = recv_buf.view(total_batch_size, chunk_size)
+
+        # Only fuse bias add for rank 0 to avoid duplicate bias addition in TP>1
+        bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+        assert self.quant_method is not None
+        output_parallel = self.quant_method.apply(self.layer,
+                                                  input_parallel,
+                                                  bias=bias_)
+
+        # prepare all-reduce data
+        output = torch.empty(local_batch_size,
+                             output_parallel.size(1),
+                             dtype=output_parallel.dtype,
+                             device=output_parallel.device)
+
+        recv_chunks = []
+        start_idx = 0
+        for size in tp_group_batchsize:
+            chunk = output_parallel[start_idx:start_idx + size, :]
+            recv_chunks.append(chunk.contiguous())
+            start_idx += size
+
+        # Reduce-scatter the results across devices
+        dist.reduce_scatter(output,
+                            recv_chunks,
+                            op=dist.ReduceOp.SUM,
+                            group=self.comm_group.device_group)
 
         # Handle bias return based on configuration
         output_bias = self.bias if self.skip_bias_add else None
@@ -666,7 +758,7 @@ def _get_row_parallel_op(
         return ShardedCPRowParallelOp(layer)
     if "down_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPRowParallelOp(layer)
-    if "o_proj" in prefix and oproj_tp_enable():
+    if ("o_proj" in prefix or re.search(r'\.wo_b$', prefix)) and oproj_tp_enable():
         return OProjRowParallelOp(layer)
     if matmul_allreduce_enable():
         return MatmulAllreduceRowParallelOp(layer)
@@ -717,6 +809,12 @@ def get_parallel_op(disable_tp, prefix, layer, direct):
         custom_op = _get_column_parallel_op(prefix, layer)
 
     if custom_op is not None:
+        # For wo_b in pure DP OTP mode, the weight is row-sliced along the output
+        # dimension (not column-sliced along the input dimension).  Keep the
+        # original TP size so that input_size_per_partition stays at the full
+        # input size and the RowParallelLinear weight is loaded unsplit.
+        if isinstance(custom_op, OProjRowParallelOp) and re.search(r'\.wo_b$', prefix):
+            return custom_op, 0, 1
         return custom_op, custom_op.tp_rank, custom_op.tp_size
 
     return None, get_tp_group().rank_in_group, get_tp_group().world_size

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -225,6 +225,7 @@ class MLPRowParallelOp(CustomRowParallelOp):
 class OProjRowParallelOp(CustomRowParallelOp):
     def __init__(self, layer):
         super().__init__(layer)
+        self.is_wo_b = False
 
     @property
     def comm_group(self):
@@ -238,9 +239,21 @@ class OProjRowParallelOp(CustomRowParallelOp):
         self,
         input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
-        # Single-operator (eager) mode: use simple matmul + all_gather path.
-        # In graph mode (capturing=True), the PD path (all-to-all + reduce-scatter)
-        # is used because it can be captured into an NPU graph.
+        # wo_b in OTP mode: weight is row-sliced, input is full (unsplit).
+        # Simple path: matmul with row shard → all_gather output.
+        if self.is_wo_b:
+            assert self.quant_method is not None
+            output_parallel = self.quant_method.apply(self.layer, input_, bias=self.bias)
+            output = torch.empty(
+                input_.shape[0], self.layer.output_size,
+                dtype=output_parallel.dtype, device=output_parallel.device)
+            dist.all_gather_into_tensor(output, output_parallel.contiguous(),
+                                        group=self.comm_group.device_group)
+            output_bias = self.bias if self.skip_bias_add else None
+            return output, output_bias
+
+        # Single-operator (eager) mode for o_proj (standard OTP):
+        # PD path (all-to-all + reduce-scatter) in eager mode.
         if get_ascend_config().vllm_config.model_config.enforce_eager:
             return self.eager_apply_impl(input_)
 
@@ -280,6 +293,22 @@ class OProjRowParallelOp(CustomRowParallelOp):
         self,
         input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        # wo_b in OTP mode: weight is row-sliced, input is full (unsplit).
+        # Simple path: matmul with row shard → all_gather output.
+        if self.is_wo_b:
+            assert self.quant_method is not None
+            output_parallel = self.quant_method.apply(self.layer, input_, bias=self.bias)
+            # Row-sliced weight: each OTP rank produces a shard of the output.
+            # All-gather to reconstruct the full output across OTP ranks.
+            output = torch.empty(
+                input_.shape[0], self.layer.output_size,
+                dtype=output_parallel.dtype, device=output_parallel.device)
+            dist.all_gather_into_tensor(output, output_parallel.contiguous(),
+                                        group=self.comm_group.device_group)
+            output_bias = self.bias if self.skip_bias_add else None
+            return output, output_bias
+
+        # o_proj (standard OTP): all-to-all + matmul + reduce-scatter (PD path)
         if self.input_is_parallel:
             input_parallel = input_
         else:
@@ -357,7 +386,13 @@ class OProjRowParallelOp(CustomRowParallelOp):
 
     def update_attrs(self):
         super().update_attrs()
-        self.input_is_parallel = self.layer.input_is_parallel
+        self.is_wo_b = re.search(r'\.wo_b$', self.prefix) is not None
+        # wo_b is row-sliced along the output dimension in OTP mode.  Its input
+        # dimension is NOT split (loaded unsplit via get_parallel_op returning
+        # tp_size=1), so input_is_parallel must be True to avoid an incorrect
+        # split_tensor_along_last_dim that would crash or corrupt the batch dim.
+        if self.is_wo_b:
+            self.input_is_parallel = True
         self.input_size_per_partition = self.layer.input_size_per_partition
 
 

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -17,6 +17,7 @@
 #
 
 from collections.abc import Callable
+import re
 
 import torch
 from vllm.distributed import get_tensor_model_parallel_rank
@@ -120,6 +121,50 @@ class AscendLinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if hasattr(self.quant_method, "process_weights_after_loading"):
             self.quant_method.process_weights_after_loading(layer)
+
+        # wo_b OTP row-slicing: in OTP mode, wo_b weight is row-sliced along
+        # the output dimension (not column-sliced along the input).  The weight
+        # is loaded unsplit (get_parallel_op returns tp_size=1), so we slice it
+        # here and release the full-weight storage to reclaim ~3 GiB NPU memory.
+        if (oproj_tp_enable() and isinstance(layer, RowParallelLinear)
+                and re.search(r'\.wo_b$', getattr(layer, 'prefix', ''))):
+            otp_group = get_otp_group()
+            otp_rank = otp_group.rank_in_group
+            otp_size = otp_group.world_size
+
+            wo_b_weight = layer.weight.data
+            total_rows = wo_b_weight.shape[0]
+            rows_per_shard = total_rows // otp_size
+
+            # Row-slice weight: each OTP rank takes its shard along dim 0
+            wo_b_shard = wo_b_weight[
+                otp_rank * rows_per_shard:(otp_rank + 1) * rows_per_shard, :
+            ].clone()
+
+            # Release old full-weight storage before reassigning
+            del wo_b_weight
+            layer.weight = torch.nn.Parameter(wo_b_shard, requires_grad=False)
+
+            # Row-slice weight_scale and weight_offset (W8A8: shape [output_rows, ...])
+            if hasattr(layer, 'weight_scale'):
+                ws = layer.weight_scale.data
+                ws_shard = ws[
+                    otp_rank * rows_per_shard:(otp_rank + 1) * rows_per_shard
+                ].clone()
+                del ws
+                layer.weight_scale = torch.nn.Parameter(
+                    ws_shard, requires_grad=False)
+
+            if hasattr(layer, 'weight_offset'):
+                wo = layer.weight_offset.data
+                wo_shard = wo[
+                    otp_rank * rows_per_shard:(otp_rank + 1) * rows_per_shard
+                ].clone()
+                del wo
+                layer.weight_offset = torch.nn.Parameter(
+                    wo_shard, requires_grad=False)
+
+            torch.npu.synchronize()  # Ensure old storage is freed
 
     def get_computed_params(self) -> set[str]:
         """Return parameter name patterns that are computed, not loaded.


### PR DESCRIPTION
Remove the graph-mode-only restriction on oproj_tensor_parallel_size by adding an eager_apply_impl that handles DP-aware all-to-all + reduce-scatter communication. Also add support for .wo_b layers in OTP mode.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
