### PR TITLE
[Misc][0.20.2rc](dsa_cp): introduce additional_config for dsa_cp

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -98,6 +98,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_context_parallel`           | bool | `False` | Whether to enable context parallelism. Can also be configured via `VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL` environment variable (deprecated). |
 | `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. Can also be configured via `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable (deprecated). |
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. Can also be configured via `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable (deprecated). |
+| `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature depends on FLASHCOMM1. Please ensure that FLASHCOMM1 is enabled before enabling this feature.|
 
 The details of each configuration option are as follows:
 

--- a/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
+++ b/tests/e2e/multicard/4-cards/long_sequence/test_basic.py
@@ -148,6 +148,7 @@ def test_deepseek_v4_w4a8_dsa_cp_basic_greedy():
         },
         additional_config={
             "enable_flashcomm1": True,
+            "enable_dsa_cp": True,
             "multistream_dsa_preprocess": True,
         },
     ) as runner:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -52,6 +52,7 @@ from vllm_ascend.utils import (
     enable_dsa_cp,
     enable_dsa_cp_with_layer_shard,
     enable_dsa_cp_with_o_proj_tp,
+    enable_sp,
     get_weight_prefetch_method,
     maybe_trans_nz,
 )
@@ -461,6 +462,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # Effective in SFA when FlashComm is enabled.
         self.enable_dsa_cp = enable_dsa_cp()
+        self.enable_sp = enable_sp()
 
         # Enable layer sharding via DSA-CP on the P node in the PD-disaggregated setup.
         self.enable_dsa_cp_with_layer_shard = enable_dsa_cp_with_layer_shard()
@@ -1124,6 +1126,9 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
         if self.enable_mlapo and num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS:
+            hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                hidden_states.contiguous(), need_gather_q_kv
+            )
             hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_with_mlapo(
                 hidden_states=hidden_states,
                 kv_cache=kv_cache,
@@ -1141,6 +1146,10 @@ class AscendSFAImpl(MLAAttentionImpl):
             weight_prefetch_method.maybe_prefetch_mla_or_sla_weight_in_current_stream(
                 inputs=self.fused_qkv_a_proj.weight, dependency=hidden_states
             )
+            if self.enable_sp and not self.enable_dsa_cp:
+                hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                    hidden_states.contiguous(), need_gather_q_kv
+                )
             qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
             q_c, kv_no_split = qkv_lora.split(
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1388,6 +1388,7 @@ def singleton(cls):
 @lru_cache(maxsize=1)
 def enable_dsa_cp() -> bool:
     from vllm.config import get_current_vllm_config
+
     vllm_config = get_current_vllm_config()
     # DSA CP is only applicable to models with indexer (e.g., DSv3.2, DSv4).
     has_indexer = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
@@ -1402,7 +1403,9 @@ def enable_dsa_cp() -> bool:
         dsa_cp_enable = bool(additional_config["enable_dsa_cp"])
 
     if dsa_cp_enable and not enable_sp():
-        raise ValueError("DSA CP requires SP to be enabled. Please enable SP(set VLLM_ASCEND_ENABLE_FLASHCOMM1=1) to use DSA CP.")
+        raise ValueError(
+            "DSA CP requires SP to be enabled. Please enable SP(set VLLM_ASCEND_ENABLE_FLASHCOMM1=1) to use DSA CP."
+        )
     return dsa_cp_enable and enable_sp()
 
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1385,17 +1385,25 @@ def singleton(cls):
     return get_instance
 
 
-# TODO: Temporarily use enable_sp to enable the dsa_cp feature of ds32.
-# and subsequent updates will introduce new interfaces. --zzhx1
 @lru_cache(maxsize=1)
 def enable_dsa_cp() -> bool:
     from vllm.config import get_current_vllm_config
-
     vllm_config = get_current_vllm_config()
-    is_ds_v32 = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
+    # DSA CP is only applicable to models with indexer (e.g., DSv3.2, DSv4).
+    has_indexer = hasattr(vllm_config.model_config, "hf_text_config") and hasattr(
         vllm_config.model_config.hf_text_config, "index_topk"
     )
-    return bool(is_ds_v32 and enable_sp())
+    if not has_indexer:
+        return False
+
+    dsa_cp_enable = False
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if additional_config is not None and "enable_dsa_cp" in additional_config:
+        dsa_cp_enable = bool(additional_config["enable_dsa_cp"])
+
+    if dsa_cp_enable and not enable_sp():
+        raise ValueError("DSA CP requires SP to be enabled. Please enable SP(set VLLM_ASCEND_ENABLE_FLASHCOMM1=1) to use DSA CP.")
+    return dsa_cp_enable and enable_sp()
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces an additional_config option to control dsa_cp.

Previously, dsa_cp was tightly coupled with FC1. On A2 hardware, due to the relatively poor performance of the All2All operator, enabling dsa_cp can lead to significant performance degradation. At the same time, there was no way to disable dsa_cp while keeping FC1 enabled through the existing configuration switches. This PR decouples the two by providing a dedicated configuration option for dsa_cp.

### Does this PR introduce _any_ user-facing change?
Yes, introduces an additional_config option. Now, we should enable both FC1 and DSA_CP if want to use dsa_cp.

https://github.com/vllm-project/vllm-ascend/pull/9697