### PR TITLE
[BugFix][Parser] Backport MiniMax M2 tool call streaming

### DIFF
--- a/tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any
+
+from openai.types.responses.function_tool import FunctionTool
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
+
+from vllm_ascend.patch.platform import (
+    patch_minimax_m2_tool_call_parser as minimax_m2_patch,
+)
+
+TC_START_ID = 1
+TC_END_ID = 2
+EOS_ID = 99
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {
+            "<minimax:tool_call>": TC_START_ID,
+            "</minimax:tool_call>": TC_END_ID,
+        }
+
+
+def _feed(parser: MinimaxM2ToolParser, chunks):
+    previous = ""
+    results = []
+    for chunk in chunks:
+        if isinstance(chunk, tuple):
+            delta, delta_ids = chunk
+        else:
+            delta = chunk
+            delta_ids = []
+
+        current = previous + delta
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=delta,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=delta_ids,
+            request=None,
+        )
+        if result is not None:
+            results.append(result)
+        previous = current
+    return results
+
+
+def _collect_content(results):
+    return "".join(result.content for result in results if result.content)
+
+
+def _collect_tool_calls(results):
+    tool_calls: dict[int, dict[str, Any]] = {}
+    for result in results:
+        for tool_call in result.tool_calls or []:
+            tool_calls.setdefault(
+                tool_call.index,
+                {
+                    "id": None,
+                    "name": "",
+                    "arguments": "",
+                },
+            )
+            if tool_call.id:
+                tool_calls[tool_call.index]["id"] = tool_call.id
+            if tool_call.function:
+                if tool_call.function.name:
+                    tool_calls[tool_call.index]["name"] += tool_call.function.name
+                if tool_call.function.arguments:
+                    tool_calls[tool_call.index]["arguments"] += tool_call.function.arguments
+    return tool_calls
+
+
+def test_registered_parser_is_patch_loaded():
+    assert MinimaxM2ToolParser.extract_tool_calls_streaming is minimax_m2_patch._patched_extract_tool_calls_streaming
+
+
+def test_plain_content_before_tool_call_is_preserved():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(
+        parser,
+        [
+            "Let me check. ",
+            '<minimax:tool_call><invoke name="get_weather">'
+            '<parameter name="city">Seattle</parameter>'
+            "</invoke></minimax:tool_call>",
+        ],
+    )
+
+    assert _collect_content(results) == "Let me check. "
+    assert len(parser.prev_tool_call_arr) == 1
+
+
+def test_streaming_emits_tool_name_before_argument_fragments():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(
+        parser,
+        [
+            "Let me check. ",
+            "<minimax:tool_call>",
+            '<invoke name="get_weather">',
+            '<parameter name="city">Sea',
+            "ttle</parameter>",
+            "</invoke></minimax:tool_call>",
+        ],
+    )
+
+    tool_deltas = [tc for result in results for tc in (result.tool_calls or [])]
+    argument_fragments = [tc.function.arguments for tc in tool_deltas[1:] if tc.function and tc.function.arguments]
+
+    assert _collect_content(results) == "Let me check. "
+    assert tool_deltas[0].function.name == "get_weather"
+    assert tool_deltas[0].function.arguments is None
+    assert argument_fragments == ['{"city":"Sea', 'ttle"', "}"]
+    assert "".join(argument_fragments) == '{"city":"Seattle"}'
+
+
+def test_streaming_partial_arguments_before_invoke_closes():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(
+        parser,
+        [
+            "<minimax:tool_call>",
+            '<invoke name="get_weather">',
+            '<parameter name="city">Sea',
+        ],
+    )
+
+    tool_deltas = [tc for result in results for tc in (result.tool_calls or [])]
+
+    assert tool_deltas[0].function.name == "get_weather"
+    assert tool_deltas[0].function.arguments is None
+    assert tool_deltas[1].function.arguments == '{"city":"Sea'
+    assert parser.prev_tool_call_arr == []
+
+
+def test_complete_single_chunk_still_reconstructs_tool_call():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(
+        parser,
+        [
+            '<minimax:tool_call><invoke name="get_weather">'
+            '<parameter name="city">Seattle</parameter>'
+            "</invoke></minimax:tool_call>",
+            ("", [EOS_ID]),
+        ],
+    )
+
+    tool_calls = _collect_tool_calls(results)
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["arguments"]) == {"city": "Seattle"}
+    assert results[-1].content == ""
+
+
+def test_start_token_can_arrive_as_special_token_id():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(
+        parser,
+        [
+            ("", [TC_START_ID]),
+            '<invoke name="get_weather">',
+            '<parameter name="city">Seattle</parameter>',
+            "</invoke>",
+            ("", [TC_END_ID]),
+            ("", [EOS_ID]),
+        ],
+    )
+
+    tool_calls = _collect_tool_calls(results)
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["arguments"]) == {"city": "Seattle"}
+    assert results[-1].content == ""
+
+
+def test_start_token_id_survives_empty_chunks_before_invoke_text():
+    parser = MinimaxM2ToolParser(FakeTokenizer())
+    results = _feed(
+        parser,
+        [
+            ("", [TC_START_ID]),
+            ("", []),
+            ("", []),
+            '<invoke name="get_weather">',
+            '<parameter name="city">Seattle</parameter>',
+            "</invoke>",
+            ("", [TC_END_ID]),
+            ("", [EOS_ID]),
+        ],
+    )
+
+    tool_calls = _collect_tool_calls(results)
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["arguments"]) == {"city": "Seattle"}
+    assert results[-1].content == ""
+
+
+def test_chat_tool_schema_drives_type_conversion():
+    parser = MinimaxM2ToolParser(
+        FakeTokenizer(),
+        tools=[
+            ChatCompletionToolsParam(
+                function=FunctionDefinition(
+                    name="get_weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"days": {"type": "integer"}},
+                    },
+                ),
+            )
+        ],
+    )
+    results = _feed(
+        parser,
+        [
+            '<minimax:tool_call><invoke name="get_weather">'
+            '<parameter name="days">5</parameter>'
+            "</invoke></minimax:tool_call>",
+        ],
+    )
+
+    parsed = json.loads(_collect_tool_calls(results)[0]["arguments"])
+
+    assert parsed["days"] == 5
+    assert isinstance(parsed["days"], int)
+
+
+def test_patch_does_not_require_private_v0202_schema_helpers(monkeypatch):
+    monkeypatch.delattr(
+        MinimaxM2ToolParser,
+        "_get_param_types_from_config",
+        raising=False,
+    )
+    monkeypatch.delattr(
+        MinimaxM2ToolParser,
+        "_convert_param_value_with_types",
+        raising=False,
+    )
+    parser = MinimaxM2ToolParser(
+        FakeTokenizer(),
+        tools=[
+            ChatCompletionToolsParam(
+                function=FunctionDefinition(
+                    name="get_weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"days": {"type": "integer"}},
+                    },
+                ),
+            )
+        ],
+    )
+    results = _feed(
+        parser,
+        [
+            '<minimax:tool_call><invoke name="get_weather">'
+            '<parameter name="days">5</parameter>'
+            "</invoke></minimax:tool_call>",
+        ],
+    )
+
+    parsed = json.loads(_collect_tool_calls(results)[0]["arguments"])
+
+    assert parsed["days"] == 5
+    assert isinstance(parsed["days"], int)
+
+
+def test_responses_function_tool_schema_drives_type_conversion():
+    parser = MinimaxM2ToolParser(
+        FakeTokenizer(),
+        tools=[
+            FunctionTool(
+                type="function",
+                name="get_weather",
+                description="Get weather data",
+                parameters={
+                    "type": "object",
+                    "properties": {"days": {"type": "integer"}},
+                },
+            )
+        ],
+    )
+    results = _feed(
+        parser,
+        [
+            '<minimax:tool_call><invoke name="get_weather">'
+            '<parameter name="days">5</parameter>'
+            "</invoke></minimax:tool_call>",
+        ],
+    )
+
+    parsed = json.loads(_collect_tool_calls(results)[0]["arguments"])
+
+    assert parsed["days"] == 5
+    assert isinstance(parsed["days"], int)

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -287,6 +287,24 @@
 #       Remove this patch once vllm-ascend upgrades to a vLLM version with the
 #       same DeepSeek V4 thinking behavior.
 #
