### PR TITLE
[CI] Clean torch compile cache in ci

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -157,6 +157,10 @@ jobs:
             uv pip install -e .
           fi
 
+      # todo(wxs): remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
+
       - name: Run vllm-project/vllm-ascend test
         env:
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
@@ -291,6 +295,10 @@ jobs:
           else
             uv pip install -e .
           fi
+
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
 
       - name: Run e2e test
         if: ${{ inputs.type == 'full' }}
@@ -433,6 +441,10 @@ jobs:
           else
             uv pip install -e .
           fi
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
+
       - name: Run vllm-project/vllm-ascend test (light)
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
@@ -566,6 +578,10 @@ jobs:
           else
             uv pip install -e .
           fi
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
+
       - name: Run vllm-project/vllm-ascend test (full)
         if: ${{ inputs.type == 'full' }}
         env:
@@ -757,6 +773,10 @@ jobs:
             uv pip install -e .
           fi
 
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
+
       - name: Run vllm-project/vllm-ascend test (light)
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
@@ -888,6 +908,10 @@ jobs:
           else
             uv pip install -e .
           fi
+
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
 
       - name: Run vllm-project/vllm-ascend test for V1 Engine
         if: ${{ inputs.type == 'full' }}
@@ -1026,6 +1050,10 @@ jobs:
         if: ${{ inputs.type == 'light' }}
         run: pip uninstall -y triton-ascend triton
 
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
+
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}
         env:
@@ -1143,6 +1171,10 @@ jobs:
       - name: Uninstall triton-ascend (310p e2e-light)
         if: ${{ inputs.type == 'light' }}
         run: pip uninstall -y triton-ascend triton
+
+      # TODO: remove this when the root cause of the cache issue is found
+      - name: Clean up torch compile cache
+        run: rm -rf ~/.cache/vllm/torch_compile_cache
 
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -159,7 +159,7 @@ jobs:
 
       # todo(wxs): remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test
         env:
@@ -297,7 +297,7 @@ jobs:
           fi
 
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run e2e test
         if: ${{ inputs.type == 'full' }}
@@ -441,7 +441,7 @@ jobs:
             uv pip install -e .
           fi
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test (light)
         env:
@@ -577,7 +577,7 @@ jobs:
             uv pip install -e .
           fi
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test (full)
         if: ${{ inputs.type == 'full' }}
@@ -771,7 +771,7 @@ jobs:
           fi
 
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test (light)
         env:
@@ -906,7 +906,7 @@ jobs:
           fi
 
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test for V1 Engine
         if: ${{ inputs.type == 'full' }}
@@ -1046,7 +1046,7 @@ jobs:
         run: pip uninstall -y triton-ascend triton
 
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}
@@ -1167,7 +1167,7 @@ jobs:
         run: pip uninstall -y triton-ascend triton
 
       - name: Clean up torch compile cache
-        run: rm -rf ~/.cache/vllm/torch_compile_cache
+        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}

--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -296,7 +296,6 @@ jobs:
             uv pip install -e .
           fi
 
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 
@@ -441,7 +440,6 @@ jobs:
           else
             uv pip install -e .
           fi
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 
@@ -578,7 +576,6 @@ jobs:
           else
             uv pip install -e .
           fi
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 
@@ -773,7 +770,6 @@ jobs:
             uv pip install -e .
           fi
 
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 
@@ -909,7 +905,6 @@ jobs:
             uv pip install -e .
           fi
 
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 
@@ -1050,7 +1045,6 @@ jobs:
         if: ${{ inputs.type == 'light' }}
         run: pip uninstall -y triton-ascend triton
 
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 
@@ -1172,7 +1166,6 @@ jobs:
         if: ${{ inputs.type == 'light' }}
         run: pip uninstall -y triton-ascend triton
 
-      # TODO: remove this when the root cause of the cache issue is found
       - name: Clean up torch compile cache
         run: rm -rf ~/.cache/vllm/torch_compile_cache
 


### PR DESCRIPTION
### What this PR does / why we need it?

- Fixes https://github.com/vllm-project/vllm-ascend/actions/runs/26798034729/job/79003682560?pr=9865, caused by https://github.com/vllm-project/vllm-ascend/pull/9744

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with new added/existing test.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
