### PR TITLE
[Feature] Cache the code start compilation for npugraph_ex

### DIFF
--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -177,7 +177,8 @@ def npugraph_ex_compile(
     # torch.compile requires the output of the fx graph to be a tuple
     if not graph_returns_tuple(graph):
         compiled_fn = make_graph_return_tuple(graph, example_inputs, npugraph_ex)
-    compiled_fn = npugraph_ex(graph, example_inputs)
+    else:
+        compiled_fn = npugraph_ex(graph, example_inputs)
     handle = (key, cache_path) 
 
     # handle = None

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import copy
 import functools
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -135,7 +135,6 @@ def npugraph_ex_compile(
     # Try npugraph_ex first, fall back to torchair for backward compatibility.
     try:
         import npugraph_ex as nge
-        from torchair.npu_fx_compiler import _CompiledFxGraph
 
         cache_path = os.path.join(cache_dir, key) if (cache_dir and key) else None
 

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -163,7 +163,7 @@ def npugraph_ex_compile(
                     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
                     with open(cache_path, "w") as f:
                         f.write(py_code)
-                    logger.debug(f"Saved compiled graph to cache: {cache_path}")
+                    logger.debug("Saved compiled graph to cache: %s", cache_path)
             return compiled_gm
 
         nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import copy
 import functools
 from collections.abc import Callable
@@ -129,6 +130,7 @@ def npugraph_ex_compile(
     ascend_compilation_config: AscendCompilationConfig,
     compile_range: Range,
     key: str | None = None,
+    cache_dir: str | None = None,
 ) -> tuple[Callable | None, Any | None]:
     # Try npugraph_ex first, fall back to torchair for backward compatibility.
     try:
@@ -156,8 +158,22 @@ def npugraph_ex_compile(
 
     # torch.compile requires the output of the fx graph to be a tuple
     if not graph_returns_tuple(graph):
-        return make_graph_return_tuple(graph, example_inputs, npugraph_ex), None
-    return npugraph_ex(graph, example_inputs), None
+        compiled_fn = make_graph_return_tuple(graph, example_inputs, npugraph_ex)
+    compiled_fn = npugraph_ex(graph, example_inputs)
+    handle = (key, cache_path)
+
+    # handle = None
+    # if isinstance(compiled_fn, _CompiledFxGraph):
+    #     py_code = compiled_fn.get_code()
+    #     if cache_path and py_code:
+    #         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+    #         with open(cache_path, "w") as f:
+    #             f.write(py_code)
+    #         handle = (key, cache_path)
+    #         logger.info(f"Saved compiled graph to cache: {cache_path}")
+
+    nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
+    return compiled_fn, handle
 
 
 class AscendCompiler(CompilerInterface):
@@ -169,11 +185,25 @@ class AscendCompiler(CompilerInterface):
 
     name = "AscendCompiler"
 
+    # TODO(wxs): add passes related to compilation in compute_hash
     def compute_hash(self, vllm_config: VllmConfig) -> str:
-        npugraph_ex_enabled = get_ascend_config().ascend_compilation_config.enable_npugraph_ex
-        if npugraph_ex_enabled:
-            self.vllm_config = vllm_config
-        return vllm_config.compute_hash()
+        self.vllm_config = vllm_config
+        ascend_compilation_config = get_ascend_config().ascend_compilation_config
+        from hashlib import sha256
+
+        import torch_npu
+
+        factors = {
+            "torch_npu_version": torch_npu.__version__,
+            "enable_npugraph_ex": ascend_compilation_config.enable_npugraph_ex,
+            "enable_static_kernel": ascend_compilation_config.enable_static_kernel,
+        }
+        logger.debug("AscendCompiler hash factors: %s", factors)
+        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10]
+
+    def initialize_cache(self, cache_dir, disable_cache=False, prefix=""):
+        self.cache_dir = cache_dir
+        self.disable_cache = disable_cache
 
     def compile(
         self,
@@ -204,10 +234,23 @@ class AscendCompiler(CompilerInterface):
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex:
+            cache_dir = getattr(self, "cache_dir", None)
             logger.info("enable_npugraph_ex is enabled, which will bring graph compilation optimization.")
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(
-                graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key
+                graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key, cache_dir
             )
         else:
             return fusion_pass_compile(graph, example_inputs, compiler_config, compile_range, key)
+        
+    def load(self, handle, graph, example_inputs, graph_index, compile_range):
+        key, path = handle
+        from torchair.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
+
+        with open(path) as f:
+            py_code = f.read()
+        artifacts = _CompiledFxArtifacts()
+        artifacts.py_code = py_code
+        logger.info("Loaded npugraph_ex compilation cache from %s", path)
+        compiled_fn = _CompiledFxGraph.load_artifacts(artifacts)
+        return compiled_fn

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -135,6 +135,8 @@ def npugraph_ex_compile(
     # Try npugraph_ex first, fall back to torchair for backward compatibility.
     try:
         import npugraph_ex as nge
+        from torchair.npu_fx_compiler import _CompiledFxGraph
+        cache_path = os.path.join(cache_dir, key) if (cache_dir and key) else None
 
         torch.npu.set_compile_mode(jit_compile=False)
         config = nge.CompilerConfig()
@@ -147,6 +149,21 @@ def npugraph_ex_compile(
         _configure_backend(
             config, ascend_compilation_config, vllm_config, process_kwargs_options=_process_kwargs_options
         )
+        import torchair.npu_fx_compiler as nfx
+        _original_get_compiled_gm = nfx._NpuFxCompiler._get_compiled_gm
+        
+        handle = None
+        def patched_get_compiled_gm(self, graph, example_inputs):
+            compiled_gm = _original_get_compiled_gm(self, graph, example_inputs)
+            if cache_path:
+                py_code = compiled_gm.get_code()
+                if py_code:
+                    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                    with open(cache_path, "w") as f:
+                        f.write(py_code)
+                    logger.info(f"Saved compiled graph to cache: {cache_path}")
+            return compiled_gm
+        nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
         npugraph_ex = nge.get_npu_backend(compiler_config=config)
     except ImportError:
         import torchair
@@ -160,7 +177,7 @@ def npugraph_ex_compile(
     if not graph_returns_tuple(graph):
         compiled_fn = make_graph_return_tuple(graph, example_inputs, npugraph_ex)
     compiled_fn = npugraph_ex(graph, example_inputs)
-    handle = (key, cache_path)
+    handle = (key, cache_path) 
 
     # handle = None
     # if isinstance(compiled_fn, _CompiledFxGraph):
@@ -173,7 +190,7 @@ def npugraph_ex_compile(
     #         logger.info(f"Saved compiled graph to cache: {cache_path}")
 
     nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
-    return compiled_fn, handle
+    return compiled_fn, None
 
 
 class AscendCompiler(CompilerInterface):
@@ -184,7 +201,6 @@ class AscendCompiler(CompilerInterface):
     """
 
     name = "AscendCompiler"
-
     # TODO(wxs): add passes related to compilation in compute_hash
     def compute_hash(self, vllm_config: VllmConfig) -> str:
         self.vllm_config = vllm_config
@@ -199,7 +215,7 @@ class AscendCompiler(CompilerInterface):
             "enable_static_kernel": ascend_compilation_config.enable_static_kernel,
         }
         logger.debug("AscendCompiler hash factors: %s", factors)
-        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10]
+        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10] 
 
     def initialize_cache(self, cache_dir, disable_cache=False, prefix=""):
         self.cache_dir = cache_dir
@@ -234,7 +250,6 @@ class AscendCompiler(CompilerInterface):
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex:
-            cache_dir = getattr(self, "cache_dir", None)
             logger.info("enable_npugraph_ex is enabled, which will bring graph compilation optimization.")
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -136,6 +136,7 @@ def npugraph_ex_compile(
     try:
         import npugraph_ex as nge
         from torchair.npu_fx_compiler import _CompiledFxGraph
+
         cache_path = os.path.join(cache_dir, key) if (cache_dir and key) else None
 
         torch.npu.set_compile_mode(jit_compile=False)
@@ -150,9 +151,11 @@ def npugraph_ex_compile(
             config, ascend_compilation_config, vllm_config, process_kwargs_options=_process_kwargs_options
         )
         import npugraph_ex.npu_fx_compiler as nfx
+
         _original_get_compiled_gm = nfx._NpuFxCompiler._get_compiled_gm
-        
+
         handle = None
+
         def patched_get_compiled_gm(self, graph, example_inputs):
             compiled_gm = _original_get_compiled_gm(self, graph, example_inputs)
             if cache_path:
@@ -163,7 +166,7 @@ def npugraph_ex_compile(
                         f.write(py_code)
                     logger.debug(f"Saved compiled graph to cache: {cache_path}")
             return compiled_gm
-        
+
         nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
         npugraph_ex = nge.get_npu_backend(compiler_config=config)
     except ImportError:
@@ -179,8 +182,7 @@ def npugraph_ex_compile(
         compiled_fn = make_graph_return_tuple(graph, example_inputs, npugraph_ex)
     else:
         compiled_fn = npugraph_ex(graph, example_inputs)
-    handle = (key, cache_path) 
-
+    handle = (key, cache_path)
 
     nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
     return compiled_fn, handle
@@ -194,6 +196,7 @@ class AscendCompiler(CompilerInterface):
     """
 
     name = "AscendCompiler"
+
     # TODO(wxs): add passes related to compilation in compute_hash
     def compute_hash(self, vllm_config: VllmConfig) -> str:
         self.vllm_config = vllm_config
@@ -208,7 +211,7 @@ class AscendCompiler(CompilerInterface):
             "enable_static_kernel": ascend_compilation_config.enable_static_kernel,
         }
         logger.debug("AscendCompiler hash factors: %s", factors)
-        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10] 
+        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10]
 
     def initialize_cache(self, cache_dir, disable_cache=False, prefix=""):
         self.cache_dir = cache_dir
@@ -247,11 +250,18 @@ class AscendCompiler(CompilerInterface):
             logger.info("enable_npugraph_ex is enabled, which will bring graph compilation optimization.")
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(
-                graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key, cache_dir
+                graph,
+                example_inputs,
+                compiler_config,
+                self.vllm_config,
+                ascend_compilation_config,
+                compile_range,
+                key,
+                cache_dir,
             )
         else:
             return fusion_pass_compile(graph, example_inputs, compiler_config, compile_range, key)
-        
+
     def load(self, handle, graph, example_inputs, graph_index, compile_range):
         key, path = handle
         from npugraph_ex.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
@@ -268,6 +278,7 @@ class AscendCompiler(CompilerInterface):
         # recreate the unflatten wrapper so callers receive the original output structure.
         if not graph_returns_tuple(graph):
             _inner_fn = compiled_fn
+
             def compiled_fn(*args, **kwargs):
                 result = _inner_fn(*args, **kwargs)
                 if isinstance(result, (tuple, list)) and len(result) == 1:

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -149,7 +149,7 @@ def npugraph_ex_compile(
         _configure_backend(
             config, ascend_compilation_config, vllm_config, process_kwargs_options=_process_kwargs_options
         )
-        import torchair.npu_fx_compiler as nfx
+        import npugraph_ex.npu_fx_compiler as nfx
         _original_get_compiled_gm = nfx._NpuFxCompiler._get_compiled_gm
         
         handle = None
@@ -161,7 +161,7 @@ def npugraph_ex_compile(
                     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
                     with open(cache_path, "w") as f:
                         f.write(py_code)
-                    logger.info(f"Saved compiled graph to cache: {cache_path}")
+                    logger.debug(f"Saved compiled graph to cache: {cache_path}")
             return compiled_gm
         
         nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
@@ -181,15 +181,6 @@ def npugraph_ex_compile(
         compiled_fn = npugraph_ex(graph, example_inputs)
     handle = (key, cache_path) 
 
-    # handle = None
-    # if isinstance(compiled_fn, _CompiledFxGraph):
-    #     py_code = compiled_fn.get_code()
-    #     if cache_path and py_code:
-    #         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-    #         with open(cache_path, "w") as f:
-    #             f.write(py_code)
-    #         handle = (key, cache_path)
-    #         logger.info(f"Saved compiled graph to cache: {cache_path}")
 
     nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
     return compiled_fn, handle
@@ -263,12 +254,24 @@ class AscendCompiler(CompilerInterface):
         
     def load(self, handle, graph, example_inputs, graph_index, compile_range):
         key, path = handle
-        from torchair.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
+        from npugraph_ex.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
 
         with open(path) as f:
             py_code = f.read()
         artifacts = _CompiledFxArtifacts()
         artifacts.py_code = py_code
-        logger.info("Loaded npugraph_ex compilation cache from %s", path)
+        logger.debug("Loaded npugraph_ex compilation cache from %s", path)
         compiled_fn = _CompiledFxGraph.load_artifacts(artifacts)
+
+        # The saved code was compiled from the graph after make_graph_return_tuple mutated it
+        # to return a flat tuple. If the original graph didn't return a tuple, we need to
+        # recreate the unflatten wrapper so callers receive the original output structure.
+        if not graph_returns_tuple(graph):
+            _inner_fn = compiled_fn
+            def compiled_fn(*args, **kwargs):
+                result = _inner_fn(*args, **kwargs)
+                if isinstance(result, (tuple, list)) and len(result) == 1:
+                    return result[0]
+                return result
+
         return compiled_fn

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -163,6 +163,7 @@ def npugraph_ex_compile(
                         f.write(py_code)
                     logger.info(f"Saved compiled graph to cache: {cache_path}")
             return compiled_gm
+        
         nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
         npugraph_ex = nge.get_npu_backend(compiler_config=config)
     except ImportError:
@@ -190,7 +191,7 @@ def npugraph_ex_compile(
     #         logger.info(f"Saved compiled graph to cache: {cache_path}")
 
     nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
-    return compiled_fn, None
+    return compiled_fn, handle
 
 
 class AscendCompiler(CompilerInterface):
@@ -250,6 +251,7 @@ class AscendCompiler(CompilerInterface):
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex:
+            cache_dir = getattr(self, "cache_dir", None)
             logger.info("enable_npugraph_ex is enabled, which will bring graph compilation optimization.")
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(


### PR DESCRIPTION
### What this PR does / why we need it?
Implement vLLM `CompilerInterface` cache protocol (initialize_cache / compile / load) for AscendCompiler when `enable_npugraph_ex=True`. 

Cache the cold start compilation, and then reuse the cached results, improving performance by about 10 seconds.

Co-authored-by: semiba11er [pierrewjc1993@163.com](mailto:pierrewjc1993@163.com)

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?

```
(EngineCore pid=860220) INFO 06-01 07:14:59 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 11.15 s
(EngineCore pid=860220) INFO 06-01 07:14:59 [decorators.py:311] Directly load AOT compilation from path /root/.cache/vllm/torch_compile_cache/torch_aot_compile/40e9a180b6b930c797012a12cc6f05a60df74eeb815fbcb596b78818482c0dc6/rank_0_0/model
(EngineCore pid=860220) INFO 06-01 07:14:59 [monitor.py:53] torch.compile took 13.47 s in total
```

```
(EngineCore pid=853067) INFO 06-01 07:05:56 [backends.py:292] Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 0.126 s
(EngineCore pid=853067) INFO 06-01 07:05:56 [decorators.py:311] Directly load AOT compilation from path /root/.cache/vllm/torch_compile_cache/torch_aot_compile/40e9a180b6b930c797012a12cc6f05a60df74eeb815fbcb596b78818482c0dc6/rank_0_0/model
(EngineCore pid=853067) INFO 06-01 07:05:56 [monitor.py:53] torch.compile took 2.34 s in total
```


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
