### PR TITLE
[Feature][P/D] Mooncake Connector Support Hybrid PCP/DCP for QWen3.5

### DIFF
--- a/tests/ut/kv_connector/test_mooncake_connector.py
+++ b/tests/ut/kv_connector/test_mooncake_connector.py
@@ -1746,6 +1746,79 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                     expected_finishes={0: worker._prefill_pp_size, 1: worker._prefill_pp_size},
                 )
 
+    def test_pd_disaggregated_hybrid_remote_pcp_splits_attention_and_final_mamba_state(self):
+        for tp_rank in range(2):
+            with self.subTest(tp_rank=tp_rank):
+                with patch.object(
+                    self.vllm_config.kv_transfer_config,
+                    "get_from_extra_config",
+                    side_effect=lambda k, d=None: {
+                        "prefill": {"tp_size": 4, "dp_size": 1, "pp_size": 1},
+                        "decode": {"tp_size": 2, "dp_size": 1, "pp_size": 1},
+                    }.get(k, d),
+                ):
+                    self.vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+                    self.vllm_config.model_config.is_deepseek_mla = False
+                    self.vllm_config.model_config.hf_text_config.num_key_value_heads = 8
+                    worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
+
+                worker._is_hma_required = True
+                worker.use_mla = False
+                worker.use_sparse = False
+                worker.num_key_value_heads = 8
+                worker.tp_size = 2
+                worker.tp_rank = tp_rank
+                worker.pcp_size = 1
+                worker.dcp_size = 1
+                worker.pcp_rank = 0
+                worker.dcp_rank = 0
+                worker._decode_tp_size = 2
+                worker._prefill_tp_size = 4
+                worker._prefill_pp_size = 1
+                worker.side_channel_port = 5000
+                worker.handshake_port = worker.side_channel_port + tp_rank
+                worker.local_remote_block_port_mapping = {}
+                worker.remote_port_send_num = {}
+                worker.kv_group2layeridx = {
+                    0: (
+                        {
+                            "kv_cache_spec_type": "FullAttentionSpec",
+                            "kv_cache_spec": {"num_kv_heads": 8},
+                        },
+                        [0, 1],
+                    ),
+                    1: ({"kv_cache_spec_type": "MambaSpec"}, [2]),
+                }
+
+                meta = types.SimpleNamespace(
+                    remote_pcp_size=2,
+                    remote_dcp_size=1,
+                    remote_ptp_size=4,
+                    remote_port=31000,
+                    remote_block_ids=([50, 51, 52, 53], [60, 61, 62, 63]),
+                    local_block_ids=([70, 71, 72, 73], [80, 81, 82, 83]),
+                    num_external_tokens=4 * worker.block_size,
+                    num_prompt_blocks=4,
+                    remote_engine_id=f"remote_hybrid_pcp_{tp_rank}",
+                    remote_host="localhost",
+                    remote_multi_nodes_meta_mapping={},
+                )
+
+                ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_hybrid_pcp", cast(ReqMeta, meta))
+                group_pulls = worker._get_group_pulls_metadata("req_hybrid_pcp", ports, 4, 31000)
+
+                self.assertEqual(len(ports), 2)
+                self.assertEqual([len(ids[0]) for ids in local_ids], [2, 2])
+                self.assertEqual([ids[1] for ids in local_ids], [[], [80, 81, 82, 83]])
+                self.assertEqual([ids[1] for ids in remote_ids], [[], [60, 61, 62, 63]])
+                self.assertTrue(worker.remote_port_send_num[meta.remote_engine_id])
+                self._assert_hybrid_group_pull_finish_flags(
+                    ports,
+                    group_pulls,
+                    expected_group_ids={0, 1},
+                    expected_finishes={0: 2, 1: 2},
+                )
+
     def test_get_tp_num_need_pulls(self):
         worker = MooncakeConnectorWorker(self.vllm_config, self.engine_id, MockKVCacheConfig())
         worker.num_key_value_heads = 8

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1709,8 +1709,6 @@ class MooncakeConnectorWorker:
         # layer indices: {group_id: (group_spec, [layer_idx0, layer_idx1, ...])}.
         self.kv_group2layeridx = self._build_kv_group2layeridx()
         has_mamba_group = self._has_mamba_group()