+# ** 12b. File: platform/patch_minimax_m2_tool_call_parser.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tool_parsers.minimax_m2_tool_parser.MinimaxM2ToolParser`
+#    Why:
+#       vLLM 0.20.2 only emits MiniMax-M2 tool-call arguments after a complete
+#       `<invoke>...</invoke>` block, so long arguments are buffered instead of
+#       streamed incrementally.
+#    How:
+#       Monkey-patch the MiniMax-M2 parser to emit the tool name once the
+#       `<invoke name=...>` header is available and then stream partial
+#       `<parameter>` values as JSON argument fragments.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/40253
+#       https://github.com/vllm-project/vllm/pull/40298
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains the upstream
+#       MiniMax-M2 incremental tool-call streaming fix.
+#
 # ** 13. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.is_cumem_allocator_available`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -30,6 +30,7 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
+import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa

--- a/vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py
@@ -1,0 +1,520 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# MiniMax M2 tool parser: backport incremental tool-call argument streaming.
+#
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import regex as re
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers import utils as tool_parser_utils
+from vllm.tool_parsers.abstract_tool_parser import Tool
+from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
+from vllm.tool_parsers.utils import (
+    extract_intermediate_diff,
+    find_tool_properties,
+)
+
+_original_init = MinimaxM2ToolParser.__init__
+# vLLM main moved schema helpers from this parser class into tool_parsers.utils.
+_extract_types_from_schema = getattr(tool_parser_utils, "extract_types_from_schema", None)
+_coerce_to_schema_type = getattr(tool_parser_utils, "coerce_to_schema_type", None)
+
+
+def _patched_init(
+    self: MinimaxM2ToolParser,
+    tokenizer: TokenizerLike,
+    tools: list[Tool] | None = None,
+) -> None:
+    _original_init(self, tokenizer, tools)
+    tool_call_ids: list[str] = []
+    tool_name_sent: list[bool] = []
+    self._tool_call_ids = tool_call_ids
+    self._tool_name_sent = tool_name_sent
+    self._tool_call_started_from_token_id = False
+
+
+def _extract_types_from_schema_fallback(schema: Any) -> list[str]:
+    if not isinstance(schema, dict):
+        return ["string"]
+
+    types: set[str] = set()
+    type_value = schema.get("type")
+    if isinstance(type_value, str):
+        types.add(type_value)
+    elif isinstance(type_value, list):
+        types.update(t for t in type_value if isinstance(t, str))
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list):
+        for value in enum_values:
+            if value is None:
+                types.add("null")
+            elif isinstance(value, bool):
+                types.add("boolean")
+            elif isinstance(value, int):
+                types.add("integer")
+            elif isinstance(value, float):
+                types.add("number")
+            elif isinstance(value, str):
+                types.add("string")
+            elif isinstance(value, list):
+                types.add("array")
+            elif isinstance(value, dict):
+                types.add("object")
+
+    for choice_field in ("anyOf", "oneOf", "allOf"):
+        choices = schema.get(choice_field)
+        if isinstance(choices, list):
+            for choice in choices:
+                types.update(_extract_types_from_schema_fallback(choice))
+
+    return list(types) if types else ["string"]
+
+
+def _extract_param_types_from_schema(schema: Any) -> list[str]:
+    if callable(_extract_types_from_schema):
+        return _extract_types_from_schema(schema)
+    return _extract_types_from_schema_fallback(schema)
+
+
+def _coerce_param_value_fallback(value: str, param_types: list[str]) -> Any:
+    type_aliases = {
+        "str": "string",
+        "text": "string",
+        "int": "integer",
+        "float": "number",
+        "bool": "boolean",
+        "dict": "object",
+        "list": "array",
+    }
+    normalized_types = {type_aliases.get(t.lower(), t.lower()) for t in param_types}
+
+    for candidate_type in ("null", "integer", "number", "boolean", "object", "array", "string"):
+        if candidate_type not in normalized_types:
+            continue
+
+        if candidate_type == "null":
+            if value.lower() == "null":
+                return None
+            continue
+        if candidate_type == "string":
+            return value
+        if candidate_type == "integer":
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                continue
+        if candidate_type == "number":
+            try:
+                val = float(value)
+                return val if val != int(val) else int(val)
+            except (ValueError, TypeError):
+                continue
+        if candidate_type == "boolean":
+            lower_val = value.lower().strip()
+            if lower_val in ("true", "1"):
+                return True
+            if lower_val in ("false", "0"):
+                return False
+            continue
+        if candidate_type in ("object", "array"):
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
+
+
+def _coerce_param_value(value: str, param_types: list[str]) -> Any:
+    if callable(_coerce_to_schema_type):
+        return _coerce_to_schema_type(value, param_types)
+    return _coerce_param_value_fallback(value, param_types)
+
+
+def _get_param_types_from_config(
+    param_name: str,
+    param_config: dict[str, Any],
+) -> list[str]:
+    param_schema = param_config.get(param_name)
+    if not isinstance(param_schema, dict):
+        return ["string"]
+    return _extract_param_types_from_schema(param_schema)
+
+
+def _patched_parse_single_invoke(
+    self: MinimaxM2ToolParser,
+    invoke_str: str,
+    tools: list[Tool] | None,
+) -> ToolCall | None:
+    name_match = re.search(r"^([^>]+)", invoke_str)
+    if not name_match:
+        return None
+
+    function_name = self._extract_name(name_match.group(1))
+    param_config = find_tool_properties(tools, function_name)
+
+    param_dict = {}
+    for match in self.parameter_complete_regex.findall(invoke_str):
+        param_match = re.search(r"^([^>]+)>(.*)", match, re.DOTALL)
+        if param_match:
+            param_name = self._extract_name(param_match.group(1))
+            param_value = param_match.group(2).strip()
+            param_type = _get_param_types_from_config(param_name, param_config)
+            param_dict[param_name] = _coerce_param_value(param_value, param_type)
+
+    return ToolCall(
+        type="function",
+        function=FunctionCall(
+            name=function_name,
+            arguments=json.dumps(param_dict, ensure_ascii=False),
+        ),
+    )
+
+
+def _reset_streaming_state(
+    self: MinimaxM2ToolParser,
+    tool_call_started: bool = False,
+) -> None:
+    self.current_tool_index = 0
+    self.prev_tool_call_arr.clear()
+    self.streamed_args_for_tool.clear()
+    self._tool_call_ids.clear()
+    self._tool_name_sent.clear()
+    self._tool_call_started_from_token_id = False
+    self.is_tool_call_started = tool_call_started
+
+
+def _ensure_streaming_slots(self: MinimaxM2ToolParser, tool_count: int) -> None:
+    while len(self.streamed_args_for_tool) < tool_count:
+        self.streamed_args_for_tool.append("")
+    while len(self._tool_call_ids) < tool_count:
+        self._tool_call_ids.append(self._generate_tool_call_id())
+    while len(self._tool_name_sent) < tool_count:
+        self._tool_name_sent.append(False)
+
+
+def _get_param_config(
+    self: MinimaxM2ToolParser,
+    function_name: str,
+) -> dict[str, Any]:
+    return find_tool_properties(self.tools, function_name)
+
+
+def _serialize_partial_param_value(
+    self: MinimaxM2ToolParser,
+    value: str,
+    param_types: list[str],
+    *,
+    is_complete: bool,
+) -> str:
+    value = value.strip()
+    if is_complete:
+        converted = _coerce_param_value(value, param_types)
+        return json.dumps(converted, ensure_ascii=False)
+
+    if not value:
+        return ""
+
+    normalized_types = {t.lower() for t in param_types}
+    string_types = {"string", "str", "text"}
+
+    if "null" in normalized_types and not (normalized_types & string_types) and "null".startswith(value.lower()):
+        return value.lower()
+
+    if {"boolean", "bool"} & normalized_types:
+        lower_value = value.lower()
+        if any(candidate.startswith(lower_value) for candidate in ("true", "false")):
+            return lower_value
+
+    if {"integer", "int", "number", "float"} & normalized_types:
+        return value
+
+    if {"object", "array"} & normalized_types and value[:1] in "{[":
+        return value
+
+    return json.dumps(value, ensure_ascii=False)[:-1]
+
+
+def _build_partial_arguments(
+    self: MinimaxM2ToolParser,
+    invoke_body: str,
+    *,
+    invoke_complete: bool,
+    param_config: dict[str, Any],
+) -> str:
+    args_parts: list[str] = []
+    search_pos = 0
+
+    while True:
+        param_start = invoke_body.find("<parameter name=", search_pos)
+        if param_start == -1:
+            break
+
+        name_start = param_start + len("<parameter name=")
+        name_end = invoke_body.find(">", name_start)
+        if name_end == -1:
+            break
+
+        param_name = self._extract_name(invoke_body[name_start:name_end])
+        value_start = name_end + 1
+        value_end = invoke_body.find("</parameter>", value_start)
+        param_complete = value_end != -1
+        if param_complete:
+            param_value = invoke_body[value_start:value_end]
+            search_pos = value_end + len("</parameter>")
+        else:
+            param_value = invoke_body[value_start:]
+            search_pos = len(invoke_body)
+
+        if not param_complete and not param_value.strip():
+            break
+
+        param_types = _get_param_types_from_config(param_name, param_config)
+        serialized_value = self._serialize_partial_param_value(
+            param_value,
+            param_types,
+            is_complete=param_complete,
+        )
+        if not serialized_value:
+            break
+
+        args_parts.append(f"{json.dumps(param_name, ensure_ascii=False)}:{serialized_value}")
+
+        if not param_complete:
+            break
+
+    if not args_parts:
+        return "{}" if invoke_complete else ""
+
+    args_json = "{" + ",".join(args_parts)
+    if invoke_complete:
+        args_json += "}"
+    return args_json
+
+
+def _get_invoke_states(
+    self: MinimaxM2ToolParser,
+    current_text: str,
+) -> list[dict[str, Any]]:
+    tool_start = current_text.find(self.tool_call_start_token)
+    if tool_start == -1:
+        if not self.is_tool_call_started:
+            return []
+        tool_payload = current_text
+    else:
+        tool_payload = current_text[tool_start + len(self.tool_call_start_token) :]
+
+    tool_end = tool_payload.find(self.tool_call_end_token)
+    if tool_end != -1:
+        tool_payload = tool_payload[:tool_end]
+
+    invoke_states: list[dict[str, Any]] = []
+    search_pos = 0
+    while True:
+        invoke_start = tool_payload.find("<invoke name=", search_pos)
+        if invoke_start == -1:
+            break
+
+        invoke_content_start = invoke_start + len("<invoke name=")
+        invoke_end = tool_payload.find("</invoke>", invoke_content_start)
+        invoke_complete = invoke_end != -1
+
+        if invoke_complete:
+            invoke_str = tool_payload[invoke_content_start:invoke_end]
+            search_pos = invoke_end + len("</invoke>")
+        else:
+            invoke_str = tool_payload[invoke_content_start:]
+            search_pos = len(tool_payload)
+
+        name_end = invoke_str.find(">")
+        if name_end == -1:
+            break
+
+        function_name = self._extract_name(invoke_str[:name_end])
+        param_config = self._get_param_config(function_name)
+        invoke_body = invoke_str[name_end + 1 :]
+        partial_args = self._build_partial_arguments(
+            invoke_body,
+            invoke_complete=invoke_complete,
+            param_config=param_config,
+        )
+
+        tool_call = self._parse_single_invoke(invoke_str, self.tools) if invoke_complete else None
+        invoke_states.append(
+            {
+                "name": function_name,
+                "arguments": partial_args,
+                "complete": invoke_complete,
+                "tool_call": tool_call,
+            }
+        )
+
+        if not invoke_complete:
+            break
+
+    return invoke_states
+
+
+def _finalize_completed_tool_call(
+    self: MinimaxM2ToolParser,
+    idx: int,
+    invoke_state: dict[str, Any],
+) -> None:
+    if not invoke_state["complete"] or len(self.prev_tool_call_arr) > idx:
+        return
+
+    tool_call = invoke_state["tool_call"]
+    if tool_call is None:
+        return
+
+    self.prev_tool_call_arr.append(
+        {
+            "name": tool_call.function.name,
+            "arguments": json.loads(tool_call.function.arguments),
+        }
+    )
+
+
+def _extract_delta_tool_call(
+    self: MinimaxM2ToolParser,
+    current_text: str,
+) -> DeltaToolCall | None:
+    invoke_states = self._get_invoke_states(current_text)
+    if not invoke_states:
+        return None
+
+    self._ensure_streaming_slots(len(invoke_states))
+
+    for idx, invoke_state in enumerate(invoke_states):
+        args_json = invoke_state["arguments"]
+        sent_args = self.streamed_args_for_tool[idx]
+        name_sent = self._tool_name_sent[idx]
+
+        if not name_sent:
+            self._tool_name_sent[idx] = True
+            self.current_tool_index = idx
+            if args_json:
+                self.streamed_args_for_tool[idx] = args_json
+            self._finalize_completed_tool_call(idx, invoke_state)
+            return DeltaToolCall(
+                index=idx,
+                id=self._tool_call_ids[idx],
+                type="function",
+                function=DeltaFunctionCall(
+                    name=invoke_state["name"],
+                    arguments=args_json or None,
+                ),
+            )
+
+        if args_json and args_json != sent_args:
+            if sent_args and args_json.startswith(sent_args):
+                args_delta = args_json[len(sent_args) :]
+            else:
+                args_delta = extract_intermediate_diff(args_json, sent_args)
+
+            if args_delta:
+                self.streamed_args_for_tool[idx] = args_json
+                self.current_tool_index = idx
+                self._finalize_completed_tool_call(idx, invoke_state)
+                return DeltaToolCall(
+                    index=idx,
+                    function=DeltaFunctionCall(arguments=args_delta),
+                )
+
+        self._finalize_completed_tool_call(idx, invoke_state)
+
+    return None
+
+
+def _patched_extract_tool_calls_streaming(
+    self: MinimaxM2ToolParser,
+    previous_text: str,
+    current_text: str,
+    delta_text: str,
+    previous_token_ids: Sequence[int],  # pylint: disable=unused-argument
+    current_token_ids: Sequence[int],  # pylint: disable=unused-argument
+    delta_token_ids: Sequence[int],
+    request: ChatCompletionRequest,  # pylint: disable=unused-argument
+) -> DeltaMessage | None:
+    start_in_text = self.tool_call_start_token in delta_text
+    start_in_ids = self.tool_call_start_token_id in delta_token_ids
+    tool_call_starting = start_in_text or start_in_ids
+    if tool_call_starting:
+        self._reset_streaming_state(tool_call_started=tool_call_starting)
+        self._tool_call_started_from_token_id = start_in_ids and not start_in_text
+    elif not previous_text:
+        if self._tool_call_started_from_token_id:
+            if current_text:
+                self._tool_call_started_from_token_id = False
+        else:
+            self._reset_streaming_state(tool_call_started=False)
+
+    if not self.is_tool_call_started:
+        return DeltaMessage(content=delta_text) if delta_text else None
+
+    content_before = None
+    if start_in_text:
+        before = delta_text[: delta_text.index(self.tool_call_start_token)]
+        content_before = before or None
+
+    delta_tool_call = self._extract_delta_tool_call(current_text)
+
+    if delta_tool_call or content_before:
+        return DeltaMessage(
+            content=content_before,
+            tool_calls=[delta_tool_call] if delta_tool_call else None,
+        )
+
+    if (
+        not delta_text
+        and delta_token_ids
+        and self.prev_tool_call_arr
+        and self.tool_call_end_token_id not in delta_token_ids
+    ):
+        return DeltaMessage(content="")
+
+    return None
+
+
+MinimaxM2ToolParser.__init__ = _patched_init
+MinimaxM2ToolParser._parse_single_invoke = _patched_parse_single_invoke
+MinimaxM2ToolParser._reset_streaming_state = _reset_streaming_state
+MinimaxM2ToolParser._ensure_streaming_slots = _ensure_streaming_slots
+MinimaxM2ToolParser._get_param_config = _get_param_config
+MinimaxM2ToolParser._serialize_partial_param_value = _serialize_partial_param_value
+MinimaxM2ToolParser._build_partial_arguments = _build_partial_arguments
+MinimaxM2ToolParser._get_invoke_states = _get_invoke_states
+MinimaxM2ToolParser._finalize_completed_tool_call = _finalize_completed_tool_call
+MinimaxM2ToolParser._extract_delta_tool_call = _extract_delta_tool_call
+MinimaxM2ToolParser.extract_tool_calls_streaming = _patched_extract_tool_calls_streaming


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes vLLM issue #39649: https://github.com/vllm-project/vllm/issues/39649 for the Ascend-patched vLLM 0.20.2 runtime.

