### PR TITLE
[BugFix]fix backend ut

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -256,6 +256,8 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend = MooncakeBackend.__new__(MooncakeBackend)
             backend.store = MagicMock()
             backend.config = MagicMock()
+            backend._lazy_init = False
+            backend._store_initialized = True
             return backend
 
     def test_exists(self):
@@ -413,6 +415,11 @@ class TestMemcacheBackendMethods(unittest.TestCase):
             backend = MemcacheBackend.__new__(MemcacheBackend)
             backend.store = MagicMock()
             backend.local_rank = 0
+            backend._lazy_init = False
+            backend._store_initialized = True
+            backend._is_a2 = False
+            backend._registered_buffers = None
+            backend._buffers_registered = False
             return backend
 
     def test_exists(self):

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -258,6 +258,7 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend.config = MagicMock()
             backend._lazy_init = False
             backend._store_initialized = True
+            backend._use_fabric_mem = False
             return backend
 
     def test_exists(self):

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -415,6 +415,7 @@ class TestMemcacheBackendMethods(unittest.TestCase):
             backend = MemcacheBackend.__new__(MemcacheBackend)
             backend.store = MagicMock()
             backend.local_rank = 0
+            # Set internal state to avoid lazy init logic during tests
             backend._lazy_init = False
             backend._store_initialized = True
             backend._is_a2 = False


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the backend unit tests in `tests/ut/distributed/ascend_store/test_backend.py`.
Recently, new attributes (such as `_lazy_init`, `_store_initialized`, `_is_a2`, `_registered_buffers`, and `_buffers_registered`) were added to `MooncakeBackend` and `MemcacheBackend` to support lazy initialization and buffer registration.
Since the unit tests construct these backend instances using `__new__` (bypassing `__init__`), these attributes were missing on the mocked instances, causing unit test failures. This PR explicitly initializes these attributes on the mocked backend instances to fix the tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested by running the modified unit tests:
```bash
pytest tests/ut/distributed/ascend_store/test_backend.py

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