-        if has_mamba_group:
-            assert self.pcp_size * self.dcp_size == 1
         layer_name_to_idx = {
             layer_name: layer_idx
             for _, (group_spec, layer_indices) in self.kv_group2layeridx.items()
@@ -1881,9 +1879,6 @@ class MooncakeConnectorWorker:
             remote_block_ids_list = [meta.remote_block_ids for _ in remote_handshake_port_list]
             return remote_handshake_port_list, local_block_ids_list, remote_block_ids_list
 
-        if self._is_hma_required:
-            raise NotImplementedError("Hybrid KV transfer only supports pcp*dcp == 1 for now.")
-
         def context_parallel_parameters_check():
             assert (meta.remote_pcp_size * meta.remote_dcp_size) % (self.pcp_size * self.dcp_size) == 0
             if not (self.use_mla or self.use_sparse):
@@ -2011,9 +2006,20 @@ class MooncakeConnectorWorker:
 
         num_external_blocks = math.ceil(meta.num_external_tokens / self.block_size)
 
-        assert math.ceil(num_external_blocks / (self.pcp_size * self.dcp_size)) == len(meta.local_block_ids[0]), (
+        kv_group_items = list(self.kv_group2layeridx.items())
+        sequence_group_idx = next(
+            (
+                group_idx
+                for group_idx, (group_spec, _) in kv_group_items
+                if group_spec["kv_cache_spec_type"] != "MambaSpec"
+            ),
+            0,
+        )
+        assert math.ceil(num_external_blocks / (self.pcp_size * self.dcp_size)) == len(
+            meta.local_block_ids[sequence_group_idx]
+        ), (
             f"num_external_blocks({num_external_blocks}), cp_size({self.pcp_size * self.dcp_size}), "
-            f"local_block_ids_len ({len(meta.local_block_ids[0])})"
+            f"local_block_ids_len ({len(meta.local_block_ids[sequence_group_idx])})"
         )
         assert meta.num_prompt_blocks >= num_external_blocks, (
             f"meta.num_prompt_blocks({meta.num_prompt_blocks}), num_external_blocks({num_external_blocks})"
@@ -2066,10 +2072,22 @@ class MooncakeConnectorWorker:
         local_block_offset = 0
         for remote_kv_id in range(len(remote_handshake_port_list)):
             num_blocks_to_pull = remote_block_nums[remote_kv_id]
-            remote_block_ids_list.append([meta.remote_block_ids[0][:num_blocks_to_pull]])
-            local_block_ids_list.append(
-                [meta.local_block_ids[0][local_block_offset : local_block_offset + num_blocks_to_pull]]
-            )
+            group_remote_block_ids: list[list[int]] = []
+            group_local_block_ids: list[list[int]] = []
+            is_final_shard = remote_kv_id == len(remote_handshake_port_list) - 1
+            for group_idx, (group_spec, _) in kv_group_items:
+                if group_spec["kv_cache_spec_type"] == "MambaSpec":
+                    # Mamba state is not context-block sharded like attention
+                    # KV. Transfer the final state from the final PCP/DCP shard.
+                    group_remote_block_ids.append(list(meta.remote_block_ids[group_idx]) if is_final_shard else [])
+                    group_local_block_ids.append(list(meta.local_block_ids[group_idx]) if is_final_shard else [])
+                    continue
+                group_remote_block_ids.append(list(meta.remote_block_ids[group_idx][:num_blocks_to_pull]))
+                group_local_block_ids.append(
+                    list(meta.local_block_ids[group_idx][local_block_offset : local_block_offset + num_blocks_to_pull])
+                )
+            remote_block_ids_list.append(tuple(group_remote_block_ids))
+            local_block_ids_list.append(tuple(group_local_block_ids))
             local_block_offset += num_blocks_to_pull
 
         tp_num_need_pulls = self._get_tp_num_need_pulls(prefill_tp_size)
@@ -2111,8 +2129,12 @@ class MooncakeConnectorWorker:
         """
         if self._is_hma_required:
             _, rank_group_pulls = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
+            num_pp_tp_ranks = prefill_tp_size * self._prefill_pp_size
             return [
-                [rank_group_pulls[remote_handshake_port - remote_base_port] for remote_handshake_port in remote_ports]
+                [
+                    rank_group_pulls[(remote_handshake_port - remote_base_port) % num_pp_tp_ranks]
+                    for remote_handshake_port in remote_ports
+                ]
                 for remote_ports in remote_handshake_port_list
             ]
 
@@ -2275,7 +2297,7 @@ class MooncakeConnectorWorker:
                     )
                     remote_port_send_num = (
                         self.remote_port_send_num[meta.remote_engine_id]
-                        if meta.remote_pcp_size * meta.remote_dcp_size > 1 and not self._has_mamba_group()
+                        if meta.remote_pcp_size * meta.remote_dcp_size > 1
                         else None
                     )
                     self.kv_recv_thread.add_request(


### PR DESCRIPTION
### What this PR does / why we need it?
Support Mooncake PD disaggregation KV transfer for hybrid attention models when PCP is enabled. Split attention KV by context-parallel shards while transferring Mamba state only from the final shard, and keep remote port completion accounting for hybrid transfers.

### Does this PR introduce _any_ user-facing change?
No user-facing API change.

### How was this patch tested?
Unit tests added/updated for Mooncake connector metadata split and group pull construction.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
