### PR TITLE
[Feature] Add VLLM_ASCEND_AUTO_DETECT_QUANTIZATION environment variable

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -113,7 +113,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Whether to use MultiBlockPool for KV cache management
     "VLLM_ASCEND_APPLY_DSV4_PATCH": lambda: bool(int(os.getenv("VLLM_ASCEND_APPLY_DSV4_PATCH", "0"))),
     # Whether to enable auto-detect quantization from model files.
-    # This feature is enabled by default. When disabled, the model will be treated as unquantized.
+    # This feature is enabled by default.
     "VLLM_ASCEND_AUTO_DETECT_QUANTIZATION": lambda: bool(int(os.getenv("VLLM_ASCEND_AUTO_DETECT_QUANTIZATION", "1"))),
 }
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -112,6 +112,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
     # Whether to use MultiBlockPool for KV cache management
     "VLLM_ASCEND_APPLY_DSV4_PATCH": lambda: bool(int(os.getenv("VLLM_ASCEND_APPLY_DSV4_PATCH", "0"))),
+    # Whether to enable auto-detect quantization from model files.
+    # This feature is enabled by default. When disabled, the model will be treated as unquantized.
+    "VLLM_ASCEND_AUTO_DETECT_QUANTIZATION": lambda: bool(int(os.getenv("VLLM_ASCEND_AUTO_DETECT_QUANTIZATION", "1"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -159,6 +159,11 @@ def maybe_auto_detect_quantization(vllm_config) -> None:
     Args:
         vllm_config: A ``vllm.config.VllmConfig`` instance (mutable).
     """
+    import vllm_ascend.envs as envs_ascend
+
+    if not envs_ascend.VLLM_ASCEND_AUTO_DETECT_QUANTIZATION:
+        return
+
     model_config = vllm_config.model_config
     model = model_config.model
     revision = model_config.revision


### PR DESCRIPTION
### What this PR does / why we need it?
In RL case, the quantization method shouldn't be auto-detected as it's not what users wanted. This PR proposes to add an env variable `VLLM_ASCEND_AUTO_DETECT_QUANTIZATION` (1 by default for compatibility)  to control the auto-detection behavior.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
