### PR TITLE
[BugFix][Platform] Backport Anthropic inline system messages

### DIFF
--- a/tests/ut/patch/platform/test_patch_anthropic_system_message.py
+++ b/tests/ut/patch/platform/test_patch_anthropic_system_message.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.entrypoints.anthropic.protocol import (
+    AnthropicCountTokensRequest,
+    AnthropicMessagesRequest,
+)
+from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
+
+from vllm_ascend.patch.platform import patch_anthropic_system_message  # noqa: F401
+
+
+def _make_request(
+    messages: list[dict],
+    **kwargs,
+) -> AnthropicMessagesRequest:
+    return AnthropicMessagesRequest(
+        model="test-model",
+        max_tokens=128,
+        messages=messages,
+        **kwargs,
+    )
+
+
+def test_inline_system_role_is_accepted_by_anthropic_requests():
+    request = _make_request([{"role": "system", "content": "Be concise."}])
+    count_request = AnthropicCountTokensRequest(
+        model="test-model",
+        messages=[{"role": "system", "content": "Be concise."}],
+    )
+
+    assert request.messages[0].role == "system"
+    assert count_request.messages[0].role == "system"
+
+
+def test_inline_system_string_is_merged_and_not_kept_as_chat_message():
+    request = _make_request(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Be concise."},
+        ],
+        system="Top-level prompt.",
+    )
+
+    result = AnthropicServingMessages._convert_anthropic_to_openai_request(request)
+
+    assert result.messages == [
+        {"role": "system", "content": "Top-level prompt.Be concise."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+
+def test_inline_system_list_content_is_merged_with_billing_header_stripped():
+    request = _make_request(
+        [
+            {"role": "user", "content": "help?"},
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "x-anthropic-billing-header: cc_version=2.1.160;",
+                    },
+                    {"type": "text", "text": "Use short answers. "},
+                    {"type": "text", "text": "Prefer examples."},
+                ],
+            },
+        ],
+        system=[
+            {"type": "text", "text": "Existing system. "},
+            {
+                "type": "text",
+                "text": "x-anthropic-billing-header: cch=d1d48;",
+            },
+        ],
+    )
+
+    result = AnthropicServingMessages._convert_anthropic_to_openai_request(request)
+
+    assert result.messages[0] == {
+        "role": "system",
+        "content": "Existing system. Use short answers. Prefer examples.",
+    }
+    assert result.messages[1] == {"role": "user", "content": "help?"}
+
+
+def test_multiple_inline_system_messages_are_all_merged():
+    request = _make_request(
+        [
+            {"role": "system", "content": "First."},
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Second."},
+        ]
+    )
+
+    result = AnthropicServingMessages._convert_anthropic_to_openai_request(request)
+
+    assert result.messages == [
+        {"role": "system", "content": "First.Second."},
+        {"role": "user", "content": "Hello"},
+    ]

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -200,6 +200,24 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       GLM47 inline zero-argument streaming parser fix.
 #
+# ** 7c. File: platform/patch_anthropic_system_message.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.anthropic.protocol.AnthropicMessage`
+#      `vllm.entrypoints.anthropic.serving.AnthropicServingMessages`
+#    Why:
+#       Recent Claude Code clients can send `role: system` entries inside the
+#       Anthropic Messages API `messages` array. The pinned vLLM rejects those
+#       requests before inference starts.
+#    How：
+#       Monkey-patch Anthropic message role validation to accept `system`, merge
+#       inline system messages with the top-level system prompt, and skip inline
+#       system entries when converting the remaining chat history.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/44000
+#       https://github.com/vllm-project/vllm/pull/44283
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #44283.
+#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -32,6 +32,7 @@ import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
+import vllm_ascend.patch.platform.patch_anthropic_system_message  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa

--- a/vllm_ascend/patch/platform/patch_anthropic_system_message.py
+++ b/vllm_ascend/patch/platform/patch_anthropic_system_message.py
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Anthropic Messages API: backport inline system message support.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from vllm.entrypoints.anthropic.protocol import (
+    AnthropicCountTokensRequest,
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+)
+from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
+
+_ANTHROPIC_MESSAGE_ROLES = Literal["user", "assistant", "system"]
+
+AnthropicMessage.__annotations__["role"] = _ANTHROPIC_MESSAGE_ROLES
+AnthropicMessage.model_fields["role"].annotation = _ANTHROPIC_MESSAGE_ROLES
+AnthropicMessage.model_rebuild(force=True)
+AnthropicMessagesRequest.model_rebuild(force=True)
+AnthropicCountTokensRequest.model_rebuild(force=True)
+
+
+def _append_system_text(system_parts: list[str], text: str | None) -> None:
+    if not text:
+        return
+    if text.startswith("x-anthropic-billing-header"):
+        return
+    system_parts.append(text)
+
+
+def _append_system_content(
+    system_parts: list[str],
+    content: str | list[Any],
+) -> None:
+    if isinstance(content, str):
+        _append_system_text(system_parts, content)
+        return
+
+    for block in content:
+        if block.type == "text":
+            _append_system_text(system_parts, block.text)
+
+
+def _patched_convert_system_message(
+    cls,
+    anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
+    openai_messages: list[dict[str, Any]],
+) -> None:
+    system_parts: list[str] = []
+
+    if anthropic_request.system:
+        _append_system_content(system_parts, anthropic_request.system)
+
+    for msg in anthropic_request.messages:
+        if msg.role == "system":
+            _append_system_content(system_parts, msg.content)
+
+    if system_parts:
+        openai_messages.append({"role": "system", "content": "".join(system_parts)})
+
+
+def _patched_convert_messages(
+    cls,
+    messages: list,
+    openai_messages: list[dict[str, Any]],
+) -> None:
+    for msg in messages:
+        if msg.role == "system":
+            continue
+
+        openai_msg: dict[str, Any] = {"role": msg.role}  # type: ignore
+
+        if isinstance(msg.content, str):
+            openai_msg["content"] = msg.content
+        else:
+            cls._convert_message_content(msg, openai_msg, openai_messages)
+
+        if not (msg.role == "user" and "content" not in openai_msg):
+            openai_messages.append(openai_msg)
+
+
+AnthropicServingMessages._convert_system_message = classmethod(_patched_convert_system_message)
+AnthropicServingMessages._convert_messages = classmethod(_patched_convert_messages)


### PR DESCRIPTION
## What this PR does / why we need it?

Backports [vLLM PR #44283](https://github.com/vllm-project/vllm/pull/44283) via a vllm-ascend platform monkey patch for the pinned /vllm-workspace/vllm runtime.

The patch accepts `role: system` entries in Anthropic Messages API `messages`, merges inline system content with the top-level `system` prompt, strips Claude Code billing headers in both places, and skips inline system entries when converting the remaining chat history.

Fixes https://github.com/vllm-project/vllm/issues/44000
Backports https://github.com/vllm-project/vllm/pull/44283

## Does this PR introduce _any_ user-facing change?

Yes. Anthropic-compatible `/v1/messages` requests from newer Claude Code clients can include `role: system` messages inside the `messages` array without failing validation.

## How was this patch tested?

- `pytest -q tests/ut/patch/platform/test_patch_anthropic_system_message.py`
- `ruff check vllm_ascend/patch/platform/patch_anthropic_system_message.py tests/ut/patch/platform/test_patch_anthropic_system_message.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py`
- `ruff format --check vllm_ascend/patch/platform/patch_anthropic_system_message.py tests/ut/patch/platform/test_patch_anthropic_system_message.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/__init__.py`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
