### PR TITLE
[Feature] [Ops] Add swiglu_limit support in unquant_apply_mlp

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -388,8 +388,8 @@ def unquant_apply_mlp(
     else:
         if swiglu_limit > 0:
             gate, up = gate_up_out.chunk(2, dim=-1)
-            gate = gate.clamp(max=swiglu_limit)
-            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+            gate.clamp_(max=swiglu_limit)
+            up.clamp_(min=-swiglu_limit, max=swiglu_limit)
         gate_up_out = torch_npu.npu_swiglu(gate_up_out)
 
     if topk_scales is not None:

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -386,6 +386,10 @@ def unquant_apply_mlp(
         limit = swiglu_limit if swiglu_limit > 0 else 7.0
         gate_up_out = swiglustep_and_mul(gate_up_out, limit=limit)
     else:
+        if swiglu_limit > 0:
+            gate, up = gate_up_out.chunk(2, dim=-1)
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
         gate_up_out = torch_npu.npu_swiglu(gate_up_out)
 
     if topk_scales is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

In RL scenario, we need to run dsv4 with bf16 dtype, which has swiglu limit.

This PR adds swiglu_limit support to the unquantized MoE MLP path, keep swiglu_limit behavior consistent across MoE MLP execution paths.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
