### PR TITLE
[BugFix][A2/A3]Preserve fp32 RoPE sin/cos for DSA compressor and rota…

### DIFF
--- a/csrc/attention/compressor/op_host/compressor_def.cpp
+++ b/csrc/attention/compressor/op_host/compressor_def.cpp
@@ -105,8 +105,85 @@ public:
             .NeedCheckSupportFlag(false)
             .PrecisionReduceFlag(true)
             .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");   // set value of aclnn support
-        this->AICore().AddConfig("ascend910b", aicore_config);
-        this->AICore().AddConfig("ascend910_93", aicore_config);
+
+        OpAICoreConfig config910;
+        config910.Input("x")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("wkv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("wgate")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("state_cache")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        config910.Input("ape")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("norm_weight")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("rope_sin")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("rope_cos")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("state_block_table")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("seqused")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("start_pos")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Output("cmp_kv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND});
+        config910.Output("state_cache")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND});
+        config910.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+        this->AICore().AddConfig("ascend910b", config910);
+        this->AICore().AddConfig("ascend910_93", config910);
         this->AICore().AddConfig("ascend950", aicore_config);
     }
 };

--- a/csrc/attention/compressor/op_host/compressor_tiling.cpp
+++ b/csrc/attention/compressor/op_host/compressor_tiling.cpp
@@ -332,6 +332,7 @@ ge::graphStatus CompressorTiling::GenTilingKey() const
     uint8_t dtype = 0;
     // 0: BSH 1:TH
     uint8_t layout = 0;
+    uint8_t ropeDtype = 0;
     uint8_t rotaryMode = static_cast<uint8_t>(*context_->rotaryMode);
     uint8_t templateId = static_cast<uint8_t>(context_->templateId);
     uint8_t cacheMode = static_cast<uint8_t>(*context_->cacheMode);
@@ -341,6 +342,13 @@ ge::graphStatus CompressorTiling::GenTilingKey() const
         dtype = 0;
     } else if (xDtype == ge::DT_FLOAT16) {
         dtype = 1;
+    }
+    auto ropeSinDtype = context_->ropeSin.desc->GetDataType();
+    auto ropeCosDtype = context_->ropeCos.desc->GetDataType();
+    bool supportFp32Rope = socVersion_ == platform_ascendc::SocVersion::ASCEND910B ||
+                           socVersion_ == platform_ascendc::SocVersion::ASCEND910_93;
+    if (ropeSinDtype == ge::DT_FLOAT && ropeCosDtype == ge::DT_FLOAT && supportFp32Rope) {
+        ropeDtype = 1;
     }
     auto xDimNum = context_->x.shape->GetStorageShape().GetDimNum();
     if (xDimNum == COMPRESSOR_DIM_NUM_3) {
@@ -355,11 +363,12 @@ ge::graphStatus CompressorTiling::GenTilingKey() const
         coff,
         rotaryMode,
         1,
-        templateId
+        templateId,
+        ropeDtype
     );
     OP_LOGI(context_->opName,
-            "Compressor dtype:%hhu layout:%hhu  coff:%hhu rotary_mode:%hhu, cacheMode: %u, template_id:%hhu", dtype,
-            layout, coff, rotaryMode, cacheMode, templateId);
+            "Compressor dtype:%hhu layout:%hhu  coff:%hhu rotary_mode:%hhu, cacheMode: %u, template_id:%hhu, rope_dtype:%hhu",
+            dtype, layout, coff, rotaryMode, cacheMode, templateId, ropeDtype);
     OP_LOGI(context_->opName, "Compressor tilingKey:%lu", context_->tilingKey);
 
     return ge::GRAPH_SUCCESS;
