### PR TITLE
[Feature][v0.20.2rc] Mooncake kvpool usage optimization (#7820)

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -108,15 +108,19 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
     "protocol": "ascend",
     "device_name": "",
     "master_server_address": "xx.xx.xx.xx:50088",
-    "global_segment_size": "1GB" (1024MB/1048576KB/1073741824B/1073741824)
+    "global_segment_size": "1GB" (1024MB/1048576KB/1073741824B/1073741824),
+    "preferred_segment": false,
+    "prefer_alloc_in_same_node": true
 }
 ```
 
 **metadata_server**: Configured as **P2PHANDSHAKE**.  
 **protocol:** Must be set to 'Ascend' on the NPU.
 **device_name**: ""
-**master_server_address**: Configured with the IP and port of the master service.  
-**global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.**
+**master_server_address**: Configured with the IP and port of the master service. It can also be set via the **MOONCAKE_MASTER** environment variable, which takes precedence over this configuration item (useful for injecting the master address through Kubernetes).  
+**global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.** It can also be set via the **MOONCAKE_GLOBAL_SEGMENT_SIZE** environment variable, which takes precedence over this configuration item.  
+**preferred_segment**: Whether to prefer storing KV on the local segment when putting objects to the KV Pool. Defaults to **false**.  
+**prefer_alloc_in_same_node**: Whether to prefer allocating KV on the same node. Defaults to **true**.
 
 #### 2.Start mooncake_master
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -256,6 +256,7 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend = MooncakeBackend.__new__(MooncakeBackend)
             backend.store = MagicMock()
             backend.config = MagicMock()
+            backend.local_seg = "127.0.0.1:1234"
             backend._lazy_init = False
             backend._store_initialized = True
             backend._use_fabric_mem = False

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -9,6 +9,7 @@ import regex as re
 import torch
 
 # Third Party
+from mooncake.store import ReplicateConfig  # type: ignore
 from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
@@ -69,25 +70,25 @@ class MooncakeBackend(Backend):
             transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
             self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
             ret = store.setup(
-                self.local_seg,
-                self.config.metadata_server,
-                self.config.global_segment_size,
-                self.config.local_buffer_size,
-                self.config.protocol,
-                self.config.device_name,
-                self.config.master_server_address,
-                transfer_engine.get_engine(),
+                local_hostname=self.local_seg,
+                metadata_server=self.config.metadata_server,
+                global_segment_size=self.config.global_segment_size,
+                local_buffer_size=self.config.local_buffer_size,
+                protocol=self.config.protocol,
+                rdma_devices=self.config.device_name,
+                master_server_addr=self.config.master_server_address,
+                engine=transfer_engine.get_engine(),
             )
         else:
             self.local_seg = local_hostname
             ret = store.setup(
-                self.local_seg,
-                self.config.metadata_server,
-                self.config.global_segment_size,
-                0,
-                self.config.protocol,
-                self.config.device_name,
-                self.config.master_server_address,
+                local_hostname=self.local_seg,
+                metadata_server=self.config.metadata_server,
+                global_segment_size=self.config.global_segment_size,
+                local_buffer_size=0,
+                protocol=self.config.protocol,
+                rdma_devices=self.config.device_name,
+                master_server_addr=self.config.master_server_address,
             )
 
         if ret != 0:
@@ -121,7 +122,11 @@ class MooncakeBackend(Backend):
         try:
             self._ensure_initialized()
             assert self.store is not None
-            res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
+            config = ReplicateConfig()
+            if self.config.preferred_segment:
+                config.preferred_segment = self.local_seg
+            config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
+            res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
             for value in res:
                 if value < 0:
                     logger.error("Failed to put key %s,res:%s", keys, res)
@@ -166,20 +171,30 @@ class MooncakeStoreConfig:
     protocol: str
     device_name: str
     master_server_address: str
+    preferred_segment: bool
+    prefer_alloc_in_same_node: bool
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         with open(file_path) as file:
             config = json.load(file)
+        master_server_address = os.getenv("MOONCAKE_MASTER", None)
+        global_segment_size_env = os.getenv("MOONCAKE_GLOBAL_SEGMENT_SIZE", None)
         return MooncakeStoreConfig(
             metadata_server=config.get("metadata_server"),
             global_segment_size=_parse_global_segment_size(
-                config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE)
+                global_segment_size_env
+                if global_segment_size_env is not None
+                else config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE)
             ),
             local_buffer_size=_parse_global_segment_size(config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)),
             protocol=config.get("protocol", "ascend"),
             device_name=config.get("device_name", ""),
-            master_server_address=config.get("master_server_address"),
+            master_server_address=master_server_address
+            if master_server_address is not None
+            else config.get("master_server_address"),
+            preferred_segment=config.get("preferred_segment", False),
+            prefer_alloc_in_same_node=config.get("prefer_alloc_in_same_node", True),
         )
 
     @staticmethod


### PR DESCRIPTION
### What this PR does / why we need it?

  Backport of #7820 to `releases/v0.20.2rc`.

  Mooncake kvpool usage optimization, including:

  1. Expose the `preferred_segment` and `prefer_alloc_in_same_node` Mooncake
     parameters so users can configure them as needed.
  2. Convert `setup` to keyword-argument calls to accommodate different
     versions of Mooncake.
  3. Make `master_server_address` retrievable from both environment variables
     and configuration files, with environment variables taking precedence.