### PR TITLE
[BugFix] Lazy initialize KV store on put

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -1,5 +1,7 @@
 # Standard
+import threading
 from enum import Enum
+from typing import Any
 
 import torch
 from vllm.config import ParallelConfig
@@ -18,7 +20,34 @@ class MmcDirect(Enum):
 
 
 class MemcacheBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+        self.local_rank = get_world_group().local_rank
+        self.store: Any | None = None
+        self._is_a2 = get_ascend_device_type() in {AscendDeviceType.A2}
+        self._lazy_init = lazy_init and not self._is_a2
+        self._store_initialized = False
+        self._store_init_lock = threading.Lock()
+        self._registered_buffers: tuple[list[int], list[int]] | None = None
+        self._buffers_registered = False
+
+        if not self._lazy_init:
+            self.store = self._setup_store()
+            self._store_initialized = True
+
+    def _ensure_initialized(self):
+        if self._store_initialized:
+            return
+
+        with self._store_init_lock:
+            if self._store_initialized:
+                return
+
+            logger.info("Initializing Memcache store on first put.")
+            self.store = self._setup_store()
+            self._store_initialized = True
+            self._register_buffers_if_needed()
+
+    def _setup_store(self):
         try:
             from memcache_hybrid import DistributedObjectStore  # type: ignore
         except ImportError as e:
@@ -28,15 +57,14 @@ class MemcacheBackend(Backend):
                 "to run vLLM with MemcacheConnector."
             ) from e
         try:
-            soc_version = get_ascend_device_type()
-            if soc_version in {AscendDeviceType.A2}:
+            if self._is_a2:
                 tmp_tensor = torch.zeros(1, device="npu")
                 output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
                 torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)
-            self.local_rank = get_world_group().local_rank
-            self.store = DistributedObjectStore()
-            res = self.store.init(self.local_rank)
+            store = DistributedObjectStore()
+            res = store.init(self.local_rank)
             assert res == 0
+            return store
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
             raise
@@ -49,17 +77,37 @@ class MemcacheBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):
-        soc_version = get_ascend_device_type()
-        if soc_version in {AscendDeviceType.A2}:
-            for ptr, size in zip(ptrs, sizes):
-                self.store.register_buffer(ptr, size)
-        else:
-            pass
+        self._registered_buffers = (list(ptrs), list(sizes))
+        self._register_buffers_if_needed()
+
+    def _register_buffers_if_needed(self):
+        if not self._is_a2:
+            return
+        if self._registered_buffers is None or self._buffers_registered:
+            return
+        if not self._store_initialized:
+            return
+        assert self.store is not None
+        ptrs, sizes = self._registered_buffers
+        for ptr, size in zip(ptrs, sizes):
+            self.store.register_buffer(ptr, size)
+        self._buffers_registered = True
 
     def exists(self, keys: list[str]) -> list[int]:
+        if self._lazy_init and not self._store_initialized:
+            logger.debug(
+                "MemcacheBackend.exists called before store initialization; treating %d keys as missing.",
+                len(keys),
+            )
+            return [0] * len(keys)
+        assert self.store is not None
         return self.store.batch_is_exist(keys)
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
+        if self._lazy_init and not self._store_initialized:
+            logger.error("MemcacheBackend.get called before store initialization, keys=%s", key)
+            return
+        assert self.store is not None
         try:
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
             for value in res:
@@ -70,9 +118,15 @@ class MemcacheBackend(Backend):
 
     def put(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         try:
+            self._ensure_initialized()
+            assert self.store is not None
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
             for value in res:
                 if value != 0:
-                    logger.error("Failed to get key %s,res:%s", key, res)
+                    logger.error("Failed to put key %s,res:%s", key, res)
+                    if self._lazy_init:
+                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
         except Exception as e:
             logger.error("Failed to put key %s,error:%s", key, e)
+            if self._lazy_init:
+                logger.error("If this is the first DSV4(compress) request, this failure is expected.")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -1,7 +1,9 @@
 # Standard
 import json
 import os
+import threading
 from dataclasses import dataclass
+from typing import Any
 
 import regex as re
 import torch
@@ -20,7 +22,35 @@ DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 
 class MooncakeBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+        self.config = MooncakeStoreConfig.load_from_env()
+        if self.config.protocol != "ascend":
+            raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
+
+        self.store: Any | None = None
+        self.local_seg: str | None = None
+        self._use_fabric_mem = os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") == "1"
+        self._lazy_init = lazy_init and self._use_fabric_mem
+        self._store_initialized = False
+        self._store_init_lock = threading.Lock()
+
+        if not self._lazy_init:
+            self.store = self._setup_store()
+            self._store_initialized = True
+
+    def _ensure_initialized(self):
+        if self._store_initialized:
+            return
+
+        with self._store_init_lock:
+            if self._store_initialized:
+                return
+
+            logger.info("Initializing Mooncake store on first put.")
+            self.store = self._setup_store()
+            self._store_initialized = True
+
+    def _setup_store(self):
         try:
             from mooncake.store import MooncakeDistributedStore  # type: ignore
         except ImportError as e:
@@ -29,44 +59,42 @@ class MooncakeBackend(Backend):
                 "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
                 "to run vLLM with MooncakeConnector."
             ) from e
