### PR TITLE
[EPLB] Fix HCCL unsupported dtype for MXFP8 scale tensors in D2D transfer

### DIFF
--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -62,6 +62,9 @@ class VllmEplbAdaptor:
                 complete_name = "model.layers." + str(self.num_dense_layers) + ".mlp.experts." + name
                 expert_tensor = self.param_dict[complete_name][0]
                 buffer_tensor = torch.empty_like(expert_tensor)
+                # HCCL does not support float8_e8m0fnu for P2P; allocate uint8 buffer instead.
+                if buffer_tensor.dtype == torch.float8_e8m0fnu:
+                    buffer_tensor = buffer_tensor.view(torch.uint8)
                 self.buffer_tensor_list[buffer_id].append(buffer_tensor)
 
     def init_expert_param_per_layer(self):
@@ -90,7 +93,7 @@ class VllmEplbAdaptor:
                     "w13_scale_bias_list",
                     "w2_scale_bias_list",
                 ]
-
+            
             elif quant_type in (QuantType.MXFP4, QuantType.MXFP8):
                 self.expert_weight_names = [
                     "w13_weight",
@@ -152,7 +155,9 @@ class VllmEplbAdaptor:
         for expert_tensor, buffer_tensor in zip(
             self.expert_param_per_layer[layer_id][local_expert_to_replace], self.buffer_tensor_list[buffer_tensor_id]
         ):
-            expert_tensor.copy_(buffer_tensor)
+            # Buffer was communicated as uint8; view back to original dtype if needed.
+            src = buffer_tensor.view(expert_tensor.dtype) if expert_tensor.dtype == torch.float8_e8m0fnu else buffer_tensor
+            expert_tensor.copy_(src)
             logger.debug("Expert tensor shape is :%s", expert_tensor.shape)
 
     def do_update_log2phy_map(self, layer_id, updated_log2phy_map):

--- a/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
+++ b/vllm_ascend/eplb/core/eplb_device_transfer_loader.py
@@ -16,6 +16,7 @@
 #
 from enum import Enum
 
+import torch
 import torch.distributed as dist
 from vllm.logger import logger
 from vllm.v1.utils import record_function_or_nullcontext
@@ -57,8 +58,10 @@ class D2DExpertWeightLoader:
             dst_rank, global_expert_id_to_send = send_info
             local_expert_id = self.eplb_adaptor.expert_map_per_layer_cpu[layer_id][global_expert_id_to_send].item()
             for src_tensor in self.eplb_adaptor.expert_param_per_layer[layer_id][local_expert_id]:
+                # HCCL does not support float8_e8m0fnu for P2P; bitcast to uint8.
+                send_tensor = src_tensor.view(torch.uint8) if src_tensor.dtype == torch.float8_e8m0fnu else src_tensor
                 self.comm_op_list.append(
-                    dist.P2POp(dist.isend, src_tensor, dst_rank, group=self.comm_group.device_group)
+                    dist.P2POp(dist.isend, send_tensor, dst_rank, group=self.comm_group.device_group)
                 )
 
         for buffer_tensor_id, recv_info in enumerate(expert_recv_info):


### PR DESCRIPTION
## Summary

When `enable_fused_mc2 == 1`, mega_moe converts weight scales from `uint8` to `float8_e8m0fnu` via `.view()`. HCCL `batch_isend_irecv` does not support `float8_e8m0fnu` for P2P communication, causing "Unsupported data type for HCCL process group" errors during EPLB D2D expert weight transfer when using MXFP8 quantization (e.g., MiniMax-M2).

## Fix

Bitcast `float8_e8m0fnu` tensors to `uint8` before P2P send, allocate `uint8` receive buffers, and view back to the original dtype after receive. All zero-copy — only the dtype tag changes, not the underlying bits.

### Files changed

- `vllm_ascend/eplb/adaptor/vllm_adaptor.py`: `init_buffer_tensor` and `do_update_expert_weight`
- `vllm_ascend/eplb/core/eplb_device_transfer_loader.py`: `generate_expert_d2d_transfer_task`

## Test plan

- [x] Tested with MiniMax-M2 + MXFP8 + EPLB + FusedMC2 on Ascend 950
- [ ] EPLB still works with W8A8/W4A8 (no behavior change for those paths)

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
