### PR TITLE
[BugFix][Quantization]: NPU MoE quantization methods support TP only.

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -379,6 +379,7 @@
   tests:
     - tests/ut/quantization
     - tests/e2e/pull_request/one_card/test_qwen3_8b_w8a8.py
+    - tests/e2e/pull_request/two_card/test_qwen3_5_35b_a3b_w8a8.py
 
 # Sample
 - name: sample
@@ -593,6 +594,7 @@
     - vllm_ascend/ops/fused_moe/token_dispatcher.py
   tests:
     - tests/e2e/pull_request/two_card/test_qwen3_moe_eplb.py
+    - tests/e2e/pull_request/two_card/test_qwen3_5_35b_a3b_w8a8.py
 
 # === Others ===
 - name: _tools

--- a/tests/e2e/pull_request/two_card/test_qwen3_5_35b_a3b_w8a8.py
+++ b/tests/e2e/pull_request/two_card/test_qwen3_5_35b_a3b_w8a8.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import os
+from unittest.mock import patch
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+EXAMPLE_PROMPTS = [
+    "Hello, my name is",
+]
+
+
+@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
+@wait_until_npu_memory_free()
+def test_qwen3_5_35b_a3b_w8a8_tp2_without_ep():
+    with VllmRunner(
+        "Eco-Tech/Qwen3.5-35B-A3B-w8a8-mtp",
+        max_model_len=4096,
+        tensor_parallel_size=2,
+        enable_expert_parallel=False,
+        quantization="ascend",
+        gpu_memory_utilization=0.9,
+        distributed_executor_backend="mp",
+        cudagraph_capture_sizes=[1, 2, 4, 8],
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(EXAMPLE_PROMPTS, max_tokens=5)
+
+    assert outputs[0][1]

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -10,7 +10,7 @@ from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD
 
 
 class TestAscendW4A8DynamicLinearMethod(TestBase):
-    @patch("vllm.distributed.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_tensor_model_parallel_world_size")
     @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
     def setUp(self, mock_get_current_vllm_config, mock_get_tp_world_size):
         mock_get_tp_world_size.return_value = 1
@@ -130,7 +130,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
 
 
 class TestAscendW4A8DynamicLinearMethodWithNpu(TestBase):
-    @patch("vllm.distributed.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_tensor_model_parallel_world_size")
     @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
     def setUp(self, mock_get_current_vllm_config, mock_get_tp_world_size):
         mock_get_tp_world_size.return_value = 1
@@ -161,12 +161,9 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
 
     @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
-    @patch("vllm_ascend.quantization.methods.w4a8.get_ep_group")
     @patch("vllm_ascend.quantization.methods.w4a8.get_mc2_group")
     @patch("torch.distributed.get_rank", return_value=0)
-    def setUp(
-        self, mock_get_rank, mock_get_mc2_group, mock_get_ep_group, get_current_vllm_config, mock_get_ascend_config
-    ):
+    def setUp(self, mock_get_rank, mock_get_mc2_group, get_current_vllm_config, mock_get_ascend_config):
         # Mock ascend config
         mock_ascend_config = Mock()
         mock_ascend_config.eplb_config.dynamic_eplb = False

--- a/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
@@ -99,11 +99,9 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
     @patch("torch.distributed.get_rank")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_mc2_group")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
-    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ep_group")
-    def setUp(self, mock_ep, mock_ascend, mock_mc2, mock_rank):
+    def setUp(self, mock_ascend, mock_mc2, mock_rank):
         with patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_current_vllm_config") as mock_vllm:
             mock_vllm.return_value = create_mock_vllm_config()
-            mock_ep.return_value = Mock()
             mock_ascend.return_value = create_mock_ascend_config()
             mock_mc2.return_value = MagicMock(
                 device_group=Mock(

--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -63,13 +63,11 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
     intermediate_size = 256
 
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.ensure_mxfp4_moe_available")
-    @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.get_ep_group")
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.get_current_vllm_config")
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.get_ascend_config")
-    def setUp(self, mock_ascend, mock_vllm, mock_ep, mock_ensure):
+    def setUp(self, mock_ascend, mock_vllm, mock_ensure):
         mock_vllm.return_value = create_mock_vllm_config()
         mock_ascend.return_value = create_mock_ascend_config()
-        mock_ep.return_value = Mock()
         mock_ensure.return_value = None
         self.scheme = AscendW4A4MXFP4DynamicFusedMoEMethod()
 

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8.py
@@ -90,13 +90,11 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
     intermediate_size = 256
 
     @patch("vllm_ascend.quantization.methods.w8a8_mxfp8.ensure_mxfp8_moe_available")
-    @patch("vllm_ascend.quantization.methods.w8a8_mxfp8.get_ep_group")
     @patch("vllm_ascend.quantization.methods.w8a8_mxfp8.get_current_vllm_config")
     @patch("vllm_ascend.quantization.methods.w8a8_mxfp8.get_ascend_config")
-    def setUp(self, mock_ascend, mock_vllm, mock_ep, mock_ensure):
+    def setUp(self, mock_ascend, mock_vllm, mock_ensure):
         mock_vllm.return_value = create_mock_vllm_config()
         mock_ascend.return_value = create_mock_ascend_config()
-        mock_ep.return_value = Mock()
         mock_ensure.return_value = None
         self.scheme = AscendW8A8MXFP8DynamicFusedMoEMethod()
 

--- a/tests/ut/quantization/methods/test_w8a8_pdmix.py
+++ b/tests/ut/quantization/methods/test_w8a8_pdmix.py
@@ -119,10 +119,9 @@ class TestAscendW8A8PDMixLinearScheme(TestBase):
 
 class TestAscendW8A8PDMixMoEScheme(TestBase):
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_mc2_group")
-    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ep_group")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_current_vllm_config")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
-    def test_get_dynamic_quant_param(self, mock_ascend, mock_vllm, mock_ep, mock_mc2):
+    def test_get_dynamic_quant_param(self, mock_ascend, mock_vllm, mock_mc2):
         mock_mc2.side_effect = AttributeError()
         mock_vllm.return_value = create_mock_vllm_config()
         mock_ascend.return_value = MagicMock(eplb_config=MagicMock(dynamic_eplb=False))

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -21,7 +21,6 @@ from typing import Any
 import torch
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
-from vllm.distributed import get_ep_group
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -125,7 +124,6 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
 
     def __init__(self):
         ensure_mxfp4_moe_available("W4A4_MXFP4 MoE quantization")
-        self.ep_group = get_ep_group()
 
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 import torch_npu
 from vllm.config import get_current_vllm_config
-from vllm.distributed import get_ep_group
+from vllm.distributed import get_tensor_model_parallel_world_size
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -95,8 +95,6 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
         quant_version = vllm_config.quant_config.quant_description.get("version", "0")
         self.new_quant_version = quant_version == "1.0.0"
-
-        from vllm.distributed import get_tensor_model_parallel_world_size
 
         self.tp_size = get_tensor_model_parallel_world_size()
 
@@ -347,7 +345,6 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
     quant_type: QuantType = QuantType.W4A8
 
     def __init__(self):
-        self.ep_group = get_ep_group()
         self.supports_eplb = True
 
         vllm_config = get_current_vllm_config()
@@ -362,7 +359,9 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         if self.quant_method == COMPRESSED_TENSORS_METHOD:
             self.weight_strategy = vllm_config.quant_config.quant_description.get("weight_strategy", "group")
 
-        self.tp_size = 1 if vllm_config.parallel_config.enable_expert_parallel else self.ep_group.world_size
+        self.tp_size = (
+            1 if vllm_config.parallel_config.enable_expert_parallel else get_tensor_model_parallel_world_size()
+        )
         self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
         if self.new_quant_version and self.tp_size > 16:
             raise ValueError("The current weight does not support moe part tp>16.")

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -21,7 +21,6 @@ from typing import Any
 import torch
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
-from vllm.distributed import get_ep_group
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -158,8 +157,6 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
     quant_type: QuantType = QuantType.W8A8
 
     def __init__(self):
-        self.ep_group = get_ep_group()
-
         vllm_config = get_current_vllm_config()
         ascend_config = get_ascend_config()
         self.use_aclgraph = (

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -22,7 +22,6 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
-from vllm.distributed import get_ep_group
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 
@@ -195,7 +194,6 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
 
     def __init__(self):
         ensure_mxfp8_moe_available("W8A8_MXFP8 MoE quantization")
-        self.ep_group = get_ep_group()
 
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the MoE (Mixture of Experts) quantization method initialization failure on Ascend NPU when **only Tensor Parallelism is enabled** without Expert Parallelism. https://github.com/vllm-project/vllm-ascend/pull/8532 only fixed non-quantized cases.
- Remove unused `self.ep_group = get_ep_group()` initialization from MoE quantization methods that do not use the EP group.
- Use `get_tensor_model_parallel_world_size()` directly for W4A8 TP checks instead of deriving TP size from the EP group.
- This aligns with vLLM upstream's convention (`ep_size == 1` means no EP) and keeps the quantization code robust across TP-only MoE deployments.

### Does this PR introduce _any_ user-facing change?
No. This is a bug fix that restores expected behavior for TP-only MoE quantized inference on NPU. No API, CLI flag, or model interface is changed.

### How was this patch tested?
- [x] Verified that MoE quantization methods no longer unconditionally access `get_ep_group()` during initialization.
- [x] Verified that `enable-expert-parallel` paths remain intact and still avoid TP-size checks that only apply to TP-only mode.
- [x] `python -m compileall -q vllm_ascend/quantization/methods/w4a4_mxfp4.py vllm_ascend/quantization/methods/w4a8.py vllm_ascend/quantization/methods/w8a8_dynamic.py vllm_ascend/quantization/methods/w8a8_mxfp8.py tests/ut/quantization/methods/test_w4a4_mxfp4.py tests/ut/quantization/methods/a2/test_w4a8.py tests/ut/quantization/methods/a2/test_w8a8_dynamic.py tests/ut/quantization/methods/test_w8a8_mxfp8.py tests/ut/quantization/methods/test_w8a8_pdmix.py`
- [x] `ruff-check` for changed Python files
- [x] `ruff-format` for changed Python files
- [x] `git diff --check`
- [ ] `pytest` not run locally because the environment is missing the `regex` Python dependency.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
