### PR TITLE
[BugFix] Include zero cached prompt token details

### DIFF
--- a/tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
+++ b/tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
@@ -113,6 +113,20 @@ def test_make_usage_info_injects_reasoning_token_details():
     assert payload["prompt_tokens_details"]["cached_tokens"] == 1
 
 
+def test_make_usage_info_injects_zero_cached_tokens():
+    fake_serving = SimpleNamespace(enable_prompt_tokens_details=True)
+    usage = minimax_usage_patch._make_usage_info(
+        fake_serving,
+        prompt_tokens=3,
+        completion_tokens=4,
+        num_cached_tokens=0,
+    )
+
+    payload = usage.model_dump(exclude_none=True)
+
+    assert payload["prompt_tokens_details"]["cached_tokens"] == 0
+
+
 def test_make_full_response_usage_sums_reasoning_tokens():
     class FakeServing:
         enable_prompt_tokens_details = False
@@ -151,7 +165,9 @@ def test_stream_usage_details_are_injected_without_replacing_source():
     state = minimax_usage_patch._create_usage_tracking_state(
         num_choices=1,
         reasoning_parser=FakeReasoningParser(),
+        enable_prompt_tokens_details=True,
     )
+    state.num_cached_tokens = 0
     state.raw_output_token_ids = [[10, 11, 2, 20]]
 
     chunk = {
@@ -174,5 +190,39 @@ def test_stream_usage_details_are_injected_without_replacing_source():
     assert payload["usage"]["completion_tokens_details"] == {
         "reasoning_tokens": 2,
     }
+    assert payload["usage"]["prompt_tokens_details"] == {
+        "cached_tokens": 0,
+    }
     assert not hasattr(minimax_usage_patch, "_extract_class_method_source")
     assert not hasattr(minimax_usage_patch, "_patch_chat_completion_stream_generator")
+
+
+def test_stream_usage_details_inject_prompt_details_without_reasoning():
+    state = minimax_usage_patch._create_usage_tracking_state(
+        num_choices=1,
+        reasoning_parser=None,
+        enable_prompt_tokens_details=True,
+    )
+    state.num_cached_tokens = 0
+
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 7,
+        },
+    }
+
+    data = minimax_usage_patch._inject_stream_usage_details(
+        f"data: {json.dumps(chunk)}\n\n",
+        state,
+    )
+    payload = json.loads(data.removeprefix("data: ").removesuffix("\n\n"))
+
+    assert payload["usage"]["prompt_tokens_details"] == {
+        "cached_tokens": 0,
+    }
+    assert "completion_tokens_details" not in payload["usage"]

--- a/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
@@ -118,7 +118,7 @@ def _make_usage_info(
     reasoning_tokens = _clamp_reasoning_tokens(reasoning_tokens, completion_tokens)
     if reasoning_tokens is not None:
         usage.completion_tokens_details = CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
-    if self.enable_prompt_tokens_details and num_cached_tokens:
+    if self.enable_prompt_tokens_details and num_cached_tokens is not None:
         usage.prompt_tokens_details = chat_serving.PromptTokenUsageInfo(cached_tokens=num_cached_tokens)
     return usage
 
@@ -132,6 +132,7 @@ class _UsageTrackingState:
     completion_tokens: list[int]
     raw_output_token_ids: list[list[int]]
     reasoning_parser: Any
+    enable_prompt_tokens_details: bool = False
     num_prompt_tokens: int = 0
     num_cached_tokens: int | None = None
     final_res: Any = None
@@ -140,11 +141,13 @@ class _UsageTrackingState:
 def _create_usage_tracking_state(
     num_choices: int,
     reasoning_parser,
+    enable_prompt_tokens_details: bool = False,
 ) -> _UsageTrackingState:
     return _UsageTrackingState(
         completion_tokens=[0] * num_choices,
         raw_output_token_ids=[[] for _ in range(num_choices)],
         reasoning_parser=reasoning_parser,
+        enable_prompt_tokens_details=enable_prompt_tokens_details,
     )
 
 
@@ -266,18 +269,27 @@ def _inject_stream_usage_details(
     if not isinstance(usage, dict):
         return data
 
+    updated_usage = False
+    if state.enable_prompt_tokens_details and state.num_cached_tokens is not None:
+        usage["prompt_tokens_details"] = {
+            "cached_tokens": state.num_cached_tokens,
+        }
+        updated_usage = True
+
     completion_tokens = usage.get("completion_tokens") or 0
     reasoning_tokens = _usage_reasoning_tokens_for_stream_chunk(
         state,
         chunk,
         completion_tokens,
     )
-    if reasoning_tokens is None:
-        return data
+    if reasoning_tokens is not None:
+        usage["completion_tokens_details"] = {
+            "reasoning_tokens": reasoning_tokens,
+        }
+        updated_usage = True
 
-    usage["completion_tokens_details"] = {
-        "reasoning_tokens": reasoning_tokens,
-    }
+    if not updated_usage:
+        return data
     return f"{prefix}{json.dumps(chunk, ensure_ascii=False)}{suffix}"
 
 
@@ -303,7 +315,11 @@ async def _wrapped_chat_completion_stream_generator(
     **extra_kwargs: Any,
 ):
     num_choices = 1 if request.n is None else request.n
-    state = _create_usage_tracking_state(num_choices, reasoning_parser)
+    state = _create_usage_tracking_state(
+        num_choices,
+        reasoning_parser,
+        enable_prompt_tokens_details=self.enable_prompt_tokens_details,
+    )
 
     original_stream_generator = self._ascend_original_chat_completion_stream_generator
     async for data in original_stream_generator(
@@ -336,7 +352,11 @@ async def _wrapped_chat_completion_full_generator(
     reasoning_parser=None,
 ):
     num_choices = 1 if request.n is None else request.n
-    state = _create_usage_tracking_state(num_choices, reasoning_parser)
+    state = _create_usage_tracking_state(
+        num_choices,
+        reasoning_parser,
+        enable_prompt_tokens_details=self.enable_prompt_tokens_details,
+    )
 
     original_full_generator = self._ascend_original_chat_completion_full_generator
     response = await original_full_generator(


### PR DESCRIPTION
### What
- Treat `num_cached_tokens=0` as a valid prompt token detail value when `--enable-prompt-tokens-details` is enabled.
- Preserve the existing MiniMax reasoning usage injection while also injecting prompt token details into streamed usage chunks.
- Add unit coverage for non-streaming and streaming zero-cache usage.

### vLLM check
Checked pinned `/vllm-workspace/vllm` at `bc150f50299199599673614f80d12a196f377655` and latest upstream vLLM `main` at `27a93cd4266151beaf7c8a89227418e86e187f30`: both chat/completion serving paths gate prompt token details on the truthiness of `num_cached_tokens`, so zero-cache details are omitted there too. This PR fixes vllm-ascend's chat usage wrapper behavior; it does not claim to prove a DS-V4 prefix-cache-hit accounting bug in vLLM.

Fixes #9891

### Tests
- `python -m pytest tests/ut/patch/platform/test_patch_minimax_usage_accounting.py`
- `python -m ruff format --check vllm_ascend/patch/platform/patch_minimax_usage_accounting.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py`
- `python -m ruff check vllm_ascend/patch/platform/patch_minimax_usage_accounting.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
