### PR TITLE
[Attention][BugFix] Add hardware synchronization and input validation, overflow checks for ngram spec decode.

### DIFF
--- a/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
+++ b/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
@@ -50,19 +50,39 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
     int64_t max_n = *maxNPtr;
     int64_t k = *kPtr;
 
+    OPS_CHECK(vocab_size <= 0,
+        OPS_LOG_E(nodeName, "vocab_size must be positive, got %ld.", vocab_size), return ge::GRAPH_FAILED);
+    OPS_CHECK(min_n < 1,
+        OPS_LOG_E(nodeName, "min_n must be >= 1, got %ld.", min_n), return ge::GRAPH_FAILED);
+    OPS_CHECK(max_n < min_n,
+        OPS_LOG_E(nodeName, "max_n(%ld) must be >= min_n(%ld).", max_n, min_n), return ge::GRAPH_FAILED);
+    OPS_CHECK(k <= 0,
+        OPS_LOG_E(nodeName, "k must be positive, got %ld.", k), return ge::GRAPH_FAILED);
+
     const gert::StorageShape *tokenIdsShape = context->GetInputShape(INPUT_TOKEN_IDS_INDEX);
     const gert::StorageShape *sampledShape = context->GetInputShape(INPUT_SAMPLED_INDEX);
     OPS_CHECK(tokenIdsShape == nullptr, OPS_LOG_E(nodeName, "tokenIdsShape is null."), return ge::GRAPH_FAILED);
     OPS_CHECK(sampledShape == nullptr, OPS_LOG_E(nodeName, "sampledShape is null."), return ge::GRAPH_FAILED);
 
-    int64_t batch_size = tokenIdsShape->GetStorageShape().GetDim(0);
-    int64_t max_seq_len = tokenIdsShape->GetStorageShape().GetDim(1);
-    int64_t max_new_tokens = sampledShape->GetStorageShape().GetDim(1);
+    auto tokenStorageShape = tokenIdsShape->GetStorageShape();
+    auto sampledStorageShape = sampledShape->GetStorageShape();
+    OPS_CHECK(tokenStorageShape.GetDimNum() < 2,
+        OPS_LOG_E(nodeName, "tokenIds shape dim num must be >= 2, got %lu.",
+            tokenStorageShape.GetDimNum()), return ge::GRAPH_FAILED);
+    OPS_CHECK(sampledStorageShape.GetDimNum() < 2,
+        OPS_LOG_E(nodeName, "sampled shape dim num must be >= 2, got %lu.",
+            sampledStorageShape.GetDimNum()), return ge::GRAPH_FAILED);
+
+    int64_t batch_size = tokenStorageShape.GetDim(0);
+    int64_t max_seq_len = tokenStorageShape.GetDim(1);
+    int64_t max_new_tokens = sampledStorageShape.GetDim(1);
 
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
     uint64_t ubSize = 0UL;
     ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+    OPS_CHECK(ubSize == 0,
+        OPS_LOG_E(nodeName, "UB size is 0, platform info may be invalid."), return ge::GRAPH_FAILED);
     int64_t ub_size_limit = static_cast<int64_t>(ubSize);
 
     int64_t align_elems = 32 / ELEM_SIZE;
@@ -70,9 +90,20 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
     int64_t max_new_tokens_align = ((max_new_tokens + align_elems - 1) / align_elems) * align_elems;
     int64_t k_align = ((k + align_elems - 1) / align_elems) * align_elems;
 
