### PR TITLE
[BugFix] [P/D] avoid MTP placeholders exceeding max model length

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -148,7 +148,7 @@ class RecomputeScheduler(Scheduler):
                 request.prompt_token_ids.pop()
                 request._all_token_ids.pop()
                 request.num_prompt_tokens -= 1
-            if self.is_mtp_kv_consumer:
+            if self.is_mtp_kv_consumer and (self.max_model_len >= (request.num_tokens + self.num_spec_tokens)):
                 request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request


### PR DESCRIPTION

### What this PR does / why we need it?
This PR fixes an issue in recompute scheduler when the decode node enables MTP.

When `is_mtp_kv_consumer` is enabled, the scheduler fills `request.spec_token_ids` with MTP placeholder tokens for newly added requests, so that decode nodes can match the full graph after pulling KV cache from prefill nodes. However, for the first incoming request on the decode node, if the original request length is already close to `max_model_len`, adding MTP placeholder tokens may make `request.num_tokens + num_spec_tokens` exceed the model length limit.

This PR adds a boundary check before filling MTP placeholder tokens:

```python
self.max_model_len >= (request.num_tokens + self.num_spec_tokens)
```
With this change, MTP placeholders are only added when the request can still fit within max_model_len, avoiding invalid scheduling behavior for the first request on the decode node.

Does this PR introduce any user-facing change?
No user-facing API change.

This only fixes scheduler behavior for decode-node MTP scenarios and prevents MTP placeholder tokens from exceeding the model length limit.

How was this patch tested?
Verified the affected recompute scheduler logic.
Tested/validated the decode-node MTP first-request scenario shown in the issue, where placeholder tokens should not be added if they would exceed max_model_len.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
