### PR TITLE
[BugFix][Model] Stabilize DeepSeek V4 hash routing weights

### DIFF
--- a/tests/ut/ops/test_select_experts.py
+++ b/tests/ut/ops/test_select_experts.py
@@ -431,6 +431,48 @@ class TestExpertsSelector:
         torch.testing.assert_close(topk_weights, expected_weights.to(hidden_states.dtype))
         assert torch.equal(topk_ids, expected_ids.to(torch.int32))
 
+    @patch("vllm_ascend.ops.fused_moe.experts_selector.get_weight_prefetch_method", return_value=MagicMock())
+    @patch("vllm_ascend.ops.fused_moe.experts_selector.check_npu_moe_gating_top_k", return_value=True)
+    def test_select_experts_sqrtsoftplus_recomputes_hash_weights(self, _, __):
+        hidden_states = torch.ones(2, 4, dtype=torch.bfloat16)
+        router_logits = torch.tensor([[0.0, 3.0, 1.0], [4.0, 0.0, 2.0]], dtype=torch.bfloat16)
+        returned_topk_ids = torch.tensor([[1, 2], [0, 2]], dtype=torch.int32)
+
+        def fake_moe_gating_top_k_hash(**kwargs):
+            assert kwargs["renorm"] == 0
+            assert kwargs["routed_scaling_factor"] == 1.0
+            bad_weights = torch.zeros(2, 2, dtype=torch.float32)
+            return bad_weights, returned_topk_ids, torch.empty(0)
+
+        with patch.object(
+            torch.ops._C_ascend,
+            "moe_gating_top_k_hash",
+            side_effect=fake_moe_gating_top_k_hash,
+            create=True,
+        ):
+            topk_weights, topk_ids = select_experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                top_k=2,
+                use_grouped_topk=True,
+                renormalize=True,
+                topk_group=1,
+                num_expert_group=1,
+                custom_routing_function=None,
+                scoring_func="sqrtsoftplus",
+                routed_scaling_factor=1.5,
+                e_score_correction_bias=None,
+                num_experts=3,
+            )
+
+        expected = F.softplus(router_logits.to(torch.float32)).sqrt().gather(1, returned_topk_ids.to(torch.int64))
+        expected = expected / expected.sum(dim=-1, keepdim=True)
+        expected = expected * 1.5
+
+        assert torch.equal(topk_ids, returned_topk_ids)
+        torch.testing.assert_close(topk_weights, expected)
+        torch.testing.assert_close(topk_weights.sum(dim=-1), torch.full((2,), 1.5))
+
     def test_select_experts_grouped_topk_bias_uses_original_weights(self):
         _require_ascend_custom_op("moe_gating_top_k")
 

--- a/tests/ut/quantization/methods/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8_dynamic.py
@@ -191,6 +191,54 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertIs(fused_experts_input.topk_weights, topk_weights)
         self.assertIs(fused_experts_input.topk_ids, topk_ids)
 
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.select_experts")
+    def test_apply_keeps_topk_weights_fp32(self, mock_select_experts, mock_extra_ctx):
+        tokens = 4
+        hidden_size = self.hidden_size
+        layer = torch.nn.Module()
+        layer.w13_weight = torch.randint(
+            -8,
+            8,
+            (self.num_experts, 2 * self.intermediate_size, hidden_size),
+            dtype=torch.int8,
+        )
+        layer.w2_weight = torch.randint(
+            -8,
+            8,
+            (self.num_experts, hidden_size, self.intermediate_size),
+            dtype=torch.int8,
+        )
+        layer.w13_weight_scale_fp32 = torch.ones(self.num_experts, 2 * self.intermediate_size, dtype=torch.float32)
+        layer.w2_weight_scale = torch.ones(self.num_experts, hidden_size, dtype=torch.float32)
+        layer.swiglu_limit = 1000000
+
+        x = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
+        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
+        topk_weights = torch.randn(tokens, 2, dtype=torch.bfloat16)
+        topk_ids = torch.randint(0, self.num_experts, (tokens, 2), dtype=torch.int64)
+
+        mock_select_experts.return_value = (topk_weights, topk_ids)
+        mock_comm = Mock()
+        mock_comm.fused_experts.return_value = torch.randn(tokens, hidden_size, dtype=torch.float32)
+        mock_extra_ctx.moe_comm_method = mock_comm
+        mock_extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+        self.quant_method.multistream_overlap_gate = False
+        self.quant_method.in_dtype = torch.bfloat16
+
+        self.quant_method.apply(
+            layer=layer,
+            x=x,
+            router_logits=router_logits,
+            top_k=2,
+            renormalize=True,
+            num_experts=self.num_experts,
+        )
+
+        fused_experts_input = mock_comm.fused_experts.call_args.kwargs["fused_experts_input"]
+        self.assertEqual(fused_experts_input.topk_weights.dtype, torch.float32)
+        torch.testing.assert_close(fused_experts_input.topk_weights, topk_weights.to(torch.float32))
+
     @patch("torch_npu.npu_format_cast")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
     def test_process_weights_after_loading(self, mock_get_config, mock_format_cast):

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -289,9 +289,7 @@ def _select_experts_with_fusion_ops(
             norm_type=2,
             out_flag=False,
         )
