### PR TITLE
[BugFix][0.20.2] Chunk wq_b matmul for NPU 65536 dimension limit

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -256,6 +256,9 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend = MooncakeBackend.__new__(MooncakeBackend)
             backend.store = MagicMock()
             backend.config = MagicMock()
+            backend._lazy_init = False
+            backend._store_initialized = True
+            backend._use_fabric_mem = False
             return backend
 
     def test_exists(self):
@@ -413,6 +416,12 @@ class TestMemcacheBackendMethods(unittest.TestCase):
             backend = MemcacheBackend.__new__(MemcacheBackend)
             backend.store = MagicMock()
             backend.local_rank = 0
+            # Set internal state to avoid lazy init logic during tests
+            backend._lazy_init = False
+            backend._store_initialized = True
+            backend._is_a2 = False
+            backend._registered_buffers = None
+            backend._buffers_registered = False
             return backend
 
     def test_exists(self):

--- a/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+)
+
+from vllm_ascend.patch.platform import (
+    patch_glm_tool_call_streaming as glm_streaming_patch,
+)
+
+
+def test_remaining_args_delta_omits_metadata_by_default():
+    original_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                id="call_current",
+                type="function",
+                function=DeltaFunctionCall(
+                    name="current_name",
+                    arguments='{"files":[',
+                ),
+            )
+        ]
+    )
+
+    result = OpenAIServingChat._create_remaining_args_delta(
+        original_delta,
+        "]}",
+        0,
+    )
+
+    tc = result.tool_calls[0]
+    assert tc.index == 0
+    assert tc.id is None
+    assert tc.type is None
+    assert tc.function.name is None
+    assert tc.function.arguments == "]}"
+    serialized = tc.model_dump(exclude_unset=True)
+    assert "id" not in serialized
+    assert "type" not in serialized
+    assert "name" not in serialized["function"]
+
+
+def test_remaining_args_delta_uses_explicit_fallback_metadata():
+    result = OpenAIServingChat._create_remaining_args_delta(
+        DeltaMessage(),
+        '{"filepath":"pong.py"}',
+        0,
+        fallback_tool_call_id="call_files",
+        fallback_tool_call_type="function",
+        fallback_tool_call_name="builtin_read_many_files",
+    )
+
+    tc = result.tool_calls[0]
+    assert tc.index == 0
+    assert tc.id == "call_files"
+    assert tc.type == "function"
+    assert tc.function.name == "builtin_read_many_files"
+    assert tc.function.arguments == '{"filepath":"pong.py"}'
+
+
+def test_terminal_argument_chunk_is_split_before_finish_chunk():
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "GLM-5",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {
+                                "arguments": '"pong.py"}',
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+                "stop_reason": None,
+            }
+        ],
+    }
+
+    chunks = glm_streaming_patch._split_terminal_tool_arg_chunk(f"data: {json.dumps(chunk)}\n\n")
+
+    assert len(chunks) == 2
+    arg_payload = json.loads(chunks[0].removeprefix("data: ").removesuffix("\n\n"))
+    finish_payload = json.loads(chunks[1].removeprefix("data: ").removesuffix("\n\n"))
+
+    arg_choice = arg_payload["choices"][0]
+    assert arg_choice["finish_reason"] is None
+    assert arg_choice["stop_reason"] is None
+    assert arg_choice["delta"]["tool_calls"][0]["function"]["arguments"] == '"pong.py"}'
+
+    finish_choice = finish_payload["choices"][0]
+    assert finish_choice["finish_reason"] == "tool_calls"
+    assert finish_choice["delta"] == {}
+
+
+def test_non_terminal_and_done_chunks_are_not_split():
+    content = 'data: {"choices":[]}\n\n'
+    done = "data: [DONE]\n\n"
+
+    assert glm_streaming_patch._split_terminal_tool_arg_chunk(content) == [content]
+    assert glm_streaming_patch._split_terminal_tool_arg_chunk(done) == [done]

--- a/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
+++ b/tests/ut/patch/platform/test_patch_tool_choice_none_content.py
@@ -1,6 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    FunctionCall,
+    ToolCall,
+    UsageInfo,
+)
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.abstract_parser import DelegatingParser
@@ -104,3 +121,99 @@ def test_responses_parser_allows_named_tool_choice_with_none_content():
 
     assert content is None
     assert tool_calls == []
