### PR TITLE
[Ops][Feature] Refactor Ascend Sampler to use torch_npu top-k top-p sampling

### DIFF
--- a/tests/ut/sample/test_sampler.py
+++ b/tests/ut/sample/test_sampler.py
@@ -1,10 +1,172 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
 from tests.ut.base import TestBase
-from vllm_ascend.sample.sampler import AscendSampler, AscendTopKTopPSampler
+from tests.ut.conftest import _npu_available
+from vllm_ascend.sample.sampler import (
+    AscendSampler,
+    AscendTopKTopPSampler,
+    apply_top_k_top_p,
+    generate_random_sequence,
+)
 
 
 class TestAscendSampler(TestBase):
+    def setUp(self):
+        if not _npu_available:
+            self.stream_patcher = patch("torch_npu.npu.Stream")
+            self.stream_patcher.start()
+
+    def tearDown(self):
+        if not _npu_available:
+            self.stream_patcher.stop()
+
     def test_init_with_raw_logprobs(self):
         sampler = AscendSampler(logprobs_mode="raw_logprobs")
         self.assertEqual(sampler.logprobs_mode, "raw_logprobs")
         self.assertTrue(hasattr(sampler, "topk_topp_sampler"))
         self.assertIsInstance(sampler.topk_topp_sampler, AscendTopKTopPSampler)