-        topk_weights = F.softplus(router_logits.to(torch.float32)).sqrt().gather(
-            1, topk_ids.to(torch.int64)
-        )
+        topk_weights = F.softplus(router_logits.to(torch.float32)).sqrt().gather(1, topk_ids.to(torch.int64))
         topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
         topk_weights = topk_weights * routed_scaling_factor
         return topk_weights, topk_ids

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -272,7 +272,7 @@ def _select_experts_with_fusion_ops(
         else:
             input_ids = None
             tid2eid_ones = None
-        topk_weights, topk_ids, _ = torch.ops._C_ascend.moe_gating_top_k_hash(
+        _, topk_ids, _ = torch.ops._C_ascend.moe_gating_top_k_hash(
             x=router_logits,
             k=top_k,
             bias=e_score_correction_bias,
@@ -280,15 +280,20 @@ def _select_experts_with_fusion_ops(
             tid2eid=tid2eid_ones,
             k_group=topk_group,
             group_count=num_expert_group,
-            routed_scaling_factor=routed_scaling_factor,
+            routed_scaling_factor=1.0,
             eps=1e-20,
             group_select_mode=1,
-            # The hash custom op currently rejects renorm != 0. Apply
-            # norm_topk_prob in Python below before returning to MoE compute.
+            # The hash custom op currently rejects renorm != 0. Use it
+            # only for expert ids and recompute weights below.
             renorm=0,
             norm_type=2,
             out_flag=False,
         )
+        topk_weights = F.softplus(router_logits.to(torch.float32)).sqrt().gather(
+            1, topk_ids.to(torch.int64)
+        )
+        topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
+        topk_weights = topk_weights * routed_scaling_factor
         return topk_weights, topk_ids
     norm_type = 0 if scoring_func == "softmax" else 1
     if e_score_correction_bias is not None and e_score_correction_bias.dtype != router_logits.dtype:

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -246,7 +246,9 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         assert topk_weights is not None
-        topk_weights = topk_weights.to(self.in_dtype)
+        # Keep router weights in FP32 for expert scaling; BF16 can flip
+        # near-tie logits on DeepSeek V4 W8A8.
+        topk_weights = topk_weights.to(torch.float32)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (


### PR DESCRIPTION
### What this PR does / why we need it?

This PR is the current DeepSeek V4 W8A8 version of the top-k/hash routing weight fix from #9676.

In the `sqrtsoftplus` hash-routing path, keep using `moe_gating_top_k_hash` for selected expert ids, but do not trust the custom op's returned routing weights. Recompute the selected `topk_weights` from FP32 `router_logits` with:

```python
sqrt(softplus(router_logits)).gather(topk_ids)
```

Then apply the existing renormalization and routed scaling. The W8A8 fused MoE path also keeps `topk_weights` in FP32 before expert execution, so BF16 conversion does not perturb near-tie routing weights.

This significantly reduces the single-concurrency / short-path abnormal BOS token probability seen in diagnostics, but it is not a complete BOS fix. Mixed long/short concurrent runs can still reproduce abnormal BOS tokens, and the MTP/spec-decode state pollution issue is being investigated separately. This PR intentionally does not include DSA changes, concurrency probe tools/artifacts, or KV/cache localization changes.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 hash-routing weights are stabilized in the W8A8 fused MoE path. There is no API or configuration change.

### How was this patch tested?

```bash
ruff check tests/ut/ops/test_select_experts.py tests/ut/quantization/methods/test_w8a8_dynamic.py vllm_ascend/ops/fused_moe/experts_selector.py vllm_ascend/quantization/methods/w8a8_dynamic.py
pytest -q tests/ut/ops/test_select_experts.py::TestExpertsSelector::test_select_experts_sqrtsoftplus_recomputes_hash_weights tests/ut/quantization/methods/test_w8a8_dynamic.py::TestAscendW8A8FusedMoEMethod::test_apply_keeps_topk_weights_fp32
```

Result: `ruff` passed; `pytest` passed with `2 passed, 16 warnings in 0.09s`.

Note: `git diff --check upstream/main...HEAD` currently reports trailing-whitespace findings on newly added lines in `vllm_ascend/ops/fused_moe/experts_selector.py`, whose file is tracked with CRLF line terminators. This sidecar task did not edit local files.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8
