### PR TITLE
[BugFix]fix DeepSeek-V4 PIECEWISE ACLGraph accuracy

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -421,7 +421,7 @@ class NPUPlatform(Platform):
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
             # If splitting ops does not contain the vllm::mla forward value, this configuration issue will
             # not be detected in advance assert.
-            compilation_config.splitting_ops.extend(["vllm::mla_forward"])
+            compilation_config.splitting_ops.extend(["vllm::mla_forward", "vllm::dsa_forward"])
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif (


### PR DESCRIPTION
## Summary

This PR fixes an accuracy issue for DeepSeek-V4 when running with PIECEWISE ACLGraph mode on Ascend.

DeepSeek-V4 DSA attention uses the Ascend custom op `vllm::dsa_forward`, but PIECEWISE splitting only added `vllm::mla_forward` as an Ascend custom attention boundary. As a result, the DSA attention path was not treated as a split boundary and could be captured inside a regular PIECEWISE graph segment, leading to incorrect outputs.

This change adds `vllm::dsa_forward` to `compilation_config.splitting_ops` together with `vllm::mla_forward`.

## Changes

- Add `vllm::dsa_forward` to PIECEWISE `splitting_ops`.

## Why

`vllm::dsa_forward` wraps the DeepSeek-V4 DSA attention path. It depends on runtime `forward_context` metadata, KV cache state, sparse attention metadata,and mutates the provided `output` tensor.

Because of these dynamic side effects, it must be handled as a PIECEWISE split boundary instead of being captured inside a normal graph segment.