This PR backports the MiniMax M2 incremental tool-call streaming parser behavior used by upstream vLLM. The existing `minimax_m2_tool_parser` waits for a complete `<invoke>...</invoke>` block before emitting arguments, so long tool-call arguments are buffered instead of streamed.

This PR adds a platform monkey patch that:

- emits the tool-call name once `<invoke name=...>` is available
- streams partial `<parameter>` content as JSON argument fragments
- preserves `prev_tool_call_arr` and `streamed_args_for_tool` for finish handling
- uses vLLM shared `find_tool_properties` helper so both Chat Completions tools and Responses `FunctionTool` schemas drive type conversion
- handles the v0.20.2 special-token path where `<minimax:tool_call>` can arrive by token id without decoded text
- keeps the token-id-started tool-call state across empty decoded chunks until actual `<invoke>` text arrives

This follows the upstream vLLM fixes proposed in:

- https://github.com/vllm-project/vllm/pull/40253
- https://github.com/vllm-project/vllm/pull/40298

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax M2 auto tool-choice streaming now emits tool-call argument deltas incrementally instead of buffering them until the closing `</invoke>` tag.

### How was this patch tested?

- `ruff check vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py`
- `python -m pytest -q tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py`
- `python -m pytest -q tests/ut/patch/platform`
- `python -m pre_commit run --hook-stage manual --files vllm_ascend/patch/platform/patch_minimax_m2_tool_call_parser.py tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
