### PR TITLE
[BugFix] Fix DSA compressed idle dummy graph OOB

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2813,6 +2813,14 @@ class NPUModelRunner(GPUModelRunner):
                         slot_mapping[
                             total_num_scheduled_tokens_compressed_list[
                                 kv_cache_gid]:num_tokens_padded].fill_(-1)
+                    elif self.use_compress:
+                        # DSA dummy/graph-capture runs do not go through
+                        # _prepare_inputs(), so no fresh compressed cache
+                        # metadata is computed for them. Reusing values from
+                        # the previous real request can feed stale block-table
+                        # and [block, offset] scatter indices to DSA kernels.
+                        slot_mapping[:num_tokens_padded].fill_(0)
+                        blk_table_tensor[:maybe_num_reqs_padded].fill_(0)
                     else:
                         slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
                         blk_table_tensor[num_reqs:num_reqs_padded].fill_(0)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #9816.

This PR fixes a DSA/compress crash that happens after a request has already returned successfully. In the failing case, the engine enters idle `execute_dummy_batch()`, replays the ACLGraph dummy path, and the NPU reports 507011 / MTE out-of-range.

The fix keeps the change scoped to the DSA/compress metadata path:

- clear stale DSA slot mapping and block table values when dummy / graph-capture runs do not have fresh compressed scheduling metadata.

### Does this PR introduce _any_ user-facing change?

No API or configuration change.

### How was this patch tested?

Code checks:

```bash
python -m py_compile vllm_ascend/worker/model_runner_v1.py
python -m ruff check vllm_ascend/worker/model_runner_v1.py
git diff --check
```

Failure was reproduced on A3, image `quay.io/ascend/vllm-ascend:nightly-releases-v0.20.2rc-a3`, model `/models/DeepSeek-V4-Flash-w8a8-mtp`, `dp=8/tp=1`, EP, MTP, async scheduling, ACLGraph `FULL_DECODE_ONLY`, `gpu_memory_utilization=0.93`, `max_model_len=450560`:

```text
The request returns 200, then idle execute_dummy_batch() replays the graph dummy path and fails with 507011 / MTE out-of-range.
```

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
