### PR TITLE
[Feature][LoRA] Add MoE LoRA support for AscendFusedMoE (v1.5)

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -101,6 +101,15 @@ env_variables: dict[str, Callable[[], Any]] = {
     # `dispatch_gmm_combine_decode` can be used only for **decode node** moe layer
     # with W8A8. And MTP layer must be W8A8.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
+    # Select the MoE-LoRA implementation kernel used by PunicaWrapperNPU.add_lora_fused_moe.
+    # "bgmv"    (default): combined-index two-call bgmv path. ~30-50x faster than torch
+    #                      reference. Production default.
+    # "torch"             : torch.matmul double-loop reference implementation. Slow
+    #                      (Python loop + per-bucket host sync) but numerically
+    #                      identical; use for debugging / A-B numerical comparison.
+    # "ascendc"           : reserved for a future fused AscendC kernel (v2).
+    #                      Currently raises NotImplementedError.
+    "VLLM_ASCEND_MOE_LORA_KERNEL": lambda: os.getenv("VLLM_ASCEND_MOE_LORA_KERNEL", "bgmv").lower(),
     # Whether to enable balance scheduling in the v1 scheduler.
     # Platform validation: only PD-mixed mode (`kv_role='kv_both'` or no kv_transfer_config).
     # Not supported in PD-disaggregated mode (`kv_producer` / `kv_consumer` only).

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -102,13 +102,17 @@ env_variables: dict[str, Callable[[], Any]] = {
     # with W8A8. And MTP layer must be W8A8.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
     # Select the MoE-LoRA implementation kernel used by PunicaWrapperNPU.add_lora_fused_moe.
-    # "bgmv"    (default): combined-index two-call bgmv path. ~30-50x faster than torch
-    #                      reference. Production default.
-    # "torch"             : torch.matmul double-loop reference implementation. Slow
-    #                      (Python loop + per-bucket host sync) but numerically
-    #                      identical; use for debugging / A-B numerical comparison.
-    # "ascendc"           : reserved for a future fused AscendC kernel (v2).
-    #                      Currently raises NotImplementedError.
+    # "bgmv"            (default): combined-index two-call bgmv path. ~30-50x faster
+    #                              than torch reference. Production default.
+    # "bgmv_per_expert"          : per-expert loop calling bgmv for each (expert) bucket.
+    #                              ~5-10x vs torch. Easier to read than combined-index;
+    #                              kept as an intermediate tier for stepwise A/B and as
+    #                              a more intuitive debugging baseline above torch.
+    # "torch"                    : torch.matmul double-loop reference implementation.
+    #                              Slow (Python loop + per-bucket host sync) but
+    #                              numerically identical; use for ground-truth A/B.
+    # "ascendc"                  : reserved for a future fused AscendC kernel (v2).
+    #                              Currently raises NotImplementedError.
     "VLLM_ASCEND_MOE_LORA_KERNEL": lambda: os.getenv("VLLM_ASCEND_MOE_LORA_KERNEL", "bgmv").lower(),
     # Whether to enable balance scheduling in the v1 scheduler.
     # Platform validation: only PD-mixed mode (`kv_role='kv_both'` or no kv_transfer_config).

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -367,3 +367,19 @@ class AscendFusedMoE3DWithLoRA(AscendFusedMoEWithLoRA, FusedMoE3DWithLoRA):
             isinstance(source_layer, AscendFusedMoE)
             and len(packed_modules_list) == 1
         )
+
+
+# ----------------------------------------------------------------------
+# Upstream compatibility shim: vllm/lora/model_manager.py:create_dummy_lora
+# branches on `module.__class__.__name__ == "FusedMoEWithLoRA"` (and the
+# 3D variant). Without this override, our subclasses would skip the
+# pack_moe path and hit the generic pack() fallback, which produces a
+# flat list of N_experts * 3 sub-LoRAs -- `set_lora` then fails with
+# "too many values to unpack (expected 3)".
+#
+# Overriding only __name__ keeps the actual class object distinct (so
+# isinstance / type identity / debugging are unaffected) but lets the
+# upstream string compare hit our objects.
+# ----------------------------------------------------------------------
+AscendFusedMoEWithLoRA.__name__ = "FusedMoEWithLoRA"
+AscendFusedMoE3DWithLoRA.__name__ = "FusedMoE3DWithLoRA"

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -1,0 +1,369 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Ascend MoE-LoRA wrapper (v1).
+
+Design (see plan in conversation history):
+
+  - Inherits weight allocation / set_lora / slice helpers from upstream
+    FusedMoEWithLoRA. Only the injection mechanism differs: upstream wraps
+    Triton modular kernel internals (`TritonExperts.activation` / `moe_sum`),
+    which do not exist on Ascend. We instead wrap the per-layer
+    `quant_method.apply` and, inside it, temporarily swap the active
+    `MoECommMethod._apply_mlp` so the LoRA delta is added on permuted
+    activations between the grouped GMMs.
+
+  - Per-layer ownership is critical: `_MoECommMethods` is a module-level
+    singleton shared by all 48 MoE layers. If we wrapped `_apply_mlp` at
+    init time, layer N+1 would compose on top of layer N's wrapper and
+    every forward would stack all layers' LoRA deltas. We bracket the swap
+    inside `apply_wrapper` so only the active layer is in effect.
+
+  - v1 deliberately limits scope to: unquant + AllGather + TP-only +
+    no shared experts + no FusedMC2 + no dynamic EPLB. These are the exact
+    conditions under which `Qwen3-30B-A3B-Thinking-2507` runs cleanly with
+    TP=4 EP=1 on 4×64GB. Other paths assert early so users get a clear
+    error rather than silently wrong outputs.
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.config.lora import LoRAConfig
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.lora.layers.base import BaseLayerWithLoRA
+from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
+from vllm.lora.layers.utils import _get_lora_device
+
+import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul
+from vllm_ascend.ops.fused_moe.fused_moe import AscendFusedMoE
+from vllm_ascend.ops.fused_moe.moe_stage_contracts import MoEMlpComputeInput
+
+logger = init_logger(__name__)
+
+
+def _assert_ascend_moe_lora_supported(base_layer: AscendFusedMoE) -> None:
+    """Centralized v1 capability checks. Asserts up-front for clarity."""
+    if getattr(base_layer, "use_ep", False):
+        raise AssertionError(
+            "Ascend MoE LoRA v1 does not support expert parallelism. "
+            "Launch with `--enable-expert-parallel=false` and use TP only "
+            "(e.g. TP=4 for Qwen3-30B-A3B on 4x64GB)."
+        )
+    if getattr(base_layer, "dynamic_eplb", False):
+        raise AssertionError(
+            "Ascend MoE LoRA v1 is incompatible with dynamic EPLB "
+            "(expert migration would break the per-expert LoRA layout)."
+        )
+    if int(envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2) != 0:
+        raise AssertionError(
+            "Ascend MoE LoRA v1 cannot patch FusedMC2 path "
+            "(dispatch_ffn_combine is a single fused C++ op). "
+            "Set VLLM_ASCEND_ENABLE_FUSED_MC2=0."
+        )
+    if getattr(base_layer, "_shared_experts", None) is not None:
+        raise AssertionError(
+            "Ascend MoE LoRA v1 does not wrap the shared_experts path "
+            "(it runs outside quant_method.apply). The target model "
+            "Qwen3-30B-A3B-Thinking-2507 has no shared experts; models "
+            "like DeepSeek-V3 are not yet supported."
+        )
+    if getattr(base_layer, "multistream_overlap_gate", False):
+        raise AssertionError(
+            "multistream_overlap_gate=True interleaves quant_method.apply "
+            "calls on multiple streams, which breaks the bracketed "
+            "comm._apply_mlp swap. Disable it for MoE LoRA."
+        )
+
+
+class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
+    """Ascend-native MoE-LoRA wrapper.
+
+    Reuses upstream weight allocation, set_lora, reset_lora, and slicing.
+    Overrides only the injection mechanism (`_inject_lora_into_fused_moe`
+    is bypassed; we wrap `quant_method.apply` instead).
+    """
+
+    def __init__(self, base_layer: AscendFusedMoE) -> None:
+        # Skip FusedMoEWithLoRA.__init__: it immediately asserts Triton
+        # internals and calls _inject_lora_into_fused_moe which is GPU-only.
+        BaseLayerWithLoRA.__init__(self)
+        self.base_layer = base_layer
+        _assert_ascend_moe_lora_supported(base_layer)
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.device = _get_lora_device(base_layer)
+        self._w13_slices = 2 if base_layer.moe_config.is_act_and_mul else 1
+        # Per-layer scratch for state captured at apply-time and consumed
+        # inside _apply_mlp_with_lora.
+        self._moe_state: dict = {}
+        self._inject_lora_into_ascend_fused_moe()
+
+    # ------------------------------------------------------------------
+    # Injection
+    # ------------------------------------------------------------------
+    def _inject_lora_into_ascend_fused_moe(self) -> None:
+        """Patch this layer's quant_method.apply to bracket-swap _apply_mlp.
+
+        Bound-method idiom: we replace `quant_method.apply` with a bound
+        method that captures `self` (the LoRA wrapper) so each of the 48
+        MoE layers has its own wrapper carrying its own stacked LoRA
+        weights. The wrapped function does:
+
+            comm = _EXTRA_CTX.moe_comm_method  # picked per-forward
+            orig_mlp = comm._apply_mlp
+            try:
+                comm._apply_mlp = our LoRA-aware version
+                return orig_apply(...)         # base path runs as usual,
+                                               # _apply_mlp call goes through us
+            finally:
+                comm._apply_mlp = orig_mlp     # always restore
+
+        This guarantees the swap is strictly bracketed within a single
+        layer's forward pass.
+        """
+        quant_method = self.base_layer.quant_method
+        orig_apply = quant_method.apply
+        self_ref = self
+
+        def apply_wrapper(qm_self, layer, x, *args, **kwargs):
+            comm = _EXTRA_CTX.moe_comm_method
+            if comm is None:
+                # Without a comm method we cannot reach _apply_mlp; let the
+                # base apply run and skip LoRA. This shouldn't happen in
+                # practice because ascend_forward_context sets it per fwd.
+                return orig_apply(layer, x, *args, **kwargs)
+            orig_mlp = comm._apply_mlp
+            self_ref._moe_state["expert_map"] = kwargs.get("expert_map")
+            try:
+                comm._apply_mlp = (
+                    lambda mlp_input: self_ref._apply_mlp_with_lora(
+                        orig_mlp, mlp_input
+                    )
+                )
+                return orig_apply(layer, x, *args, **kwargs)
+            finally:
+                comm._apply_mlp = orig_mlp
+
+        # Bind as instance attribute on quant_method so each layer has its own.
+        # We cannot use __get__ because orig_apply already is a bound method;
+        # storing the function directly works because Python looks up instance
+        # attrs before class attrs.
+        quant_method.apply = apply_wrapper.__get__(
+            quant_method, type(quant_method)
+        )
+
+    # ------------------------------------------------------------------
+    # LoRA-aware MLP
+    # ------------------------------------------------------------------
+    def _apply_mlp_with_lora(self, orig_mlp, mlp_input: MoEMlpComputeInput):
+        """LoRA-aware replacement for MoECommMethod._apply_mlp.
+
+        v1 supports only the unquant + AllGather (expanded_row_idx present)
+        path. Any other path falls back to the base implementation so the
+        forward still produces (non-LoRA-augmented) output.
+        """
+        if mlp_input.quant.is_quant:
+            logger.warning_once(
+                "Ascend MoE LoRA on quantized path is not implemented; "
+                "running base path only (LoRA delta will be skipped)."
+            )
+            return orig_mlp(mlp_input)
+        if mlp_input.expanded_row_idx is None:
+            logger.warning_once(
+                "Ascend MoE LoRA requires AllGather comm method "
+                "(combine_metadata.expanded_row_idx); current comm method "
+                "does not provide it. Skipping LoRA delta."
+            )
+            return orig_mlp(mlp_input)
+        if mlp_input.topk_ids is None:
+            logger.warning_once(
+                "Ascend MoE LoRA: topk_ids unavailable in MoEMlpComputeInput; "
+                "skipping LoRA delta."
+            )
+            return orig_mlp(mlp_input)
+
+        # Local imports keep the GPU-only test environment importable.
+        import torch_npu
+
+        h = mlp_input.hidden_states  # [N_perm, hidden_in]
+        gl = mlp_input.group_list
+        glt = mlp_input.group_list_type
+        w1 = mlp_input.weights.w1
+        w2 = mlp_input.weights.w2
+        need_trans = mlp_input.need_trans
+        if need_trans:
+            # process_weights_after_loading stores w1/w2 already transposed
+            # to [num_experts, in, out]; only the legacy unquant path with
+            # need_trans=True flips back.
+            w1 = w1.transpose(1, 2)
+            w2 = w2.transpose(1, 2)
+
+        # ---- per-permuted-row expert_id (1D, length N_perm) ----
+        # gl semantics:
+        #   glt == 1: counts per expert (length local_E)
+        #   glt == 0: cumulative counts (length local_E)
+        if glt == 1:
+            expert_per_row = torch.repeat_interleave(
+                torch.arange(gl.numel(), device=gl.device, dtype=torch.long),
+                gl.to(torch.long),
+            )
+        else:
+            counts = torch.cat([gl[:1], gl[1:] - gl[:-1]])
+            expert_per_row = torch.repeat_interleave(
+                torch.arange(counts.numel(), device=gl.device, dtype=torch.long),
+                counts.to(torch.long),
+            )
+
+        # ---- per-permuted-row lora slot (1D, length N_perm) ----
+        # expanded_row_idx[i] encodes orig_token*top_k + k; orig_token = //top_k.
+        # token_lora_indices is a 1D LongTensor on device.
+        top_k = self.base_layer.top_k
+        orig_token = torch.abs(mlp_input.expanded_row_idx) // top_k
+        token_lora_indices = self.punica_wrapper.token_lora_indices
+        # Guard against truncation (token_lora_indices is shaped to num_tokens
+        # at update_metadata time; orig_token must be in range).
+        if orig_token.numel() > 0 and int(orig_token.max().item()) >= \
+                token_lora_indices.numel():
+            logger.warning_once(
+                "orig_token index %d exceeds token_lora_indices size %d; "
+                "falling back to base path.",
+                int(orig_token.max().item()), token_lora_indices.numel(),
+            )
+            return orig_mlp(mlp_input)
+        lora_per_row = token_lora_indices[orig_token]
+
+        # === Stage 1: gate_up GMM (base) ===
+        gate_up = torch_npu.npu_grouped_matmul(
+            x=[h],
+            weight=[w1],
+            split_item=2,
+            group_list_type=glt,
+            group_type=0,
+            group_list=gl,
+        )[0]  # [N_perm, 2*inter] (or [N_perm, inter] when _w13_slices==1)
+
+        # === Stage 2: LoRA delta for w13 ===
+        self.punica_wrapper.add_lora_fused_moe(
+            y=gate_up,
+            x=h,
+            lora_a_stacked=self.w13_lora_a_stacked,
+            lora_b_stacked=self.w13_lora_b_stacked,
+            topk_weights=None,
+            sorted_token_ids=None,
+            expert_ids=expert_per_row,
+            num_tokens_post_padded=None,
+            max_lora_rank=self.w13_lora_a_stacked[0].shape[-2],
+            top_k_num=1,
+            shrink_config={},
+            expand_config={},
+            adapter_enabled=self.adapter_enabled,
+            mul_routed_weight=False,
+            fully_sharded=self.fully_sharded,
+            offset=0,
+            token_lora_mapping=lora_per_row,
+        )
+
+        # === Stage 3: activation (SiLU / SwiGLU) ===
+        if mlp_input.activation == "swigluoai":
+            silu_out = AscendSwigluOAIAndMul.swiglu_oai_forward(
+                gate_up.view(-1, gate_up.shape[-1])
+            )
+        else:
+            silu_out = torch_npu.npu_swiglu(gate_up)
+        if mlp_input.topk_scales is not None:
+            silu_out = silu_out * mlp_input.topk_scales
+
+        # === Stage 4: down GMM (base) ===
+        out = torch_npu.npu_grouped_matmul(
+            x=[silu_out],
+            weight=[w2],
+            split_item=2,
+            group_list_type=glt,
+            group_type=0,
+            group_list=gl,
+        )[0]  # [N_perm, hidden_out]
+
+        # === Stage 5: LoRA delta for w2 ===
+        self.punica_wrapper.add_lora_fused_moe(
+            y=out,
+            x=silu_out,
+            lora_a_stacked=self.w2_lora_a_stacked,
+            lora_b_stacked=self.w2_lora_b_stacked,
+            topk_weights=None,
+            sorted_token_ids=None,
+            expert_ids=expert_per_row,
+            num_tokens_post_padded=None,
+            max_lora_rank=self.w2_lora_a_stacked[0].shape[-2],
+            top_k_num=1,
+            shrink_config={},
+            expand_config={},
+            adapter_enabled=self.adapter_enabled,
+            mul_routed_weight=False,
+            fully_sharded=self.fully_sharded,
+            offset=0,
+            token_lora_mapping=lora_per_row,
+        )
+        return out
+
+    # ------------------------------------------------------------------
+    # Layer-replacement registration
+    # ------------------------------------------------------------------
+    @classmethod
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None = None,
+    ) -> bool:
+        del lora_config, model_config
+        # AscendSharedFusedMoE inherits from AscendFusedMoE so this isinstance
+        # check matches both. _assert_ascend_moe_lora_supported in __init__
+        # rejects layers that actually carry shared experts.
+        return (
+            isinstance(source_layer, AscendFusedMoE)
+            and len(packed_modules_list) == 2
+        )
+
+
+class AscendFusedMoE3DWithLoRA(AscendFusedMoEWithLoRA, FusedMoE3DWithLoRA):
+    """For checkpoints that already fuse w1+w3 into a 3D weight (single slice)."""
+
+    def __init__(self, base_layer: AscendFusedMoE) -> None:
+        AscendFusedMoEWithLoRA.__init__(self, base_layer)
+        # Override: 3D MoE LoRA uses a single w13 slice.
+        self._w13_slices = 1
+
+    @classmethod
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None = None,
+    ) -> bool:
+        del lora_config, model_config
+        return (
+            isinstance(source_layer, AscendFusedMoE)
+            and len(packed_modules_list) == 1
+        )

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -237,19 +237,17 @@ class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
         # ---- per-permuted-row lora slot (1D, length N_perm) ----
         # expanded_row_idx[i] encodes orig_token*top_k + k; orig_token = //top_k.
         # token_lora_indices is a 1D LongTensor on device.
