### PR TITLE
[Performance] Improve CPP performance on var-len seqence

### DIFF
--- a/vllm_ascend/core/profiling_chunk_predictor.py
+++ b/vllm_ascend/core/profiling_chunk_predictor.py
@@ -60,7 +60,7 @@ class ChunkSizePredictor:
         self.min_chunk = min_chunk
         self.history_fitted = False
 
-    def clamp_quadratic_and_linear_if_negative(self, fitted_a: float, fitted_b: float) -> tuple[float, float]:
+    def clamp_quadratic_and_linear_if_negative(self, fitted_a: float, fitted_b: float) -> float:
         """In theory, for the Transfomur structure of LLM, the fitted quadratic and linear
         terms should not be negative. Can perform zero clamping for inaccurate fitting
         """
@@ -225,13 +225,32 @@ class ChunkSizePredictor:
         page_size: int,
         target_time: float = 0,
     ) -> int | None:
-        """Predict next chunk size x such that f(L+x) - f(L) = target_latency."""
+        """Predict next chunk size x such that f(L+x) - f(L) = target_latency.
+
+        Args:
+            num_computed_tokens: Number of tokens already computed (L),
+                representing the current position in the sequence.
+            base_chunk_size: The default/fallback chunk size used as a
+                baseline for smoothing the predicted value.
+            page_size: The memory page size, used together with 64 to
+                determine the alignment granularity of the final chunk size.
+            target_time: Override target latency in seconds. If > 0, this
+                value is used instead of self.target_latency for the
+                prediction equation.
+
+        Returns:
+            The predicted and aligned chunk size as an int, or None if
+            the model is not ready, the discriminant is negative, or the
+            prediction yields an invalid result.
+        """
         if not self.is_ready or self.target_latency is None:
             return None
 
         if self.quadratic_coeff_a <= 0:
             return None
 
+        # f(L+x)-f(L) = a*x^2 + (2a*L+b)*x = target_latency
+        # Standard form: A*x^2 + B*x + C = 0
         A = self.quadratic_coeff_a
         B = 2 * self.quadratic_coeff_a * num_computed_tokens + self.linear_coeff_b
 
@@ -269,7 +288,24 @@ class ChunkSizePredictor:
         target_time: float = 0,
     ) -> int | None:
         """Predict next chunk size x using the history-aware model
-        f(C,H) = a*C(C+H) + b*C + c*H."""
+        f(C,H) = a*C(C+H) + b*C + c*H.
+
+        Args:
+            num_computed_tokens: Number of tokens already computed (C),
+                representing the current computed position in the sequence.
+            base_chunk_size: The default/fallback chunk size used as a
+                baseline for smoothing the predicted value.
+            page_size: The memory page size, used together with 64 to
+                determine the alignment granularity of the final chunk size.
+            target_time: Override target latency in seconds. If > 0, this
+                value is used instead of self.target_latency for the
+                prediction equation.
+
+        Returns:
+            The predicted and aligned chunk size as an int, or None if
+            the model is not ready, the discriminant is negative, or the
+            prediction yields an invalid result.
+        """
         if not self.is_ready or self.target_latency is None:
             return None
 
@@ -279,7 +315,9 @@ class ChunkSizePredictor:
         if self.quadratic_chunk_a <= 0:
             return None
 
-        # a*C^2 + (a*H + b)*C + b*H + c - T = 0
+        # f(x,H) = a*x*(x+H) + b*x + c*H, solving f(x,H)=T gives:
+        # a*x^2 + (a*H + b)*x + (b*H + c - T) = 0
+        # Standard form: A*x^2 + B*x + C = 0, where H=num_computed_tokens, T=target_latency
         A = self.quadratic_chunk_a
         B = self.quadratic_chunk_a * num_computed_tokens + self.linear_chunk_b
         if target_time > 0:

--- a/vllm_ascend/core/profiling_chunk_predictor.py
+++ b/vllm_ascend/core/profiling_chunk_predictor.py
@@ -68,10 +68,9 @@ class ChunkSizePredictor:
             logger.warning("Fitted a=%.2e is not positive. Setting a=1e-9.", fitted_a)
             fitted_a = 1e-9
         if fitted_b < 0:
-            logger.warning("Fitted b=%.2e is not positive. Setting b=0.0.", fitted_b)
-            fitted_b = 1e-9
+            logger.warning("Fitted b=%.2e is not positive. The performance may deteriorate..", fitted_b)
 
-        return fitted_a, fitted_b
+        return fitted_a
 
     def fit(self, seq_lens: list[int], latencies: list[float]) -> bool:
         """Fit quadratic coefficients f(l) = al^2 + bl + c from data points.
@@ -113,7 +112,7 @@ class ChunkSizePredictor:
                 logger.warning("Failed to fit quadratic model: %s", fallback_error)
                 return False
 