+
+
+def _chat_response(message: ChatMessage) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="test-model",
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=message,
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def test_chat_completion_response_omits_empty_tool_calls_payload():
+    response = _chat_response(ChatMessage(role="assistant", content="done"))
+
+    payload = response.model_dump()
+
+    assert "tool_calls" not in payload["choices"][0]["message"]
+    parsed = OpenAIChatCompletion.model_validate(payload)
+    assert parsed.choices[0].message.tool_calls is None
+
+
+def test_chat_completion_response_keeps_non_empty_tool_calls_payload():
+    response = _chat_response(
+        ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_weather",
+                        arguments='{"city": "Beijing"}',
+                    )
+                )
+            ],
+        )
+    )
+
+    message = response.model_dump()["choices"][0]["message"]
+
+    assert len(message["tool_calls"]) == 1
+    assert message["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def _stream_response(delta: DeltaMessage) -> ChatCompletionStreamResponse:
+    return ChatCompletionStreamResponse(
+        id="chatcmpl-test",
+        object="chat.completion.chunk",
+        created=1,
+        model="test-model",
+        choices=[
+            ChatCompletionResponseStreamChoice(
+                index=0,
+                delta=delta,
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def test_chat_completion_stream_response_omits_empty_tool_calls_payload():
+    response = _stream_response(DeltaMessage(content="done", tool_calls=[]))
+
+    payload = response.model_dump(exclude_unset=True)
+    payload_json = response.model_dump_json(exclude_unset=True)
+
+    assert "tool_calls" not in payload["choices"][0]["delta"]
+    parsed = ChatCompletionChunk.model_validate_json(payload_json)
+    assert parsed.choices[0].delta.tool_calls is None
+
+
+def test_chat_completion_stream_response_keeps_non_empty_tool_calls_payload():
+    response = _stream_response(
+        DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call-test",
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name="get_weather",
+                        arguments='{"city": "Beijing"}',
+                    ),
+                )
+            ]
+        )
+    )
+
+    delta = response.model_dump(exclude_unset=True)["choices"][0]["delta"]
+
+    assert len(delta["tool_calls"]) == 1
+    assert delta["tool_calls"][0]["function"]["name"] == "get_weather"

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1009,14 +1009,37 @@ class AscendDSACPImpl(DSAAttentionImpl):
             qr_local, qr_pertoken_scale_local = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 q_a, self.q_norm.weight, epsilon=self.eps
             )
-            q = torch_npu.npu_quant_matmul(
-                qr_local,
-                self.wq_b.weight,
-                self.wq_b.weight_scale,
-                pertoken_scale=qr_pertoken_scale_local,
-                bias=self.wq_b.bias,
-                output_dtype=hidden_states_local.dtype,
-            )
+            if getattr(self.wq_b, "_is_chunked", False):
+                q = torch.cat(
+                    [
+                        torch_npu.npu_quant_matmul(
+                            qr_local,
+                            self.wq_b.weight_1,
+                            self.wq_b.weight_1_scale,
+                            pertoken_scale=qr_pertoken_scale_local,
+                            bias=self.wq_b.bias,
+                            output_dtype=hidden_states_local.dtype,
+                        ),
+                        torch_npu.npu_quant_matmul(
+                            qr_local,
+                            self.wq_b.weight_2,
+                            self.wq_b.weight_2_scale,
+                            pertoken_scale=qr_pertoken_scale_local,
+                            bias=None,
+                            output_dtype=hidden_states_local.dtype,
+                        ),
+                    ],
+                    dim=-1,
+                )
+            else:
+                q = torch_npu.npu_quant_matmul(
+                    qr_local,
+                    self.wq_b.weight,
+                    self.wq_b.weight_scale,
+                    pertoken_scale=qr_pertoken_scale_local,
+                    bias=self.wq_b.bias,
+                    output_dtype=hidden_states_local.dtype,
+                )
         else:
             qr_local = self.q_norm(self.wq_a(hidden_states_local))
             q = self.wq_b(qr_local)

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1009,7 +1009,11 @@ class AscendDSACPImpl(DSAAttentionImpl):
             qr_local, qr_pertoken_scale_local = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 q_a, self.q_norm.weight, epsilon=self.eps
             )
