### PR TITLE
[BugFix]mutually exclude fused mc2 and multistream_overlap_shared_expert

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -630,8 +630,8 @@ class NPUPlatform(Platform):
                 "Please disable VLLM_ASCEND_ENABLE_FUSED_MC2 by setting it to 0."
             )
 
-        if get_ascend_config().enable_fused_mc2 == 1 and get_ascend_config().multistream_overlap_shared_expert:
-            get_ascend_config().multistream_overlap_shared_expert = False
+        if ascend_config.enable_fused_mc2 == 1 and ascend_config.multistream_overlap_shared_expert:
+            ascend_config.multistream_overlap_shared_expert = False
             logger.warning_once(
                 "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "
                 "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -630,6 +630,13 @@ class NPUPlatform(Platform):
                 "Please disable VLLM_ASCEND_ENABLE_FUSED_MC2 by setting it to 0."
             )
 
+        if get_ascend_config().enable_fused_mc2 == 1 and get_ascend_config().multistream_overlap_shared_expert:
+            get_ascend_config().multistream_overlap_shared_expert = False
+            logger.warning_once(
+                "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "
+                "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
+            )
+
     @classmethod
     def import_kernels(cls) -> None:
         # Directly importing vllm_ascend_C prevents ASCEND_RT_VISIBLE_DEVICES


### PR DESCRIPTION
…ybrid connector (#9808)

### What this PR does / why we need it?
VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2 = 1) and multistream_overlap_shared_expert cannot be enabled at the same time.
This patch automatically disables multistream_overlap_shared_expert when fused mc2 is enabled, and logs a warning.

### Does this PR introduce _any_ user-facing change? No.

### How was this patch tested?
Tested by P/D accuracy test.

---------

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