+
+
+def _mock_ascend_config(enable_reduce_sample=False):
+    """Create a mock ascend config for tests that need get_ascend_config()."""
+    mock_config = MagicMock()
+    mock_config.enable_reduce_sample = enable_reduce_sample
+    return mock_config
+
+
+class TestAscendTopKTopPSampler(TestBase):
+    """Test that sampler patches are correctly applied in vllm_ascend source."""
+
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_ascend_top_k_top_p_sampler_has_dsa_stream(self):
+        """AscendTopKTopPSampler should have dsa_stream attribute."""
+        instance = AscendTopKTopPSampler(logprobs_mode="raw_logprobs")
+        self.assertTrue(hasattr(instance, "dsa_stream"))
+        self.assertTrue(hasattr(instance, "logprobs_mode"))
+
+    @patch("vllm_ascend.sample.sampler.get_ascend_config", return_value=_mock_ascend_config())
+    @patch("vllm_ascend.sample.sampler.generate_random_sequence")
+    @patch("vllm_ascend.sample.sampler.torch_npu.npu_top_k_top_p_sample")
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_forward_native_logprobs_modes(self, mock_sample, mock_gen_rand, mock_get_cfg):
+        """forward_native should handle all logprobs_mode variants."""
+        batch_size, vocab_size = 2, 8
+        logits = torch.randn(batch_size, vocab_size)
+        k = torch.tensor([5] * batch_size, dtype=torch.int32)
+        p = torch.tensor([0.9] * batch_size, dtype=torch.bfloat16)
+        mock_sample.return_value = (
+            torch.zeros(batch_size, dtype=torch.int64),
+            logits.type(torch.float32),
+        )
+        mock_gen_rand.return_value = torch.randn(batch_size, vocab_size, dtype=torch.float32)
+
+        for mode in ["raw_logprobs", "processed_logits", "processed_logprobs"]:
+            with self.subTest(mode=mode):
+                instance = AscendTopKTopPSampler(logprobs_mode=mode)
+                sampled, logprobs = instance.forward_native(logits, {}, k, p)
+                self.assertEqual(sampled.shape, (batch_size,))
+                self.assertEqual(sampled.dtype, torch.int64)
+
+    @patch("vllm_ascend.sample.sampler.get_ascend_config", return_value=_mock_ascend_config())
+    @patch("vllm_ascend.sample.sampler.generate_random_sequence")
+    @patch("vllm_ascend.sample.sampler.torch_npu.npu_top_k_top_p_sample")
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_forward_native_default_k_p(self, mock_sample, mock_gen_rand, mock_get_cfg):
+        """forward_native with k=None or p=None should use defaults."""
+        batch_size, vocab_size = 2, 8
+        logits = torch.randn(batch_size, vocab_size)
+        mock_sample.return_value = (
+            torch.zeros(batch_size, dtype=torch.int64),
+            logits.type(torch.float32),
+        )
+        mock_gen_rand.return_value = torch.randn(batch_size, vocab_size, dtype=torch.float32)
+
+        instance = AscendTopKTopPSampler(logprobs_mode="raw_logprobs")
+
+        for k, p, label in [
+            (None, torch.tensor([0.9] * batch_size, dtype=torch.bfloat16), "k=None"),
+            (torch.tensor([5] * batch_size, dtype=torch.int32), None, "p=None"),
+        ]:
+            with self.subTest(label=label):
+                sampled, logprobs = instance.forward_native(logits, {}, k, p)
+                self.assertEqual(sampled.shape, (batch_size,))
+                # self.assertEqual(sampled.dtype, torch.bfloat16)
+
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_ascend_sampler_init_creates_topk_topp_sampler(self):
+        """AscendSampler.__init__ should create topk_topp_sampler."""
+        instance = AscendSampler(logprobs_mode="raw_logprobs")
+        self.assertTrue(hasattr(instance, "topk_topp_sampler"))
+
+    @patch("vllm_ascend.sample.sampler.get_ascend_config", return_value=_mock_ascend_config())
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_apply_top_k_top_p(self, mock_get_cfg):
+        """apply_top_k_top_p should handle all k/p combinations."""
+        batch_size, vocab_size = 4, 16
+        logits = torch.randn(batch_size, vocab_size, dtype=torch.bfloat16, device="npu")
+
+        for k, p, label in [
+            (torch.tensor([3] * batch_size, dtype=torch.int32, device="npu"), None, "k only"),
+            (None, torch.tensor([0.9] * batch_size, dtype=torch.bfloat16, device="npu"), "p only"),
+            (
+                torch.tensor([5] * batch_size, dtype=torch.int32, device="npu"),
+                torch.tensor([0.95] * batch_size, dtype=torch.bfloat16, device="npu"),
+                "k and p",
+            ),
+            (None, None, "neither"),
+        ]:
+            with self.subTest(label=label):
+                result = apply_top_k_top_p(logits, k, p)
+                self.assertEqual(result.shape, logits.shape)
+                expected_dtype = torch.bfloat16 if (k is None and p is None) else torch.float32
+                self.assertEqual(result.dtype, expected_dtype)
+                if k is None and p is None:
+                    torch.testing.assert_close(result, logits, msg="k=None, p=None should be identity")
+
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_ascend_top_k_top_p_sampler_set_q_event(self):
+        """set_q_event should store q and event."""
+        instance = AscendTopKTopPSampler(logprobs_mode="raw_logprobs")
+        q = torch.randn(2, 4)
+        event = torch.npu.Event()
+        instance.set_q_event(q, event)
+        self.assertIs(instance.q, q)
+        self.assertIs(instance.async_event, event)
+
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_generate_random_sequence(self):
+        """generate_random_sequence should return a tensor of the same shape."""
+        logits = torch.randn(2, 4)
+        generators: dict[int, torch.Generator] = {}
+        stream = torch.npu.Stream()
+        result = generate_random_sequence(logits, generators, stream)
+        self.assertEqual(result.shape, logits.shape)
+        self.assertEqual(result.dtype, torch.float32)
+
+    @pytest.mark.skipif(not _npu_available, reason="NPU not available")
+    def test_generate_random_sequence_with_generators(self):
+        """generate_random_sequence with non-empty generators."""
+        logits = torch.randn(2, 4)
+        gen0 = torch.Generator()
+        gen1 = torch.Generator()
+        generators = {0: gen0, 1: gen1}
+        stream = torch.npu.Stream()
+        result = generate_random_sequence(logits, generators, stream)
+        self.assertEqual(result.shape, logits.shape)
+        self.assertEqual(result.dtype, torch.float32)
+
+    @patch("vllm_ascend.sample.sampler.get_ascend_config", return_value=_mock_ascend_config())
+    def test_ascend_sampler_greedy_sample(self, mock_get_cfg):
+        """AscendSampler.greedy_sample returns argmax over logits."""
+        logits = torch.randn(3, 10)
+        result = AscendSampler.greedy_sample(logits)
+        expected = logits.argmax(dim=-1).view(-1)
+        torch.testing.assert_close(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -1,5 +1,5 @@
 import torch
-import vllm.envs as envs
+import torch_npu
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -8,37 +8,27 @@ from vllm.v1.sample.sampler import Sampler
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.sample.penalties import apply_all_penalties
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream, npu_stream_switch
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream
 
 DEFAULT_LOGPROBS_MODE = "raw_logprobs"
 
 _SAMPLING_EPS = 1e-5
 
 
-def random_sample(
-    probs: torch.Tensor,
+def generate_random_sequence(
+    logits: torch.Tensor,
     generators: dict[int, torch.Generator],
+    stream: torch.npu.Stream,
 ) -> torch.Tensor:
-    """Randomly sample from the probabilities.
-
-    We use this function instead of torch.multinomial because torch.multinomial
-    causes CPU-NPU synchronization.
-    """
-    # NOTE(woosuk): To batch-process the requests without their own seeds,
-    # which is the common case, we first assume that every request does
-    # not have its own seed. Then, we overwrite the values for the requests
-    # that have their own seeds.
-    with npu_stream_switch(global_stream()):
-        q = torch.empty_like(probs)
-        if len(generators) != probs.shape[0]:
+    with torch_npu.npu.stream(stream):
+        q = torch.empty_like(logits, dtype=torch.float32)
+        if len(generators) != logits.shape[0]:
             q.exponential_()
         if generators:
-            # TODO(woosuk): This can be slow because we handle each request
-            # one by one. Optimize this.
             for i, generator in generators.items():
                 q[i].exponential_(generator=generator)
-    torch.npu.current_stream().wait_stream(global_stream())
-    return probs.div_(q).argmax(dim=-1).view(-1)
+    torch.npu.current_stream().wait_stream(stream)
+    return q
 
 
 class AscendSampler(Sampler):
@@ -115,6 +105,7 @@ class AscendTopKTopPSampler(TopKTopPSampler):
         super().__init__(**kwargs)
         self.apply_top_k_top_p = apply_top_k_top_p
         self.top_k = None
+        self.dsa_stream = torch_npu.npu.Stream()
 
     def set_q_event(self, q, event):
         # Pass in async exponential results.
@@ -132,36 +123,31 @@ class AscendTopKTopPSampler(TopKTopPSampler):
         """Override pytorch native implementation to torch_npu"""
         # when batch_invariant mode is enabled, we should use vllm's implementation.
         # or it will make batch_invariant mode not working.
-        if envs.VLLM_BATCH_INVARIANT:
-            return super().forward_native(logits, generators, k, p)
+        logits_to_return = None
+        res = None
 
-        if get_ascend_config().enable_reduce_sample:
-            cand_logits, cand_idx = self.apply_top_k_top_p(logits, k, p, self.top_k)
-            logits_to_return = None
-            if self.logprobs_mode == "processed_logits":
-                logits_to_return = cand_logits
-            elif self.logprobs_mode == "processed_logprobs":
-                logits_to_return = cand_logits.log_softmax(dim=-1, dtype=torch.float32)
+        if self.logprobs_mode == "processed_logits":
+            logits_to_return = logits
+        elif self.logprobs_mode == "processed_logprobs":
+            logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
 
-            probs = cand_logits.softmax(dim=-1, dtype=torch.float32)
-            pos = random_sample(probs, generators)  # [B]
-
-            next_token = cand_idx.gather(dim=1, index=pos.unsqueeze(1)).squeeze(1)  # [B]
-            return next_token, logits_to_return
+        if p is not None:
+            p = p.to(device=logits.device, dtype=torch.float32)
         else:
-            logits = self.apply_top_k_top_p(logits, k, p)
-            logits_to_return = None
-            if self.logprobs_mode == "processed_logits":
-                logits_to_return = logits
-            elif self.logprobs_mode == "processed_logprobs":
-                logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
+            p = torch.ones(logits.shape[0], dtype=torch.float32, device=logits.device)
 
-            probs = logits.softmax(dim=-1, dtype=torch.float32)
-            if get_ascend_config().enable_async_exponential:
-                # Add synchronize to prevent synchronize error.
-                self.async_event.synchronize()
-                return probs.div_(self.q).argmax(dim=-1).view(-1), logits_to_return
-            return random_sample(probs, generators), logits_to_return
+        if k is not None:
+            k = k.to(device=logits.device, dtype=torch.int32)
+        else:
+            k = torch.ones((logits.shape[0],), dtype=torch.int32, device=logits.device) * logits.shape[1]
+
+        q = generate_random_sequence(logits, generators, self.dsa_stream).type(torch.float32)
+        if get_ascend_config().enable_reduce_sample:
+            local_vals, _ = torch.topk(logits, k=self.top_k, dim=-1)
+            res = torch_npu.npu_top_k_top_p_sample(local_vals, k, p, q)
+        else:
+            res = torch_npu.npu_top_k_top_p_sample(logits, k, p, q)
+        return res[0], logits_to_return
 
 
 def _apply_top_k_top_p_pytorch(
@@ -245,6 +231,20 @@ def _apply_top_k_top_p_ascendc(
     p: torch.Tensor,
     top_k: int | None = None,
 ) -> torch.Tensor:
+    if p is None and k is None:
+        return logits
+
+    logits = logits.type(torch.float32)
+    if p is not None:
+        p = p.type(torch.float32)
+    else:
+        p = torch.ones(logits.shape[0], dtype=torch.float32, device=logits.device)
+
+    if k is not None:
+        k = k.type(torch.int32)
+    else:
+        k = torch.ones((logits.shape[0],), dtype=torch.int32, device=logits.device) * logits.shape[1]
+
     if get_ascend_config().enable_reduce_sample:
         tp_group = get_tp_group()
         B, V_local = logits.shape
@@ -257,16 +257,13 @@ def _apply_top_k_top_p_ascendc(
 
         local_vals, local_idx = torch.topk(logits, k=k_for_topk, dim=-1)
         local_global_idx = local_idx + rank * V_local
-        gathered_vals = tp_group.all_gather(local_vals, dim=-1)
-        gathered_idx = tp_group.all_gather(local_global_idx, dim=-1)
+        gathered_vals = tp_group.all_gather(local_vals, dim=-1)  # [B, top_k*tp]
+        gathered_idx = tp_group.all_gather(local_global_idx, dim=-1)  # [B, top_k*tp]
 
-        if not (p is None and k is None):
-            gathered_vals = torch.ops._C_ascend.npu_apply_top_k_top_p(gathered_vals, k=k, p=p)
+        gathered_vals = torch_npu.npu_top_k_top_p_sample(gathered_vals, k, p, is_need_logits=True)[1]
         return gathered_vals, gathered_idx
-
-    if p is None and k is None:
-        return logits
-    return torch.ops._C_ascend.npu_apply_top_k_top_p(logits, k=k, p=p)
+    else:
+        return torch_npu.npu_top_k_top_p_sample(logits, k, p, is_need_logits=True)[1]
 
 
 apply_top_k_top_p = (


### PR DESCRIPTION
### What this PR does / why we need it?
This PR refactors the `AscendTopKTopPSampler` to use the native `torch_npu.npu_top_k_top_p_sample` operator instead of custom C++ ops. It introduces a helper function `generate_random_sequence` to asynchronously generate exponential random variables for sampling. Additionally, the PR updates `_apply_top_k_top_p_ascendc` to leverage the new NPU sampling operator.

Feedback:
- In `generate_random_sequence`, use `torch.npu.current_stream()` instead of `torch.npu.default_stream()` to wait for the stream, preventing potential race conditions in multi-stream environments.
- In `_apply_top_k_top_p_ascendc`, ensure that `p` and `k` are explicitly moved to the same device as `logits` to avoid device mismatch runtime errors.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New unit tests have been added in `tests/ut/sample/test_sampler.py` covering various sampling configurations and helper functions.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