-            if getattr(self.wq_b, "_is_chunked", False):
+            if getattr(self.wq_b, "_chunk_size", 0):
+                bias = self.wq_b.bias
+                chunk_size = self.wq_b._chunk_size
+                bias_1 = bias[:chunk_size] if bias is not None else None
+                bias_2 = bias[chunk_size:] if bias is not None else None
                 q = torch.cat(
                     [
                         torch_npu.npu_quant_matmul(
@@ -1017,7 +1021,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                             self.wq_b.weight_1,
                             self.wq_b.weight_1_scale,
                             pertoken_scale=qr_pertoken_scale_local,
-                            bias=self.wq_b.bias,
+                            bias=bias_1,
                             output_dtype=hidden_states_local.dtype,
                         ),
                         torch_npu.npu_quant_matmul(
@@ -1025,7 +1029,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                             self.wq_b.weight_2,
                             self.wq_b.weight_2_scale,
                             pertoken_scale=qr_pertoken_scale_local,
-                            bias=None,
+                            bias=bias_2,
                             output_dtype=hidden_states_local.dtype,
                         ),
                     ],

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -148,7 +148,7 @@ class RecomputeScheduler(Scheduler):
                 request.prompt_token_ids.pop()
                 request._all_token_ids.pop()
                 request.num_prompt_tokens -= 1
-            if self.is_mtp_kv_consumer:
+            if self.is_mtp_kv_consumer and (self.max_model_len >= (request.num_tokens + self.num_spec_tokens)):
                 request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -1,5 +1,7 @@
 # Standard
+import threading
 from enum import Enum
+from typing import Any
 
 import torch
 from vllm.config import ParallelConfig
@@ -18,7 +20,34 @@ class MmcDirect(Enum):
 
 
 class MemcacheBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+        self.local_rank = get_world_group().local_rank
+        self.store: Any | None = None
+        self._is_a2 = get_ascend_device_type() in {AscendDeviceType.A2}
+        self._lazy_init = lazy_init and not self._is_a2
+        self._store_initialized = False
+        self._store_init_lock = threading.Lock()
+        self._registered_buffers: tuple[list[int], list[int]] | None = None
+        self._buffers_registered = False
+
+        if not self._lazy_init:
+            self.store = self._setup_store()
+            self._store_initialized = True
+
+    def _ensure_initialized(self):
+        if self._store_initialized:
+            return
+
+        with self._store_init_lock:
+            if self._store_initialized:
+                return
+
+            logger.info("Initializing Memcache store on first put.")
+            self.store = self._setup_store()
+            self._store_initialized = True
+            self._register_buffers_if_needed()
+
+    def _setup_store(self):
         try:
             from memcache_hybrid import DistributedObjectStore  # type: ignore
         except ImportError as e:
@@ -28,15 +57,14 @@ class MemcacheBackend(Backend):
                 "to run vLLM with MemcacheConnector."
             ) from e
         try:
-            soc_version = get_ascend_device_type()
-            if soc_version in {AscendDeviceType.A2}:
+            if self._is_a2:
                 tmp_tensor = torch.zeros(1, device="npu")
                 output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
                 torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)
-            self.local_rank = get_world_group().local_rank
-            self.store = DistributedObjectStore()
-            res = self.store.init(self.local_rank)
+            store = DistributedObjectStore()
+            res = store.init(self.local_rank)
             assert res == 0
+            return store
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
             raise
@@ -49,17 +77,37 @@ class MemcacheBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):
-        soc_version = get_ascend_device_type()
-        if soc_version in {AscendDeviceType.A2}:
-            for ptr, size in zip(ptrs, sizes):
-                self.store.register_buffer(ptr, size)
-        else:
-            pass
+        self._registered_buffers = (list(ptrs), list(sizes))
+        self._register_buffers_if_needed()
+
+    def _register_buffers_if_needed(self):
+        if not self._is_a2:
+            return
+        if self._registered_buffers is None or self._buffers_registered:
+            return
+        if not self._store_initialized:
+            return
+        assert self.store is not None
+        ptrs, sizes = self._registered_buffers
+        for ptr, size in zip(ptrs, sizes):
+            self.store.register_buffer(ptr, size)
+        self._buffers_registered = True
 
     def exists(self, keys: list[str]) -> list[int]:
+        if self._lazy_init and not self._store_initialized:
+            logger.debug(
+                "MemcacheBackend.exists called before store initialization; treating %d keys as missing.",
+                len(keys),
+            )
+            return [0] * len(keys)
+        assert self.store is not None
         return self.store.batch_is_exist(keys)
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
+        if self._lazy_init and not self._store_initialized:
+            logger.error("MemcacheBackend.get called before store initialization, keys=%s", key)
+            return
+        assert self.store is not None
         try:
             res = self.store.batch_get_into_layers(key, addr, size, MmcDirect.COPY_G2L.value)
             for value in res:
