### PR TITLE
[BugFix][SpecDecode] Keep draft lm_head for DFlash with reduced (d2t) vocab

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -336,13 +336,29 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # some model definition do not define lm_head explicitly
         # and reuse embed_tokens for lm_head, e.g., CohereForCausalLM
         if self.method in ("eagle", "dflash"):
-            logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
-            if hasattr(model, "lm_head"):
-                self.model.lm_head = model.lm_head
-            elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
-                self.model.lm_head = model.get_language_model().lm_head
+            # For DFlash drafters trained with a reduced draft vocabulary, the
+            # draft model ships its own lm_head of shape [draft_vocab_size,
+            # hidden] whose rows map to a trained subset of the target vocab via
+            # the draft_id_to_target_id (d2t) buffer. Overwriting it with the
+            # target lm_head ([target_vocab_size, hidden]) makes the draft emit
+            # logits over the wrong vocabulary, so the verifier rejects almost
+            # every speculative token. Keep the draft's own lm_head in that case.
+            draft_has_own_lm_head = (
+                self.method == "dflash" and getattr(self.model, "draft_id_to_target_id", None) is not None
+            )
+            if draft_has_own_lm_head:
+                logger.info(
+                    "DFlash draft uses d2t vocab remapping; keeping the draft's "
+                    "own lm_head instead of sharing the target lm_head."
+                )
             else:
-                logger.warning("Target model has no accessible lm_head for sharing.")
+                logger.info("Loading EAGLE or DFLASH LM head weights from the target model.")
+                if hasattr(model, "lm_head"):
+                    self.model.lm_head = model.lm_head
+                elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
+                    self.model.lm_head = model.get_language_model().lm_head
+                else:
+                    logger.warning("Target model has no accessible lm_head for sharing.")
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():


### PR DESCRIPTION
AscendSpecDecodeBaseProposer._maybe_share_lm_head unconditionally replaced
the draft model's lm_head with the target model's lm_head whenever method was
in ("eagle", "dflash"). DFlash speculators trained with a reduced draft
vocabulary (e.g. RedHatAI/Qwen3-8B-speculator.dflash: draft_vocab_size=32000
vs target vocab_size=151936) ship their own lm_head of shape
[draft_vocab_size, hidden] whose rows map to a trained subset of the target
vocabulary via the draft_id_to_target_id (d2t) buffer. Overwriting that head
with the target lm_head made the draft emit logits over the wrong vocabulary,
so after the d2t scatter the verifier rejected almost every speculative token.

Gate the share on draft_id_to_target_id: when a dflash draft exposes a
non-None d2t mapping, keep its own lm_head; otherwise share the target
lm_head exactly as before. EAGLE / EAGLE3 / MTP / full-vocab DFlash drafters
(d2t is None) are unaffected.

Validated on Ascend 910B4-1 (single card, TP=1, enforce_eager, temperature=0,
num_speculative_tokens=7) with RedHatAI/Qwen3-8B-speculator.dflash drafting
for a Qwen3-8B verifier. Without the fix, reduced-vocab DFlash draft acceptance
collapses to ~1%. With the fix, measured under the same reasoning-enabled
harness RedHat used for its H100 model-card numbers, NPU per-position draft
acceptance matches or exceeds the H100 reference: HumanEval Pos1 0.800 vs 0.799
(mean accept length 3.30 vs 3.41); GSM8K Pos1 0.841 vs 0.822 (mean accept
length 3.82 vs 3.74, within 102-104% at every one of the 7 positions).
Validated on both the eagle_proposer.py (49b6396) and llm_base_proposer.py
(this branch) layouts with statistically identical acceptance.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
