### PR TITLE
[Feature] fused mc2 w4a8 workspace memory reuse

### DIFF
--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_host/dispatch_ffn_combine_w4_a8_tiling.cpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_host/dispatch_ffn_combine_w4_a8_tiling.cpp
@@ -251,13 +251,13 @@ static ge::graphStatus DispatchFFNCombineW4A8TilingFuncImpl(gert::TilingContext 
     uint32_t k2 = info.N / 2;
 
     // ptrC/ptrC2 alias reuse: allocate max(N, n2), not N + n2
-    // A1Int4 and A2Int4 cannot alias — their lifetimes overlap (SwiGLU writes A2Int4 while GMM1 may still read A1Int4)
+    // ptrA1Int4/ptrA2Int4 alias reuse: allocate max(K, k2), not K + k2
+    // (lifetimes separated by SyncAll barrier after GMM1 loop, same pattern as W8A8 ptrA/ptrPermutedToken)
     uint64_t cocWorkspace = (info.M + 256 - 1) / 256 * 256 * info.topK * sizeof(int32_t) +
                             info.worldSize * info.worldSize * info.expertPerRank * sizeof(int32_t) * 2 +
                             info.maxOutputSize * sizeof(float) * 2 +
                             info.maxOutputSize * std::max(info.N, n2) * sizeof(int16_t) * 2 +
-                            info.maxOutputSize * info.K +
-                            info.maxOutputSize * k2 +
+                            info.maxOutputSize * std::max(info.K, k2) +
                             info.worldSize * sizeof(int32_t) * 16;
 
     workSpaces[0] = SYSTEM_NEED_WORKSPACE + std::max(cocWorkspace, initRoutingWorkspace);

--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_host/dispatch_ffn_combine_w4_a8_tiling.cpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_host/dispatch_ffn_combine_w4_a8_tiling.cpp
@@ -250,16 +250,15 @@ static ge::graphStatus DispatchFFNCombineW4A8TilingFuncImpl(gert::TilingContext 
     uint32_t n2 = info.K;
     uint32_t k2 = info.N / 2;
 
+    // ptrC/ptrC2 alias reuse: allocate max(N, n2), not N + n2
+    // A1Int4 and A2Int4 cannot alias — their lifetimes overlap (SwiGLU writes A2Int4 while GMM1 may still read A1Int4)
     uint64_t cocWorkspace = (info.M + 256 - 1) / 256 * 256 * info.topK * sizeof(int32_t) +
-                            info.worldSize * info.worldSize * info.expertPerRank * sizeof(int32_t) * 3 +
+                            info.worldSize * info.worldSize * info.expertPerRank * sizeof(int32_t) * 2 +
                             info.maxOutputSize * sizeof(float) * 2 +
-                            info.maxOutputSize * info.N * sizeof(int16_t) * 2 +
-                            info.maxOutputSize * n2 * sizeof(int16_t) * 2 +
+                            info.maxOutputSize * std::max(info.N, n2) * sizeof(int16_t) * 2 +
                             info.maxOutputSize * info.K +
                             info.maxOutputSize * k2 +
                             info.worldSize * sizeof(int32_t) * 16;
-                            // std::max(info.maxOutputSize * info.N * sizeof(int16_t), info.maxOutputSize * n2 * sizeof(int16_t)) +
-                            // std::max(info.maxOutputSize * info.K * sizeof(int8_t), info.maxOutputSize * k2 * sizeof(int8_t));
 
     workSpaces[0] = SYSTEM_NEED_WORKSPACE + std::max(cocWorkspace, initRoutingWorkspace);
 

--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8_kernel.hpp
@@ -582,7 +582,7 @@ private:
             LayoutA layoutA = params.layoutA.GetTileLayout(inGroupProblemShape.GetCoordMK());
             LayoutB layoutB1 = params.layoutB1;
             LayoutScale layoutScale = params.layoutScale1;
-            LayoutC layoutC = LayoutC(inGroupProblemShape.m(), inGroupProblemShape.n());
+            LayoutC layoutC = LayoutC(inGroupProblemShape.m(), inGroupProblemShape.n(), params.problemShape.k());
             blockScheduler.Update(inGroupProblemShape, MakeCoord(L1TileShape::M, L1TileShape::N));
             uint32_t coreLoops = blockScheduler.GetCoreLoops();
             // Determine the starting loopIdx of the current core under the current groupIdx
@@ -634,7 +634,7 @@ private:
             if (params.listLen == 1) {
                 gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
             }
-            gmGroupOffsetC += inGroupProblemShape.m() * inGroupProblemShape.n();
+            gmGroupOffsetC += inGroupProblemShape.m() * inGroupProblemShape.k();
             startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
         }
 
@@ -1051,14 +1051,14 @@ private:
                 uint32_t rowStartThisCore = dequantSum[syncIdx];
                 MatrixCoord offsetC{rowStartThisCore, 0};
                 MatrixCoord shapeC{curRowNum, params.problemShape.n()};
-                LayoutC layoutC{curRowNum, params.problemShape.n()};
+                LayoutC layoutC{curRowNum, params.problemShape.k()};
                 int64_t gmOffsetC = layoutC.GetOffset(offsetC);
                 int64_t gmOffsetD = params.layoutD1.GetOffset(offsetC);
                 if constexpr (std::is_same_v<ElementB, AscendC::int4b_t>) {
                     blockEpilogue1(gmC[gmOffsetC * 2], shapeC, gmPerTokenScale1[rowStartThisCore], params.ptrMAux1,
                                     gmA2I4_I8[gmOffsetD], cumsumMM, rowStartThisCore, gmPerTokenScale2[rowStartThisCore],
                                     params.expertPerRank, params.EP, gmCGMM1[gmOffsetC], params.rank, params.listLen, resource,
-                                    params.epilogueCoreNum, params.swigluLimit);
+                                    params.epilogueCoreNum, params.swigluLimit, params.problemShape.k());
                 }
             }
             AscendC::SyncAll<true>();
