### PR TITLE
[PrefixCache][BugFix] Fix Deepseek-V4 compress attn groups prefix caching hit

### DIFF
--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -20,8 +20,6 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.request import Request
 
-from vllm_ascend.utils import vllm_version_is
-
 
 class CompressAttentionManager(FullAttentionManager):
     def __init__(self, kv_cache_spec: MLAAttentionSpec, block_pool: BlockPool, **kwargs) -> None:
@@ -164,19 +162,22 @@ class CompressAttentionManager(FullAttentionManager):
             request: The request.
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
-            alignment_tokens: The cache-hit alignment used by upstream vLLM
-                main. v0.20.2 does not expose this argument in the base class.
         """
-        num_tokens //= self.compress_ratio
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // (self.block_size * self.compress_ratio)
 
-        if vllm_version_is("0.20.2"):
-            return super().cache_blocks(request, num_tokens)
+        if num_cached_blocks >= num_full_blocks:
+            return
 
-        return super().cache_blocks(
-            request,
-            num_tokens,
-            alignment_tokens=alignment_tokens,
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size * self.compress_ratio,
+            kv_cache_group_id=self.kv_cache_group_id,
         )
+        self.num_cached_block[request.request_id] = num_full_blocks
 
     @classmethod
     def find_longest_cache_hit(
@@ -197,7 +198,7 @@ class CompressAttentionManager(FullAttentionManager):
         #     "CompressAttentionManager can only be used for compressor attention groups"
         # )
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
-        block_size = kv_cache_spec.block_size
+        block_size = kv_cache_spec.block_size * kv_cache_spec.compress_ratio
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
         max_num_blocks = max_length // block_size

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -21,9 +21,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
-    UniformTypeKVCacheSpecs,
     MambaSpec,
-    MLAAttentionSpec,
 )
 
 from vllm_ascend import envs

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -17,7 +17,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec, MambaSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec, UniformTypeKVCacheSpecs, MambaSpec, MLAAttentionSpec
 
 from vllm_ascend import envs
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
@@ -110,6 +110,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             return block_size
         if self.dcp_world_size * self.pcp_world_size > 1:
             block_size *= self.dcp_world_size * self.pcp_world_size
+        if hasattr(kv_cache_spec, "compress_ratio"):
+            compress_ratio = kv_cache_spec.compress_ratio if kv_cache_spec.compress_ratio >= 1 else 1
+            block_size *= compress_ratio
         return block_size
 
     def verify_and_split_kv_cache_groups(self) -> None:
@@ -156,7 +159,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # block cache hit yet.
         # NOTE: use 16k as the alignment tokens for model with compress ratio
         block_sizes = [
-            self._get_effective_block_size(spec) * getattr(spec, "compress_ratio", 1)
+            self._get_effective_block_size(spec)
             for spec, _, _ in self.attention_groups
         ]
         self.lcm_block_size = lcm(*block_sizes)
@@ -186,7 +189,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
             effective_block_size = self._get_effective_block_size(kv_cache_spec)
-            if effective_block_size == self.hash_block_size:
+            if kv_cache_spec.block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, effective_block_size)
 
@@ -242,8 +245,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
                 curr_hit_length = _new_hit_length
-                compress_ratio = getattr(spec, "compress_ratio", 1)
-                curr_hit_length = len(hit_blocks[0]) * effective_block_size * max(compress_ratio, 1)
+                curr_hit_length = len(hit_blocks[0]) * effective_block_size
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 
@@ -254,6 +256,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 break
 
         # Truncate full attention blocks to final hit_length (if present)
+        # NOTE(zxr): for deepseek-v4, there is two fullattn groups, but
+        # in this function, only the first fullattn group is truncate by
+        # the belowing codes(c4), c128 layer does not truncate, which may
+        # have prefix cache block hit.
+        # Due to slidingwindow attn, deepseek-v4 decode node can't have
+        # any prefix cache hit, because `hit_length` of SWA is 0.
         spec, group_ids, _ = self.attention_groups[0]
         if isinstance(spec, FullAttentionSpec):
             num_blocks = hit_length // self._get_effective_block_size(spec)

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -17,7 +17,14 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec, UniformTypeKVCacheSpecs, MambaSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+    MambaSpec,
+    MLAAttentionSpec,
+)
 
 from vllm_ascend import envs
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
@@ -158,10 +165,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # each attention type. Requiring this because we don't support partial
         # block cache hit yet.
         # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [
-            self._get_effective_block_size(spec)
-            for spec, _, _ in self.attention_groups
-        ]
+        block_sizes = [self._get_effective_block_size(spec) for spec, _, _ in self.attention_groups]
         self.lcm_block_size = lcm(*block_sizes)
 
     def find_longest_cache_hit(


### PR DESCRIPTION
### What this PR does / why we need it?
The kvcache caching and hash of the deepseek-v4 `compressor_kv` do not consider `compress_ratio`. This PR processes `compress_ratio` so that the prefix cache can be correctly hit.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By CI.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
