### PR TITLE
[Feature] The mooncake protocol and device name are configurable.

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1542,7 +1542,7 @@ class MooncakeConnectorWorker:
         device_index = (self.pp_rank + self.pcp_rank) * self.tp_size + self.tp_rank
         self.handshake_port = self.side_channel_port + device_index
         self.sockets: dict = {}
-        self.engine = global_te.get_transfer_engine(self.side_channel_host, device_name=None)
+        self.engine = global_te.get_transfer_engine(self.side_channel_host)
         self.te_rpc_port = self.engine.get_rpc_port()
 
         # Background thread for sending or receiving KV caches.

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1358,7 +1358,7 @@ class MooncakeConnectorWorker:
         device_index = self.pp_rank * self.tp_size + self.tp_rank
         self.handshake_port = self.side_channel_port + device_index
         self.sockets: dict = {}
-        self.engine = global_te.get_transfer_engine(self.side_channel_host, device_name=None)
+        self.engine = global_te.get_transfer_engine(self.side_channel_host)
         self.te_rpc_port = self.engine.get_rpc_port()
 
         # Background thread for sending or receiving KV caches.

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -1082,7 +1082,7 @@ class MooncakeLayerwiseConnectorWorker:
         self.handshake_port = self.side_channel_port + self.tp_rank
         self.sockets: dict = {}
         logger.info("Initializing Mooncake work %s", engine_id)
-        self.engine = global_te.get_transfer_engine(self.side_channel_host, device_name=None)
+        self.engine = global_te.get_transfer_engine(self.side_channel_host)
         self.te_rpc_port = self.engine.get_rpc_port()
 
         # Background thread for sending or receiving KV caches.

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -66,7 +66,7 @@ class MooncakeBackend(Backend):
         # and only can be used for 800 I/T A3 series.
         # Required supporting hardware versions are as follows:
         if not self._use_fabric_mem:
-            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
+            transfer_engine = global_te.get_transfer_engine(local_hostname)
             self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
             ret = store.setup(
                 self.local_seg,
@@ -104,7 +104,7 @@ class MooncakeBackend(Backend):
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
         if not self._use_fabric_mem:
             local_hostname = get_ip()
-            global_te.get_transfer_engine(local_hostname, device_name=None)
+            global_te.get_transfer_engine(local_hostname)
             global_te.register_buffer(ptrs, lengths)
 
     def exists(self, keys: list[str]) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -8,7 +8,7 @@ class GlobalTE:
         self.transfer_engine_lock = threading.Lock()
         self.register_buffer_lock = threading.Lock()
 
-    def get_transfer_engine(self, hostname: str, device_name: str | None):
+    def get_transfer_engine(self, hostname: str):
         if self.transfer_engine is None:
             with self.transfer_engine_lock:
                 # Double-Checked Locking
@@ -21,9 +21,18 @@ class GlobalTE:
                             "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
                             "to run vLLM with MooncakeConnector."
                         ) from e
+
+                    protocol = kv_transfer_config.kv_connector_extra_config.get(
+                        "mooncake_protocol", "ascend"
+                    )
+                    device_name = kv_transfer_config.kv_connector_extra_config.get(
+                        "device_name", ""
+                    )
+                    logger.info(
+                        "The Mooncake Transfer Engine is using %s as its protocol, %s as its device.", protocol, device_name
+                    )
                     self.transfer_engine = TransferEngine()
-                    device_name = device_name if device_name is not None else ""
-                    ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", "ascend", device_name)
+                    ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", protocol, device_name)
                     if ret_value != 0:
                         raise RuntimeError(f"TransferEngine initialization failed with ret_value: {ret_value}")
         return self.transfer_engine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
The protocol used by the 950PR and H20 heterogeneous systems is RDMA. Therefore, RDMA must be configured for Mooncake.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
```    
--kv-transfer-config
  '{"kv_connector": "MooncakeConnectorV1",
  "kv_role": "kv_producer",
  "kv_port": "30000",
  "engine_id": "0",
  "kv_connector_extra_config": {
            "mooncake_protocol": "rdma",
            "device_name": "mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_8",
            "prefill": {
                "dp_size": 1,
                "tp_size": 4,
                "pp_size": 2
             },
             "decode": {
                "dp_size": 1,
                "tp_size": 8,
                "pp_size": 1
             }
      }
  }'
```
