### PR TITLE
[CI] Improve nightly/e2e trigger robustness and add file-level test granularity

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -49,6 +49,11 @@ on:
         type: string
         default: ''
         description: branch name used as prefix in artifact/benchmark names to distinguish dual-branch test runs
+      tests_override:
+        required: false
+        type: string
+        default: ''
+        description: specific file name to run within the tests directory (e.g. "test_ops.py"), overrides running the full directory
     secrets:
       OBS_ACCESS_KEY:
         required: false
@@ -208,11 +213,16 @@ jobs:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_USE_MODELSCOPE: True
           VLLM_CI_RUNNER: ${{ inputs.runner }}
+          TESTS_OVERRIDE: ${{ inputs.tests_override }}
         working-directory: /vllm-workspace/vllm-ascend
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-          echo "Running pytest with tests path: ${{ inputs.tests }}"
-          pytest -sv "${{ inputs.tests }}" \
+          TESTS_PATH="${{ inputs.tests }}"
+          if [ -n "$TESTS_OVERRIDE" ]; then
+            TESTS_PATH="${TESTS_PATH%/}/$TESTS_OVERRIDE"
+          fi
+          echo "Running pytest with tests path: $TESTS_PATH"
+          pytest -sv "$TESTS_PATH" \
           --ignore=tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py
 
       - name: Run Pytest (YAML-driven)

--- a/.github/workflows/_parse_trigger.yaml
+++ b/.github/workflows/_parse_trigger.yaml
@@ -23,7 +23,7 @@ on:
       runner:
         required: false
         type: string
-        default: linux-aarch64-a2b3-0
+        default: ubuntu-latest
       parse_e2e_comment:
         required: false
         type: boolean
@@ -42,6 +42,9 @@ on:
       ref:
         description: "The vllm-ascend ref (commit SHA for PRs, branch/tag name otherwise)"
         value: ${{ jobs.parse_nightly_trigger.outputs.ref }}
+      file_overrides:
+        description: "JSON map of test name to specific file override (e.g. {\"test_custom_op\":\"test_ops.py\"})"
+        value: ${{ jobs.parse_nightly_trigger.outputs.file_overrides }}
       allowed:
         description: "Whether the actor is allowed to trigger e2e tests"
         value: ${{ jobs.parse_e2e_comment.outputs.allowed }}
@@ -73,6 +76,7 @@ jobs:
       run: ${{ steps.parse.outputs.run }}
       filter: ${{ steps.parse.outputs.filter }}
       ref: ${{ steps.parse.outputs.ref }}
+      file_overrides: ${{ steps.parse.outputs.file_overrides }}
     steps:
       - name: Parse trigger
         id: parse
@@ -87,9 +91,24 @@ jobs:
               const match = body.trim().match(/^\/nightly(?:\s+(.+))?$/m);
               if (!match) return null;
               const args = (match[1] || '').trim();