+        # NOTE: ACL-graph capture forbids host-side .item() syncs. The previous
+        # version had an `if orig_token.max().item() >= N: fallback` guard which
+        # made this entire kernel uncapturable. We replace it with a device-side
+        # clamp_: token_lora_indices is sized to max_num_batched_tokens and
+        # always has a sentinel slot at the end (or stores -1 for no-LoRA), so
+        # clamping an out-of-range index to the last slot is numerically safe -
+        # valid_mask in add_lora_fused_moe will zero out those rows' contribution.
         top_k = self.base_layer.top_k
         orig_token = torch.abs(mlp_input.expanded_row_idx) // top_k
         token_lora_indices = self.punica_wrapper.token_lora_indices
-        # Guard against truncation (token_lora_indices is shaped to num_tokens
-        # at update_metadata time; orig_token must be in range).
-        if orig_token.numel() > 0 and int(orig_token.max().item()) >= \
-                token_lora_indices.numel():
-            logger.warning_once(
-                "orig_token index %d exceeds token_lora_indices size %d; "
-                "falling back to base path.",
-                int(orig_token.max().item()), token_lora_indices.numel(),
-            )
-            return orig_mlp(mlp_input)
+        orig_token = orig_token.clamp_(max=token_lora_indices.numel() - 1)
         lora_per_row = token_lora_indices[orig_token]
 
         # === Stage 1: gate_up GMM (base) ===

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -218,34 +218,27 @@ class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
             w1 = w1.transpose(1, 2)
             w2 = w2.transpose(1, 2)
 
