### PR TITLE
[BugFix][Ops] Fix ACL dtype mapping table

### DIFF
--- a/csrc/aclnn_torch_adapter/op_api_common.h
+++ b/csrc/aclnn_torch_adapter/op_api_common.h
@@ -86,7 +86,7 @@ extern thread_local int g_hashOffset;
   _(at::ScalarType::Half, ACL_FLOAT16)              \
   _(at::ScalarType::Float, ACL_FLOAT)               \
   _(at::ScalarType::Double, ACL_DOUBLE)             \
-  _(at::ScalarType::ComplexHalf, ACL_DT_UNDEFINED)  \
+  _(at::ScalarType::ComplexHalf, ACL_COMPLEX32)     \
   _(at::ScalarType::ComplexFloat, ACL_COMPLEX64)    \
   _(at::ScalarType::ComplexDouble, ACL_COMPLEX128)  \
   _(at::ScalarType::Bool, ACL_BOOL)                 \
@@ -96,6 +96,34 @@ extern thread_local int g_hashOffset;
   _(at::ScalarType::BFloat16, ACL_BF16)             \
   _(at::ScalarType::QUInt4x2, ACL_DT_UNDEFINED)     \
   _(at::ScalarType::QUInt2x4, ACL_DT_UNDEFINED)     \
+  _(at::ScalarType::Bits1x8, ACL_DT_UNDEFINED)      \
+  _(at::ScalarType::Bits2x4, ACL_DT_UNDEFINED)      \
+  _(at::ScalarType::Bits4x2, ACL_DT_UNDEFINED)      \
+  _(at::ScalarType::Bits8, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::Bits16, ACL_DT_UNDEFINED)       \
+  _(at::ScalarType::Float8_e5m2, ACL_FLOAT8_E5M2)   \
+  _(at::ScalarType::Float8_e4m3fn, ACL_FLOAT8_E4M3FN) \
+  _(at::ScalarType::Float8_e5m2fnuz, ACL_DT_UNDEFINED) \
+  _(at::ScalarType::Float8_e4m3fnuz, ACL_DT_UNDEFINED) \
+  _(at::ScalarType::UInt16, ACL_UINT16)             \
+  _(at::ScalarType::UInt32, ACL_UINT32)             \
+  _(at::ScalarType::UInt64, ACL_UINT64)             \
+  _(at::ScalarType::UInt1, ACL_UINT1)               \
+  _(at::ScalarType::UInt2, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::UInt3, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::UInt4, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::UInt5, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::UInt6, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::UInt7, ACL_DT_UNDEFINED)        \
+  _(at::ScalarType::Int1, ACL_DT_UNDEFINED)         \
+  _(at::ScalarType::Int2, ACL_DT_UNDEFINED)         \
+  _(at::ScalarType::Int3, ACL_DT_UNDEFINED)         \
+  _(at::ScalarType::Int4, ACL_INT4)                 \
+  _(at::ScalarType::Int5, ACL_DT_UNDEFINED)         \
+  _(at::ScalarType::Int6, ACL_DT_UNDEFINED)         \
+  _(at::ScalarType::Int7, ACL_DT_UNDEFINED)         \
+  _(at::ScalarType::Float8_e8m0fnu, ACL_FLOAT8_E8M0) \
+  _(at::ScalarType::Float4_e2m1fn_x2, ACL_FLOAT4_E2M1) \
   _(at::ScalarType::Undefined, ACL_DT_UNDEFINED)    \
   _(at::ScalarType::NumOptions, ACL_DT_UNDEFINED)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR syncs the torch `ScalarType` to `aclDataType` table in `csrc/aclnn_torch_adapter/op_api_common.h` with the PyTorch 2.10 scalar enum layout used by the current main branch and the CANN 9.0 `aclDataType` enum set.

The main fix is keeping table indices aligned with `at::ScalarType` and mapping low-precision dtypes when CANN 9.0 provides corresponding ACL data types:
- `Float8_e5m2` -> `ACL_FLOAT8_E5M2`
- `Float8_e4m3fn` -> `ACL_FLOAT8_E4M3FN`
- `Float8_e8m0fnu` -> `ACL_FLOAT8_E8M0`
- `Float4_e2m1fn_x2` -> `ACL_FLOAT4_E2M1`
- `UInt1` -> `ACL_UINT1`
- `Int4` -> `ACL_INT4`

Torch-only scalar types without matching CANN 9.0 ACL enum values, such as FP8 `fnuz`, Bits types, and other sub-byte integer widths, remain mapped to `ACL_DT_UNDEFINED`.

### Does this PR introduce _any_ user-facing change?

No public API change. It fixes internal dtype conversion for custom torch binding paths using supported low-precision tensors.

### How was this patch tested?

- `git diff --check`
- `PATH=/tmp/vllm-ascend-lint-venv/bin:$PATH bash format.sh ci`

Build was not run locally because this macOS checkout does not have torch/CANN installed.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