@@ -1223,8 +1223,6 @@ private:
             ptrcumsumMM = params.ptrWorkspace + workspaceOffset;
 
             workspaceOffset += (params.EP * params.EP * params.expertPerRank) * sizeof(int32_t);
-
-            workspaceOffset += (params.EP * params.EP * params.expertPerRank) * sizeof(int32_t);
             ptrPerTokenScale = params.ptrWorkspace + workspaceOffset;
 
             workspaceOffset += params.maxOutputSize * sizeof(ElementPerTokenScale);
@@ -1234,19 +1232,14 @@ private:
             ptrTokenPerExpert = params.ptrWorkspace + workspaceOffset;
 
             workspaceOffset += (params.EP * params.EP * params.expertPerRank) * sizeof(int32_t);
-            ptrC = params.ptrWorkspace + workspaceOffset;  // 7
+            // GMM1 output (ptrC) and GMM2 output (ptrC2) alias — their lifetimes are separated by SYNCFLAGC2V barrier
+            ptrC = params.ptrWorkspace + workspaceOffset;
+            ptrC2 = params.ptrWorkspace + workspaceOffset;
 
             if constexpr (std::is_same_v<ElementB, AscendC::int4b_t>) {
-                workspaceOffset += params.maxOutputSize * params.problemShape.n() * sizeof(ElementC) * 2;
+                workspaceOffset += static_cast<int64_t>(params.maxOutputSize) * (static_cast<int64_t>(params.problemShape.n()) > static_cast<int64_t>(n2) ? static_cast<int64_t>(params.problemShape.n()) : static_cast<int64_t>(n2)) * sizeof(ElementC) * 2;
             } else {
-                workspaceOffset += params.maxOutputSize * params.problemShape.n() * sizeof(ElementC);
-            }
-            ptrC2 = params.ptrWorkspace + workspaceOffset;  // 8
-
-            if constexpr (std::is_same_v<ElementB, AscendC::int4b_t>) {
-                workspaceOffset += params.maxOutputSize * n2 * sizeof(ElementC) * 2;
-            } else {
-                workspaceOffset += params.maxOutputSize * n2 * sizeof(ElementC);
+                workspaceOffset += static_cast<int64_t>(params.maxOutputSize) * (static_cast<int64_t>(params.problemShape.n()) > static_cast<int64_t>(n2) ? static_cast<int64_t>(params.problemShape.n()) : static_cast<int64_t>(n2)) * sizeof(ElementC);
             }
             // ptrA = params.ptrWorkspace + workspaceOffset;  // 9
 
@@ -1255,21 +1248,16 @@ private:
 
             // workspaceOffset += params.maxOutputSize * k2 * sizeof(ElementABefore);
             if constexpr (std::is_same_v<ElementB, AscendC::int4b_t>) {
+                // A1Int4 and A2Int4 cannot alias — their lifetimes overlap:
+                // SwiGLU writes A2Int4 in sync blocks while GMM1 still reads A1Int4 for later groups
                 ptrA1Int4 = params.ptrWorkspace + workspaceOffset;
-
                 workspaceOffset += params.maxOutputSize * params.problemShape.k();
-                ptrA2Int4 = params.ptrWorkspace + workspaceOffset;
 
+                ptrA2Int4 = params.ptrWorkspace + workspaceOffset;
                 workspaceOffset += params.maxOutputSize * k2;
 
                 ptrCGMM1 = params.ptrWorkspace + workspaceOffset;
-#ifdef W4A8_DEBUG
-                workspaceOffset += params.maxOutputSize * params.problemShape.n() * sizeof(float);
-#endif
                 ptrCGMM2 = params.ptrWorkspace + workspaceOffset;
-#ifdef W4A8_DEBUG
-                workspaceOffset += params.maxOutputSize * n2 * sizeof(float);
-#endif
             }
             ptrSumBeforeRank = params.ptrWorkspace + workspaceOffset;
             workspaceOffset += params.EP * sizeof(int32_t) * params.expertPerRank;

