### PR TITLE
[v0.20.2][BugFix][Ascend950][spec decode] Fix draft model index out of range error caused by `token_indices_to_sample`

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -672,7 +672,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs_padded = common_attn_metadata.num_reqs
             # In the below scenario, padding has been applied by _pad_query_start_loc_for_fia in the model runner.
             # We need to unpad here for eager mode to maintain compatibility.
-            if (enable_sp() and not self.vllm_config.model_config.use_mla) and self.pcp_size * self.dcp_size == 1:
+            if not self.vllm_config.model_config.use_mla and self.pcp_size * self.dcp_size == 1:
                 common_attn_metadata.block_table_tensor = self._adjust_tensor(
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
@@ -838,6 +838,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         token_indices_to_sample_len = token_indices_to_sample.shape[0]
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
+        self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
         with set_ascend_forward_context(
             multi_steps_attn_metadata[0],


### PR DESCRIPTION
### What this PR does / why we need it?
1. `token_indices_to_sample` has dirty data which will lead to index out of range error on A5.
2. As the FIA op on A5 checks the shape of block table, when the target model is in graph mode and the draft model is in eager mode, the shape of block table is mismatched.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- vLLM version: v0.20.2
