### PR TITLE
[Misc][BugFix] Disagg proxy: stop retrying on HTTP errors and fix resource leaks

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -670,6 +670,7 @@ async def _handle_select_instance(api: str, req_data: Any, request_length: int):
     prefiller_idx = proxy_state.select_prefiller(prefiller_score)
     prefiller = proxy_state.prefillers[prefiller_idx]
     # Send request to prefiller
+    prefiller_released = False
     try:
         response = await send_request_to_service(
             prefiller.client,
@@ -680,13 +681,15 @@ async def _handle_select_instance(api: str, req_data: Any, request_length: int):
             max_retries=global_args.max_retries,
             base_delay=global_args.retry_delay,
         )
-    except Exception:
         proxy_state.release_prefiller(prefiller_idx, prefiller_score)
+        prefiller_released = True
+        response_json = response.json()
+        kv_transfer_params = response_json.get("kv_transfer_params", {})
+    except Exception:
+        if not prefiller_released:
+            proxy_state.release_prefiller(prefiller_idx, prefiller_score)
         proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
         raise
-    proxy_state.release_prefiller(prefiller_idx, prefiller_score)
-    response_json = response.json()
-    kv_transfer_params = response_json.get("kv_transfer_params", {})
     if kv_transfer_params:
         req_data["kv_transfer_params"] = kv_transfer_params
     # Select decoder

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -607,7 +607,10 @@ async def send_request_to_service(
             response = await client.post(endpoint, json=req_data, headers=headers)
             response.raise_for_status()
             return response
-        except (httpx.RequestError, httpx.HTTPStatusError) as e:
+        except httpx.HTTPStatusError as e:
+            logger.error("HTTP error for %s: %s", endpoint, e)
+            raise
+        except httpx.RequestError as e:
             logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, e)
             last_exc = e
             if attempt < max_retries:
@@ -635,7 +638,10 @@ async def stream_service_response_with_retry(
                     first_chunk_sent = True
                     yield chunk
                 return  # Success, exit after streaming
-        except (httpx.RequestError, httpx.HTTPStatusError) as e:
+        except httpx.HTTPStatusError as e:
+            logger.error("HTTP error for streaming %s: %s", endpoint, e)
+            raise
+        except httpx.RequestError as e:
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, e)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
@@ -664,15 +670,20 @@ async def _handle_select_instance(api: str, req_data: Any, request_length: int):
     prefiller_idx = proxy_state.select_prefiller(prefiller_score)
     prefiller = proxy_state.prefillers[prefiller_idx]
     # Send request to prefiller
-    response = await send_request_to_service(
-        prefiller.client,
-        prefiller_idx,
-        api,
-        req_data,
-        request_id,
-        max_retries=global_args.max_retries,
-        base_delay=global_args.retry_delay,
-    )
+    try:
+        response = await send_request_to_service(
+            prefiller.client,
+            prefiller_idx,
+            api,
+            req_data,
+            request_id,
+            max_retries=global_args.max_retries,
+            base_delay=global_args.retry_delay,
+        )
+    except Exception:
+        proxy_state.release_prefiller(prefiller_idx, prefiller_score)
+        proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
+        raise
     proxy_state.release_prefiller(prefiller_idx, prefiller_score)
     response_json = response.json()
     kv_transfer_params = response_json.get("kv_transfer_params", {})
@@ -682,7 +693,11 @@ async def _handle_select_instance(api: str, req_data: Any, request_length: int):
     decoder_score = proxy_state.calculate_decode_scores(request_length)
     logger.debug("Decoder score: %f", decoder_score)
     # Use the prefiller's kv_transfer_params to select decoder