@@ -70,9 +118,15 @@ class MemcacheBackend(Backend):
 
     def put(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         try:
+            self._ensure_initialized()
+            assert self.store is not None
             res = self.store.batch_put_from_layers(key, addr, size, MmcDirect.COPY_L2G.value)
             for value in res:
                 if value != 0:
-                    logger.error("Failed to get key %s,res:%s", key, res)
+                    logger.error("Failed to put key %s,res:%s", key, res)
+                    if self._lazy_init:
+                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
         except Exception as e:
             logger.error("Failed to put key %s,error:%s", key, e)
+            if self._lazy_init:
+                logger.error("If this is the first DSV4(compress) request, this failure is expected.")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -1,7 +1,9 @@
 # Standard
 import json
 import os
+import threading
 from dataclasses import dataclass
+from typing import Any
 
 import regex as re
 import torch
@@ -20,7 +22,35 @@ DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 
 class MooncakeBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+        self.config = MooncakeStoreConfig.load_from_env()
+        if self.config.protocol != "ascend":
+            raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
+
+        self.store: Any | None = None
+        self.local_seg: str | None = None
+        self._use_fabric_mem = os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") == "1"
+        self._lazy_init = lazy_init and self._use_fabric_mem
+        self._store_initialized = False
+        self._store_init_lock = threading.Lock()
+
+        if not self._lazy_init:
+            self.store = self._setup_store()
+            self._store_initialized = True
+
+    def _ensure_initialized(self):
+        if self._store_initialized:
+            return
+
+        with self._store_init_lock:
+            if self._store_initialized:
+                return
+
+            logger.info("Initializing Mooncake store on first put.")
+            self.store = self._setup_store()
+            self._store_initialized = True
+
+    def _setup_store(self):
         try:
             from mooncake.store import MooncakeDistributedStore  # type: ignore
         except ImportError as e:
@@ -29,44 +59,42 @@ class MooncakeBackend(Backend):
                 "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
                 "to run vLLM with MooncakeConnector."
             ) from e
-        self.config = MooncakeStoreConfig.load_from_env()
-        self.store = MooncakeDistributedStore()
-        if self.config.protocol == "ascend":
-            local_hostname = get_ip()
-            # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
-            # and only can be used for 800 I/T A3 series.
-            # Required supporting hardware versions are as follows:
-            if os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") != "1":
-                transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
-                self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
-                ret = self.store.setup(
-                    self.local_seg,
-                    self.config.metadata_server,
-                    self.config.global_segment_size,
-                    self.config.local_buffer_size,
-                    self.config.protocol,
-                    self.config.device_name,
-                    self.config.master_server_address,
-                    transfer_engine.get_engine(),
-                )
-            else:
-                self.local_seg = local_hostname
-                ret = self.store.setup(
-                    self.local_seg,
-                    self.config.metadata_server,
-                    self.config.global_segment_size,
-                    0,
-                    self.config.protocol,
-                    self.config.device_name,
-                    self.config.master_server_address,
-                )
 
-            if ret != 0:
-                msg = "Initialize mooncake failed."
-                logger.error(msg)
-                raise RuntimeError(msg)
+        store = MooncakeDistributedStore()
+        local_hostname = get_ip()
+        # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
+        # and only can be used for 800 I/T A3 series.
+        # Required supporting hardware versions are as follows:
+        if not self._use_fabric_mem:
+            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
+            self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
+            ret = store.setup(
+                self.local_seg,
+                self.config.metadata_server,
+                self.config.global_segment_size,
+                self.config.local_buffer_size,
+                self.config.protocol,
+                self.config.device_name,
+                self.config.master_server_address,
+                transfer_engine.get_engine(),
+            )
         else:
-            raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
+            self.local_seg = local_hostname
+            ret = store.setup(
+                self.local_seg,
+                self.config.metadata_server,
+                self.config.global_segment_size,
+                0,
+                self.config.protocol,
+                self.config.device_name,
+                self.config.master_server_address,
+            )
+
+        if ret != 0:
+            msg = "Initialize mooncake failed."
+            logger.error(msg)
+            raise RuntimeError(msg)
+        return store
 
     def set_device(self):
         local_rank = get_world_group().local_rank