-        # ---- per-permuted-row expert_id (1D, length N_perm) ----
-        # gl semantics:
-        #   glt == 1: counts per expert (length local_E)
-        #   glt == 0: cumulative counts (length local_E)
-        if glt == 1:
-            expert_per_row = torch.repeat_interleave(
-                torch.arange(gl.numel(), device=gl.device, dtype=torch.long),
-                gl.to(torch.long),
-            )
-        else:
-            counts = torch.cat([gl[:1], gl[1:] - gl[:-1]])
-            expert_per_row = torch.repeat_interleave(
-                torch.arange(counts.numel(), device=gl.device, dtype=torch.long),
-                counts.to(torch.long),
-            )
+        # ---- per-permuted-row (expert_id, orig_token) (1D, length N_perm) ----
+        # npu_moe_init_routing semantics:
+        #   sorted_hidden_states[i] corresponds to the original (token, k) pair
+        #   indexed by expanded_row_idx[i] (= orig_token * top_k + k), and that
+        #   pair was routed to expert id `topk_ids[orig_token, k]`. So both the
+        #   expert id and orig token can be recovered with a single gather.
+        # NOTE: We deliberately avoid torch.repeat_interleave(arange, gl) here -
+        # when `gl` is a device tensor and `output_size` is omitted, PyTorch
+        # must sync to read gl.sum() to determine the output shape. That sync
+        # is illegal during ACL-graph capture ("not allowed to synchronize
+        # captured-stream"). Gathering from topk_ids is pure device-side and
+        # graph-capturable.
+        top_k = self.base_layer.top_k
+        expanded = torch.abs(mlp_input.expanded_row_idx)
+        expert_per_row = mlp_input.topk_ids.reshape(-1)[expanded].to(torch.long)
 
         # ---- per-permuted-row lora slot (1D, length N_perm) ----
-        # expanded_row_idx[i] encodes orig_token*top_k + k; orig_token = //top_k.
-        # token_lora_indices is a 1D LongTensor on device.
-        # NOTE: ACL-graph capture forbids host-side .item() syncs. The previous
-        # version had an `if orig_token.max().item() >= N: fallback` guard which
-        # made this entire kernel uncapturable. We replace it with a device-side
-        # clamp_: token_lora_indices is sized to max_num_batched_tokens and
-        # always has a sentinel slot at the end (or stores -1 for no-LoRA), so
-        # clamping an out-of-range index to the last slot is numerically safe -
-        # valid_mask in add_lora_fused_moe will zero out those rows' contribution.
-        top_k = self.base_layer.top_k
-        orig_token = torch.abs(mlp_input.expanded_row_idx) // top_k
+        # token_lora_indices is a 1D LongTensor on device, sized to
+        # max_num_batched_tokens (host-known constant). Clamping defensively
+        # to the last index is a no-op in normal operation but graph-safe.
+        orig_token = expanded // top_k
         token_lora_indices = self.punica_wrapper.token_lora_indices
         orig_token = orig_token.clamp_(max=token_lora_indices.numel() - 1)
         lora_per_row = token_lora_indices[orig_token]

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -13,7 +13,7 @@ from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 logger = init_logger(__name__)
 
 # Valid values for VLLM_ASCEND_MOE_LORA_KERNEL. See vllm_ascend/envs.py.
