### PR TITLE
[Feature][310p]Qwen3.5 Support MTP

### DIFF
--- a/tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py
+++ b/tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from tests.e2e.conftest import VllmRunner
+
+
+def test_qwen3_5_mtp_tp1_eager():
+    example_prompts = ["Hello, my name is"]
+    with VllmRunner(
+        "Qwen/Qwen3.5-4B",
+        tensor_parallel_size=1,
+        enforce_eager=True,
+        dtype="float16",
+        max_model_len=2048,
+        mamba_ssm_cache_dtype="float16",
+        speculative_config={
+            "method": "qwen3_5_mtp",
+            "num_speculative_tokens": 1,
+        },
+    ) as vllm_model:
+        vllm_model.generate_greedy(example_prompts, max_tokens=8)

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -212,9 +212,7 @@ class TestAscendAttentionBackendImpl310(TestBase):
 
         mock_paged_attention.assert_called_once()
 
-    @patch(
-        "vllm_ascend._310p.attention.attention_v1.AscendAttentionBackendImpl310.forward_chunked_prefill_310"
-    )
+    @patch("vllm_ascend._310p.attention.attention_v1.AscendAttentionBackendImpl310.forward_chunked_prefill_310")
     def test_forward_mtp_310(self, mock_chunked_prefill):
         query = torch.randn(4, 8 * 64)
         key, value = None, None

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -212,11 +212,18 @@ class TestAscendAttentionBackendImpl310(TestBase):
 
         mock_paged_attention.assert_called_once()
 
-    def test_forward_mtp_310(self):
+    @patch(
+        "vllm_ascend._310p.attention.attention_v1.AscendAttentionBackendImpl310.forward_chunked_prefill_310"
+    )
+    def test_forward_mtp_310(self, mock_chunked_prefill):
         query = torch.randn(4, 8 * 64)
         key, value = None, None
         output = torch.empty_like(query)
         metadata = self.attn_metadata
         metadata.attn_state = AscendAttentionState.SpecDecoding
-        with self.assertRaises(NotImplementedError):
-            output = self.impl.forward_impl(query, key, value, None, metadata, output)
+        mock_chunked_prefill.return_value = output
+
+        result = self.impl.forward_impl(query, key, value, None, metadata, output)
+
+        mock_chunked_prefill.assert_called_once_with(query, metadata, output)
+        self.assertIs(result, output)

--- a/tests/ut/_310p/sample/test_sampler_310.py
+++ b/tests/ut/_310p/sample/test_sampler_310.py
@@ -56,12 +56,22 @@ class _FakeQ:
     def npu(self):
         return self
 
-    def exponential_(self):
-        self.default_exponential_called = True
+    def exponential_(self, generator=None):
+        if generator is None:
+            self.default_exponential_called = True
         return self
 
     def __getitem__(self, idx):
         return self.rows[idx]
+
+    def __setitem__(self, idx, value):
+        self.rows[idx] = value
+
+
+def _empty_like_side_effect(q_instances, template):
+    if isinstance(template, _FakeRow):
+        return _FakeRow()
+    return next(q_instances)
 
 
 class _FakeCPUGenerator:
@@ -90,6 +100,7 @@ class TestSampler310pStandalone(unittest.TestCase):
 
         fake_q_first = _FakeQ(batch_size=2)
         fake_q_second = _FakeQ(batch_size=2)
+        q_instances = iter([fake_q_first, fake_q_second])
 
         npu_stream = MagicMock()
         generator = MagicMock()