@@ -74,22 +102,41 @@ class MooncakeBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
-        if os.getenv("ASCEND_ENABLE_USE_FABRIC_MEM", "0") != "1":
+        if not self._use_fabric_mem:
+            local_hostname = get_ip()
+            global_te.get_transfer_engine(local_hostname, device_name=None)
             global_te.register_buffer(ptrs, lengths)
 
     def exists(self, keys: list[str]) -> list[int]:
+        if self._lazy_init and not self._store_initialized:
+            logger.debug(
+                "MooncakeBackend.exists called before store initialization; treating %d keys as missing.",
+                len(keys),
+            )
+            return [0] * len(keys)
+        assert self.store is not None
         return self.store.batch_is_exist(keys)
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         try:
+            self._ensure_initialized()
+            assert self.store is not None
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
             for value in res:
                 if value < 0:
                     logger.error("Failed to put key %s,res:%s", keys, res)
+                    if self._lazy_init:
+                        logger.error("If this is the first DSV4(compress) request, this failure is expected.")
         except Exception as e:
             logger.error("Failed to put key %s,error:%s", keys, e)
+            if self._lazy_init:
+                logger.error("If this is the first DSV4(compress) request, this failure is expected.")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+        if self._lazy_init and not self._store_initialized:
+            logger.error("MooncakeBackend.get called before store initialization, keys=%s", keys)
+            return
+        assert self.store is not None
         logger.debug(
             "MooncakeBackend.get enter keys=%d sample_keys=%s",
             len(keys),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -183,8 +183,14 @@ class KVPoolWorker:
         backend_module = importlib.import_module(backend_path)
         real_backend = getattr(backend_module, backend_name)
 
+        backend_kwargs = {}
+        if self.backend.lower() in {"mooncake", "memcache"}:
+            # DSV4 exposes compress_ratios; only use lazy store init for this
+            # compressed-model path.
+            backend_kwargs["lazy_init"] = self.use_compress
         self.m_store = real_backend(  # type: ignore[misc]
-            parallel_config
+            parallel_config,
+            **backend_kwargs,
         )
         kv_event_config = vllm_config.kv_events_config
         self.enable_kv_events = False

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -162,6 +162,26 @@
 #       Remove this patch once the runtime vLLM version contains the upstream
 #       MiniMax usage-accounting fix.
 #
+# ** 7a. File: platform/patch_glm_tool_call_streaming.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#    Why:
+#       GLM tool-call streaming can emit final remaining-argument chunks with
+#       repeated tool-call metadata, and can combine terminal argument bytes with
+#       `finish_reason="tool_calls"` in the same SSE chunk.
+#    How：
+#       Monkey-patch remaining-argument delta construction to emit only argument
+#       fragments by default, and split terminal argument chunks into an argument
+#       chunk followed by an empty finish chunk.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/44098
+#       https://github.com/vllm-project/vllm/pull/44099
+#       https://github.com/vllm-project/vllm-ascend/issues/8327
+#       https://github.com/vllm-project/vllm-ascend/pull/8178
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains the upstream
+#       GLM tool-call final chunk fixes.
+#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -30,6 +30,7 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
+import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
@@ -1,0 +1,127 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# OpenAI chat streaming: backport GLM tool-call final chunk fixes.
+#
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+)
+
+
+def _create_remaining_args_delta(
+    delta_message: DeltaMessage,
+    remaining_call: str,
+    index: int,
+    fallback_tool_call_id: str | None = None,
+    fallback_tool_call_type: str | None = None,
+    fallback_tool_call_name: str | None = None,
+) -> DeltaMessage:
+    function_kwargs: dict[str, str] = {"arguments": remaining_call}
+    if fallback_tool_call_name is not None:
+        function_kwargs["name"] = fallback_tool_call_name
+
+    tool_call_kwargs: dict[str, Any] = {
+        "index": index,
+        "function": DeltaFunctionCall(**function_kwargs),
+    }
+    if fallback_tool_call_id is not None:
+        tool_call_kwargs["id"] = fallback_tool_call_id
+    if fallback_tool_call_type is not None:
+        tool_call_kwargs["type"] = fallback_tool_call_type
+
+    return DeltaMessage(tool_calls=[DeltaToolCall(**tool_call_kwargs)])
+
+
+def _terminal_tool_arg_choice(choice: dict[str, Any]) -> bool:
+    if choice.get("finish_reason") != "tool_calls":
+        return False
+    delta = choice.get("delta") or {}
+    for tool_call in delta.get("tool_calls") or []:
+        function = tool_call.get("function") or {}
+        if function.get("arguments"):
+            return True
+    return False
+
+
+def _split_terminal_tool_arg_chunk(data: str) -> list[str]:
+    prefix = "data: "
+    suffix = "\n\n"
+    if not data.startswith(prefix):
+        return [data]
+
+    payload = data[len(prefix) :]
+    if payload.endswith(suffix):
+        payload = payload[: -len(suffix)]
+    if payload == "[DONE]":
+        return [data]
+
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        return [data]
+
+    choices = chunk.get("choices") or []
+    if len(choices) != 1 or not _terminal_tool_arg_choice(choices[0]):
+        return [data]
+
+    arg_chunk = copy.deepcopy(chunk)
+    arg_choice = arg_chunk["choices"][0]
+    arg_choice["finish_reason"] = None
+    arg_choice["stop_reason"] = None
+
+    finish_chunk = copy.deepcopy(chunk)
+    finish_choice = finish_chunk["choices"][0]
+    finish_choice["delta"] = {}
+
+    return [
+        f"{prefix}{json.dumps(arg_chunk, ensure_ascii=False)}{suffix}",
+        f"{prefix}{json.dumps(finish_chunk, ensure_ascii=False)}{suffix}",
+    ]
+
+
+if not hasattr(OpenAIServingChat, "_ascend_glm_original_chat_completion_stream_generator"):
+    OpenAIServingChat._ascend_glm_original_chat_completion_stream_generator = (
+        OpenAIServingChat.chat_completion_stream_generator
+    )
+
+
+async def _wrapped_chat_completion_stream_generator(
+    self,
+    *args,
+    **kwargs,
+):
+    original_stream_generator = self._ascend_glm_original_chat_completion_stream_generator
+    async for data in original_stream_generator(*args, **kwargs):
+        for chunk in _split_terminal_tool_arg_chunk(data):
+            yield chunk
+
+
+OpenAIServingChat._create_remaining_args_delta = staticmethod(_create_remaining_args_delta)
+_wrapped_chat_completion_stream_generator.__module__ = OpenAIServingChat.__module__
+_wrapped_chat_completion_stream_generator.__qualname__ = (
+    f"{OpenAIServingChat.__qualname__}.chat_completion_stream_generator"
+)
+OpenAIServingChat.chat_completion_stream_generator = _wrapped_chat_completion_stream_generator