-        fitted_a, fitted_b = self.clamp_quadratic_and_linear_if_negative(fitted_a, fitted_b)
+        fitted_a = self.clamp_quadratic_and_linear_if_negative(fitted_a, fitted_b)
 
         self.quadratic_coeff_a = fitted_a
         self.linear_coeff_b = fitted_b
@@ -162,7 +161,7 @@ class ChunkSizePredictor:
             logger.warning("Failed to fit chunked model: %s", e)
             return False
 
-        fitted_a, fitted_b = self.clamp_quadratic_and_linear_if_negative(fitted_a, fitted_b)
+        fitted_a = self.clamp_quadratic_and_linear_if_negative(fitted_a, fitted_b)
 
         self.quadratic_chunk_a = fitted_a
         self.linear_chunk_b = fitted_b

--- a/vllm_ascend/core/profiling_chunk_predictor.py
+++ b/vllm_ascend/core/profiling_chunk_predictor.py
@@ -224,6 +224,7 @@ class ChunkSizePredictor:
         num_computed_tokens: int,
         base_chunk_size: int,
         page_size: int,
+        target_time: float = 0,
     ) -> int | None:
         """Predict next chunk size x such that f(L+x) - f(L) = target_latency."""
         if not self.is_ready or self.target_latency is None:
@@ -234,7 +235,11 @@ class ChunkSizePredictor:
 
         A = self.quadratic_coeff_a
         B = 2 * self.quadratic_coeff_a * num_computed_tokens + self.linear_coeff_b
-        C = -self.target_latency
+
+        if target_time > 0:
+            C = -target_time
+        else:
+            C = -self.target_latency
 
         discriminant = B * B - 4 * A * C
         if discriminant < 0:
@@ -262,6 +267,7 @@ class ChunkSizePredictor:
         num_computed_tokens: int,
         base_chunk_size: int,
         page_size: int,
+        target_time: float = 0,
     ) -> int | None:
         """Predict next chunk size x using the history-aware model
         f(C,H) = a*C(C+H) + b*C + c*H."""
@@ -277,7 +283,10 @@ class ChunkSizePredictor:
         # a*C^2 + (a*H + b)*C + b*H + c - T = 0
         A = self.quadratic_chunk_a
         B = self.quadratic_chunk_a * num_computed_tokens + self.linear_chunk_b
-        C = self.linear_chunk_b * num_computed_tokens + self.constant_chunk_c - self.target_latency
+        if target_time > 0:
+            C = self.linear_chunk_b * num_computed_tokens + self.constant_chunk_c - target_time
+        else:
+            C = self.linear_chunk_b * num_computed_tokens + self.constant_chunk_c - self.target_latency
 
         discriminant = B * B - 4 * A * C
         if discriminant < 0:
@@ -336,19 +345,15 @@ class ProfilingChunkManager:
         if not self.is_ready:
             return None
 
-        # NOTE(gjc): We found that the FIA operator has abnormal performance
-        # when processing multiple request groups in a batch, so the target_latency
-        # feature is temporarily fixed. It will be enabled again after the
-        # issues with the FIA operator are resolved. Therefore, in multi-request
-        # concurrent scenarios, there is still room for performance improvement in CPP.
-        # self.predictor.target_latency = target_time
-
-        if not self.history_ready:
+        if not self.history_ready or num_computed_tokens == 0:
             predict_func = self.predictor.predict
         else:
             predict_func = self.predictor.predict_with_history
         return predict_func(
-            num_computed_tokens=num_computed_tokens, base_chunk_size=self.base_chunk_size, page_size=self.page_size
+            num_computed_tokens=num_computed_tokens,
+            base_chunk_size=self.base_chunk_size,
+            page_size=self.page_size,
+            target_time=target_time,
         )
 
     def predict_time(self, num_new_tokens: int, num_computed_tokens: int) -> float:
@@ -356,7 +361,7 @@ class ProfilingChunkManager:
         if not self.is_ready:
             return 0.0
 
-        if not self.history_ready:
+        if not self.history_ready or num_computed_tokens == 0:
             predict_func = self.predictor.get_time
         else:
             predict_func = self.predictor.get_time_with_history

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -246,7 +246,8 @@ class ProfilingChunkScheduler(Scheduler):
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
         num_scheduled_tokens: dict[str, int] = {}
         # >>> PROFILING CHUNK >>>
-        time_budget = self.profiling_chunk_manager.predictor.target_latency
+        target_latency = self.profiling_chunk_manager.predictor.target_latency
+        time_budget = target_latency if target_latency is not None else float("inf")
         # <<< PROFILING CHUNK <<<
         token_budget = self.max_num_scheduled_tokens
         if self._pause_state == PauseState.PAUSED_ALL:

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -82,6 +82,7 @@ class ProfilingChunkScheduler(Scheduler):
 
         init_ascend_config(vllm_config)
         profiling_cfg = get_ascend_config().profiling_chunk_config
