### PR TITLE
[Misc] issue auto-label fix: remove qwen3-dense and qwen3 235b/480b model from llm-model label

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -31,7 +31,7 @@ flashcomm:
 rl:
   - '/(\b(verl|rl)\b)/i'
 llm-model:
-  - '/(deepseek(?:[- ]*(?:r1|v3(?:\.2)?))?\S*|(kimi k2|kimik2|kimi-k2)(?!\.5)|(kimi k2\.5|kimik2\.5|kimi-k2\.5)|glm5|glm-5|glm 5|qwen3-(?:235b|480b)\S*|Qwen3-(?:32B|8B|30B)\S*|qwen3-next\S*|\bglm[- ]?4\.[0-9]+(?![^v\s]*v)\S*)/i'
+  - '/(deepseek(?:[- ]*(?:r1|v3(?:\.2)?))?\S*|(kimi k2|kimik2|kimi-k2)(?!\.5)|(kimi k2\.5|kimik2\.5|kimi-k2\.5)|glm5|glm-5|glm 5|qwen3-next\S*|\bglm[- ]?4\.[0-9]+(?![^v\s]*v)\S*)/i'
 deepseek:
   - '/(deepseek(?:[- ]*(?:r1|v3(?:\.2)?))?\S*)/i'
 kimi-k2:


### PR DESCRIPTION
### What this PR does / why we need it?
Remove qwen3-dense and qwen3 235b/480b model from llm-model label as these model has been moved to gqa-model label.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