-        self.config = MooncakeStoreConfig.load_from_env()
-        self.store = MooncakeDistributedStore()
-        if self.config.protocol == "ascend":
-            local_hostname = get_ip()
-            # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
-            # and only can be used for 800 I/T A3 series.
-            # Required supporting hardware versions are as follows:
-            if os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") != "1":
-                transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
-                self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
-                ret = self.store.setup(
-                    self.local_seg,
-                    self.config.metadata_server,
-                    self.config.global_segment_size,
-                    self.config.local_buffer_size,
-                    self.config.protocol,
-                    self.config.device_name,
-                    self.config.master_server_address,
-                    transfer_engine.get_engine(),
-                )
-            else:
-                self.local_seg = local_hostname
-                ret = self.store.setup(
-                    self.local_seg,
-                    self.config.metadata_server,
-                    self.config.global_segment_size,
-                    0,
-                    self.config.protocol,
-                    self.config.device_name,
-                    self.config.master_server_address,
-                )
 
-            if ret != 0:
-                msg = "Initialize mooncake failed."
-                logger.error(msg)
-                raise RuntimeError(msg)
+        store = MooncakeDistributedStore()
+        local_hostname = get_ip()
+        # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
+        # and only can be used for 800 I/T A3 series.
+        # Required supporting hardware versions are as follows:
+        if not self._use_fabric_mem:
+            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
+            self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
+            ret = store.setup(
+                self.local_seg,
+                self.config.metadata_server,
+                self.config.global_segment_size,
+                self.config.local_buffer_size,
+                self.config.protocol,
+                self.config.device_name,
+                self.config.master_server_address,
+                transfer_engine.get_engine(),
+            )
         else:
-            raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
+            self.local_seg = local_hostname
+            ret = store.setup(
+                self.local_seg,
+                self.config.metadata_server,
+                self.config.global_segment_size,
+                0,
+                self.config.protocol,
+                self.config.device_name,
+                self.config.master_server_address,
+            )
+
+        if ret != 0:
+            msg = "Initialize mooncake failed."
+            logger.error(msg)
+            raise RuntimeError(msg)
+        return store
 
     def set_device(self):
         local_rank = get_world_group().local_rank
@@ -74,22 +102,41 @@ class MooncakeBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
-        if os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") != "1":
+        if not self._use_fabric_mem:
+            local_hostname = get_ip()
+            global_te.get_transfer_engine(local_hostname, device_name=None)
             global_te.register_buffer(ptrs, lengths)
 
     def exists(self, keys: list[str]) -> list[int]:
+        if self._lazy_init and not self._store_initialized:
+            logger.debug(
+                "MooncakeBackend.exists called before store initialization; treating %d keys as missing.",
+                len(keys),
+            )
+            return [0] * len(keys)
+        assert self.store is not None
         return self.store.batch_is_exist(keys)
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         try:
+            self._ensure_initialized()
+            assert self.store is not None
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
             for value in res:
                 if value < 0:
                     logger.error("Failed to put key %s,res:%s", keys, res)
+                    if self._lazy_init:
+                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
         except Exception as e:
             logger.error("Failed to put key %s,error:%s", keys, e)
+            if self._lazy_init:
+                logger.error("If this is the first DSV4(compress) request, this failure is expected.")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+        if self._lazy_init and not self._store_initialized:
+            logger.error("MooncakeBackend.get called before store initialization, keys=%s", keys)
+            return
+        assert self.store is not None
         logger.debug(
             "MooncakeBackend.get enter keys=%d sample_keys=%s",
             len(keys),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -183,8 +183,14 @@ class KVPoolWorker:
         backend_module = importlib.import_module(backend_path)
         real_backend = getattr(backend_module, backend_name)
 
+        backend_kwargs = {}
+        if self.backend.lower() in {"mooncake", "memcache"}:
+            # DSV4 exposes compress_ratios; only use lazy store init for this
+            # compressed-model path.
+            backend_kwargs["lazy_init"] = self.use_compress
         self.m_store = real_backend(  # type: ignore[misc]
-            parallel_config
+            parallel_config,
+            **backend_kwargs,
         )
         kv_event_config = vllm_config.kv_events_config
         self.enable_kv_events = False


### PR DESCRIPTION
### What this PR does / why we need it

Avoid initializing external KV stores during KV Pool backend construction only for the DSV4/compressed-model path, detected by compress_ratios.

Mooncake uses lazy store init only when both DSV4/compress and fabric memory are enabled. Mooncake non-fabric-memory mode keeps the previous eager initialization behavior even for compressed models. Memcache follows the same rule on non-A2 devices, while the A2 path keeps the previous eager initialization and buffer registration behavior even for compressed models.

When lazy init is enabled, the store is set up on the first put() call and guarded by a lock so later put() calls reuse the same store. Before the first put(), exists() treats keys as missing so the first store request can reach put().

In lazy-init paths, put failure logs include a hint that the failure is expected if this is the first DSV4/compress request, without tracking put attempts in connector state.

### Special notes for your reviewer

None.

### Validation

vLLM version: v0.20.1
vLLM main: vllm-project/vllm@c7aa186

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
