### PR TITLE
[Attention][Feature] Support Sparse Flash Attention on Ascend A5 devices

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -16,6 +16,20 @@ from vllm_ascend.utils import enable_dsa_cp
 
 
 class TestAscendSFABackend(TestBase):
+    def setUp(self):
+        self.mock_config = MagicMock()
+        mock_parallel_config = MagicMock()
+        mock_parallel_config.prefill_context_parallel_size = 1
+        mock_parallel_config.decode_context_parallel_size = 1
+        self.mock_config.parallel_config = mock_parallel_config
+
+        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
+        self.utils_patcher.start()
+
+        from vllm_ascend.attention.utils import enable_cp
+
+        enable_cp.cache_clear()
+
     def test_get_name(self):
         self.assertEqual(AscendSFABackend.get_name(), "ASCEND_SFA")
 
@@ -29,6 +43,18 @@ class TestAscendSFABackend(TestBase):
     def test_get_impl_cls(self):
         result = AscendSFABackend.get_impl_cls()
         self.assertEqual(result, AscendSFAImpl)
+
+    @patch("vllm_ascend.attention.sfa_v1.enable_cp")
+    def test_get_builder_cls_with_cp(self, mock_enable_cp):
+        mock_enable_cp.return_value = True
+        builder_cls = AscendSFABackend.get_builder_cls()
+        self.assertIsNotNone(builder_cls)
+
+    @patch("vllm_ascend.attention.sfa_v1.enable_cp")
+    def test_get_impl_cls_with_cp(self, mock_enable_cp):
+        mock_enable_cp.return_value = True
+        impl_cls = AscendSFABackend.get_impl_cls()
+        self.assertIsNotNone(impl_cls)
 
 
 class TestAscendSFAMetadata(TestBase):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -238,16 +238,7 @@ class AscendConfig:
                     "enable_kv_nz is only supported in pd scenario and can only be used in D node."
                 )
 
-        from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
-
-        # Disable Sparse C8 for A5
-        # A5 has not been fully validated for this path and may carry hidden risks.
-        # TODO(rjg-lyh): Enable A5 support after sufficient validation.
-        self.enable_sparse_c8 = (
-            additional_config.get("enable_sparse_c8", False)
-            and use_sparse
-            and get_ascend_device_type() != AscendDeviceType.A5
-        )
+        self.enable_sparse_c8 = additional_config.get("enable_sparse_c8", False) and use_sparse
         quant_config = getattr(vllm_config, "quant_config", None)
         self._sparse_c8_layer_ids, self._sparse_c8_layer_names = self._parse_sparse_c8_layers_from_quant_config(
             quant_config
@@ -338,21 +329,24 @@ class AscendConfig:
         if not isinstance(quant_description, dict):
             return set(), set()
 
+        QUANT_SUFFIXES = (".indexer.quant_type", ".indexer.wq_b_weight")
+        VALID_QUANT_TYPES = ("INT8_DYNAMIC", "W8A8_MXFP8")
+
         layer_ids: set[int] = set()
         layer_names: set[str] = set()
-        suffix = ".indexer.quant_type"
         from vllm.model_executor.models.utils import extract_layer_index
 
         for key, value in quant_description.items():
-            if not isinstance(key, str) or not key.endswith(suffix):
+            if not isinstance(key, str):
                 continue
-            if value != "INT8_DYNAMIC":
+            matched_suffix = next((s for s in QUANT_SUFFIXES if key.endswith(s)), None)
+            if matched_suffix is None or value not in VALID_QUANT_TYPES:
                 continue
-            layer_name = key[: -len(suffix)].rstrip(".")
+            layer_name = key[: -len(matched_suffix)].rstrip(".")
             if not layer_name:
                 continue
             layer_names.add(layer_name)
-            layer_ids.update({extract_layer_index(layer_name)})
+            layer_ids.add(extract_layer_index(layer_name))
         return layer_ids, layer_names
 
     def is_sparse_c8_layer(self, layer_name: str | None) -> bool:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -35,6 +35,7 @@ from vllm_ascend.attention.utils import (
     wait_for_kv_layer_from_connector,
 )
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.mxfp_compat import FLOAT8_E8M0FNU_DTYPE
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.ops.layer_shard_linear import (
     is_hidden_layer,
@@ -44,15 +45,17 @@ from vllm_ascend.ops.layer_shard_linear import (
 )
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.quantization.methods import AscendW8A8LinearMethod
+from vllm_ascend.quantization.methods import AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
+    AscendDeviceType,
     _round_up,
     dispose_layer,
     enable_dsa_cp,
     enable_dsa_cp_with_layer_shard,
     enable_dsa_cp_with_o_proj_tp,
     enable_sp,
+    get_ascend_device_type,
     get_weight_prefetch_method,
     maybe_trans_nz,
 )
@@ -457,8 +460,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         # dsa c8
         self.use_sparse_c8_indexer = ascend_config.is_sparse_c8_layer(self.layer_name)
         if self.use_sparse_c8_indexer:
-            self.c8_k_cache_dtype = torch.int8
-            self.c8_k_scale_cache_dtype = torch.float16
+            if get_ascend_device_type() == AscendDeviceType.A5:
+                self.c8_k_cache_dtype = torch.float8_e4m3fn
+                self.c8_k_scale_cache_dtype = torch.float32
+            else:
+                self.c8_k_cache_dtype = torch.int8
+                self.c8_k_scale_cache_dtype = torch.float16
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
@@ -553,9 +560,12 @@ class AscendSFAImpl(MLAAttentionImpl):
                 None,
             )
             reasons = []
-            if self.fused_qkv_a_proj is None or not isinstance(quant_method, AscendW8A8LinearMethod):
+            is_quantized = isinstance(quant_method, (AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod))
+            if self.fused_qkv_a_proj is None:
+                reasons.append("fused_qkv_a_proj is None, mlapo is disabled.")
+            if not is_quantized and get_ascend_device_type() != AscendDeviceType.A5:
                 reasons.append(
-                    "Currently mlapo only supports W8A8 quantization in SFA scenario."
+                    "Currently mlapo only supports W8A8 quantization in SFA scenario on non-A5 devices."
                     "Some layers in your model are not quantized with W8A8,"
                     "thus mlapo is disabled for these layers."
                 )
@@ -566,7 +576,20 @@ class AscendSFAImpl(MLAAttentionImpl):
                 for msg in reasons:
                     logger.warning_once(msg)
             else:
