### PR TITLE
[Performance][SpecDecode] Enable vocab-parallel local argmax for Qwen3 MTP draft sampling

### DIFF
--- a/tests/ut/patch/worker/patch_common/test_patch_qwen3_mtp_local_argmax.py
+++ b/tests/ut/patch/worker/patch_common/test_patch_qwen3_mtp_local_argmax.py
@@ -1,0 +1,115 @@
+"""Tests for patch_qwen3_mtp_local_argmax.py
+
+Verifies that Qwen3_5MTP and Qwen3NextMTP get the get_top_tokens method
+patched onto them.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def _apply_patches():
+    """Apply ascend_vllm patches before each test."""
+    import vllm_ascend.patch.worker.patch_qwen3_mtp_local_argmax  # noqa: F401
+
+
+class TestQwen3MTPGetTopTokens:
+    def _make_mock_mtp(self, model_cls):
+        """Create a minimal mock MTP instance with required attrs."""
+        instance = MagicMock(spec=model_cls)
+        instance.logits_processor = MagicMock()
+        instance.lm_head = MagicMock()
+        return instance
+
+    def test_qwen3_5_mtp_has_get_top_tokens(self):
+        from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+        assert hasattr(Qwen3_5MTP, "get_top_tokens"), "Qwen3_5MTP should have get_top_tokens after patching"
+        assert callable(Qwen3_5MTP.get_top_tokens)
+
+    def test_qwen3_next_mtp_has_get_top_tokens(self):
+        from vllm.model_executor.models.qwen3_next_mtp import Qwen3NextMTP
+
+        assert hasattr(Qwen3NextMTP, "get_top_tokens"), "Qwen3NextMTP should have get_top_tokens after patching"
+        assert callable(Qwen3NextMTP.get_top_tokens)
+
+    def test_get_top_tokens_calls_logits_processor(self):
+        from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+        instance = self._make_mock_mtp(Qwen3_5MTP)
+        hidden_states = torch.randn(4, 128)
+
+        expected = torch.tensor([1, 2, 3, 4])
+        instance.logits_processor.get_top_tokens.return_value = expected
+
+        result = Qwen3_5MTP.get_top_tokens(instance, hidden_states, spec_step_idx=0)
+
+        instance.logits_processor.get_top_tokens.assert_called_once_with(instance.lm_head, hidden_states)
+        assert torch.equal(result, expected)
+
+    def test_get_top_tokens_ignores_spec_step_idx(self):
+        """The spec_step_idx parameter should be accepted but ignored."""
+        from vllm.model_executor.models.qwen3_next_mtp import Qwen3NextMTP
+
+        instance = self._make_mock_mtp(Qwen3NextMTP)
+        hidden_states = torch.randn(2, 64)
+        instance.logits_processor.get_top_tokens.return_value = torch.tensor([0, 1])
+
+        # Should not raise regardless of spec_step_idx value
+        result = Qwen3NextMTP.get_top_tokens(instance, hidden_states, spec_step_idx=999)
+        assert result is not None
+
+    def test_patch_is_idempotent(self):
+        """Applying the patch a second time should not cause issues."""
+        import importlib
+
+        import vllm_ascend.patch.worker.patch_qwen3_mtp_local_argmax as mod1
+
+        importlib.reload(mod1)
+
+        from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+        assert hasattr(Qwen3_5MTP, "get_top_tokens")
+
+    def test_get_top_tokens_on_next_mtp_returns_correct_values(self):
+        """Verify get_top_tokens on Qwen3NextMTP returns correct token ids."""
+        from vllm.model_executor.models.qwen3_next_mtp import Qwen3NextMTP
+
+        instance = self._make_mock_mtp(Qwen3NextMTP)
+        hidden_states = torch.randn(3, 128)
+        expected = torch.tensor([5, 10, 15])
+        instance.logits_processor.get_top_tokens.return_value = expected
+
+        result = Qwen3NextMTP.get_top_tokens(instance, hidden_states)
+
+        instance.logits_processor.get_top_tokens.assert_called_once_with(instance.lm_head, hidden_states)
+        assert torch.equal(result, expected)
+
+    def test_get_top_tokens_handles_single_token(self):
+        """Verify get_top_tokens works with a single token batch."""
+        from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+        instance = self._make_mock_mtp(Qwen3_5MTP)
+        hidden_states = torch.randn(1, 128)
+        expected = torch.tensor([42])
+        instance.logits_processor.get_top_tokens.return_value = expected
+
+        result = Qwen3_5MTP.get_top_tokens(instance, hidden_states, spec_step_idx=0)
+
+        assert torch.equal(result, expected)
+
+    def test_get_top_tokens_handles_empty_batch(self):
+        """Verify get_top_tokens handles zero-length batch gracefully."""
+        from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+        instance = self._make_mock_mtp(Qwen3_5MTP)
+        hidden_states = torch.randn(0, 128)
+        expected = torch.tensor([], dtype=torch.long)
+        instance.logits_processor.get_top_tokens.return_value = expected
+
+        result = Qwen3_5MTP.get_top_tokens(instance, hidden_states, spec_step_idx=0)
+
+        assert result.numel() == 0

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -2539,11 +2539,8 @@ class TestRunMergedDraft(TestBase):
         forward_context.attn_metadata = None
         multi_steps_attn_metadata = [MagicMock(), MagicMock(), MagicMock()]
 
-        mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_reduce_sample = True
         with (
             patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=False),
-            patch.object(llm_base_proposer, "get_ascend_config", return_value=mock_ascend_config),
             patch.object(llm_base_proposer, "get_forward_context", return_value=forward_context),
         ):
             draft_token_ids = self.proposer._run_merged_draft(
@@ -2605,11 +2602,8 @@ class TestRunMergedDraft(TestBase):
             }
         )
 
-        mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_reduce_sample = False
         with (
             patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=False),
-            patch.object(llm_base_proposer, "get_ascend_config", return_value=mock_ascend_config),
         ):
             draft_token_ids = self.proposer._run_merged_draft(
                 num_input_tokens=12,
@@ -2660,11 +2654,8 @@ class TestRunMergedDraft(TestBase):
         forward_context.attn_metadata = None
         multi_steps_attn_metadata = [MagicMock(), MagicMock(), MagicMock()]
 
-        mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_reduce_sample = False
         with (
             patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=True),
-            patch.object(llm_base_proposer, "get_ascend_config", return_value=mock_ascend_config),
             patch.object(llm_base_proposer, "get_forward_context", return_value=forward_context),
         ):
             draft_token_ids = self.proposer._run_merged_draft(
@@ -2719,8 +2710,6 @@ class TestRunMergedDraft(TestBase):
             (1, False, torch.tensor([1, 3], dtype=torch.int64), (2, 1)),
             (2, True, torch.tensor([0, 1, 2, 3], dtype=torch.int64), (2, 2)),
         ]
-        mock_ascend_config = MagicMock()
-        mock_ascend_config.enable_reduce_sample = False
         for num_speculative_tokens, parallel_drafting, token_indices_to_sample, expected_shape in test_cases:
             with self.subTest(num_speculative_tokens=num_speculative_tokens, parallel_drafting=parallel_drafting):
                 self.proposer.method = "eagle3"
@@ -2733,7 +2722,6 @@ class TestRunMergedDraft(TestBase):
 
                 with (
                     patch.object(llm_base_proposer, "lmhead_tp_enable", return_value=False),
-                    patch.object(llm_base_proposer, "get_ascend_config", return_value=mock_ascend_config),
                 ):
                     draft_token_ids = self.proposer._run_merged_draft(
                         num_input_tokens=4,

--- a/tests/ut/spec_decode/test_base_proposer.py
+++ b/tests/ut/spec_decode/test_base_proposer.py
@@ -1,0 +1,586 @@
+# ruff: noqa: E501
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.spec_decode.eagle_proposer import AscendSpecDecodeBaseProposer
+
+_LMHEAD_TARGET = "vllm_ascend.spec_decode.llm_base_proposer.lmhead_tp_enable"
+_EXTRA_CTX_TARGET = "vllm_ascend.spec_decode.llm_base_proposer._EXTRA_CTX"
+_FORWARD_CTX_TARGET = "vllm_ascend.spec_decode.llm_base_proposer.get_forward_context"
+_PCP_GROUP_TARGET = "vllm_ascend.spec_decode.llm_base_proposer.get_pcp_group"
+
+
+def _make_proposer_mock(**attrs):
+    """Create a MagicMock with the right spec and extra attributes for testing."""
+    mock = MagicMock(spec=AscendSpecDecodeBaseProposer)
+    for k, v in attrs.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class TestBaseProposerUsesDraftVocabRemapping:
+    def test_no_remapping_returns_false(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(model=MagicMock(spec=object))
+        del instance.model.draft_id_to_target_id
+
+        result = AscendSpecDecodeBaseProposer._uses_draft_vocab_remapping(instance)
+        assert result is False
+
+    def test_remapping_none_returns_false(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(model=MagicMock(draft_id_to_target_id=None))
+
+        result = AscendSpecDecodeBaseProposer._uses_draft_vocab_remapping(instance)
+        assert result is False
+
+    def test_remapping_exists_returns_true(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(model=MagicMock(draft_id_to_target_id={0: 0, 1: 1}))
+
+        result = AscendSpecDecodeBaseProposer._uses_draft_vocab_remapping(instance)
+        assert result is True
+
+
+class TestBaseProposerCanUseLocalArgmaxReduction:
+    def test_all_conditions_met(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(
+            use_local_argmax_reduction=True,
+        )
+        instance._uses_draft_vocab_remapping.return_value = False
+
+        with patch(_LMHEAD_TARGET, return_value=False):
+            result = AscendSpecDecodeBaseProposer._can_use_local_argmax_reduction(instance)
+            assert result is True
+
+    def test_lmhead_tp_disables(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(
+            use_local_argmax_reduction=True,
+        )
+
+        with patch(_LMHEAD_TARGET, return_value=True):
+            result = AscendSpecDecodeBaseProposer._can_use_local_argmax_reduction(instance)
+            assert result is False
+
+    def test_disabled_by_config(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(
+            use_local_argmax_reduction=False,
+        )
+
+        with patch(_LMHEAD_TARGET, return_value=False):
+            result = AscendSpecDecodeBaseProposer._can_use_local_argmax_reduction(instance)
+            assert result is False
+
+    def test_vocab_remapping_disables(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(
+            use_local_argmax_reduction=True,
+        )
+        instance._uses_draft_vocab_remapping.return_value = True
+
+        with patch(_LMHEAD_TARGET, return_value=False):
+            result = AscendSpecDecodeBaseProposer._can_use_local_argmax_reduction(instance)
+            assert result is False
+
+
+class TestBaseProposerDraftArgmax:
+    def test_local_argmax_when_applicable(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        expected = torch.tensor([1, 2, 3])
+        instance = _make_proposer_mock(
+            model=MagicMock(get_top_tokens=MagicMock(return_value=expected)),
+        )
+        instance._can_use_local_argmax_reduction.return_value = True
+
+        hidden_states = torch.randn(3, 64)
+        result = AscendSpecDecodeBaseProposer._draft_argmax(instance, hidden_states, num_indices=3)
+
+        instance.model.get_top_tokens.assert_called_once_with(hidden_states)
+        assert torch.equal(result, expected)
+
+    def test_fallback_to_compute_logits(self):
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        logits = torch.randn(3, 100)
+        instance = _make_proposer_mock(
+            model=MagicMock(compute_logits=MagicMock(return_value=logits)),
+        )
+        instance._can_use_local_argmax_reduction.return_value = False
+
+        hidden_states = torch.randn(3, 64)
+        with patch(_LMHEAD_TARGET, return_value=False):
+            result = AscendSpecDecodeBaseProposer._draft_argmax(instance, hidden_states, num_indices=3)
+
+        instance.model.compute_logits.assert_called_once_with(hidden_states)
+        assert result.shape == (3,)
+
+    def test_fallback_with_lmhead_tp_truncates_logits(self):
+        """When lmhead_tp_enable and num_indices < logits.shape[0], logits are truncated."""
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        logits = torch.randn(5, 100)
+        instance = _make_proposer_mock(
+            model=MagicMock(compute_logits=MagicMock(return_value=logits)),
+        )
+        instance._can_use_local_argmax_reduction.return_value = False
+
+        hidden_states = torch.randn(5, 64)
+        with patch(_LMHEAD_TARGET, return_value=True):
+            result = AscendSpecDecodeBaseProposer._draft_argmax(instance, hidden_states, num_indices=3)
+
+        instance.model.compute_logits.assert_called_once_with(hidden_states)
+        assert result.shape == (3,)
+
+    def test_fallback_with_lmhead_tp_no_truncate(self):
+        """When lmhead_tp_enable but num_indices >= logits.shape[0], no truncation."""
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        logits = torch.randn(3, 100)
+        instance = _make_proposer_mock(
+            model=MagicMock(compute_logits=MagicMock(return_value=logits)),
+        )
+        instance._can_use_local_argmax_reduction.return_value = False
+
+        hidden_states = torch.randn(3, 64)
+        with patch(_LMHEAD_TARGET, return_value=True):
+            result = AscendSpecDecodeBaseProposer._draft_argmax(instance, hidden_states, num_indices=3)
+
+        instance.model.compute_logits.assert_called_once_with(hidden_states)
+        assert result.shape == (3,)
+
+    def test_local_argmax_raises_when_model_lacks_get_top_tokens(self):
+        """When local argmax is enabled but model has no get_top_tokens, raise ValueError."""
+        from vllm_ascend.spec_decode.eagle_proposer import (
+            AscendSpecDecodeBaseProposer,
+        )
+
+        instance = _make_proposer_mock(
+            model=MagicMock(spec=object),
+        )
+        # Remove get_top_tokens from the model mock
+        del instance.model.get_top_tokens
+        instance._can_use_local_argmax_reduction.return_value = True
+
+        hidden_states = torch.randn(3, 64)
+        with pytest.raises(ValueError, match="does not implement get_top_tokens"):
+            AscendSpecDecodeBaseProposer._draft_argmax(instance, hidden_states, num_indices=3)
+
+
+class TestBaseProposerMergeDraft(TestBase):
+    def _make_instance(self, **overrides):
+        """Create a minimal mock instance for _run_merged_draft testing."""
+        attrs = dict(
+            input_ids=torch.arange(256, device="cpu"),
+            hidden_states=torch.randn(256, 64),
+            model=MagicMock(),
+            method="mtp",
+            pass_hidden_states_to_model=False,
+            num_speculative_tokens=1,
+            parallel_drafting=False,
+            pcp_size=1,
+            dcp_size=1,
+            use_cuda_graph=False,
+            uses_mrope=False,
+            device="cpu",
+            supports_mm_inputs=False,
+            _draft_attn_layer_names=[],
+            vllm_config=MagicMock(
+                model_config=MagicMock(max_model_len=1024),
+            ),
+        )
+        attrs.update(overrides)
+
+        instance = _make_proposer_mock(**attrs)
+
+        instance.model_returns_tuple = MagicMock(return_value=False)
+        instance._get_positions = MagicMock(return_value=torch.arange(10))
+        instance._draft_argmax = MagicMock(return_value=torch.tensor([0, 1, 2]))
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(10, 64),
+                torch.arange(10),
+                torch.randn(10, 64),
+            )
+        )
+        instance.maybe_pad_and_reduce = MagicMock(
+            return_value=(
+                torch.randn(10, 64),
+                torch.arange(10),
+            )
+        )
+        instance._set_positions = MagicMock()
+        return instance
+
+    def _call_run_merged_draft(self, instance, token_indices=None, **kwargs):
+        """Call _run_merged_draft with patched lmhead_tp_enable and standard args."""
+        if token_indices is None:
+            token_indices = torch.tensor([0, 1, 2])
+
+        defaults = dict(
+            num_input_tokens=5,
+            batch_size=3,
+            token_indices_to_sample=token_indices,
+            target_positions=None,
+            inputs_embeds=None,
+            multi_steps_attn_metadata=None,
+            num_tokens=5,
+        )
+        defaults.update(kwargs)
+
+        with patch(_LMHEAD_TARGET, return_value=False), patch(_EXTRA_CTX_TARGET, MagicMock()):
+            return AscendSpecDecodeBaseProposer._run_merged_draft(instance, **defaults)
+
+    def test_early_exit_single_token(self):
+        instance = self._make_instance(num_speculative_tokens=1)
+        result = self._call_run_merged_draft(instance)
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_parallel_drafting_early_exit(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            parallel_drafting=True,
+        )
+        result = self._call_run_merged_draft(instance)
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (1, 3)
+
+    def test_lmhead_tp_path(self):
+        instance = self._make_instance(
+            num_speculative_tokens=1,
+            vllm_config=MagicMock(scheduler_config=MagicMock(max_num_seqs=32)),
+            runner=MagicMock(uniform_decode_query_len=4),
+        )
+
+        token_indices = torch.tensor([0, 1, 2])
+        with patch(_LMHEAD_TARGET, return_value=True):
+            result = AscendSpecDecodeBaseProposer._run_merged_draft(
+                instance,
+                num_input_tokens=5,
+                batch_size=3,
+                token_indices_to_sample=token_indices,
+                target_positions=None,
+                inputs_embeds=None,
+                multi_steps_attn_metadata=None,
+                num_tokens=5,
+            )
+
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_dflash_method(self):
+        instance = self._make_instance(
+            method="dflash",
+            num_speculative_tokens=1,
+        )
+        instance.build_model_inputs_first_pass = MagicMock(
+            return_value={
+                "input_ids": instance.input_ids[:5],
+            }
+        )
+
+        result = self._call_run_merged_draft(instance)
+        instance.build_model_inputs_first_pass.assert_called_once_with(5)
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_pass_hidden_states_to_model(self):
+        instance = self._make_instance(
+            num_speculative_tokens=1,
+            pass_hidden_states_to_model=True,
+        )
+        result = self._call_run_merged_draft(instance)
+        instance.maybe_pad_and_reduce.assert_called()
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_model_returns_tuple(self):
+        last_hs = torch.randn(5, 64)
+        hs = torch.randn(5, 64)
+        instance = self._make_instance(num_speculative_tokens=1)
+        instance.model_returns_tuple = MagicMock(return_value=True)
+        instance.model.return_value = (last_hs, hs)
+
+        result = self._call_run_merged_draft(instance)
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_multi_step_generation(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            arange=torch.arange(5),
+            positions=torch.arange(5),
+        )
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(3, 64),
+                torch.arange(3),
+                torch.randn(3, 64),
+            )
+        )
+        instance._draft_argmax = MagicMock(return_value=torch.tensor([0, 1, 2]))
+
+        with patch(_FORWARD_CTX_TARGET, return_value=MagicMock()):
+            result = self._call_run_merged_draft(instance)
+
+        assert instance._draft_argmax.call_count == 3
+        assert result.shape == (3, 3)
+
+    def test_multi_step_with_lmhead_tp(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            method="mtp",
+            arange=torch.arange(128),
+            positions=torch.arange(128),
+            vllm_config=MagicMock(
+                scheduler_config=MagicMock(max_num_seqs=32),
+                model_config=MagicMock(max_model_len=1024),
+            ),
+            runner=MagicMock(uniform_decode_query_len=4),
+        )
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(128, 64),
+                torch.arange(128),
+                torch.randn(128, 64),
+            )
+        )
+        instance._draft_argmax = MagicMock(return_value=torch.arange(3))
+
+        token_indices = torch.tensor([0, 1, 2])
+        with (
+            patch(_LMHEAD_TARGET, return_value=True),
+            patch(_EXTRA_CTX_TARGET, MagicMock()),
+            patch(_FORWARD_CTX_TARGET, return_value=MagicMock()),
+        ):
+            result = AscendSpecDecodeBaseProposer._run_merged_draft(
+                instance,
+                num_input_tokens=5,
+                batch_size=3,
+                token_indices_to_sample=token_indices,
+                target_positions=None,
+                inputs_embeds=None,
+                multi_steps_attn_metadata=None,
+                num_tokens=5,
+            )
+
+        assert instance._draft_argmax.call_count == 3
+        assert result.shape == (3, 3)
+
+    def test_supports_mm_inputs(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            supports_mm_inputs=True,
+            arange=torch.arange(5),
+            positions=torch.arange(5),
+            inputs_embeds=torch.randn(10, 64),
+        )
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(3, 64),
+                torch.arange(3),
+                torch.randn(3, 64),
+            )
+        )
+        instance.model.embed_input_ids = MagicMock(return_value=torch.randn(3, 64))
+        instance._draft_argmax = MagicMock(return_value=torch.tensor([0, 1, 2]))
+
+        with patch(_FORWARD_CTX_TARGET, return_value=MagicMock()):
+            result = self._call_run_merged_draft(instance)
+
+        instance.model.embed_input_ids.assert_called()
+        assert result.shape == (3, 3)
+
+    def test_uses_mrope_path(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            uses_mrope=True,
+            mrope_positions=torch.arange(30).view(3, 10),
+            arange=torch.arange(5),
+            positions=torch.arange(5),
+        )
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(3, 64),
+                torch.arange(3),
+                torch.randn(3, 64),
+            )
+        )
+        instance._draft_argmax = MagicMock(return_value=torch.tensor([0, 1, 2]))
+
+        with patch(_FORWARD_CTX_TARGET, return_value=MagicMock()):
+            result = self._call_run_merged_draft(instance)
+
+        assert instance._draft_argmax.call_count == 3
+        assert result.shape == (3, 3)
+
+    def test_multi_step_with_pass_hidden_states(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            pass_hidden_states_to_model=True,
+            arange=torch.arange(5),
+            positions=torch.arange(5),
+        )
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(3, 64),
+                torch.arange(3),
+                torch.randn(3, 64),
+            )
+        )
+        instance._draft_argmax = MagicMock(return_value=torch.tensor([0, 1, 2]))
+
+        with patch(_FORWARD_CTX_TARGET, return_value=MagicMock()):
+            result = self._call_run_merged_draft(instance)
+
+        assert instance._draft_argmax.call_count == 3
+        assert result.shape == (3, 3)
+
+    def test_multi_step_model_returns_tuple(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            arange=torch.arange(5),
+            positions=torch.arange(5),
+        )
+        instance.model_returns_tuple = MagicMock(return_value=True)
+        instance.model.return_value = (torch.randn(5, 64), torch.randn(5, 64))
+        instance.maybe_all_gather_and_unpad = MagicMock(
+            return_value=(
+                torch.randn(3, 64),
+                torch.arange(3),
+                torch.randn(3, 64),
+            )
+        )
+        instance._draft_argmax = MagicMock(return_value=torch.tensor([0, 1, 2]))
+
+        with patch(_FORWARD_CTX_TARGET, return_value=MagicMock()):
+            result = self._call_run_merged_draft(instance)
+
+        assert instance._draft_argmax.call_count == 3
+        assert result.shape == (3, 3)
+
+    def test_pcp_size_gt_one_path(self):
+        instance = self._make_instance(
+            num_speculative_tokens=1,
+            pcp_size=2,
+            runner=MagicMock(
+                pcp_manager=MagicMock(
+                    pcp_allgather_restore_idx=MagicMock(gpu=torch.arange(20)),
+                ),
+            ),
+        )
+        mock_pcp_group = MagicMock()
+        mock_pcp_group.all_gather.return_value = torch.randn(20, 64)
+
+        token_indices = torch.tensor([0, 1, 2])
+        with patch(_LMHEAD_TARGET, return_value=False), patch(_PCP_GROUP_TARGET, return_value=mock_pcp_group):
+            result = AscendSpecDecodeBaseProposer._run_merged_draft(
+                instance,
+                num_input_tokens=5,
+                batch_size=3,
+                token_indices_to_sample=token_indices,
+                target_positions=None,
+                inputs_embeds=None,
+                multi_steps_attn_metadata=None,
+                num_tokens=5,
+            )
+
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_pcp_size_gt_one_eagle_path(self):
+        instance = self._make_instance(
+            num_speculative_tokens=1,
+            pcp_size=2,
+            method="eagle",
+            runner=MagicMock(
+                pcp_manager=MagicMock(
+                    pcp_allgather_restore_idx=MagicMock(gpu=torch.arange(20)),
+                ),
+            ),
+        )
+        mock_pcp_group = MagicMock()
+        mock_pcp_group.all_gather.return_value = torch.randn(20, 64)
+
+        token_indices = torch.tensor([0, 1, 2])
+        with patch(_LMHEAD_TARGET, return_value=False), patch(_PCP_GROUP_TARGET, return_value=mock_pcp_group):
+            result = AscendSpecDecodeBaseProposer._run_merged_draft(
+                instance,
+                num_input_tokens=5,
+                batch_size=3,
+                token_indices_to_sample=token_indices,
+                target_positions=None,
+                inputs_embeds=None,
+                multi_steps_attn_metadata=None,
+                num_tokens=5,
+            )
+
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 1)
+
+    def test_pcp_and_dcp_gt_one_prefill_path(self):
+        instance = self._make_instance(
+            num_speculative_tokens=3,
+            pcp_size=1,
+            dcp_size=4,
+            parallel_drafting=False,
+        )
+        instance._draft_argmax.return_value = torch.tensor([0, 1, 2])
+
+        token_indices = torch.tensor([0, 1, 2])
+        with patch(_LMHEAD_TARGET, return_value=False):
+            result = AscendSpecDecodeBaseProposer._run_merged_draft(
+                instance,
+                num_input_tokens=5,
+                batch_size=3,
+                token_indices_to_sample=token_indices,
+                target_positions=None,
+                inputs_embeds=None,
+                multi_steps_attn_metadata=None,
+                num_tokens=5,
+                is_prefill=True,
+            )
+
+        instance._draft_argmax.assert_called_once()
+        assert result.shape == (3, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -41,6 +41,7 @@ if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_gdn_attn  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
+    import vllm_ascend.patch.worker.patch_qwen3_mtp_local_argmax  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_mtp_local_argmax.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_mtp_local_argmax.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Enable vocab-parallel local argmax for Qwen3 MTP draft sampling."""
+
+import torch
+from torch import nn
+from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+from vllm.model_executor.models.qwen3_next_mtp import Qwen3NextMTP
+
+
+def _qwen_mtp_get_top_tokens(
+    self: nn.Module,
+    hidden_states: torch.Tensor,
+    spec_step_idx: int = 0,
+) -> torch.Tensor:
+    del spec_step_idx
+    return self.logits_processor.get_top_tokens(self.lm_head, hidden_states)
+
+
+if not hasattr(Qwen3_5MTP, "get_top_tokens"):
+    Qwen3_5MTP.get_top_tokens = _qwen_mtp_get_top_tokens
+
+if not hasattr(Qwen3NextMTP, "get_top_tokens"):
+    Qwen3NextMTP.get_top_tokens = _qwen_mtp_get_top_tokens

