### PR TITLE
[BugFix][Platform] Patch GLM tool-call final chunks

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+)
+
+from vllm_ascend.patch.platform import (
+    patch_glm_tool_call_streaming as glm_streaming_patch,
+)
+
+
+def test_remaining_args_delta_omits_metadata_by_default():
+    original_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                id="call_current",
+                type="function",
+                function=DeltaFunctionCall(
+                    name="current_name",
+                    arguments='{"files":[',
+                ),
+            )
+        ]
+    )
+
+    result = OpenAIServingChat._create_remaining_args_delta(
+        original_delta,
+        "]}",
+        0,
+    )
+
+    tc = result.tool_calls[0]
+    assert tc.index == 0
+    assert tc.id is None
+    assert tc.type is None
+    assert tc.function.name is None
+    assert tc.function.arguments == "]}"
+    serialized = tc.model_dump(exclude_unset=True)
+    assert "id" not in serialized
+    assert "type" not in serialized
+    assert "name" not in serialized["function"]
+
+
+def test_remaining_args_delta_uses_explicit_fallback_metadata():
+    result = OpenAIServingChat._create_remaining_args_delta(
+        DeltaMessage(),
+        '{"filepath":"pong.py"}',
+        0,
+        fallback_tool_call_id="call_files",
+        fallback_tool_call_type="function",
+        fallback_tool_call_name="builtin_read_many_files",
+    )
+
+    tc = result.tool_calls[0]
+    assert tc.index == 0
+    assert tc.id == "call_files"
+    assert tc.type == "function"
+    assert tc.function.name == "builtin_read_many_files"
+    assert tc.function.arguments == '{"filepath":"pong.py"}'
+
+
+def test_terminal_argument_chunk_is_split_before_finish_chunk():
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "GLM-5",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {
+                                "arguments": '"pong.py"}',
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+                "stop_reason": None,
+            }
+        ],
+    }
+
+    chunks = glm_streaming_patch._split_terminal_tool_arg_chunk(f"data: {json.dumps(chunk)}\n\n")
+
+    assert len(chunks) == 2
+    arg_payload = json.loads(chunks[0].removeprefix("data: ").removesuffix("\n\n"))
+    finish_payload = json.loads(chunks[1].removeprefix("data: ").removesuffix("\n\n"))
+
+    arg_choice = arg_payload["choices"][0]
+    assert arg_choice["finish_reason"] is None
+    assert arg_choice["stop_reason"] is None
+    assert arg_choice["delta"]["tool_calls"][0]["function"]["arguments"] == '"pong.py"}'
+
+    finish_choice = finish_payload["choices"][0]
+    assert finish_choice["finish_reason"] == "tool_calls"
+    assert finish_choice["delta"] == {}
+
+
+def test_non_terminal_and_done_chunks_are_not_split():
+    content = 'data: {"choices":[]}\n\n'
+    done = "data: [DONE]\n\n"
+
+    assert glm_streaming_patch._split_terminal_tool_arg_chunk(content) == [content]
+    assert glm_streaming_patch._split_terminal_tool_arg_chunk(done) == [done]

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -162,6 +162,26 @@
 #       Remove this patch once the runtime vLLM version contains the upstream
 #       MiniMax usage-accounting fix.
 #
