### PR TITLE
[BugFix][310P] fix Qwen3-Embedding-8B and Qwen3-VL-Embedding-8B run failed on 310P

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -57,6 +57,8 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         self.layer = mock.MagicMock()
         mock_dtype = mock.PropertyMock(return_value=torch.float16)
         type(self.layer.weight.data).dtype = mock_dtype
+        mock_is_meta = mock.PropertyMock(return_value=False)
+        type(self.layer.weight.data).is_meta = mock_is_meta
         self.layer.precast_fp32_weight = False
 
     @patch("vllm_ascend.utils.get_ascend_config")

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -197,8 +197,6 @@ class AscendW8A8DynamicLinearMethod310(AscendW8A8Linear310pScheme):
             quantized_x = quantized_x.squeeze(dim=1)
             pertoken_scale = pertoken_scale.squeeze(dim=1)
 
-        bias_i32 = bias.to(torch.int32) if bias is not None else None
-
         # NOTE(310P):
         # - Currently, W8A8 dynamic quantization supports only symmetric quantization.
         output = torch_npu.npu_quant_matmul(
@@ -206,7 +204,7 @@ class AscendW8A8DynamicLinearMethod310(AscendW8A8Linear310pScheme):
             layer.weight.data,
             layer.weight_scale,
             pertoken_scale=pertoken_scale,
-            bias=bias_i32,
+            bias=bias,
             output_dtype=x.dtype,
         )
         if need_unsqz:

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -197,6 +197,8 @@ class AscendW8A8DynamicLinearMethod310(AscendW8A8Linear310pScheme):
             quantized_x = quantized_x.squeeze(dim=1)
             pertoken_scale = pertoken_scale.squeeze(dim=1)
 
+        bias_i32 = bias.to(torch.int32) if bias is not None else None
+
         # NOTE(310P):
         # - Currently, W8A8 dynamic quantization supports only symmetric quantization.
         output = torch_npu.npu_quant_matmul(
@@ -204,7 +206,7 @@ class AscendW8A8DynamicLinearMethod310(AscendW8A8Linear310pScheme):
             layer.weight.data,
             layer.weight_scale,
             pertoken_scale=pertoken_scale,
-            bias=bias,
+            bias=bias_i32,
             output_dtype=x.dtype,
         )
         if need_unsqz:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -211,6 +211,10 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if weight.dtype == torch.float32:
         return False
 
+    # meta tensor cannot use NZ.
+    if weight.is_meta:
+        return False
+
     # 310P always converts to NZ.
     if is_310p():
         return True
@@ -235,6 +239,7 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
 # - 310P: always convert supported weights to FRACTAL_NZ
 # - non-310P: follow VLLM_ASCEND_ENABLE_NZ
 # - FP32: never convert
+# - meta tensor: never convert
 def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:
     if not _should_trans_nz(weight):
         return weight

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -211,7 +211,7 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if weight.dtype == torch.float32:
         return False
 
-    # meta tensor cannot use NZ.
+    # meta tensor only keeps shape/dtype meta info without physical memory, it is not necessary to trans it to NZ
     if weight.is_meta:
         return False
 


### PR DESCRIPTION
### What this PR does / why we need it?
fix Qwen3-Embedding-8B and Qwen3-VL-Embedding-8B trans nz failed on 310P.

### Does this PR introduce _any_ user-facing change?
run Qwen3-Embedding-8B or Qwen3-VL-Embedding-8B model
### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