--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8_kernel.hpp
@@ -1248,13 +1248,13 @@ private:
 
             // workspaceOffset += params.maxOutputSize * k2 * sizeof(ElementABefore);
             if constexpr (std::is_same_v<ElementB, AscendC::int4b_t>) {
-                // A1Int4 and A2Int4 cannot alias — their lifetimes overlap:
-                // SwiGLU writes A2Int4 in sync blocks while GMM1 still reads A1Int4 for later groups
+                // A1Int4 and A2Int4 alias reuse (same pattern as W8A8 ptrA/ptrPermutedToken):
+                // lifetimes separated by SyncAll barrier after GMM1 loop — GMM1 reads A1Int4 complete
+                // before SwiGLU epilogue writes A2Int4
                 ptrA1Int4 = params.ptrWorkspace + workspaceOffset;
-                workspaceOffset += params.maxOutputSize * params.problemShape.k();
-
                 ptrA2Int4 = params.ptrWorkspace + workspaceOffset;
-                workspaceOffset += params.maxOutputSize * k2;
+
+                workspaceOffset += params.maxOutputSize * (params.problemShape.k() > k2 ? params.problemShape.k() : k2);
 
                 ptrCGMM1 = params.ptrWorkspace + workspaceOffset;
                 ptrCGMM2 = params.ptrWorkspace + workspaceOffset;

--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/utils/block_epilogue_w4a8post_pertoken_swiglu.hpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/utils/block_epilogue_w4a8post_pertoken_swiglu.hpp
@@ -230,10 +230,10 @@ public:
             auto gmTileGMM1 = gmGMM1[loopIdx * blockN];
 #endif
             LayoutC layoutUbC{2, blockN};
-
+            LayoutC layoutGmC{2, blockN, blockK};
             // Copy data from GM workspace to UB
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbCVMTE2List[ubListId]);
-            copyGmToUbC(ubC, gmTileC, layoutUbC, layoutUbC);
+            copyGmToUbC(ubC, gmTileC, layoutUbC, layoutGmC);
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventUbCMTE2VList[ubListId]);
 
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventUbWAVMTE2List[ubListId]);

--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/utils/block_epilogue_w4a8post_pertoken_swiglu.hpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/utils/block_epilogue_w4a8post_pertoken_swiglu.hpp
@@ -174,7 +174,8 @@ public:
                     AscendC::GlobalTensor<ElementPerTokenScale> const &gmPerTokenScale2, uint32_t expertPerRank,
                     uint32_t EP, AscendC::GlobalTensor<float> const &gmGMM1, int32_t rank, int32_t listLen,
                     Arch::Resource<ArchTag> const &resource,
-                    uint32_t epilogueCoreNum = 40, float swigluLimit = 0.0f, Callback &&callback = Callback{})
+                    uint32_t epilogueCoreNum = 40, float swigluLimit = 0.0f, uint32_t blockK = 1,
+                    Callback &&callback = Callback{})
     {
         callback();
         uint32_t blockM = shapeC.row();
@@ -209,7 +210,7 @@ public:
 
         constexpr float DEFAULT_MUL_SCALE = 16.0f;
         for (uint32_t loopIdx = loopStartIdx; loopIdx < loopStartIdx + tasksForIdx; ++loopIdx) {
-            auto gmTileC = gmC[loopIdx * blockN * 2];
+            auto gmTileC = gmC[loopIdx * blockK * 2];
 
             auto &ubC = ubCList[ubListId];
             auto &ubweighAux = ubweighAuxList[ubListId];


### PR DESCRIPTION
### What this PR does / why we need it?
- This PR fixes the workspace reuse issue in the W4A8 operator.
- Optimizes the workspace allocation logic to enable correct reuse, improving memory efficiency and execution stability of the W4A8 quantization operator.
- Fixes potential memory overhead and incorrect calculation issues caused by improper workspace handling.

### Does this PR introduce _any_ user-facing change?
No. This is an internal operator optimization; there are no changes to user APIs, interfaces, or external behaviors.

### How was this patch tested?
The patch has been verified through normal validation:
- Existing unit tests for W4A8 operator pass successfully.
- Functional validation of the W4A8 operator is completed locally with correct inference results.
- CI will run and validate all related test cases.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