@@ -887,13 +896,36 @@ ge::graphStatus CompressorTiling::CheckDtypeConsistencyX(const gert::CompileTime
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus CompressorTiling::CheckDtypeConsistencyRope() const
+{
+    auto sinDtype = context_->ropeSin.desc->GetDataType();
+    auto cosDtype = context_->ropeCos.desc->GetDataType();
+    OP_CHECK_IF(
+        sinDtype != cosDtype,
+        OP_LOGE(context_->opName, "%s datatype should be same with %s: %s, but got %s", ROPE_COS_NAME.c_str(),
+                ROPE_SIN_NAME.c_str(), DataTypeToSerialString(sinDtype).c_str(),
+                DataTypeToSerialString(cosDtype).c_str()),
+        return ge::GRAPH_FAILED);
+    OP_CHECK_IF(
+        sinDtype != context_->dtype && sinDtype != ge::DT_FLOAT,
+        OP_LOGE(context_->opName, "rope datatype should be same with x or DT_FLOAT, x is %s, but got %s",
+                DataTypeToSerialString(context_->dtype).c_str(), DataTypeToSerialString(sinDtype).c_str()),
+        return ge::GRAPH_FAILED);
+    bool supportFp32Rope = socVersion_ == platform_ascendc::SocVersion::ASCEND910B ||
+                           socVersion_ == platform_ascendc::SocVersion::ASCEND910_93;
+    OP_CHECK_IF(
+        sinDtype == ge::DT_FLOAT && !supportFp32Rope,
+        OP_LOGE(context_->opName, "float32 rope is only enabled on ascend910b and ascend910_93."),
+        return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus CompressorTiling::CheckDtypeConsistency() const
 {
     if (CheckDtypeConsistencyX(context_->wkv.desc, WKV_NAME) != ge::GRAPH_SUCCESS ||
         CheckDtypeConsistencyX(context_->wgate.desc, WGATE_NAME) != ge::GRAPH_SUCCESS ||
         CheckDtypeConsistencyX(context_->normWeight.desc, NORM_WEIGHT_NAME) != ge::GRAPH_SUCCESS ||
-        CheckDtypeConsistencyX(context_->ropeSin.desc, ROPE_SIN_NAME) != ge::GRAPH_SUCCESS ||
-        CheckDtypeConsistencyX(context_->ropeCos.desc, ROPE_COS_NAME) != ge::GRAPH_SUCCESS ||
+        CheckDtypeConsistencyRope() != ge::GRAPH_SUCCESS ||
         CheckDtypeConsistencyX(context_->cmpKv.desc, CMP_KV_NAME) != ge::GRAPH_SUCCESS) {
         return ge::GRAPH_FAILED;
     }

--- a/csrc/attention/compressor/op_host/compressor_tiling.h
+++ b/csrc/attention/compressor/op_host/compressor_tiling.h
@@ -114,8 +114,8 @@ const std::map<std::string, std::vector<ge::DataType>> DTYPE_SUPPORT_MAP = {
     {STATE_CACHE_NAME,        {ge::DT_FLOAT}},
     {APE_NAME,                {ge::DT_FLOAT}},
     {NORM_WEIGHT_NAME,        {ge::DT_BF16, ge::DT_FLOAT16}},
-    {ROPE_SIN_NAME,           {ge::DT_BF16, ge::DT_FLOAT16}},
-    {ROPE_COS_NAME,           {ge::DT_BF16, ge::DT_FLOAT16}},
+    {ROPE_SIN_NAME,           {ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT}},
+    {ROPE_COS_NAME,           {ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT}},
     {STATE_BLOCK_TABLE_NAME,  {ge::DT_INT32}},
     {CU_SEQLENS_NAME,         {ge::DT_INT32}},
     {SEQUSED_NAME,            {ge::DT_INT32}},
@@ -345,6 +345,7 @@ private:
     ge::graphStatus CheckShapeConsistency() const;
     ge::graphStatus CheckShapeConsistencyRope() const;
     ge::graphStatus CheckDtypeConsistencyX(const gert::CompileTimeTensorDesc *desc, const std::string &name) const;
+    ge::graphStatus CheckDtypeConsistencyRope() const;
     ge::graphStatus CheckDtypeConsistency() const;
     ge::graphStatus CheckMultiParaConsistency() const;
     ge::graphStatus CheckDimNumConsistency() const;

--- a/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
+++ b/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
@@ -70,6 +70,7 @@ public:
     // 中间计算数据类型为float，高精度模式
     using T = float;
     using X_T = typename AscendC::Conditional<X_DTYPE, bfloat16_t, half>::type;
+    using ROPE_T = typename AscendC::Conditional<COMP::ropeDtype == ROPE_DTYPE::FP32, float, X_T>::type;
 
     __aicore__ inline CompressorBlockVectorPerf(){};
     // =================================设置参数=================================
@@ -241,8 +242,8 @@ private:
     GlobalTensor<T> stateCacheGm_;
     GlobalTensor<T> apeGm_;
     GlobalTensor<X_T> normWeightGm_;
-    GlobalTensor<X_T> ropeSinGm_;
-    GlobalTensor<X_T> ropeCosGm_;
+    GlobalTensor<ROPE_T> ropeSinGm_;
+    GlobalTensor<ROPE_T> ropeCosGm_;
     GlobalTensor<X_T> cmpKvOutGm_;
 
     // ================================Local Buffer区====================================
@@ -295,8 +296,8 @@ __aicore__ inline void CompressorBlockVectorPerf<COMP>::Init(
     stateCacheGm_.SetGlobalBuffer((__gm__ T *)stateCache);
     apeGm_.SetGlobalBuffer((__gm__ T *)ape);
     normWeightGm_.SetGlobalBuffer((__gm__ X_T *)normWeight);
-    ropeSinGm_.SetGlobalBuffer((__gm__ X_T *)ropeSin);
-    ropeCosGm_.SetGlobalBuffer((__gm__ X_T *)ropeCos);
+    ropeSinGm_.SetGlobalBuffer((__gm__ ROPE_T *)ropeSin);
+    ropeCosGm_.SetGlobalBuffer((__gm__ ROPE_T *)ropeCos);
     cmpKvOutGm_.SetGlobalBuffer((__gm__ X_T *)cmpKvOut);
     isExistSeqUsed = (seqUsed != nullptr);
     isExistStartPos = (startPos != nullptr);
@@ -1296,20 +1297,25 @@ __aicore__ inline void CompressorBlockVectorPerf<COMP>::SingleCalRope(const Loca
 {
     uint32_t computeSize = curDealScSize * constInfo_.ropeHeadDim;
     uint64_t SinCosOffset = globalScStart * constInfo_.ropeHeadDim;
-    // sin与cos各占一半, 实际分别最多只会用8K,总占用16K
-    LocalTensor<X_T> cosUb = inputQue1.AllocTensor<X_T>();
-    LocalTensor<X_T> sinUb = cosUb[BUFFER_SIZE_BYTE_8K / sizeof(X_T)];
+    // sin/cos each reserves 16KB so fp32 rope can use the same compute tile.
+    LocalTensor<ROPE_T> cosUb = inputQue1.AllocTensor<ROPE_T>();
+    LocalTensor<ROPE_T> sinUb = cosUb[BUFFER_SIZE_BYTE_16K / sizeof(ROPE_T)];
     DataCopy(cosUb, ropeCosGm_[SinCosOffset], computeSize);
     DataCopy(sinUb, ropeSinGm_[SinCosOffset], computeSize);
     inputQue1.EnQue(sinUb);
-    inputQue1.DeQue<X_T>();
+    inputQue1.DeQue<ROPE_T>();
 
     LocalTensor<T> ropeCosFp32Local = tmpBuff2.Get<T>();
     LocalTensor<T> ropeSinFp32Local = ropeCosFp32Local[BUFFER_SIZE_BYTE_16K / sizeof(T)].template ReinterpretCast<T>();
     LocalTensor<T> tempLocal = ropeSinFp32Local[BUFFER_SIZE_BYTE_16K / sizeof(T)].template ReinterpretCast<T>();
     PipeBarrier<PIPE_V>();
-    Cast(ropeCosFp32Local, cosUb, RoundMode::CAST_NONE, computeSize);
-    Cast(ropeSinFp32Local, sinUb, RoundMode::CAST_NONE, computeSize);
+    if constexpr (IsSameType<ROPE_T, T>::value) {
+        DataCopy(ropeCosFp32Local, cosUb, computeSize);
+        DataCopy(ropeSinFp32Local, sinUb, computeSize);
+    } else {
+        Cast(ropeCosFp32Local, cosUb, RoundMode::CAST_NONE, computeSize);
+        Cast(ropeSinFp32Local, sinUb, RoundMode::CAST_NONE, computeSize);
+    }
     PipeBarrier<PIPE_V>();
     inputQue1.FreeTensor(sinUb);
     RotaryPosEmb<COMP::rotaryMode>(normResUb[rowCnt * constInfo_.headDim], normResUb[rowCnt * constInfo_.headDim],

--- a/csrc/attention/compressor/op_kernel/compressor.cpp
+++ b/csrc/attention/compressor/op_kernel/compressor.cpp
@@ -28,7 +28,7 @@ using namespace Compressor;
         op.Process();                                                                                                  \
     } while (0)
 
-template<uint8_t XLayout, uint8_t XDType, uint8_t Coff, uint8_t RotaryMode, uint8_t CacheMode, uint8_t TemplateId>
+template<uint8_t XLayout, uint8_t XDType, uint8_t Coff, uint8_t RotaryMode, uint8_t CacheMode, uint8_t TemplateId, uint8_t RopeDType>
 __global__ __aicore__ void compressor(
     __gm__ uint8_t *x,
     __gm__ uint8_t *wKv,
@@ -56,6 +56,7 @@ __global__ __aicore__ void compressor(
     TPipe pipe;
     constexpr auto xLayout = static_cast<X_LAYOUT>(XLayout);
     constexpr auto xDtype = static_cast<X_DTYPE>(XDType);
+    constexpr auto ropeDtype = static_cast<ROPE_DTYPE>(RopeDType);
     constexpr auto coff = static_cast<COFF>(Coff);
     constexpr auto rotaryMode = static_cast<ROTARY_MODE>(RotaryMode);
     constexpr auto cacheMode = static_cast<CACHE_MODE>(CacheMode);
@@ -69,8 +70,8 @@ __global__ __aicore__ void compressor(
 //     INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernel, xLayout, xDtype, coff, rotaryMode);
 // #endif
     if constexpr (static_cast<TEMPLATE_ID>(TemplateId) == TEMPLATE_ID::PERF) {
-        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernelPerf, xLayout, xDtype, coff, rotaryMode);
+        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernelPerf, xLayout, xDtype, ropeDtype, coff, rotaryMode);
     } else {
-        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernel, xLayout, xDtype, coff, rotaryMode);
+        INVOKE_COMPRESSOR_GENERAL_OP_IMPL(CompressorKernel, xLayout, xDtype, ropeDtype, coff, rotaryMode);
     }
 }

--- a/csrc/attention/compressor/op_kernel/compressor_comm.h
+++ b/csrc/attention/compressor/op_kernel/compressor_comm.h
@@ -78,6 +78,11 @@ enum class X_DTYPE : std::uint8_t {
     FP16 = static_cast<std::uint8_t>(1)
 };
 
+enum class ROPE_DTYPE : std::uint8_t {
+    SAME_AS_X = static_cast<std::uint8_t>(0),
+    FP32 = static_cast<std::uint8_t>(1)
+};
+
 enum class COFF : std::uint8_t {
     DISABLE = static_cast<std::uint8_t>(1),
     OVERLAP = static_cast<std::uint8_t>(2)
@@ -99,10 +104,11 @@ enum class TEMPLATE_ID:uint8_t {
     PERF = 2
 };
 
-template <X_LAYOUT X_L, X_DTYPE X_T, COFF C, ROTARY_MODE Rotary_Mode, typename... Args>
+template <X_LAYOUT X_L, X_DTYPE X_T, ROPE_DTYPE R_T, COFF C, ROTARY_MODE Rotary_Mode, typename... Args>
 struct COMPType {
     static constexpr X_LAYOUT xLayout = X_L;
     static constexpr X_DTYPE xDtype = X_T;
+    static constexpr ROPE_DTYPE ropeDtype = R_T;
     static constexpr COFF coff = C;
     static constexpr ROTARY_MODE rotaryMode = Rotary_Mode;
 };

--- a/csrc/attention/compressor/op_kernel/compressor_template_tiling_key.h
+++ b/csrc/attention/compressor/op_kernel/compressor_template_tiling_key.h
@@ -37,6 +37,8 @@ ASCENDC_TPL_ARGS_DECL(compressor, // 算子唯一标识，与opType保持一致
     ASCENDC_TPL_UINT_DECL(CACHE_MODE, ASCENDC_TPL_2_BW, ASCENDC_TPL_UI_LIST, 1, 2),
     // bit:11-12  template_id 0:empty_tensor 1:normal 2:full load
     ASCENDC_TPL_UINT_DECL(TEMPLATE_ID, ASCENDC_TPL_2_BW, ASCENDC_TPL_UI_LIST, 0, 1, 2),
+    // bit:13 rope dtype 0:same as x 1:fp32
+    ASCENDC_TPL_UINT_DECL(ROPE_DTYPE, ASCENDC_TPL_1_BW, ASCENDC_TPL_UI_LIST, 0, 1),
 );
 
 ASCENDC_TPL_SEL(
@@ -47,6 +49,7 @@ ASCENDC_TPL_SEL(
                         ASCENDC_TPL_UINT_SEL(ROTARY_MODE, ASCENDC_TPL_UI_LIST, 1, 2),
                         ASCENDC_TPL_UINT_SEL(CACHE_MODE, ASCENDC_TPL_UI_LIST, 1, 2),
                         ASCENDC_TPL_UINT_SEL(TEMPLATE_ID, ASCENDC_TPL_UI_LIST, 0, 1, 2),
+                        ASCENDC_TPL_UINT_SEL(ROPE_DTYPE, ASCENDC_TPL_UI_LIST, 0, 1),
                         ASCENDC_TPL_TILING_STRUCT_SEL(optiling::CompressorTilingData)),
 );
 

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_a3_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_a3_tiling.cpp
@@ -75,6 +75,7 @@ private:
     int64_t tilingKey_ =1;
     bool isAlign_ = false;
     bool isSpecial_ = false;
+    bool isFp32Rope_ = false;
     int64_t oneBlockSize_ = 0;
     int64_t dtypeSize_ = 2;
     int64_t xdim0_ = 0;
@@ -241,8 +242,16 @@ ge::graphStatus InplacePartialRotaryMulTiling::CheckInput()
 {
     auto xInput = context_->GetInputShape(0);
     auto inputR1 = context_->GetInputShape(1);
-    auto inputR2 = context_->GetInputShape(1);
-    auto dataDtype = context_->GetInputDesc(0)->GetDataType();
+    auto inputR2 = context_->GetInputShape(2);
+    auto xDesc = context_->GetInputDesc(0);
+    auto r1Desc = context_->GetInputDesc(1);
+    auto r2Desc = context_->GetInputDesc(2);
+    OPS_ERR_IF(xDesc == nullptr || r1Desc == nullptr || r2Desc == nullptr,
+        OPS_LOG_E(context_->GetNodeName(), "get input desc nullptr."),
+        return ge::GRAPH_FAILED);
+    auto dataDtype = xDesc->GetDataType();
+    auto r1Dtype = r1Desc->GetDataType();
+    auto r2Dtype = r2Desc->GetDataType();
     if (dataDtype == ge::DT_FLOAT16 || dataDtype == ge::DT_BF16) {
         dtypeSize_ = FP16_BF16_DTYPE_SIZE;
         oneBlockSize_ = ALIGN_16;
@@ -250,6 +259,13 @@ ge::graphStatus InplacePartialRotaryMulTiling::CheckInput()
         dtypeSize_ = FP32_DTYPE_SIZE;
         oneBlockSize_ = ALIGN_32;
     }
+    OPS_ERR_IF(r1Dtype != r2Dtype,
+        OPS_LOG_E(context_->GetNodeName(), "cos and sin dtype must be same."),
+        return ge::GRAPH_FAILED);
+    OPS_ERR_IF(r1Dtype != dataDtype && r1Dtype != ge::DT_FLOAT,
+        OPS_LOG_E(context_->GetNodeName(), "cos/sin dtype must be same as x or float32."),
+        return ge::GRAPH_FAILED);
+    isFp32Rope_ = (dataDtype != ge::DT_FLOAT && r1Dtype == ge::DT_FLOAT);
 
     OPS_ERR_IF(xInput == nullptr || inputR1 == nullptr || inputR2 == nullptr, OPS_LOG_E(context_->GetNodeName(), "get input nullptr."),
         return ge::GRAPH_FAILED);
@@ -323,6 +339,9 @@ ge::graphStatus InplacePartialRotaryMulTiling::CheckInput()
         if (r1dim1_ == dim1_) {
             isBrc_ = false;
             tilingKey_ = tilingKey_ + 1;
+        }
+        if (isFp32Rope_) {
+            tilingKey_ += 10;
         }
     }
     if (xdim3_ % oneBlockSize_ == 0){
@@ -510,7 +529,8 @@ ge::graphStatus InplacePartialRotaryMulTiling::DoTiling()
         CheckInput() != ge::GRAPH_SUCCESS,
         OPS_LOG_E(context_->GetNodeName(), "CheckInputShapes is failed"),
         return ge::GRAPH_FAILED);
-    if (CalTilingData() == ge::GRAPH_SUCCESS) {
+    ge::graphStatus calStatus = CalTilingData();
+    if (calStatus == ge::GRAPH_SUCCESS) {
         FillTilingData();
         PrintTilingData();
         context_->SetBlockDim(usedCoreNum_);
@@ -521,6 +541,9 @@ ge::graphStatus InplacePartialRotaryMulTiling::DoTiling()
         tilingData_.SaveToBuffer(context_->GetRawTilingData()->GetData(), context_->GetRawTilingData()->GetCapacity());
         context_->GetRawTilingData()->SetDataSize(tilingData_.GetDataSize());
         return ge::GRAPH_SUCCESS;
+    } else if (isFp32Rope_) {
+        OPS_LOG_E(context_->GetNodeName(), "float32 cos/sin only supports the special interleave tiling path.");
+        return ge::GRAPH_FAILED;
     } else {
         // 开始走原始的71的逻辑
         tilingKey_ = BASE_KEY;

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_def.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_def.cpp
@@ -21,27 +21,27 @@ public:
     {
         this->Input("x")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("cos")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("sin")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
         this->Output("x")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16})
-            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
         this->Attr("mode").AttrType(OPTIONAL).Int(0);
         this->Attr("partial_slice").AttrType(OPTIONAL).ListInt({0, 0});
 

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_proto.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_proto.cpp
@@ -24,9 +24,9 @@ namespace ge {
  * @li x: A 4D tensor which rotary position embedding is applied, format supports ND, and data type must be float16,
  * float or bfloat16.
  * @li cos: A 4D tensor which is "cos" in rotary position embedding, format supports ND, data type must be the same as
- * "x", and shape must be the same as "sin".
+ * "x" or float32, and shape must be the same as "sin".
  * @li sin: A 4D tensor which is "sin" in rotary position embedding, format supports ND, data type must be the same as
- * "x", and shape must be the same as "cos".
+ * "cos".
  * @par Outputs:
  * y: A 4D tensor which is the result of rotary position embedding, format supports ND, data type must be the same as
  * "x", and shape must be the same as "x".

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
@@ -62,6 +62,20 @@ ge::graphStatus Tiling4RotaryPositionEmbedding(gert::TilingContext *context)
                return ge::GRAPH_FAILED);
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
     auto socVersion = ascendcPlatform.GetSocVersion();
+    auto xDesc = context->GetInputDesc(0);
+    auto cosDesc = context->GetInputDesc(1);
+    auto sinDesc = context->GetInputDesc(2);
+    OPS_ERR_IF(xDesc == nullptr || cosDesc == nullptr || sinDesc == nullptr,
+               OPS_REPORT_VECTOR_INNER_ERR("Tiling4RotaryPositionEmbedding", "input desc is null"),
+               return ge::GRAPH_FAILED);
+    bool useFp32Rope = xDesc->GetDataType() != ge::DT_FLOAT &&
+                       cosDesc->GetDataType() == ge::DT_FLOAT &&
+                       sinDesc->GetDataType() == ge::DT_FLOAT;
+    bool supportFp32Rope = socVersion == platform_ascendc::SocVersion::ASCEND910B ||
+                           socVersion == platform_ascendc::SocVersion::ASCEND910_93;
+    if (useFp32Rope && supportFp32Rope) {
+        return Tiling4InplacePartialRotaryMul(context);
+    }
     if (socVersion == platform_ascendc::SocVersion::ASCEND950)
     {
         std::vector<std::unique_ptr<RopeRegBaseTilingClass>> regBaseTilingCases;

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.cpp
@@ -58,6 +58,8 @@
 
 #define TILING_KEY1 1
 #define TILING_KEY2 2
+#define TILING_KEY1_FP32_ROPE 11
+#define TILING_KEY2_FP32_ROPE 12
 
 using namespace AscendC;
 using namespace InplacePartialRotaryMul;
@@ -226,6 +228,18 @@ extern "C" __global__ __aicore__ void inplace_partial_rotary_mul(GM_ADDR x, GM_A
         }
         if (TILING_KEY_IS(TILING_KEY2)) {
             InplacePartialRotaryMul::InplacePartialRotaryMulABA<DTYPE_X, false> op;
+            op.Init(x, cos, sin, y, workspace, tilingData1, &pipe);
+            op.Process();
+            return;
+        }
+        if (TILING_KEY_IS(TILING_KEY1_FP32_ROPE)) {
+            InplacePartialRotaryMul::InplacePartialRotaryMulABA<DTYPE_X, true, float> op;
+            op.Init(x, cos, sin, y, workspace, tilingData1, &pipe);
+            op.Process();
+            return;
+        }
+        if (TILING_KEY_IS(TILING_KEY2_FP32_ROPE)) {
+            InplacePartialRotaryMul::InplacePartialRotaryMulABA<DTYPE_X, false, float> op;
             op.Init(x, cos, sin, y, workspace, tilingData1, &pipe);
             op.Process();
             return;

--- a/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_kernel/inplace_partial_rotary_mul.h
@@ -26,7 +26,7 @@
 namespace InplacePartialRotaryMul {
 using namespace AscendC;
 
-template <typename T, bool isBrc>
+template <typename T, bool isBrc, typename R = T>
 class InplacePartialRotaryMulABA {
 public:
     __aicore__ inline InplacePartialRotaryMulABA() {};
@@ -34,7 +34,7 @@ public:
         const RopeRegbaseTilingData *tilingData, TPipe *pipe);
     __aicore__ inline void Process();
     __aicore__ inline void CopyInData(LocalTensor<T> &xUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset);
-    __aicore__ inline void CopyInDataR(LocalTensor<T> &xUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset);
+    __aicore__ inline void CopyInDataR(LocalTensor<R> &xUb, GlobalTensor<R> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset);
     __aicore__ inline void SetGatherSrcOffset(LocalTensor<int32_t> &idsUb, int64_t count);
     __aicore__ inline void ComputeMul(LocalTensor<float> &dtsUb, LocalTensor<float> & src0Ub, LocalTensor<float> &src1Ub, int64_t onceA, int64_t numHead,int64_t headDim);
     __aicore__ inline void  InterleavedInversion(int64_t count,LocalTensor<float> &ub);
@@ -46,7 +46,7 @@ private:
 
     //需要的tilingdata
     int64_t halfNumx_ = 0;
-    int64_t halfNumr1_ = 0;
+    int64_t ropeUbOffset_ = 0;
     int64_t xNum_= 0;
     int64_t r1Num_= 0;
     int64_t count_ = 0;
@@ -55,8 +55,8 @@ private:
     int32_t perBlock32 = ONE_BLOCK_SIZE / sizeof(float);
 
     GlobalTensor<T> xGm_;
-    GlobalTensor<T> r1Gm_;
-    GlobalTensor<T> r2Gm_;
+    GlobalTensor<R> r1Gm_;
+    GlobalTensor<R> r2Gm_;
     GlobalTensor<T> yGm_;
 
     TQue<QuePosition::VECIN, 1> xQue_;
@@ -66,6 +66,7 @@ private:
     TBuf<QuePosition::VECCALC> idsBuf_;
     BinaryRepeatParams repeatParams_{1, 1, 1, 0, 0, 0};
     DataCopyPadExtParams<T> dataCopyPadParams_{false, 0, 0, 0};
+    DataCopyPadExtParams<R> dataCopyRPadParams_{false, 0, 0, 0};
 
     int64_t usedCoreNum_=0;
     int64_t numHead_ =0;
@@ -81,8 +82,8 @@ private:
 
 };
 
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::Init(GM_ADDR x, GM_ADDR r1, GM_ADDR r2, GM_ADDR y, GM_ADDR workspace,
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::Init(GM_ADDR x, GM_ADDR r1, GM_ADDR r2, GM_ADDR y, GM_ADDR workspace,
     const RopeRegbaseTilingData *tilingData, TPipe *pipe)
 {
     blockIdx_ = GetBlockIdx();
@@ -101,8 +102,8 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::Init(GM_ADDR x, GM_
     start_ = tiling_->start;
 
     xGm_.SetGlobalBuffer((__gm__ T *)x);
-    r1Gm_.SetGlobalBuffer((__gm__ T *)r1);
-    r2Gm_.SetGlobalBuffer((__gm__ T *)r2);
+    r1Gm_.SetGlobalBuffer((__gm__ R *)r1);
+    r2Gm_.SetGlobalBuffer((__gm__ R *)r2);
     yGm_.SetGlobalBuffer((__gm__ T *)y);
     count_ = numHead_ * headDim_;
     xNum_ = ubFactor_ * count_;
@@ -115,11 +116,13 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::Init(GM_ADDR x, GM_
     pipe_->InitBuffer(idsBuf_, count_ *sizeof(uint32_t));
     if constexpr(sizeof(T) != sizeof(float)) {
         halfNumx_ = xNum_;
-        halfNumr1_ = r1Num_;
+    }
+    if constexpr(sizeof(R) != sizeof(float)) {
+        ropeUbOffset_ = r1Num_;
     }
 }
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::CopyInData(LocalTensor<T> &xUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset)
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::CopyInData(LocalTensor<T> &xUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset)
 {
     DataCopyExtParams copyParams;
     copyParams.blockCount = blockCout;
@@ -128,18 +131,18 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::CopyInData(LocalTen
     copyParams.dstStride = 0;
     DataCopyPad(xUb[ubOffset], xGm[gmOffset], copyParams, dataCopyPadParams_);
 }
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::CopyInDataR(LocalTensor<T> &xUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset)
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::CopyInDataR(LocalTensor<R> &xUb, GlobalTensor<R> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset)
 {
     DataCopyExtParams copyParams;
     copyParams.blockCount = blockCout;
-    copyParams.blockLen = blockLen * sizeof(T);
+    copyParams.blockLen = blockLen * sizeof(R);
     copyParams.srcStride = 0; //整个输入的大小
     copyParams.dstStride = 0;
-    DataCopyPad(xUb[ubOffset], xGm[gmOffset], copyParams, dataCopyPadParams_);
+    DataCopyPad(xUb[ubOffset], xGm[gmOffset], copyParams, dataCopyRPadParams_);
 }
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::SetGatherSrcOffset(LocalTensor<int32_t> &idsUb, int64_t count)
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::SetGatherSrcOffset(LocalTensor<int32_t> &idsUb, int64_t count)
 {
     for (int32_t i = 0; i < 8; ++i) {
         idsUb.SetValue(i, i ^ 1); // XOR with 1 to swap even and odd indices
@@ -162,8 +165,8 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::SetGatherSrcOffset(
     }
     Muls(idsUb, idsUb, 4, count);
 }
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::ComputeMul(LocalTensor<float> &dtsUb, LocalTensor<float> & src0Ub, LocalTensor<float> &src1Ub, int64_t onceA, int64_t numHead,int64_t headDim)
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::ComputeMul(LocalTensor<float> &dtsUb, LocalTensor<float> & src0Ub, LocalTensor<float> &src1Ub, int64_t onceA, int64_t numHead,int64_t headDim)
 {
     int64_t count = numHead *headDim;
     if constexpr(!isBrc) {
@@ -191,8 +194,8 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::ComputeMul(LocalTen
     }
     PipeBarrier<PIPE_V>();
 }
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::InterleavedInversion(int64_t count,LocalTensor<float> &ub)
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::InterleavedInversion(int64_t count,LocalTensor<float> &ub)
 {
     // 做奇数位的*-1
     SetMaskNorm();
@@ -210,8 +213,8 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::InterleavedInversio
     }
     ResetMask();
 }
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::DataCopyOut(LocalTensor<T> &yUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset)
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::DataCopyOut(LocalTensor<T> &yUb, GlobalTensor<T> &xGm, int64_t blockCout, int64_t blockLen, int64_t gmOffset, int64_t ubOffset)
 {
     DataCopyExtParams copyParams;
     copyParams.blockCount = blockCout;
@@ -221,8 +224,8 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::DataCopyOut(LocalTe
     DataCopyPad(yGm_[gmOffset], yUb[ubOffset], copyParams);
 }
 
-template <typename T, bool isBrc>
-__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::Process()
+template <typename T, bool isBrc, typename R>
+__aicore__ inline void InplacePartialRotaryMulABA<T, isBrc, R>::Process()
 {
     if (blockIdx_ >= usedCoreNum_) {
         return;
@@ -245,26 +248,28 @@ __aicore__ inline void InplacePartialRotaryMulABA<T, isBrc>::Process()
         CopyInData(xUb, xGm_, blockCout , headDim_, gmOffset, halfNumx_);
         xQue_.EnQue<T>(xUb);
 
-        LocalTensor<T> r1Ub = r1Que_.AllocTensor<T>();
+        LocalTensor<R> r1Ub = r1Que_.AllocTensor<R>();
         int64_t r1Offset = blockIdx_ * blockFactor_ * headDim_ + i * ubFactor_ * headDim_;
-        CopyInDataR(r1Ub, r1Gm_, ubSize , headDim_, r1Offset, halfNumr1_);
-        r1Que_.EnQue<T>(r1Ub);
+        CopyInDataR(r1Ub, r1Gm_, ubSize , headDim_, r1Offset, ropeUbOffset_);
+        r1Que_.EnQue<R>(r1Ub);
 
-        LocalTensor<T> r2Ub = r2Que_.AllocTensor<T>();
-        CopyInDataR(r2Ub, r2Gm_, ubSize , headDim_, r1Offset, halfNumr1_);
-        r2Que_.EnQue<T>(r2Ub);
+        LocalTensor<R> r2Ub = r2Que_.AllocTensor<R>();
+        CopyInDataR(r2Ub, r2Gm_, ubSize , headDim_, r1Offset, ropeUbOffset_);
+        r2Que_.EnQue<R>(r2Ub);
 
         xUb = xQue_.DeQue<T>();
-        r1Ub = r1Que_.DeQue<T>();
-        r2Ub = r2Que_.DeQue<T>();
+        r1Ub = r1Que_.DeQue<R>();
+        r2Ub = r2Que_.DeQue<R>();
         LocalTensor<float> xUbFp32 = xUb.template ReinterpretCast<float>();
         LocalTensor<float> r1UbFp32 = r1Ub.template ReinterpretCast<float>();
         LocalTensor<float> r2UbFp32 = r2Ub.template ReinterpretCast<float>();
         if constexpr(sizeof(T) != sizeof(float)) {
             // 非fp32时需要做cast
             Cast(xUbFp32, xUb[halfNumx_], RoundMode::CAST_NONE, xtotalNum);
-            Cast(r1UbFp32, r1Ub[halfNumr1_], RoundMode::CAST_NONE, r1totalNum);
-            Cast(r2UbFp32, r2Ub[halfNumr1_], RoundMode::CAST_NONE, r1totalNum);
+        }
+        if constexpr(sizeof(R) != sizeof(float)) {
+            Cast(r1UbFp32, r1Ub[ropeUbOffset_], RoundMode::CAST_NONE, r1totalNum);
+            Cast(r2UbFp32, r2Ub[ropeUbOffset_], RoundMode::CAST_NONE, r1totalNum);
         }
         PipeBarrier<PIPE_V>();
         LocalTensor<T> yUb = yQue_.AllocTensor<T>();

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -7,6 +7,8 @@ import torch_npu
 from vllm.config import VllmConfig
 from vllm.platforms import current_platform
 
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
 
 class RopeGlobalState:
     def __init__(self):
@@ -117,7 +119,8 @@ class ComplexExpRotaryEmbedding(nn.Module):
             rope_groups = ["default"]
         self.layername = layername
         self.rotary_dim = rotary_dim
-        dtype = torch.get_default_dtype()
+        use_fp32_rope = get_ascend_device_type() in {AscendDeviceType.A2, AscendDeviceType.A3}
+        dtype = torch.float32 if use_fp32_rope else torch.get_default_dtype()
         beta_fast = extra_kwargs.get("beta_fast", 32)
         beta_slow = extra_kwargs.get("beta_slow", 1)
         config_key = (
@@ -141,8 +144,11 @@ class ComplexExpRotaryEmbedding(nn.Module):
                 dtype=torch.float32,
             )
             freqs = torch.einsum("i,j -> ij", t, inv_freq)
-            cos = freqs.cos().repeat_interleave(2, dim=-1).to(dtype)
-            sin = freqs.sin().repeat_interleave(2, dim=-1).to(dtype)
+            cos = freqs.cos().repeat_interleave(2, dim=-1)
+            sin = freqs.sin().repeat_interleave(2, dim=-1)
+            if not use_fp32_rope:
+                cos = cos.to(dtype)
+                sin = sin.to(dtype)
             cos = cos.to(current_platform.device_type)
             sin = sin.to(current_platform.device_type)
 


### PR DESCRIPTION
## Summary
This PR keeps DeepSeek DSA RoPE sin/cos tensors in fp32 from generation to operator invocation, and updates related Ascend custom ops to accept fp32 RoPE inputs On A2/A3 Platform.

## Changes
- Keep RoPE sin/cos generation and runtime buffers in fp32 in rope_dsv4.py.
- Update InplacePartialRotaryMul to support fp32 cos/sin when x is fp16/bf16.
- Update Compressor to support fp32 rope_sin/rope_cos through op registration, tiling key, dtype checks, and kernel dispatch.
- Split compressor rope dtype from activation/output dtype in arch32 vector paths.

## Motivation
For long DeepSeek V4 Pro generation, lowering RoPE sin/cos to fp16/bf16 before DSA preprocessing may introduce precision loss. This PR keeps RoPE coefficients fp32 while preserving existing fp16/bf16 activation and output behavior.
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