+        self.profiling_chunk_config = profiling_cfg
         base_chunk = self.max_num_scheduled_tokens
 
         self.profiling_chunk_manager = ProfilingChunkManager(
@@ -245,13 +246,7 @@ class ProfilingChunkScheduler(Scheduler):
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
         num_scheduled_tokens: dict[str, int] = {}
         # >>> PROFILING CHUNK >>>
-        # NOTE(gjc): We found that the FIA operator has abnormal performance
-        # when processing multiple request groups in a batch, so the time_budget
-        # feature is temporarily disabled. It will be enabled again after the
-        # issues with the FIA operator are resolved. Therefore, in multi-request
-        # concurrent scenarios, there is still room for performance improvement in CPP.
-        # time_budget = self.profiling_chunk_manager.predictor.target_latency
-        time_budget = 0.01
+        time_budget = self.profiling_chunk_manager.predictor.target_latency
         # <<< PROFILING CHUNK <<<
         token_budget = self.max_num_scheduled_tokens
         if self._pause_state == PauseState.PAUSED_ALL:
@@ -318,8 +313,8 @@ class ProfilingChunkScheduler(Scheduler):
             if (
                 self.profiling_chunk_manager is not None
                 and self.profiling_chunk_manager.is_ready
-                and num_new_tokens > 1
-                and request.num_computed_tokens > 0
+                and request.num_computed_tokens < request.num_prompt_tokens
+                and (request.num_computed_tokens > 0 or not self.profiling_chunk_config.need_timing)
             ):
                 predicted_chunk = self.profiling_chunk_manager.predict_chunk_size(
                     num_computed_tokens=request.num_computed_tokens,
@@ -327,6 +322,8 @@ class ProfilingChunkScheduler(Scheduler):
                 )
                 if predicted_chunk is not None and predicted_chunk > 0:
                     num_new_tokens = min(predicted_chunk, num_new_tokens)
+                else:
+                    break
             # <<< PROFILING CHUNK <<<
 
             if self.need_mamba_block_aligned_split:
@@ -386,7 +383,7 @@ class ProfilingChunkScheduler(Scheduler):
             token_budget -= num_new_tokens
             # Decode requests (num_new_tokens == 1) have negligible latency;
             # skip time_budget accounting so they don't starve other requests.
-            if num_new_tokens > 1:
+            if request.num_computed_tokens < request.num_prompt_tokens:
                 time_budget -= self.profiling_chunk_manager.predict_time(num_new_tokens, request.num_computed_tokens)
             req_index += 1
 
@@ -525,8 +522,8 @@ class ProfilingChunkScheduler(Scheduler):
                     if (
                         self.profiling_chunk_manager is not None
                         and self.profiling_chunk_manager.is_ready
-                        and num_new_tokens > 1
-                        and request.num_computed_tokens > 0
+                        and request.num_computed_tokens < request.num_prompt_tokens
+                        and (request.num_computed_tokens > 0 or not self.profiling_chunk_config.need_timing)
                     ):
                         predicted_chunk = self.profiling_chunk_manager.predict_chunk_size(
                             num_computed_tokens=num_computed_tokens,
@@ -534,6 +531,8 @@ class ProfilingChunkScheduler(Scheduler):
                         )
                         if predicted_chunk is not None and predicted_chunk > 0:
                             num_new_tokens = min(num_new_tokens, predicted_chunk)
+                        else:
+                            break
                     # <<< PROFILING CHUNK <<<
 
                     if not self.scheduler_config.enable_chunked_prefill and num_new_tokens > token_budget:
@@ -647,7 +646,7 @@ class ProfilingChunkScheduler(Scheduler):
                 token_budget -= num_new_tokens
                 # Decode requests (num_new_tokens == 1) have negligible latency;
                 # skip time_budget accounting so they don't starve other requests.
-                if num_new_tokens > 1:
+                if request.num_computed_tokens < request.num_prompt_tokens:
                     time_budget -= self.profiling_chunk_manager.predict_time(
                         num_new_tokens, request.num_computed_tokens
                     )


### PR DESCRIPTION
### What this PR does / why we need it?
We fixed the perf issues of CPP, which is mainly about var-len scenes. We improve the scheduling strategy with a new time budget.
Meanwhile, we fixed the function issue when CPP + mtp is enabled. In previous versions, there may have been issues with not being able to enter the image. 
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
We conducted tests using the minimax model on a dataset ranging from 4k to 64k. The input throughput increases from 10,000 tps to 13,300 tps on 950.

On 910c device, the input throughput increases from 8,000 tps to 8,700 tps.


- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