-              if (!args || args === 'all') return 'all';
-              // Wrap with commas for exact-name matching: ",name1,name2,"
-              return ',' + args.split(/\s+/).join(',') + ',';
+              if (!args) return null;
+              // Strip /file suffixes to get base names for filter matching
+              const names = args.split(/\s+/).map(a => a.split('/')[0]);
+              return ',' + names.join(',') + ',';
+            }
+
+            function parseFileOverrides(body) {
+              if (!body) return {};
+              const match = body.trim().match(/^\/nightly(?:\s+(.+))?$/m);
+              if (!match) return {};
+              const args = (match[1] || '').trim();
+              if (!args || args === 'all') return {};
+              const overrides = {};
+              args.split(/\s+/).forEach(arg => {
+                const idx = arg.indexOf('/');
+                if (idx !== -1) overrides[arg.slice(0, idx)] = arg.slice(idx + 1);
+              });
+              return overrides;
             }
 
             function getRef() {
@@ -108,13 +127,9 @@ jobs:
             // 1. workflow_dispatch: use input test_cases
             if (eventName === 'workflow_dispatch' && workflowDispatchTestCases) {
               core.setOutput('run', 'true');
-              // Convert comma-separated list to the filter format
-              if (workflowDispatchTestCases === 'all') {
-                core.setOutput('filter', 'all');
-              } else {
-                const filter = ',' + workflowDispatchTestCases.split(',').map(s => s.trim()).join(',') + ',';
-                core.setOutput('filter', filter);
-              }
+              core.setOutput('file_overrides', '{}');
+              const filter = ',' + workflowDispatchTestCases.split(',').map(s => s.trim()).join(',') + ',';
+              core.setOutput('filter', filter);
               return;
             }
 
@@ -122,6 +137,7 @@ jobs:
             if (eventName === 'schedule') {
               core.setOutput('run', 'true');
               core.setOutput('filter', 'all');
+              core.setOutput('file_overrides', '{}');
               return;
             }
 
@@ -131,6 +147,7 @@ jobs:
               if (!labels.includes('nightly-test')) {
                 core.setOutput('run', 'false');
                 core.setOutput('filter', '');
+                core.setOutput('file_overrides', '{}');
                 return;
               }
               // Search comments for latest /nightly command
@@ -142,25 +159,29 @@ jobs:
                 per_page: 100,
               });
               let filter = null;
+              let matchedBody = null;
               for (let i = comments.length - 1; i >= 0; i--) {
                 const result = parseNightlyComment(comments[i].body);
-                if (result !== null) { filter = result; break; }
+                if (result !== null) { filter = result; matchedBody = comments[i].body; break; }
               }
               // No /nightly comment found: do not run any tests
               if (filter === null) {
                 core.info('nightly-test label present but no /nightly comment found; skipping.');
                 core.setOutput('run', 'false');
                 core.setOutput('filter', '');
+                core.setOutput('file_overrides', '{}');
                 return;
               }
               core.setOutput('run', 'true');
               core.setOutput('filter', filter);
+              core.setOutput('file_overrides', JSON.stringify(parseFileOverrides(matchedBody)));
               return;
             }
 
             // Fallback
             core.setOutput('run', 'false');
             core.setOutput('filter', '');
+            core.setOutput('file_overrides', '{}');
 
   parse_e2e_comment:
     name: Parse /e2e comment

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -34,9 +34,8 @@ on:
           - main
           - releases/v0.18.0
       test_cases:
-        description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'
-        required: false
-        default: 'all'
+        description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group")'
+        required: true
         type: string
   pull_request:
     branches:
@@ -173,6 +172,7 @@ jobs:
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      tests_override: ${{ fromJSON(needs.parse-trigger.outputs.file_overrides || '{}')[matrix.test_config.name] || '' }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -35,9 +35,8 @@ on:
           - main
           - releases/v0.18.0
       test_cases:
-        description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'
-        required: false
-        default: 'all'
+        description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group")'
+        required: true
         type: string
   pull_request:
     branches:
@@ -313,6 +312,7 @@ jobs:
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
+      tests_override: ${{ fromJSON(needs.parse-trigger.outputs.file_overrides || '{}')[matrix.test_config.name] || '' }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -366,6 +366,7 @@ jobs:
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
+      tests_override: ${{ fromJSON(needs.parse-trigger.outputs.file_overrides || '{}')[matrix.test_config.name] || '' }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (

--- a/docs/source/developer_guide/contribution/nightly_ci_test.md
+++ b/docs/source/developer_guide/contribution/nightly_ci_test.md
@@ -17,9 +17,9 @@ First, post one of the following comments in the PR to specify which tests to ru
 
 | Comment | Effect |
 |---------|--------|
-| `/nightly` | Run **all** nightly tests |
-| `/nightly all` | Run **all** nightly tests (same as above) |
 | `/nightly test1 test2 ...` | Run only the **named** tests |
+| `/nightly test1/file.py test2 ...` | Run `test1` with a specific file, `test2` with the full directory |
+| `/nightly accuracy-group-1` | Run **all** accuracy tests (any `accuracy-group-*` keyword triggers the full accuracy suite) |
 
 ### 2. Add the label
 
@@ -50,7 +50,7 @@ matching the filter will be dispatched, which saves hardware resources.
 
 | | Scheduled / Manual Dispatch | PR-triggered |
 |---|----------------------------|---|
-| Trigger | Cron (daily) or `workflow_dispatch` | Label `nightly-test` + `/nightly` comment |
+| Trigger | Cron (daily) or `workflow_dispatch` | Label `nightly-test` + `/nightly <names>` comment |
 | Code tested | Pre-built nightly image | Your PR's HEAD commit (source installed fresh) |
 | Test scope | All tests | Configurable via `/nightly <names>` |
 | vLLM + vllm-ascend | From image | Checked out and installed from source |
@@ -67,21 +67,32 @@ When a PR run is detected (`is_pr_test: true`), the workflow additionally:
 The test names you can pass to `/nightly` correspond to the `name` fields in the
 workflow matrix.
 
+Tests marked with **📁** use a directory as their test target. For these tests, you can
+append a specific filename (e.g. `test_custom_op/test_fused_moe_ops.py`) to run only
+that file instead of the entire directory.
+
 ### A2 workflow (`.github/workflows/schedule_nightly_test_a2.yaml`)
 
 **Single-node tests**:
 
 | Test name | Description |
 |-----------|-------------|
-| `test_custom_op` | Custom operator tests (single card) |
-| `test_custom_op_multi_card` | Custom operator tests (multi card) |
+| `test_custom_op` 📁 | Custom operator tests (single card) |
+| `test_custom_op_multi_card` 📁 | Custom operator tests (multi card) |
 | `qwen3-32b` | Qwen3-32B model test |
 | `qwen3-next-80b-a3b-instruct` | Qwen3-Next-80B-A3B-Instruct model test |
 | `qwen3-32b-int8` | Qwen3-32B INT8 quantization test |
-| `accuracy-group-1` | Accuracy tests: Qwen3-VL-8B, Qwen3-8B, Qwen2-Audio-7B, etc. |
-| `accuracy-group-2` | Accuracy tests: ERNIE-4.5, InternVL3_5-8B, Molmo-7B, Llama-3.2-3B, etc. |
-| `accuracy-group-3` | Accuracy tests: Qwen3-30B-A3B, Qwen3-VL-30B-A3B, etc. |
-| `accuracy-group-4` | Accuracy tests: Qwen3-Next-80B-A3B, Qwen3-Omni-30B-A3B, etc. |
+| `accuracy-group-1` ⚠️ | Accuracy tests: Qwen3-VL-8B, Qwen3-8B, Qwen2-Audio-7B, etc. |
+| `accuracy-group-2` ⚠️ | Accuracy tests: ERNIE-4.5, InternVL3_5-8B, Molmo-7B, Llama-3.2-3B, etc. |
+| `accuracy-group-3` ⚠️ | Accuracy tests: Qwen3-30B-A3B, Qwen3-VL-30B-A3B, etc. |
+| `accuracy-group-4` ⚠️ | Accuracy tests: Qwen3-Next-80B-A3B, Qwen3-Omni-30B-A3B, etc. |
+
+:::{warning}
+⚠️ All `accuracy-group-*` names share the same trigger logic: the workflow checks for the
+substring `accuracy-group` in the filter, so **any one of them triggers the full accuracy
+test suite** (all groups defined in `tests/e2e/models/configs/accuracy_groups_a2.json`).
+Specifying `accuracy-group-2` does not restrict execution to group 2 only.
+:::
 
 **Multi-node tests**:
 
@@ -92,7 +103,7 @@ workflow matrix.
 
 :::{note}
 The `doc-test` job in the A2 workflow only runs on `schedule` or `workflow_dispatch`
-events — it will **not** run on PR-triggered runs even with `/nightly all`.
+events — it will **not** run on PR-triggered runs.
 :::
 
 ### A3 workflow (`.github/workflows/schedule_nightly_test_a3.yaml`)
@@ -136,22 +147,15 @@ events — it will **not** run on PR-triggered runs even with `/nightly all`.
 | `qwen3-32b-int8` | Qwen3-32B-Int8 |
 | `qwen3-32b-int8-prefix-cache` | Qwen3-32B-Int8 prefix cache |
 | `deepseek-r1-0528-w8a8-prefix-cache` | DeepSeek-R1-0528-W8A8 prefix cache |
-| `custom-multi-ops` | Custom multi-card operator tests |
+| `custom-multi-ops` 📁 | Custom multi-card operator tests |
 
 :::{warning}
 The A3 resource pool has a maximum concurrency of **5×16 NPUs**. Multi-node tests
-run with `max-parallel: 2` to avoid resource exhaustion. Running `/nightly all` on
-A3 will queue a large number of jobs — prefer targeting specific test names when
-possible.
+run with `max-parallel: 2` to avoid resource exhaustion. Always target specific test
+names to avoid resource exhaustion.
 :::
 
 ## Examples
-
-Run all available nightly tests against your PR:
-
-```text
-/nightly
-```
 
 Run only the custom operator single-card test:
 
@@ -163,6 +167,30 @@ Run two specific tests at once:
 
 ```text
 /nightly test_custom_op qwen3-32b
+```
+
+Run only a specific file within a directory-based test (📁 tests only):
+
+```text
+/nightly test_custom_op/test_fused_moe_ops.py
+```
+
+Mix file-level and full-directory targets:
+
+```text
+/nightly test_custom_op/test_fused_moe_ops.py test_custom_op_multi_card
+```
+
+Run accuracy tests (triggers the full accuracy suite regardless of which group is specified):
+
+```text
+/nightly accuracy-group-1
+```
+
+Run accuracy tests together with other tests:
+
+```text
+/nightly accuracy-group-1 test_custom_op
 ```
 
 Re-trigger after fixing an issue: just push a new commit. The `synchronize` event


### PR DESCRIPTION

### What this PR does / why we need it?

This PR makes several improvements to the nightly and e2e CI trigger mechanisms:

- **Remove `/nightly all` full-suite trigger from comment**: The `/nightly all` option has been removed. Only specific test names are now accepted via the `/nightly` comment — `/nightly all` is treated as no command and skips all tests, same as a bare `/nightly`. Full-suite runs are only available via the scheduled (cron) trigger. `workflow_dispatch` now requires explicit test names (the `test_cases` input is mandatory with no default).

- **Fix previous run not being cancelled on new commit push**: The `_parse_trigger.yaml` default runner was `linux-aarch64-a2b3-0` (a self-hosted NPU runner). When NPU hardware was occupied by running tests, the new workflow triggered by `synchronize` event could not start its `parse-trigger` job promptly, preventing GitHub's `cancel-in-progress` mechanism from firing. Changed to `ubuntu-latest` so the trigger job starts immediately and cancels the previous run.

- **Add file-level granularity for directory-based tests**: For pytest-driven tests whose `tests` field points to a directory (e.g. `test_custom_op`, `test_custom_op_multi_card`, `custom-multi-ops`), contributors can now run a single file instead of the whole directory by appending `name/file.py` in the comment: /nightly test_custom_op/test_fused_moe_ops.py

- **Fix `/e2e` comment trigger requiring wrong label**: The `parse-trigger` job in `E2E-Full` was gated on the general-purpose `ready` label, causing unnecessary runs for every PR that had `ready`. Changed to require both `ready` **and** a dedicated `e2e-test` label, consistent with how `nightly-test` works for nightly tests.

- **Update documentation**: Reflects all the above changes, adds `📁` markers for directory-based tests, documents the `accuracy-group-*` substring-match behavior, and adds new examples.

### Does this PR introduce _any_ user-facing change?

Yes:
- `/nightly` alone no longer triggers all tests — use `/nightly all` instead.
- `/e2e` comment tests now require both `ready` and `e2e-test` labels (previously only `ready`).
- New `name/file.py` syntax supported for directory-based nightly tests.

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
