### PR TITLE
[BugFix] Skip npugraph_ex cache for graphs containing Triton kernels

### DIFF
--- a/.github/workflows/_e2e_test.yaml
+++ b/.github/workflows/_e2e_test.yaml
@@ -157,10 +157,6 @@ jobs:
             uv pip install -e .
           fi
 
-      # todo(wxs): remove this when the root cause of the cache issue is found
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
-
       - name: Run vllm-project/vllm-ascend test
         env:
           PYTORCH_NPU_ALLOC_CONF: max_split_size_mb:256
@@ -295,9 +291,6 @@ jobs:
           else
             uv pip install -e .
           fi
-
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run e2e test
         if: ${{ inputs.type == 'full' }}
@@ -440,8 +433,6 @@ jobs:
           else
             uv pip install -e .
           fi
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test (light)
         env:
@@ -576,8 +567,6 @@ jobs:
           else
             uv pip install -e .
           fi
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test (full)
         if: ${{ inputs.type == 'full' }}
@@ -770,8 +759,6 @@ jobs:
             uv pip install -e .
           fi
 
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test (light)
         env:
@@ -905,8 +892,6 @@ jobs:
             uv pip install -e .
           fi
 
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test for V1 Engine
         if: ${{ inputs.type == 'full' }}
@@ -1045,8 +1030,6 @@ jobs:
         if: ${{ inputs.type == 'light' }}
         run: pip uninstall -y triton-ascend triton
 
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}
@@ -1166,8 +1149,6 @@ jobs:
         if: ${{ inputs.type == 'light' }}
         run: pip uninstall -y triton-ascend triton
 
-      - name: Clean up torch compile cache
-        run: find ~/.cache/vllm/torch_compile_cache -mindepth 1 -maxdepth 1 ! -name "torch_aot_compile" -exec rm -rf {} + 2>/dev/null || true
 
       - name: Run vllm-project/vllm-ascend test
         if: ${{ inputs.contains_310 }}

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -326,6 +326,7 @@ class AscendCompiler(CompilerInterface):
         artifacts.py_code = py_code
         logger.debug("Loaded npugraph_ex compilation cache from %s", path)
         compiled_fn = _CompiledFxGraph.load_artifacts(artifacts)
+        assert compiled_fn is not None, "Failed to load npugraph_ex compilation cache"
 
         # The saved code was compiled from the graph after make_graph_return_tuple mutated it
         # to return a flat tuple. If the original graph didn't return a tuple, we need to

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -291,6 +291,7 @@ class AscendCompiler(CompilerInterface):
             # "fake mode mismatch" in aot_module_simplified.
             graph = copy.deepcopy(graph)
             from torch._guards import detect_fake_mode
+
             current_fake_mode = detect_fake_mode()
             if current_fake_mode is not None:
                 example_inputs = [

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -160,10 +160,22 @@ def npugraph_ex_compile(
             if cache_path:
                 py_code = compiled_gm.get_code()
                 if py_code:
-                    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-                    with open(cache_path, "w") as f:
-                        f.write(py_code)
-                    logger.debug("Saved compiled graph to cache: %s", cache_path)
+                    # Triton kernel indices (kernel_side_table) are registered in-process
+                    # at compile time and are not serializable across process boundaries.
+                    # Graphs containing triton_kernel_wrapper calls must not be cached,
+                    # because loading the py_code in a new process will hit an
+                    # AssertionError in kernel_side_table.get_kernel().
+                    if "triton_kernel_wrapper" in py_code:
+                        logger.info(
+                            "Skipping npugraph_ex cache for graph containing Triton kernels "
+                            "(kernel_side_table indices are process-local): %s",
+                            cache_path,
+                        )
+                    else:
+                        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                        with open(cache_path, "w") as f:
+                            f.write(py_code)
+                        logger.debug("Saved compiled graph to cache: %s", cache_path)
             return compiled_gm
 
         nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
@@ -263,6 +275,48 @@ class AscendCompiler(CompilerInterface):
 
     def load(self, handle, graph, example_inputs, graph_index, compile_range):
         key, path = handle
+
+        # Cache file may be absent when the graph was skipped at save time (e.g. it
+        # contained Triton kernels whose kernel_side_table indices are process-local
+        # and cannot be serialized).  Fall back to a fresh compilation so the Triton
+        # kernels are properly registered in the current process.
+        if not path or not os.path.exists(path):
+            logger.debug(
+                "npugraph_ex cache miss for key %s (file absent or not saved), recompiling",
+                key,
+            )
+            # Mirror the same pre-processing done in compile(): deepcopy the graph
+            # to prevent make_graph_return_tuple from mutating the caller's copy,
+            # and re-wrap FakeTensor inputs under the current fake mode to avoid
+            # "fake mode mismatch" in aot_module_simplified.
+            graph = copy.deepcopy(graph)
+            from torch._guards import detect_fake_mode
+            current_fake_mode = detect_fake_mode()
+            if current_fake_mode is not None:
+                example_inputs = [
+                    current_fake_mode.from_tensor(inp)
+                    if (
+                        isinstance(inp, torch.Tensor)
+                        and hasattr(inp, "fake_mode")
+                        and inp.fake_mode is not current_fake_mode
+                    )
+                    else inp
+                    for inp in example_inputs
+                ]
+            ascend_compilation_config = get_ascend_config().ascend_compilation_config
+            assert hasattr(self, "vllm_config")
+            compiled_fn, _ = npugraph_ex_compile(
+                graph,
+                example_inputs,
+                {},
+                self.vllm_config,
+                ascend_compilation_config,
+                compile_range,
+                key,
+                getattr(self, "cache_dir", None),
+            )
+            return compiled_fn
+
         from npugraph_ex.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
 
         with open(path) as f:


### PR DESCRIPTION
### What this PR does / why we need it?
Triton kernel indices are registered in a process-local `kernel_side_table` at compile time and cannot be serialized across process boundaries. Loading cached `py_code` that contains `triton_kernel_wrapper` calls in a new process causes `AssertionError in kernel_side_table.get_kernel()`.

Fix by skipping the cache write in `patched_get_compiled_gm` when `py_code` contains `triton_kernel_wrapper` references. In load(), fall back to fresh compilation when the cache file is absent, applying the same graph deepcopy and FakeTensor mode normalization as `compile()` to avoid fake mode mismatch errors from aot_module_simplified.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
CI passed with new added/existing test.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
