### PR TITLE
[Ascend950][BugFix] Fix MoonViT3dPretrainedModel.to overriding quantized ViT weight dtype

### DIFF
--- a/vllm_ascend/patch/worker/patch_kimi_k25.py
+++ b/vllm_ascend/patch/worker/patch_kimi_k25.py
@@ -18,7 +18,13 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.model_executor.models.kimi_k25_vit import Learnable2DInterpPosEmbDivided_fixed, get_rope_shape_decorate
+from vllm.model_executor.models.kimi_k25_vit import (
+    Learnable2DInterpPosEmbDivided_fixed,
+    MoonViT3dPretrainedModel,
+    get_rope_shape_decorate,
+)
+
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 @get_rope_shape_decorate
@@ -63,3 +69,22 @@ class AscendLearnable2DInterpPosEmbDivided_fixed(nn.Module):
 
 
 Learnable2DInterpPosEmbDivided_fixed.forward = AscendLearnable2DInterpPosEmbDivided_fixed.forward
+
+
+# Patch MoonViT3dPretrainedModel.to() to ignore the `dtype` argument.
+# When KimiK25ForConditionalGeneration.__init__ calls:
+#     self.vision_tower = self.vision_tower.to(device=..., dtype=model_config.dtype)
+# the `dtype=model_config.dtype` (e.g. bf16) would overwrite the fp8 parameters
+# created by the Ascend quantization scheme, causing a dtype mismatch later
+# in weight_loader when the checkpoint's fp8 weights are loaded.
+if get_ascend_device_type() == AscendDeviceType.A5:
+    _original_moonvit_to = MoonViT3dPretrainedModel.to
+
+    def _patched_moonvit_to(self, *args, **kwargs):
+        # Filter out dtype from positional arguments and remove from kwargs
+        # to prevent overriding quantized weight dtypes on A5.
+        new_args = tuple(a for a in args if not isinstance(a, torch.dtype))
+        kwargs.pop("dtype", None)
+        return _original_moonvit_to(self, *new_args, **kwargs)
+
+    MoonViT3dPretrainedModel.to = _patched_moonvit_to


### PR DESCRIPTION

### What this PR does / why we need it?

On Ascend A5 devices, loading KimiK25 models with quantized ViT weights (mxfp8) fails because the initialization flow calls .to(dtype=...), which converts the quantized weights to the model's default dtype (e.g., bf16). This causes a RuntimeError: dtype mismatch during weight loading.
This PR patches MoonViT3dPretrainedModel.to() to ignore the dtype argument on A5 devices, ensuring the quantized weight dtypes are preserved.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
