### PR TITLE
[Feature][SpecDecode] Add Zipf speculative decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if (CMAKE_INSTALL_PREFIX STREQUAL /usr/local)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/out" CACHE STRINGS "path to install()")
 endif()
 
+if(NOT DEFINED ZIPF_CACHE_INSTALL_PATH)
+  set(ZIPF_CACHE_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/spec_decode/zipf_cache")
+endif()
+
 set(ASCEND_CANN_PACKAGE_PATH ${ASCEND_HOME_PATH})
 if(EXISTS ${ASCEND_HOME_PATH}/tools/tikcpp/ascendc_kernel_cmake)
     set(ASCENDC_CMAKE_DIR ${ASCEND_HOME_PATH}/tools/tikcpp/ascendc_kernel_cmake)
@@ -110,6 +114,33 @@ set(
 )
 
 pybind11_add_module(vllm_ascend_C ${VLLM_ASCEND_SRC})
+
+# ZipfCache is an internal native extension used by Ascend speculative decoding.
+# It is installed under vllm_ascend/spec_decode/zipf_cache instead of exposing a
+# top-level Python package.
+set(ZIPF_CACHE_SRC
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/src/cityhash.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/src/local_hash.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/src/token_generalizer.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/src/zipf_cache.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/src/async_worker.c
+)
+
+add_library(zipf_cache_static STATIC ${ZIPF_CACHE_SRC})
+set_target_properties(zipf_cache_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(zipf_cache_static PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/include
+)
+target_link_libraries(zipf_cache_static PRIVATE pthread m)
+
+pybind11_add_module(_zipf_cache_cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/src/pybind_zipf_cache.cpp
+)
+target_include_directories(_zipf_cache_cpp PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/zipf_cache/include
+)
+target_link_libraries(_zipf_cache_cpp PRIVATE zipf_cache_static pthread m)
+add_dependencies(vllm_ascend_C _zipf_cache_cpp)
 
 # Detect aclrtMemcpyBatchAsync availability (CANN 8.5+)
 # Can be overridden via VLLM_ASCEND_ENABLE_BATCH_MEMCPY env var (registered
@@ -203,3 +234,5 @@ if(SOC_VERSION MATCHES "ascend310p.*|ascend950")
 else()
   install(TARGETS vllm_ascend_C vllm_ascend_kernels DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
 endif()
+
+install(TARGETS _zipf_cache_cpp DESTINATION ${ZIPF_CACHE_INSTALL_PATH})

--- a/csrc/zipf_cache/include/async_worker.h
+++ b/csrc/zipf_cache/include/async_worker.h
@@ -1,0 +1,67 @@
+#ifndef ASYNC_WORKER_H
+#define ASYNC_WORKER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// 异步任务类型
+typedef enum {
+    ASYNC_TASK_WARMUP,
+    ASYNC_TASK_UPDATE,
+} AsyncTaskType;
+
+// 异步任务
+typedef struct {
+    AsyncTaskType type;
+    uint64_t req_hash;
+    uint32_t* tokens;       // 拥有所有权，需要 free
+    size_t token_count;
+} AsyncTask;
+
+// 任务队列（环形缓冲区）
+#define ASYNC_QUEUE_CAPACITY 4096
+
+typedef struct {
+    AsyncTask tasks[ASYNC_QUEUE_CAPACITY];
+    volatile size_t head;   // 消费者读
+    volatile size_t tail;   // 生产者写
+    size_t count;           // 当前队列中的任务数（仅生产者维护）
+} AsyncQueue;
+
+// 异步工作线程
+typedef struct {
+    pthread_t thread;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond_work;    // 有新任务
+    pthread_cond_t cond_done;    // 任务全部完成
+    AsyncQueue queue;
+    volatile int running;        // 线程是否运行
+    volatile int pending;        // 待处理任务数（原子递增/递减）
+    void* cache;                 // ZipfCache* (避免循环依赖用 void*)
+} AsyncWorker;
+
+// 创建异步工作线程
+AsyncWorker* async_worker_create(void* cache);
+
+// 提交任务（非阻塞，拷贝 tokens 数据）
+void async_worker_submit_warmup(AsyncWorker* worker, uint64_t req_hash,
+                                const uint32_t* tokens, size_t count);
+void async_worker_submit_update(AsyncWorker* worker, uint64_t req_hash,
+                                const uint32_t* tokens, size_t count);
+
+// 等待所有待处理任务完成（fence）
+void async_worker_fence(AsyncWorker* worker);
+
+// 销毁
+void async_worker_free(AsyncWorker* worker);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ASYNC_WORKER_H

--- a/csrc/zipf_cache/include/cityhash.h
+++ b/csrc/zipf_cache/include/cityhash.h
@@ -1,0 +1,24 @@
+#ifndef CITYHASH_H
+#define CITYHASH_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// 简化版 CityHash64 实现 - 针对小数据优化
+// 基于 Google CityHash 算法
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t cityhash64(const void* data, size_t len);
+uint64_t cityhash64_with_seed(const void* data, size_t len, uint64_t seed);
+
+// 针对 N-Gram 优化的哈希函数
+uint64_t ngram_hash(const uint32_t* tokens, uint8_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CITYHASH_H

--- a/csrc/zipf_cache/include/hot_tier.h
+++ b/csrc/zipf_cache/include/hot_tier.h
@@ -1,0 +1,26 @@
+#ifndef HOT_TIER_H
+#define HOT_TIER_H
+
+#include "types.h"
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// 开放寻址哈希表的辅助函数（被 local_hash.c 使用）
+
+static inline uint32_t hot_tier_hash(uint64_t key, size_t size) {
+    return (uint32_t)(key % size);
+}
+
+static inline uint32_t hot_tier_probe(uint32_t h, uint32_t i, size_t size) {
+    return (h + i) % size;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HOT_TIER_H

--- a/csrc/zipf_cache/include/local_hash.h
+++ b/csrc/zipf_cache/include/local_hash.h
@@ -1,0 +1,103 @@
+#ifndef LOCAL_HASH_H
+#define LOCAL_HASH_H
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// req_id 索引表条目
+typedef struct {
+    uint64_t req_id;
+    size_t   slot;
+} ReqIdIndexEntry;
+
+#define REQ_INDEX_EMPTY 0xFFFFFFFFFFFFFFFFULL
+
+typedef struct {
+    LocalHash** hashes;
+    size_t capacity;
+    size_t count;
+    size_t local_capacity;
+    size_t unigram_capacity;
+    float unigram_threshold;
+    size_t gen_capacity;
+    // req_id 快速索引
+    ReqIdIndexEntry* index;
+    size_t index_capacity;
+    uint64_t access_counter;
+} LocalHashManager;
+
+LocalHashManager* local_hash_manager_create(size_t max_hashes,
+                                            size_t local_capacity,
+                                            size_t unigram_capacity,
+                                            float unigram_threshold,
+                                            size_t gen_capacity);
+
+LocalHash* local_hash_manager_get_or_create(LocalHashManager* manager,
+                                            uint64_t req_id);
+
+// 查询 n-gram（带 gram 级别，用于 Space-Saving 阈值判断）
+int local_hash_query_with_level(const LocalHash* local,
+                                uint64_t ngram_hash,
+                                uint8_t level,
+                                uint32_t* out_next_token);
+
+// 查询 n-gram（默认级别，向后兼容）
+int local_hash_query(const LocalHash* local,
+                    uint64_t ngram_hash,
+                    uint32_t* out_next_token);
+
+int local_hash_query_unigram(const LocalHash* local,
+                             uint32_t key_token,
+                             uint32_t* out_next_token);
+
+// 更新：Space-Saving Misra-Gries 策略
+int local_hash_update(LocalHash* local,
+                     uint64_t ngram_hash,
+                     uint32_t next_token);
+
+void local_hash_update_unigram(LocalHash* local,
+                               uint32_t key_token,
+                               uint32_t next_token);
+
+int local_hash_can_generate(const LocalHash* local);
+void local_hash_reset_history(LocalHash* local);
+void local_hash_set_history(LocalHash* local, const uint32_t* tokens, uint8_t len, uint8_t max_window);
+const uint32_t* local_hash_get_history(const LocalHash* local, uint8_t* out_len);
+
+// 泛化层查询：带 gram 级别的 Space-Saving 阈值判断
+int local_hash_query_generalized_with_level(const LocalHash* local,
+                                            uint64_t gen_hash,
+                                            uint8_t level,
+                                            uint32_t* out_next_token);
+
+// 泛化层查询：默认级别，向后兼容
+int local_hash_query_generalized(const LocalHash* local,
+                                 uint64_t gen_hash,
+                                 uint32_t* out_next_token);
+
+// 泛化层更新：Space-Saving Misra-Gries 策略
+int local_hash_update_generalized(LocalHash* local,
+                                  uint64_t gen_hash,
+                                  uint32_t next_token);
+
+void local_hash_manager_cleanup(LocalHashManager* manager, size_t keep_count);
+void local_hash_manager_free(LocalHashManager* manager);
+
+typedef struct {
+    size_t total_hashes;
+    size_t total_entries;
+    size_t total_unigram;
+    size_t total_gen_entries;
+    size_t memory_bytes;
+} LocalHashStats;
+
+LocalHashStats local_hash_manager_stats(const LocalHashManager* manager);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LOCAL_HASH_H

--- a/csrc/zipf_cache/include/token_generalizer.h
+++ b/csrc/zipf_cache/include/token_generalizer.h
@@ -1,0 +1,168 @@
+#ifndef TOKEN_GENERALIZER_H
+#define TOKEN_GENERALIZER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Token Generalizer - 基于运行时频率的 token 泛化
+ *
+ * 核心思路：
+ * - 高频 token（结构性 token：标点、介词、关键字等）保留原始 ID
+ * - 低频 token（内容性 token：变量名、数字、字符串等）映射到通配符 ID
+ * - 泛化后的 n-gram 可以匹配结构相似但内容不同的模式
+ *
+ * 实现：
+ * - 使用哈希表记录每个 token 的出现频率
+ * - 当频率 >= 阈值时，token 被视为"高频"，保留原始 ID
+ * - 否则映射到 WILDCARD_TOKEN
+ * - 阈值可以固定，也可以自适应（维护 top-K）
+ */
+
+#define WILDCARD_TOKEN 0xFFFFFFFE
+#define GENERALIZER_EMPTY_KEY 0xFFFFFFFF
+
+// 多桶泛化：低频 token 按共现分布分到不同的语义桶
+#define NUM_WILDCARD_BUCKETS 16
+#define WILDCARD_BASE 0xFFFF0000  // 桶 ID = WILDCARD_BASE + bucket (0..15)
+
+// 频率表条目（含共现分布 hash）
+typedef struct {
+    uint32_t token;          // token ID
+    uint32_t count;          // 出现次数
+    uint32_t context_hash;   // 左邻居累积 hash（用于语义分桶）
+} FreqEntry;
+
+// Token 泛化器
+typedef struct {
+    FreqEntry* entries;       // 哈希表
+    size_t capacity;          // 哈希表容量
+    size_t count;             // 已使用的槽数
+
+    uint32_t freq_threshold;  // 频率阈值：>= 此值的 token 保留原始 ID
+    uint32_t total_updates;   // 总更新次数（用于自适应阈值）
+
+    // 快速查找缓存：高频 token 的 bitmap（可选优化）
+    // 对于 vocab_size <= 256K，用 bitmap 可以做到 O(1) 查找
+    uint8_t* high_freq_bitmap; // bitmap[token / 8] & (1 << (token % 8))
+    size_t bitmap_size;        // bitmap 字节数
+    uint32_t bitmap_vocab_max; // bitmap 覆盖的最大 token ID
+} TokenGeneralizer;
+
+// 创建泛化器
+// capacity: 频率表容量（建议 vocab_size * 2）
+// freq_threshold: 初始频率阈值
+// bitmap_vocab_max: bitmap 覆盖的最大 token ID（0 表示不使用 bitmap）
+TokenGeneralizer* token_generalizer_create(size_t capacity,
+                                           uint32_t freq_threshold,
+                                           uint32_t bitmap_vocab_max);
+
+// 释放泛化器
+void token_generalizer_free(TokenGeneralizer* gen);
+
+// 更新 token 频率（带左邻居信息，用于共现分布分桶）
+// prev_token: 前一个 token（用于累积 context_hash），0xFFFFFFFF 表示无前驱
+// 返回更新后的频率
+uint32_t token_generalizer_update(TokenGeneralizer* gen, uint32_t token, uint32_t prev_token);
+
+// 批量更新 token 频率（带左邻居信息）
+void token_generalizer_update_batch(TokenGeneralizer* gen,
+                                    const uint32_t* tokens,
+                                    size_t count);
+
+// 泛化单个 token
+// 高频 token 返回原始 ID，低频 token 返回语义桶 ID
+static inline uint32_t token_generalizer_map(const TokenGeneralizer* gen,
+                                              uint32_t token) {
+    if (!gen) return token;
+
+    // 快速路径：bitmap 查找（只判断高频/低频）
+    if (gen->high_freq_bitmap && token <= gen->bitmap_vocab_max) {
+        size_t byte_idx = token >> 3;
+        uint8_t bit_mask = 1U << (token & 7);
+        if (gen->high_freq_bitmap[byte_idx] & bit_mask) {
+            return token;  // 高频，保留
+        }
+        // 低频，需要查哈希表获取 context_hash 来分桶
+        size_t cap = gen->capacity;
+        uint32_t h = (token * 2654435761U) % cap;
+        for (uint32_t i = 0; i < 16; i++) {
+            size_t slot = (h + i) % cap;
+            if (gen->entries[slot].token == GENERALIZER_EMPTY_KEY) {
+                // 未见过，用 token ID 做 fallback 分桶
+                return WILDCARD_BASE + (token % NUM_WILDCARD_BUCKETS);
+            }
+            if (gen->entries[slot].token == token) {
+                uint32_t bucket = gen->entries[slot].context_hash % NUM_WILDCARD_BUCKETS;
+                return WILDCARD_BASE + bucket;
+            }
+        }
+        return WILDCARD_BASE + (token % NUM_WILDCARD_BUCKETS);
+    }
+
+    // 慢速路径：哈希表查找
+    size_t cap = gen->capacity;
+    uint32_t h = (token * 2654435761U) % cap;
+    for (uint32_t i = 0; i < 16; i++) {
+        size_t slot = (h + i) % cap;
+        if (gen->entries[slot].token == GENERALIZER_EMPTY_KEY) {
+            return WILDCARD_BASE + (token % NUM_WILDCARD_BUCKETS);
+        }
+        if (gen->entries[slot].token == token) {
+            if (gen->entries[slot].count >= gen->freq_threshold) {
+                return token;  // 高频，保留
+            }
+            uint32_t bucket = gen->entries[slot].context_hash % NUM_WILDCARD_BUCKETS;
+            return WILDCARD_BASE + bucket;
+        }
+    }
+    return WILDCARD_BASE + (token % NUM_WILDCARD_BUCKETS);
+}
+
+// 泛化 n-gram 并计算 hash
+// 将 tokens 中的每个 token 泛化后计算 hash
+// out_generalized: 可选输出，存放泛化后的 token 序列
+// 返回泛化后的 n-gram hash
+uint64_t token_generalizer_hash_ngram(const TokenGeneralizer* gen,
+                                      const uint32_t* tokens,
+                                      uint8_t length,
+                                      uint32_t* out_generalized);
+
+// 检查泛化后的 n-gram 是否与精确 n-gram 不同
+// （如果所有 token 都是高频的，泛化后和原始相同，不需要额外存储）
+static inline int token_generalizer_is_different(const TokenGeneralizer* gen,
+                                                  const uint32_t* tokens,
+                                                  uint8_t length) {
+    if (!gen) return 0;
+    for (uint8_t i = 0; i < length; i++) {
+        if (token_generalizer_map(gen, tokens[i]) != tokens[i]) {
+            return 1;  // 至少有一个 token 被泛化了
+        }
+    }
+    return 0;  // 全部保留，泛化后相同
+}
+
+// 获取统计信息
+typedef struct {
+    size_t capacity;
+    size_t count;           // 不同 token 数
+    uint32_t freq_threshold;
+    uint32_t total_updates;
+    size_t high_freq_count; // 高频 token 数
+    size_t num_wildcard_buckets; // 通配符桶数量
+    size_t memory_bytes;
+} GeneralizerStats;
+
+GeneralizerStats token_generalizer_stats(const TokenGeneralizer* gen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TOKEN_GENERALIZER_H

--- a/csrc/zipf_cache/include/types.h
+++ b/csrc/zipf_cache/include/types.h
@@ -1,0 +1,162 @@
+#ifndef ZIPF_TYPES_H
+#define ZIPF_TYPES_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// ============================================================
+// N-Gram 条目 - Space-Saving Top-2 设计（16 字节）
+// ============================================================
+// Misra-Gries 近似 Top-K：维护 2 个候选 token 及其计数
+// 解决"最后写入覆盖"导致的翻转问题
+
+typedef struct __attribute__((packed, aligned(16))) {
+    uint32_t signature;      // 32 位哈希签名
+    uint32_t token1;         // 最高频候选 token
+    uint32_t token2;         // 次高频候选 token
+    uint16_t count1;         // token1 计数
+    uint16_t count2;         // token2 计数
+} NgramEntry;  // 16 bytes
+
+#define NGRAM_EMPTY_SIG 0
+
+static inline int ngram_entry_is_empty(const NgramEntry* e) {
+    return e->signature == NGRAM_EMPTY_SIG;
+}
+
+// N-gram 查询阈值：线性衰减公式
+// 长 gram 更确定，阈值低；短 gram 不确定，阈值高
+// threshold(level) = clamp(50 - 4 * level, 15, 50)
+// level 2 → 42%, level 4 → 34%, level 8 → 18%
+static inline uint16_t ngram_threshold_for_level(uint8_t level) {
+    int t = 50 - 4 * (int)level;
+    if (t < 15) t = 15;
+    if (t > 50) t = 50;
+    return (uint16_t)t;
+}
+
+// ============================================================
+// 热数据层条目（保留兼容性）
+// ============================================================
+typedef struct __attribute__((packed, aligned(16))) {
+    uint32_t signature;
+    uint32_t token1;
+    uint32_t token2;
+    uint16_t count1;
+    uint16_t count2;
+} HotEntry;
+
+// N-Gram 键 - 编译时上限
+#define MAX_NGRAM_ORDER 8
+
+// 默认窗口配置
+#define DEFAULT_MIN_WINDOW 2
+#define DEFAULT_MAX_WINDOW 4
+
+// ============================================================
+// 1-Gram 特殊存储结构
+// ============================================================
+
+typedef struct {
+    uint32_t token;
+    uint32_t count;
+} UnigramTokenEntry;
+
+typedef struct {
+    uint32_t key_token;
+    UnigramTokenEntry* tokens;
+    uint16_t token_count;
+    uint16_t capacity;
+    uint32_t max_token;
+    uint32_t max_count;
+    uint32_t total_count;
+} UnigramEntry;
+
+#define UNIGRAM_EMPTY_KEY 0xFFFFFFFF
+
+// 栈分配批量操作的最大大小
+#define STACK_BATCH_SIZE 128
+
+typedef struct {
+    uint32_t tokens[MAX_NGRAM_ORDER];
+    uint8_t length;
+} ZipfKey;
+
+// 查询结果
+typedef struct {
+    uint32_t next_token;
+    uint8_t hit;
+    uint8_t from_local;
+} QueryResult;
+
+// 局部hash表（每个req_id一个）
+typedef struct {
+    // n-gram (2-gram及以上) 存储
+    NgramEntry* entries;
+    size_t capacity;
+    size_t count;
+
+    // 1-gram 专用存储
+    UnigramEntry* unigram_entries;
+    size_t unigram_capacity;
+    size_t unigram_count;
+    float unigram_threshold;
+
+    uint64_t req_id;
+    uint64_t last_access;
+    uint32_t generation_count;
+
+    // 历史窗口
+    uint32_t history[MAX_NGRAM_ORDER];
+    uint8_t history_len;
+
+    // 泛化层 n-gram 存储
+    NgramEntry* gen_entries;
+    size_t gen_capacity;
+    size_t gen_count;
+
+    // Adaptive-K 状态（per-request）
+    float ema_accepted;          // EMA of accepted token count
+    int16_t consecutive_fail;    // 连续失败次数
+    int16_t consecutive_success; // 连续成功次数
+    int16_t last_adaptive_k;    // 上一轮的 adaptive_k
+    uint8_t is_initialized;      // 是否已初始化 adaptive-k 状态
+} LocalHash;
+
+// 硬编码常量
+#define ZIPF_HARDCODED_SHARED_CAPACITY  16777216
+#define ZIPF_HARDCODED_LOCAL_CAPACITY   262144
+#define ZIPF_HARDCODED_MAX_LOCAL_HASHES 10000
+#define ZIPF_HARDCODED_UNIGRAM_CAPACITY 131072
+#define ZIPF_HARDCODED_UNIGRAM_THRESHOLD 0.50f
+
+// 配置参数（仅保留可调参数）
+typedef struct {
+    uint8_t min_window;
+    uint8_t max_window;
+    uint8_t skip_shared;
+    // 泛化层配置
+    uint8_t enable_generalized;
+    uint32_t gen_freq_threshold;
+    size_t gen_capacity;
+    uint32_t gen_bitmap_vocab_max;
+    // 查询优先级：泛化层 vs 共享hash
+    // 0 = shared 优先（local → shared → 泛化）
+    // 1 = 泛化优先（local → 泛化 → shared）
+    uint8_t generalized_before_shared;
+} ZipfConfig;
+
+static inline ZipfConfig zipf_default_config(void) {
+    return (ZipfConfig){
+        .min_window = DEFAULT_MIN_WINDOW,
+        .max_window = DEFAULT_MAX_WINDOW,
+        .skip_shared = 0,
+        .enable_generalized = 1,
+        .gen_freq_threshold = 8,
+        .gen_capacity = 64 * 1024,
+        .gen_bitmap_vocab_max = 256 * 1024,
+        .generalized_before_shared = 1,
+    };
+}
+
+#endif // ZIPF_TYPES_H

--- a/csrc/zipf_cache/include/zipf_cache.h
+++ b/csrc/zipf_cache/include/zipf_cache.h
@@ -1,0 +1,361 @@
+#ifndef ZIPF_CACHE_H
+#define ZIPF_CACHE_H
+
+#include "types.h"
+#include "local_hash.h"
+#include "token_generalizer.h"
+#include "async_worker.h"
+#include <stdatomic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Zipf Cache - 完整的推测解码加速系统
+// 优化版本：移除所有锁，适用于vLLM串行调用场景
+// 1-gram 特殊处理已集成到 LocalHash 中
+
+typedef struct {
+    // 共享hash（所有req_id共享的动态存储，包含1-gram）
+    LocalHash* shared_hash;
+
+    // 局部hash管理器（每个req_id一个局部hash，包含1-gram）
+    LocalHashManager* local_manager;
+
+    // Token 泛化器（运行时频率统计 + 泛化映射）
+    TokenGeneralizer* generalizer;
+
+    // 统计
+    _Atomic uint64_t query_count;
+    _Atomic uint64_t shared_hit_count;
+    _Atomic uint64_t local_hit_count;
+    _Atomic uint64_t unigram_hit_count;
+    _Atomic uint64_t generalized_hit_count;
+    _Atomic uint64_t update_count;
+
+    // 配置
+    ZipfConfig config;
+
+    // 异步工作线程（用于后台 warmup/update）
+    AsyncWorker* async_worker;
+} ZipfCache;
+
+// 哈希函数声明
+uint64_t zipf_hash(const uint32_t* tokens, uint8_t length);
+
+// 创建缓存
+ZipfCache* zipf_cache_create(const ZipfConfig* config);
+
+// 推测查询 - 带req_id的版本（无锁优化版）
+// 查询顺序：对于每个n-gram级别，依次查询 局部hash → 泛化层 → 共享hash
+// 如果未命中，降级到更短的n-gram，直到1-gram
+// 1-gram使用概率判断
+static inline int zipf_cache_query_with_req(ZipfCache* cache,
+                                            uint64_t req_id,
+                                            const uint32_t* context_tokens,
+                                            uint8_t context_len,
+                                            uint32_t* out_next_token) {
+    if (!cache || context_len == 0) return 0;
+
+    atomic_fetch_add_explicit(&cache->query_count, 1, memory_order_relaxed);
+
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+
+    // 从最长的n-gram开始，逐级降级查询
+    for (uint8_t len = context_len; len >= 1; len--) {
+        const uint32_t* key_start = context_tokens + (context_len - len);
+
+        if (len == 1) {
+            // 1-gram 使用概率判断（硬编码启用 unigram）
+            uint32_t key_token = key_start[0];
+
+            // 查局部hash的1-gram
+            if (local && local_hash_query_unigram(local, key_token, out_next_token)) {
+                atomic_fetch_add_explicit(&cache->unigram_hit_count, 1, memory_order_relaxed);
+                return 1;
+            }
+
+            // 查共享hash的1-gram
+            if (!cache->config.skip_shared && cache->shared_hash &&
+                local_hash_query_unigram(cache->shared_hash, key_token, out_next_token)) {
+                atomic_fetch_add_explicit(&cache->unigram_hit_count, 1, memory_order_relaxed);
+                return 1;
+            }
+        } else {
+            // 2-gram及以上，使用 Space-Saving Top-2 查询
+            uint64_t hash = zipf_hash(key_start, len);
+
+            // 查局部hash（精确匹配，带级别阈值）
+            if (local && local_hash_query_with_level(local, hash, len, out_next_token)) {
+                atomic_fetch_add_explicit(&cache->local_hit_count, 1, memory_order_relaxed);
+                return 1;
+            }
+
+            if (cache->config.generalized_before_shared) {
+                // 泛化层优先于 shared
+                if (cache->config.enable_generalized && cache->generalizer &&
+                    local && token_generalizer_is_different(cache->generalizer, key_start, len)) {
+                    uint64_t gen_hash = token_generalizer_hash_ngram(
+                        cache->generalizer, key_start, len, NULL);
+                    if (local_hash_query_generalized_with_level(local, gen_hash, len,
+                            out_next_token)) {
+                        atomic_fetch_add_explicit(&cache->generalized_hit_count, 1, memory_order_relaxed);
+                        return 1;
+                    }
+                }
+
+                if (!cache->config.skip_shared && cache->shared_hash &&
+                    local_hash_query_with_level(cache->shared_hash, hash, len, out_next_token)) {
+                    atomic_fetch_add_explicit(&cache->shared_hit_count, 1, memory_order_relaxed);
+                    return 1;
+                }
+            } else {
+                // shared 优先于泛化层
+                if (!cache->config.skip_shared && cache->shared_hash &&
+                    local_hash_query_with_level(cache->shared_hash, hash, len, out_next_token)) {
+                    atomic_fetch_add_explicit(&cache->shared_hit_count, 1, memory_order_relaxed);
+                    return 1;
+                }
+
+                if (cache->config.enable_generalized && cache->generalizer &&
+                    local && token_generalizer_is_different(cache->generalizer, key_start, len)) {
+                    uint64_t gen_hash = token_generalizer_hash_ngram(
+                        cache->generalizer, key_start, len, NULL);
+                    if (local_hash_query_generalized_with_level(local, gen_hash, len,
+                            out_next_token)) {
+                        atomic_fetch_add_explicit(&cache->generalized_hit_count, 1, memory_order_relaxed);
+                        return 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+// 兼容旧接口（不带req_id，无全局hash，直接返回0）
+static inline int zipf_cache_query(ZipfCache* cache,
+                                    const uint32_t* context_tokens,
+                                    uint8_t context_len,
+                                    uint32_t* out_next_token) {
+    (void)context_tokens;
+    (void)context_len;
+    (void)out_next_token;
+
+    atomic_fetch_add_explicit(&cache->query_count, 1, memory_order_relaxed);
+
+    // 全局hash已移除，此接口不再有效
+    return 0;
+}
+
+// 批量推测查询（带req_id）
+void zipf_cache_query_batch_with_req(ZipfCache* cache,
+                                     const uint64_t* req_ids,
+                                     const ZipfKey* keys,
+                                     QueryResult* results,
+                                     size_t batch_size);
+
+// 更新 - 带req_id，写入局部hash
+void zipf_cache_update_with_req(ZipfCache* cache,
+                                uint64_t req_id,
+                                const uint32_t* context_tokens,
+                                uint8_t context_len,
+                                uint32_t next_token);
+
+// 新版多级 n-gram 更新（带历史窗口）
+// 对于每个新 token，同时更新 min_window 到 max_window 级别的 n-gram
+// 自动维护历史窗口，支持连续调用
+void zipf_cache_update_with_history(ZipfCache* cache,
+                                    uint64_t req_id,
+                                    const uint32_t* new_tokens,
+                                    size_t new_token_count);
+
+// 批量多级 n-gram 更新（带历史窗口）
+// flat_tokens: 所有 request 的 token 拼接成的扁平数组
+// offsets: 每个 request 在 flat_tokens 中的起始偏移
+// token_counts: 每个 request 的 token 数量
+void zipf_cache_update_with_history_batch(
+    ZipfCache* cache,
+    const uint64_t* req_ids,
+    const uint32_t* flat_tokens,
+    const size_t* offsets,
+    const size_t* token_counts,
+    size_t batch_size);
+
+// 设置历史窗口（用于初始化上下文，如 prompt tokens）
+void zipf_cache_set_history(ZipfCache* cache,
+                            uint64_t req_id,
+                            const uint32_t* tokens,
+                            size_t token_count);
+
+// Prompt-aware 预热：扫描整个 prompt，提取所有 n-gram 预填充到 local hash
+// 同时设置历史窗口为 prompt 最后 max_window 个 token
+void zipf_cache_warmup_from_prompt(ZipfCache* cache,
+                                   uint64_t req_id,
+                                   const uint32_t* prompt_tokens,
+                                   size_t prompt_len);
+
+// 重置历史窗口
+void zipf_cache_reset_context(ZipfCache* cache, uint64_t req_id);
+
+// 批量更新 - 带req_id
+void zipf_cache_update_batch_with_req(ZipfCache* cache,
+                                      const uint64_t* req_ids,
+                                      const ZipfKey* contexts,
+                                      const uint32_t* next_tokens,
+                                      size_t batch_size);
+
+// 获取统计信息
+typedef struct {
+    uint64_t query_count;
+    uint64_t shared_hit_count;
+    uint64_t local_hit_count;
+    uint64_t unigram_hit_count;
+    uint64_t generalized_hit_count;
+    double shared_hit_rate;
+    double local_hit_rate;
+    double unigram_hit_rate;
+    double generalized_hit_rate;
+    double total_hit_rate;
+    uint64_t update_count;
+    LocalHashStats local_stats;
+    size_t shared_entries;      // 共享hash中的n-gram条目数
+    size_t shared_unigram;      // 共享hash中的1-gram条目数
+    GeneralizerStats gen_stats; // 泛化器统计
+} ZipfCacheStats;
+
+ZipfCacheStats zipf_cache_stats(const ZipfCache* cache);
+
+// 释放缓存
+void zipf_cache_free(ZipfCache* cache);
+
+// ============================================================
+// 链式推测 API - 用于 vLLM 推测解码集成
+// ============================================================
+
+/**
+ * 链式推测多个 token（带req_id版本）
+ *
+ * 从给定上下文开始，连续查询预测 token，直到遇到 miss 或达到 max_tokens。
+ * 每次查询后，将预测的 token 加入上下文窗口（滑动窗口，最多 4 个）。
+ *
+ * @param cache         缓存实例
+ * @param req_id        请求ID
+ * @param context       初始上下文 token 数组
+ * @param context_len   上下文长度（1-4，超过 4 会截取最后 4 个）
+ * @param out_tokens    输出缓冲区，存放预测的 token
+ * @param max_tokens    最大推测数量
+ * @return              实际推测的 token 数量（0 表示第一次就 miss）
+ */
+int zipf_cache_speculate_chain_with_req(
+    ZipfCache* cache,
+    uint64_t req_id,
+    const uint32_t* context,
+    uint8_t context_len,
+    uint32_t* out_tokens,
+    int max_tokens
+);
+
+/**
+ * 批量链式推测结果
+ */
+typedef struct {
+    int count;              // 实际推测的 token 数量
+} SpeculateChainResult;
+
+/**
+ * 批量链式推测（带req_id）
+ */
+void zipf_cache_speculate_chain_batch_with_req(
+    ZipfCache* cache,
+    const uint64_t* req_ids,
+    const ZipfKey* contexts,
+    uint32_t* out_tokens,
+    int* out_counts,
+    size_t batch_size,
+    int max_tokens
+);
+
+// ============================================================
+// Propose API - 完整的 propose 逻辑下沉到 C 层
+// ============================================================
+
+/**
+ * Adaptive-K 配置
+ */
+typedef struct {
+    float ema_alpha;             // EMA 平滑系数（默认 0.3）
+    int num_speculative_tokens;  // 最大推测 token 数
+    float fail_threshold;        // 接受率低于此值视为失败（默认 0.3）
+    float success_threshold;     // 接受率高于此值视为成功（默认 0.5）
+    int max_penalty;             // 最大惩罚值（默认 3）
+    int max_bonus;               // 最大奖励值（默认 3）
+    int min_k;                   // adaptive_k 下限（默认 1）
+    int max_k;                   // adaptive_k 上限（默认 128）
+} AdaptiveKConfig;
+
+static inline AdaptiveKConfig adaptive_k_default_config(void) {
+    return (AdaptiveKConfig){
+        .ema_alpha = 0.3f,
+        .num_speculative_tokens = 5,
+        .fail_threshold = 0.3f,
+        .success_threshold = 0.5f,
+        .max_penalty = 3,
+        .max_bonus = 3,
+        .min_k = 1,
+        .max_k = 128,
+    };
+}
+
+/**
+ * 单个请求的 propose 输入
+ */
+typedef struct {
+    uint64_t req_hash;           // 请求 hash（用作 req_id）
+    const uint32_t* token_ids;   // 该请求的完整 token 序列（prompt + generated）
+    int num_tokens;              // 当前 token 总数（不含 spec tokens）
+    int num_prompt_tokens;       // prompt token 数
+    const uint32_t* sampled_ids; // 上一轮验证通过的 token（用于 update）
+    int num_sampled;             // sampled_ids 长度
+    int max_model_len;           // 模型最大长度
+    uint8_t is_valid;            // 是否参与推测（0=跳过）
+} ProposeRequest;
+
+/**
+ * 单个请求的 propose 输出
+ */
+typedef struct {
+    uint32_t* draft_tokens;      // 输出的 draft token 缓冲区
+    int num_draft_tokens;        // 实际输出的 draft token 数
+} ProposeResult;
+
+/**
+ * 批量 propose - 完整的 propose 逻辑在 C 层执行
+ *
+ * 对每个有效请求：
+ * 1. 新请求：warmup_from_prompt
+ * 2. update_with_history（用 sampled_ids）
+ * 3. 计算 adaptive-k
+ * 4. speculate_chain
+ * 5. 截断到 min(adaptive_k, max_model_len - num_tokens - 1)
+ *
+ * @param cache          缓存实例
+ * @param requests       请求数组
+ * @param results        结果数组（调用者预分配）
+ * @param batch_size     批大小
+ * @param ak_config      adaptive-k 配置
+ */
+void zipf_cache_propose_batch(
+    ZipfCache* cache,
+    const ProposeRequest* requests,
+    ProposeResult* results,
+    size_t batch_size,
+    const AdaptiveKConfig* ak_config
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZIPF_CACHE_H

--- a/csrc/zipf_cache/src/async_worker.c
+++ b/csrc/zipf_cache/src/async_worker.c
@@ -1,0 +1,167 @@
+#include "async_worker.h"
+#include "zipf_cache.h"
+#include <stdlib.h>
+#include <string.h>
+
+// ============================================================
+// 后台线程函数
+// ============================================================
+
+static void process_task(AsyncWorker* worker, const AsyncTask* task) {
+    ZipfCache* cache = (ZipfCache*)worker->cache;
+    switch (task->type) {
+        case ASYNC_TASK_WARMUP:
+            zipf_cache_warmup_from_prompt(cache, task->req_hash,
+                                          task->tokens, task->token_count);
+            break;
+        case ASYNC_TASK_UPDATE:
+            zipf_cache_update_with_history(cache, task->req_hash,
+                                           task->tokens, task->token_count);
+            break;
+    }
+    free(task->tokens);
+}
+
+static void* worker_thread_func(void* arg) {
+    AsyncWorker* worker = (AsyncWorker*)arg;
+
+    while (1) {
+        pthread_mutex_lock(&worker->mutex);
+
+        // 等待任务或退出信号
+        while (worker->queue.head == worker->queue.tail && worker->running) {
+            pthread_cond_wait(&worker->cond_work, &worker->mutex);
+        }
+
+        if (!worker->running && worker->queue.head == worker->queue.tail) {
+            pthread_mutex_unlock(&worker->mutex);
+            break;
+        }
+
+        // 取出一个任务
+        size_t head = worker->queue.head;
+        AsyncTask task = worker->queue.tasks[head % ASYNC_QUEUE_CAPACITY];
+        worker->queue.head = head + 1;
+
+        pthread_mutex_unlock(&worker->mutex);
+
+        // 执行任务（不持锁）
+        process_task(worker, &task);
+
+        // 递减 pending 计数，通知 fence
+        pthread_mutex_lock(&worker->mutex);
+        worker->pending--;
+        if (worker->pending == 0) {
+            pthread_cond_broadcast(&worker->cond_done);
+        }
+        pthread_mutex_unlock(&worker->mutex);
+    }
+
+    return NULL;
+}
+
+// ============================================================
+// 公共 API
+// ============================================================
+
+AsyncWorker* async_worker_create(void* cache) {
+    AsyncWorker* worker = calloc(1, sizeof(AsyncWorker));
+    if (!worker) return NULL;
+
+    worker->cache = cache;
+    worker->running = 1;
+    worker->pending = 0;
+    worker->queue.head = 0;
+    worker->queue.tail = 0;
+    worker->queue.count = 0;
+
+    pthread_mutex_init(&worker->mutex, NULL);
+    pthread_cond_init(&worker->cond_work, NULL);
+    pthread_cond_init(&worker->cond_done, NULL);
+
+    if (pthread_create(&worker->thread, NULL, worker_thread_func, worker) != 0) {
+        pthread_mutex_destroy(&worker->mutex);
+        pthread_cond_destroy(&worker->cond_work);
+        pthread_cond_destroy(&worker->cond_done);
+        free(worker);
+        return NULL;
+    }
+
+    return worker;
+}
+
+static void submit_task(AsyncWorker* worker, AsyncTaskType type,
+                        uint64_t req_hash, const uint32_t* tokens, size_t count) {
+    if (!worker || !tokens || count == 0) return;
+
+    // 拷贝 token 数据（生产者拥有原始数据的生命周期不确定）
+    uint32_t* tokens_copy = malloc(count * sizeof(uint32_t));
+    if (!tokens_copy) return;
+    memcpy(tokens_copy, tokens, count * sizeof(uint32_t));
+
+    pthread_mutex_lock(&worker->mutex);
+
+    size_t tail = worker->queue.tail;
+    // 如果队列满了，丢弃（不应该发生，4096 足够大）
+    if (tail - worker->queue.head >= ASYNC_QUEUE_CAPACITY) {
+        pthread_mutex_unlock(&worker->mutex);
+        free(tokens_copy);
+        return;
+    }
+
+    AsyncTask* task = &worker->queue.tasks[tail % ASYNC_QUEUE_CAPACITY];
+    task->type = type;
+    task->req_hash = req_hash;
+    task->tokens = tokens_copy;
+    task->token_count = count;
+
+    worker->queue.tail = tail + 1;
+    worker->pending++;
+
+    pthread_cond_signal(&worker->cond_work);
+    pthread_mutex_unlock(&worker->mutex);
+}
+
+void async_worker_submit_warmup(AsyncWorker* worker, uint64_t req_hash,
+                                const uint32_t* tokens, size_t count) {
+    submit_task(worker, ASYNC_TASK_WARMUP, req_hash, tokens, count);
+}
+
+void async_worker_submit_update(AsyncWorker* worker, uint64_t req_hash,
+                                const uint32_t* tokens, size_t count) {
+    submit_task(worker, ASYNC_TASK_UPDATE, req_hash, tokens, count);
+}
+
+void async_worker_fence(AsyncWorker* worker) {
+    if (!worker) return;
+    pthread_mutex_lock(&worker->mutex);
+    while (worker->pending > 0) {
+        pthread_cond_wait(&worker->cond_done, &worker->mutex);
+    }
+    pthread_mutex_unlock(&worker->mutex);
+}
+
+void async_worker_free(AsyncWorker* worker) {
+    if (!worker) return;
+
+    // 停止线程
+    pthread_mutex_lock(&worker->mutex);
+    worker->running = 0;
+    pthread_cond_signal(&worker->cond_work);
+    pthread_mutex_unlock(&worker->mutex);
+
+    pthread_join(worker->thread, NULL);
+
+    // 清理未处理的任务
+    while (worker->queue.head < worker->queue.tail) {
+        size_t head = worker->queue.head;
+        AsyncTask* task = &worker->queue.tasks[head % ASYNC_QUEUE_CAPACITY];
+        free(task->tokens);
+        worker->queue.head = head + 1;
+    }
+
+    pthread_mutex_destroy(&worker->mutex);
+    pthread_cond_destroy(&worker->cond_work);
+    pthread_cond_destroy(&worker->cond_done);
+    free(worker);
+}

--- a/csrc/zipf_cache/src/async_worker.c
+++ b/csrc/zipf_cache/src/async_worker.c
@@ -153,7 +153,7 @@ void async_worker_free(AsyncWorker* worker) {
     pthread_join(worker->thread, NULL);
 
     // 清理未处理的任务
-    while (worker->queue.head < worker->queue.tail) {
+    while (worker->queue.tail - worker->queue.head > 0) {
         size_t head = worker->queue.head;
         AsyncTask* task = &worker->queue.tasks[head % ASYNC_QUEUE_CAPACITY];
         free(task->tokens);

--- a/csrc/zipf_cache/src/cityhash.c
+++ b/csrc/zipf_cache/src/cityhash.c
@@ -1,0 +1,101 @@
+#include "cityhash.h"
+#include <string.h>
+
+// CityHash64 常量
+static const uint64_t k0 = 0xc3a5c85c97cb3127ULL;
+static const uint64_t k1 = 0xb492b66fbe98f273ULL;
+static const uint64_t k2 = 0x9ae16a3b2f90404fULL;
+
+static inline uint64_t rotate64(uint64_t val, int shift) {
+    return shift == 0 ? val : ((val >> shift) | (val << (64 - shift)));
+}
+
+static inline uint64_t fetch64(const char* p) {
+    uint64_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static inline uint32_t fetch32(const char* p) {
+    uint32_t result;
+    memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+static inline uint64_t hash_len_16(uint64_t u, uint64_t v, uint64_t mul) {
+    uint64_t a = (u ^ v) * mul;
+    a ^= (a >> 47);
+    uint64_t b = (v ^ a) * mul;
+    b ^= (b >> 47);
+    b *= mul;
+    return b;
+}
+
+static uint64_t hash_len_0_to_16(const char* s, size_t len) {
+    if (len >= 8) {
+        uint64_t mul = k2 + len * 2;
+        uint64_t a = fetch64(s) + k2;
+        uint64_t b = fetch64(s + len - 8);
+        uint64_t c = rotate64(b, 37) * mul + a;
+        uint64_t d = (rotate64(a, 25) + b) * mul;
+        return hash_len_16(c, d, mul);
+    }
+    if (len >= 4) {
+        uint64_t mul = k2 + len * 2;
+        uint64_t a = fetch32(s);
+        return hash_len_16(len + (a << 3), fetch32(s + len - 4), mul);
+    }
+    if (len > 0) {
+        uint8_t a = (uint8_t)s[0];
+        uint8_t b = (uint8_t)s[len >> 1];
+        uint8_t c = (uint8_t)s[len - 1];
+        uint32_t y = (uint32_t)a + ((uint32_t)b << 8);
+        uint32_t z = (uint32_t)len + ((uint32_t)c << 2);
+        return ((uint64_t)(y * k2) ^ (uint64_t)(z * k0)) * k2;
+    }
+    return k2;
+}
+
+static uint64_t hash_len_17_to_32(const char* s, size_t len) {
+    uint64_t mul = k2 + len * 2;
+    uint64_t a = fetch64(s) * k1;
+    uint64_t b = fetch64(s + 8);
+    uint64_t c = fetch64(s + len - 8) * mul;
+    uint64_t d = fetch64(s + len - 16) * k2;
+    return hash_len_16(rotate64(a + b, 43) + rotate64(c, 30) + d,
+                       a + rotate64(b + k2, 18) + c, mul);
+}
+
+uint64_t cityhash64(const void* data, size_t len) {
+    const char* s = (const char*)data;
+
+    if (len <= 16) {
+        return hash_len_0_to_16(s, len);
+    }
+    if (len <= 32) {
+        return hash_len_17_to_32(s, len);
+    }
+
+    // 对于更长的数据，使用简化版本
+    uint64_t x = fetch64(s + len - 40);
+    uint64_t y = fetch64(s + len - 16) + fetch64(s + len - 56);
+    uint64_t z = hash_len_16(fetch64(s + len - 48) + len,
+                             fetch64(s + len - 24), k2);
+
+    uint64_t v0 = len + rotate64(fetch64(s + len - 32), 30) * k0;
+    uint64_t v1 = rotate64(y + z, 42) * k0 + fetch64(s + len - 8);
+    uint64_t w0 = rotate64(x + v0, 33) * k0;
+    uint64_t w1 = (y + fetch64(s)) * k0;
+
+    return hash_len_16(v0 + w1, w0 + v1, k2);
+}
+
+uint64_t cityhash64_with_seed(const void* data, size_t len, uint64_t seed) {
+    return hash_len_16(cityhash64(data, len) - k2, seed, k2);
+}
+
+// 针对 N-Gram 优化的哈希函数
+uint64_t ngram_hash(const uint32_t* tokens, uint8_t length) {
+    // 直接对 token 数组进行哈希
+    return cityhash64(tokens, length * sizeof(uint32_t));
+}

--- a/csrc/zipf_cache/src/local_hash.c
+++ b/csrc/zipf_cache/src/local_hash.c
@@ -1,0 +1,493 @@
+#include "local_hash.h"
+#include "hot_tier.h"
+#include <stdlib.h>
+#include <string.h>
+
+// ============================================================
+// NgramEntry 签名生成
+// ============================================================
+static inline uint32_t make_ngram_sig(uint64_t hash) {
+    uint32_t sig = (uint32_t)(hash >> 32);
+    if (sig == NGRAM_EMPTY_SIG) sig = 1;
+    return sig;
+}
+
+// ============================================================
+// 1-gram 哈希函数
+// ============================================================
+static inline uint32_t unigram_hash(uint32_t key, size_t size) {
+    return (key * 2654435761U) % size;
+}
+
+static inline uint32_t unigram_probe(uint32_t h, uint32_t i, size_t size) {
+    return (h + i) % size;
+}
+
+// ============================================================
+// 1-gram 初始化辅助函数
+// ============================================================
+#define INITIAL_TOKEN_CAPACITY 4
+
+static void init_unigram_entries(UnigramEntry* entries, size_t capacity) {
+    for (size_t i = 0; i < capacity; i++) {
+        entries[i].key_token = UNIGRAM_EMPTY_KEY;
+        entries[i].tokens = NULL;
+        entries[i].token_count = 0;
+        entries[i].capacity = 0;
+        entries[i].max_token = 0;
+        entries[i].max_count = 0;
+        entries[i].total_count = 0;
+    }
+}
+
+static void free_unigram_entries(UnigramEntry* entries, size_t capacity) {
+    if (!entries) return;
+    for (size_t i = 0; i < capacity; i++) {
+        if (entries[i].tokens) free(entries[i].tokens);
+    }
+    free(entries);
+}
+
+static LocalHash* local_hash_create(uint64_t req_id, size_t capacity,
+                                    size_t unigram_capacity, float unigram_threshold,
+                                    size_t gen_capacity) {
+    LocalHash* local = calloc(1, sizeof(LocalHash));
+    if (!local) return NULL;
+
+    local->entries = calloc(capacity, sizeof(NgramEntry));
+    if (!local->entries) { free(local); return NULL; }
+
+    if (unigram_capacity > 0) {
+        size_t adjusted = (size_t)(unigram_capacity / 0.7);
+        if (adjusted < unigram_capacity) adjusted = unigram_capacity;
+        local->unigram_entries = calloc(adjusted, sizeof(UnigramEntry));
+        if (!local->unigram_entries) { free(local->entries); free(local); return NULL; }
+        init_unigram_entries(local->unigram_entries, adjusted);
+        local->unigram_capacity = adjusted;
+    }
+
+    if (gen_capacity > 0) {
+        local->gen_entries = calloc(gen_capacity, sizeof(NgramEntry));
+        if (!local->gen_entries) {
+            free_unigram_entries(local->unigram_entries, local->unigram_capacity);
+            free(local->entries); free(local); return NULL;
+        }
+        local->gen_capacity = gen_capacity;
+    }
+    local->gen_count = 0;
+    local->capacity = capacity;
+    local->count = 0;
+    local->unigram_count = 0;
+    local->unigram_threshold = unigram_threshold;
+    local->req_id = req_id;
+    local->last_access = 0;
+    local->generation_count = 0;
+    local->history_len = 0;
+    memset(local->history, 0, sizeof(local->history));
+    // Adaptive-K 状态初始化
+    local->ema_accepted = 0.0f;
+    local->consecutive_fail = 0;
+    local->consecutive_success = 0;
+    local->last_adaptive_k = 0;
+    local->is_initialized = 0;
+    return local;
+}
+
+static void local_hash_free(LocalHash* local) {
+    if (!local) return;
+    free(local->entries);
+    free(local->gen_entries);
+    free_unigram_entries(local->unigram_entries, local->unigram_capacity);
+    free(local);
+}
+
+LocalHashManager* local_hash_manager_create(size_t max_hashes,
+                                            size_t local_capacity,
+                                            size_t unigram_capacity,
+                                            float unigram_threshold,
+                                            size_t gen_capacity) {
+    LocalHashManager* manager = calloc(1, sizeof(LocalHashManager));
+    if (!manager) return NULL;
+    manager->hashes = calloc(max_hashes, sizeof(LocalHash*));
+    if (!manager->hashes) { free(manager); return NULL; }
+    size_t index_cap = max_hashes * 2;
+    if (index_cap < 16) index_cap = 16;
+    manager->index = malloc(index_cap * sizeof(ReqIdIndexEntry));
+    if (!manager->index) { free(manager->hashes); free(manager); return NULL; }
+    for (size_t i = 0; i < index_cap; i++) manager->index[i].req_id = REQ_INDEX_EMPTY;
+    manager->index_capacity = index_cap;
+    manager->access_counter = 0;
+    manager->capacity = max_hashes;
+    manager->count = 0;
+    manager->local_capacity = local_capacity;
+    manager->unigram_capacity = unigram_capacity;
+    manager->unigram_threshold = unigram_threshold;
+    manager->gen_capacity = gen_capacity;
+    return manager;
+}
+
+// 索引表内部哈希函数
+static inline size_t req_index_hash(uint64_t req_id, size_t cap) {
+    return (size_t)((req_id * 11400714819323198485ULL) >> 32) % cap;
+}
+
+static inline size_t req_index_find(const LocalHashManager* manager, uint64_t req_id) {
+    size_t cap = manager->index_capacity;
+    size_t h = req_index_hash(req_id, cap);
+    for (size_t i = 0; i < cap; i++) {
+        size_t slot = (h + i) % cap;
+        if (manager->index[slot].req_id == REQ_INDEX_EMPTY) return (size_t)-1;
+        if (manager->index[slot].req_id == req_id) return manager->index[slot].slot;
+    }
+    return (size_t)-1;
+}
+
+static inline void req_index_insert(LocalHashManager* manager, uint64_t req_id, size_t slot) {
+    size_t cap = manager->index_capacity;
+    size_t h = req_index_hash(req_id, cap);
+    for (size_t i = 0; i < cap; i++) {
+        size_t idx = (h + i) % cap;
+        if (manager->index[idx].req_id == REQ_INDEX_EMPTY) {
+            manager->index[idx].req_id = req_id;
+            manager->index[idx].slot = slot;
+            return;
+        }
+    }
+}
+
+static inline void req_index_remove(LocalHashManager* manager, uint64_t req_id) {
+    size_t cap = manager->index_capacity;
+    size_t h = req_index_hash(req_id, cap);
+    for (size_t i = 0; i < cap; i++) {
+        size_t idx = (h + i) % cap;
+        if (manager->index[idx].req_id == REQ_INDEX_EMPTY) return;
+        if (manager->index[idx].req_id == req_id) {
+            manager->index[idx].req_id = REQ_INDEX_EMPTY;
+            size_t next = (idx + 1) % cap;
+            while (manager->index[next].req_id != REQ_INDEX_EMPTY) {
+                size_t natural = req_index_hash(manager->index[next].req_id, cap);
+                int needs_move;
+                if (idx < next) needs_move = (natural <= idx || natural > next);
+                else needs_move = (natural <= idx && natural > next);
+                if (needs_move) {
+                    manager->index[idx] = manager->index[next];
+                    manager->index[next].req_id = REQ_INDEX_EMPTY;
+                    idx = next;
+                }
+                next = (next + 1) % cap;
+            }
+            return;
+        }
+    }
+}
+
+static void req_index_rebuild(LocalHashManager* manager) {
+    size_t cap = manager->index_capacity;
+    for (size_t i = 0; i < cap; i++) manager->index[i].req_id = REQ_INDEX_EMPTY;
+    for (size_t i = 0; i < manager->count; i++) {
+        if (manager->hashes[i]) req_index_insert(manager, manager->hashes[i]->req_id, i);
+    }
+}
+
+LocalHash* local_hash_manager_get_or_create(LocalHashManager* manager, uint64_t req_id) {
+    if (!manager) return NULL;
+    size_t found = req_index_find(manager, req_id);
+    if (found != (size_t)-1) {
+        manager->hashes[found]->last_access = ++manager->access_counter;
+        return manager->hashes[found];
+    }
+    if (manager->count >= manager->capacity)
+        local_hash_manager_cleanup(manager, manager->capacity * 3 / 4);
+    LocalHash* local = local_hash_create(req_id, manager->local_capacity,
+                                         manager->unigram_capacity,
+                                         manager->unigram_threshold,
+                                         manager->gen_capacity);
+    if (!local) return NULL;
+    local->last_access = ++manager->access_counter;
+    size_t slot = manager->count;
+    manager->hashes[slot] = local;
+    manager->count++;
+    req_index_insert(manager, req_id, slot);
+    return local;
+}
+
+// Space-Saving Top-2 查询（带 gram 级别阈值）
+int local_hash_query_with_level(const LocalHash* local, uint64_t ngram_hash, uint8_t level, uint32_t* out_next_token) {
+    if (!local || !local->entries) return 0;
+    uint32_t sig = make_ngram_sig(ngram_hash);
+    uint32_t h = hot_tier_hash(ngram_hash, local->capacity);
+    __builtin_prefetch(&local->entries[h], 0, 3);
+    for (uint32_t i = 0; i < 8; i++) {
+        uint32_t slot = hot_tier_probe(h, i, local->capacity);
+        const NgramEntry* entry = &local->entries[slot];
+        if (ngram_entry_is_empty(entry)) return 0;
+        if (entry->signature == sig) {
+            if (entry->count1 == 0) return 0;
+            uint16_t total = entry->count1 + entry->count2;
+            uint16_t thresh = ngram_threshold_for_level(level);
+            // 整数比较避免浮点：count1 * 100 >= total * thresh
+            if ((uint32_t)entry->count1 * 100 >= (uint32_t)total * thresh) {
+                *out_next_token = entry->token1;
+                return 1;
+            }
+            return 0;
+        }
+    }
+    return 0;
+}
+
+// 向后兼容：默认使用 level=0（使用默认阈值）
+int local_hash_query(const LocalHash* local, uint64_t ngram_hash, uint32_t* out_next_token) {
+    return local_hash_query_with_level(local, ngram_hash, 0, out_next_token);
+}
+
+int local_hash_query_unigram(const LocalHash* local, uint32_t key_token, uint32_t* out_next_token) {
+    if (!local || !local->unigram_entries || local->unigram_capacity == 0) return 0;
+    uint32_t h = unigram_hash(key_token, local->unigram_capacity);
+    for (uint32_t i = 0; i < 8; i++) {
+        uint32_t slot = unigram_probe(h, i, local->unigram_capacity);
+        const UnigramEntry* entry = &local->unigram_entries[slot];
+        if (entry->key_token == UNIGRAM_EMPTY_KEY) return 0;
+        if (entry->key_token == key_token) {
+            if (entry->total_count == 0) return 0;
+            float probability = (float)entry->max_count / (float)entry->total_count;
+            if (probability > local->unigram_threshold) {
+                *out_next_token = entry->max_token;
+                return 1;
+            }
+            return 0;
+        }
+    }
+    return 0;
+}
+
+// Space-Saving Misra-Gries 更新
+int local_hash_update(LocalHash* local, uint64_t ngram_hash, uint32_t next_token) {
+    if (!local || !local->entries) return -1;
+    uint32_t sig = make_ngram_sig(ngram_hash);
+    uint32_t h = hot_tier_hash(ngram_hash, local->capacity);
+    for (uint32_t i = 0; i < 8; i++) {
+        uint32_t slot = hot_tier_probe(h, i, local->capacity);
+        NgramEntry* entry = &local->entries[slot];
+        if (ngram_entry_is_empty(entry)) {
+            // 新条目
+            entry->signature = sig;
+            entry->token1 = next_token;
+            entry->token2 = 0;
+            entry->count1 = 1;
+            entry->count2 = 0;
+            local->count++;
+            local->generation_count++;
+            return 0;
+        }
+        if (entry->signature == sig) {
+            // 已存在的条目，Space-Saving 更新
+            if (next_token == entry->token1) {
+                // 命中 token1
+                if (entry->count1 < 65535) entry->count1++;
+            } else if (next_token == entry->token2) {
+                // 命中 token2
+                if (entry->count2 < 65535) entry->count2++;
+                // 如果 token2 超过 token1，交换
+                if (entry->count2 > entry->count1) {
+                    uint32_t tt = entry->token1; entry->token1 = entry->token2; entry->token2 = tt;
+                    uint16_t tc = entry->count1; entry->count1 = entry->count2; entry->count2 = tc;
+                }
+            } else {
+                // 第三个 token，Misra-Gries 衰减
+                if (entry->count2 > 0) {
+                    entry->count2--;
+                    if (entry->count1 > 0) entry->count1--;
+                } else {
+                    // count2 已经是 0，替换 token2
+                    entry->token2 = next_token;
+                    entry->count2 = 1;
+                }
+            }
+            return 0;
+        }
+    }
+    return -1;
+}
+
+void local_hash_update_unigram(LocalHash* local, uint32_t key_token, uint32_t next_token) {
+    if (!local || !local->unigram_entries || local->unigram_capacity == 0) return;
+    uint32_t h = unigram_hash(key_token, local->unigram_capacity);
+    for (uint32_t i = 0; i < local->unigram_capacity; i++) {
+        uint32_t slot = unigram_probe(h, i, local->unigram_capacity);
+        UnigramEntry* entry = &local->unigram_entries[slot];
+        if (entry->key_token == UNIGRAM_EMPTY_KEY) {
+            entry->key_token = key_token;
+            entry->max_count = 0;
+            entry->total_count = 0;
+            local->unigram_count++;
+        }
+        if (entry->key_token == key_token) {
+            for (uint16_t j = 0; j < entry->token_count; j++) {
+                if (entry->tokens[j].token == next_token) {
+                    entry->tokens[j].count++;
+                    entry->total_count++;
+                    if (entry->tokens[j].count > entry->max_count) {
+                        entry->max_count = entry->tokens[j].count;
+                        entry->max_token = next_token;
+                    }
+                    return;
+                }
+            }
+            if (entry->token_count >= entry->capacity) {
+                uint16_t new_cap = entry->capacity == 0 ? INITIAL_TOKEN_CAPACITY : entry->capacity * 2;
+                UnigramTokenEntry* new_tokens = realloc(entry->tokens, new_cap * sizeof(UnigramTokenEntry));
+                if (!new_tokens) return;
+                entry->tokens = new_tokens;
+                entry->capacity = new_cap;
+            }
+            entry->tokens[entry->token_count].token = next_token;
+            entry->tokens[entry->token_count].count = 1;
+            entry->token_count++;
+            entry->total_count++;
+            if (entry->max_count == 0) { entry->max_count = 1; entry->max_token = next_token; }
+            return;
+        }
+    }
+}
+
+int local_hash_can_generate(const LocalHash* local) {
+    if (!local) return 0;
+    return local->generation_count < local->capacity;
+}
+void local_hash_reset_history(LocalHash* local) {
+    if (!local) return;
+    local->history_len = 0;
+    memset(local->history, 0, sizeof(local->history));
+}
+void local_hash_set_history(LocalHash* local, const uint32_t* tokens, uint8_t len, uint8_t max_window) {
+    if (!local || !tokens) return;
+    uint8_t copy_len = len;
+    const uint32_t* src = tokens;
+    if (len > max_window) { copy_len = max_window; src = tokens + (len - max_window); }
+    memcpy(local->history, src, copy_len * sizeof(uint32_t));
+    local->history_len = copy_len;
+}
+const uint32_t* local_hash_get_history(const LocalHash* local, uint8_t* out_len) {
+    if (!local) { if (out_len) *out_len = 0; return NULL; }
+    if (out_len) *out_len = local->history_len;
+    return local->history;
+}
+
+// 泛化层查询：Space-Saving Top-2 带级别阈值
+int local_hash_query_generalized_with_level(const LocalHash* local, uint64_t gen_hash, uint8_t level, uint32_t* out_next_token) {
+    if (!local || !local->gen_entries || local->gen_capacity == 0) return 0;
+    uint32_t sig = make_ngram_sig(gen_hash);
+    uint32_t h = hot_tier_hash(gen_hash, local->gen_capacity);
+    __builtin_prefetch(&local->gen_entries[h], 0, 3);
+    for (uint32_t i = 0; i < 8; i++) {
+        uint32_t slot = hot_tier_probe(h, i, local->gen_capacity);
+        const NgramEntry* entry = &local->gen_entries[slot];
+        if (ngram_entry_is_empty(entry)) return 0;
+        if (entry->signature == sig) {
+            if (entry->count1 == 0) return 0;
+            uint16_t total = entry->count1 + entry->count2;
+            uint16_t thresh = ngram_threshold_for_level(level);
+            if ((uint32_t)entry->count1 * 100 >= (uint32_t)total * thresh) {
+                *out_next_token = entry->token1;
+                return 1;
+            }
+            return 0;
+        }
+    }
+    return 0;
+}
+
+// 向后兼容
+int local_hash_query_generalized(const LocalHash* local, uint64_t gen_hash, uint32_t* out_next_token) {
+    return local_hash_query_generalized_with_level(local, gen_hash, 0, out_next_token);
+}
+
+// 泛化层更新：Space-Saving Misra-Gries
+int local_hash_update_generalized(LocalHash* local, uint64_t gen_hash, uint32_t next_token) {
+    if (!local || !local->gen_entries || local->gen_capacity == 0) return -1;
+    uint32_t sig = make_ngram_sig(gen_hash);
+    uint32_t h = hot_tier_hash(gen_hash, local->gen_capacity);
+    for (uint32_t i = 0; i < 8; i++) {
+        uint32_t slot = hot_tier_probe(h, i, local->gen_capacity);
+        NgramEntry* entry = &local->gen_entries[slot];
+        if (ngram_entry_is_empty(entry)) {
+            entry->signature = sig;
+            entry->token1 = next_token;
+            entry->token2 = 0;
+            entry->count1 = 1;
+            entry->count2 = 0;
+            local->gen_count++;
+            return 0;
+        }
+        if (entry->signature == sig) {
+            if (next_token == entry->token1) {
+                if (entry->count1 < 65535) entry->count1++;
+            } else if (next_token == entry->token2) {
+                if (entry->count2 < 65535) entry->count2++;
+                if (entry->count2 > entry->count1) {
+                    uint32_t tt = entry->token1; entry->token1 = entry->token2; entry->token2 = tt;
+                    uint16_t tc = entry->count1; entry->count1 = entry->count2; entry->count2 = tc;
+                }
+            } else {
+                if (entry->count2 > 0) {
+                    entry->count2--;
+                    if (entry->count1 > 0) entry->count1--;
+                } else {
+                    entry->token2 = next_token;
+                    entry->count2 = 1;
+                }
+            }
+            return 0;
+        }
+    }
+    return -1;
+}
+
+void local_hash_manager_cleanup(LocalHashManager* manager, size_t keep_count) {
+    if (!manager || manager->count <= keep_count) return;
+    for (size_t i = 0; i < manager->count - 1; i++)
+        for (size_t j = 0; j < manager->count - i - 1; j++)
+            if (manager->hashes[j]->last_access < manager->hashes[j + 1]->last_access) {
+                LocalHash* temp = manager->hashes[j];
+                manager->hashes[j] = manager->hashes[j + 1];
+                manager->hashes[j + 1] = temp;
+            }
+    for (size_t i = keep_count; i < manager->count; i++) {
+        local_hash_free(manager->hashes[i]);
+        manager->hashes[i] = NULL;
+    }
+    manager->count = keep_count;
+    req_index_rebuild(manager);
+}
+
+void local_hash_manager_free(LocalHashManager* manager) {
+    if (!manager) return;
+    for (size_t i = 0; i < manager->count; i++) local_hash_free(manager->hashes[i]);
+    free(manager->hashes);
+    free(manager->index);
+    free(manager);
+}
+
+LocalHashStats local_hash_manager_stats(const LocalHashManager* manager) {
+    LocalHashStats stats = {0};
+    if (!manager) return stats;
+    stats.total_hashes = manager->count;
+    for (size_t i = 0; i < manager->count; i++) {
+        if (manager->hashes[i]) {
+            LocalHash* local = manager->hashes[i];
+            stats.total_entries += local->count;
+            stats.total_unigram += local->unigram_count;
+            stats.total_gen_entries += local->gen_count;
+            stats.memory_bytes += local->capacity * sizeof(NgramEntry);
+            stats.memory_bytes += local->gen_capacity * sizeof(NgramEntry);
+            stats.memory_bytes += local->unigram_capacity * sizeof(UnigramEntry);
+            for (size_t j = 0; j < local->unigram_capacity; j++) {
+                if (local->unigram_entries && local->unigram_entries[j].key_token != UNIGRAM_EMPTY_KEY)
+                    stats.memory_bytes += local->unigram_entries[j].capacity * sizeof(UnigramTokenEntry);
+            }
+        }
+    }
+    stats.memory_bytes += sizeof(LocalHashManager) + manager->capacity * sizeof(LocalHash*);
+    return stats;
+}

--- a/csrc/zipf_cache/src/local_hash.c
+++ b/csrc/zipf_cache/src/local_hash.c
@@ -444,15 +444,16 @@ int local_hash_update_generalized(LocalHash* local, uint64_t gen_hash, uint32_t 
     return -1;
 }
 
+static int compare_local_hash_last_access(const void* a, const void* b) {
+    const LocalHash* access_a = *(const LocalHash* const*)a;
+    const LocalHash* access_b = *(const LocalHash* const*)b;
+    return (access_a->last_access < access_b->last_access) -
+           (access_a->last_access > access_b->last_access);
+}
+
 void local_hash_manager_cleanup(LocalHashManager* manager, size_t keep_count) {
     if (!manager || manager->count <= keep_count) return;
-    for (size_t i = 0; i < manager->count - 1; i++)
-        for (size_t j = 0; j < manager->count - i - 1; j++)
-            if (manager->hashes[j]->last_access < manager->hashes[j + 1]->last_access) {
-                LocalHash* temp = manager->hashes[j];
-                manager->hashes[j] = manager->hashes[j + 1];
-                manager->hashes[j + 1] = temp;
-            }
+    qsort(manager->hashes, manager->count, sizeof(LocalHash*), compare_local_hash_last_access);
     for (size_t i = keep_count; i < manager->count; i++) {
         local_hash_free(manager->hashes[i]);
         manager->hashes[i] = NULL;

--- a/csrc/zipf_cache/src/pybind_zipf_cache.cpp
+++ b/csrc/zipf_cache/src/pybind_zipf_cache.cpp
@@ -1,0 +1,587 @@
+/**
+ * pybind11 bindings for ZipfCache
+ *
+ * High-performance Python bindings with minimal overhead.
+ * Uses opaque pointer to avoid C/C++ atomic compatibility issues.
+ *
+ * 硬编码参数（不再暴露给 Python）：
+ * - global_capacity = 33554432 (已移除 global_hash)
+ * - shared_capacity = 8388608
+ * - local_capacity = 40000
+ * - max_local_hashes = 10000
+ * - unigram_capacity = 131072
+ * - unigram_threshold = 0.75
+ * - enable_unigram = true
+ * - init_score = 28800, decay_same = 0/8, decay_diff = 0/3
+ *
+ * 可配置参数：
+ * - min_window, max_window
+ * - skip_shared
+ * - enable_generalized, gen_freq_threshold, gen_capacity, gen_bitmap_vocab_max, gen_min_score
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <vector>
+#include <optional>
+#include <stdexcept>
+#include <cstdint>
+#include <memory>
+
+// Forward declare C types as opaque
+struct ZipfCache;
+struct ZipfConfig;
+struct ZipfKey;
+struct QueryResult;
+struct ZipfCacheStats;
+struct LocalHashStats;
+struct GeneralizerStats;
+
+// C API declarations
+extern "C" {
+
+struct ZipfConfig {
+    uint8_t min_window;
+    uint8_t max_window;
+    uint8_t skip_shared;
+    uint8_t enable_generalized;
+    uint32_t gen_freq_threshold;
+    size_t gen_capacity;
+    uint32_t gen_bitmap_vocab_max;
+    uint8_t generalized_before_shared;
+};
+
+struct ZipfKey {
+    uint32_t tokens[8];  // MAX_NGRAM_ORDER = 8
+    uint8_t length;
+};
+
+struct QueryResult {
+    uint32_t next_token;
+    uint8_t hit;
+    uint8_t from_local;
+};
+
+struct LocalHashStats {
+    size_t total_hashes;
+    size_t total_entries;
+    size_t total_unigram;
+    size_t total_gen_entries;
+    size_t memory_bytes;
+};
+
+struct GeneralizerStats {
+    size_t capacity;
+    size_t count;
+    uint32_t freq_threshold;
+    uint32_t total_updates;
+    size_t high_freq_count;
+    size_t num_wildcard_buckets;
+    size_t memory_bytes;
+};
+
+struct ZipfCacheStats {
+    uint64_t query_count;
+    uint64_t shared_hit_count;
+    uint64_t local_hit_count;
+    uint64_t unigram_hit_count;
+    uint64_t generalized_hit_count;
+    double shared_hit_rate;
+    double local_hit_rate;
+    double unigram_hit_rate;
+    double generalized_hit_rate;
+    double total_hit_rate;
+    uint64_t update_count;
+    LocalHashStats local_stats;
+    size_t shared_entries;
+    size_t shared_unigram;
+    GeneralizerStats gen_stats;
+};
+
+ZipfCache* zipf_cache_create(const ZipfConfig* config);
+void zipf_cache_free(ZipfCache* cache);
+void zipf_cache_query_batch_with_req(ZipfCache* cache, const uint64_t* req_ids, const ZipfKey* keys, QueryResult* results, size_t batch_size);
+void zipf_cache_update_with_req(ZipfCache* cache, uint64_t req_id, const uint32_t* context_tokens, uint8_t context_len, uint32_t next_token);
+void zipf_cache_update_with_history(ZipfCache* cache, uint64_t req_id, const uint32_t* new_tokens, size_t new_token_count);
+void zipf_cache_update_with_history_batch(ZipfCache* cache, const uint64_t* req_ids, const uint32_t* flat_tokens, const size_t* offsets, const size_t* token_counts, size_t batch_size);
+void zipf_cache_set_history(ZipfCache* cache, uint64_t req_id, const uint32_t* tokens, size_t token_count);
+void zipf_cache_warmup_from_prompt(ZipfCache* cache, uint64_t req_id, const uint32_t* prompt_tokens, size_t prompt_len);
+void zipf_cache_reset_context(ZipfCache* cache, uint64_t req_id);
+void zipf_cache_update_batch_with_req(ZipfCache* cache, const uint64_t* req_ids, const ZipfKey* contexts, const uint32_t* next_tokens, size_t batch_size);
+ZipfCacheStats zipf_cache_stats(const ZipfCache* cache);
+int zipf_cache_speculate_chain_with_req(ZipfCache* cache, uint64_t req_id, const uint32_t* context, uint8_t context_len, uint32_t* out_tokens, int max_tokens);
+void zipf_cache_speculate_chain_batch_with_req(ZipfCache* cache, const uint64_t* req_ids, const ZipfKey* contexts, uint32_t* out_tokens, int* out_counts, size_t batch_size, int max_tokens);
+uint64_t zipf_hash(const uint32_t* tokens, uint8_t length);
+
+// Propose API
+struct AdaptiveKConfig {
+    float ema_alpha;
+    int num_speculative_tokens;
+    float fail_threshold;
+    float success_threshold;
+    int max_penalty;
+    int max_bonus;
+    int min_k;
+    int max_k;
+};
+
+struct ProposeRequest {
+    uint64_t req_hash;
+    const uint32_t* token_ids;
+    int num_tokens;
+    int num_prompt_tokens;
+    const uint32_t* sampled_ids;
+    int num_sampled;
+    int max_model_len;
+    uint8_t is_valid;
+};
+
+struct ProposeResult {
+    uint32_t* draft_tokens;
+    int num_draft_tokens;
+};
+
+void zipf_cache_propose_batch(
+    ZipfCache* cache,
+    const ProposeRequest* requests,
+    ProposeResult* results,
+    size_t batch_size,
+    const AdaptiveKConfig* ak_config
+);
+
+}
+
+namespace py = pybind11;
+
+class PyZipfCache {
+public:
+    PyZipfCache(
+        // 可配置参数
+        uint8_t min_window = 2,
+        uint8_t max_window = 4,
+        bool skip_shared = false,
+        // Generalized parameters
+        bool enable_generalized = true,
+        uint32_t gen_freq_threshold = 8,
+        size_t gen_capacity = 64 * 1024,
+        uint32_t gen_bitmap_vocab_max = 256 * 1024,
+        // Query priority
+        bool generalized_before_shared = true
+    ) {
+        ZipfConfig config{};
+        config.min_window = min_window;
+        config.max_window = max_window;
+        config.skip_shared = skip_shared ? 1 : 0;
+        config.enable_generalized = enable_generalized ? 1 : 0;
+        config.gen_freq_threshold = gen_freq_threshold;
+        config.gen_capacity = gen_capacity;
+        config.gen_bitmap_vocab_max = gen_bitmap_vocab_max;
+        config.generalized_before_shared = generalized_before_shared ? 1 : 0;
+
+        cache_ = zipf_cache_create(&config);
+        if (!cache_) {
+            throw std::runtime_error("Failed to create ZipfCache");
+        }
+        max_window_ = max_window;
+    }
+
+    ~PyZipfCache() {
+        if (cache_) {
+            zipf_cache_free(cache_);
+        }
+    }
+
+    // Disable copy
+    PyZipfCache(const PyZipfCache&) = delete;
+    PyZipfCache& operator=(const PyZipfCache&) = delete;
+
+    // Move constructor
+    PyZipfCache(PyZipfCache&& other) noexcept : cache_(other.cache_), max_window_(other.max_window_) {
+        other.cache_ = nullptr;
+    }
+    PyZipfCache& operator=(PyZipfCache&& other) noexcept {
+        if (this != &other) {
+            if (cache_) zipf_cache_free(cache_);
+            cache_ = other.cache_;
+            max_window_ = other.max_window_;
+            other.cache_ = nullptr;
+        }
+        return *this;
+    }
+
+private:
+    PyZipfCache(ZipfCache* cache, uint8_t max_window = 4) : cache_(cache), max_window_(max_window) {}
+
+public:
+    // Query with req_id (local + shared hash)
+    std::optional<uint32_t> query_with_req(uint64_t req_id, const std::vector<uint32_t>& context) {
+        if (context.empty() || context.size() > max_window_) return std::nullopt;
+        ZipfKey key;
+        key.length = context.size();
+        for (size_t i = 0; i < context.size(); i++) key.tokens[i] = context[i];
+        QueryResult result;
+        zipf_cache_query_batch_with_req(cache_, &req_id, &key, &result, 1);
+        if (result.hit) return result.next_token;
+        return std::nullopt;
+    }
+
+    // Batch query with req_ids
+    std::vector<std::optional<uint32_t>> query_batch_with_req(
+        const std::vector<uint64_t>& req_ids,
+        const std::vector<std::vector<uint32_t>>& contexts
+    ) {
+        size_t n = contexts.size();
+        std::vector<std::optional<uint32_t>> results(n);
+        if (n == 0) return results;
+        if (n != req_ids.size()) throw std::invalid_argument("req_ids and contexts must have same length");
+        std::vector<ZipfKey> keys(n);
+        std::vector<QueryResult> query_results(n);
+        for (size_t i = 0; i < n; i++) {
+            const auto& ctx = contexts[i];
+            size_t len = std::min(ctx.size(), size_t(max_window_));
+            keys[i].length = len;
+            for (size_t j = 0; j < len; j++) keys[i].tokens[j] = ctx[ctx.size() - len + j];
+        }
+        zipf_cache_query_batch_with_req(cache_, req_ids.data(), keys.data(), query_results.data(), n);
+        for (size_t i = 0; i < n; i++) {
+            if (query_results[i].hit) results[i] = query_results[i].next_token;
+        }
+        return results;
+    }
+
+    // Update with req_id (legacy API)
+    void update_with_req(uint64_t req_id, const std::vector<uint32_t>& context, uint32_t next_token) {
+        if (context.empty()) return;
+        size_t len = std::min(context.size(), size_t(max_window_));
+        const uint32_t* ptr = context.data() + context.size() - len;
+        zipf_cache_update_with_req(cache_, req_id, ptr, len, next_token);
+    }
+
+    void update_with_history(uint64_t req_id, const std::vector<uint32_t>& new_tokens) {
+        if (new_tokens.empty()) return;
+        zipf_cache_update_with_history(cache_, req_id, new_tokens.data(), new_tokens.size());
+    }
+
+    void update_with_history_batch(
+        const std::vector<uint64_t>& req_ids,
+        const std::vector<std::vector<uint32_t>>& token_arrays
+    ) {
+        size_t n = req_ids.size();
+        if (n == 0 || n != token_arrays.size()) return;
+        size_t total_tokens = 0;
+        std::vector<size_t> offsets(n);
+        std::vector<size_t> counts(n);
+        for (size_t i = 0; i < n; i++) {
+            offsets[i] = total_tokens;
+            counts[i] = token_arrays[i].size();
+            total_tokens += counts[i];
+        }
+        std::vector<uint32_t> flat(total_tokens);
+        for (size_t i = 0; i < n; i++) {
+            if (counts[i] > 0) {
+                std::memcpy(&flat[offsets[i]], token_arrays[i].data(), counts[i] * sizeof(uint32_t));
+            }
+        }
+        zipf_cache_update_with_history_batch(cache_, req_ids.data(), flat.data(), offsets.data(), counts.data(), n);
+    }
+
+    void set_history(uint64_t req_id, const std::vector<uint32_t>& tokens) {
+        if (tokens.empty()) return;
+        zipf_cache_set_history(cache_, req_id, tokens.data(), tokens.size());
+    }
+
+    void warmup_from_prompt(uint64_t req_id, const std::vector<uint32_t>& prompt_tokens) {
+        if (prompt_tokens.empty()) return;
+        zipf_cache_warmup_from_prompt(cache_, req_id, prompt_tokens.data(), prompt_tokens.size());
+    }
+
+    void reset_context(uint64_t req_id) {
+        zipf_cache_reset_context(cache_, req_id);
+    }
+
+    void update_batch_with_req(
+        const std::vector<uint64_t>& req_ids,
+        const std::vector<std::vector<uint32_t>>& contexts,
+        const std::vector<uint32_t>& next_tokens
+    ) {
+        size_t n = contexts.size();
+        if (n == 0) return;
+        if (n != next_tokens.size() || n != req_ids.size()) {
+            throw std::invalid_argument("req_ids, contexts and next_tokens must have same length");
+        }
+        std::vector<ZipfKey> keys(n);
+        for (size_t i = 0; i < n; i++) {
+            const auto& ctx = contexts[i];
+            size_t len = std::min(ctx.size(), size_t(max_window_));
+            keys[i].length = len;
+            for (size_t j = 0; j < len; j++) keys[i].tokens[j] = ctx[ctx.size() - len + j];
+        }
+        zipf_cache_update_batch_with_req(cache_, req_ids.data(), keys.data(), next_tokens.data(), n);
+    }
+
+    // Chain speculation with req_id
+    std::vector<uint32_t> speculate_chain_with_req(
+        uint64_t req_id,
+        const std::vector<uint32_t>& context,
+        int max_tokens
+    ) {
+        if (context.empty() || max_tokens <= 0) return {};
+        size_t len = std::min(context.size(), size_t(max_window_));
+        const uint32_t* ptr = context.data() + context.size() - len;
+        std::vector<uint32_t> out(max_tokens);
+        int count = zipf_cache_speculate_chain_with_req(cache_, req_id, ptr, len, out.data(), max_tokens);
+        out.resize(count);
+        return out;
+    }
+
+    // Batch chain speculation with req_ids
+    std::vector<std::vector<uint32_t>> speculate_chain_batch_with_req(
+        const std::vector<uint64_t>& req_ids,
+        const std::vector<std::vector<uint32_t>>& contexts,
+        int max_tokens
+    ) {
+        size_t n = contexts.size();
+        if (n == 0 || max_tokens <= 0) return std::vector<std::vector<uint32_t>>(n);
+        if (n != req_ids.size()) throw std::invalid_argument("req_ids and contexts must have same length");
+        std::vector<ZipfKey> keys(n);
+        for (size_t i = 0; i < n; i++) {
+            const auto& ctx = contexts[i];
+            size_t len = std::min(ctx.size(), size_t(max_window_));
+            keys[i].length = len;
+            for (size_t j = 0; j < len; j++) keys[i].tokens[j] = ctx[ctx.size() - len + j];
+        }
+        std::vector<uint32_t> out_tokens(n * max_tokens);
+        std::vector<int> out_counts(n);
+        zipf_cache_speculate_chain_batch_with_req(cache_, req_ids.data(), keys.data(), out_tokens.data(), out_counts.data(), n, max_tokens);
+        std::vector<std::vector<uint32_t>> results(n);
+        for (size_t i = 0; i < n; i++) {
+            int count = out_counts[i];
+            results[i].resize(count);
+            for (int j = 0; j < count; j++) results[i][j] = out_tokens[i * max_tokens + j];
+        }
+        return results;
+    }
+
+    // Get statistics
+    py::dict stats() {
+        ZipfCacheStats s = zipf_cache_stats(cache_);
+        return py::dict(
+            py::arg("query_count") = s.query_count,
+            py::arg("shared_hit_count") = s.shared_hit_count,
+            py::arg("local_hit_count") = s.local_hit_count,
+            py::arg("unigram_hit_count") = s.unigram_hit_count,
+            py::arg("generalized_hit_count") = s.generalized_hit_count,
+            py::arg("total_hit_rate") = s.total_hit_rate,
+            py::arg("shared_hit_rate") = s.shared_hit_rate,
+            py::arg("local_hit_rate") = s.local_hit_rate,
+            py::arg("unigram_hit_rate") = s.unigram_hit_rate,
+            py::arg("generalized_hit_rate") = s.generalized_hit_rate,
+            py::arg("update_count") = s.update_count,
+            py::arg("shared_entries") = s.shared_entries,
+            py::arg("shared_unigram") = s.shared_unigram,
+            py::arg("local_hashes") = s.local_stats.total_hashes,
+            py::arg("local_entries") = s.local_stats.total_entries,
+            py::arg("local_unigram") = s.local_stats.total_unigram,
+            py::arg("local_gen_entries") = s.local_stats.total_gen_entries,
+            py::arg("local_memory_mb") = s.local_stats.memory_bytes / (1024.0 * 1024.0),
+            py::arg("gen_unique_tokens") = s.gen_stats.count,
+            py::arg("gen_high_freq_count") = s.gen_stats.high_freq_count,
+            py::arg("gen_freq_threshold") = s.gen_stats.freq_threshold,
+            py::arg("gen_memory_mb") = s.gen_stats.memory_bytes / (1024.0 * 1024.0),
+            py::arg("gen_wildcard_buckets") = s.gen_stats.num_wildcard_buckets
+        );
+    }
+
+    /**
+     * propose_batch - 完整的 propose 逻辑下沉到 C 层
+     *
+     * 参数：
+     *   req_hashes:        list[int]          请求 hash 列表
+     *   token_ids_rows:    list[numpy.ndarray] 每个请求的 token_ids（int32 numpy array）
+     *   num_tokens_list:   list[int]          每个请求的当前 token 数
+     *   num_prompt_list:   list[int]          每个请求的 prompt token 数
+     *   sampled_token_ids: list[list[int]]    每个请求上一轮验证通过的 token
+     *   valid_mask:        list[bool]         每个请求是否参与推测
+     *   max_model_len:     int                模型最大长度
+     *   num_spec_tokens:   int                初始推测 token 数
+     *   ema_alpha:         float              EMA 平滑系数
+     *   max_spec_tokens:   int                最大推测 token 数
+     *
+     * 返回：list[list[int]]  每个请求的 draft token 列表
+     */
+    std::vector<std::vector<uint32_t>> propose_batch(
+        const std::vector<uint64_t>& req_hashes,
+        // token_ids_rows: 每个请求的完整 token 序列（numpy int32 array）
+        const std::vector<py::array_t<int32_t>>& token_ids_rows,
+        const std::vector<int>& num_tokens_list,
+        const std::vector<int>& num_prompt_list,
+        const std::vector<std::vector<uint32_t>>& sampled_token_ids,
+        const std::vector<bool>& valid_mask,
+        int max_model_len,
+        int num_spec_tokens,
+        float ema_alpha,
+        int max_spec_tokens = 128
+    ) {
+        size_t n = req_hashes.size();
+        std::vector<std::vector<uint32_t>> results(n);
+        if (n == 0) return results;
+        if (max_spec_tokens < num_spec_tokens) {
+            throw std::invalid_argument(
+                "max_spec_tokens must be >= num_spec_tokens");
+        }
+
+        // 配置 adaptive-k
+        AdaptiveKConfig ak_config;
+        ak_config.ema_alpha = ema_alpha;
+        ak_config.num_speculative_tokens = num_spec_tokens;
+        ak_config.fail_threshold = 0.3f;
+        ak_config.success_threshold = 0.5f;
+        ak_config.max_penalty = 3;
+        ak_config.max_bonus = 3;
+        ak_config.min_k = 1;
+        ak_config.max_k = max_spec_tokens;
+
+        // 预分配 draft token 缓冲区
+        int max_draft = max_spec_tokens;
+        std::vector<uint32_t> draft_buf(n * max_draft, 0);
+
+        // 在 GIL 持有时提取所有 numpy 指针
+        std::vector<const uint32_t*> token_ptrs(n);
+        for (size_t i = 0; i < n; i++) {
+            token_ptrs[i] = reinterpret_cast<const uint32_t*>(
+                token_ids_rows[i].data());
+        }
+
+        // 构建请求和结果数组
+        std::vector<ProposeRequest> requests(n);
+        std::vector<ProposeResult> c_results(n);
+
+        for (size_t i = 0; i < n; i++) {
+            requests[i].req_hash = req_hashes[i];
+            requests[i].token_ids = token_ptrs[i];
+            requests[i].num_tokens = num_tokens_list[i];
+            requests[i].num_prompt_tokens = num_prompt_list[i];
+
+            if (!sampled_token_ids[i].empty()) {
+                requests[i].sampled_ids = sampled_token_ids[i].data();
+                requests[i].num_sampled = sampled_token_ids[i].size();
+            } else {
+                requests[i].sampled_ids = nullptr;
+                requests[i].num_sampled = 0;
+            }
+
+            requests[i].max_model_len = max_model_len;
+            requests[i].is_valid = valid_mask[i] ? 1 : 0;
+
+            c_results[i].draft_tokens = &draft_buf[i * max_draft];
+            c_results[i].num_draft_tokens = 0;
+        }
+
+        // 释放 GIL 调用 C 层
+        {
+            py::gil_scoped_release release;
+            zipf_cache_propose_batch(
+                cache_, requests.data(), c_results.data(), n, &ak_config);
+        }
+
+        // 转换结果
+        for (size_t i = 0; i < n; i++) {
+            int count = c_results[i].num_draft_tokens;
+            if (count > 0) {
+                results[i].assign(
+                    c_results[i].draft_tokens,
+                    c_results[i].draft_tokens + count);
+            }
+        }
+        return results;
+    }
+
+private:
+    ZipfCache* cache_ = nullptr;
+    uint8_t max_window_ = 4;
+};
+
+
+PYBIND11_MODULE(_zipf_cache_cpp, m) {
+    m.doc() = "High-performance ZipfCache with pybind11 bindings (simplified, no global hash)";
+
+    m.def("zipf_hash", [](const std::vector<uint32_t>& tokens) -> uint64_t {
+        if (tokens.empty() || tokens.size() > 8) {
+            throw std::invalid_argument("tokens must have 1-8 elements");
+        }
+        return zipf_hash(tokens.data(), tokens.size());
+    }, py::arg("tokens"), "Compute hash for n-gram tokens");
+
+    py::class_<PyZipfCache>(m, "ZipfCache")
+        .def(py::init<uint8_t, uint8_t, bool, bool, uint32_t, size_t, uint32_t, bool>(),
+             py::arg("min_window") = 2,
+             py::arg("max_window") = 4,
+             py::arg("skip_shared") = false,
+             py::arg("enable_generalized") = true,
+             py::arg("gen_freq_threshold") = 8,
+             py::arg("gen_capacity") = 64 * 1024,
+             py::arg("gen_bitmap_vocab_max") = 256 * 1024,
+             py::arg("generalized_before_shared") = true,
+             "Create a new ZipfCache.\n\n"
+             "Hardcoded params: shared_capacity=8M, local_capacity=40K, max_local_hashes=10K,\n"
+             "unigram_capacity=128K, unigram_threshold=0.75.\n"
+             "Chain length control is delegated to Python-layer adaptive-k.\n"
+             "C layer uses pure hit-driven speculation: hit → continue, miss → stop.\n\n"
+             "Configurable:\n"
+             "- min_window/max_window: n-gram window range\n"
+             "- skip_shared: skip shared hash queries/updates\n"
+             "- Generalized layer parameters\n"
+             "- generalized_before_shared: query priority (true=local→gen→shared, false=local→shared→gen)")
+        .def("query_with_req", &PyZipfCache::query_with_req,
+             py::arg("req_id"), py::arg("context"),
+             "Query for next token prediction with req_id (local + shared hash)")
+        .def("query_batch_with_req", &PyZipfCache::query_batch_with_req,
+             py::arg("req_ids"), py::arg("contexts"),
+             "Batch query with req_ids (local + shared hash)")
+        .def("update_with_req", &PyZipfCache::update_with_req,
+             py::arg("req_id"), py::arg("context"), py::arg("next_token"),
+             "Update cache with observed token (legacy API)")
+        .def("update_with_history", &PyZipfCache::update_with_history,
+             py::arg("req_id"), py::arg("new_tokens"),
+             py::call_guard<py::gil_scoped_release>(),
+             "Update cache with new tokens using history window (GIL released)")
+        .def("update_with_history_batch", &PyZipfCache::update_with_history_batch,
+             py::arg("req_ids"), py::arg("token_arrays"),
+             py::call_guard<py::gil_scoped_release>(),
+             "Batch update with history window (GIL released)")
+        .def("set_history", &PyZipfCache::set_history,
+             py::arg("req_id"), py::arg("tokens"),
+             "Set history window for a request")
+        .def("warmup_from_prompt", &PyZipfCache::warmup_from_prompt,
+             py::arg("req_id"), py::arg("prompt_tokens"),
+             py::call_guard<py::gil_scoped_release>(),
+             "Scan prompt and pre-fill local hash (GIL released)")
+        .def("reset_context", &PyZipfCache::reset_context,
+             py::arg("req_id"),
+             "Reset history window")
+        .def("update_batch_with_req", &PyZipfCache::update_batch_with_req,
+             py::arg("req_ids"), py::arg("contexts"), py::arg("next_tokens"),
+             "Batch update with req_ids")
+        .def("speculate_chain_with_req", &PyZipfCache::speculate_chain_with_req,
+             py::arg("req_id"), py::arg("context"), py::arg("max_tokens"),
+             py::call_guard<py::gil_scoped_release>(),
+             "Chain speculation with req_id (GIL released)")
+        .def("speculate_chain_batch_with_req", &PyZipfCache::speculate_chain_batch_with_req,
+             py::arg("req_ids"), py::arg("contexts"), py::arg("max_tokens"),
+             "Batch chain speculation with req_ids")
+        .def("stats", &PyZipfCache::stats,
+             "Get cache statistics")
+        .def("propose_batch", &PyZipfCache::propose_batch,
+             py::arg("req_hashes"),
+             py::arg("token_ids_rows"),
+             py::arg("num_tokens_list"),
+             py::arg("num_prompt_list"),
+             py::arg("sampled_token_ids"),
+             py::arg("valid_mask"),
+             py::arg("max_model_len"),
+             py::arg("num_spec_tokens"),
+             py::arg("ema_alpha") = 0.3f,
+             py::arg("max_spec_tokens") = 128,
+             "Batch propose with full logic in C layer");
+}

--- a/csrc/zipf_cache/src/pybind_zipf_cache.cpp
+++ b/csrc/zipf_cache/src/pybind_zipf_cache.cpp
@@ -426,6 +426,12 @@ public:
         size_t n = req_hashes.size();
         std::vector<std::vector<uint32_t>> results(n);
         if (n == 0) return results;
+        if (token_ids_rows.size() != n || num_tokens_list.size() != n ||
+            num_prompt_list.size() != n || sampled_token_ids.size() != n ||
+            valid_mask.size() != n) {
+            throw std::invalid_argument(
+                "All input lists must have the same length as req_hashes");
+        }
         if (max_spec_tokens < num_spec_tokens) {
             throw std::invalid_argument(
                 "max_spec_tokens must be >= num_spec_tokens");

--- a/csrc/zipf_cache/src/token_generalizer.c
+++ b/csrc/zipf_cache/src/token_generalizer.c
@@ -1,0 +1,184 @@
+#include "token_generalizer.h"
+#include "cityhash.h"
+#include <stdio.h>
+
+// ============================================================
+// 内部哈希函数
+// ============================================================
+static inline uint32_t freq_hash(uint32_t token, size_t cap) {
+    return (token * 2654435761U) % cap;
+}
+
+static inline uint32_t freq_probe(uint32_t h, uint32_t i, size_t cap) {
+    return (h + i) % cap;
+}
+
+// ============================================================
+// 创建 / 释放
+// ============================================================
+
+TokenGeneralizer* token_generalizer_create(size_t capacity,
+                                           uint32_t freq_threshold,
+                                           uint32_t bitmap_vocab_max) {
+    TokenGeneralizer* gen = calloc(1, sizeof(TokenGeneralizer));
+    if (!gen) return NULL;
+
+    // 确保容量合理
+    if (capacity < 1024) capacity = 1024;
+
+    gen->entries = malloc(capacity * sizeof(FreqEntry));
+    if (!gen->entries) {
+        free(gen);
+        return NULL;
+    }
+
+    // 初始化所有槽为空
+    for (size_t i = 0; i < capacity; i++) {
+        gen->entries[i].token = GENERALIZER_EMPTY_KEY;
+        gen->entries[i].count = 0;
+        gen->entries[i].context_hash = 0;
+    }
+
+    gen->capacity = capacity;
+    gen->count = 0;
+    gen->freq_threshold = freq_threshold;
+    gen->total_updates = 0;
+
+    // 创建 bitmap（如果请求）
+    if (bitmap_vocab_max > 0) {
+        gen->bitmap_size = (bitmap_vocab_max + 8) / 8;
+        gen->high_freq_bitmap = calloc(gen->bitmap_size, 1);
+        gen->bitmap_vocab_max = bitmap_vocab_max;
+        // bitmap 分配失败不是致命错误，退化到哈希表查找
+    } else {
+        gen->high_freq_bitmap = NULL;
+        gen->bitmap_size = 0;
+        gen->bitmap_vocab_max = 0;
+    }
+
+    return gen;
+}
+
+void token_generalizer_free(TokenGeneralizer* gen) {
+    if (!gen) return;
+    free(gen->entries);
+    free(gen->high_freq_bitmap);
+    free(gen);
+}
+
+// ============================================================
+// 频率更新
+// ============================================================
+
+uint32_t token_generalizer_update(TokenGeneralizer* gen, uint32_t token, uint32_t prev_token) {
+    if (!gen) return 0;
+
+    size_t cap = gen->capacity;
+    uint32_t h = freq_hash(token, cap);
+
+    for (uint32_t i = 0; i < 16; i++) {
+        size_t slot = freq_probe(h, i, cap);
+        FreqEntry* e = &gen->entries[slot];
+
+        if (e->token == GENERALIZER_EMPTY_KEY) {
+            // 新 token，插入
+            e->token = token;
+            e->count = 1;
+            // 初始化 context_hash（如果有前驱 token）
+            if (prev_token != 0xFFFFFFFF) {
+                e->context_hash = prev_token * 2654435761U;
+            } else {
+                e->context_hash = 0;
+            }
+            gen->count++;
+            gen->total_updates++;
+            return 1;
+        }
+
+        if (e->token == token) {
+            // 已存在，增加计数
+            e->count++;
+            gen->total_updates++;
+
+            // 累积左邻居信息到 context_hash
+            if (prev_token != 0xFFFFFFFF) {
+                e->context_hash = (e->context_hash * 31) + (prev_token * 2654435761U);
+            }
+
+            // 如果刚达到阈值，更新 bitmap
+            if (e->count == gen->freq_threshold &&
+                gen->high_freq_bitmap &&
+                token <= gen->bitmap_vocab_max) {
+                size_t byte_idx = token >> 3;
+                uint8_t bit_mask = 1U << (token & 7);
+                gen->high_freq_bitmap[byte_idx] |= bit_mask;
+            }
+
+            return e->count;
+        }
+    }
+
+    // 探测失败（表太满），忽略
+    gen->total_updates++;
+    return 0;
+}
+
+void token_generalizer_update_batch(TokenGeneralizer* gen,
+                                    const uint32_t* tokens,
+                                    size_t count) {
+    if (!gen || !tokens) return;
+    for (size_t i = 0; i < count; i++) {
+        uint32_t prev = (i > 0) ? tokens[i - 1] : 0xFFFFFFFF;
+        token_generalizer_update(gen, tokens[i], prev);
+    }
+}
+
+// ============================================================
+// 泛化 n-gram hash
+// ============================================================
+
+uint64_t token_generalizer_hash_ngram(const TokenGeneralizer* gen,
+                                      const uint32_t* tokens,
+                                      uint8_t length,
+                                      uint32_t* out_generalized) {
+    if (!gen || !tokens || length == 0) return 0;
+
+    uint32_t buf[8];  // MAX_NGRAM_ORDER = 8
+    uint32_t* dest = out_generalized ? out_generalized : buf;
+
+    for (uint8_t i = 0; i < length; i++) {
+        dest[i] = token_generalizer_map(gen, tokens[i]);
+    }
+
+    return ngram_hash(dest, length);
+}
+
+// ============================================================
+// 统计
+// ============================================================
+
+GeneralizerStats token_generalizer_stats(const TokenGeneralizer* gen) {
+    GeneralizerStats stats = {0};
+    if (!gen) return stats;
+
+    stats.capacity = gen->capacity;
+    stats.count = gen->count;
+    stats.freq_threshold = gen->freq_threshold;
+    stats.total_updates = gen->total_updates;
+
+    // 计算高频 token 数
+    for (size_t i = 0; i < gen->capacity; i++) {
+        if (gen->entries[i].token != GENERALIZER_EMPTY_KEY &&
+            gen->entries[i].count >= gen->freq_threshold) {
+            stats.high_freq_count++;
+        }
+    }
+
+    stats.memory_bytes = sizeof(TokenGeneralizer) +
+                         gen->capacity * sizeof(FreqEntry) +
+                         gen->bitmap_size;
+
+    stats.num_wildcard_buckets = NUM_WILDCARD_BUCKETS;
+
+    return stats;
+}

--- a/csrc/zipf_cache/src/zipf_cache.c
+++ b/csrc/zipf_cache/src/zipf_cache.c
@@ -1,0 +1,784 @@
+#include "zipf_cache.h"
+#include "cityhash.h"
+#include "token_generalizer.h"
+#include "async_worker.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+// ============================================================
+// 1-gram 辅助函数（用于共享hash的初始化）
+// ============================================================
+static void init_unigram_entries(UnigramEntry* entries, size_t capacity) {
+    for (size_t i = 0; i < capacity; i++) {
+        entries[i].key_token = UNIGRAM_EMPTY_KEY;
+        entries[i].tokens = NULL;
+        entries[i].token_count = 0;
+        entries[i].capacity = 0;
+        entries[i].max_token = 0;
+        entries[i].max_count = 0;
+        entries[i].total_count = 0;
+    }
+}
+
+static void free_unigram_entries(UnigramEntry* entries, size_t capacity) {
+    if (!entries) return;
+    for (size_t i = 0; i < capacity; i++) {
+        if (entries[i].tokens) {
+            free(entries[i].tokens);
+        }
+    }
+    free(entries);
+}
+
+// 哈希函数
+uint64_t zipf_hash(const uint32_t* tokens, uint8_t length) {
+    return ngram_hash(tokens, length);
+}
+
+ZipfCache* zipf_cache_create(const ZipfConfig* config) {
+    ZipfCache* cache = calloc(1, sizeof(ZipfCache));
+    if (!cache) return NULL;
+
+    cache->config = config ? *config : zipf_default_config();
+
+    // 使用硬编码常量创建共享hash
+    size_t shared_capacity = ZIPF_HARDCODED_SHARED_CAPACITY;
+    cache->shared_hash = calloc(1, sizeof(LocalHash));
+    if (!cache->shared_hash) {
+        free(cache);
+        return NULL;
+    }
+
+    // 分配n-gram存储
+    cache->shared_hash->entries = calloc(shared_capacity, sizeof(NgramEntry));
+    if (!cache->shared_hash->entries) {
+        free(cache->shared_hash);
+        free(cache);
+        return NULL;
+    }
+    cache->shared_hash->capacity = shared_capacity;
+    cache->shared_hash->count = 0;
+
+    // 分配1-gram存储（硬编码启用）
+    {
+        size_t unigram_alloc = (size_t)(ZIPF_HARDCODED_UNIGRAM_CAPACITY / 0.7);
+        cache->shared_hash->unigram_entries = calloc(unigram_alloc, sizeof(UnigramEntry));
+        if (!cache->shared_hash->unigram_entries) {
+            free(cache->shared_hash->entries);
+            free(cache->shared_hash);
+            free(cache);
+            return NULL;
+        }
+        init_unigram_entries(cache->shared_hash->unigram_entries, unigram_alloc);
+        cache->shared_hash->unigram_capacity = unigram_alloc;
+        cache->shared_hash->unigram_threshold = ZIPF_HARDCODED_UNIGRAM_THRESHOLD;
+    }
+    cache->shared_hash->unigram_count = 0;
+    cache->shared_hash->req_id = 0;
+    cache->shared_hash->generation_count = 0;
+
+    // 创建局部hash管理器
+    size_t local_capacity = ZIPF_HARDCODED_LOCAL_CAPACITY;
+    size_t gen_local_capacity = cache->config.enable_generalized
+        ? local_capacity
+        : 0;
+    cache->local_manager = local_hash_manager_create(
+        ZIPF_HARDCODED_MAX_LOCAL_HASHES,
+        local_capacity,
+        ZIPF_HARDCODED_UNIGRAM_CAPACITY,
+        ZIPF_HARDCODED_UNIGRAM_THRESHOLD,
+        gen_local_capacity
+    );
+    if (!cache->local_manager) {
+        free_unigram_entries(cache->shared_hash->unigram_entries, cache->shared_hash->unigram_capacity);
+        free(cache->shared_hash->entries);
+        free(cache->shared_hash);
+        free(cache);
+        return NULL;
+    }
+
+    // 创建 Token 泛化器
+    if (cache->config.enable_generalized) {
+        cache->generalizer = token_generalizer_create(
+            cache->config.gen_capacity,
+            cache->config.gen_freq_threshold,
+            cache->config.gen_bitmap_vocab_max
+        );
+        if (!cache->generalizer) {
+            cache->config.enable_generalized = 0;
+        }
+    } else {
+        cache->generalizer = NULL;
+    }
+
+    atomic_init(&cache->query_count, 0);
+    atomic_init(&cache->shared_hit_count, 0);
+    atomic_init(&cache->local_hit_count, 0);
+    atomic_init(&cache->unigram_hit_count, 0);
+    atomic_init(&cache->generalized_hit_count, 0);
+    atomic_init(&cache->update_count, 0);
+
+    // 创建异步工作线程
+    cache->async_worker = async_worker_create(cache);
+    // async_worker 创建失败不是致命错误，退化到同步模式
+
+    return cache;
+}
+
+void zipf_cache_query_batch_with_req(ZipfCache* cache,
+                                     const uint64_t* req_ids,
+                                     const ZipfKey* keys,
+                                     QueryResult* results,
+                                     size_t batch_size) {
+    if (!cache || batch_size == 0) return;
+
+    uint64_t local_hits = 0;
+    uint64_t shared_hits = 0;
+    uint64_t unigram_hits = 0;
+    uint64_t gen_hits = 0;
+
+    for (size_t i = 0; i < batch_size; i++) {
+        results[i].hit = 0;
+        results[i].from_local = 0;
+
+        LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_ids[i]);
+        uint8_t context_len = keys[i].length;
+
+        for (uint8_t len = context_len; len >= 1 && !results[i].hit; len--) {
+            const uint32_t* key_start = keys[i].tokens + (context_len - len);
+
+            if (len == 1) {
+                // 1-gram 使用概率判断
+                uint32_t key_token = key_start[0];
+
+                if (local && local_hash_query_unigram(local, key_token, &results[i].next_token)) {
+                    results[i].hit = 1;
+                    results[i].from_local = 4;
+                    unigram_hits++;
+                    break;
+                }
+
+                if (!cache->config.skip_shared && cache->shared_hash &&
+                    local_hash_query_unigram(cache->shared_hash, key_token, &results[i].next_token)) {
+                    results[i].hit = 1;
+                    results[i].from_local = 3;
+                    unigram_hits++;
+                    break;
+                }
+            } else {
+                uint64_t hash = zipf_hash(key_start, len);
+
+                if (local && local_hash_query_with_level(local, hash, len, &results[i].next_token)) {
+                    results[i].hit = 1;
+                    results[i].from_local = 1;
+                    local_hits++;
+                    break;
+                }
+
+                if (cache->config.generalized_before_shared) {
+                    // 泛化层优先于 shared
+                    if (cache->config.enable_generalized && cache->generalizer &&
+                        local && token_generalizer_is_different(cache->generalizer, key_start, len)) {
+                        uint64_t gen_hash = token_generalizer_hash_ngram(
+                            cache->generalizer, key_start, len, NULL);
+                        if (local_hash_query_generalized_with_level(local, gen_hash, len,
+                                &results[i].next_token)) {
+                            results[i].hit = 1;
+                            results[i].from_local = 5;
+                            gen_hits++;
+                            break;
+                        }
+                    }
+
+                    if (!cache->config.skip_shared && cache->shared_hash &&
+                        local_hash_query_with_level(cache->shared_hash, hash, len, &results[i].next_token)) {
+                        results[i].hit = 1;
+                        results[i].from_local = 2;
+                        shared_hits++;
+                        break;
+                    }
+                } else {
+                    // shared 优先于泛化层
+                    if (!cache->config.skip_shared && cache->shared_hash &&
+                        local_hash_query_with_level(cache->shared_hash, hash, len, &results[i].next_token)) {
+                        results[i].hit = 1;
+                        results[i].from_local = 2;
+                        shared_hits++;
+                        break;
+                    }
+
+                    if (cache->config.enable_generalized && cache->generalizer &&
+                        local && token_generalizer_is_different(cache->generalizer, key_start, len)) {
+                        uint64_t gen_hash = token_generalizer_hash_ngram(
+                            cache->generalizer, key_start, len, NULL);
+                        if (local_hash_query_generalized_with_level(local, gen_hash, len,
+                                &results[i].next_token)) {
+                            results[i].hit = 1;
+                            results[i].from_local = 5;
+                            gen_hits++;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    atomic_fetch_add_explicit(&cache->query_count, batch_size, memory_order_relaxed);
+    atomic_fetch_add_explicit(&cache->local_hit_count, local_hits, memory_order_relaxed);
+    atomic_fetch_add_explicit(&cache->shared_hit_count, shared_hits, memory_order_relaxed);
+    atomic_fetch_add_explicit(&cache->unigram_hit_count, unigram_hits, memory_order_relaxed);
+    atomic_fetch_add_explicit(&cache->generalized_hit_count, gen_hits, memory_order_relaxed);
+}
+
+void zipf_cache_update_with_req(ZipfCache* cache,
+                                uint64_t req_id,
+                                const uint32_t* context_tokens,
+                                uint8_t context_len,
+                                uint32_t next_token) {
+    if (!cache || context_len == 0) return;
+
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+
+    if (context_len == 1) {
+        // 1-gram 更新
+        uint32_t key_token = context_tokens[0];
+        if (local) {
+            local_hash_update_unigram(local, key_token, next_token);
+        }
+        if (!cache->config.skip_shared && cache->shared_hash) {
+            local_hash_update_unigram(cache->shared_hash, key_token, next_token);
+        }
+    } else {
+        uint64_t hash = zipf_hash(context_tokens, context_len);
+        if (local && local_hash_can_generate(local)) {
+            local_hash_update(local, hash, next_token);
+        }
+        if (!cache->config.skip_shared && cache->shared_hash) {
+            local_hash_update(cache->shared_hash, hash, next_token);
+        }
+    }
+
+    atomic_fetch_add_explicit(&cache->update_count, 1, memory_order_relaxed);
+}
+
+// 多级 n-gram 更新（带历史窗口）
+void zipf_cache_update_with_history(ZipfCache* cache,
+                                    uint64_t req_id,
+                                    const uint32_t* new_tokens,
+                                    size_t new_token_count) {
+    if (!cache || !new_tokens || new_token_count == 0) return;
+
+    uint8_t min_win = cache->config.min_window;
+    uint8_t max_win = cache->config.max_window;
+
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+    if (!local) return;
+
+    uint8_t hist_len = local->history_len;
+    uint32_t* history = local->history;
+
+    int enable_gen = cache->config.enable_generalized && cache->generalizer;
+
+    for (size_t i = 0; i < new_token_count; i++) {
+        uint32_t next_token = new_tokens[i];
+
+        if (enable_gen) {
+            // 传入前一个 token 用于共现分布分桶
+            uint32_t prev_token = (hist_len >= 1) ? history[hist_len - 1] : 0xFFFFFFFF;
+            token_generalizer_update(cache->generalizer, next_token, prev_token);
+        }
+
+        // 更新 1-gram
+        if (hist_len >= 1) {
+            uint32_t key_token = history[hist_len - 1];
+            local_hash_update_unigram(local, key_token, next_token);
+            if (!cache->config.skip_shared && cache->shared_hash) {
+                local_hash_update_unigram(cache->shared_hash, key_token, next_token);
+            }
+        }
+
+        // 更新各级 n-gram
+        for (uint8_t x = min_win; x <= max_win; x++) {
+            if (hist_len >= x) {
+                const uint32_t* key_start = history + (hist_len - x);
+                uint64_t hash = zipf_hash(key_start, x);
+
+                if (local_hash_can_generate(local)) {
+                    local_hash_update(local, hash, next_token);
+                }
+                if (!cache->config.skip_shared && cache->shared_hash) {
+                    local_hash_update(cache->shared_hash, hash, next_token);
+                }
+                if (enable_gen &&
+                    token_generalizer_is_different(cache->generalizer, key_start, x)) {
+                    uint64_t gen_hash = token_generalizer_hash_ngram(
+                        cache->generalizer, key_start, x, NULL);
+                    local_hash_update_generalized(local, gen_hash, next_token);
+                }
+            }
+        }
+
+        // 滑动历史窗口
+        if (hist_len < max_win) {
+            history[hist_len] = next_token;
+            hist_len++;
+        } else {
+            for (uint8_t j = 0; j < max_win - 1; j++) {
+                history[j] = history[j + 1];
+            }
+            history[max_win - 1] = next_token;
+        }
+    }
+
+    local->history_len = hist_len;
+    atomic_fetch_add_explicit(&cache->update_count, new_token_count, memory_order_relaxed);
+}
+
+void zipf_cache_set_history(ZipfCache* cache,
+                            uint64_t req_id,
+                            const uint32_t* tokens,
+                            size_t token_count) {
+    if (!cache || !tokens) return;
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+    if (!local) return;
+    local_hash_set_history(local, tokens,
+                           token_count > 255 ? 255 : (uint8_t)token_count,
+                           cache->config.max_window);
+}
+
+void zipf_cache_warmup_from_prompt(ZipfCache* cache,
+                                   uint64_t req_id,
+                                   const uint32_t* prompt_tokens,
+                                   size_t prompt_len) {
+    if (!cache || !prompt_tokens || prompt_len == 0) return;
+    uint8_t min_win = cache->config.min_window;
+    uint8_t max_win = cache->config.max_window;
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+    if (!local) return;
+    int enable_gen = cache->config.enable_generalized && cache->generalizer;
+    for (size_t i = min_win; i < prompt_len; i++) {
+        uint32_t next_token = prompt_tokens[i];
+        if (enable_gen) {
+            uint32_t prev_token = (i > 0) ? prompt_tokens[i - 1] : 0xFFFFFFFF;
+            token_generalizer_update(cache->generalizer, next_token, prev_token);
+        }
+        if (i >= 1) {
+            uint32_t key_token = prompt_tokens[i - 1];
+            local_hash_update_unigram(local, key_token, next_token);
+        }
+        for (uint8_t x = min_win; x <= max_win; x++) {
+            if (i >= x) {
+                const uint32_t* key_start = prompt_tokens + (i - x);
+                uint64_t hash = zipf_hash(key_start, x);
+                local_hash_update(local, hash, next_token);
+                if (enable_gen &&
+                    token_generalizer_is_different(cache->generalizer, key_start, x)) {
+                    uint64_t gen_hash = token_generalizer_hash_ngram(
+                        cache->generalizer, key_start, x, NULL);
+                    local_hash_update_generalized(local, gen_hash, next_token);
+                }
+            }
+        }
+    }
+    local_hash_set_history(local, prompt_tokens,
+                           prompt_len > 255 ? 255 : (uint8_t)prompt_len,
+                           max_win);
+}
+
+void zipf_cache_reset_context(ZipfCache* cache, uint64_t req_id) {
+    if (!cache) return;
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+    if (!local) return;
+    local_hash_reset_history(local);
+}
+
+void zipf_cache_update_batch_with_req(ZipfCache* cache,
+                                      const uint64_t* req_ids,
+                                      const ZipfKey* contexts,
+                                      const uint32_t* next_tokens,
+                                      size_t batch_size) {
+    if (!cache || !req_ids || !contexts || !next_tokens || batch_size == 0) return;
+    for (size_t i = 0; i < batch_size; i++) {
+        uint64_t hash = zipf_hash(contexts[i].tokens, contexts[i].length);
+        LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_ids[i]);
+        if (local && local_hash_can_generate(local)) {
+            local_hash_update(local, hash, next_tokens[i]);
+        }
+        if (cache->shared_hash && ZIPF_HARDCODED_SHARED_CAPACITY > 0) {
+            local_hash_update(cache->shared_hash, hash, next_tokens[i]);
+        }
+    }
+    atomic_fetch_add_explicit(&cache->update_count, batch_size, memory_order_relaxed);
+}
+
+void zipf_cache_update_with_history_batch(
+    ZipfCache* cache,
+    const uint64_t* req_ids,
+    const uint32_t* flat_tokens,
+    const size_t* offsets,
+    const size_t* token_counts,
+    size_t batch_size
+) {
+    if (!cache || !req_ids || !flat_tokens || !offsets || !token_counts
+        || batch_size == 0) return;
+    for (size_t i = 0; i < batch_size; i++) {
+        if (token_counts[i] == 0) continue;
+        zipf_cache_update_with_history(
+            cache, req_ids[i],
+            flat_tokens + offsets[i], token_counts[i]);
+    }
+}
+
+ZipfCacheStats zipf_cache_stats(const ZipfCache* cache) {
+    ZipfCacheStats stats = {0};
+    if (!cache) return stats;
+
+    stats.query_count = atomic_load(&cache->query_count);
+    stats.shared_hit_count = atomic_load(&cache->shared_hit_count);
+    stats.local_hit_count = atomic_load(&cache->local_hit_count);
+    stats.unigram_hit_count = atomic_load(&cache->unigram_hit_count);
+    stats.generalized_hit_count = atomic_load(&cache->generalized_hit_count);
+
+    uint64_t total_hits = stats.shared_hit_count +
+                          stats.local_hit_count + stats.unigram_hit_count +
+                          stats.generalized_hit_count;
+    stats.total_hit_rate = stats.query_count > 0 ?
+        (double)total_hits / stats.query_count : 0.0;
+    stats.shared_hit_rate = stats.query_count > 0 ?
+        (double)stats.shared_hit_count / stats.query_count : 0.0;
+    stats.local_hit_rate = stats.query_count > 0 ?
+        (double)stats.local_hit_count / stats.query_count : 0.0;
+    stats.unigram_hit_rate = stats.query_count > 0 ?
+        (double)stats.unigram_hit_count / stats.query_count : 0.0;
+    stats.generalized_hit_rate = stats.query_count > 0 ?
+        (double)stats.generalized_hit_count / stats.query_count : 0.0;
+
+    stats.update_count = atomic_load(&cache->update_count);
+    stats.local_stats = local_hash_manager_stats(cache->local_manager);
+
+    if (cache->shared_hash) {
+        stats.shared_entries = cache->shared_hash->count;
+        stats.shared_unigram = cache->shared_hash->unigram_count;
+    }
+
+    if (cache->generalizer) {
+        stats.gen_stats = token_generalizer_stats(cache->generalizer);
+    }
+
+    return stats;
+}
+
+void zipf_cache_free(ZipfCache* cache) {
+    if (!cache) return;
+    // 先停止异步工作线程
+    async_worker_free(cache->async_worker);
+    if (cache->shared_hash) {
+        free(cache->shared_hash->entries);
+        free(cache->shared_hash->gen_entries);
+        free_unigram_entries(cache->shared_hash->unigram_entries, cache->shared_hash->unigram_capacity);
+        free(cache->shared_hash);
+    }
+    local_hash_manager_free(cache->local_manager);
+    token_generalizer_free(cache->generalizer);
+    free(cache);
+}
+
+// ============================================================
+// 链式推测 API 实现（纯命中驱动，长度控制由 Python 层 adaptive-k 负责）
+// ============================================================
+
+static inline int query_single_level(
+    const LocalHash* local,
+    const LocalHash* shared,
+    const ZipfCache* cache,
+    const uint32_t* window,
+    uint8_t window_len,
+    uint8_t level,
+    uint32_t* out_token
+) {
+    if (window_len < level) return 0;
+
+    if (level == 1) {
+        // 1-gram: local → shared
+        uint32_t key_token = window[window_len - 1];
+        if (local && local_hash_query_unigram(local, key_token, out_token)) return 1;
+        if (shared && local_hash_query_unigram(shared, key_token, out_token)) return 1;
+        return 0;
+    }
+
+    const uint32_t* key_start = window + (window_len - level);
+    uint64_t hash = zipf_hash(key_start, level);
+
+    // local 精确匹配（带级别阈值）
+    if (local && local_hash_query_with_level(local, hash, level, out_token)) return 1;
+
+    // local → 泛化 → shared 或 local → shared → 泛化，取决于配置
+    int gen_before_shared = cache->config.generalized_before_shared;
+
+    if (gen_before_shared) {
+        // 泛化层优先于 shared
+        if (cache->config.enable_generalized && cache->generalizer &&
+            local && token_generalizer_is_different(cache->generalizer, key_start, level)) {
+            uint64_t gen_hash = token_generalizer_hash_ngram(
+                cache->generalizer, key_start, level, NULL);
+            if (local_hash_query_generalized_with_level(local, gen_hash, level, out_token)) {
+                atomic_fetch_add_explicit(
+                    (_Atomic uint64_t*)&cache->generalized_hit_count, 1, memory_order_relaxed);
+                return 1;
+            }
+        }
+        if (shared && local_hash_query_with_level(shared, hash, level, out_token)) return 1;
+    } else {
+        // shared 优先于泛化层
+        if (shared && local_hash_query_with_level(shared, hash, level, out_token)) return 1;
+        if (cache->config.enable_generalized && cache->generalizer &&
+            local && token_generalizer_is_different(cache->generalizer, key_start, level)) {
+            uint64_t gen_hash = token_generalizer_hash_ngram(
+                cache->generalizer, key_start, level, NULL);
+            if (local_hash_query_generalized_with_level(local, gen_hash, level, out_token)) {
+                atomic_fetch_add_explicit(
+                    (_Atomic uint64_t*)&cache->generalized_hit_count, 1, memory_order_relaxed);
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+int zipf_cache_speculate_chain_with_req(
+    ZipfCache* cache,
+    uint64_t req_id,
+    const uint32_t* context,
+    uint8_t context_len,
+    uint32_t* out_tokens,
+    int max_tokens
+) {
+    if (!cache || !context || !out_tokens || max_tokens <= 0 || context_len == 0) {
+        return 0;
+    }
+
+    LocalHash* local = local_hash_manager_get_or_create(cache->local_manager, req_id);
+    if (!local || !local_hash_can_generate(local)) {
+        return 0;
+    }
+
+    LocalHash* shared = (!cache->config.skip_shared) ? cache->shared_hash : NULL;
+
+    uint8_t min_win = cache->config.min_window;
+    uint8_t max_win = cache->config.max_window;
+
+    uint32_t window[MAX_NGRAM_ORDER];
+    uint8_t window_len;
+
+    if (context_len > max_win) {
+        window_len = max_win;
+        int start = context_len - max_win;
+        for (int i = 0; i < max_win; i++) {
+            window[i] = context[start + i];
+        }
+    } else {
+        window_len = context_len;
+        for (int i = 0; i < window_len; i++) {
+            window[i] = context[i];
+        }
+    }
+
+    int count = 0;
+    while (count < max_tokens && local_hash_can_generate(local)) {
+        uint32_t next_token = 0;
+        int hit = 0;
+
+        // 从最高级 n-gram 开始查询，逐级降级
+        for (int x = max_win; x >= min_win; x--) {
+            if (query_single_level(local, shared, cache,
+                                   window, window_len, x, &next_token)) {
+                hit = 1;
+                break;
+            }
+        }
+
+        // 1-gram fallback
+        if (!hit && window_len >= 1) {
+            if (query_single_level(local, shared, cache,
+                                   window, window_len, 1, &next_token)) {
+                hit = 1;
+            }
+        }
+
+        if (!hit) break;
+
+        out_tokens[count++] = next_token;
+
+        // 滑动窗口
+        if (window_len < max_win) {
+            window[window_len++] = next_token;
+        } else {
+            for (int i = 0; i < max_win - 1; i++) {
+                window[i] = window[i + 1];
+            }
+            window[max_win - 1] = next_token;
+        }
+    }
+
+    atomic_fetch_add_explicit(&cache->query_count, 1, memory_order_relaxed);
+    if (count > 0) {
+        atomic_fetch_add_explicit(&cache->local_hit_count, 1, memory_order_relaxed);
+    }
+    return count;
+}
+
+void zipf_cache_speculate_chain_batch_with_req(
+    ZipfCache* cache,
+    const uint64_t* req_ids,
+    const ZipfKey* contexts,
+    uint32_t* out_tokens,
+    int* out_counts,
+    size_t batch_size,
+    int max_tokens
+) {
+    if (!cache || !req_ids || !contexts || !out_tokens || !out_counts ||
+        batch_size == 0 || max_tokens <= 0) return;
+    for (size_t i = 0; i < batch_size; i++) {
+        out_counts[i] = zipf_cache_speculate_chain_with_req(
+            cache, req_ids[i],
+            contexts[i].tokens, contexts[i].length,
+            &out_tokens[i * max_tokens], max_tokens);
+    }
+}
+
+// ============================================================
+// Propose API 实现
+// ============================================================
+
+static inline int compute_adaptive_k(
+    LocalHash* local,
+    int num_sampled,
+    const AdaptiveKConfig* ak
+) {
+    if (!local->is_initialized) {
+        // 首次初始化
+        local->ema_accepted = (float)ak->num_speculative_tokens;
+        local->consecutive_fail = 0;
+        local->consecutive_success = 0;
+        local->last_adaptive_k = ak->num_speculative_tokens;
+        local->is_initialized = 1;
+    }
+
+    // EMA 更新
+    float ema = ak->ema_alpha * (float)num_sampled
+              + (1.0f - ak->ema_alpha) * local->ema_accepted;
+    local->ema_accepted = ema;
+
+    // 接受率
+    float acceptance_rate = (float)num_sampled / (float)(local->last_adaptive_k + 1);
+
+    if (acceptance_rate < ak->fail_threshold) {
+        local->consecutive_fail++;
+        local->consecutive_success = 0;
+    } else if (acceptance_rate >= ak->success_threshold) {
+        local->consecutive_success++;
+        local->consecutive_fail = 0;
+    }
+
+    int penalty = local->consecutive_fail;
+    if (penalty > ak->max_penalty) penalty = ak->max_penalty;
+    int bonus = local->consecutive_success;
+    if (bonus > ak->max_bonus) bonus = ak->max_bonus;
+
+    int adaptive_k = (int)(ema + 0.999999f) + 1 - penalty + bonus;
+    if (adaptive_k < ak->min_k) adaptive_k = ak->min_k;
+    if (adaptive_k > ak->max_k) adaptive_k = ak->max_k;
+
+    local->last_adaptive_k = (int16_t)adaptive_k;
+    return adaptive_k;
+}
+
+void zipf_cache_propose_batch(
+    ZipfCache* cache,
+    const ProposeRequest* requests,
+    ProposeResult* results,
+    size_t batch_size,
+    const AdaptiveKConfig* ak_config
+) {
+    if (!cache || !requests || !results || batch_size == 0) return;
+
+    uint8_t max_win = cache->config.max_window;
+
+    // Step 0: Fence — 等待上一轮的异步 warmup/update 完成
+    if (cache->async_worker) {
+        async_worker_fence(cache->async_worker);
+    }
+
+    // Step 1: 对每个请求做 speculate（同步，快路径）
+    //         同时收集需要 warmup/update 的任务
+    for (size_t i = 0; i < batch_size; i++) {
+        results[i].num_draft_tokens = 0;
+
+        const ProposeRequest* req = &requests[i];
+        if (!req->is_valid || req->num_sampled == 0) continue;
+        if (req->num_tokens >= req->max_model_len) continue;
+
+        LocalHash* local = local_hash_manager_get_or_create(
+            cache->local_manager, req->req_hash);
+        if (!local) continue;
+
+        // 新请求：提交异步 warmup（不阻塞）
+        if (!local->is_initialized) {
+            if (req->num_prompt_tokens > 0 && req->token_ids && cache->async_worker) {
+                async_worker_submit_warmup(
+                    cache->async_worker, req->req_hash,
+                    req->token_ids, (size_t)req->num_prompt_tokens);
+            } else if (req->num_prompt_tokens > 0 && req->token_ids) {
+                // 无异步工作线程，同步 warmup
+                zipf_cache_warmup_from_prompt(
+                    cache, req->req_hash,
+                    req->token_ids, (size_t)req->num_prompt_tokens);
+            }
+        }
+
+        // 提交异步 update（不阻塞）
+        if (req->num_sampled > 0 && req->sampled_ids) {
+            if (cache->async_worker) {
+                async_worker_submit_update(
+                    cache->async_worker, req->req_hash,
+                    req->sampled_ids, (size_t)req->num_sampled);
+            } else {
+                zipf_cache_update_with_history(
+                    cache, req->req_hash,
+                    req->sampled_ids, (size_t)req->num_sampled);
+            }
+        }
+
+        // Compute adaptive-k
+        int adaptive_k = compute_adaptive_k(local, req->num_sampled, ak_config);
+
+        // Prepare context for speculation
+        int spec_start = req->num_tokens - max_win;
+        if (spec_start < 0) spec_start = 0;
+        int ctx_len = req->num_tokens - spec_start;
+        if (ctx_len > max_win) ctx_len = max_win;
+        if (ctx_len <= 0 || !req->token_ids) continue;
+
+        const uint32_t* context = req->token_ids + spec_start;
+
+        // Compute max draft length
+        int max_draft = req->max_model_len - req->num_tokens - 1;
+        if (adaptive_k < max_draft) max_draft = adaptive_k;
+        if (max_draft <= 0) continue;
+
+        // Speculate（同步，使用当前缓存状态）
+        // 注意：新请求的 warmup 还在后台执行，所以第一次 speculate 可能 miss
+        // 这是预期行为——延迟一步学习，换取不阻塞 propose
+        int count = zipf_cache_speculate_chain_with_req(
+            cache, req->req_hash,
+            context, (uint8_t)ctx_len,
+            results[i].draft_tokens, max_draft);
+
+        results[i].num_draft_tokens = count;
+    }
+    // warmup/update 任务已提交到后台，会在 GPU forward 期间执行
+    // 下一次 propose_batch 开头的 fence 会确保它们完成
+}

--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -152,6 +152,68 @@ Suffix Decoding can achieve better performance for tasks with high repetition, s
         print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
     ```
 
+## Speculating using Zipf Decoding
+
+Zipf Decoding is a lightweight speculative decoding proposer for Ascend. It does not use a draft model. Instead, it builds a native Zipf cache from previous tokens and proposes continuations from repeated or template-like token patterns.
+
+Zipf Decoding is intended for pattern-heavy workloads such as repeated text, structured outputs, logs, code-like templates, and other prompts where local token continuations are often reused. In local NPU smoke tests, this path showed better behavior than suffix decoding on repetitive workloads, but it is not expected to be faster for every workload.
+
+> [!NOTE]
+> Upstream vLLM does not currently accept `method="zipf"` or Zipf-specific fields in `speculative_config`. Use an upstream-supported speculative decoding method as the carrier, then select the Ascend Zipf proposer through `additional_config["ascend_spec_decode_method"] = "zipf"`.
+
+- Offline inference
+
+  ```python
+    from vllm import LLM, SamplingParams
+
+    prompts = [
+        "Repeat the word hello ten times.",
+        "Explain speculative decoding in one paragraph.",
+    ]
+    sampling_params = SamplingParams(temperature=0, max_tokens=64)
+
+    llm = LLM(
+        model="meta-llama/Meta-Llama-3.1-8B-Instruct",
+        tensor_parallel_size=1,
+        speculative_config={
+            "method": "suffix",
+            "num_speculative_tokens": 3,
+        },
+        additional_config={
+            "ascend_spec_decode_method": "zipf",
+            "zipf_config": {
+                "zipf_ngram_size": 4,
+                "zipf_min_window": 1,
+                "zipf_initial_speculative_tokens": 2,
+                "zipf_skip_shared": False,
+                "zipf_generalized_before_shared": True,
+            },
+        },
+    )
+
+    outputs = llm.generate(prompts, sampling_params)
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+    ```
+
+Zipf configuration options:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `zipf_ngram_size` | `4` | Maximum n-gram window size used by the Zipf cache. |
+| `zipf_min_window` | `2` | Minimum n-gram window size used by the Zipf cache. |
+| `zipf_initial_speculative_tokens` | `num_speculative_tokens` | Initial number of Zipf draft tokens to propose. It must be no larger than `num_speculative_tokens`. |
+| `zipf_skip_shared` | `False` | Whether to skip shared-cache lookup and update. |
+| `zipf_generalized_before_shared` | `True` | Whether generalized-cache lookup is attempted before shared-cache lookup. |
+
+Known limitations:
+
+1. `method="zipf"` cannot be passed directly to `speculative_config` until upstream vLLM accepts Zipf in `SpeculativeConfig`.
+2. Zipf Decoding is most useful for repetitive and pattern-heavy workloads. For general chat workloads, benchmark with your own prompts before enabling it by default.
+
 ## Extracting Hidden States
 
 The `extract_hidden_states` method is a special speculative decoding mode that does not perform actual speculation. Instead, it extracts hidden states from specified layers of the target model and saves them to disk. This is primarily used for collecting training data for EAGLE-style draft models.

--- a/setup.py
+++ b/setup.py
@@ -306,10 +306,24 @@ class cmake_build_ext(build_ext):
             raise RuntimeError(f"CMake configuration failed: {e}")
 
         install_path = os.path.join(ROOT_DIR, self.build_lib)
+        zipf_cache_install_path = os.path.join(
+            ROOT_DIR,
+            self.build_lib,
+            "vllm_ascend",
+            "spec_decode",
+            "zipf_cache",
+        )
         if isinstance(self.distribution.get_command_obj("develop"), develop):
             install_path = os.path.join(ROOT_DIR, "vllm_ascend")
+            zipf_cache_install_path = os.path.join(
+                ROOT_DIR,
+                "vllm_ascend",
+                "spec_decode",
+                "zipf_cache",
+            )
         # add CMAKE_INSTALL_PATH
         cmake_args += [f"-DCMAKE_INSTALL_PREFIX={install_path}"]
+        cmake_args += [f"-DZIPF_CACHE_INSTALL_PATH={zipf_cache_install_path}"]
 
         cmake_args += [f"-DCMAKE_PREFIX_PATH={pybind11_cmake_path}"]
 

--- a/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
+++ b/tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
@@ -233,6 +233,53 @@ def test_qwen3_vl_eagle(
         ref_llm.model.chat(test_prompts, sampling_config)
 
 
+def test_zipf_correctness(
+    test_prompts: list[list[dict[str, Any]]],
+    sampling_config: SamplingParams,
+    model_name: str,
+):
+    """
+    Compare the outputs of a original LLM and a speculative LLM
+    should be the same when using Zipf speculative decoding.
+    """
+    with VllmRunner(model_name, max_model_len=1024, cudagraph_capture_sizes=[1, 2, 4, 8]) as ref_llm:
+        ref_outputs = ref_llm.model.chat(test_prompts, sampling_config)
+
+    with VllmRunner(
+        model_name,
+        speculative_config={
+            "method": "suffix",
+            "num_speculative_tokens": 3,
+        },
+        additional_config={
+            "ascend_spec_decode_method": "zipf",
+            "zipf_config": {
+                "zipf_ngram_size": 4,
+                "zipf_min_window": 1,
+                "zipf_initial_speculative_tokens": 2,
+                "zipf_skip_shared": False,
+                "zipf_generalized_before_shared": True,
+            },
+        },
+        cudagraph_capture_sizes=[1, 2, 4, 8],
+        max_model_len=1024,
+    ) as runner:
+        spec_outputs = runner.model.chat(test_prompts, sampling_config)
+    matches = 0
+    misses = 0
+    for ref_output, spec_output in zip(ref_outputs, spec_outputs):
+        if ref_output.outputs[0].text == spec_output.outputs[0].text:
+            matches += 1
+        else:
+            misses += 1
+            print(f"ref_output: {ref_output.outputs[0].text}")
+            print(f"spec_output: {spec_output.outputs[0].text}")
+
+    # Heuristic: expect at least 70% of the prompts to match exactly
+    # Upon failure, inspect the outputs to check for inaccuracy.
+    assert matches > int(0.66 * len(ref_outputs))
+
+
 def test_suffix_acceptance(
     test_prompts: list[list[dict[str, Any]]],
     sampling_config: SamplingParams,

--- a/tests/ut/spec_decode/test_zipf_config.py
+++ b/tests/ut/spec_decode/test_zipf_config.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_ascend.spec_decode import get_spec_decode_method
+from vllm_ascend.spec_decode.config import get_ascend_spec_decode_method, get_zipf_config
+from vllm_ascend.spec_decode.zipf_proposer import AscendZipfDecodingProposer
+
+
+def make_vllm_config(additional_config=None):
+    vllm_config = MagicMock()
+    vllm_config.speculative_config = MagicMock()
+    vllm_config.speculative_config.method = "suffix"
+    vllm_config.speculative_config.num_speculative_tokens = 3
+    vllm_config.model_config.max_model_len = 1024
+    vllm_config.additional_config = additional_config
+    return vllm_config
+
+
+def test_ascend_spec_decode_method_defaults_to_speculative_config_method():
+    vllm_config = make_vllm_config()
+
+    assert get_ascend_spec_decode_method(vllm_config) == "suffix"
+
+
+def test_ascend_spec_decode_method_uses_additional_config_override():
+    vllm_config = make_vllm_config({"ascend_spec_decode_method": "zipf"})
+
+    assert get_ascend_spec_decode_method(vllm_config) == "zipf"
+
+
+def test_zipf_config_reads_additional_config_values():
+    vllm_config = make_vllm_config(
+        {
+            "zipf_config": {
+                "zipf_ngram_size": 4,
+                "zipf_min_window": 1,
+                "zipf_initial_speculative_tokens": 2,
+                "zipf_skip_shared": False,
+                "zipf_generalized_before_shared": True,
+            }
+        }
+    )
+
+    assert get_zipf_config(vllm_config) == {
+        "zipf_ngram_size": 4,
+        "zipf_min_window": 1,
+        "zipf_initial_speculative_tokens": 2,
+        "zipf_skip_shared": False,
+        "zipf_generalized_before_shared": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("zipf_config", "error"),
+    [
+        ({"zipf_initial_speculative_tokens": 4}, "less than or equal"),
+        ({"zipf_min_window": 0}, "greater than 0"),
+        ({"zipf_ngram_size": 9}, "less than or equal to 8"),
+        ({"zipf_min_window": 5, "zipf_ngram_size": 4}, "greater than or equal"),
+        ({"zipf_skip_shared": 1}, "zipf_skip_shared must be a boolean"),
+    ],
+)
+def test_zipf_config_validates_values(zipf_config, error):
+    vllm_config = make_vllm_config({"zipf_config": zipf_config})
+
+    with pytest.raises(ValueError, match=error):
+        get_zipf_config(vllm_config)
+
+
+def test_get_spec_decode_method_creates_zipf_proposer_from_override():
+    vllm_config = make_vllm_config(
+        {
+            "ascend_spec_decode_method": "zipf",
+            "zipf_config": {
+                "zipf_ngram_size": 4,
+                "zipf_min_window": 1,
+                "zipf_initial_speculative_tokens": 2,
+                "zipf_skip_shared": True,
+                "zipf_generalized_before_shared": False,
+            },
+        }
+    )
+    runner = MagicMock()
+
+    zipf_cache_module = ModuleType("vllm_ascend.spec_decode.zipf_cache")
+    mock_zipf_cache = MagicMock()
+    zipf_cache_module.ZipfCache = mock_zipf_cache
+    with patch.dict("sys.modules", {"vllm_ascend.spec_decode.zipf_cache": zipf_cache_module}):
+        proposer = get_spec_decode_method(
+            get_ascend_spec_decode_method(vllm_config),
+            vllm_config,
+            device=None,
+            runner=runner,
+        )
+
+    assert isinstance(proposer, AscendZipfDecodingProposer)
+    assert proposer.num_speculative_tokens == 2
+    assert proposer.max_speculative_tokens == 3
+    assert proposer.min_window == 1
+    assert proposer.max_window == 4
+    assert proposer.skip_shared is True
+    mock_zipf_cache.assert_called_once_with(
+        min_window=1,
+        max_window=4,
+        skip_shared=True,
+        generalized_before_shared=False,
+    )

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -48,6 +48,7 @@ from vllm_ascend._310p.npu_input_batch import NPUInputBatch310 as NPUInputBatch
 from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
 from vllm_ascend._310p.sample.sampler import AscendSampler310
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.spec_decode.config import get_ascend_spec_decode_method
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
@@ -83,8 +84,8 @@ class NPUModelRunner310(NPUModelRunner):
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
             self.rejection_sampler = RejectionSampler(self.sampler)
-        if self.speculative_config is not None and self.speculative_config.method == "ngram":
-            # 310P ngram requires decode-only graph shapes to be built with q_len=1.
+        if self.speculative_config is not None and get_ascend_spec_decode_method(self.vllm_config) in ("ngram", "zipf"):
+            # 310P hash-based proposers require decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.
             self.cudagraph_dispatcher.uniform_decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
 
@@ -103,11 +104,11 @@ class NPUModelRunner310(NPUModelRunner):
 
     @contextmanager
     def temporary_modify_uniform_decode_query_len(self):
-        # This is only needed for the 310P ngram path where dispatcher uses q_len=1
+        # This is only needed for 310P hash-based proposers where dispatcher uses q_len=1
         # while runner's default uniform_decode_query_len remains 1 + num_spec_tokens.
         # TODO: remove this temporary override after upstream supports independent
         # decode capture query_len for backend-specific paths.
-        if self.speculative_config is None or self.speculative_config.method != "ngram":
+        if self.speculative_config is None or get_ascend_spec_decode_method(self.vllm_config) not in ("ngram", "zipf"):
             yield
             return
 

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -28,6 +28,7 @@ from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
+from vllm_ascend.spec_decode.zipf_proposer import AscendZipfDecodingProposer
 
 
 def get_spec_decode_method(method, vllm_config, device, runner):
@@ -35,6 +36,8 @@ def get_spec_decode_method(method, vllm_config, device, runner):
         return AscendNgramProposer(vllm_config, runner)
     elif method == "ngram_gpu":
         return AscendNgramProposerNPU(vllm_config, device, runner)
+    elif method == "zipf":
+        return AscendZipfDecodingProposer(vllm_config, runner)
     elif method == "suffix":
         return AscendSuffixDecodingProposer(vllm_config, runner)
     elif method == "medusa":

--- a/vllm_ascend/spec_decode/config.py
+++ b/vllm_ascend/spec_decode/config.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2025 The vLLM team.
+#
+# This file is a part of the vllm-ascend project.
+
+ASCEND_SPEC_DECODE_METHOD_CONFIG_KEY = "ascend_spec_decode_method"
+ZIPF_CONFIG_KEY = "zipf_config"
+
+DEFAULT_ZIPF_NGRAM_SIZE = 4
+DEFAULT_ZIPF_MIN_WINDOW = 2
+MAX_ZIPF_NGRAM_SIZE = 8
+DEFAULT_ZIPF_SKIP_SHARED = False
+DEFAULT_ZIPF_GENERALIZED_BEFORE_SHARED = True
+
+
+def get_ascend_spec_decode_method(vllm_config):
+    """Return the Ascend-specific speculative decoding method.
+
+    Upstream vLLM validates speculative_config.method against its own schema.
+    Ascend-only methods that are not in upstream yet are selected through
+    additional_config while speculative_config still enables the vLLM spec
+    decode pipeline and provides num_speculative_tokens.
+    """
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if speculative_config is None:
+        return None
+
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    return additional_config.get(
+        ASCEND_SPEC_DECODE_METHOD_CONFIG_KEY,
+        speculative_config.method,
+    )
+
+
+def get_zipf_config(vllm_config):
+    speculative_config = vllm_config.speculative_config
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    zipf_config = additional_config.get(ZIPF_CONFIG_KEY, {})
+    if not isinstance(zipf_config, dict):
+        raise ValueError("additional_config.zipf_config must be a dictionary.")
+
+    max_speculative_tokens = speculative_config.num_speculative_tokens
+    initial_speculative_tokens = zipf_config.get(
+        "zipf_initial_speculative_tokens",
+        max_speculative_tokens,
+    )
+    min_window = zipf_config.get("zipf_min_window", DEFAULT_ZIPF_MIN_WINDOW)
+    ngram_size = zipf_config.get("zipf_ngram_size", DEFAULT_ZIPF_NGRAM_SIZE)
+    skip_shared = zipf_config.get("zipf_skip_shared", DEFAULT_ZIPF_SKIP_SHARED)
+    generalized_before_shared = zipf_config.get(
+        "zipf_generalized_before_shared",
+        DEFAULT_ZIPF_GENERALIZED_BEFORE_SHARED,
+    )
+
+    if not isinstance(initial_speculative_tokens, int):
+        raise ValueError("zipf_initial_speculative_tokens must be an integer.")
+    if initial_speculative_tokens <= 0:
+        raise ValueError("zipf_initial_speculative_tokens must be greater than 0.")
+    if initial_speculative_tokens > max_speculative_tokens:
+        raise ValueError(
+            "zipf_initial_speculative_tokens must be less than or equal to speculative_config.num_speculative_tokens."
+        )
+
+    if not isinstance(min_window, int) or not isinstance(ngram_size, int):
+        raise ValueError("zipf_min_window and zipf_ngram_size must be integers.")
+    if min_window <= 0:
+        raise ValueError("zipf_min_window must be greater than 0.")
+    if ngram_size < min_window:
+        raise ValueError("zipf_ngram_size must be greater than or equal to zipf_min_window.")
+    if ngram_size > MAX_ZIPF_NGRAM_SIZE:
+        raise ValueError(f"zipf_ngram_size must be less than or equal to {MAX_ZIPF_NGRAM_SIZE}.")
+
+    if not isinstance(skip_shared, bool):
+        raise ValueError("zipf_skip_shared must be a boolean.")
+    if not isinstance(generalized_before_shared, bool):
+        raise ValueError("zipf_generalized_before_shared must be a boolean.")
+
+    return {
+        "zipf_initial_speculative_tokens": initial_speculative_tokens,
+        "zipf_min_window": min_window,
+        "zipf_ngram_size": ngram_size,
+        "zipf_skip_shared": skip_shared,
+        "zipf_generalized_before_shared": generalized_before_shared,
+    }

--- a/vllm_ascend/spec_decode/zipf_cache/__init__.py
+++ b/vllm_ascend/spec_decode/zipf_cache/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2025 The vLLM team.
+#
+# This file is a part of the vllm-ascend project.
+
+from vllm_ascend.spec_decode.zipf_cache._zipf_cache_cpp import ZipfCache, zipf_hash
+
+__all__ = ["ZipfCache", "zipf_hash"]

--- a/vllm_ascend/spec_decode/zipf_proposer.py
+++ b/vllm_ascend/spec_decode/zipf_proposer.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -18,6 +19,11 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
     from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+def _stable_req_hash(req_id: str) -> int:
+    digest = hashlib.blake2b(str(req_id).encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, byteorder="little", signed=False)
 
 
 class AscendZipfDecodingProposer:
@@ -100,7 +106,7 @@ class AscendZipfDecodingProposer:
             if num_tokens >= input_batch.max_model_len:
                 continue
 
-            req_hashes.append(hash(req_id) & 0xFFFFFFFFFFFFFFFF)
+            req_hashes.append(_stable_req_hash(req_id))
             token_ids_rows.append(input_batch.token_ids_cpu[req_index])
             num_tokens_list.append(num_tokens)
             num_prompt_list.append(int(input_batch.num_prompt_tokens[req_index]))

--- a/vllm_ascend/spec_decode/zipf_proposer.py
+++ b/vllm_ascend/spec_decode/zipf_proposer.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2025 The vLLM team.
+#
+# This file is a part of the vllm-ascend project.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from vllm.logger import logger
+
+from vllm_ascend.spec_decode.config import get_zipf_config
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+    from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+class AscendZipfDecodingProposer:
+    """Zipf-based speculative decoding proposer for the Ascend V1 runner."""
+
+    def __init__(self, vllm_config: VllmConfig, runner: NPUModelRunner):
+        config = vllm_config.speculative_config
+        assert config is not None
+        zipf_config = get_zipf_config(vllm_config)
+
+        self.runner = runner
+        self.num_speculative_tokens = zipf_config["zipf_initial_speculative_tokens"]
+        self.max_speculative_tokens = config.num_speculative_tokens
+        self.max_model_len = vllm_config.model_config.max_model_len
+        self.min_window = zipf_config["zipf_min_window"]
+        self.max_window = zipf_config["zipf_ngram_size"]
+        self.skip_shared = zipf_config["zipf_skip_shared"]
+        self.ema_alpha = 0.3
+
+        from vllm_ascend.spec_decode.zipf_cache import ZipfCache
+
+        logger.info(
+            "Creating Ascend Zipf cache: min_window=%d, max_window=%d, skip_shared=%s",
+            self.min_window,
+            self.max_window,
+            self.skip_shared,
+        )
+        self.zipf_cache = ZipfCache(
+            min_window=self.min_window,
+            max_window=self.max_window,
+            skip_shared=self.skip_shared,
+            generalized_before_shared=zipf_config["zipf_generalized_before_shared"],
+        )
+
+    def load_model(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    @torch.inference_mode()
+    def dummy_run(
+        self,
+        num_tokens: int,
+        with_prefill: bool | None = None,
+        in_graph_capturing: bool | None = None,
+        num_reqs: int | None = None,
+        num_tokens_across_dp: int | None = None,
+        aclgraph_runtime_mode: Any | None = None,
+        batch_descriptor: Any | None = None,
+        dummy_compute_logits: Any = lambda hidden_states: None,
+        is_profile: bool = False,
+    ) -> None:
+        pass
+
+    def propose(
+        self,
+        sampled_token_ids: list[list[int]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> list[list[int]]:
+        input_batch = self.runner.input_batch
+        batch_size = min(len(sampled_token_ids), input_batch.num_reqs)
+
+        req_hashes: list[int] = []
+        token_ids_rows = []
+        num_tokens_list: list[int] = []
+        num_prompt_list: list[int] = []
+        valid_mask: list[bool] = []
+        c_sampled: list[list[int]] = []
+        c_to_orig: list[int] = []
+
+        for req_index in range(batch_size):
+            sampled_ids = sampled_token_ids[req_index]
+            if not sampled_ids:
+                continue
+
+            req_id = input_batch.req_ids[req_index]
+            if req_id in input_batch.spec_decode_unsupported_reqs:
+                continue
+
+            num_tokens = int(input_batch.num_tokens_no_spec[req_index])
+            if num_tokens >= input_batch.max_model_len:
+                continue
+
+            req_hashes.append(hash(req_id) & 0xFFFFFFFFFFFFFFFF)
+            token_ids_rows.append(input_batch.token_ids_cpu[req_index])
+            num_tokens_list.append(num_tokens)
+            num_prompt_list.append(int(input_batch.num_prompt_tokens[req_index]))
+            c_sampled.append(sampled_ids)
+            valid_mask.append(True)
+            c_to_orig.append(req_index)
+
+        draft_token_ids: list[list[int]] = [[] for _ in range(len(sampled_token_ids))]
+
+        if req_hashes:
+            batch_results = self.zipf_cache.propose_batch(
+                req_hashes,
+                token_ids_rows,
+                num_tokens_list,
+                num_prompt_list,
+                c_sampled,
+                valid_mask,
+                self.max_model_len,
+                self.num_speculative_tokens,
+                self.ema_alpha,
+                self.max_speculative_tokens,
+            )
+            for result_index, orig_index in enumerate(c_to_orig):
+                draft = batch_results[result_index]
+                if draft:
+                    draft_token_ids[orig_index] = list(draft)
+
+        return draft_token_ids
+
+    def get_stats(self) -> dict[str, Any]:
+        stats = self.zipf_cache.stats()
+        return {
+            "query_count": stats["query_count"],
+            "shared_hit_count": stats["shared_hit_count"],
+            "local_hit_count": stats["local_hit_count"],
+            "shared_hit_rate": stats["shared_hit_rate"],
+            "local_hit_rate": stats["local_hit_rate"],
+            "total_hit_rate": stats["total_hit_rate"],
+            "update_count": stats["update_count"],
+            "shared_entries": stats["shared_entries"],
+            "local_hashes": stats["local_hashes"],
+            "local_entries": stats["local_entries"],
+            "local_memory_mb": stats["local_memory_mb"],
+        }

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -127,6 +127,7 @@ from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
+from vllm_ascend.spec_decode.config import get_ascend_spec_decode_method
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
@@ -138,6 +139,7 @@ from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
 from vllm_ascend.spec_decode.suffix_proposer import AscendSuffixDecodingProposer
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
+from vllm_ascend.spec_decode.zipf_proposer import AscendZipfDecodingProposer
 from vllm_ascend.utils import (
     calc_split_factor,
     check_gdn_layer,
@@ -534,6 +536,7 @@ class NPUModelRunner(GPUModelRunner):
         self.drafter: (
             AscendNgramProposer
             | AscendNgramProposerNPU
+            | AscendZipfDecodingProposer
             | AscendEagleProposer
             | AscendDraftModelProposer
             | AscendDflashProposer
@@ -544,13 +547,14 @@ class NPUModelRunner(GPUModelRunner):
         ) = None
         self.actual_seq_lengths_q: list[int] = []
         self.decode_token_per_req = 1
+        self.spec_decode_method = get_ascend_spec_decode_method(self.vllm_config)
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             assert spec_token_num > 0
             self.decode_token_per_req = 1 + spec_token_num
             if get_pp_group().is_last_rank:
                 self.drafter = self._get_drafter()
-                if self.speculative_config.method == "eagle3":
+                if self.spec_decode_method == "eagle3":
                     assert isinstance(self.drafter, AscendEagleProposer)
                     self.use_aux_hidden_state_outputs = self.drafter.eagle3_use_aux_hidden_state
                 elif self.speculative_config.method == "extract_hidden_states":
@@ -561,7 +565,7 @@ class NPUModelRunner(GPUModelRunner):
         self.num_discarded_requests = 0
 
     def _get_drafter(self):
-        return get_spec_decode_method(self.speculative_config.method, self.vllm_config, self.device, self)
+        return get_spec_decode_method(self.spec_decode_method, self.vllm_config, self.device, self)
 
     def _use_aclgraph(self) -> bool:
         return (
@@ -1434,7 +1438,7 @@ class NPUModelRunner(GPUModelRunner):
         if not self.drafter:
             # Speculative decoding is not enabled.
             draft_token_ids = None
-        elif isinstance(self.drafter, (AscendNgramProposer, AscendSuffixDecodingProposer)):
+        elif isinstance(self.drafter, (AscendNgramProposer, AscendZipfDecodingProposer, AscendSuffixDecodingProposer)):
             draft_token_ids = self.drafter.propose(valid_sampled_token_ids)
         elif isinstance(self.drafter, AscendNgramProposerNPU):
             batch_size = min(self.input_batch.num_reqs, self.token_ids_gpu_tensor.shape[0])


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Ascend Zipf speculative decoding support.

The main changes are:

- Add Zipf speculative decoding configuration parsing through `additional_config`.
- Add a Zipf proposer implementation for Ascend speculative decoding.
- Integrate Zipf proposer selection into the suffix speculative decoding path.
- Add native cache support used by the Zipf proposer.
- Add documentation for Zipf speculative decoding configuration and usage.
- Add e2e coverage for Zipf decoding correctness.

This enables users to run suffix-style speculative decoding with the Ascend Zipf proposer by setting:

```python
speculative_config={
    "method": "suffix",
    "num_speculative_tokens": 3,
},
additional_config={
    "ascend_spec_decode_method": "zipf",
    "zipf_config": {
        "zipf_ngram_size": 4,
        "zipf_min_window": 1,
        "zipf_initial_speculative_tokens": 2,
        "zipf_skip_shared": False,
        "zipf_generalized_before_shared": True,
    },
}
```

The feature is useful for workloads where repeated or locally predictable token patterns can be exploited without a separate draft model.

Performance comparison will be added later after additional benchmark runs are completed.

### Does this PR introduce _any_ user-facing change?

Yes.

This PR adds a new optional Ascend speculative decoding mode, enabled through `additional_config`:

```python
additional_config={
    "ascend_spec_decode_method": "zipf",
    "zipf_config": {
        "zipf_ngram_size": 4,
        "zipf_min_window": 1,
        "zipf_initial_speculative_tokens": 2,
        "zipf_skip_shared": False,
        "zipf_generalized_before_shared": True,
    },
}
```

Existing behavior is unchanged unless users explicitly opt into Zipf speculative decoding.

### How was this patch tested?

Unit test:

```bash
pytest -sv tests/ut/spec_decode/test_zipf_config.py
```

Formatting and lint check:

```bash
bash format.sh ci
```

Manual NPU smoke test:

```bash
cd /vllm-workspace
VLLM_WORKER_MULTIPROC_METHOD=spawn \
OMP_NUM_THREADS=1 \
MKL_NUM_THREADS=1 \
OPENBLAS_NUM_THREADS=1 \
python vllm_ascend_pr/test_LLM.py
```

Result: the script ran successfully and produced normal model output.

The new Zipf e2e correctness test was added, but it was not fully completed in my local environment due to environment issues:

```bash
VLLM_TEST_MODEL=/data/share/Meta-Llama-3.1-8B-Instruct \
pytest -sv tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py::test_zipf_correctness
```

Syntax check for the updated e2e test file:

```bash
python -m py_compile tests/e2e/singlecard/spec_decode/test_v1_spec_decode.py
```

Performance comparison is still pending and will be provided in a follow-up PR comment once benchmark runs are complete.

Note: Parts of the code and documentation in this PR were prepared with AI assistance and reviewed by the author.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