+# ** 7a. File: platform/patch_glm_tool_call_streaming.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#    Why:
+#       GLM tool-call streaming can emit final remaining-argument chunks with
+#       repeated tool-call metadata, and can combine terminal argument bytes with
+#       `finish_reason="tool_calls"` in the same SSE chunk.
+#    How：
+#       Monkey-patch remaining-argument delta construction to emit only argument
+#       fragments by default, and split terminal argument chunks into an argument
+#       chunk followed by an empty finish chunk.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/44098
+#       https://github.com/vllm-project/vllm/pull/44099
+#       https://github.com/vllm-project/vllm-ascend/issues/8327
+#       https://github.com/vllm-project/vllm-ascend/pull/8178
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains the upstream
+#       GLM tool-call final chunk fixes.
+#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -30,6 +30,7 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
+import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
@@ -1,0 +1,127 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# OpenAI chat streaming: backport GLM tool-call final chunk fixes.
+#
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+)
+
+
+def _create_remaining_args_delta(
+    delta_message: DeltaMessage,
+    remaining_call: str,
+    index: int,
+    fallback_tool_call_id: str | None = None,
+    fallback_tool_call_type: str | None = None,
+    fallback_tool_call_name: str | None = None,
+) -> DeltaMessage:
+    function_kwargs: dict[str, str] = {"arguments": remaining_call}
+    if fallback_tool_call_name is not None:
+        function_kwargs["name"] = fallback_tool_call_name
+
+    tool_call_kwargs: dict[str, Any] = {
+        "index": index,
+        "function": DeltaFunctionCall(**function_kwargs),
+    }
+    if fallback_tool_call_id is not None:
+        tool_call_kwargs["id"] = fallback_tool_call_id
+    if fallback_tool_call_type is not None:
+        tool_call_kwargs["type"] = fallback_tool_call_type
+
+    return DeltaMessage(tool_calls=[DeltaToolCall(**tool_call_kwargs)])
+
+
+def _terminal_tool_arg_choice(choice: dict[str, Any]) -> bool:
+    if choice.get("finish_reason") != "tool_calls":
+        return False
+    delta = choice.get("delta") or {}
+    for tool_call in delta.get("tool_calls") or []:
+        function = tool_call.get("function") or {}
+        if function.get("arguments"):
+            return True
+    return False
+
+
+def _split_terminal_tool_arg_chunk(data: str) -> list[str]:
+    prefix = "data: "
+    suffix = "\n\n"
+    if not data.startswith(prefix):
+        return [data]
+
+    payload = data[len(prefix) :]
+    if payload.endswith(suffix):
+        payload = payload[: -len(suffix)]
+    if payload == "[DONE]":
+        return [data]
+
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        return [data]
+
+    choices = chunk.get("choices") or []
+    if len(choices) != 1 or not _terminal_tool_arg_choice(choices[0]):
+        return [data]
+
+    arg_chunk = copy.deepcopy(chunk)
+    arg_choice = arg_chunk["choices"][0]
+    arg_choice["finish_reason"] = None
+    arg_choice["stop_reason"] = None
+
+    finish_chunk = copy.deepcopy(chunk)
+    finish_choice = finish_chunk["choices"][0]
+    finish_choice["delta"] = {}
+
+    return [
+        f"{prefix}{json.dumps(arg_chunk, ensure_ascii=False)}{suffix}",
+        f"{prefix}{json.dumps(finish_chunk, ensure_ascii=False)}{suffix}",
+    ]
+
+
+if not hasattr(OpenAIServingChat, "_ascend_glm_original_chat_completion_stream_generator"):
+    OpenAIServingChat._ascend_glm_original_chat_completion_stream_generator = (
+        OpenAIServingChat.chat_completion_stream_generator
+    )
+
+
+async def _wrapped_chat_completion_stream_generator(
+    self,
+    *args,
+    **kwargs,
+):
+    original_stream_generator = self._ascend_glm_original_chat_completion_stream_generator
+    async for data in original_stream_generator(*args, **kwargs):
+        for chunk in _split_terminal_tool_arg_chunk(data):
+            yield chunk
+
+
+OpenAIServingChat._create_remaining_args_delta = staticmethod(_create_remaining_args_delta)
+_wrapped_chat_completion_stream_generator.__module__ = OpenAIServingChat.__module__
+_wrapped_chat_completion_stream_generator.__qualname__ = (
+    f"{OpenAIServingChat.__qualname__}.chat_completion_stream_generator"
+)
+OpenAIServingChat.chat_completion_stream_generator = _wrapped_chat_completion_stream_generator


### PR DESCRIPTION
### What this PR does / why we need it?

Backports the serving-layer GLM tool-call final chunk fixes while keeping the upstream vLLM GLM parser implementation.

The patch fixes the two remaining GLM streaming protocol issues tracked by #8327:

- final remaining-argument chunks no longer re-emit `id`, `type`, or `function.name` by default
- terminal argument chunks with `finish_reason="tool_calls"` are split into an argument chunk with `finish_reason=null`, followed by an empty finish chunk

This intentionally does not restore the old GLM parser state-machine monkey patch; upstream vLLM already contains the parser-side terminal argument drainage / incremental streaming behavior. The new patch only covers the serving-layer final chunk behavior that is still missing upstream.

Related upstream tracking:

### Does this PR introduce _any_ user-facing change?

Yes. GLM OpenAI-compatible streaming tool-call responses no longer repeat function metadata in final argument chunks, and final argument bytes are sent before the empty `tool_calls` finish chunk.

### How was this patch tested?

- `ruff check vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py vllm_ascend/patch/platform/__init__.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py`
- `python -m py_compile vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py`
- `python -m pytest -q tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py` (`4 passed`)
- import probe confirmed both MiniMax usage wrapper and GLM final-chunk wrapper are installed on `OpenAIServingChat`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
