### PR TITLE
[BugFix][KV pool] DSv4 fix lookup/load mismatch

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -345,6 +345,10 @@ class ChunkedTokenDatabase:
         if not block_hashes:
             return
         group_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        group_block_size *= cache_family_ratio
         block_hashes = get_block_hashes(
             block_hashes,
             group_block_size,
@@ -366,6 +370,10 @@ class ChunkedTokenDatabase:
             if start_idx < mask_num:
                 continue
             else:
+                start_idx //= cache_family_ratio
+                end_idx //= cache_family_ratio
+                if end_idx <= start_idx:
+                    continue
                 yield (
                     start_idx,
                     end_idx,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -283,10 +283,22 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not keys:
                 continue
 
+            exists_states = self.lookup(keys)
+            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+
+            if not missing_indices:
+                continue
+
+            starts = [starts[index] for index in missing_indices]
+            ends = [ends[index] for index in missing_indices]
+            keys = [keys[index] for index in missing_indices]
+            block_hashes = [block_hashes[index] for index in missing_indices]
+
             logger.info(
-                "Storing KV cache for %d out of %d blocks for request %s in group %d",
+                "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
                 len(keys),
                 token_len // group_block_size,
+                len(missing_indices),
                 req_id,
                 group_id,
             )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -283,22 +283,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not keys:
                 continue
 
-            exists_states = self.lookup(keys)
-            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
-
-            if not missing_indices:
-                continue
-
-            starts = [starts[index] for index in missing_indices]
-            ends = [ends[index] for index in missing_indices]
-            keys = [keys[index] for index in missing_indices]
-            block_hashes = [block_hashes[index] for index in missing_indices]
-
             logger.info(
-                "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
+                "Storing KV cache for %d out of %d blocks for request %s in group %d",
                 len(keys),
                 token_len // group_block_size,
-                len(missing_indices),
                 req_id,
                 group_id,
             )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -577,7 +577,6 @@ class KVPoolWorker:
                 continue
 
             request.skip_null_blocks_by_group = self.group_uses_align_state
-            request.disable_tp_key_sharding = (self.use_mla or self.use_sparse) and self.put_step > 1
             request.current_event = current_event
             self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
                 request.req_id

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -444,7 +444,8 @@ class KVPoolWorker:
                 )
                 continue
             request.skip_null_blocks_by_group = self.group_uses_align_state
-            load_group_ids = request.kv_cache_group_ids or [0]
+            load_group_ids = self._get_lookup_gate_group_ids(request.kv_cache_group_ids or [0])
+            request.kv_cache_group_ids = load_group_ids
             token_len = request.token_len_chunk
             if (load_spec.kvpool_cached_tokens % self.cache_transfer_granularity != 0) and (
                 load_spec.kvpool_cached_tokens == token_len - 1

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -906,7 +906,6 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
             for group_id in kv_cache_group_ids:
                 end = 0
                 keys = []

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -444,8 +444,7 @@ class KVPoolWorker:
                 )
                 continue
             request.skip_null_blocks_by_group = self.group_uses_align_state
-            load_group_ids = self._get_lookup_gate_group_ids(request.kv_cache_group_ids or [0])
-            request.kv_cache_group_ids = load_group_ids
+            load_group_ids = request.kv_cache_group_ids or [0]
             token_len = request.token_len_chunk
             if (load_spec.kvpool_cached_tokens % self.cache_transfer_granularity != 0) and (
                 load_spec.kvpool_cached_tokens == token_len - 1

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -906,6 +906,7 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
+            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
             for group_id in kv_cache_group_ids:
                 end = 0
                 keys = []


### PR DESCRIPTION
## Summary
- keep the draft PR parked while narrowing the KV pool lookup/load mismatch
- reverted the full-group scheduler lookup change because it can suppress otherwise valid external-cache hits
- reverted the gate-load change because it can leave non-gate KV/state groups unrestored

## Validation
vLLM version: v0.20.1
vLLM main: vllm-project/vllm@c7aa186

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
