### PR TITLE
[BugFix][0.20.2] Chunk wq_b matmul for NPU 65536 dimension limit

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1009,14 +1009,41 @@ class AscendDSACPImpl(DSAAttentionImpl):
             qr_local, qr_pertoken_scale_local = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
                 q_a, self.q_norm.weight, epsilon=self.eps
             )
-            q = torch_npu.npu_quant_matmul(
-                qr_local,
-                self.wq_b.weight,
-                self.wq_b.weight_scale,
-                pertoken_scale=qr_pertoken_scale_local,
-                bias=self.wq_b.bias,
-                output_dtype=hidden_states_local.dtype,
-            )
+            if getattr(self.wq_b, "_chunk_size", 0):
+                bias = self.wq_b.bias
+                chunk_size = self.wq_b._chunk_size
+                bias_1 = bias[:chunk_size] if bias is not None else None
+                bias_2 = bias[chunk_size:] if bias is not None else None
+                q = torch.cat(
+                    [
+                        torch_npu.npu_quant_matmul(
+                            qr_local,
+                            self.wq_b.weight_1,
+                            self.wq_b.weight_1_scale,
+                            pertoken_scale=qr_pertoken_scale_local,
+                            bias=bias_1,
+                            output_dtype=hidden_states_local.dtype,
+                        ),
+                        torch_npu.npu_quant_matmul(
+                            qr_local,
+                            self.wq_b.weight_2,
+                            self.wq_b.weight_2_scale,
+                            pertoken_scale=qr_pertoken_scale_local,
+                            bias=bias_2,
+                            output_dtype=hidden_states_local.dtype,
+                        ),
+                    ],
+                    dim=-1,
+                )
+            else:
+                q = torch_npu.npu_quant_matmul(
+                    qr_local,
+                    self.wq_b.weight,
+                    self.wq_b.weight_scale,
+                    pertoken_scale=qr_pertoken_scale_local,
+                    bias=self.wq_b.bias,
+                    output_dtype=hidden_states_local.dtype,
+                )
         else:
             qr_local = self.q_norm(self.wq_a(hidden_states_local))
             q = self.wq_b(qr_local)

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -84,8 +84,8 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             quantized_x = quantized_x.squeeze(dim=1)
             pertoken_scale = pertoken_scale.squeeze(dim=1)
 
