### PR TITLE
[BugFix](dsa): align dtype of params for inplace_partial_rotary_mul_npu

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1758,7 +1758,7 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
     at::ScalarType original_type = x.scalar_type();
     at::Tensor x_cast = x.to(r1.scalar_type());
     EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x_cast, r1, r2, it->second, partial_slice);
-    x.copy_(x_cast.to(original_type));
+    x.copy_(x_cast);
 }
 
 std::tuple<at::Tensor, at::Tensor> npu_rms_norm_dynamic_quant_npu(

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1750,7 +1750,15 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
     }
     auto origin_dim_num = x.dim();
     TORCH_CHECK(origin_dim_num == BSND_DIM_NUM, "Input tensor x's dim num should be 4, actual ", origin_dim_num, ".");
-    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, r2, it->second, partial_slice);
+    if (x.scalar_type() == r1.scalar_type()) {
+        EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, r2, it->second, partial_slice);
+        return;
+    }
+
+    at::ScalarType original_type = x.scalar_type();
+    at::Tensor x_cast = x.to(r1.scalar_type());
+    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x_cast, r1, r2, it->second, partial_slice);
+    x.copy_(x_cast.to(original_type));
 }
 
 std::tuple<at::Tensor, at::Tensor> npu_rms_norm_dynamic_quant_npu(

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1755,7 +1755,6 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
         return;
     }
 
-    at::ScalarType original_type = x.scalar_type();
     at::Tensor x_cast = x.to(r1.scalar_type());
     EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x_cast, r1, r2, it->second, partial_slice);
     x.copy_(x_cast);


### PR DESCRIPTION
### What this PR does / why we need it?
PR #9739 changes the `cos`/`sin` dtype of DeepSeek V4 on A2/A3 to FP32. However, `QuantMatMul` currently does not support FP32, so we need to realign the dtype of `x`—usually BF16—to FP32 in `inplace_partial_rotary_mul_npu`.

| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | 50861a | accuracy | gen | 96.74 |


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
