### PR TITLE
[BugFix][MoE] Use max_num_batched_tokens for dispatch_ffn_combine workspace sizing

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
+from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -270,8 +271,11 @@ class FusedMC2CommImpl(MoECommMethod):
         super().__init__(moe_config)
         if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
+            vllm_config = get_current_vllm_config()
+            self.max_output_size = vllm_config.scheduler_config.max_num_batched_tokens
         else:
             self.expert_token_nums = None
+            self.max_output_size = 0
 
     def pad_and_split_input_ids(self, input_ids):
         return self.prepare_finalize.pad_and_split_input_ids(input_ids)  # type: ignore[attr-defined]
@@ -317,7 +321,7 @@ class FusedMC2CommImpl(MoECommMethod):
                 bias2=fused_experts_input.weights.w2_scale_bias,
                 probs=fused_experts_input.topk_weights.to(torch.float32),
                 group=self.token_dispatcher.moe_all_to_all_group_name,
-                max_output_size=131072,
+                max_output_size=self.max_output_size,
                 swiglu_limit=fused_experts_input.swiglu_limit,
                 x_active_mask=fused_experts_input.routing.mc2_mask,
                 out=out,


### PR DESCRIPTION
### What this PR does / why we need it

The `dispatch_ffn_combine` CANN operator in `FusedMC2CommImpl` was using a hardcoded `max_output_size=131072` to allocate its internal workspace. The CANN tiling code allocates workspace proportional to this parameter:

- **W4A8**: `maxOutputSize × (N×4 + K×4 + K + K/2)`
- **W8A8**: `maxOutputSize × (K×3 + small_terms)`

For DeepSeek V4 Pro (K=7168, N=18432), the W4A8 workspace was ~8.37 GB per operator call with `max_output_size=131072`, far exceeding the actual requirement. With `max_num_batched_tokens=4096`, the workspace drops to ~262 MB.

This caused KV cache available space to drop from 12.43 GiB to 5.37 GiB when `enable_fused_mc2=1`. After this fix, KV cache is 12.86 GiB (even slightly better than the non-fused path's 12.43 GiB).

**Fix**: Read `max_num_batched_tokens` from `vllm_config.scheduler_config` in `FusedMC2CommImpl.__init__()` and pass it as `max_output_size` instead of the hardcoded 131072.

### Does this PR introduce _any_ user-facing change?

Yes. Users with `enable_fused_mc2=1` will see significantly more KV cache memory available (~7 GB improvement on DeepSeek V4 Pro prefill). No accuracy or API changes.

### How was this patch tested?

Tested on DeepSeek V4 Pro prefill (A3 NPU, TP=8, DP=4, W4A8 quantization):

- `enable_fused_mc2=0` (baseline): KV cache = 12.43 GiB
- `enable_fused_mc2=1` (before fix): KV cache = 5.37 GiB
- `enable_fused_mc2=1` (after fix): KV cache = 12.86 GiB

End-to-end inference correctness verified with request sending.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