-        if getattr(layer, "_chunk_size", 0):
-            chunk_size = layer._chunk_size
+        chunk_size = getattr(layer, "_chunk_size", 0)
+        if isinstance(chunk_size, int) and chunk_size > 0:
             bias_1 = bias[:chunk_size] if bias is not None else None
             bias_2 = bias[chunk_size:] if bias is not None else None
             output = torch.cat(
@@ -124,7 +124,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
 
     def process_weights_after_loading(self, layer):
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        if "wq_b" in layer.prefix and layer.weight.shape[1] >= 65536 and enable_dsa_cp():
+        if "wq_b" in getattr(layer, "prefix", "") and layer.weight.shape[1] >= 65536 and enable_dsa_cp():
             # TODO(jianzs): Remove this workaround after
             # `torch_npu.npu_quant_matmul` supports large weight dimensions.
             chunk_size = layer.weight.shape[1] // 2

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -29,7 +29,7 @@ from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.flash_common3_context import get_flash_common3_context
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
-from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, enable_dsa_cp, maybe_trans_nz
 
 from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
 from .registry import register_scheme
@@ -83,25 +83,71 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             need_unsqz = True
             quantized_x = quantized_x.squeeze(dim=1)
             pertoken_scale = pertoken_scale.squeeze(dim=1)
-        output = torch_npu.npu_quant_matmul(
-            quantized_x,
-            layer.weight,
-            layer.weight_scale,
-            pertoken_scale=pertoken_scale,
-            bias=bias,
-            output_dtype=x.dtype,
-        )
+
+        if getattr(layer, "_chunk_size", 0):
+            chunk_size = layer._chunk_size
+            bias_1 = bias[:chunk_size] if bias is not None else None
+            bias_2 = bias[chunk_size:] if bias is not None else None
+            output = torch.cat(
+                [
+                    torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        layer.weight_1,
+                        layer.weight_1_scale,
+                        pertoken_scale=pertoken_scale,
+                        bias=bias_1,
+                        output_dtype=x.dtype,
+                    ),
+                    torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        layer.weight_2,
+                        layer.weight_2_scale,
+                        pertoken_scale=pertoken_scale,
+                        bias=bias_2,
+                        output_dtype=x.dtype,
+                    ),
+                ],
+                dim=-1,
+            )
+        else:
+            output = torch_npu.npu_quant_matmul(
+                quantized_x,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=bias,
+                output_dtype=x.dtype,
+            )
         if need_unsqz:
             output = output.unsqueeze(dim=1)
         return output
 
     def process_weights_after_loading(self, layer):
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        # cast quantized weight tensors in NZ format for higher inference speed
-        layer.weight.data = maybe_trans_nz(layer.weight.data)
-        layer.weight_scale.data = layer.weight_scale.data.flatten()
-        layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
-        layer.weight_offset.data = layer.weight_offset.data.flatten()
+        if "wq_b" in layer.prefix and layer.weight.shape[1] >= 65536 and enable_dsa_cp():
+            # TODO(jianzs): Remove this workaround after
+            # `torch_npu.npu_quant_matmul` supports large weight dimensions.
+            chunk_size = layer.weight.shape[1] // 2
+            assert chunk_size < 65536, \
+                "Even after chunking, the weight dimension is still larger than 65536."
+            layer._chunk_size = chunk_size
+            layer.weight_1 = maybe_trans_nz(layer.weight.data[:, :chunk_size].contiguous())
+            layer.weight_2 = maybe_trans_nz(layer.weight.data[:, chunk_size:].contiguous())
+            layer.weight_1_scale = layer.weight_scale.data[:chunk_size].flatten().contiguous()
+            layer.weight_2_scale = layer.weight_scale.data[chunk_size:].flatten().contiguous()
+            layer.weight_1_scale_fp32 = layer.weight_1_scale.to(torch.float32)
+            layer.weight_2_scale_fp32 = layer.weight_2_scale.to(torch.float32)
+            layer.weight_1_offset = layer.weight_offset.data[:chunk_size].flatten().contiguous()
+            layer.weight_2_offset = layer.weight_offset.data[chunk_size:].flatten().contiguous()
+            del layer.weight
+            del layer.weight_scale
+            del layer.weight_offset
+        else:
+            # cast quantized weight tensors in NZ format for higher inference speed
+            layer.weight.data = maybe_trans_nz(layer.weight.data)
+            layer.weight_scale.data = layer.weight_scale.data.flatten()
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+            layer.weight_offset.data = layer.weight_offset.data.flatten()
 
 
 @register_scheme("W8A8_DYNAMIC", "moe")

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -128,8 +128,7 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             # TODO(jianzs): Remove this workaround after
             # `torch_npu.npu_quant_matmul` supports large weight dimensions.
             chunk_size = layer.weight.shape[1] // 2
-            assert chunk_size < 65536, \
-                "Even after chunking, the weight dimension is still larger than 65536."
+            assert chunk_size < 65536, "Even after chunking, the weight dimension is still larger than 65536."
             layer._chunk_size = chunk_size
             layer.weight_1 = maybe_trans_nz(layer.weight.data[:, :chunk_size].contiguous())
             layer.weight_2 = maybe_trans_nz(layer.weight.data[:, chunk_size:].contiguous())


### PR DESCRIPTION
## Summary

- `torch_npu.npu_quant_matmul` does not support weight dimensions >= 65536. When DSA context parallel is enabled, the `wq_b` linear layer's output dimension exceeds this limit, causing `aclnnQuantMatmulV5` to fail with error code 161002.
- Split the `wq_b` weight into two chunks along the output dimension so each chunk stays below 65536. Two `npu_quant_matmul` calls are issued and their outputs concatenated along the last dimension.
- Guard the chunking with `enable_dsa_cp()` since only DSA-CP models hit the 65536 limit on `wq_b`.

## Changes

- **w8a8_dynamic.py**: Add chunked path in `process_weights_after_loading()` that splits weight/scale/offset into halves, flattens scales/offsets to 1D, and applies `maybe_trans_nz` for NZ format conversion. Add chunked forward in `apply()` with two matmul + `torch.cat`.
- **dsa_cp.py**: Add chunked forward in the DSA CP attention path for `wq_b`, matching the same two-matmul-and-cat pattern.

## Test Plan

- [x] Deploy DeepSeek V4 prefill service on Ascend A3 (2 nodes, TP=4, DP=4) with DSA-CP enabled
- [x] Verified `npu_quant_matmul` no longer fails with AclNN_Parameter_Error
- [x] Passed prefill CI perf test (50 requests, throughput 19460 tok/s; 10 requests, mean TTFT 5.7s)

cc @jianzs https://github.com/vllm-project/vllm-ascend/pull/9780