### PR TITLE
[BugFix][CI] Fix Qwen3-VL MMMU accuracy test failure by enabling chat template

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -115,10 +115,16 @@ jobs:
           mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
           ls -R /vllm-workspace
 
+      - name: Set MAX_JOBS based on runner
+        run: |
+          CARDS=$(echo "${{ inputs.runner }}" | grep -oE '[0-9]+$')
+          echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
+
       - name: Install vllm-project/vllm-ascend
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: /vllm-workspace/vllm-ascend
         env:
+          MAX_JOBS: ${{ env.MAX_JOBS }}
           PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://triton-ascend.osinfra.cn/pypi/simple https://download.pytorch.org/whl/cpu/"
         run: |
           git config --global --add safe.directory /vllm-workspace/vllm-ascend

--- a/.github/workflows/_e2e_nightly_single_node_models.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_models.yaml
@@ -101,10 +101,16 @@ jobs:
         run: |
           mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
 
+      - name: Set MAX_JOBS based on runner
+        run: |
+          CARDS=$(echo "${{ inputs.runner }}" | grep -oE '[0-9]+$')
+          echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
+
       - name: Install vllm-project/vllm-ascend
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: /vllm-workspace/vllm-ascend
         env:
+          MAX_JOBS: ${{ env.MAX_JOBS }}
           PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://triton-ascend.osinfra.cn/pypi/simple https://download.pytorch.org/whl/cpu/"
         run: |
           git config --global --add safe.directory /vllm-workspace/vllm-ascend

--- a/tests/e2e/models/configs/Qwen3-Omni-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-Omni-30B-A3B-Instruct.yaml
@@ -17,6 +17,6 @@ tasks:
     value: 0.60
 
 num_fewshot: 0
-apply_chat_template: false
+apply_chat_template: true
 fewshot_as_multiturn: false
 batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -17,6 +17,6 @@ tasks:
     value: 0.58
 
 num_fewshot: 0
-apply_chat_template: false
+apply_chat_template: true
 fewshot_as_multiturn: false
 batch_size: "auto"

--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct-W8A8.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct-W8A8.yaml
@@ -17,6 +17,6 @@ tasks:
     value: 0.52
 
 num_fewshot: 0
-apply_chat_template: false
+apply_chat_template: true
 fewshot_as_multiturn: false
 batch_size: 32

--- a/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
+++ b/tests/e2e/models/configs/Qwen3-VL-8B-Instruct.yaml
@@ -16,6 +16,6 @@ tasks:
     value: 0.55
 
 num_fewshot: 0
-apply_chat_template: false
+apply_chat_template: true
 fewshot_as_multiturn: false
 batch_size: 32


### PR DESCRIPTION
### What this PR does / why we need it?

**Problem**

The nightly CI `single-node-accuracy-tests` for `Qwen3-VL-30B-A3B-Instruct` (and other Qwen3 VL models) has been failing with:

```
AssertionError: Failed to apply prompt replacement for mm_items['image'][0]
```

This happens in `Qwen3VLMultiModalProcessor._apply_prompt_updates()` (`vllm/vllm/multimodal/processing/processor.py:1565`). The processor tries to find `<|vision_start|><|image_pad|><|vision_end|>` in the tokenized prompt to replace with image tokens, but the placeholder doesn't exist.

**Root cause**

PR #8362 (`[Test] Add ASR model accuracy test`) standardized the YAML format for all accuracy test configs. During this standardization, it added `apply_chat_template: false` to all VL model configs (Qwen3-VL-30B-A3B-Instruct, Qwen3-VL-8B-Instruct, Qwen3-VL-8B-Instruct-W8A8, Qwen3-Omni-30B-A3B-Instruct).

Before this commit, these configs didn't have the `apply_chat_template` field, and lm_eval's default behavior (also `false`) did not cause issues because the multimodal pipeline in earlier vllm versions was more lenient when placeholders were missing.

The fundamental issue is: **Qwen3-VL / Qwen3-Omni models rely on their chat template to inject image placeholder tokens `<|vision_start|><|image_pad|><|vision_end|>` into the prompt**. When `apply_chat_template` is `false`, the MMMU dataset's raw prompt text is used without placeholders, and the multimodal processor cannot find where to insert image tokens.

**Timeline investigation**

- Config initially created: `cd69385d` — no `apply_chat_template` field
- PR #8362 (Apr 29): `2b97cd0d` — added `apply_chat_template: false` as part of YAML format unification
- Nightly CI tests passed on May 6 but started failing on May 7
- The behavior change between May 6 and May 7 is attributed to an update in the CI base Docker image (`quay.io/ascend/vllm-ascend:nightly-main`), where a newer vllm version began enforcing stricter checks in the multimodal processor

**Fix**

1. Set `apply_chat_template: true` for all affected Qwen3 VL model configs:

   - `Qwen3-VL-30B-A3B-Instruct.yaml` (accuracy-group-3)
   - `Qwen3-VL-8B-Instruct.yaml` (accuracy-group-1)
   - `Qwen3-VL-8B-Instruct-W8A8.yaml` (accuracy-group-1)
   - `Qwen3-Omni-30B-A3B-Instruct.yaml` (accuracy-group-4)

2. Cherry-pick PR #9877 to add dynamic `MAX_JOBS` based on runner in nightly single node workflows, preventing OOM during CANN operator compilation on smaller runners.

### Does this PR introduce _any_ user-facing change?

No. This only affects CI accuracy test configurations. The `apply_chat_template` field is specific to lm_eval's configuration format and does not affect production vllm inference behavior.

### How was this patch tested?

- [Qwen3-VL-30B-A3B-Instruct] accuracy-group-3 CI passed after the fix
- [Qwen3-VL-8B-Instruct, Qwen3-VL-8B-Instruct-W8A8] accuracy-group-1 CI passed after the fix + PR #9877 cherry-pick
- [Qwen3-Omni-30B-A3B-Instruct] accuracy-group-4 CI pending

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