-    decoder_idx = proxy_state.select_decoder(decoder_score)
+    try:
+        decoder_idx = proxy_state.select_decoder(decoder_score)
+    except RuntimeError:
+        proxy_state.release_prefiller_kv(prefiller_idx, prefiller_score)
+        raise
     decoder = proxy_state.decoders[decoder_idx]
     logger.debug("Using %s %s", prefiller.url, decoder.url)
     return InstanceInfo(
@@ -731,6 +746,7 @@ async def _handle_completions(api: str, request: Request):
             nonlocal instance_info
             generated_token = ""
             released_kv = False
+            decoder_released = False
             retry_count = 0
             retry = True
             completion_tokens = 0
@@ -740,6 +756,12 @@ async def _handle_completions(api: str, request: Request):
                 if not released_kv:
                     proxy_state.release_prefiller_kv(instance_info.prefiller_idx, instance_info.prefiller_score)
                     released_kv = True
+
+            def release_decoder_once():
+                nonlocal decoder_released
+                if not decoder_released:
+                    proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
+                    decoder_released = True
 
             # Only one await per chunk, minimal logic in loop
             try:
@@ -793,6 +815,9 @@ async def _handle_completions(api: str, request: Request):
                         if stop_reason == "recomputed":
                             retry = True
                             retry_count += 1
+                            # Release current instance resources before re-selecting
+                            release_decoder_once()
+                            release_prefiller_kv_once()
                             if chat_flag:
                                 messages[0]["content"] = origin_prompt + generated_token
                             else:
@@ -800,6 +825,8 @@ async def _handle_completions(api: str, request: Request):
                             req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
                             tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
                             instance_info = await _handle_select_instance(api, req_data, tmp_request_length)
+                            released_kv = False
+                            decoder_released = False
                             break
                         if retry_count > 0 and not stream_flag:
                             if chat_flag:
@@ -823,7 +850,7 @@ async def _handle_completions(api: str, request: Request):
             finally:
                 # After streaming is done or cancelled, release tokens.
                 release_prefiller_kv_once()
-                proxy_state.release_decoder(instance_info.decoder_idx, instance_info.decoder_score)
+                release_decoder_once()
                 proxy_state.request_num -= 1
 
         # Determine the correct media type based on stream flag


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes two categories of bugs in the disaggregated prefill load-balance proxy server:

**1. Retry logic incorrectly retried HTTP status errors (4xx/5xx)**

Both `send_request_to_service` and `stream_service_response_with_retry` caught `(httpx.RequestError, httpx.HTTPStatusError)` together and retried on all of them. A 400 Bad Request or 500 Internal Server Error would be retried 3 times with exponential backoff — wasting time and hammering a failing backend for errors that won't resolve on retry.

Fix: Split the except clauses. `HTTPStatusError` (4xx/5xx) now logs and raises immediately without retry. Only `RequestError` (network errors: connection refused, timeout, reset, etc.) is retried.

**2. Resource leaks on failure paths**

- **a) Prefill failure leaked `active_tokens` + `active_kv_cache`:** In `_handle_select_instance`, if `send_request_to_service` raised, `release_prefiller` was never called, causing the prefiller's load counters to stay permanently inflated. Over time this starves the node as the priority heap sees it as fully loaded.

  Fix: Wrap `send_request_to_service` in try/except; on any exception, release both `active_tokens` and `active_kv_cache` before re-raising.

- **b) Decoder selection failure leaked `active_kv_cache`:** If `select_decoder` raised `RuntimeError` (no decoders available), the prefiller's `active_kv_cache` was never released.

  Fix: Catch `RuntimeError` from `select_decoder` and release `active_kv_cache` before re-raising.

- **c) Recomputed retry leaked old instance resources:** When `stop_reason == "recomputed"`, `instance_info` was replaced with a new selection via `_handle_select_instance`, but the old decoder's `active_tokens` and old prefiller's `active_kv_cache` were never released. Each recomputed retry leaked one unit of load on both the old prefiller and decoder, gradually inflating all nodes' priority scores.

  Fix: Before replacing `instance_info`, call `release_decoder_once()` and `release_prefiller_kv_once()` to free the old instance. After successful re-selection, reset `released_kv` and `decoder_released` flags for the new instance.

- **d) Double-release of decoder in finally block:** The finally block unconditionally called `proxy_state.release_decoder()`, which would double-release the old decoder if `instance_info` was replaced during a recomputed retry that subsequently failed.

  Fix: Introduce `release_decoder_once()` (mirroring the existing `release_prefiller_kv_once` pattern) and use it in the finally block to guard against double-release.

### Does this PR introduce _any_ user-facing change?

No. Internal bug fixes to the load-balance proxy server's error handling and resource management. No API or behavior changes for correctly functioning requests.

### How was this patch tested?

- Code review and manual analysis of all failure paths in `_handle_select_instance` and `generate_stream`
- Verified that `select_prefiller` / `select_decoder` resource acquisition is always paired with a corresponding release on every exception path
- Verified that recomputed retry correctly releases old instance resources before selecting a new one
- Verified that `HTTPStatusError` is no longer retried (immediate raise) while `RequestError` still retries with exponential backoff

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