--- a/vllm_ascend/patch/worker/patch_qwen3_mtp_local_argmax.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_mtp_local_argmax.py
@@ -18,8 +18,16 @@
 
 import torch
 from torch import nn
-from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
-from vllm.model_executor.models.qwen3_next_mtp import Qwen3NextMTP
+
+try:
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+except ImportError:
+    Qwen3_5MTP = None
+
+try:
+    from vllm.model_executor.models.qwen3_next_mtp import Qwen3NextMTP
+except ImportError:
+    Qwen3NextMTP = None
 
 
 def _qwen_mtp_get_top_tokens(
@@ -31,8 +39,8 @@ def _qwen_mtp_get_top_tokens(
     return self.logits_processor.get_top_tokens(self.lm_head, hidden_states)
 
 
-if not hasattr(Qwen3_5MTP, "get_top_tokens"):
+if Qwen3_5MTP is not None and not hasattr(Qwen3_5MTP, "get_top_tokens"):
     Qwen3_5MTP.get_top_tokens = _qwen_mtp_get_top_tokens
 
-if not hasattr(Qwen3NextMTP, "get_top_tokens"):
+if Qwen3NextMTP is not None and not hasattr(Qwen3NextMTP, "get_top_tokens"):
     Qwen3NextMTP.get_top_tokens = _qwen_mtp_get_top_tokens

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -207,6 +207,38 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.enable_enpu = self.runner.enable_enpu
         self.use_eagle = self.runner.use_eagle
 
+    def _uses_draft_vocab_remapping(self) -> bool:
+        return hasattr(self.model, "draft_id_to_target_id") and self.model.draft_id_to_target_id is not None
+
+    def _can_use_local_argmax_reduction(self) -> bool:
+        return self.use_local_argmax_reduction and not lmhead_tp_enable() and not self._uses_draft_vocab_remapping()
+
+    def _draft_argmax(
+        self,
+        hidden_states: torch.Tensor,
+        num_indices: int,
+        token_indices_to_sample: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if self._can_use_local_argmax_reduction():
+            if not hasattr(self.model, "get_top_tokens"):
+                raise ValueError(
+                    "use_local_argmax_reduction is enabled but draft model "
+                    f"{self.model.__class__.__name__} does not implement "
+                    "get_top_tokens()."
+                )
+            return self.model.get_top_tokens(hidden_states), token_indices_to_sample
+
+        logits = self.model.compute_logits(hidden_states)
+        if lmhead_tp_enable():
+            logits = get_lmhead_tp_group().all_to_all(logits)
+        else:
+            logits = self.model.model.logits_processor._gather_logits(logits)
+        if lmhead_tp_enable() and num_indices < logits.shape[0]:
+            logits = logits[:num_indices]
+            if token_indices_to_sample is not None:
+                token_indices_to_sample = token_indices_to_sample[:num_indices]
+        return logits.argmax(dim=-1), token_indices_to_sample
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -425,8 +457,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     def _freeze_draft_step_attn_metadata(self, attn_metadata):
         decode_metadata = getattr(attn_metadata, "decode", None)
         if decode_metadata is not None:
-            if decode_metadata.sas_metadata is not None:
-                decode_metadata.sas_metadata = decode_metadata.sas_metadata.clone()
+            sas_metadata = getattr(decode_metadata, "sas_metadata", None)
+            if sas_metadata is not None:
+                decode_metadata.sas_metadata = sas_metadata.clone()
         return attn_metadata
 
     @torch.inference_mode()
@@ -1023,15 +1056,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         draft_token_ids = draft_token_ids[:num_indices]
                         token_indices_to_sample = token_indices_to_sample[:num_indices]
                 else:
-                    logits = self.model.compute_logits(sample_hidden_states)
-                    if lmhead_tp_enable():
-                        logits = get_lmhead_tp_group().all_to_all(logits)
-                    else:
-                        logits = self.model.model.logits_processor._gather_logits(logits)
-                    if lmhead_tp_enable() and num_indices < logits.shape[0]:
-                        logits = logits[:num_indices]
-                        token_indices_to_sample = token_indices_to_sample[:num_indices]
-                    draft_token_ids = logits.argmax(dim=-1)
+                    draft_token_ids, token_indices_to_sample = self._draft_argmax(
+                        sample_hidden_states, num_indices, token_indices_to_sample
+                    )
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable() and num_indices < logits.shape[0]:
@@ -1176,15 +1203,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                             draft_token_ids = draft_token_ids[:num_indices]
                             token_indices_to_sample = token_indices_to_sample[:num_indices]
                     else:
-                        logits = self.model.compute_logits(sample_hidden_states)
-                        if lmhead_tp_enable():
-                            logits = get_lmhead_tp_group().all_to_all(logits)
-                        else:
-                            logits = self.model.model.logits_processor._gather_logits(logits)
-                        if lmhead_tp_enable() and num_indices < logits.shape[0]:
-                            logits = logits[:num_indices]
-                            token_indices_to_sample = token_indices_to_sample[:num_indices]
-                        draft_token_ids = logits.argmax(dim=-1)
+                        draft_token_ids, token_indices_to_sample = self._draft_argmax(
+                            sample_hidden_states, num_indices, token_indices_to_sample
+                        )
                 else:
                     logits = self.model.compute_logits(sample_hidden_states)
                     if lmhead_tp_enable() and num_indices < logits.shape[0]:
@@ -1545,10 +1566,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 block_size = 128
 
             # Compute the slot mapping.
-            if self.uses_mrope:
-                block_numbers = clamped_positions[0] // block_size
-            else:
-                block_numbers = clamped_positions // block_size
+            block_numbers = clamped_positions[0] // block_size if self.uses_mrope else clamped_positions // block_size
             block_ids = old_common_metadata.block_table_tensor.gather(dim=1, index=block_numbers.view(-1, 1))
             block_ids = block_ids.view(-1)
             if self.uses_mrope:


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request enables vocab-parallel local argmax for Qwen3 MTP draft sampling. It introduces a patch for `Qwen3_5MTP` and `Qwen3NextMTP` to add the `get_top_tokens` method, and refactors `AscendSpecDecodeBaseProposer` to utilize `_draft_argmax` and related helper methods instead of relying on the old `enable_reduce_sample` configuration. Additionally, comprehensive unit tests have been added to verify these changes.

Feedback:
- In `llm_base_proposer.py`, directly accessing `decode_metadata.sas_metadata` can raise an `AttributeError` if the attention metadata class does not define it. Using `getattr` is recommended for safety.
- In `patch_qwen3_mtp_local_argmax.py`, unconditional imports of `Qwen3_5MTP` and `Qwen3NextMTP` may crash engine startup if the installed vLLM version does not contain these models. These imports should be wrapped in `try-except` blocks.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested via newly added unit tests in `test_patch_qwen3_mtp_local_argmax.py` and `test_base_proposer.py`.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