@@ -100,7 +111,11 @@ class TestSampler310pStandalone(unittest.TestCase):
         with (
             patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
             patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-            patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+            patch.object(
+                sampler_310p.torch,
+                "empty_like",
+                side_effect=lambda template: _empty_like_side_effect(q_instances, template),
+            ),
             patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
             patch.object(
                 sampler_310p.torch,
@@ -131,6 +146,7 @@ class TestSampler310pStandalone(unittest.TestCase):
         probs.view.return_value = torch.tensor([1])
 
         fake_q = _FakeQ(batch_size=1)
+        q_instances = iter([fake_q])
         npu_stream = MagicMock()
         generator = MagicMock()
         generator.get_state.side_effect = RuntimeError("state read failed")
@@ -144,7 +160,11 @@ class TestSampler310pStandalone(unittest.TestCase):
         with (
             patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
             patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-            patch.object(sampler_310p.torch, "empty_like", return_value=fake_q),
+            patch.object(
+                sampler_310p.torch,
+                "empty_like",
+                side_effect=lambda template: _empty_like_side_effect(q_instances, template),
+            ),
             patch.object(sampler_310p.torch, "Generator", side_effect=_FailSetStateCPUGenerator),
             patch.object(
                 sampler_310p.torch,
@@ -171,6 +191,7 @@ class TestSampler310pStandalone(unittest.TestCase):
 
         fake_q_first = _FakeQ(batch_size=1)
         fake_q_second = _FakeQ(batch_size=1)
+        q_instances = iter([fake_q_first, fake_q_second])
         npu_stream = MagicMock()
 
         generator_first = MagicMock()
@@ -184,7 +205,11 @@ class TestSampler310pStandalone(unittest.TestCase):
         with (
             patch.object(sampler_310p, "npu_stream_switch", return_value=nullcontext()),
             patch.object(sampler_310p, "global_stream", return_value=MagicMock()),
-            patch.object(sampler_310p.torch, "empty_like", side_effect=[fake_q_first, fake_q_second]),
+            patch.object(
+                sampler_310p.torch,
+                "empty_like",
+                side_effect=lambda template: _empty_like_side_effect(q_instances, template),
+            ),
             patch.object(sampler_310p.torch, "Generator", side_effect=_FakeCPUGenerator) as gen_ctor,
             patch.object(
                 sampler_310p.torch,

--- a/tests/ut/_310p/test_kv_block_zeroer_310p.py
+++ b/tests/ut/_310p/test_kv_block_zeroer_310p.py
@@ -1,0 +1,73 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from tests.ut.base import TestBase
+from vllm_ascend._310p.kv_block_zeroer import AscendKVBlockZeroer310
+
+
+class TestAscendKVBlockZeroer310(TestBase):
+    def setUp(self):
+        self.zeroer = AscendKVBlockZeroer310(torch.device("cpu"), pin_memory=False)
+
+    def test_zero_block_ids_noop_when_empty(self):
+        kv = torch.ones(4, 2, 3)
+        self.zeroer._kv_tensors = [kv]
+        self.zeroer._logical_page_ratio = 1
+
+        self.zeroer.zero_block_ids([])
+        self.assertTrue(torch.all(kv == 1))
+
+    def test_zero_block_ids_zeros_target_slices(self):
+        kv = torch.ones(6, 2, 3)
+        self.zeroer._kv_tensors = [kv]
+        self.zeroer._logical_page_ratio = 2
+
+        self.zeroer.zero_block_ids([1])
+
+        self.assertTrue(torch.all(kv[:2] == 1))
+        self.assertTrue(torch.all(kv[2:4] == 0))
+        self.assertTrue(torch.all(kv[4:] == 1))
+
+    def test_init_meta_deduplicates_kv_pointers(self):
+        k_cache = torch.zeros(4, 2, 3)
+        v_cache = k_cache
+        layer_context = SimpleNamespace(kv_cache=(k_cache, v_cache))
+        spec = FullAttentionSpec(
+            block_size=128,
+            num_kv_heads=2,
+            head_size=64,
+            dtype=torch.float16,
+        )
+        group = SimpleNamespace(
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+            layer_names=["layer_0"],
+        )
+
+        self.zeroer.init_meta(
+            attn_groups_iter=[group],
+            kernel_block_sizes=[[64]],
+            cache_dtype="float16",
+            runner_only_attn_layers=set(),
+            static_forward_context={"layer_0": layer_context},
+        )
+
+        self.assertEqual(len(self.zeroer._kv_tensors), 1)
+        self.assertEqual(self.zeroer._logical_page_ratio, 2)

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -289,6 +289,10 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
 
         return output
 
+    def forward_spec_decoding_310(self, query, attn_metadata, output):
+        """Execute SpecDecoding on 310P using full query rows plus splitfuse mask."""
+        return self.forward_chunked_prefill_310(query, attn_metadata, output)
+
     def forward_impl(self, query, key, value, kv_cache, attn_metadata, output):
         """
         Main dispatch method for attention operations.
@@ -322,6 +326,8 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         elif state in [AscendAttentionState.ChunkedPrefill, AscendAttentionState.PrefillCacheHit]:
             output = self.forward_chunked_prefill_310(query, attn_metadata, output)
         # Condition for SpecDecoding: Specified for mtp, which is not supported yet.
+        elif state == AscendAttentionState.SpecDecoding:
+            output = self.forward_spec_decoding_310(query, attn_metadata, output)
         else:
             raise NotImplementedError(f"AscendAttentionState: {state} is not supported for 310P currently.")
         return output

--- a/vllm_ascend/_310p/kv_block_zeroer.py
+++ b/vllm_ascend/_310p/kv_block_zeroer.py
@@ -37,7 +37,7 @@ class AscendKVBlockZeroer310(KVBlockZeroer):
     def init_meta(
         self,
         attn_groups_iter: Iterable["AttentionGroup"],
-        kernel_block_sizes: list[int],
+        kernel_block_sizes: list[list[int]],
         cache_dtype: str,
         runner_only_attn_layers: set[str],
         static_forward_context: dict[str, Any],

--- a/vllm_ascend/_310p/kv_block_zeroer.py
+++ b/vllm_ascend/_310p/kv_block_zeroer.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
+
+
+class AscendKVBlockZeroer310(KVBlockZeroer):
+    """310P KV block zeroer without Triton.
+
+    Atlas 300I DUO does not support Triton. For MTP >= 2 hybrid models, newly
+    allocated attention KV blocks must be zeroed via direct tensor writes.
+    """
+
+    def __init__(self, device: torch.device, pin_memory: bool) -> None:
+        super().__init__(device, pin_memory)
+        self._kv_tensors: list[torch.Tensor] = []
+        self._logical_page_ratio: int = 1
+
+    def init_meta(
+        self,
+        attn_groups_iter: Iterable["AttentionGroup"],
+        kernel_block_sizes: list[int],
+        cache_dtype: str,
+        runner_only_attn_layers: set[str],
+        static_forward_context: dict[str, Any],
+    ) -> None:
+        seen_ptrs: set[int] = set()
+        self._kv_tensors = []
+        self._logical_page_ratio = 1
+
+        for group in attn_groups_iter:
+            spec = group.kv_cache_spec
+            if not isinstance(spec, FullAttentionSpec):
+                continue
+            if group.kv_cache_group_id >= len(kernel_block_sizes):
+                continue
+            kernel_bs = kernel_block_sizes[group.kv_cache_group_id][0]
+            ratio = spec.block_size // kernel_bs
+            if not self._kv_tensors:
+                self._logical_page_ratio = ratio
+
+            for layer_name in group.layer_names:
+                if layer_name in runner_only_attn_layers:
+                    continue
+                kv_tuple = static_forward_context[layer_name].kv_cache
+                assert len(kv_tuple) == 2, "K and V are not stored separately"
+                for kv in kv_tuple:
+                    dp = kv.data_ptr()
+                    if dp in seen_ptrs:
+                        continue
+                    seen_ptrs.add(dp)
+                    self._kv_tensors.append(kv)
+
+    def zero_block_ids(self, block_ids: list[int]) -> None:
+        if not block_ids or not self._kv_tensors:
+            return
+
+        ratio = self._logical_page_ratio
+        for block_id in block_ids:
+            start = block_id * ratio
+            end = start + ratio
+            for kv in self._kv_tensors:
+                kv[start:end].zero_()

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -39,7 +39,6 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
-from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
@@ -48,6 +47,7 @@ from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
 from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
@@ -83,7 +83,7 @@ class NPUModelRunner310(NPUModelRunner):
         logger.info_once("Weight layout uses FRACTAL_NZ.")
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
-            self.rejection_sampler = RejectionSampler(self.sampler)
+            self.rejection_sampler = AscendRejectionSampler(self.sampler)
         if self.speculative_config is not None and self.speculative_config.method == "ngram":
             # 310P ngram requires decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -43,6 +43,7 @@ from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 from vllm_ascend._310p.block_table import MultiGroupBlockTable as MultiGroupBlockTable310
+from vllm_ascend._310p.kv_block_zeroer import AscendKVBlockZeroer310
 from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
 from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
 from vllm_ascend._310p.sample.sampler import AscendSampler310
@@ -600,6 +601,17 @@ class NPUModelRunner310(NPUModelRunner):
         # naturally consistent there. 310P ngram needs temporary alignment.
         with self.temporary_modify_uniform_decode_query_len():
             super()._check_and_update_cudagraph_mode(attention_backends, kv_cache_groups)
+
+    def _init_kv_zero_meta(self) -> None:
+        """310P uses torch zeroing because Triton is not available."""
+        self._kv_block_zeroer = AscendKVBlockZeroer310(self.device, self.pin_memory)
+        self._kv_block_zeroer.init_meta(
+            attn_groups_iter=self._kv_cache_spec_attn_group_iterator(),
+            kernel_block_sizes=self.kernel_block_sizes,
+            cache_dtype=self.cache_config.cache_dtype,
+            runner_only_attn_layers=self.runner_only_attn_layers,
+            static_forward_context=(self.compilation_config.static_forward_context),
+        )
 
     def initialize_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """

--- a/vllm_ascend/_310p/ops/fla/gdn_310.py
+++ b/vllm_ascend/_310p/ops/fla/gdn_310.py
@@ -108,6 +108,33 @@ def _310p_get_state_dtype(self) -> tuple[torch.dtype, torch.dtype]:
 _original_get_state_dtype = GatedDeltaNetAttention.get_state_dtype
 
 
+def _merge_spec_and_non_spec_outputs_310(
+    core_attn_out: torch.Tensor,
+    num_actual_tokens: int,
+    spec_token_indx: torch.Tensor,
+    non_spec_token_indx: torch.Tensor,
+    core_attn_out_spec: torch.Tensor,
+    core_attn_out_non_spec: torch.Tensor,
+) -> None:
+    """Merge spec/non-spec GDN outputs back into the batch layout.
+
+    Avoid NPU ``index_copy_`` (IndexPutV2) which fails on some layouts; use
+    direct indexing instead. Validate lengths so mixed prefill+spec batches
+    do not pass mismatched tensors from spec ops.
+    """
+    spec_out = core_attn_out_spec.squeeze(0)
+    non_spec_out = core_attn_out_non_spec.squeeze(0)
+    n_spec = spec_token_indx.numel()
+    n_non_spec = non_spec_token_indx.numel()
+    if spec_out.shape[0] != n_spec:
+        raise RuntimeError(f"GDN spec output length {spec_out.shape[0]} != spec_token_indx {n_spec}")
+    if non_spec_out.shape[0] != n_non_spec:
+        raise RuntimeError(f"GDN non-spec output length {non_spec_out.shape[0]} != non_spec_token_indx {n_non_spec}")
+    out = core_attn_out[:num_actual_tokens]
+    out[spec_token_indx] = spec_out
+    out[non_spec_token_indx] = non_spec_out
+
+
 class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
     get_state_dtype = _310p_get_state_dtype
 
@@ -171,6 +198,9 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
+            # Align with spec sub-batch only (mixed prefill+spec has fewer spec decodes
+            # than total requests; full-batch tensor fails tiling / wrong state offset).
+            spec_num_accepted = num_accepted_tokens[: attn_metadata.num_spec_decodes].to(torch.int64)
             mixed_qkv_spec = torch.ops._C_ascend.npu_causal_conv1d_310(
                 mixed_qkv_spec,
                 conv_weights,
@@ -179,7 +209,7 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                 query_start_loc=spec_query_start_loc.to(torch.int64),
                 cache_indices=spec_state_indices_tensor[:, 0][: attn_metadata.num_spec_decodes].to(torch.int64),
                 initial_state_mode=None,
-                num_accepted_tokens=num_accepted_tokens.to(torch.int64),
+                num_accepted_tokens=spec_num_accepted,
                 activation_mode=activation_num,
                 pad_slot_id=PAD_SLOT_ID,
                 run_mode=1,
@@ -252,7 +282,7 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
                     state=ssm_state,
                     cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
                     ssm_state_indices=spec_state_indices_tensor,
-                    num_accepted_tokens=num_accepted_tokens,
+                    num_accepted_tokens=spec_num_accepted,
                     use_qk_l2norm_in_kernel=True,
                 )
             else:
@@ -309,17 +339,14 @@ class AscendGatedDeltaNetAttention310(GatedDeltaNetAttention):
             )
         # 3. Merge core attention output
         if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
-            merged_out = torch.empty(
-                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
-                dtype=core_attn_out_non_spec.dtype,
-                device=core_attn_out_non_spec.device,
+            _merge_spec_and_non_spec_outputs_310(
+                core_attn_out,
+                num_actual_tokens,
+                spec_token_indx,
+                non_spec_token_indx,
+                core_attn_out_spec,
+                core_attn_out_non_spec,
             )
-            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
-            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
-            if not enable_sp():
-                core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
-            else:
-                core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)[:num_actual_tokens]
         elif spec_sequence_masks is not None:
             if not enable_sp():
                 core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)

--- a/vllm_ascend/_310p/sample/sampler.py
+++ b/vllm_ascend/_310p/sample/sampler.py
@@ -29,6 +29,42 @@ from vllm_ascend.utils import global_stream, npu_stream_switch
 _CPU_GENERATOR_CACHE_310P: dict[int, tuple[torch.Generator, int]] = {}
 
 
+def _get_cpu_generator_310p(i: int, generator: torch.Generator) -> torch.Generator:
+    cache_entry = _CPU_GENERATOR_CACHE_310P.get(i)
+    if cache_entry is None or cache_entry[1] != id(generator):
+        cpu_generator = torch.Generator(device="cpu")
+        try:
+            # Keep RNG stream consistent with the original generator.
+            cpu_generator.set_state(generator.get_state())
+        except Exception:
+            cpu_generator.manual_seed(generator.initial_seed())
+        cache_entry = (cpu_generator, id(generator))
+        _CPU_GENERATOR_CACHE_310P[i] = cache_entry
+    return cache_entry[0]
+
+
+def fill_exponential_310p(
+    q: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    has_draft_mask: torch.Tensor | None = None,
+) -> None:
+    """Fill ``q`` with exponential values using CPU RNG for 310P stability."""
+    with npu_stream_switch(global_stream()):
+        q_cpu = q.cpu()
+        if len(generators) != q_cpu.shape[0]:
+            q_cpu.exponential_()
+        if generators:
+            for i, generator in generators.items():
+                temp_q = torch.empty_like(q_cpu[i])
+                temp_q.exponential_(generator=_get_cpu_generator_310p(i, generator))
+                if has_draft_mask is not None:
+                    q_cpu[i] = torch.where(has_draft_mask[i], temp_q, q_cpu[i])
+                else:
+                    q_cpu[i] = temp_q
+        q.copy_(q_cpu.to(q.device))
+    torch.npu.current_stream().wait_stream(global_stream())
+
+
 def _random_sample_310p(
     probs: torch.Tensor,
     generators: dict[int, torch.Generator],
@@ -41,18 +77,7 @@ def _random_sample_310p(
             q.exponential_()
         if generators:
             for i, generator in generators.items():
-                cache_entry = _CPU_GENERATOR_CACHE_310P.get(i)
-                if cache_entry is None or cache_entry[1] != id(generator):
-                    cpu_generator = torch.Generator(device="cpu")
-                    try:
-                        # Keep RNG stream consistent with the original generator.
-                        cpu_generator.set_state(generator.get_state())
-                    except Exception:
-                        cpu_generator.manual_seed(generator.initial_seed())
-                    cache_entry = (cpu_generator, id(generator))
-                    _CPU_GENERATOR_CACHE_310P[i] = cache_entry
-                cpu_generator, _ = cache_entry
-                q[i].exponential_(generator=cpu_generator)
+                q[i].exponential_(generator=_get_cpu_generator_310p(i, generator))
         q = q.npu()
     torch.npu.current_stream().wait_stream(global_stream())
     return probs.div_(q).argmax(dim=-1).view(-1)

--- a/vllm_ascend/_310p/sample/sampler.py
+++ b/vllm_ascend/_310p/sample/sampler.py
@@ -43,6 +43,24 @@ def _get_cpu_generator_310p(i: int, generator: torch.Generator) -> torch.Generat
     return cache_entry[0]
 
 
+def _fill_exponential_cpu_310p(
+    q_cpu: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    has_draft_mask: torch.Tensor | None = None,
+) -> None:
+    """Fill a CPU tensor with exponential values for 310P stability."""
+    if len(generators) != q_cpu.shape[0]:
+        q_cpu.exponential_()
+    if generators:
+        for i, generator in generators.items():
+            temp_q = torch.empty_like(q_cpu[i])
+            temp_q.exponential_(generator=_get_cpu_generator_310p(i, generator))
+            if has_draft_mask is not None:
+                q_cpu[i] = torch.where(has_draft_mask[i], temp_q, q_cpu[i])
+            else:
+                q_cpu[i] = temp_q
+
+
 def fill_exponential_310p(
     q: torch.Tensor,
     generators: dict[int, torch.Generator],
@@ -51,16 +69,7 @@ def fill_exponential_310p(
     """Fill ``q`` with exponential values using CPU RNG for 310P stability."""
     with npu_stream_switch(global_stream()):
         q_cpu = q.cpu()
-        if len(generators) != q_cpu.shape[0]:
-            q_cpu.exponential_()
-        if generators:
-            for i, generator in generators.items():
-                temp_q = torch.empty_like(q_cpu[i])
-                temp_q.exponential_(generator=_get_cpu_generator_310p(i, generator))
-                if has_draft_mask is not None:
-                    q_cpu[i] = torch.where(has_draft_mask[i], temp_q, q_cpu[i])
-                else:
-                    q_cpu[i] = temp_q
+        _fill_exponential_cpu_310p(q_cpu, generators, has_draft_mask)
         q.copy_(q_cpu.to(q.device))
     torch.npu.current_stream().wait_stream(global_stream())
 
@@ -71,13 +80,8 @@ def _random_sample_310p(
 ) -> torch.Tensor:
     """310P-specific random sampling with CPU exponential generation for q."""
     with npu_stream_switch(global_stream()):
-        q = torch.empty_like(probs)
-        q = q.cpu()
-        if len(generators) != q.shape[0]:
-            q.exponential_()
-        if generators:
-            for i, generator in generators.items():
-                q[i].exponential_(generator=_get_cpu_generator_310p(i, generator))
+        q = torch.empty_like(probs).cpu()
+        _fill_exponential_cpu_310p(q, generators)
         q = q.npu()
     torch.npu.current_stream().wait_stream(global_stream())
     return probs.div_(q).argmax(dim=-1).view(-1)

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -28,6 +28,7 @@ from vllm_ascend.ops.triton.reject_sample import (
 )
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.sample.sampler import apply_top_k_top_p
+from vllm_ascend.utils import is_310p
 
 
 class AscendRejectionSampler(RejectionSampler):
@@ -681,15 +682,19 @@ def sample_recovered_tokens(
         dtype=torch.float32,
         device=device,
     )
-    q.exponential_()
-
     num_draft_tensor = torch.tensor(num_draft_tokens, pin_memory=True).to(device, non_blocking=True)
     has_draft_mask = num_draft_tensor > 0
+    if is_310p():
+        from vllm_ascend._310p.sample.sampler import fill_exponential_310p
 
-    for i, generator in sampling_metadata.generators.items():
-        temp_q = torch.empty_like(q[i])
-        temp_q.exponential_(generator=generator)
-        q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
+        fill_exponential_310p(q, sampling_metadata.generators, has_draft_mask)
+    else:
+        q.exponential_()
+
+        for i, generator in sampling_metadata.generators.items():
+            temp_q = torch.empty_like(q[i])
+            temp_q.exponential_(generator=generator)
+            q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
     if HAS_TRITON:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1634,7 +1634,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         discard_sampled_tokens_req_indices = discard_request_indices[:num_discarded_requests]
 
         valid_sampled_token_ids_gpu = sampled_token_ids.clone()
-        valid_sampled_token_ids_gpu.index_fill_(0, discard_sampled_tokens_req_indices, -1)
+        if discard_sampled_tokens_req_indices.numel() != 0:
+            valid_sampled_token_ids_gpu.index_fill_(0, discard_sampled_tokens_req_indices, -1)
 
         # Generate a mask for all valid tokens within those requests
         valid_mask = (valid_sampled_token_ids_gpu != -1) & (valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size)


### PR DESCRIPTION
### What this PR does / why we need it?

This pull request enables speculative decoding support on the 310P Ascend platform. It introduces the `forward_spec_decoding_310` attention path, integrates `AscendRejectionSampler` in the 310P model runner, and implements CPU-based exponential sampling (`fill_exponential_310p`) to ensure stability. It also adds a safeguard in `llm_base_proposer.py` to prevent errors during empty index filling.

Feedback: A critical device mismatch issue was found in `fill_exponential_310p` where `has_draft_mask` (on NPU) is used in `torch.where` with CPU tensors. This must be fixed by copying `has_draft_mask` to the CPU first.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested via speculative decoding execution on 310P.


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
