### PR TITLE
[BugFix] Patch GLM47 inline zero-arg streaming tool calls

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
@@ -47,9 +47,7 @@ def _request():
 
 
 def _collect_tool_args(tool_calls):
-    return "".join(
-        tc.function.arguments for tc in tool_calls if tc.function.arguments
-    )
+    return "".join(tc.function.arguments for tc in tool_calls if tc.function.arguments)
 
 
 def test_glm47_streaming_inline_zero_arg_tool_call_waits_until_complete():

--- a/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import MagicMock
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.abstract_parser import _WrappedParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import (
+    DeepSeekV3ReasoningWithThinkingParser,
+)
+from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
+
+from vllm_ascend.patch.platform import patch_glm47_tool_call_parser  # noqa: F401
+
+MOCK_TOKENIZER = MagicMock()
+MOCK_TOKENIZER.get_vocab.return_value = {
+    "<think>": 154841,
+    "</think>": 154842,
+    "<tool_call>": 154843,
+    "</tool_call>": 154844,
+    "<arg_key>": 154847,
+    "</arg_key>": 154848,
+    "<arg_value>": 154849,
+    "</arg_value>": 154850,
+}
+
+
+def _request():
+    return ChatCompletionRequest(
+        model="glm5",
+        messages=[{"role": "user", "content": "What time is it?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_time",
+                    "description": "Get the current date and time",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+            }
+        ],
+        tool_choice="auto",
+    )
+
+
+def _collect_tool_args(tool_calls):
+    return "".join(
+        tc.function.arguments for tc in tool_calls if tc.function.arguments
+    )
+
+
+def test_glm47_streaming_inline_zero_arg_tool_call_waits_until_complete():
+    request = _request()
+    parser = Glm47MoeModelToolParser(MOCK_TOKENIZER, request.tools)
+
+    first = parser.extract_tool_calls_streaming(
+        previous_text="",
+        current_text="<tool_call>get",
+        delta_text="<tool_call>get",
+        previous_token_ids=[],
+        current_token_ids=[154843, 455],
+        delta_token_ids=[154843, 455],
+        request=request,
+    )
+    assert first is None
+
+    second = parser.extract_tool_calls_streaming(
+        previous_text="<tool_call>get",
+        current_text="<tool_call>get_current_time</tool_call>",
+        delta_text="_current_time</tool_call>",
+        previous_token_ids=[154843, 455],
+        current_token_ids=[154843, 455, 11075, 3009, 154844],
+        delta_token_ids=[11075, 3009, 154844],
+        request=request,
+    )
+
+    assert second is not None
+    assert second.tool_calls
+    assert second.tool_calls[0].function.name == "get_current_time"
+    assert json.loads(_collect_tool_args(second.tool_calls)) == {}
+
+
+def test_glm45_reasoning_glm47_streaming_inline_zero_arg_tool_call():
+    request = _request()
+    _WrappedParser.reasoning_parser_cls = DeepSeekV3ReasoningWithThinkingParser
+    _WrappedParser.tool_parser_cls = Glm47MoeModelToolParser
+    parser = _WrappedParser(MOCK_TOKENIZER, request.tools)
+
+    first = parser.parse_delta(
+        "Need current time.",
+        [2001, 2002],
+        request,
+        prompt_token_ids=[],
+    )
+    second = parser.parse_delta(
+        "</think><tool_call>get_current_time</tool_call>",
+        [154842, 154843, 455, 11075, 3009, 154844],
+        request,
+    )
+
+    assert first is not None
+    assert first.reasoning == "Need current time."
+    assert second is not None
+    assert second.tool_calls
+    assert second.tool_calls[0].function.name == "get_current_time"
+    assert json.loads(_collect_tool_args(second.tool_calls)) == {}

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -182,6 +182,24 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       GLM tool-call final chunk fixes.
 #
+# ** 7b. File: platform/patch_glm47_tool_call_parser.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tool_parsers.glm47_moe_tool_parser.Glm47MoeModelToolParser`
+#    Why:
+#       vLLM's GLM47 streaming parser can drop complete inline zero-argument
+#       tool calls such as `<tool_call>get_current_time</tool_call>`, while
+#       non-streaming parses the same output correctly.
+#    How：
+#       Monkey-patch GLM47 tool-call region extraction so complete inline
+#       zero-argument regions are normalized for the existing streaming name
+#       extractor without emitting partial names for incomplete regions.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/44326
+#       https://github.com/vllm-project/vllm/pull/44327
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains the upstream
+#       GLM47 inline zero-argument streaming parser fix.
+#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -31,6 +31,7 @@ else:
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
+import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa

--- a/vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py
@@ -31,18 +31,12 @@ def _patched_extract_tool_call_regions(
     self: Glm47MoeModelToolParser,
     text: str,
 ) -> list[tuple[str, bool]]:
-    original_extract_tool_call_regions = (
-        self._ascend_original_extract_tool_call_regions
-    )
+    original_extract_tool_call_regions = self._ascend_original_extract_tool_call_regions
     regions = original_extract_tool_call_regions(text)
     normalized_regions: list[tuple[str, bool]] = []
 
     for inner_text, is_complete in regions:
-        if (
-            is_complete
-            and self.arg_key_start not in inner_text
-            and "\n" not in inner_text
-        ):
+        if is_complete and self.arg_key_start not in inner_text and "\n" not in inner_text:
             tool_name = inner_text.strip()
             inner_text = f"{tool_name}\n" if tool_name else inner_text
         normalized_regions.append((inner_text, is_complete))

--- a/vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# GLM-4.7 tool-call streaming parser compatibility patch.
+#
+
+from __future__ import annotations
+
+from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
+
+if not hasattr(Glm47MoeModelToolParser, "_ascend_original_extract_tool_call_regions"):
+    Glm47MoeModelToolParser._ascend_original_extract_tool_call_regions = (
+        Glm47MoeModelToolParser._extract_tool_call_regions
+    )
+
+
+def _patched_extract_tool_call_regions(
+    self: Glm47MoeModelToolParser,
+    text: str,
+) -> list[tuple[str, bool]]:
+    original_extract_tool_call_regions = (
+        self._ascend_original_extract_tool_call_regions
+    )
+    regions = original_extract_tool_call_regions(text)
+    normalized_regions: list[tuple[str, bool]] = []
+
+    for inner_text, is_complete in regions:
+        if (
+            is_complete
+            and self.arg_key_start not in inner_text
+            and "\n" not in inner_text
+        ):
+            tool_name = inner_text.strip()
+            inner_text = f"{tool_name}\n" if tool_name else inner_text
+        normalized_regions.append((inner_text, is_complete))
+
+    return normalized_regions
+
+
+Glm47MoeModelToolParser._extract_tool_call_regions = _patched_extract_tool_call_regions


### PR DESCRIPTION
## Summary
- add a temporary vLLM-Ascend monkeypatch for the upstream GLM47 streaming parser bug where complete inline zero-argument tool calls such as `<tool_call>get_current_time</tool_call>` are dropped
- keep incomplete inline regions buffered so partial names like `<tool_call>get` are not emitted early
- add UT coverage for `glm47` alone and for `glm45` reasoning combined with `glm47` tool parsing

## Upstream

## Test Plan
- `PYTHONPATH=$PWD python -m pytest tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py -q`
- `python -m ruff check vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py vllm_ascend/patch/platform/__init__.py`
- `git diff --check`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
