### PR TITLE
[BugFix][0.20.2]fix backend ut

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -256,6 +256,9 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend = MooncakeBackend.__new__(MooncakeBackend)
             backend.store = MagicMock()
             backend.config = MagicMock()
+            backend._lazy_init = False
+            backend._store_initialized = True
+            backend._use_fabric_mem = False
             return backend
 
     def test_exists(self):
@@ -413,6 +416,12 @@ class TestMemcacheBackendMethods(unittest.TestCase):
             backend = MemcacheBackend.__new__(MemcacheBackend)
             backend.store = MagicMock()
             backend.local_rank = 0
+            # Set internal state to avoid lazy init logic during tests
+            backend._lazy_init = False
+            backend._store_initialized = True
+            backend._is_a2 = False
+            backend._registered_buffers = None
+            backend._buffers_registered = False
             return backend
 
     def test_exists(self):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the backend unit tests for `MooncakeBackend` and `MemcacheBackend` by properly initializing internal state variables (`_lazy_init`, `_store_initialized`, `_use_fabric_mem`, `_is_a2`, `_registered_buffers`, `_buffers_registered`) during test setup in `_make_backend`. This avoids lazy initialization logic and missing attribute errors during unit test execution.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested by running the modified unit tests in `tests/ut/distributed/ascend_store/test_backend.py`.