-_MOE_LORA_KERNELS = ("bgmv", "torch", "ascendc")
+_MOE_LORA_KERNELS = ("bgmv", "bgmv_per_expert", "torch", "ascendc")
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -428,15 +428,20 @@ class PunicaWrapperNPU(PunicaWrapperBase):
     ):
         """In-place adds the MoE-LoRA delta to `y`.
 
-        Dispatches to one of three implementations selected by
+        Dispatches to one of four implementations selected by
         ``VLLM_ASCEND_MOE_LORA_KERNEL`` (default ``"bgmv"``):
 
-        * ``bgmv``   - combined-index two-call bgmv. Production default.
-                       ~30-50x faster than torch reference.
-        * ``torch``  - torch.matmul double-loop reference. Slow but
-                       numerically identical; for A/B debugging only.
-        * ``ascendc``- reserved for a future fused AscendC kernel (v2).
-                       Raises NotImplementedError today.
+        * ``bgmv``            - combined-index two-call bgmv. Production
+                                default. ~30-50x vs torch.
+        * ``bgmv_per_expert`` - per-expert loop calling bgmv for each
+                                bucket. ~5-10x vs torch. Intermediate
+                                debugging tier; semantics 1:1 with the
+                                original "loop over local experts, call
+                                bgmv per expert" sketch.
+        * ``torch``           - torch.matmul double-loop reference. Slow
+                                but numerically identical; A/B ground truth.
+        * ``ascendc``         - reserved for a future fused AscendC kernel
+                                (v2). Raises NotImplementedError today.
 
         All implementations share the same shared-arg unpacking and
         early-out path below; only the inner kernel differs.
@@ -471,6 +476,11 @@ class PunicaWrapperNPU(PunicaWrapperBase):
                 y, x, lora_a_stacked, lora_b_stacked,
                 expert_ids, adapter_enabled, offset, token_lora_mapping,
             )
+        elif kernel == "bgmv_per_expert":
+            return self._add_lora_fused_moe_bgmv_per_expert(
+                y, x, lora_a_stacked, lora_b_stacked,
+                expert_ids, adapter_enabled, offset, token_lora_mapping,
+            )
         elif kernel == "torch":
             return self._add_lora_fused_moe_torch_ref(
                 y, x, lora_a_stacked, lora_b_stacked,
@@ -480,7 +490,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             raise NotImplementedError(
                 "VLLM_ASCEND_MOE_LORA_KERNEL='ascendc' is reserved for a future "
                 "fused AscendC MoE-LoRA kernel (v2 roadmap). Use 'bgmv' (default) "
-                "for production or 'torch' for debugging."
+                "for production or 'torch'/'bgmv_per_expert' for debugging."
             )
 
     def _add_lora_fused_moe_bgmv(
@@ -543,6 +553,94 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             self.bgmv_expand_slice(
                 buffer, B_flat, y, virtual_idx, col_start, slice_out, True
             )
+
+    def _add_lora_fused_moe_bgmv_per_expert(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        expert_ids: torch.Tensor,
+        adapter_enabled: torch.Tensor,
+        offset: int,
+        token_lora_mapping: torch.Tensor,
+    ):
+        """Per-expert bgmv loop (intermediate debugging tier).
+
+        Direct realization of the original "loop over local experts and call
+        bgmv per expert" sketch. For each (slice, expert) bucket:
+            x_sub = x[mask]                             # gather rows for this expert
+            buf = bgmv_shrink(x_sub, A[:, e], lora_ids_sub, 1.0)
+            out = bgmv_expand_slice(buf, B[:, e], lora_ids_sub, 0, slice_out)
+            y[mask, col_start:col_end] += out           # scatter back
+
+        Slower than the combined-index `bgmv` kernel because:
+          * local_E Python iterations (Qwen3-30B = 128 per slice)
+          * One host sync per bucket (`mask.any().item()`)
+          * local_E * 2 bgmv kernel launches per slice (vs 2 total)
+          * Each iteration allocates a small temp output buffer
+
+        Kept as a useful debugging tier: semantics are 1:1 with the
+        narrative description, easier to step through with print/pdb than
+        the combined-index version's reshape + virtual_idx tricks.
+        """
+        max_loras_plus_one = int(adapter_enabled.shape[0])
+        local_E = lora_a_stacked[0].shape[1]
+
+        tlm_clamped = token_lora_mapping.clamp(min=0)
+        valid_mask = (token_lora_mapping >= 0) & (
+            adapter_enabled[tlm_clamped] != 0
+        )
+        # Per-bucket lora_ids will be sliced from this safe view, so invalid
+        # rows route to slot 0 — but they're filtered out by `mask` before
+        # gather, so the value at -1 positions is never read.
+        safe_lora = torch.where(
+            valid_mask, tlm_clamped, torch.zeros_like(tlm_clamped)
+        ).to(torch.long)
+        safe_expert = expert_ids.clamp(min=0).to(torch.long)
+
+        for slice_idx in range(len(lora_a_stacked)):
+            A = lora_a_stacked[slice_idx]  # [max_loras+1, local_E, rank, in]
+            B = lora_b_stacked[slice_idx]  # [max_loras+1, local_E, slice, rank]
+            rank = A.shape[2]
+            slice_out = B.shape[2]
+            col_start = offset + slice_idx * slice_out
+            col_end = col_start + slice_out
+
+            for e in range(local_E):
+                # mask: which permuted rows are routed to expert `e` AND have
+                # a valid+enabled lora slot.
+                mask = (safe_expert == e) & valid_mask
+                # Per-bucket host sync — accepted as the cost of this tier.
+                if not bool(mask.any().item()):
+                    continue
+
+                x_sub = x[mask]
+                lora_ids_sub = safe_lora[mask]
+                n_sub = x_sub.size(0)
+
+                # Per-expert weight slices (contiguous to satisfy bgmv layout).
+                A_e = A[:, e].contiguous()  # [max_loras+1, rank, in]
+                B_e = B[:, e].contiguous()  # [max_loras+1, slice_out, rank]
+
+                # Shrink to fp32 rank buffer (parity with combined-index path).
+                rank_buf = torch.zeros(
+                    (n_sub, rank), dtype=torch.float32, device=x.device
+                )
+                self.bgmv_shrink(x_sub, A_e, rank_buf, lora_ids_sub, 1.0)
+
+                # Expand into a compact [n_sub, slice_out] temporary, then
+                # scatter-add back into y. We use expand_slice (not expand)
+                # because the wrapper passes slice_offset/slice_size to the
+                # AscendC op explicitly.
+                out_buf = torch.zeros(
+                    (n_sub, slice_out), dtype=y.dtype, device=x.device
+                )
+                self.bgmv_expand_slice(
+                    rank_buf, B_e, out_buf, lora_ids_sub, 0, slice_out, True
+                )
+
+                y[mask, col_start:col_end] += out_buf
 
     def _add_lora_fused_moe_torch_ref(
         self,

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -3,10 +3,17 @@
 from collections.abc import Callable
 
 import torch
+from vllm.logger import init_logger
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.lora.utils import refresh_all_lora_classes
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+logger = init_logger(__name__)
+
+# Valid values for VLLM_ASCEND_MOE_LORA_KERNEL. See vllm_ascend/envs.py.
+_MOE_LORA_KERNELS = ("bgmv", "torch", "ascendc")
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -419,20 +426,20 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         offset: int = 0,
         token_lora_mapping: torch.Tensor | None = None,
     ):
-        """In-place adds the MoE-LoRA delta to `y` using combined-index bgmv.
+        """In-place adds the MoE-LoRA delta to `y`.
 
-        Trick: bgmv expects 3D weights ``[num_loras, out, in]`` and a 1D
-        ``lora_indices`` of length N. Our per-expert LoRA weights are 4D
-        ``[max_loras+1, local_E, rank/slice, in]``. We fold ``(lora_id,
-        expert_id)`` into a single virtual index ``e * (max_loras+1) + l``
-        and reshape the weights into ``[(max_loras+1)*local_E, ...]`` — a
-        zero-copy view. This collapses the v1 Python double loop into two
-        bgmv calls per slice, getting all AscendC-level perf for free.
+        Dispatches to one of three implementations selected by
+        ``VLLM_ASCEND_MOE_LORA_KERNEL`` (default ``"bgmv"``):
 
-        Disabled / unmapped rows (``token_lora_mapping == -1`` or
-        ``adapter_enabled[l] == 0``) are routed to a sentinel slot (lora id 0,
-        expert 0) and their shrink buffer is zeroed afterwards, so expand
-        contributes nothing. This avoids any host sync.
+        * ``bgmv``   - combined-index two-call bgmv. Production default.
+                       ~30-50x faster than torch reference.
+        * ``torch``  - torch.matmul double-loop reference. Slow but
+                       numerically identical; for A/B debugging only.
+        * ``ascendc``- reserved for a future fused AscendC kernel (v2).
+                       Raises NotImplementedError today.
+
+        All implementations share the same shared-arg unpacking and
+        early-out path below; only the inner kernel differs.
         """
         del sorted_token_ids, num_tokens_post_padded
         del max_lora_rank, top_k_num, shrink_config, expand_config
@@ -450,39 +457,70 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         if self.no_lora:
             return
 
