### PR TITLE
[Feature] dsv4 supports piecewise graph mode.

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -485,12 +485,15 @@ class NPUPlatform(Platform):
                 all2all_backend=vllm_config.parallel_config.all2all_backend,
                 data_parallel_size=vllm_config.parallel_config.data_parallel_size,
             )
-            # NOTE: Theoretically, we should also add vllm::mla_forward and vllm::dsa_forward in the attention ops.
-            # Since the process is created in the spawn mode, the value of the class attribute
-            # attention ops transmitted is still the one before modification, so it has not been modified.
-            # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
-            # If splitting ops does not contain the vllm::mla_forward and vllm::dsa_forward value, this configuration issue will
-            # not be detected in advance assert.
+            # NOTE: Theoretically, we should also add vllm::mla_forward and
+            # vllm::dsa_forward in the attention ops. Since the process is
+            # created in the spawn mode, the value of the class attribute
+            # attention ops transmitted is still the one before modification,
+            # so it has not been modified. This will cause in scenarios where
+            # both piecewise and splitting ops are configured simultaneously,
+            # If splitting ops does not contain the vllm::mla_forward and
+            # vllm::dsa_forward value, this configuration issue will not be
+            # detected in advance assert.
             compilation_config.splitting_ops.extend(
                 [
                     "vllm::mla_forward",

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -209,7 +209,7 @@ class NPUPlatform(Platform):
             "DeepSeek V4 PIECEWISE cudagraph is not supported yet."
         )
 
-        """Set sp_min_token_num=1 when enable_sp and not set."""
+        # Set sp_min_token_num=1 when enable_sp and not set.
         pass_config = vllm_config.compilation_config.pass_config
         if pass_config.enable_sp and pass_config.sp_min_token_num is None:
             from vllm_ascend.compilation.passes.sequence_parallelism import get_sp_min_token_num
@@ -485,15 +485,12 @@ class NPUPlatform(Platform):
                 all2all_backend=vllm_config.parallel_config.all2all_backend,
                 data_parallel_size=vllm_config.parallel_config.data_parallel_size,
             )
-            # NOTE: Theoretically, we should also add vllm::mla_forward and
-            # vllm::dsa_forward in the attention ops. Since the process is
-            # created in the spawn mode, the value of the class attribute
-            # attention ops transmitted is still the one before modification,
-            # so it has not been modified. This will cause in scenarios where
-            # both piecewise and splitting ops are configured simultaneously,
-            # If splitting ops does not contain the vllm::mla_forward and
-            # vllm::dsa_forward value, this configuration issue will not be
-            # detected in advance assert.
+            # NOTE: Theoretically, we should also add this in the attention ops.
+            # Since the process is created in the spawn mode, the value of the class attribute
+            # attention ops transmitted is still the one before modification, so it has not been modified.
+            # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
+            # If splitting ops does not contain the this value, this configuration issue will
+            # not be detected in advance assert.
             compilation_config.splitting_ops.extend(
                 [
                     "vllm::mla_forward",

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -199,7 +199,14 @@ class NPUPlatform(Platform):
 
     @classmethod
     def apply_config_platform_defaults(cls, vllm_config: VllmConfig) -> None:
-        """Apply Ascend-specific defaults. Set sp_min_token_num=1 when enable_sp and not set."""
+        """Apply Ascend-specific defaults."""
+        # Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
+        # carry @support_torch_compile. This makes vLLM auto-enable the breakable
+        # cudagraph PIECEWISE path, which is not supported on Ascend yet.
+        # Disable it by default unless the user explicitly opts in via the env var.
+        os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "0"
+
+        """Set sp_min_token_num=1 when enable_sp and not set."""
         pass_config = vllm_config.compilation_config.pass_config
         if pass_config.enable_sp and pass_config.sp_min_token_num is None:
             from vllm_ascend.compilation.passes.sequence_parallelism import get_sp_min_token_num
@@ -475,13 +482,16 @@ class NPUPlatform(Platform):
                 all2all_backend=vllm_config.parallel_config.all2all_backend,
                 data_parallel_size=vllm_config.parallel_config.data_parallel_size,
             )
-            # NOTE: Theoretically, we should also add vllm::mla_forward in the attention ops.
+            # NOTE: Theoretically, we should also add vllm::mla_forward and vllm::dsa_forward in the attention ops.
             # Since the process is created in the spawn mode, the value of the class attribute
             # attention ops transmitted is still the one before modification, so it has not been modified.
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
-            # If splitting ops does not contain the vllm::mla forward value, this configuration issue will
+            # If splitting ops does not contain the vllm::mla_forward and vllm::dsa_forward value, this configuration issue will
             # not be detected in advance assert.
-            compilation_config.splitting_ops.extend(["vllm::mla_forward"])
+            compilation_config.splitting_ops.extend([
+                "vllm::mla_forward",
+                "vllm::dsa_forward",
+            ])
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -203,8 +203,11 @@ class NPUPlatform(Platform):
         # Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
         # carry @support_torch_compile. This makes vLLM auto-enable the breakable
         # cudagraph PIECEWISE path, which is not supported on Ascend yet.
-        # Disable it by default unless the user explicitly opts in via the env var.
-        os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "0"
+        envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
+        logger.info(
+            "Breakable cudagraph is force disabled on Ascend because "
+            "DeepSeek V4 PIECEWISE cudagraph is not supported yet."
+        )
 
         """Set sp_min_token_num=1 when enable_sp and not set."""
         pass_config = vllm_config.compilation_config.pass_config
@@ -488,10 +491,12 @@ class NPUPlatform(Platform):
             # This will cause in scenarios where both piecewise and splitting ops are configured simultaneously,
             # If splitting ops does not contain the vllm::mla_forward and vllm::dsa_forward value, this configuration issue will
             # not be detected in advance assert.
-            compilation_config.splitting_ops.extend([
-                "vllm::mla_forward",
-                "vllm::dsa_forward",
-            ])
+            compilation_config.splitting_ops.extend(
+                [
+                    "vllm::mla_forward",
+                    "vllm::dsa_forward",
+                ]
+            )
             update_aclgraph_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():


### PR DESCRIPTION
### What this PR does / why we need it?
For PIECEWISE cudagraphs, attention-like custom ops must be listed in `splitting_ops` so they are kept outside the captured subgraphs. However, `vllm::dsa_forward` is not currently included, so DeepSeek V4's DSA attention may be captured inside a piecewise graph.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
