### PR TITLE
[CI] Change nightly tests to releases/v0.20.2rc

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -99,9 +99,9 @@ jobs:
       max-parallel: 6
       matrix:
         branch_meta:
-          - branch_ref: main
-            schedule_tag_pattern: main
-            artifact_prefix: digests
+          - branch_ref: releases/v0.20.2rc
+            schedule_tag_pattern: releases-v0.20.2rc
+            artifact_prefix: digests-releases-v0.20.2rc
         build_meta:
           - name: A2 Ubuntu
             dockerfile: Dockerfile

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -108,7 +108,7 @@ jobs:
               normalized=$(echo "$input_branch" | tr '/' '-')
               echo "vllm_ascend_branches=[\"${normalized}\"]"
             else
-              echo 'vllm_ascend_branches=["main"]'
+              echo 'vllm_ascend_branches=["releases-v0.20.2rc"]'
             fi
           } >> $GITHUB_OUTPUT
 
@@ -120,7 +120,7 @@ jobs:
         vllm_ascend_branch: >-
           ${{ github.event_name == 'workflow_dispatch' 
               && fromJSON(format('["{0}"]', inputs.vllm_ascend_branch))
-              || fromJSON('["main"]') }}
+              || fromJSON('["main", "releases/v0.20.2rc"]') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -105,7 +105,7 @@ jobs:
               normalized=$(echo "$input_branch" | tr '/' '-')
               echo "vllm_ascend_branches=[\"${normalized}\"]"
             else
-              echo 'vllm_ascend_branches=["main"]'
+              echo 'vllm_ascend_branches=["releases-v0.20.2rc"]'
             fi
           } >> $GITHUB_OUTPUT
 
@@ -117,7 +117,7 @@ jobs:
         vllm_ascend_branch: >-
           ${{ github.event_name == 'workflow_dispatch' 
               && fromJSON(format('["{0}"]', inputs.vllm_ascend_branch))
-              || fromJSON('["main"]') }}
+              || fromJSON('["main", "releases/v0.20.2rc"]') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3


### PR DESCRIPTION
### What this PR does / why we need it?
Change nightly tests to banrch `releases/v0.20.2rc`
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