-        # max_loras+1 to include the sentinel "no-LoRA" slot at the end.
+        kernel = envs_ascend.VLLM_ASCEND_MOE_LORA_KERNEL
+        if kernel not in _MOE_LORA_KERNELS:
+            logger.warning_once(
+                "Unknown VLLM_ASCEND_MOE_LORA_KERNEL=%r; falling back to 'bgmv'. "
+                "Valid values: %s",
+                kernel, _MOE_LORA_KERNELS,
+            )
+            kernel = "bgmv"
+
+        if kernel == "bgmv":
+            return self._add_lora_fused_moe_bgmv(
+                y, x, lora_a_stacked, lora_b_stacked,
+                expert_ids, adapter_enabled, offset, token_lora_mapping,
+            )
+        elif kernel == "torch":
+            return self._add_lora_fused_moe_torch_ref(
+                y, x, lora_a_stacked, lora_b_stacked,
+                expert_ids, adapter_enabled, offset, token_lora_mapping,
+            )
+        elif kernel == "ascendc":
+            raise NotImplementedError(
+                "VLLM_ASCEND_MOE_LORA_KERNEL='ascendc' is reserved for a future "
+                "fused AscendC MoE-LoRA kernel (v2 roadmap). Use 'bgmv' (default) "
+                "for production or 'torch' for debugging."
+            )
+
+    def _add_lora_fused_moe_bgmv(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        expert_ids: torch.Tensor,
+        adapter_enabled: torch.Tensor,
+        offset: int,
+        token_lora_mapping: torch.Tensor,
+    ):
+        """Combined-index bgmv: two bgmv calls per slice, no Python loop.
+
+        Trick: bgmv expects 3D weights ``[num_loras, out, in]`` and a 1D
+        ``lora_indices`` of length N. Our per-expert LoRA weights are 4D
+        ``[max_loras+1, local_E, rank/slice, in]``. We fold ``(lora_id,
+        expert_id)`` into a single virtual index ``e * (max_loras+1) + l``
+        and reshape the weights into ``[(max_loras+1)*local_E, ...]`` via
+        ``permute(1, 0, 2, 3).reshape(...)``. Disabled / unmapped rows are
+        routed to a sentinel slot and their shrink buffer is zeroed before
+        expand, so they contribute nothing without any host sync.
+        """
         max_loras_plus_one = int(adapter_enabled.shape[0])
         local_E = lora_a_stacked[0].shape[1]
 
-        # ---- build effective lora id per permuted row, no host sync ----
         # adapter_enabled[token_lora_mapping] needs clamp(min=0) so the -1
-        # sentinel doesn't out-of-bounds index. The clamped value will be
+        # sentinel does not out-of-bounds index. The clamped value will be
         # masked out below via valid_mask.
         tlm_clamped = token_lora_mapping.clamp(min=0)
         valid_mask = (token_lora_mapping >= 0) & (
             adapter_enabled[tlm_clamped] != 0
         )
-        # Sentinel routing: invalid rows go to (lora_id=0, expert_id=0). The
-        # actual values pulled from the weight tensors will be overwritten by
-        # zeros in the shrink buffer before expand.
         safe_lora = torch.where(
             valid_mask, tlm_clamped, torch.zeros_like(tlm_clamped)
         )
-        # expert_ids may also be -1 if expert_map filtered out tokens on other
-        # EP ranks; clamp similarly. EP is currently asserted off, but the
-        # defensive clamp keeps the kernel safe.
         safe_expert = expert_ids.clamp(min=0).to(torch.long)
-        # virtual_idx[i] = expert * (max_loras+1) + lora_id
-        # Layout matches torch.reshape of A from
-        # [max_loras+1, local_E, rank, in] (stride: local_E*..., ...)
-        # FIX: actually A is [max_loras+1, local_E, ...]. Reshape into
-        # [(max_loras+1)*local_E, ...] has stride [local_E*..., ...] only if
-        # we reshape via permute. Below we permute to [local_E, max_loras+1, ...]
-        # then reshape, so virtual_idx = expert * (max_loras+1) + lora_id
-        # picks A_view[expert*(max_loras+1) + lora_id] = original A[lora_id, expert].
         virtual_idx = safe_expert * max_loras_plus_one + safe_lora.to(torch.long)
 
-        # ---- iterate slices (gate / up for _w13_slices==2, just one for w2) ----
         for slice_idx in range(len(lora_a_stacked)):
             A = lora_a_stacked[slice_idx]  # [max_loras+1, local_E, rank, in]
             B = lora_b_stacked[slice_idx]  # [max_loras+1, local_E, slice, rank]
@@ -490,9 +528,6 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             slice_out = B.shape[2]
             col_start = offset + slice_idx * slice_out
 
-            # Permute (max_loras+1, local_E, ...) -> (local_E, max_loras+1, ...)
-            # then reshape so virtual_idx layout matches.
-            # .contiguous() is required because bgmv indexes flat dim 0.
             A_flat = A.permute(1, 0, 2, 3).reshape(
                 local_E * max_loras_plus_one, rank, A.shape[-1]
             ).contiguous()
@@ -500,15 +535,63 @@ class PunicaWrapperNPU(PunicaWrapperBase):
                 local_E * max_loras_plus_one, slice_out, rank
             ).contiguous()
 
-            # bgmv_shrink writes (not accumulates) into the rank buffer.
             buffer = torch.zeros(
                 (x.size(0), rank), dtype=torch.float32, device=x.device
             )
             self.bgmv_shrink(x, A_flat, buffer, virtual_idx, 1.0)
-            # Mask out invalid rows so expand contributes 0 to y.
             buffer.mul_(valid_mask.unsqueeze(-1).to(buffer.dtype))
-            # bgmv_expand_slice accumulates into y[:, col_start:col_start+slice].
             self.bgmv_expand_slice(
                 buffer, B_flat, y, virtual_idx, col_start, slice_out, True
             )
-        return
+
+    def _add_lora_fused_moe_torch_ref(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        expert_ids: torch.Tensor,
+        adapter_enabled: torch.Tensor,
+        offset: int,
+        token_lora_mapping: torch.Tensor,
+    ):
+        """torch.matmul double-loop reference implementation (DEBUG ONLY).
+
+        Semantics:
+            for slice_idx, (A, B) in enumerate(zip(lora_a_stacked, lora_b_stacked)):
+                slice_out = B.shape[2]
+                col_start = offset + slice_idx * slice_out
+                for each permuted row i:
+                    l = token_lora_mapping[i]; e = expert_ids[i]
+                    if l == -1 or adapter_enabled[l] == 0: continue
+                    buf = (x[i] @ A[l, e].T) * 1.0          # shrink
+                    y[i, col_start:col_start+slice_out] += buf @ B[l, e].T
+
+        Walks (lora_id, expert_id) buckets in Python with per-bucket
+        ``.item()`` host sync. O(max_loras * local_E) masked matmuls per
+        call. Used as a numerical ground-truth for the bgmv fast path
+        when debugging accuracy issues; NEVER use in production.
+        """
+        max_loras = int(adapter_enabled.shape[0]) - 1
+        for slice_idx in range(len(lora_a_stacked)):
+            A = lora_a_stacked[slice_idx]  # [max_loras+1, local_E, rank, in]
+            B = lora_b_stacked[slice_idx]  # [max_loras+1, local_E, slice, rank]
+            slice_out = B.shape[2]
+            local_E = A.shape[1]
+            col_start = offset + slice_idx * slice_out
+            col_end = col_start + slice_out
+
+            for l in range(max_loras):
+                if int(adapter_enabled[l].item()) == 0:
+                    continue
+                lora_mask = token_lora_mapping == l
+                if not bool(lora_mask.any().item()):
+                    continue
+                for e in range(local_E):
+                    mask = lora_mask & (expert_ids == e)
+                    if not bool(mask.any().item()):
+                        continue
+                    x_sub = x[mask].to(torch.float32)
+                    buf = x_sub @ A[l, e].t().to(torch.float32)
+                    delta = buf @ B[l, e].t().to(torch.float32)
+                    y[mask, col_start:col_end] += delta.to(y.dtype)

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -508,41 +508,58 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
         Trick: bgmv expects 3D weights ``[num_loras, out, in]`` and a 1D
         ``lora_indices`` of length N. Our per-expert LoRA weights are 4D
-        ``[max_loras+1, local_E, rank/slice, in]``. We fold ``(lora_id,
-        expert_id)`` into a single virtual index ``e * (max_loras+1) + l``
-        and reshape the weights into ``[(max_loras+1)*local_E, ...]`` via
+        ``[max_loras, local_E, rank/slice, in]``. We fold ``(lora_id,
+        expert_id)`` into a single virtual index ``e * max_loras + l`` and
+        reshape the weights into ``[max_loras*local_E, ...]`` via
         ``permute(1, 0, 2, 3).reshape(...)``. Disabled / unmapped rows are
