### PR TITLE
[BugFix][Model] Keep DSV4 compressor fp32 inputs

### DIFF
--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -509,7 +509,8 @@ class Compressor(nn.Module):
             prefix=f"{prefix}.wgate",
             return_bias=False,
         )
-        self.norm = RMSNorm(self.head_dim, config.rms_norm_eps)
+        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
+        self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
 
         state_dtype = torch.float32
         # TODO(zyj): change following codes if block_size is configurable & refactor the magic numbers

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -7,8 +7,6 @@ import torch_npu
 from vllm.config import VllmConfig
 from vllm.platforms import current_platform
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
-
 
 class RopeGlobalState:
     def __init__(self):
@@ -119,8 +117,7 @@ class ComplexExpRotaryEmbedding(nn.Module):
             rope_groups = ["default"]
         self.layername = layername
         self.rotary_dim = rotary_dim
-        use_fp32_rope = get_ascend_device_type() in {AscendDeviceType.A2, AscendDeviceType.A3}
-        dtype = torch.float32 if use_fp32_rope else torch.get_default_dtype()
+        dtype = torch.float32
         beta_fast = extra_kwargs.get("beta_fast", 32)
         beta_slow = extra_kwargs.get("beta_slow", 1)
         config_key = (
@@ -146,9 +143,6 @@ class ComplexExpRotaryEmbedding(nn.Module):
             freqs = torch.einsum("i,j -> ij", t, inv_freq)
             cos = freqs.cos().repeat_interleave(2, dim=-1)
             sin = freqs.sin().repeat_interleave(2, dim=-1)
-            if not use_fp32_rope:
-                cos = cos.to(dtype)
-                sin = sin.to(dtype)
             cos = cos.to(current_platform.device_type)
             sin = sin.to(current_platform.device_type)
 


### PR DESCRIPTION
### What this PR does / why we need it?
Keeps the DSV4 compressor model-side inputs aligned with the fp32 compressor kernel expectations:
- creates DSV4 compressor RMSNorm weights as fp32 on A5, so both compressor and indexer compressor norm weights are loaded and stored as fp32 without per-call casts
- constructs DSV4 RoPE cos/sin caches as fp32 directly instead of building default-dtype caches and conditionally casting them

This is split from the model-side portion that was intentionally left out of #9350.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- `python -m py_compile vllm_ascend/models/deepseek_v4.py vllm_ascend/ops/rope_dsv4.py`
- `git diff --check upstream/main...HEAD`
- `PATH=/tmp/vllm-ascend-lint-venv/bin:$PATH bash format.sh ci`
- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