-    int64_t ub_per_row = (max_seq_len_align + max_new_tokens_align + k_align) * ELEM_SIZE;
-    int64_t ub_overhead = 4 * 32 + static_cast<int64_t>(max_n) * ELEM_SIZE
-        + ((max_seq_len_align + 7) / 8);  // maskBuf
+    int64_t sum_align = max_seq_len_align + max_new_tokens_align + k_align;
+    OPS_CHECK(sum_align < 0 || sum_align < max_seq_len_align,
+        OPS_LOG_E(nodeName, "UB row size overflow in align sum."), return ge::GRAPH_FAILED);
+    OPS_CHECK(sum_align > INT64_MAX / ELEM_SIZE,
+        OPS_LOG_E(nodeName, "UB row size overflow in per-row calc."), return ge::GRAPH_FAILED);
+    int64_t ub_per_row = sum_align * ELEM_SIZE;
+
+    int64_t max_n_bytes = static_cast<int64_t>(max_n) * ELEM_SIZE;
+    OPS_CHECK(max_n_bytes / ELEM_SIZE != max_n,
+        OPS_LOG_E(nodeName, "max_n * ELEM_SIZE overflow."), return ge::GRAPH_FAILED);
+    int64_t mask_bytes = (max_seq_len_align + 7) / 8;
+    int64_t ub_overhead = 4 * 32 + max_n_bytes + mask_bytes;
+    OPS_CHECK(ub_overhead < 0,
+        OPS_LOG_E(nodeName, "UB overhead overflow."), return ge::GRAPH_FAILED);
     int64_t ub_available = ub_size_limit - ub_overhead;
     int64_t max_block_rows = (ub_available > 0) ? (ub_available / ub_per_row) : 1;
     max_block_rows = std::max(max_block_rows, static_cast<int64_t>(1));

--- a/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
+++ b/csrc/attention/ngram_spec_decode/op_host/ngram_spec_decode_tiling.cpp
@@ -77,6 +77,13 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
     int64_t max_seq_len = tokenStorageShape.GetDim(1);
     int64_t max_new_tokens = sampledStorageShape.GetDim(1);
 
+    OPS_CHECK(batch_size <= 0,
+        OPS_LOG_E(nodeName, "batch_size must be positive, got %ld.", batch_size), return ge::GRAPH_FAILED);
+    OPS_CHECK(max_seq_len <= 0,
+        OPS_LOG_E(nodeName, "max_seq_len must be positive, got %ld.", max_seq_len), return ge::GRAPH_FAILED);
+    OPS_CHECK(max_new_tokens <= 0,
+        OPS_LOG_E(nodeName, "max_new_tokens must be positive, got %ld.", max_new_tokens), return ge::GRAPH_FAILED);
+
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(context->GetPlatformInfo());
     uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
     uint64_t ubSize = 0UL;
@@ -97,9 +104,9 @@ static ge::graphStatus NgramSpecDecodeTilingFunc(gert::TilingContext *context)
         OPS_LOG_E(nodeName, "UB row size overflow in per-row calc."), return ge::GRAPH_FAILED);
     int64_t ub_per_row = sum_align * ELEM_SIZE;
 
-    int64_t max_n_bytes = static_cast<int64_t>(max_n) * ELEM_SIZE;
     OPS_CHECK(max_n_bytes / ELEM_SIZE != max_n,
         OPS_LOG_E(nodeName, "max_n * ELEM_SIZE overflow."), return ge::GRAPH_FAILED);
+    int64_t max_n_bytes = static_cast<int64_t>(max_n) * ELEM_SIZE;
     int64_t mask_bytes = (max_seq_len_align + 7) / 8;
     int64_t ub_overhead = 4 * 32 + max_n_bytes + mask_bytes;
     OPS_CHECK(ub_overhead < 0,

--- a/csrc/attention/ngram_spec_decode/op_host/op_api/aclnn_ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_host/op_api/aclnn_ngram_spec_decode.cpp
@@ -62,7 +62,7 @@ aclnnStatus aclnnNgramSpecDecode(
     aclOpExecutor *executor,
     aclrtStream stream)
 {
-    if (NnopbaseSetHcclServerType) {
+    if (&NnopbaseSetHcclServerType != nullptr) {
         NnopbaseSetHcclServerType(executor, NNOPBASE_HCCL_SERVER_TYPE_MTE);
     }
     return aclnnInnerNgramSpecDecode(workspace, workspaceSize, executor, stream);

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
@@ -324,6 +324,9 @@ private:
             numValidLocal.SetValue(i, valid_draft_count);
         }
 
+        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(evtSToMte3);
+        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(evtSToMte3);
+
         uint32_t metaBytes32 = static_cast<uint32_t>(rows) * ELEM_SIZE;
         AscendC::DataCopyExtParams nextParams{1, metaBytes32, 0, 0, 0};
         AscendC::DataCopyPad(nextTokensGm[start_row], nextLocal, nextParams);

--- a/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
+++ b/csrc/attention/ngram_spec_decode/op_kernel/ngram_spec_decode.cpp
@@ -91,6 +91,12 @@ public:
         pipe.InitBuffer(draftBuf, br * static_cast<uint32_t>(this->k_align) * ELEM_SIZE);
         pipe.InitBuffer(numValidBuf, br_align * ELEM_SIZE);
         pipe.InitBuffer(suffixBuf, static_cast<uint32_t>(this->max_n_val) * ELEM_SIZE);
+
+        this->evtMte2ToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_S));
+        this->evtMte2ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
+        this->evtSToMte3 = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::S_MTE3));
+        this->evtMte3ToMte2 = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE3_MTE2));
+        this->evtVToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_S));
     }
 
     __aicore__ inline void Process()
