### PR TITLE
[Feature] [redo] Cache the code start compilation for npugraph_ex 

### DIFF
--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -135,7 +135,7 @@ def npugraph_ex_compile(
     # Try npugraph_ex first, fall back to torchair for backward compatibility.
     try:
         import npugraph_ex as nge
-        
+
         cache_path = os.path.join(cache_dir, key) if (cache_dir and key) else None
         torch.npu.set_compile_mode(jit_compile=False)
         config = nge.CompilerConfig()
@@ -201,7 +201,6 @@ def npugraph_ex_compile(
         return compiled_fn, None
 
 
-
 class AscendCompiler(CompilerInterface):
     """
     AscendCompiler is a custom compiler interface for the Ascend platform.
@@ -225,12 +224,11 @@ class AscendCompiler(CompilerInterface):
             "enable_static_kernel": ascend_compilation_config.enable_static_kernel,
         }
         logger.info("AscendCompiler hash factors: %s", factors)
-        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10] 
+        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10]
 
     def initialize_cache(self, cache_dir, disable_cache=False, prefix=""):
         self.cache_dir = cache_dir
         self.disable_cache = disable_cache
-
 
     def compile(
         self,
@@ -268,11 +266,18 @@ class AscendCompiler(CompilerInterface):
             )
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(
-                graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key, cache_dir
+                graph,
+                example_inputs,
+                compiler_config,
+                self.vllm_config,
+                ascend_compilation_config,
+                compile_range,
+                key,
+                cache_dir,
             )
         else:
             return fusion_pass_compile(graph, example_inputs, compiler_config, compile_range, key)
-        
+
     def load(self, handle, graph, example_inputs, graph_index, compile_range):
         key, path = handle
         # Cache file may be absent when the graph was skipped at save time (e.g. it
@@ -314,9 +319,9 @@ class AscendCompiler(CompilerInterface):
                 compile_range,
                 key,
                 getattr(self, "cache_dir", None),
-            ) 
+            )
             return compiled_fn
-        
+
         from npugraph_ex.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
 
         with open(path) as f:

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -152,8 +152,6 @@ def npugraph_ex_compile(
 
         _original_get_compiled_gm = nfx._NpuFxCompiler._get_compiled_gm
 
-        handle = None
-
         def patched_get_compiled_gm(self, graph, example_inputs):
             compiled_gm = _original_get_compiled_gm(self, graph, example_inputs)
             if cache_path:

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -17,6 +17,7 @@
 #
 import copy
 import functools
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -129,11 +130,13 @@ def npugraph_ex_compile(
     ascend_compilation_config: AscendCompilationConfig,
     compile_range: Range,
     key: str | None = None,
+    cache_dir: str | None = None,
 ) -> tuple[Callable | None, Any | None]:
     # Try npugraph_ex first, fall back to torchair for backward compatibility.
     try:
         import npugraph_ex as nge
-
+        
+        cache_path = os.path.join(cache_dir, key) if (cache_dir and key) else None
         torch.npu.set_compile_mode(jit_compile=False)
         config = nge.CompilerConfig()
         # _process_kwargs_options exists in both old and new npugraph_ex,
@@ -145,19 +148,58 @@ def npugraph_ex_compile(
         _configure_backend(
             config, ascend_compilation_config, vllm_config, process_kwargs_options=_process_kwargs_options
         )
-        npugraph_ex = nge.get_npu_backend(compiler_config=config)
+        import npugraph_ex.npu_fx_compiler as nfx
+
+        _original_get_compiled_gm = nfx._NpuFxCompiler._get_compiled_gm
+
+        handle = None
+
+        def patched_get_compiled_gm(self, graph, example_inputs):
+            compiled_gm = _original_get_compiled_gm(self, graph, example_inputs)
+            if cache_path:
+                py_code = compiled_gm.get_code()
+                if py_code:
+                    # Triton kernel indices (kernel_side_table) are registered in-process
+                    # at compile time and are not serializable across process boundaries.
+                    # Graphs containing triton_kernel_wrapper calls must not be cached,
+                    # because loading the py_code in a new process will hit an
+                    # AssertionError in kernel_side_table.get_kernel().
+                    if "triton_kernel_wrapper" in py_code:
+                        logger.info(
+                            "Skipping npugraph_ex cache for graph containing Triton kernels "
+                            "(kernel_side_table indices are process-local): %s",
+                            cache_path,
+                        )
+                    else:
+                        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                        with open(cache_path, "w") as f:
+                            f.write(py_code)
+                        logger.info("Saved compiled graph to cache: %s", cache_path)
+            return compiled_gm
+
+        nfx._NpuFxCompiler._get_compiled_gm = patched_get_compiled_gm
+        backend = nge.get_npu_backend(compiler_config=config)
+        # torch.compile requires the output of the fx graph to be a tuple
+        if not graph_returns_tuple(graph):
+            compiled_fn = make_graph_return_tuple(graph, example_inputs, backend)
+        else:
+            compiled_fn = backend(graph, example_inputs)
+        nfx._NpuFxCompiler._get_compiled_gm = _original_get_compiled_gm
+        return compiled_fn, (key, cache_path)
     except ImportError:
         import torchair
 
         torch.npu.set_compile_mode(jit_compile=False)
         config = torchair.CompilerConfig()
         _configure_backend(config, ascend_compilation_config, vllm_config)
-        npugraph_ex = torchair.get_npu_backend(compiler_config=config)
+        backend = torchair.get_npu_backend(compiler_config=config)
+        # torch.compile requires the output of the fx graph to be a tuple
+        if not graph_returns_tuple(graph):
+            compiled_fn = make_graph_return_tuple(graph, example_inputs, backend)
+        else:
+            compiled_fn = backend(graph, example_inputs)
+        return compiled_fn, None
 
-    # torch.compile requires the output of the fx graph to be a tuple
-    if not graph_returns_tuple(graph):
-        return make_graph_return_tuple(graph, example_inputs, npugraph_ex), None
-    return npugraph_ex(graph, example_inputs), None
 
 
 class AscendCompiler(CompilerInterface):
@@ -169,11 +211,26 @@ class AscendCompiler(CompilerInterface):
 
     name = "AscendCompiler"
 
+    # TODO(wxs): add passes related to compilation in compute_hash
     def compute_hash(self, vllm_config: VllmConfig) -> str:
-        npugraph_ex_enabled = get_ascend_config().ascend_compilation_config.enable_npugraph_ex
-        if npugraph_ex_enabled:
-            self.vllm_config = vllm_config
-        return vllm_config.compute_hash()
+        self.vllm_config = vllm_config
+        ascend_compilation_config = get_ascend_config().ascend_compilation_config
+        from hashlib import sha256
+
+        import torch_npu
+
+        factors = {
+            "torch_npu_version": torch_npu.__version__,
+            "enable_npugraph_ex": ascend_compilation_config.enable_npugraph_ex,
+            "enable_static_kernel": ascend_compilation_config.enable_static_kernel,
+        }
+        logger.info("AscendCompiler hash factors: %s", factors)
+        return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10] 
+
+    def initialize_cache(self, cache_dir, disable_cache=False, prefix=""):
+        self.cache_dir = cache_dir
+        self.disable_cache = disable_cache
+
 
     def compile(
         self,
@@ -204,13 +261,81 @@ class AscendCompiler(CompilerInterface):
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex:
+            cache_dir = None if getattr(self, "disable_cache", False) else getattr(self, "cache_dir", None)
             logger.info_once(
                 "enable_npugraph_ex is enabled, which will bring graph compilation optimization.",
                 scope="global",
             )
             assert hasattr(self, "vllm_config")
             return npugraph_ex_compile(
-                graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key
+                graph, example_inputs, compiler_config, self.vllm_config, ascend_compilation_config, compile_range, key, cache_dir
             )
         else:
             return fusion_pass_compile(graph, example_inputs, compiler_config, compile_range, key)
+        
+    def load(self, handle, graph, example_inputs, graph_index, compile_range):
+        key, path = handle
+        # Cache file may be absent when the graph was skipped at save time (e.g. it
+        # contained Triton kernels whose kernel_side_table indices are process-local
+        # and cannot be serialized).  Fall back to a fresh compilation so the Triton
+        # kernels are properly registered in the current process.
+        if not path or not os.path.exists(path):
+            logger.info(
+                "npugraph_ex cache miss for key %s (file absent or not saved), recompiling",
+                key,
+            )
+            # Mirror the same pre-processing done in compile(): deepcopy the graph
+            # to prevent make_graph_return_tuple from mutating the caller's copy,
+            # and re-wrap FakeTensor inputs under the current fake mode to avoid
+            # "fake mode mismatch" in aot_module_simplified.
+            graph = copy.deepcopy(graph)
+            from torch._guards import detect_fake_mode
+
+            current_fake_mode = detect_fake_mode()
+            if current_fake_mode is not None:
+                example_inputs = [
+                    current_fake_mode.from_tensor(inp)
+                    if (
+                        isinstance(inp, torch.Tensor)
+                        and hasattr(inp, "fake_mode")
+                        and inp.fake_mode is not current_fake_mode
+                    )
+                    else inp
+                    for inp in example_inputs
+                ]
+            ascend_compilation_config = get_ascend_config().ascend_compilation_config
+            assert hasattr(self, "vllm_config")
+            compiled_fn, _ = npugraph_ex_compile(
+                graph,
+                example_inputs,
+                {},
+                self.vllm_config,
+                ascend_compilation_config,
+                compile_range,
+                key,
+                getattr(self, "cache_dir", None),
+            ) 
+            return compiled_fn
+        
+        from npugraph_ex.npu_fx_compiler import _CompiledFxArtifacts, _CompiledFxGraph
+
+        with open(path) as f:
+            py_code = f.read()
+        artifacts = _CompiledFxArtifacts()
+        artifacts.py_code = py_code
+        logger.info("Loaded npugraph_ex compilation cache from %s", path)
+        compiled_fn = _CompiledFxGraph.load_artifacts(artifacts)
+
+        # The saved code was compiled from the graph after make_graph_return_tuple mutated it
+        # to return a flat tuple. If the original graph didn't return a tuple, we need to
+        # recreate the unflatten wrapper so callers receive the original output structure.
+        if not graph_returns_tuple(graph):
+            _inner_fn = compiled_fn
+
+            def compiled_fn(*args, **kwargs):
+                result = _inner_fn(*args, **kwargs)
+                if isinstance(result, (tuple, list)) and len(result) == 1:
+                    return result[0]
+                return result
+
+        return compiled_fn

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -19,7 +19,7 @@ import copy
 import functools
 import os
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.fx as fx
@@ -327,7 +327,7 @@ class AscendCompiler(CompilerInterface):
         artifacts = _CompiledFxArtifacts()
         artifacts.py_code = py_code
         logger.info("Loaded npugraph_ex compilation cache from %s", path)
-        compiled_fn = _CompiledFxGraph.load_artifacts(artifacts)
+        compiled_fn = cast(Callable[..., Any], _CompiledFxGraph.load_artifacts(artifacts))
 
         # The saved code was compiled from the graph after make_graph_return_tuple mutated it
         # to return a flat tuple. If the original graph didn't return a tuple, we need to


### PR DESCRIPTION
### What this PR does / why we need it?
Implement vLLM `CompilerInterface` cache protocol (initialize_cache / compile / load) for AscendCompiler when `enable_npugraph_ex=True`. 

Cache the cold start compilation, and then reuse the cached results, improving performance by about 10 seconds.

Note: Triton kernel indices are registered in a process-local `kernel_side_table` at compile time and cannot be serialized across process boundaries. Loading cached `py_code` that contains `triton_kernel_wrapper` calls in a new process causes `AssertionError in kernel_side_table.get_kernel()`. Fix by skipping the cache write in `patched_get_compiled_gm` when `py_code` contains `triton_kernel_wrapper` references. In load(), fall back to fresh compilation when the cache file is absent.

Co-authored-by: semiba11er [pierrewjc1993@163.com](mailto:pierrewjc1993@163.com)

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?

```
(EngineCore pid=860220) INFO 06-01 07:14:59 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 11.15 s
(EngineCore pid=860220) INFO 06-01 07:14:59 [decorators.py:311] Directly load AOT compilation from path /root/.cache/vllm/torch_compile_cache/torch_aot_compile/40e9a180b6b930c797012a12cc6f05a60df74eeb815fbcb596b78818482c0dc6/rank_0_0/model
(EngineCore pid=860220) INFO 06-01 07:14:59 [monitor.py:53] torch.compile took 13.47 s in total
```

```
(EngineCore pid=853067) INFO 06-01 07:05:56 [backends.py:292] Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 0.126 s
(EngineCore pid=853067) INFO 06-01 07:05:56 [decorators.py:311] Directly load AOT compilation from path /root/.cache/vllm/torch_compile_cache/torch_aot_compile/40e9a180b6b930c797012a12cc6f05a60df74eeb815fbcb596b78818482c0dc6/rank_0_0/model
(EngineCore pid=853067) INFO 06-01 07:05:56 [monitor.py:53] torch.compile took 2.34 s in total
```


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