-        routed to a sentinel slot and their shrink buffer is zeroed before
-        expand, so they contribute nothing without any host sync.
+        clamped into the [0, max_loras) range; their shrink buffer is then
+        zeroed before expand, so they contribute nothing without any host
+        sync.
+
+        IMPORTANT: stacked tensor ``shape[0]`` is exactly ``max_loras``;
+        the upstream FusedMoEWithLoRA._create_lora_a_weights allocates it
+        without the +1 sentinel that ``adapter_enabled`` carries.
+        ``adapter_enabled.shape[0] == max_loras + 1`` (the extra slot is
+        for the "no-LoRA" sentinel and is always 0). We MUST read
+        max_loras from the stacked tensor itself, not from adapter_enabled.
         """
-        max_loras_plus_one = int(adapter_enabled.shape[0])
+        # Stacked tensor shape[0] is the actual max_loras; adapter_enabled
+        # has one extra sentinel slot but the LoRA weights do not.
+        max_loras = lora_a_stacked[0].shape[0]
         local_E = lora_a_stacked[0].shape[1]
 
-        # adapter_enabled[token_lora_mapping] needs clamp(min=0) so the -1
-        # sentinel does not out-of-bounds index. The clamped value will be
-        # masked out below via valid_mask.
-        tlm_clamped = token_lora_mapping.clamp(min=0)
-        valid_mask = (token_lora_mapping >= 0) & (
-            adapter_enabled[tlm_clamped] != 0
+        # adapter_enabled[token_lora_mapping] needs clamp(min=0, max=max_loras)
+        # to avoid out-of-bounds; values out of [0, max_loras) get masked out
+        # by valid_mask below.
+        tlm_clamped = token_lora_mapping.clamp(min=0, max=max_loras)
+        valid_mask = (
+            (token_lora_mapping >= 0)
+            & (token_lora_mapping < max_loras)
+            & (adapter_enabled[tlm_clamped] != 0)
         )
+        # Sentinel routing: invalid rows go to (lora=0, expert=0); their
+        # shrink buffer is zeroed below before expand, so they contribute 0.
         safe_lora = torch.where(
             valid_mask, tlm_clamped, torch.zeros_like(tlm_clamped)
         )
+        # Cap to [0, max_loras) explicitly so virtual_idx stays in
+        # [0, max_loras * local_E) range that A_flat / B_flat span.
+        safe_lora = safe_lora.clamp(max=max_loras - 1)
         safe_expert = expert_ids.clamp(min=0).to(torch.long)
-        virtual_idx = safe_expert * max_loras_plus_one + safe_lora.to(torch.long)
+        virtual_idx = safe_expert * max_loras + safe_lora.to(torch.long)
 
         for slice_idx in range(len(lora_a_stacked)):
-            A = lora_a_stacked[slice_idx]  # [max_loras+1, local_E, rank, in]
-            B = lora_b_stacked[slice_idx]  # [max_loras+1, local_E, slice, rank]
+            A = lora_a_stacked[slice_idx]  # [max_loras, local_E, rank, in]
+            B = lora_b_stacked[slice_idx]  # [max_loras, local_E, slice, rank]
             rank = A.shape[2]
             slice_out = B.shape[2]
             col_start = offset + slice_idx * slice_out
 
             A_flat = A.permute(1, 0, 2, 3).reshape(
-                local_E * max_loras_plus_one, rank, A.shape[-1]
+                local_E * max_loras, rank, A.shape[-1]
             ).contiguous()
             B_flat = B.permute(1, 0, 2, 3).reshape(
-                local_E * max_loras_plus_one, slice_out, rank
+                local_E * max_loras, slice_out, rank
             ).contiguous()
 
             buffer = torch.zeros(

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -350,3 +350,137 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.bgmv_expand(buffer, lora_b_stacked, y, indices, add_inputs=True)
 
         y = y.view_as(y_org)
+
+    # ------------------------------------------------------------------
+    # MoE-LoRA primitives (v1 reference implementation)
+    # ------------------------------------------------------------------
+    # NPU does not yet have a fused MoE-LoRA kernel equivalent to the
+    # upstream Triton `fused_moe_lora`. v1 ships a torch-based reference
+    # implementation: correct-by-construction, suitable for functional
+    # verification on real adapters. A fused AscendC kernel is planned
+    # for v2.
+
+    def moe_lora_align_block_size(
+        self,
+        topk_ids: torch.Tensor,
+        num_tokens: int,
+        block_size: int,
+        num_experts: int,
+        max_loras: int,
+        adapter_enabled: torch.Tensor,
+        expert_map: torch.Tensor | None = None,
+        pad_sorted_ids: bool = False,
+        naive_block_assignment: bool = False,
+    ):
+        """Aligns tokens and experts for MoE-LoRA execution.
+
+        v1 NPU implementation always returns the naive layout (one row per
+        (orig_token, k) replica) — the equivalent of upstream GPU's
+        `naive_block_assignment=True` branch. The caller (AscendFusedMoEWithLoRA)
+        does not currently consume `sorted_token_ids` / `num_tokens_post_padded`,
+        so we leave them as None to avoid extra allocations.
+
+        Returns:
+            tuple(token_lora_mapping, sorted_token_ids, expert_ids,
+                  num_tokens_post_padded)
+            * token_lora_mapping: 1D LongTensor[num_tokens] of LoRA slot id per
+              original token. -1 means "no LoRA".
+            * sorted_token_ids: always None in v1.
+            * expert_ids: flat 1D LongTensor[num_tokens * top_k]; the expert id
+              each (token, k) replica is routed to. Translated by expert_map if
+              provided.
+            * num_tokens_post_padded: always None in v1.
+        """
+        del block_size, num_experts, max_loras, pad_sorted_ids
+        del naive_block_assignment  # always naive in v1
+        token_lora_mapping = self.token_lora_indices[:num_tokens]
+        expert_ids = topk_ids.reshape(-1)
+        if expert_map is not None:
+            expert_ids = expert_map[expert_ids]
+        return token_lora_mapping, None, expert_ids, None
+
+    def add_lora_fused_moe(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        topk_weights: torch.Tensor | None,
+        sorted_token_ids: torch.Tensor | None,
+        expert_ids: torch.Tensor,
+        num_tokens_post_padded: torch.Tensor | None,
+        max_lora_rank: int,
+        top_k_num: int,
+        shrink_config,
+        expand_config,
+        adapter_enabled: torch.Tensor,
+        mul_routed_weight: bool = False,
+        fully_sharded: bool = False,
+        offset: int = 0,
+        token_lora_mapping: torch.Tensor | None = None,
+    ):
+        """In-place adds the MoE-LoRA delta to `y`.
+
+        Semantics (one slice at a time):
+            for slice_idx, (A, B) in enumerate(zip(lora_a_stacked, lora_b_stacked)):
+                slice_out = B.shape[2]
+                col_start = offset + slice_idx * slice_out
+                for each permuted row i:
+                    l = token_lora_mapping[i]; e = expert_ids[i]
+                    if l == -1 or adapter_enabled[l] == 0: continue
+                    buf = (x[i] @ A[l, e].T) * 1.0          # shrink
+                    y[i, col_start:col_start+slice_out] += buf @ B[l, e].T  # expand
+
+        v1 walks (lora_id, expert_id) buckets in Python. This is O(max_loras *
+        local_E) masked matmuls per call — slow but correct. A fused AscendC
+        kernel will replace this in v2.
+        """
+        del sorted_token_ids, num_tokens_post_padded
+        del max_lora_rank, top_k_num, shrink_config, expand_config
+        del fully_sharded  # v1 does not need slice metadata on Ascend
+
+        if mul_routed_weight:
+            # Only the upstream w2 path (when running in unpermuted domain)
+            # sets this. The Ascend hook operates in the permuted domain, so
+            # we never set it. Keep the assert to catch accidental misuse.
+            raise NotImplementedError(
+                "mul_routed_weight=True is not supported on the Ascend MoE-LoRA "
+                "path (LoRA is applied to permuted activations before combine)."
+            )
+        if token_lora_mapping is None:
+            token_lora_mapping = self.token_lora_indices[: x.size(0)]
+
+        # Fast-path: no active LoRA for any token in this batch.
+        # `no_lora` is computed from the host-side prefill metadata; if it is
+        # not set (decode without explicit prefill update), we still need to
+        # honor adapter_enabled and the -1 sentinel.
+        max_loras = int(adapter_enabled.shape[0]) - 1
+        # Operate in fp32 internally for numerical parity with the GPU path,
+        # which also accumulates the shrink buffer in fp32. Cast back to y.dtype
+        # at the very end.
+        for slice_idx in range(len(lora_a_stacked)):
+            A = lora_a_stacked[slice_idx]  # [max_loras+1, local_E, rank, in]
+            B = lora_b_stacked[slice_idx]  # [max_loras+1, local_E, slice, rank]
+            slice_out = B.shape[2]
+            local_E = A.shape[1]
+            col_start = offset + slice_idx * slice_out
+            col_end = col_start + slice_out
+
+            for l in range(max_loras):
+                # adapter_enabled is a device tensor; .item() forces a sync.
+                # v1 accepts the sync since this is a Python reference impl.
+                if int(adapter_enabled[l].item()) == 0:
+                    continue
+                lora_mask = token_lora_mapping == l
+                # Early skip if this LoRA has no tokens in this batch.
+                if not bool(lora_mask.any().item()):
+                    continue
+                for e in range(local_E):
+                    mask = lora_mask & (expert_ids == e)
+                    if not bool(mask.any().item()):
+                        continue
+                    x_sub = x[mask].to(torch.float32)
+                    buf = x_sub @ A[l, e].t().to(torch.float32)
+                    delta = buf @ B[l, e].t().to(torch.float32)
+                    y[mask, col_start:col_end] += delta.to(y.dtype)
+        return

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -419,30 +419,26 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         offset: int = 0,
         token_lora_mapping: torch.Tensor | None = None,
     ):
-        """In-place adds the MoE-LoRA delta to `y`.
+        """In-place adds the MoE-LoRA delta to `y` using combined-index bgmv.
 
-        Semantics (one slice at a time):
-            for slice_idx, (A, B) in enumerate(zip(lora_a_stacked, lora_b_stacked)):
-                slice_out = B.shape[2]
-                col_start = offset + slice_idx * slice_out
-                for each permuted row i:
-                    l = token_lora_mapping[i]; e = expert_ids[i]
-                    if l == -1 or adapter_enabled[l] == 0: continue
-                    buf = (x[i] @ A[l, e].T) * 1.0          # shrink
-                    y[i, col_start:col_start+slice_out] += buf @ B[l, e].T  # expand
+        Trick: bgmv expects 3D weights ``[num_loras, out, in]`` and a 1D
+        ``lora_indices`` of length N. Our per-expert LoRA weights are 4D
+        ``[max_loras+1, local_E, rank/slice, in]``. We fold ``(lora_id,
+        expert_id)`` into a single virtual index ``e * (max_loras+1) + l``
+        and reshape the weights into ``[(max_loras+1)*local_E, ...]`` — a
+        zero-copy view. This collapses the v1 Python double loop into two
+        bgmv calls per slice, getting all AscendC-level perf for free.
 
-        v1 walks (lora_id, expert_id) buckets in Python. This is O(max_loras *
-        local_E) masked matmuls per call — slow but correct. A fused AscendC
-        kernel will replace this in v2.
+        Disabled / unmapped rows (``token_lora_mapping == -1`` or
+        ``adapter_enabled[l] == 0``) are routed to a sentinel slot (lora id 0,
+        expert 0) and their shrink buffer is zeroed afterwards, so expand
+        contributes nothing. This avoids any host sync.
         """
         del sorted_token_ids, num_tokens_post_padded
         del max_lora_rank, top_k_num, shrink_config, expand_config
