### PR TITLE
[CI] Rename the CI variant label from a2 to 910b to align with the CANN base image naming convention.

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
+++ b/.github/workflows/dockerfiles/Dockerfile.buildwheel.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 ARG PY_VERSION=3.12
-FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_28-py${PY_VERSION}
+FROM quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_34-py${PY_VERSION}
 
 ARG SOC_VERSION="ascend310p1"
 

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -158,7 +158,7 @@ jobs:
           mkdir -p dist/variants
           python3 .github/workflows/scripts/wheel/make_variant.py \
             -c .github/workflows/scripts/wheel/config.json \
-            -l a2
+            -l 910b
           echo "Generated variant wheels:"
           ls dist/variants/
 

--- a/.github/workflows/scripts/wheel/config.json
+++ b/.github/workflows/scripts/wheel/config.json
@@ -13,9 +13,9 @@
       "skip_plugin_validation": true
     },
     {
-      "variant_label": "a2",
+      "variant_label": "910b",
       "properties": [
-        "ascend :: npu_type :: a2"
+        "ascend :: npu_type :: 910b"
       ],
       "skip_plugin_validation": true
     },

--- a/.github/workflows/scripts/wheel/pyproject.toml
+++ b/.github/workflows/scripts/wheel/pyproject.toml
@@ -4,4 +4,4 @@ namespace = ["ascend"]
 [variant.providers.ascend]
 enable-if = "platform_system == 'Linux'"
 plugin-api = "huawei_ascend_variant_provider.plugin:AscendVariantPlugin"
-requires = ["huawei-ascend-variant-provider>=0.0.2,<1.0.0"]
+requires = ["huawei-ascend-variant-provider>=0.0.2,<0.0.3"]

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -180,12 +180,18 @@ source $HOME/.local/bin/env
 # Install vllm-project/vllm. The newest supported version is |vllm_version|.
 pip install vllm==|pip_vllm_version|
 
-# clear uv cache and Install vllm-project/vllm-ascend from wheelnext index.
-uv cache clean
+# Install vllm-project/vllm-ascend from wheelnext index.
 uv pip install --system \
 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant   \
 --index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple \
 vllm-ascend==|pip_vllm_ascend_version|
+
+```
+
+```{note}
+If you encounter errors during `uv pip install` (e.g., corrupted cache or stale package data), try clearing the uv cache first and then re-run the install command:
+
+    uv cache clean
 
 ```
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -180,9 +180,11 @@ source $HOME/.local/bin/env
 # Install vllm-project/vllm. The newest supported version is |vllm_version|.
 pip install vllm==|pip_vllm_version|
 
-# Install vllm-project/vllm-ascend from wheelnext index.
+# clear uv cache and Install vllm-project/vllm-ascend from wheelnext index.
+uv cache clean
 uv pip install --system \
---extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant https://mirrors.huaweicloud.com/ascend/repos/pypi   \
+--extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant   \
+--index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple \
 vllm-ascend==|pip_vllm_ascend_version|
 
 ```


### PR DESCRIPTION
### What this PR does / why we need it?
1. The name rules of the a2 whl package follow the cann base imag name:
310P: quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_28-py${PY_VERSION}
910b: quay.io/ascend/manylinux:9.0.0-910b-manylinux_2_28-py${PY_VERSION}
a3: quay.io/ascend/manylinux:9.0.0-a3-manylinux_2_28-py${PY_VERSION}

- Update make_variant.py call in schedule_release_code_and_wheel.yml to use -l 910b
- Update config.json variant_label and npu_type property from a2 to 910b
- Update installation.md with uv cache clean and tsinghua index-url

2. upgrade 310p wheel  base image to `quay.io/ascend/manylinux:9.1.0-beta.1-310p-manylinux_2_34-py${PY_VERSION}`

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