@@ -104,7 +110,13 @@ public:
                 ProcessChunkedRows(this->row_offset + cur_offset, cur_rows);
             } else {
                 CopyIn(this->row_offset + cur_offset, cur_rows);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(evtMte2ToV);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(evtMte2ToV);
                 Compute(cur_rows);
+                AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(evtSToMte3);
+                AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(evtSToMte3);
                 CopyOut(this->row_offset + cur_offset, cur_rows);
             }
             cur_offset += cur_rows;
@@ -147,9 +159,16 @@ private:
                 sampledParams, sampledPad);
         }
 
+        // Ensure all MTE2 DataCopy operations for numTokens, discard, sampled
+        // have completed before S-pipe GetValue reads them in the per-row loop.
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+
         for (uint32_t i = 0; i < rows; ++i) {
             uint64_t gmRow = static_cast<uint64_t>(start_row + i) * msl;
             int32_t seq_len = numTokensLocal.GetValue(i);
+            if (seq_len < 0) { seq_len = 0; }
+            if (seq_len > this->max_seq_len) { seq_len = this->max_seq_len; }
             int32_t discard = discardLocal.GetValue(i);
             int32_t valid_count = 0;
 
@@ -171,6 +190,8 @@ private:
             if (valid_count > avail_space) valid_count = avail_space;
 
             LoadGmElements(gmRow + backup_pos, 1);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
             int32_t backup_token = tokenLocal.GetValue(0);
 
             if (valid_count > 0) {
@@ -184,7 +205,11 @@ private:
                 for (int32_t j = 0; j < valid_count; ++j) {
                     tokenLocal.SetValue(j, sampledLocal.GetValue(i * mnta + j));
                 }
+                AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(evtSToMte3);
+                AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(evtSToMte3);
                 StoreGmElements(gmRow + seq_len, valid_count);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(evtMte3ToMte2);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(evtMte3ToMte2);
             }
 
             int32_t best_match_pos = -1;
@@ -194,6 +219,8 @@ private:
                 int32_t suffix_gm_start = nt - this->max_n_val;
                 if (suffix_gm_start < 0) suffix_gm_start = 0;
                 LoadGmElements(gmRow + suffix_gm_start, this->max_n_val);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
                 for (int32_t s = 0; s < this->max_n_val; ++s) {
                     suffixLocal.SetValue(static_cast<uint32_t>(s), tokenLocal.GetValue(static_cast<uint32_t>(s)));
                 }
@@ -211,6 +238,8 @@ private:
                         int32_t load_count = chunk_count + (ngram_len - 1);
                         if (chunk_start + load_count > nt) load_count = nt - chunk_start;
                         LoadGmElements(gmRow + chunk_start, load_count);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(evtMte2ToV);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(evtMte2ToV);
 
                         uint32_t cmp_count = ((static_cast<uint32_t>(chunk_count) + 63u) / 64u) * 64u;
                         uint32_t max_cmp = SAFE_CHUNK > 8192u ? 8192u : SAFE_CHUNK;
@@ -227,6 +256,8 @@ private:
                             AscendC::CompareScalar<int32_t, uint8_t>(
                                 maskLocal, tokenLocal[cmp_off],
                                 suffix0, AscendC::CMPMODE::EQ, aligned);
+                            AscendC::SetFlag<AscendC::HardEvent::V_S>(evtVToS);
+                            AscendC::WaitFlag<AscendC::HardEvent::V_S>(evtVToS);
 
                             for (uint32_t p = 0; p < elements; ++p) {
                                 uint8_t bv = maskLocal.GetValue(p >> 3);
@@ -262,6 +293,8 @@ private:
                 int32_t draft_load = (tokens_available < this->k_val) ? tokens_available : this->k_val;
                 if (draft_load > 0) {
                     LoadGmElements(gmRow + draft_start, draft_load);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(evtMte2ToS);
                     for (int32_t j = 0; j < this->k_val; ++j) {
                         if (j < draft_load) {
                             draftLocal.SetValue(i * ka + j, tokenLocal.GetValue(static_cast<uint32_t>(j)));
@@ -412,6 +445,8 @@ private:
         uint32_t ka = this->k_align;
 
         int32_t seq_len = numTokensLocal.GetValue(idx);
+        if (seq_len < 0) { seq_len = 0; }
+        if (seq_len > this->max_seq_len) { seq_len = this->max_seq_len; }
         int32_t discard = discardLocal.GetValue(idx);
         int32_t valid_count = 0;
 
@@ -489,6 +524,8 @@ private:
                             AscendC::CompareScalar<int32_t, uint8_t>(
                                 maskLocal, tokenLocal[static_cast<uint32_t>(cmp_off)],
                                 suffix0, AscendC::CMPMODE::EQ, count_aligned);
+                            AscendC::SetFlag<AscendC::HardEvent::V_S>(evtVToS);
+                            AscendC::WaitFlag<AscendC::HardEvent::V_S>(evtVToS);
 
                             for (int32_t p = 0; p < static_cast<int32_t>(elements); ++p) {
                                 uint8_t byte_val = maskLocal.GetValue(static_cast<uint32_t>(p) >> 3);
@@ -641,6 +678,12 @@ private:
     uint32_t my_rows;
     uint32_t row_offset;
     bool is_large_row;
+
+    event_t evtMte2ToS;
+    event_t evtMte2ToV;
+    event_t evtSToMte3;
+    event_t evtMte3ToMte2;
+    event_t evtVToS;
 };
 
 extern "C" __global__ __aicore__ void ngram_spec_decode(


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds synchronization logic to the `ngram_spec_decode` operator to resolve runtime errors caused by asynchronous execution.

When validating ngram speculative decoding based on PR9008 across a 4-NPU setup, curl requests hung with no response and the vLLM runtime threw exceptions.
Root cause analysis confirmed missing implicit synchronization during compilation for the `ngram_spec_decode` kernel; explicit synchronization code is manually added in this patch.

### Does this PR introduce _any_ user-facing change?
No user-facing changes.

### How was this patch tested?
1. Post-fix curl validation is performed on both single-NPU and 4-NPU environments with correct results.
2. End-to-end vLLM benchmark runs cover three datasets (AIMO, InstructCoder, sonnet, 200 prompts each). We compare accepted token counts between vanilla `ngram_gpu` and optimized ngram speculative decoding, and the speculative path yields nearly identical accepted token volumes.
3. Isolated unit testing & profiling for the standalone `ngram_spec_decode` operator:
   - Performance remains consistent vs pre-PR baseline;
   - All 380 functional test cases pass.

#### Accepted tokens benchmark stats
**Qwen3-8B / ngram_npu (speculative decode):**
- AIMO: 113187 accepted tokens
- InstructCoder: 1243 accepted tokens
- sonnet: 873 accepted tokens

**Qwen3-8B / baseline ngram_cpu:**
- AIMO: 104772 accepted tokens
- InstructCoder: 1201 accepted tokens
- sonnet: 945 accepted tokens

*Standalone operator performance verification*
root@localhost:/home/vllm-dcn/output_operators/ngram_spec_decode# python tests/bench_ngram_spec_decode.py
NPU: Ascend910B3
PyTorch: 2.10.0+cpu

   BS   SeqLen |   CPU Mean  CPU Median |   NPU Mean  NPU Median |   Speedup
--------------------------------------------------------------------------------
65x128      128 |    127.865     127.699 |      0.191       0.186 |   688.58x
1x128      128 |      1.578       1.562 |      0.075       0.075 |    21.06x
1x1024     1024 |     18.399      18.395 |      0.104       0.101 |   182.39x
1x8192     8192 |    139.839     139.840 |      0.359       0.359 |   389.87x
1x65536    65536 |    406.936     407.159 |      0.927       0.927 |   438.81x
8x128      128 |     16.987      16.978 |      0.078       0.083 |   204.93x
8x1024     1024 |    108.557     108.476 |      0.115       0.111 |   976.56x
8x8192     8192 |    968.889     969.095 |      0.442       0.442 |  2191.47x
8x65536    65536 |   7402.292    7399.017 |      2.817       2.813 |  2631.09x
64x128      128 |    123.456     123.296 |      0.183       0.182 |   679.52x
64x1024     1024 |    933.901     934.353 |      0.818       0.817 |  1143.05x
64x8192     8192 |   7116.977    7116.515 |      6.274       6.273 |  1134.49x
64x65536    65536 |  57725.045   57718.753 |     52.454      52.444 |  1100.70x

### What this PR does / why we need it?
本PR目的是在ngram_spec_decode算子增加同步代码，避免异步处理错误。

在NPU 4卡上，基于PR9008版本测试ngram_gpu投机推理，发现curl测试没有响应，同时vllm有报错。

经过定位发现是ngram_spec_decode算子在编译过程中没有自动同步，因此手工增加了同步的代码。

### Does this PR introduce _any_ user-facing change?
无

### How was this patch tested?
1. 修改后基于NPU 4卡和单卡进行了Curl测试，结果正确。2. 进行了vllm bench 性能测试，测试了AIMO/InstructCoder/sonnet三个数据集的各200条数据，对比了ngramp_gpu和ngram投机推理结果，投机推理接受token数据基本一致。3. 进行了单独的ngram_spec_decode算子性能测试，相比与修改前性能基本一致；单算子的功能测试，380个用例全部通过。

Qwen3-8B/ngram_npu/aimo性能测试 Accepted tokens:                         113187 
Qwen3-8B/ngram_npu/InstructCoder性能测试 Accepted tokens:                         1243
Qwen3-8B/ngram_npu/sonnet性能测试 Accepted tokens:                         873 

Qwen3-8B/ngram/aimo性能测试 Accepted tokens:                         104772 
Qwen3-8B/ngram/InstructCoder性能测试  Accepted tokens:                         1201 
Qwen3-8B/ngram/sonnet性能测试 Accepted tokens:                         945  

单算子性能测试
root@localhost:/home/vllm-dcn/output_operators/ngram_spec_decode# python tests/bench_ngram_spec_decode.py
NPU: Ascend910B3
PyTorch: 2.10.0+cpu

   BS   SeqLen |   CPU Mean  CPU Median |   NPU Mean  NPU Median |   Speedup
--------------------------------------------------------------------------------
65x128      128 |    127.865     127.699 |      0.191       0.186 |   688.58x
1x128      128 |      1.578       1.562 |      0.075       0.075 |    21.06x
1x1024     1024 |     18.399      18.395 |      0.104       0.101 |   182.39x
1x8192     8192 |    139.839     139.840 |      0.359       0.359 |   389.87x
1x65536    65536 |    406.936     407.159 |      0.927       0.927 |   438.81x
8x128      128 |     16.987      16.978 |      0.078       0.083 |   204.93x
8x1024     1024 |    108.557     108.476 |      0.115       0.111 |   976.56x
8x8192     8192 |    968.889     969.095 |      0.442       0.442 |  2191.47x
8x65536    65536 |   7402.292    7399.017 |      2.817       2.813 |  2631.09x
64x128      128 |    123.456     123.296 |      0.183       0.182 |   679.52x
64x1024     1024 |    933.901     934.353 |      0.818       0.817 |  1143.05x
64x8192     8192 |   7116.977    7116.515 |      6.274       6.273 |  1134.49x
64x65536    65536 |  57725.045   57718.753 |     52.454      52.444 |  1100.70x

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
