### PR TITLE
[BugFix][Model] Preserve DeepSeek shared expert SwiGLU attrs

### DIFF
--- a/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp
+++ b/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp
@@ -455,11 +455,18 @@ ge::graphStatus DequantSwigluQuantDskTiling::CheckStaticQuantShape(const int64_t
                   return ge::GRAPH_FAILED);
   colLen = quantShape.GetDim(quantShape.GetDimNum() - 1);
   if(quantShape.GetDimNum() == 1){
+    if (!hasGroupIndex_ && colLen == outDimy_) {
+      return ge::GRAPH_SUCCESS;
+    }
+    const std::string expectedShape = hasGroupIndex_
+        ? ("[" + std::to_string(groupNum_) + ", ] or [" +
+           std::to_string(groupNum_) + ", " + std::to_string(outDimy_) + "]")
+        : ("[1], [" + std::to_string(outDimy_) + "] or [1, " +
+           std::to_string(outDimy_) + "]");
     OP_CHECK_IF(colLen != groupNum_,
               OP_LOGE_FOR_INVALID_SHAPE(context_->GetNodeName(), paramName,
                   Ops::Base::ToString(quantShape).c_str(),
-                  ("[" + std::to_string(groupNum_) + ", ] or [" +
-                   std::to_string(groupNum_) + ", " + std::to_string(outDimy_) + "]").c_str()),
+                  expectedShape.c_str()),
               return ge::GRAPH_FAILED);
     colLen = 1;
   }
