### PR TITLE
[DSV4][KVCache] Support block size [32,64,128] to improve APC

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -207,7 +207,7 @@ class AscendDSABackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
-        return [8, 32, 128]
+        return [2, 4, 8, 16, 32, 64, 128]
 
 
 @dataclass

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -82,6 +82,7 @@ from vllm_ascend.utils import (
     get_dsv4_compress_ratio,
     vllm_version_is,
 )
+from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 
 if vllm_version_is("0.20.2"):
     from vllm.model_executor.layers.deepseek_compressor import CompressorStateCache  # type:ignore
@@ -513,7 +514,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=8,
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][2],
             )
         elif compress_ratio == 128:
             self.state_cache = CompressorStateCache(
@@ -521,7 +522,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=32,
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][3],
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -24,6 +24,12 @@ from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 
 
+# cache_config.block_size: [mla; swa; c4 state; c128 state], [page_size_padded_t1, page_size_padded_t2]
+DSV4_BLOCK_SIZES = {
+    128: [[128, 128, 8, 32], [16640, 131072]],
+    64: [[64, 64, 4, 16], [8320, 65536]],
+    32: [[32, 32, 2, 8], [4160, 32768]],
+}
 class DSAAttention(nn.Module, AttentionLayerBase):
     """Multi-Head Latent Attention layer.
 
@@ -151,7 +157,7 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
         return MLAAttentionSpec(
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=kv_cache_dtype,

--- a/vllm_ascend/patch/worker/patch_deepseek_compressor.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_compressor.py
@@ -11,6 +11,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 from vllm_ascend.patch.platform.patch_kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
 
 if vllm_version_is("0.20.2"):
     from vllm.model_executor.layers import (
@@ -53,7 +54,11 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config) -> KVCacheSpec:
-        page_size_padded = 16640 if self.state_dim == 2 * 256 and self.compress_ratio == 4 else 131072
+        if self.state_dim == 2 * 256 and self.compress_ratio == 4 :
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][0]
+        else:
+            page_size_padded = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1][1]
+
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
             num_kv_heads=1,
@@ -83,7 +88,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         return AscendMLAAttentionSpec(  # Only has one vector instead of K + V
-            block_size=128,
+            block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
@@ -117,7 +122,7 @@ class AscendDeepseekV4SWACache(DeepseekV4SWACache):
         # same page size. The C4A KV block shape [256//4, head_dim] = [64, head_dim]
         # determines the SWA block size of 64 tokens per block.
         # TODO(cmq): make SWA block size automatically determined and configurable.
-        self.block_size = 128
+        self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         # TODO(cmq): alignment = 0 if A3 else 128

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1289,6 +1289,7 @@ def get_flashcomm2_reorgnized_batch_ids(global_tp_size) -> list[list[int]]:
 
     return reorgnized_batch_ids
 
+_ENIGINE_CORE_BLOCK_SIZE = None
 
 def refresh_block_size(vllm_config):
     """
@@ -1305,8 +1306,27 @@ def refresh_block_size(vllm_config):
         cache_config.block_size = 128
 
     if model_config.hf_config.model_type == "deepseek_v4":
-        # TODO(qcs): generalize the block_size
-        cache_config.block_size = 128
+        # NOTE(cmq): use _ENIGINE_CORE_BLOCK_SIZE as the cache_config.block_size
+        # is updated in the core process, but it will be updated to the minimized
+        # block_size among all the kvcache groups, which will leading to a wrong
+        # block_size in DeepSeek V4 scenario.
+        global _ENIGINE_CORE_BLOCK_SIZE
+
+        if _ENIGINE_CORE_BLOCK_SIZE is not None:
+            cache_config.block_size = _ENIGINE_CORE_BLOCK_SIZE
+            return
+
+        if cache_config.block_size is None:
+            cache_config.block_size = 32
+        elif cache_config.block_size not in [32, 64, 128]:
+            logger.warning(
+                "For deepseek_v4 model, block size should be 32, 64 or 128. "
+                "Setting block size to 32 for better performance."
+            )
+            cache_config.block_size = 32
+
+        _ENIGINE_CORE_BLOCK_SIZE = cache_config.block_size
+        return
 
     if not scheduler_config or not model_config:
         return


### PR DESCRIPTION
### What this PR does / why we need it?
Support block size [32,64,128] to improve APC

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