--- a/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
+++ b/vllm_ascend/patch/platform/patch_tool_choice_none_content.py
@@ -19,14 +19,63 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from openai.types.responses import ToolChoiceFunction
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
+    ChatCompletionResponse,
+    ChatCompletionStreamResponse,
 )
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.parser.abstract_parser import DelegatingParser
 
 _NO_FORCED_TOOL_CALL = "_vllm_ascend_no_forced_tool_call"
+
+_original_chat_completion_response_model_dump = ChatCompletionResponse.model_dump
+_original_chat_completion_stream_response_model_dump = ChatCompletionStreamResponse.model_dump
+
+
+def _omit_empty_tool_calls(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        return payload
+
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        for field_name in ("message", "delta"):
+            message = choice.get(field_name)
+            if isinstance(message, dict) and message.get("tool_calls") == []:
+                message.pop("tool_calls")
+
+    return payload
+
+
+def _patched_chat_completion_response_model_dump(self, *args, **kwargs):
+    return _omit_empty_tool_calls(_original_chat_completion_response_model_dump(self, *args, **kwargs))
+
+
+def _patched_chat_completion_stream_response_model_dump(self, *args, **kwargs):
+    return _omit_empty_tool_calls(_original_chat_completion_stream_response_model_dump(self, *args, **kwargs))
+
+
+def _patched_chat_completion_stream_response_model_dump_json(self, *args, **kwargs):
+    dump_kwargs = dict(kwargs)
+    indent = dump_kwargs.pop("indent", None)
+    ensure_ascii = dump_kwargs.pop("ensure_ascii", False)
+    payload = _patched_chat_completion_stream_response_model_dump(self, *args, **dump_kwargs)
+    separators = None if indent is not None else (",", ":")
+    return json.dumps(payload, ensure_ascii=ensure_ascii, indent=indent, separators=separators)
+
+
+ChatCompletionResponse.model_dump = _patched_chat_completion_response_model_dump
+ChatCompletionStreamResponse.model_dump = _patched_chat_completion_stream_response_model_dump
+ChatCompletionStreamResponse.model_dump_json = _patched_chat_completion_stream_response_model_dump_json
 
 
 def _is_forced_tool_choice(request) -> bool:

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -84,7 +84,10 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             quantized_x = quantized_x.squeeze(dim=1)
             pertoken_scale = pertoken_scale.squeeze(dim=1)
 
-        if getattr(layer, "_is_chunked", False):
+        if getattr(layer, "_chunk_size", 0):
+            chunk_size = layer._chunk_size
+            bias_1 = bias[:chunk_size] if bias is not None else None
+            bias_2 = bias[chunk_size:] if bias is not None else None
             output = torch.cat(
                 [
                     torch_npu.npu_quant_matmul(
@@ -92,7 +95,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
                         layer.weight_1,
                         layer.weight_1_scale,
                         pertoken_scale=pertoken_scale,
-                        bias=bias,
+                        bias=bias_1,
                         output_dtype=x.dtype,
                     ),
                     torch_npu.npu_quant_matmul(
@@ -100,7 +103,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
                         layer.weight_2,
                         layer.weight_2_scale,
                         pertoken_scale=pertoken_scale,
-                        bias=None,  # Only apply bias to the first chunk to avoid double counting
+                        bias=bias_2,
                         output_dtype=x.dtype,
                     ),
                 ],
@@ -125,8 +128,9 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             # TODO(jianzs): Remove this workaround after
             # `torch_npu.npu_quant_matmul` supports large weight dimensions.
             chunk_size = layer.weight.shape[1] // 2
-            assert chunk_size < 65536, "Even after chunking, the weight dimension is still larger than 65536."
-            layer._is_chunked = True
+            assert chunk_size < 65536, \
+                "Even after chunking, the weight dimension is still larger than 65536."
+            layer._chunk_size = chunk_size
             layer.weight_1 = maybe_trans_nz(layer.weight.data[:, :chunk_size].contiguous())
             layer.weight_2 = maybe_trans_nz(layer.weight.data[:, chunk_size:].contiguous())
             layer.weight_1_scale = layer.weight_scale.data[:chunk_size].flatten().contiguous()

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -128,8 +128,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             # TODO(jianzs): Remove this workaround after
             # `torch_npu.npu_quant_matmul` supports large weight dimensions.
             chunk_size = layer.weight.shape[1] // 2
-            assert chunk_size < 65536, \
-                "Even after chunking, the weight dimension is still larger than 65536."
+            assert chunk_size < 65536, "Even after chunking, the weight dimension is still larger than 65536."
             layer._chunk_size = chunk_size
             layer.weight_1 = maybe_trans_nz(layer.weight.data[:, :chunk_size].contiguous())
             layer.weight_2 = maybe_trans_nz(layer.weight.data[:, chunk_size:].contiguous())

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -29,7 +29,7 @@ from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.flash_common3_context import get_flash_common3_context
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
-from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, enable_dsa_cp, maybe_trans_nz
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -83,25 +83,67 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             need_unsqz = True
             quantized_x = quantized_x.squeeze(dim=1)
             pertoken_scale = pertoken_scale.squeeze(dim=1)
-        output = torch_npu.npu_quant_matmul(
-            quantized_x,
-            layer.weight,
-            layer.weight_scale,
-            pertoken_scale=pertoken_scale,
-            bias=bias,
-            output_dtype=x.dtype,
-        )
+
+        if getattr(layer, "_is_chunked", False):
+            output = torch.cat(
+                [
+                    torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        layer.weight_1,
+                        layer.weight_1_scale,
+                        pertoken_scale=pertoken_scale,
+                        bias=bias,
+                        output_dtype=x.dtype,
+                    ),
+                    torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        layer.weight_2,
+                        layer.weight_2_scale,
+                        pertoken_scale=pertoken_scale,
+                        bias=None,  # Only apply bias to the first chunk to avoid double counting
+                        output_dtype=x.dtype,
+                    ),
+                ],
+                dim=-1,
+            )
+        else:
+            output = torch_npu.npu_quant_matmul(
+                quantized_x,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=bias,
+                output_dtype=x.dtype,
+            )
         if need_unsqz:
             output = output.unsqueeze(dim=1)
         return output
 
     def process_weights_after_loading(self, layer):
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        # cast quantized weight tensors in NZ format for higher inference speed
-        layer.weight.data = maybe_trans_nz(layer.weight.data)
-        layer.weight_scale.data = layer.weight_scale.data.flatten()
-        layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
-        layer.weight_offset.data = layer.weight_offset.data.flatten()
+        if "wq_b" in layer.prefix and layer.weight.shape[1] >= 65536 and enable_dsa_cp():
+            # TODO(jianzs): Remove this workaround after
+            # `torch_npu.npu_quant_matmul` supports large weight dimensions.
+            chunk_size = layer.weight.shape[1] // 2
+            assert chunk_size < 65536, "Even after chunking, the weight dimension is still larger than 65536."
+            layer._is_chunked = True
+            layer.weight_1 = maybe_trans_nz(layer.weight.data[:, :chunk_size].contiguous())
+            layer.weight_2 = maybe_trans_nz(layer.weight.data[:, chunk_size:].contiguous())
+            layer.weight_1_scale = layer.weight_scale.data[:chunk_size].flatten().contiguous()
+            layer.weight_2_scale = layer.weight_scale.data[chunk_size:].flatten().contiguous()
+            layer.weight_1_scale_fp32 = layer.weight_1_scale.to(torch.float32)
+            layer.weight_2_scale_fp32 = layer.weight_2_scale.to(torch.float32)
+            layer.weight_1_offset = layer.weight_offset.data[:chunk_size].flatten().contiguous()
+            layer.weight_2_offset = layer.weight_offset.data[chunk_size:].flatten().contiguous()
+            del layer.weight
+            del layer.weight_scale
+            del layer.weight_offset
+        else:
+            # cast quantized weight tensors in NZ format for higher inference speed
+            layer.weight.data = maybe_trans_nz(layer.weight.data)
+            layer.weight_scale.data = layer.weight_scale.data.flatten()
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+            layer.weight_offset.data = layer.weight_offset.data.flatten()
 
 
 @register_scheme("W8A8_DYNAMIC", "moe")

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2794,6 +2794,14 @@ class NPUModelRunner(GPUModelRunner):
                         slot_mapping[
                             total_num_scheduled_tokens_compressed_list[
                                 kv_cache_gid]:num_tokens_padded].fill_(-1)
