### PR TITLE
[0.20.2][PrefixCache][BugFix] Fix Deepseek-V4 compress attn groups prefix caching hit

### DIFF
--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -160,7 +160,7 @@ class CompressAttentionManager(FullAttentionManager):
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // (self.block_size * self.compress_ratio)
-        logger.info(f'single manager: {self.kv_cache_group_id=} {num_cached_blocks=} {num_full_blocks=}')
+        logger.info(f"single manager: {self.kv_cache_group_id=} {num_cached_blocks=} {num_full_blocks=}")
 
         if num_cached_blocks >= num_full_blocks:
             return

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -158,9 +158,22 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
         """
-        num_tokens //= self.compress_ratio
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // (self.block_size * self.compress_ratio)
+        logger.info(f'single manager: {self.kv_cache_group_id=} {num_cached_blocks=} {num_full_blocks=}')
 
-        return super().cache_blocks(request, num_tokens)
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size * self.compress_ratio,
+            kv_cache_group_id=self.kv_cache_group_id,
+        )
+        self.num_cached_block[request.request_id] = num_full_blocks
 
     @classmethod
     def find_longest_cache_hit(
@@ -181,7 +194,7 @@ class CompressAttentionManager(FullAttentionManager):
         #     "CompressAttentionManager can only be used for compressor attention groups"
         # )
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple([] for _ in range(len(kv_cache_group_ids)))
-        block_size = kv_cache_spec.block_size
+        block_size = kv_cache_spec.block_size * kv_cache_spec.compress_ratio
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
         max_num_blocks = max_length // block_size

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -21,8 +21,6 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
-    UniformTypeKVCacheSpecs,
-    MLAAttentionSpec,
 )
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -17,7 +17,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec, UniformTypeKVCacheSpecs, MLAAttentionSpec
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
 
@@ -170,6 +170,11 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         """
 
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+            if hasattr(kv_cache_spec, "compress_ratio"):
+                compress_ratio = kv_cache_spec.compress_ratio if kv_cache_spec.compress_ratio >= 1 else 1
+                if kv_cache_spec.block_size * compress_ratio == self.hash_block_size:
+                    return block_hashes
+                return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size * compress_ratio)
             if kv_cache_spec.block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size)
@@ -235,6 +240,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 break
 
         # Truncate full attention blocks to final hit_length (if present)
+        # NOTE(zxr): for deepseek-v4, there is two fullattn groups, but
+        # in this function, only the first fullattn group is truncate by
+        # the belowing codes(c4), c128 layer does not truncate, which may
+        # have prefix cache block hit.
+        # Due to slidingwindow attn, deepseek-v4 decode node can't have
+        # any prefix cache hit, because `hit_length` of SWA is 0.
         spec, group_ids, _ = self.attention_groups[0]
         if isinstance(spec, FullAttentionSpec):
             num_blocks = hit_length // spec.block_size

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -17,7 +17,13 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec, UniformTypeKVCacheSpecs, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+    MLAAttentionSpec,
+)
 
 from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
 
@@ -174,7 +180,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 compress_ratio = kv_cache_spec.compress_ratio if kv_cache_spec.compress_ratio >= 1 else 1
                 if kv_cache_spec.block_size * compress_ratio == self.hash_block_size:
                     return block_hashes
-                return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size * compress_ratio)
+                return BlockHashListWithBlockSize(
+                    block_hashes, self.hash_block_size, kv_cache_spec.block_size * compress_ratio
+                )
             if kv_cache_spec.block_size == self.hash_block_size:
                 return block_hashes
             return BlockHashListWithBlockSize(block_hashes, self.hash_block_size, kv_cache_spec.block_size)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
The kvcache caching and hash of the deepseek-v4 `compressor_kv` do not consider `compress_ratio`. This PR processes `compress_ratio` so that the prefix cache can be correctly hit.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By CI.
