### PR TITLE
[CI]skip test_models[Qwen/Qwen3-8B]

### DIFF
--- a/tests/e2e/multicard/2-cards/test_qwen3_performance.py
+++ b/tests/e2e/multicard/2-cards/test_qwen3_performance.py
@@ -49,6 +49,7 @@ vllm_bench_cases = {
 # The origin baseline: 1600.0. For some uncertain reasons, the throughput is decreased to 1514.0
 baseline_throughput = 1514.0  # baseline throughput for Qwen3-8B, measured with num_prompts=500
 
+
 @pytest.mark.skip(reason="Temporarily skipped due to flaky failures, pending investigation.")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.asyncio

--- a/tests/e2e/multicard/2-cards/test_qwen3_performance.py
+++ b/tests/e2e/multicard/2-cards/test_qwen3_performance.py
@@ -49,7 +49,7 @@ vllm_bench_cases = {
 # The origin baseline: 1600.0. For some uncertain reasons, the throughput is decreased to 1514.0
 baseline_throughput = 1514.0  # baseline throughput for Qwen3-8B, measured with num_prompts=500
 
-
+@pytest.mark.skip(reason="Temporarily skipped due to flaky failures, pending investigation.")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.asyncio
 async def test_models(model: str) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?
Skips the flaky test test_models[Qwen/Qwen3-8B] via @pytest.mark.skip.
The test fails intermittently in CI, blocking merges. 
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