+                    elif self.use_compress:
+                        # DSA dummy/graph-capture runs do not go through
+                        # _prepare_inputs(), so no fresh compressed cache
+                        # metadata is computed for them. Reusing values from
+                        # the previous real request can feed stale block-table
+                        # and [block, offset] scatter indices to DSA kernels.
+                        slot_mapping[:num_tokens_padded].fill_(0)
+                        blk_table_tensor[:maybe_num_reqs_padded].fill_(0)
                     else:
                         slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
                         blk_table_tensor[num_reqs:num_reqs_padded].fill_(0)


### PR DESCRIPTION
## Summary

- `torch_npu.npu_quant_matmul` does not support weight dimensions >= 65536. When DSA context parallel is enabled, the `wq_b` linear layer's output dimension exceeds this limit, causing `aclnnQuantMatmulV5` to fail with error code 161002.
- Split the `wq_b` weight into two chunks along the output dimension so each chunk stays below 65536. Two `npu_quant_matmul` calls are issued and their outputs concatenated along the last dimension.
- Guard the chunking with `enable_dsa_cp()` since only DSA-CP models hit the 65536 limit on `wq_b`.

## Changes

- **w8a8_dynamic.py**: Add chunked path in `process_weights_after_loading()` that splits weight/scale/offset into halves, flattens scales/offsets to 1D, and applies `maybe_trans_nz` for NZ format conversion. Add chunked forward in `apply()` with two matmul + `torch.cat`.
- **dsa_cp.py**: Add chunked forward in the DSA CP attention path for `wq_b`, matching the same two-matmul-and-cat pattern.

## Test Plan

- [x] Deploy DeepSeek V4 prefill service on Ascend A3 (2 nodes, TP=4, DP=4) with DSA-CP enabled
- [x] Verified `npu_quant_matmul` no longer fails with AclNN_Parameter_Error
- [x] Passed prefill CI perf test (50 requests, throughput 19460 tok/s; 10 requests, mean TTFT 5.7s)

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