@@ -497,9 +504,6 @@ ge::graphStatus DequantSwigluQuantDskTiling::CheckIllegalParam() {
 }
 
 ge::graphStatus DequantSwigluQuantDskTiling::GetShapeAttrsInfoInner() {
-  if (!IsPerformanceAndGroupIndexBrach()) {
-    return ge::GRAPH_SUCCESS;
-  }
   // get 2H from x, get H from y, check if 2H can be divided by 64
   auto shapeX = context_->GetInputShape(0);
   OP_CHECK_NULL_WITH_CONTEXT(context_, shapeX);
@@ -521,7 +525,7 @@ ge::graphStatus DequantSwigluQuantDskTiling::GetShapeAttrsInfoInner() {
   // set the relevant param of group, hasGroupIndex_, groupNum_ and speGroupType_
   auto shapeGroupIndex = context_->GetOptionalInputShape(INPUT_GROUP_INDEX);
   hasGroupIndex_ = shapeGroupIndex != nullptr;
-  groupNum_ = 0;
+  groupNum_ = 1;
   speGroupType_ = false;
   if (hasGroupIndex_) {
     const gert::Shape& inputShapeGroupIndex = shapeGroupIndex->GetStorageShape();
@@ -561,7 +565,16 @@ bool DequantSwigluQuantDskTiling::IsPerformanceAndGroupIndexBrach() {
 }
 
 bool DequantSwigluQuantDskTiling::IsCapable() {
-  return IsPerformanceAndGroupIndexBrach();
+  if (IsPerformanceAndGroupIndexBrach()) {
+    return true;
+  }
+  auto* attrs = context_->GetAttrs();
+  if (attrs == nullptr) {
+    return false;
+  }
+  auto* swigluMode = attrs->GetAttrPointer<int>(SWIGLU_MODE_INDEX);
+  bool needsV2Swiglu = swigluMode != nullptr && *swigluMode != 0;
+  return needsV2Swiglu;
 }
 
 void DequantSwigluQuantDskTiling::CountTilingKey() {

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -775,6 +775,66 @@ class TestAscendFusedMoESharedExperts:
         torch.testing.assert_close(part1_out, gate_up)
         torch.testing.assert_close(part2_out, F.sigmoid(gate_out) * down_out)
 
+    def test_quantized_shared_experts_pass_deepseek_swiglu_attrs(self, monkeypatch):
+        layer = AscendFusedMoE.__new__(AscendFusedMoE)
+        if not hasattr(layer, "_forward_shared_experts"):
+            pytest.skip("Current AscendFusedMoE has no shared expert fast path")
+        layer.multistream_overlap_shared_expert = False
+        layer.quant_type = QuantType.W8A8
+
+        shared_experts = MagicMock()
+        shared_experts.gate_up_proj.weight = torch.ones(4, 4)
+        shared_experts.gate_up_proj.weight_scale = torch.ones(4)
+        shared_experts.gate_up_proj.weight_scale_fp32 = torch.ones(8)
+        shared_experts.down_proj.weight = torch.ones(4, 4)
+        shared_experts.down_proj.weight_scale = torch.ones(4)
+        layer._shared_experts = shared_experts
+
+        stream = MagicMock()
+        monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", MagicMock(return_value=stream))
+        monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock(return_value=stream))
+        monkeypatch.setattr(fused_moe_module, "_EXTRA_CTX", SimpleNamespace(moe_comm_type=MoECommType.ALLGATHER))
+
+        quantized_hidden = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2)
+        monkeypatch.setattr(
+            fused_moe_module.torch_npu,
+            "npu_dynamic_quant",
+            MagicMock(return_value=(quantized_hidden, pertoken_scale)),
+        )
+        gate_up_int32 = torch.ones(2, 8, dtype=torch.int32)
+        shared_out = torch.ones(2, 4)
+        monkeypatch.setattr(
+            fused_moe_module.torch_npu,
+            "npu_quant_matmul",
+            MagicMock(side_effect=[gate_up_int32, shared_out]),
+        )
+        dequant_swiglu_quant = MagicMock(return_value=(torch.ones(2, 4, dtype=torch.int8), torch.ones(2)))
+        monkeypatch.setattr(
+            fused_moe_module.torch.ops._C_ascend,
+            "npu_dequant_swiglu_quant",
+            dequant_swiglu_quant,
+            raising=False,
+        )
+
+        fused_moe_evts = SimpleNamespace(
+            before_routed_experts=MagicMock(),
+            after_routed_experts=None,
+            before_gmm2=None,
+            before_combine=None,
+            swiglu_limit=10.0,
+        )
+
+        result = layer._forward_shared_experts(torch.ones(2, 4), fused_moe_evts)
+
+        torch.testing.assert_close(result, shared_out)
+        dequant_swiglu_quant.assert_called_once()
+        kwargs = dequant_swiglu_quant.call_args.kwargs
+        assert kwargs["swiglu_mode"] == 1
+        assert kwargs["clamp_limit"] == 10.0
+        assert kwargs["glu_alpha"] == 1.0
+        assert kwargs["glu_bias"] == 0.0
+
     @pytest.mark.parametrize("has_shared_experts", [False, True])
     def test_shared_forward_impl_routes_shared_output(self, monkeypatch, has_shared_experts):
         layer = AscendFusedMoE.__new__(AscendFusedMoE)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -764,6 +764,8 @@ class AscendFusedMoE(FusedMoE):
                     quant_mode=1,
                     swiglu_mode=1,
                     clamp_limit=fused_moe_evts.swiglu_limit,
+                    glu_alpha=1.0,
+                    glu_bias=0.0,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the DeepSeek shared expert quantized SwiGLU path. For no-group `npu_dequant_swiglu_quant` calls with `swiglu_mode=1`, the old priority=1 tiling path could be selected and drop v2 attributes such as `clamp_limit`, `glu_alpha`, and `glu_bias`.

Changes:
- Let `DequantSwigluQuantDskTiling` handle no-group `swiglu_mode != 0` calls so v2 tiling data is written.
- Keep operator defaults unchanged and pass DeepSeek standard SwiGLU parameters explicitly from the shared expert call site: `glu_alpha=1.0`, `glu_bias=0.0`.
- Add a unit test to lock the shared expert call contract.

Part of #9589. PTA reference: #9590.

### Does this PR introduce _any_ user-facing change?

No. This fixes internal DeepSeek shared expert accuracy behavior on Ascend.

### How was this patch tested?

```bash
git diff --check
pytest -q tests/ut/ops/test_fused_moe.py::TestAscendFusedMoESharedExperts
cd csrc
bash build.sh --pkg --ops=dequant_swiglu_quant --soc=ascend910_93
```

Results:
- `git diff --check`: pass
- shared expert UT: 5 passed
- `dequant_swiglu_quant` csrc package build: pass

E2E real-model validation was intentionally not run in this PR preparation step.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