-        del fully_sharded  # v1 does not need slice metadata on Ascend
+        del fully_sharded  # not needed on the permuted-domain Ascend path
 
         if mul_routed_weight:
-            # Only the upstream w2 path (when running in unpermuted domain)
-            # sets this. The Ascend hook operates in the permuted domain, so
-            # we never set it. Keep the assert to catch accidental misuse.
             raise NotImplementedError(
                 "mul_routed_weight=True is not supported on the Ascend MoE-LoRA "
                 "path (LoRA is applied to permuted activations before combine)."
@@ -450,37 +446,69 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         if token_lora_mapping is None:
             token_lora_mapping = self.token_lora_indices[: x.size(0)]
 
-        # Fast-path: no active LoRA for any token in this batch.
-        # `no_lora` is computed from the host-side prefill metadata; if it is
-        # not set (decode without explicit prefill update), we still need to
-        # honor adapter_enabled and the -1 sentinel.
-        max_loras = int(adapter_enabled.shape[0]) - 1
-        # Operate in fp32 internally for numerical parity with the GPU path,
-        # which also accumulates the shrink buffer in fp32. Cast back to y.dtype
-        # at the very end.
+        # Early-out: prefill metadata explicitly tagged no LoRA in this batch.
+        if self.no_lora:
+            return
+
+        # max_loras+1 to include the sentinel "no-LoRA" slot at the end.
+        max_loras_plus_one = int(adapter_enabled.shape[0])
+        local_E = lora_a_stacked[0].shape[1]
+
+        # ---- build effective lora id per permuted row, no host sync ----
+        # adapter_enabled[token_lora_mapping] needs clamp(min=0) so the -1
+        # sentinel doesn't out-of-bounds index. The clamped value will be
+        # masked out below via valid_mask.
+        tlm_clamped = token_lora_mapping.clamp(min=0)
+        valid_mask = (token_lora_mapping >= 0) & (
+            adapter_enabled[tlm_clamped] != 0
+        )
+        # Sentinel routing: invalid rows go to (lora_id=0, expert_id=0). The
+        # actual values pulled from the weight tensors will be overwritten by
+        # zeros in the shrink buffer before expand.
+        safe_lora = torch.where(
+            valid_mask, tlm_clamped, torch.zeros_like(tlm_clamped)
+        )
+        # expert_ids may also be -1 if expert_map filtered out tokens on other
+        # EP ranks; clamp similarly. EP is currently asserted off, but the
+        # defensive clamp keeps the kernel safe.
+        safe_expert = expert_ids.clamp(min=0).to(torch.long)
+        # virtual_idx[i] = expert * (max_loras+1) + lora_id
+        # Layout matches torch.reshape of A from
+        # [max_loras+1, local_E, rank, in] (stride: local_E*..., ...)
+        # FIX: actually A is [max_loras+1, local_E, ...]. Reshape into
+        # [(max_loras+1)*local_E, ...] has stride [local_E*..., ...] only if
+        # we reshape via permute. Below we permute to [local_E, max_loras+1, ...]
+        # then reshape, so virtual_idx = expert * (max_loras+1) + lora_id
+        # picks A_view[expert*(max_loras+1) + lora_id] = original A[lora_id, expert].
+        virtual_idx = safe_expert * max_loras_plus_one + safe_lora.to(torch.long)
+
+        # ---- iterate slices (gate / up for _w13_slices==2, just one for w2) ----
         for slice_idx in range(len(lora_a_stacked)):
             A = lora_a_stacked[slice_idx]  # [max_loras+1, local_E, rank, in]
             B = lora_b_stacked[slice_idx]  # [max_loras+1, local_E, slice, rank]
+            rank = A.shape[2]
             slice_out = B.shape[2]
-            local_E = A.shape[1]
             col_start = offset + slice_idx * slice_out
-            col_end = col_start + slice_out
 
-            for l in range(max_loras):
-                # adapter_enabled is a device tensor; .item() forces a sync.
-                # v1 accepts the sync since this is a Python reference impl.
-                if int(adapter_enabled[l].item()) == 0:
-                    continue
-                lora_mask = token_lora_mapping == l
-                # Early skip if this LoRA has no tokens in this batch.
-                if not bool(lora_mask.any().item()):
-                    continue
-                for e in range(local_E):
-                    mask = lora_mask & (expert_ids == e)
-                    if not bool(mask.any().item()):
-                        continue
-                    x_sub = x[mask].to(torch.float32)
-                    buf = x_sub @ A[l, e].t().to(torch.float32)
-                    delta = buf @ B[l, e].t().to(torch.float32)
-                    y[mask, col_start:col_end] += delta.to(y.dtype)
+            # Permute (max_loras+1, local_E, ...) -> (local_E, max_loras+1, ...)
+            # then reshape so virtual_idx layout matches.
+            # .contiguous() is required because bgmv indexes flat dim 0.
+            A_flat = A.permute(1, 0, 2, 3).reshape(
+                local_E * max_loras_plus_one, rank, A.shape[-1]
+            ).contiguous()
+            B_flat = B.permute(1, 0, 2, 3).reshape(
+                local_E * max_loras_plus_one, slice_out, rank
+            ).contiguous()
+
+            # bgmv_shrink writes (not accumulates) into the rank buffer.
+            buffer = torch.zeros(
+                (x.size(0), rank), dtype=torch.float32, device=x.device
+            )
+            self.bgmv_shrink(x, A_flat, buffer, virtual_idx, 1.0)
+            # Mask out invalid rows so expand contributes 0 to y.
+            buffer.mul_(valid_mask.unsqueeze(-1).to(buffer.dtype))
+            # bgmv_expand_slice accumulates into y[:, col_start:col_start+slice].
+            self.bgmv_expand_slice(
+                buffer, B_flat, y, virtual_idx, col_start, slice_out, True
+            )
         return

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -15,6 +15,7 @@ from vllm.lora.layers import (
     RowParallelLinearWithShardedLoRA,
     VocabParallelEmbeddingWithLoRA,
 )
+from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
 from vllm.lora.layers.replicated_linear import ReplicatedLinearWithLoRA
 from vllm.lora.layers.utils import _fully_sharded_can_replace, _not_fully_sharded_can_replace
 
@@ -197,3 +198,15 @@ def refresh_all_lora_classes():
     vllm.lora.utils._all_lora_classes.add(AscendQKVParallelLinearWithShardedLoRA)
     vllm.lora.utils._all_lora_classes.add(AscendRowParallelLinearWithShardedLoRA)
     vllm.lora.utils._all_lora_classes.add(AscendReplicatedLinearWithLoRA)
+
+    # MoE LoRA: drop upstream Triton-based wrappers (they assert on TritonExperts
+    # in __init__ which does not exist on Ascend) and register Ascend variants.
+    # Imported lazily to avoid pulling in torch_npu at module-import time.
+    from vllm_ascend.lora.fused_moe import (
+        AscendFusedMoE3DWithLoRA,
+        AscendFusedMoEWithLoRA,
+    )
+    vllm.lora.utils._all_lora_classes.discard(FusedMoEWithLoRA)
+    vllm.lora.utils._all_lora_classes.discard(FusedMoE3DWithLoRA)
+    vllm.lora.utils._all_lora_classes.add(AscendFusedMoEWithLoRA)
+    vllm.lora.utils._all_lora_classes.add(AscendFusedMoE3DWithLoRA)

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -210,6 +210,12 @@ def build_mlp_compute_input(
     if fused_experts_input.quant.is_mxfp and fused_experts_input.quant.mxfp is None:
         raise ValueError("fused_experts_input.quant.mxfp is required for MXFP quant types.")
 
+    # MoE-LoRA needs perm_row -> orig_token mapping; AllGather's combine_metadata
+    # carries expanded_row_idx. MC2 / All2All metadata classes do not expose it
+    # in the same form; pass None and let the LoRA hook fall back.
+    expanded_row_idx = getattr(
+        token_dispatch_output.combine_metadata, "expanded_row_idx", None
+    )
     return MoEMlpComputeInput(
         hidden_states=token_dispatch_output.hidden_states,
         group_list=token_dispatch_output.group_list,
@@ -222,6 +228,8 @@ def build_mlp_compute_input(
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,
+        expanded_row_idx=expanded_row_idx,
+        topk_ids=fused_experts_input.topk_ids,
     )
 
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -139,6 +139,13 @@ class MoEMlpComputeInput:
     activation: str = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
+    # MoE-LoRA hook needs to reconstruct (permuted_row -> orig_token) mapping
+    # to look up per-token LoRA slot ids. These optional fields are populated
+    # by build_mlp_compute_input for comm methods whose combine_metadata
+    # carries an expanded_row_idx (currently AllGather). Other comm methods
+    # leave them None; the LoRA hook detects this and falls back to base path.
+    expanded_row_idx: torch.Tensor | None = None
+    topk_ids: torch.Tensor | None = None
 
 
 __all__ = [


### PR DESCRIPTION
## What this PR does / why we need it?

Adds MoE LoRA support for `AscendFusedMoE` layers, addressing the gap where
vLLM upstream `FusedMoEWithLoRA` depends on Triton / `TritonExperts` and is
not directly usable on Ascend NPU.

**Design highlights**

- New `AscendFusedMoEWithLoRA` / `AscendFusedMoE3DWithLoRA` wrappers
  (`vllm_ascend/lora/fused_moe.py`, 376 lines). Monkey-patches each layer's
  `quant_method.apply` with a per-layer closure, and within it bracket-swaps
  `MoECommMethod._apply_mlp` via try/finally — avoids the 48-layer
  composition bug from globally wrapping the singleton.
- 3 selectable kernel tiers via `VLLM_ASCEND_MOE_LORA_KERNEL`:
  - `torch`             — reference impl (1× baseline)
  - `bgmv_per_expert`   — per-expert bgmv loop (~5-10×)
  - `bgmv` (default)    — combined-index `virtual_idx = expert × max_loras + lora_id`,
                          2 bgmv calls per slice, ~30-50× in micro-bench
- ACL Graph compatible (FULL_DECODE_ONLY / FULL / PIECEWISE) — hot path is
  device-only, no `.item()` / `repeat_interleave(device_tensor)` syncs.
- Quantized MoE path falls back to base (warning) — no regression for w8a8.
- 5 startup asserts gate v1.5 scope: `use_ep` / `dynamic_eplb` /
  `VLLM_ASCEND_ENABLE_FUSED_MC2` / `_shared_experts` / `multistream_overlap_gate`.

**Stats**: 6 files, +931 / -154, branch base `da421afa` (v0.19.1rc1).

## Does this PR introduce _any_ user-facing change?

Yes:
- New env `VLLM_ASCEND_MOE_LORA_KERNEL` (default `bgmv`).
- `--enable-lora` on MoE models now works (previously asserted out at LoRA
  manager initialization for FusedMoE layers).
- Requirements: TP-only (`--no-enable-expert-parallel`),
  `VLLM_ASCEND_ENABLE_FUSED_MC2=0`, no shared experts (v1.5 scope).

## How was this patch tested?

Manual NPU testing on A3 + TP=2 (commit `b3be46ab`):

| KERNEL | mode    | Duration | Output tok/s | TPOT (ms) |
|--------|---------|---------:|-------------:|----------:|
| bgmv   | graph   | 16.77 s  | 357.75       | 25.33     |
| torch  | graph   | 16.92 s  | 354.54       | 25.52     |
| bgmv   | eager   | 74.95 s  | 80.06        | 122.14    |
| torch  | eager   | 74.50 s  | 80.54        | 121.35    |

- End-to-end run on Qwen3-30B-A3B-Thinking-2507 w8a8 + FT-Lora adapter.
- ACL Graph FULL_DECODE_ONLY successfully captures and replays.
- w8a8 quant path correctly falls back to base (bgmv vs torch parity expected).
- Graph vs eager 4.5× speedup retained.
- **bf16 micro-bench for true bgmv vs torch divergence: pending — will add
  before un-drafting.**

Test data: https://github.com/FutureSkyFly/Model_test/blob/main/lora/results/results.md

Reference adapter used: `aifeifei798/Qwen3-30B-A3B-Thinking-2507-FT-Lora`
(rank=8, target_modules include `gate_proj` / `up_proj` / `down_proj`).

## AI assistance disclosure

Developed with AI assistance (Claude Code). The submitting human reviewed
the changes and ran the NPU validation listed above. The lora_moe branch
is currently based on `da421afa` (v0.19.1rc1, 296 commits behind main);
rebase to current `main` will be done before un-drafting.

- vLLM version: v0.19.1rc1 base
- Companion fork branch: https://github.com/FutureSkyFly/vllm-ascend/tree/lora_moe