-                self._process_weights_for_fused_mlapo(act_dtype)
+                self.mlapo_is_quantized = is_quantized
+                if get_ascend_device_type() == AscendDeviceType.A5:
+                    if is_quantized:
+                        self._process_weights_for_fused_mlapo_a5(act_dtype)
+                    else:
+                        self._process_weights_for_fused_mlapo_a5_float(act_dtype)
+                else:
+                    self._process_weights_for_fused_mlapo(act_dtype)
+
+        if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
+            if hasattr(self, "mlapo_is_quantized") and not self.mlapo_is_quantized:
+                self.c8_k_cache_dtype = act_dtype
+                self.c8_k_scale_cache_dtype = act_dtype
+
         if not self.enable_mlapo:
             # if mlapo, W_UK_T can't trans nz
             self.W_UK_T = maybe_trans_nz(self.W_UK_T)
@@ -656,6 +679,45 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.q_proj.deq_scale = None
             self.q_proj.quant_bias = None
             torch.npu.empty_cache()
+
+    def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
+        assert self.fused_qkv_a_proj is not None
+        assert self.q_proj is not None
+        weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
+        self.weight_dq = torch_npu.npu_format_cast(weight_dq, 29)
+
+        weight_uq_qr = self.q_proj.weight.data.contiguous()
+        self.weight_uq_qr_scale = self.q_proj.weight_scale.data.transpose(0, 1)
+        self.weight_uq_qr_scale = self.weight_uq_qr_scale.reshape(
+            -1, self.weight_uq_qr_scale.shape[1] * self.weight_uq_qr_scale.shape[2]
+        )
+        self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, 29)
+
+        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
+        self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
+
+        weight_scale = self.fused_qkv_a_proj.weight_scale
+        weight_scale = weight_scale.transpose(0, 1)
+        weight_scale = weight_scale.reshape(-1, weight_scale.shape[1] * weight_scale.shape[2])
+        self.weight_dq_scale = weight_scale[: self.q_lora_rank, ...]
+        self.weight_dkv_kr_scale = weight_scale[self.q_lora_rank :, ...]
+
+    def _process_weights_for_fused_mlapo_a5_float(self, act_dtype: torch.dtype):
+        assert self.fused_qkv_a_proj is not None
+        assert self.q_proj is not None
+        self.fused_qkv_a_proj.weight.data = self.fused_qkv_a_proj.weight.data.T
+        weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
+        self.weight_dq_cpu = weight_dq.cpu()
+        self.weight_dq = torch_npu.npu_format_cast(weight_dq, 29)
+
+        weight_uq_qr = self.q_proj.weight.data.T
+        weight_uq_qr = weight_uq_qr.contiguous()
+        self.weight_uq_qr_cpu = weight_uq_qr.cpu()
+        self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, 29)
+
+        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
+        self.weight_dkv_kr_cpu = weight_dkv_kr.cpu()
+        self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
 
     def forward_mha(
         self,
@@ -841,6 +903,13 @@ class AscendSFAImpl(MLAAttentionImpl):
             res = torch.empty((num_input_tokens, self.local_num_heads, self.v_head_dim), dtype=x.dtype, device=x.device)
             torch.ops._C_ascend.batch_matmul_transpose(x, self.W_UV, res)
             x = res.reshape(-1, self.local_num_heads * self.v_head_dim)
+        elif hasattr(torch_npu, "npu_transpose_batchmatmul"):
+            # Convert from (N, B, L)/(N, B, 1, L) to (N, B, L)
+            x = x.view(-1, self.local_num_heads, self.kv_lora_rank)
+            # Multiply (N, B, L) x (N, L, V) -> (B, N, V)
+            x = torch_npu.npu_transpose_batchmatmul(x, self.W_UV, perm_x1=(1, 0, 2), perm_y=(1, 0, 2))
+            # Convert from (N, B, V) to (B, N * V)
+            x = x.reshape(-1, self.local_num_heads * self.v_head_dim)
         else:
             # Convert from (B, N, L) to (N, B, L)
             x = x.view(-1, self.local_num_heads, self.kv_lora_rank).transpose(0, 1)
@@ -853,61 +922,21 @@ class AscendSFAImpl(MLAAttentionImpl):
     def _sfa_preprocess_with_mlapo(
         self,
         hidden_states: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        kv_cache: tuple[torch.Tensor, ...],
         cos: torch.Tensor,
         sin: torch.Tensor,
         slot_mapping: torch.Tensor,
         num_input_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        k_nope, k_pe = kv_cache[0], kv_cache[1]
-        ql_nope = torch.empty(
-            (num_input_tokens, self.W_UK_T.shape[0], k_nope.shape[-1]),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        q_pe = torch.empty(
-            (num_input_tokens, self.W_UK_T.shape[0], k_pe.shape[-1]),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        q_c = torch.empty(
-            (num_input_tokens, self.q_lora_rank),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        torch.ops._C_ascend.mla_preprocess(
+        return DeviceOperator.sfa_preprocess_with_mlapo(
+            self,
             hidden_states,
-            self.wd_qkv,
-            self.deq_scale_qkv,
-            self.gamma1,
-            self.beta1,
-            self.wu_q,
-            self.qb_deq_scl,
-            self.gamma2,
+            kv_cache,
             cos,
             sin,
-            self.W_UK_T,
-            k_nope,
-            k_pe,
             slot_mapping,
-            quant_scale0=self.quant_scale0,
-            quant_offset0=self.quant_offset0,
-            bias0=self.quant_bias_qkv,
-            quant_scale1=self.quant_scale1,
-            quant_offset1=self.quant_offset1,
-            bias1=self.qb_qt_bias,
-            ctkv_scale=self.ctkv_scale,
-            q_nope_scale=self.q_nope_scale,
-            cache_mode="krope_ctkv",
-            quant_mode="per_tensor_quant_asymm",
-            enable_inner_out=True,
-            q_out0=ql_nope,
-            kv_cache_out0=k_nope,
-            q_out1=q_pe,
-            kv_cache_out1=k_pe,
-            inner_out=q_c,
+            num_input_tokens,
         )
-        return hidden_states, ql_nope, q_pe, q_c
 
     def indexer_select_pre_process(
         self,
@@ -954,7 +983,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self,
         x: torch.Tensor,
         q_c: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: M,
         cos: torch.Tensor,
         sin: torch.Tensor,
@@ -963,7 +992,27 @@ class AscendSFAImpl(MLAAttentionImpl):
     ):
         kw, _ = self.wk_weights_proj(x)
         weights = kw[:, self.head_dim :]
-        q_li, _ = self.wq_b(q_c)  # [b,s,1536] @ [1536,64*128] = [b,s,64*128]
+        if isinstance(q_c, tuple):
+            # MLAPO in C8 scenario already quantizes q_c to MXFP8 (fp8) with a per-token scale.
+            # Skip wq_b's internal npu_dynamic_mx_quant and directly use the
+            # pre-quantized values in npu_quant_matmul to avoid double quantization.
+            q_c_tensor, q_c_scale = q_c
+            q_c_tensor = q_c_tensor.view(-1, q_c_tensor.shape[-1])
+            if q_c_scale.dim() == 2:
+                q_c_scale = q_c_scale.view(q_c_scale.shape[0], -1, 2)
+            q_li = torch_npu.npu_quant_matmul(
+                q_c_tensor,
+                self.wq_b.weight,
+                self.wq_b.weight_scale,
+                scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                pertoken_scale=q_c_scale,
+                pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                bias=None,
+                output_dtype=x.dtype,
+                group_sizes=[1, 1, getattr(self.wq_b.quant_method.quant_method, "group_size", 32)],
+            )
+        else:
+            q_li, _ = self.wq_b(q_c)
         q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
         if HAS_TRITON:
             q_li = rope_forward_triton_siso(
@@ -979,61 +1028,27 @@ class AscendSFAImpl(MLAAttentionImpl):
             q_li_pe = q_li_pe.squeeze(2)
             q_li = torch.cat([q_li_pe, q_li_nope], dim=-1)  # [b*s,64,128]
 
+        q_li_scale = None
+        q_li_shape_ori = None
         if self.use_sparse_c8_indexer:
             q_li_shape_ori = q_li.shape
             q_li = q_li @ AscendSFAImpl.q_hadamard
             q_li, q_li_scale = torch_npu.npu_dynamic_quant(q_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
-            q_li_scale = q_li_scale.to(self.c8_k_scale_cache_dtype)
+            q_li_scale = q_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
 
-        # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
-        # So two branches are maintained temporarily.
-        # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
-        if self.use_sparse_c8_indexer:
-            assert len(kv_cache) == 4
-            weights = weights.to(torch.float16)
-            topk_indices = torch.ops._C_ascend.npu_lightning_indexer_quant(
-                query=q_li.view(q_li_shape_ori),
-                key=kv_cache[2],
-                weights=weights,
-                query_dequant_scale=q_li_scale.view(q_li_shape_ori[:-1]),
-                key_dequant_scale=kv_cache[3].squeeze(2),  # B S N D -> B S D
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                query_quant_mode=0,
-                key_quant_mode=0,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        elif self.use_torch_npu_lightning_indexer:
-            topk_indices, _ = torch_npu.npu_lightning_indexer(
-                query=q_li,
-                key=kv_cache[2],
-                weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        else:
-            topk_indices, _ = torch.ops._C_ascend.npu_lightning_indexer(
-                query=q_li,
-                key=kv_cache[2],
-                weights=weights,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-                block_table=attn_metadata.block_table,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=2048,
-                sparse_mode=3,
-            )
-        return topk_indices
+        return DeviceOperator.indexer_select_post_process(
+            self,
+            q_li,
+            q_li_scale,
+            q_li_shape_ori,
+            weights,
+            kv_cache,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
+            self.use_sparse_c8_indexer,
+            self.use_torch_npu_lightning_indexer,
+        )
 
     def _get_indexcache_topk_indices(self, num_tokens: int) -> torch.Tensor:
         if self.topk_indices_buffer is None:
@@ -1058,34 +1073,22 @@ class AscendSFAImpl(MLAAttentionImpl):
     def _execute_sparse_flash_attention_process(
         self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
     ):
-        block_table = attn_metadata.block_table
-        kv = kv_cache[0]
-        key_rope = kv_cache[1]
-
-        attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
-            query=ql_nope,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=self.scale,
-            sparse_block_size=1,
-            block_table=block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=actual_seq_lengths_key,
-            query_rope=q_pe,
-            key_rope=key_rope,
-            layout_query="TND",
-            layout_kv="PA_BSND",
-            sparse_mode=3,
-            attention_mode=2,
+        return DeviceOperator.execute_sparse_flash_attention_process(
+            self,
+            ql_nope,
+            q_pe,
+            kv_cache,
+            topk_indices,
+            attn_metadata,
+            actual_seq_lengths_query,
+            actual_seq_lengths_key,
         )
-        return attn_output
 
     def forward(
         self,
         layer_name,
         hidden_states: torch.Tensor,  # query in unified attn
-        kv_cache: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: M,
         need_gather_q_kv: bool = False,
         output: torch.Tensor | None = None,
@@ -1126,7 +1129,9 @@ class AscendSFAImpl(MLAAttentionImpl):
         }
 
         # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
-        if self.enable_mlapo and num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS:
+        if self.enable_mlapo and (
+            get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+        ):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                 hidden_states.contiguous(), need_gather_q_kv
             )
@@ -1252,17 +1257,30 @@ class AscendSFAImpl(MLAAttentionImpl):
         if kv_cache is not None:
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event = torch.npu.Event()
+
+            if self.use_sparse_c8_indexer and get_ascend_device_type() == AscendDeviceType.A5:
+                dsa_k_cache_idx = 1
+                dsa_k_scale_cache_idx = 2
+            else:
+                dsa_k_cache_idx = 2
+                dsa_k_scale_cache_idx = 3
+
             torch_npu.npu_scatter_nd_update_(
-                kv_cache[2].view(-1, k_li.shape[-1]), slot_mapping.view(-1, 1), k_li.view(-1, k_li.shape[-1])
+                kv_cache[dsa_k_cache_idx].view(-1, k_li.shape[-1]),
+                slot_mapping.view(-1, 1),
+                k_li.view(-1, k_li.shape[-1]),
             )  # b, s, n, d
             if self.use_sparse_c8_indexer:
-                assert len(kv_cache) == 4
-                assert k_li_scale is not None
-                torch_npu.npu_scatter_nd_update_(
-                    kv_cache[3].view(-1, k_li_scale.shape[-1]),
-                    slot_mapping.view(-1, 1),
-                    k_li_scale.view(-1, k_li_scale.shape[-1]),
-                )
+                if get_ascend_device_type() == AscendDeviceType.A5:
+                    assert len(kv_cache) == 3
+                else:
+                    assert len(kv_cache) == 4
+                if k_li_scale is not None:
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li_scale.view(-1, k_li_scale.shape[-1]),
+                    )
             if self.is_kv_producer:
                 attn_metadata.reshape_cache_event.record()
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+from typing import Any
+
 import torch
 import torch.nn.functional as F
 import torch_npu
@@ -298,6 +300,166 @@ class BaseDeviceAdaptor:
             decode_q_nope, decode_q_pe, decode_k_nope, decode_k_pe, dequant_scale_q_nope=dequant_scale_q_nope
         )
         return decode_preprocess_res, None
+
+    @staticmethod
+    def sfa_preprocess_with_mlapo(
+        sfa_impl,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        num_input_tokens: int,
+    ) -> tuple:
+        k_nope, k_pe = kv_cache[0], kv_cache[1]
+        ql_nope = torch.empty(
+            (num_input_tokens, sfa_impl.W_UK_T.shape[0], k_nope.shape[-1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        q_pe = torch.empty(
+            (num_input_tokens, sfa_impl.W_UK_T.shape[0], k_pe.shape[-1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        q_c = torch.empty(
+            (num_input_tokens, sfa_impl.q_lora_rank),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        torch.ops._C_ascend.mla_preprocess(
+            hidden_states,
+            sfa_impl.wd_qkv,
+            sfa_impl.deq_scale_qkv,
+            sfa_impl.gamma1,
+            sfa_impl.beta1,
+            sfa_impl.wu_q,
+            sfa_impl.qb_deq_scl,
+            sfa_impl.gamma2,
+            cos,
+            sin,
+            sfa_impl.W_UK_T,
+            k_nope,
+            k_pe,
+            slot_mapping,
+            quant_scale0=sfa_impl.quant_scale0,
+            quant_offset0=sfa_impl.quant_offset0,
+            bias0=sfa_impl.quant_bias_qkv,
+            quant_scale1=sfa_impl.quant_scale1,
+            quant_offset1=sfa_impl.quant_offset1,
+            bias1=sfa_impl.qb_qt_bias,
+            ctkv_scale=sfa_impl.ctkv_scale,
+            q_nope_scale=sfa_impl.q_nope_scale,
+            cache_mode="krope_ctkv",
+            quant_mode="per_tensor_quant_asymm",
+            enable_inner_out=True,
+            q_out0=ql_nope,
+            kv_cache_out0=k_nope,
+            q_out1=q_pe,
+            kv_cache_out1=k_pe,
+            inner_out=q_c,
+        )
+        return hidden_states, ql_nope, q_pe, q_c
+
+    @staticmethod
+    def indexer_select_post_process(
+        sfa_impl,
+        q_li: torch.Tensor,
+        q_li_scale: torch.Tensor | None,
+        q_li_shape_ori: tuple[Any, ...] | None,
+        weights: torch.Tensor,
+        kv_cache: tuple,
+        attn_metadata,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+        use_sparse_c8_indexer: bool,
+        use_torch_npu_lightning_indexer: bool,
+    ) -> torch.Tensor:
+        # DSV3.2 currently has graph compilation issues when using torch_npu.npu.lightning_indexer.
+        # So two branches are maintained temporarily.
+        # TODO: torch.ops._C_ascend.npu_lightning_indexer needs to be removed.
+        if sfa_impl.use_sparse_c8_indexer:
+            assert len(kv_cache) == 4
+            assert q_li_scale is not None
+            assert q_li_shape_ori is not None
+            weights = weights.to(torch.float16)
+            topk_indices = torch.ops._C_ascend.npu_lightning_indexer_quant(
+                query=q_li.view(q_li_shape_ori),
+                key=kv_cache[2],
+                weights=weights,
+                query_dequant_scale=q_li_scale.view(q_li_shape_ori[:-1]),
+                key_dequant_scale=kv_cache[3].squeeze(2),  # B S N D -> B S D
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+                block_table=attn_metadata.block_table,
+                query_quant_mode=0,
+                key_quant_mode=0,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=2048,
+                sparse_mode=3,
+            )
+        elif sfa_impl.use_torch_npu_lightning_indexer:
+            topk_indices, _ = torch_npu.npu_lightning_indexer(
+                query=q_li,
+                key=kv_cache[2],
+                weights=weights,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+                block_table=attn_metadata.block_table,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=2048,
+                sparse_mode=3,
+            )
+        else:
+            topk_indices, _ = torch.ops._C_ascend.npu_lightning_indexer(
+                query=q_li,
+                key=kv_cache[2],
+                weights=weights,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+                block_table=attn_metadata.block_table,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=2048,
+                sparse_mode=3,
+            )
+        return topk_indices
+
+    @staticmethod
+    def execute_sparse_flash_attention_process(
+        sfa_impl,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv_cache: tuple,
+        topk_indices: torch.Tensor,
+        attn_metadata,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+    ) -> torch.Tensor:
+        block_table = attn_metadata.block_table
+        kv = kv_cache[0]
+        key_rope = kv_cache[1]
+
+        attn_output, _, _ = torch.ops._C_ascend.npu_sparse_flash_attention(
+            query=ql_nope,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            query_rope=q_pe,
+            key_rope=key_rope,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=3,
+            attention_mode=2,
+        )
+        return attn_output
 
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
         context_layer = torch.empty_like(query)
@@ -1136,6 +1298,225 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     def get_dsa_kernel_block_sizes():
         """A5: return supported kernel block sizes."""
         return [8, 16, 128]
+
+    @staticmethod
+    def sfa_preprocess_with_mlapo(
+        sfa_impl,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        num_input_tokens: int,
+    ) -> tuple:
+        bsz = num_input_tokens
+        slot_mapping = slot_mapping[:bsz]
+        hidden_states_temp = hidden_states[:bsz].unsqueeze(1)
+        cos = cos[:bsz, ...]
+        sin = sin[:bsz, ...]
+
+        is_quantized = getattr(sfa_impl, "mlapo_is_quantized", True)
+
+        cos_shape = cos.shape
+        cos = cos.view(cos_shape[0], 1, cos_shape[-1])
+        sin = sin.view(cos_shape[0], 1, cos_shape[-1])
+
+        decode_k_nope = kv_cache[0]
+        use_c8 = getattr(sfa_impl, "use_sparse_c8_indexer", False)
+        kr_cache = (
+            torch.zeros(0, 0, decode_k_nope.shape[-2], cos_shape[-1], dtype=torch.bfloat16, device=decode_k_nope.device)
+            if use_c8
+            else kv_cache[1]
+        )
+
+        if is_quantized:
+            hidden_states_temp, dynamic_scale = torch_npu.npu_dynamic_mx_quant(
+                hidden_states_temp, dst_type=torch.float8_e4m3fn
+            )
+            dynamic_scale = dynamic_scale.reshape(hidden_states_temp.shape[0] * hidden_states_temp.shape[1], -1)
+
+            decode_q_nope, q_pe, _, q_c, q_c_scale = torch_npu.npu_mla_prolog_v3(
+                token_x=hidden_states_temp,
+                weight_dq=sfa_impl.weight_dq,
+                weight_uq_qr=sfa_impl.weight_uq_qr,
+                weight_uk=sfa_impl.W_UK_T,
+                weight_dkv_kr=sfa_impl.weight_dkv_kr,
+                rmsnorm_gamma_cq=sfa_impl.q_a_layernorm.weight.data,
+                rmsnorm_gamma_ckv=sfa_impl.kv_a_layernorm.weight.data,
+                rope_sin=sin,
+                rope_cos=cos,
+                kv_cache=decode_k_nope,
+                kr_cache=kr_cache,
+                cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
+                dequant_scale_x=dynamic_scale.view(torch.float8_e8m0fnu),
+                dequant_scale_w_dq=sfa_impl.weight_dq_scale.view(torch.float8_e8m0fnu),
+                dequant_scale_w_uq_qr=sfa_impl.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
+                dequant_scale_w_dkv_kr=sfa_impl.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
+                cache_mode="PA_BSND",
+                weight_quant_mode=3,
+                kv_cache_quant_mode=3 if use_c8 else 0,
+                query_quant_mode=0,
+                ckvkr_repo_mode=1 if use_c8 else 0,
+                quant_scale_repo_mode=1 if use_c8 else 0,
+                query_norm_flag=True,
+            )
+
+            decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
+            q_pe = q_pe.view(bsz, sfa_impl.num_heads, 64)
+            q_c = q_c.view(-1, q_c.shape[-1])
+            q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
+            return hidden_states, decode_q_nope, q_pe, (q_c, q_c_scale)
+        else:
+            decode_q_nope, q_pe, _, q_c, _ = torch_npu.npu_mla_prolog_v3(
+                token_x=hidden_states_temp,
+                weight_dq=sfa_impl.weight_dq,
+                weight_uq_qr=sfa_impl.weight_uq_qr,
+                weight_uk=sfa_impl.W_UK_T,
+                weight_dkv_kr=sfa_impl.weight_dkv_kr,
+                rmsnorm_gamma_cq=sfa_impl.q_a_layernorm.weight.data,
+                rmsnorm_gamma_ckv=sfa_impl.kv_a_layernorm.weight.data,
+                rope_sin=sin,
+                rope_cos=cos,
+                kv_cache=decode_k_nope,
+                kr_cache=kr_cache,
+                cache_index=slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
+                cache_mode="PA_BSND",
+                weight_quant_mode=0,
+                kv_cache_quant_mode=0,
+                query_quant_mode=0,
+                ckvkr_repo_mode=0,
+                quant_scale_repo_mode=0,
+                query_norm_flag=True,
+            )
+
+            decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
+            q_pe = q_pe.view(bsz, sfa_impl.num_heads, 64)
+            q_c = q_c.view(-1, q_c.shape[-1])
+            return hidden_states, decode_q_nope, q_pe, q_c
+
+    @staticmethod
+    def indexer_select_post_process(
+        sfa_impl,
+        q_li: torch.Tensor,
+        q_li_scale: torch.Tensor | None,
+        q_li_shape_ori: tuple[Any, ...] | None,
+        weights: torch.Tensor,
+        kv_cache: tuple,
+        attn_metadata,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+        use_sparse_c8_indexer: bool,
+        use_torch_npu_lightning_indexer: bool,
+    ) -> torch.Tensor:
+        if use_sparse_c8_indexer:
+            assert len(kv_cache) == 3
+            assert q_li_shape_ori is not None
+
+            if q_li_scale is not None:
+                q_li_scale = q_li_scale.view(q_li_shape_ori[:-1])
+                key_dequant_scale = kv_cache[2].squeeze(2)
+
+                topk_indices = torch_npu.npu_quant_lightning_indexer(
+                    query=q_li.view(q_li_shape_ori),
+                    key=kv_cache[1],
+                    weights=weights,
+                    query_dequant_scale=q_li_scale,
+                    key_dequant_scale=key_dequant_scale,
+                    actual_seq_lengths_query=actual_seq_lengths_query,
+                    actual_seq_lengths_key=actual_seq_lengths_key,
+                    block_table=attn_metadata.block_table,
+                    query_quant_mode=0,
+                    key_quant_mode=0,
+                    layout_query="TND",
+                    layout_key="PA_BSND",
+                    sparse_count=2048,
+                    sparse_mode=3,
+                )
+            else:
+                topk_indices, _ = torch_npu.npu_lightning_indexer(
+                    query=q_li.view(q_li_shape_ori),
+                    key=kv_cache[1],
+                    weights=weights,
+                    actual_seq_lengths_query=actual_seq_lengths_query,
+                    actual_seq_lengths_key=actual_seq_lengths_key,
+                    block_table=attn_metadata.block_table,
+                    layout_query="TND",
+                    layout_key="PA_BSND",
+                    sparse_count=2048,
+                    sparse_mode=3,
+                )
+        else:
+            topk_indices, _ = torch_npu.npu_lightning_indexer(
+                query=q_li,
+                key=kv_cache[2],
+                weights=weights,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_key=actual_seq_lengths_key,
+                block_table=attn_metadata.block_table,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=2048,
+                sparse_mode=3,
+            )
+        return topk_indices
+
+    @staticmethod
+    def execute_sparse_flash_attention_process(
+        sfa_impl,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv_cache: tuple,
+        topk_indices: torch.Tensor,
+        attn_metadata,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+    ) -> torch.Tensor:
+        block_table = attn_metadata.block_table
+        kv = kv_cache[0]
+        key_rope = kv_cache[1]
+
+        if kv.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
+            query = torch.cat([ql_nope, q_pe], dim=-1)
+
+            attn_output = torch_npu.npu_kv_quant_sparse_flash_attention(
+                query=query,
+                key=kv,
+                value=kv,
+                sparse_indices=topk_indices,
+                scale_value=sfa_impl.scale,
+                sparse_block_size=1,
+                block_table=block_table,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_kv=actual_seq_lengths_key,
+                layout_query="TND",
+                layout_kv="PA_BSND",
+                sparse_mode=3,
+                attention_mode=2,
+                quant_scale_repo_mode=1,
+                tile_size=128,
+                key_quant_mode=2,
+                value_quant_mode=2,
+                rope_head_dim=64,
+            )
+        else:
+            attn_output, _, _ = torch_npu.npu_sparse_flash_attention(
+                query=ql_nope,
+                key=kv,
+                value=kv,
+                sparse_indices=topk_indices,
+                scale_value=sfa_impl.scale,
+                sparse_block_size=1,
+                block_table=block_table,
+                actual_seq_lengths_query=actual_seq_lengths_query,
+                actual_seq_lengths_kv=actual_seq_lengths_key,
+                query_rope=q_pe,
+                key_rope=key_rope,
+                layout_query="TND",
+                layout_kv="PA_BSND",
+                sparse_mode=3,
+                attention_mode=2,
+            )
+        return attn_output
 
     def npu_flash_attention(query, key, value, seq_lens_cpu, head_num, scale_value, num_kv_heads):
         seq_lens_cpu = list(seq_lens_cpu.cumsum(0))

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1362,7 +1362,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             )
 
             decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
-            q_pe = q_pe.view(bsz, sfa_impl.num_heads, 64)
+            q_pe = q_pe.view(bsz, sfa_impl.num_heads, -1)
             q_c = q_c.view(-1, q_c.shape[-1])
             q_c_scale = q_c_scale.view(-1, q_c_scale.shape[-1])
             return hidden_states, decode_q_nope, q_pe, (q_c, q_c_scale)
@@ -1390,7 +1390,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             )
 
             decode_q_nope = decode_q_nope.view(bsz, sfa_impl.num_heads, sfa_impl.kv_lora_rank)
-            q_pe = q_pe.view(bsz, sfa_impl.num_heads, 64)
+            q_pe = q_pe.view(bsz, sfa_impl.num_heads, -1)
             q_c = q_c.view(-1, q_c.shape[-1])
             return hidden_states, decode_q_nope, q_pe, q_c
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 import vllm.model_executor.layers.attention.mla_attention
@@ -14,6 +14,16 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+
+def _get_c8_k_cache_dtype() -> torch.dtype:
+    return torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+
+
+def _get_c8_k_scale_cache_dtype() -> torch.dtype:
+    return torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else torch.float16
 
 
 @dataclass(frozen=True)
@@ -46,8 +56,8 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     scale_dtype: torch.dtype = torch.int8
     sparse_head_dim: tuple[int, ...] | None = None
     cache_sparse_c8: bool = False
-    c8_k_cache_dtype: torch.dtype = torch.int8
-    c8_k_scale_cache_dtype: torch.dtype = torch.float16
+    c8_k_cache_dtype: torch.dtype = field(default_factory=_get_c8_k_cache_dtype)
+    c8_k_scale_cache_dtype: torch.dtype = field(default_factory=_get_c8_k_scale_cache_dtype)
 
     @property
     def page_size_bytes(self) -> int:
@@ -55,19 +65,22 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             assert self.sparse_head_dim is not None
             assert len(self.sparse_head_dim) == 3
             num_heads_per_page = self.block_size * self.num_kv_heads
-            # kv_cache[0]: bfloat16, kv_cache[1]: bfloat16
-            kv_lora_rank, qk_rope_head_dim = self.sparse_head_dim[:2]
-            k_pe_nope_bytes = num_heads_per_page * (kv_lora_rank + qk_rope_head_dim) * get_dtype_size(self.dtype)
-            # kv_cache[2]: int8
-            index_head_dim = self.sparse_head_dim[-1]
-            indexer_k_bytes = num_heads_per_page * index_head_dim * get_dtype_size(self.c8_k_cache_dtype)
-            # kv_cache[3]: float16
-            # since the scale is stored per token, head_dim is set to 1.
-            index_scale_head_dim = 1
-            indexer_k_scale_bytes = (
-                num_heads_per_page * index_scale_head_dim * get_dtype_size(self.c8_k_scale_cache_dtype)
-            )
-            return k_pe_nope_bytes + indexer_k_bytes + indexer_k_scale_bytes
+
+            kv_lora_rank, qk_rope_head_dim, index_head_dim = self.sparse_head_dim
+
+            # A5: kv_lora and k_rope are merged into a single CKV tensor (fp8).
+            # A3: separate kv_lora + k_rope (bf16).
+            if qk_rope_head_dim == 0:
+                kv_dtype = self.c8_k_cache_dtype  # A5 CKV: float8_e4m3fn
+                kv_dim = kv_lora_rank
+            else:
+                kv_dtype = self.dtype  # A3 kv_lora + k_rope: bfloat16
+                kv_dim = kv_lora_rank + qk_rope_head_dim
+
+            kv_bytes = num_heads_per_page * kv_dim * get_dtype_size(kv_dtype)
+            qli_bytes = num_heads_per_page * index_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+            qli_scale_bytes = num_heads_per_page * 1 * get_dtype_size(self.c8_k_scale_cache_dtype)
+            return kv_bytes + qli_bytes + qli_scale_bytes
 
         return (
             self.block_size
@@ -85,7 +98,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             - kv_cache[0]
             - kv_cache[1]
             - kv_cache[2]
-            - kv_cache[3] (None if Sparse C8 is disabled)
+            - kv_cache[3] (None if Sparse C8 is disabled or Sparse C8 on A5 device)
         """
 
         assert self.sparse_head_dim is not None
@@ -96,6 +109,15 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
 
             kv_lora_rank, qk_rope_head_dim, index_k_head_dim = self.sparse_head_dim
 
+            if qk_rope_head_dim == 0:
+                # A5: ckv (float8_e4m3fn) and qli share c8_k_cache_dtype;
+                ckv_virtual = kv_lora_rank * get_dtype_size(self.c8_k_cache_dtype)
+                qk_rope_virtual = 0
+                qli_virtual = index_k_head_dim * get_dtype_size(self.c8_k_cache_dtype)
+                scale_virtual = get_dtype_size(self.c8_k_scale_cache_dtype)
+                return (ckv_virtual, qk_rope_virtual, qli_virtual, scale_virtual)
+
+            # A3: keep the original element-count / byte mix
             factor = get_dtype_size(self.dtype) // get_dtype_size(self.c8_k_cache_dtype)
             index_k_head_dim_virtual = index_k_head_dim // factor
 
@@ -113,12 +135,22 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             virtual_dims = get_sparse_head_dim_virtual()
             total_virtual_head_dim = sum(virtual_dims)
 
-            return (
-                total_virtual_head_dim / virtual_dims[0],  # kv_cache[0]
-                total_virtual_head_dim / virtual_dims[1],  # kv_cache[1]
-                total_virtual_head_dim / virtual_dims[2],  # kv_cache[2]
-                total_virtual_head_dim / virtual_dims[3],  # kv_cache[3]
-            )
+            if virtual_dims[1] == 0:
+                # A5: ckv merged (kv_lora + k_rope + scale) → 3-tensor
+                return (
+                    total_virtual_head_dim / virtual_dims[0],  # kv_cache[0]: ckv
+                    total_virtual_head_dim / virtual_dims[2],  # kv_cache[1]: qli
+                    total_virtual_head_dim / virtual_dims[3],  # kv_cache[2]: qli_scale
+                    None,  # kv_cache[3] does not exist for A5
+                )
+            else:
+                # A3: 4-tensor
+                return (
+                    total_virtual_head_dim / virtual_dims[0],  # kv_cache[0]
+                    total_virtual_head_dim / virtual_dims[1],  # kv_cache[1]
+                    total_virtual_head_dim / virtual_dims[2],  # kv_cache[2]
+                    total_virtual_head_dim / virtual_dims[3],  # kv_cache[3]
+                )
 
         return (
             self.head_size / self.sparse_head_dim[0],  # kv_cache[0]

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -80,7 +80,6 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         if x.dim() > 2:
             x = x.view(-1, x.shape[-1])
         quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(x, dst_type=torch.float8_e4m3fn)
-        pertoken_scale = dynamic_scale
         output_dtype = x.dtype
         if bias is not None and bias.dtype != torch.float32:
             bias = bias.to(torch.float32)
@@ -90,7 +89,7 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
             layer.weight,
             layer.weight_scale,
             scale_dtype=FLOAT8_E8M0FNU_DTYPE,
-            pertoken_scale=pertoken_scale,
+            pertoken_scale=dynamic_scale,
             pertoken_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
             bias=bias,
             output_dtype=output_dtype,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -331,11 +331,16 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_sparse:
             if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
                 # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
-                # The merged dimension = kv_lora_rank + qk_rope_head_dim * 2 + quant_scale(16).
                 # qk_rope_head_dim = 0 signals the merged layout.
+                # ckv_dim = kv_lora_rank                    (fp8, 1 byte/elem)
+                #         + qk_rope_head_dim * 2             (bf16→fp8: 2/1 bytes)
+                #         + 4 * 4                            (quant_scale metadata:
+                #                                              4 = kv_lora_rank / tile_size(128),
+                #                                              4 = float32→fp8: 4/1 bytes)
+                A5_CKV_SCALE_METADATA_BYTES = 4 * 4
                 ckv = self.model_config.hf_text_config.kv_lora_rank
                 rope = self.model_config.hf_text_config.qk_rope_head_dim
-                a5_ckv_dim = ckv + rope * 2 + 4 * 4
+                a5_ckv_dim = ckv + rope * 2 + A5_CKV_SCALE_METADATA_BYTES
                 self.sparse_head_dim = (
                     a5_ckv_dim,
                     0,
@@ -4054,7 +4059,10 @@ class NPUModelRunner(GPUModelRunner):
                             k_dim,
                         )
                         if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
-                            # A5 sparse C8: CKV tensor includes merged kv_lora, k_rope, and scale metadata
+                            # A5 sparse C8: CKV tensor = kv_lora(fp8) + k_rope(bf16→fp8) + quant_scale_metadata
+                            #   kv_lora_rank                    : fp8, 1 byte/elem
+                            #   qk_rope_head_dim * 2            : bf16→fp8 ratio (2/1 bytes)
+                            #   4 * 4                           : quant_scale (4 elements × float32→fp8 ratio)
                             k_shape = (
                                 mla_num_blocks,
                                 mla_block_size,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -329,16 +329,33 @@ class NPUModelRunner(GPUModelRunner):
             vllm_config.model_config.hf_text_config, "compress_ratios"
         )
         if self.use_sparse:
-            self.sparse_head_dim = (
-                self.model_config.hf_text_config.kv_lora_rank,
-                self.model_config.hf_text_config.qk_rope_head_dim,
-                self.model_config.hf_text_config.index_head_dim,
-            )
+            if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
+                # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
+                # The merged dimension = kv_lora_rank + qk_rope_head_dim * 2 + quant_scale(16).
+                # qk_rope_head_dim = 0 signals the merged layout.
+                ckv = self.model_config.hf_text_config.kv_lora_rank
+                rope = self.model_config.hf_text_config.qk_rope_head_dim
+                a5_ckv_dim = ckv + rope * 2 + 4 * 4
+                self.sparse_head_dim = (
+                    a5_ckv_dim,
+                    0,
+                    self.model_config.hf_text_config.index_head_dim,
+                )
+            else:
+                self.sparse_head_dim = (
+                    self.model_config.hf_text_config.kv_lora_rank,
+                    self.model_config.hf_text_config.qk_rope_head_dim,
+                    self.model_config.hf_text_config.index_head_dim,
+                )
         # dsa c8
         self.use_sparse_c8_indexer = self.ascend_config.enable_sparse_c8
         if self.use_sparse_c8_indexer:
-            self.c8_k_cache_dtype = torch.int8
-            self.c8_k_scale_cache_dtype = torch.float16
+            if get_ascend_device_type() == AscendDeviceType.A5:
+                self.c8_k_cache_dtype = torch.float8_e4m3fn
+                self.c8_k_scale_cache_dtype = torch.float32
+            else:
+                self.c8_k_cache_dtype = torch.int8
+                self.c8_k_scale_cache_dtype = torch.float16
 
         self.attn_backend = get_attn_backend(
             0,
@@ -3691,10 +3708,19 @@ class NPUModelRunner(GPUModelRunner):
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
                         sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
-                        k_tensor_split_factor = sparse_kv_cache_ratio[0]
-                        v_tensor_split_factor = sparse_kv_cache_ratio[1]
-                        dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
-                        dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
+                        
+                        # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
+                        # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
+                        if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                            k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
+                            v_tensor_split_factor = None  # merged
+                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
+                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]  # qli_scale
+                        else:
+                            k_tensor_split_factor = sparse_kv_cache_ratio[0]
+                            v_tensor_split_factor = sparse_kv_cache_ratio[1]
+                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
+                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
@@ -3710,7 +3736,10 @@ class NPUModelRunner(GPUModelRunner):
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
 
                     k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                    v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                    if v_tensor_split_factor is not None:
+                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                    else:
+                        v_tensor_size = None
                     dsa_k_tensor_size = None
                     dsa_k_scale_tensor_size = None
                     #### for deepseek sparse attention
@@ -3722,7 +3751,9 @@ class NPUModelRunner(GPUModelRunner):
                     # for other attentions, e.g., self_attn, sliding window attn
                     if self.vllm_config.kv_transfer_config is None:
                         k_tensor = torch.zeros(k_tensor_size, dtype=torch.int8, device=self.device)
-                        v_tensor = torch.zeros(v_tensor_size, dtype=torch.int8, device=self.device)
+                        v_tensor = None
+                        if v_tensor_size is not None:
+                            v_tensor = torch.zeros(v_tensor_size, dtype=torch.int8, device=self.device)
                         #### for deepseek sparse attention
                         if dsa_k_tensor_size is not None:
                             dsa_k_tensor = torch.zeros(dsa_k_tensor_size, dtype=torch.int8, device=self.device)
@@ -3732,9 +3763,11 @@ class NPUModelRunner(GPUModelRunner):
                             )
                     else:
                         k_tensor = torch.zeros(k_tensor_size + alignment, dtype=torch.int8, device=self.device)
-                        v_tensor = torch.zeros(v_tensor_size + alignment, dtype=torch.int8, device=self.device)
+                        v_tensor = None
+                        if v_tensor_size is not None:
+                            v_tensor = torch.zeros(v_tensor_size + alignment, dtype=torch.int8, device=self.device)
+                            v_tensor = self._align_memory(v_tensor, alignment)[:v_tensor_size]
                         k_tensor = self._align_memory(k_tensor, alignment)[:k_tensor_size]
-                        v_tensor = self._align_memory(v_tensor, alignment)[:v_tensor_size]
                         #### for deepseek sparse attention
                         if dsa_k_tensor_size is not None:
                             dsa_k_tensor = torch.zeros(
@@ -3754,9 +3787,14 @@ class NPUModelRunner(GPUModelRunner):
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
                             if self.use_sparse:
                                 if current_sparse_c8:
-                                    kv_cache_raw_tensors[layer_name_inner] = (
-                                        k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
-                                    )
+                                    if get_ascend_device_type() == AscendDeviceType.A5:
+                                        kv_cache_raw_tensors[layer_name_inner] = (
+                                            k_tensor, dsa_k_tensor, dsa_k_scale_tensor
+                                        )
+                                    else:
+                                        kv_cache_raw_tensors[layer_name_inner] = (
+                                            k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
+                                        )
                                 else:
                                     kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor, dsa_k_tensor)
                             else:
@@ -3895,16 +3933,28 @@ class NPUModelRunner(GPUModelRunner):
                     if self.use_sparse and "cache_only_layers" not in layer_name:
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
-                            raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
-                                layer_name]
-                            assert raw_dsa_k_tensor is not None
-                            assert raw_dsa_k_scale_tensor is not None
-                            sum_page_size_bytes = (
-                                raw_k_tensor.numel()
-                                + raw_v_tensor.numel()
-                                + raw_dsa_k_tensor.numel()
-                                + raw_dsa_k_scale_tensor.numel()
-                            )
+                            if get_ascend_device_type() == AscendDeviceType.A5:
+                                raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
+                                    layer_name]
+                                assert raw_dsa_k_tensor is not None
+                                assert raw_dsa_k_scale_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel()
+                                    + raw_dsa_k_tensor.numel()
+                                    + raw_dsa_k_scale_tensor.numel()
+                                )
+                            else:
+                                raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
+                                    kv_cache_raw_tensors[layer_name]  # type: ignore
+                                )
+                                assert raw_dsa_k_tensor is not None
+                                assert raw_dsa_k_scale_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel()
+                                    + raw_v_tensor.numel()
+                                    + raw_dsa_k_tensor.numel()
+                                    + raw_dsa_k_scale_tensor.numel()
+                                )
                         else:
                             raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor = kv_cache_raw_tensors[  # type: ignore
                                 layer_name]
@@ -3937,7 +3987,6 @@ class NPUModelRunner(GPUModelRunner):
                         ]
                         sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
                     assert raw_k_tensor is not None
-                    assert raw_v_tensor is not None
                     assert sum_page_size_bytes % current_kv_cache_spec.page_size_bytes == 0
                     num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
 
@@ -4004,6 +4053,16 @@ class NPUModelRunner(GPUModelRunner):
                             num_kv_heads,
                             k_dim,
                         )
+                        if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                            # A5 sparse C8: CKV tensor includes merged kv_lora, k_rope, and scale metadata
+                            k_shape = (
+                                mla_num_blocks,
+                                mla_block_size,
+                                num_kv_heads,
+                                self.model_config.hf_text_config.kv_lora_rank
+                                + self.model_config.hf_text_config.qk_rope_head_dim * 2
+                                + 4 * 4,
+                            )
                         v_shape = (
                             mla_num_blocks,
                             mla_block_size,
@@ -4015,8 +4074,16 @@ class NPUModelRunner(GPUModelRunner):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
+                    
+                    # A5 sparse C8: ckv uses float8_e4m3fn
+                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                        k_cache_dtype = self.c8_k_cache_dtype
+                    
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-                    v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
+                    if self.use_sparse and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                        v_cache = None
+                    else:
+                        v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
 
                     if self.use_sparse:
                         dsa_k_cache_shape = (
@@ -4041,7 +4108,12 @@ class NPUModelRunner(GPUModelRunner):
                                 .view(self.c8_k_scale_cache_dtype)
                                 .view(dsa_k_scale_cache_shape)
                             )
-                            kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache, dsa_k_scale_cache)
+                            if get_ascend_device_type() == AscendDeviceType.A5:
+                                kv_caches[layer_name] = (k_cache, dsa_k_cache, dsa_k_scale_cache)
+                            elif v_cache is not None:
+                                kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache, dsa_k_scale_cache)
+                            else:
+                                kv_caches[layer_name] = (k_cache, dsa_k_cache, dsa_k_scale_cache)
                         else:
                             # dsa_k
                             dsa_k_cache = raw_dsa_k_tensor.view(current_kv_cache_spec.dtype).view(dsa_k_cache_shape)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds support for the Ascend A5 NPU sparse C8 KV cache layout when using W8A8_MXFP8 quantization with MLAPO (MLA Pre-optimization, `npu_mla_prolog_v3`). The A5 C8 layout differs from the existing A3 C8 layout in two major aspects:

#### 1. KV Cache Layout (model_runner_v1.py)

On A5, the KV cache tuple changes from A3's 4-tensor layout to a 3-tensor layout:

| Device | KV Cache Tuple | Description |
|--------|---------------|-------------|
| A3 | `(kv_lora_bf16, k_rope_bf16, k_li_int8, k_li_scale_fp16)` | 4-tensor, separate kv_lora & k_rope |
| A5 | `(ckv_fp8, k_li_fp8, k_li_scale_fp32)` | 3-tensor, kv_lora & k_rope merged as CKV |

Key changes:
- **`sparse_head_dim = (656, 0, index_head_dim)`**: Setting `qk_rope_head_dim = 0` signals that k_rope is folded into the CKV tensor. The merged CKV dimension 656 = kv_lora_rank(512) + qk_rope_head_dim(64×2) + quant_scale(4×4).
- **`c8_k_cache_dtype = float8_e4m3fn`**: Both the CKV tensor and the k_li tensor use MXFP8 format (1 byte per element) instead of int8 on A3.
- **`c8_k_scale_cache_dtype = float32`**: KV cache scale stored as float32.
- **No separate `v_tensor`**: The merge means there's no independent k_rope storage, so `v_cache = None` and `v_tensor` is not allocated.
- **`k_cache_dtype` override**: CKV uses `c8_k_cache_dtype` (float8_e4m3fn) rather than the default bf16.
- **`k_shape` override**: CKV has `head_dim=656` (merged kv_lora + qk_rope + quant_scale metadata).

#### 2. Pre-quantized `wq_b` Input (w8a8_mxfp8.py)

When MLAPO is enabled on A5, the `npu_mla_prolog_v3` operator already quantizes the `q_c` output to MXFP8 format and produces a quantization scale. The existing `indexer_select_post_process` passes `q_c` to `wq_b(q_c)`, which used to call `npu_dynamic_mx_quant` itself — this would double-quantize the input and cause accuracy loss.

To avoid this, `AscendW8A8MXFP8DynamicLinearMethod.apply()` now accepts a **tuple input** `(quantized_tensor, scale)`:

```python
x = (fp8_q_c_tensor, q_c_scale)  # pre-quantized by npu_mla_prolog_v3
```

When `x` is a tuple, the method skips `npu_dynamic_mx_quant` and uses the pre-quantized values directly in `npu_quant_matmul`, similar to the `pertoken_scale` pattern.

### Does this PR introduce any user-facing change?

No. The changes are internal to the KV cache allocation and attention compute path. Users only need to:
- Use A5 NPU hardware.
- Enable `--enable-sparse-c8` in the model config
- Use W8A8_MXFP8 quantization

The behavior for A3 devices and non-C8 sparse paths remains unchanged.

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
