### PR TITLE
[Misc][310P] 310P Log Rectification

### DIFF
--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -80,7 +80,7 @@ class NPUModelRunner310(NPUModelRunner):
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
         self._acl_format = ACL_FORMAT_FRACTAL_NZ
-        logger.info_once("[310P] Weight layout uses FRACTAL_NZ.")
+        logger.info_once("Weight layout uses FRACTAL_NZ.")
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
             self.rejection_sampler = RejectionSampler(self.sampler)
@@ -88,7 +88,7 @@ class NPUModelRunner310(NPUModelRunner):
             # 310P ngram requires decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.
             self.cudagraph_dispatcher.uniform_decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
-            logger.info_once("[310P] Ngram speculative decoding uses uniform_decode_query_len=1 for graph capture.")
+            logger.info_once("Ngram speculative decoding uses uniform_decode_query_len=1 for graph capture.")
 
     def _update_states(self, scheduler_output: SchedulerOutput):
         deferred = super()._update_states(scheduler_output)
@@ -613,19 +613,19 @@ class NPUModelRunner310(NPUModelRunner):
         """
         # 310P limitation: KV transfer is not supported
         if self.vllm_config.kv_transfer_config is not None:
-            logger.error("[310P] KV cache transfer is not supported.")
+            logger.error("KV cache transfer is not supported.")
             raise ValueError("KV cache transfer is not supported for 310P.")
         if self.use_sparse:
-            logger.error("[310P] Deepseek Sparse Attention is not supported.")
+            logger.error("Deepseek Sparse Attention is not supported.")
             raise ValueError("Deepseek Sparse Attention is not supported for 310P.")
         if self.model_config.use_mla:
-            logger.error("[310P] MLAAttention is not supported.")
+            logger.error("MLAAttention is not supported.")
             raise ValueError("MLAAttention is not supported for 310P.")
         # Initialize the memory buffer for KV cache
         kv_caches = self._allocate_kv_cache_tensors(kv_cache_config)
         # Set up cross-layer KV cache sharing
         for layer_name, target_layer_name in self.shared_kv_cache_layers.items():
-            logger.debug("[310P] %s reuses KV cache of %s", layer_name, target_layer_name)
+            logger.debug("%s reuses KV cache of %s", layer_name, target_layer_name)
             kv_caches[layer_name] = kv_caches[target_layer_name]
 
         from vllm.v1.worker.utils import bind_kv_cache

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -80,6 +80,7 @@ class NPUModelRunner310(NPUModelRunner):
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
         self._acl_format = ACL_FORMAT_FRACTAL_NZ
+        logger.info_once("[310P] Weight layout uses FRACTAL_NZ.")
         self.sampler = AscendSampler310()
         if getattr(self, "rejection_sampler", None) is not None:
             self.rejection_sampler = RejectionSampler(self.sampler)
@@ -87,6 +88,7 @@ class NPUModelRunner310(NPUModelRunner):
             # 310P ngram requires decode-only graph shapes to be built with q_len=1.
             # Keep dispatcher's internal query_len in sync to avoid key-init assert.
             self.cudagraph_dispatcher.uniform_decode_query_len = _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN
+            logger.info_once("[310P] Ngram speculative decoding uses uniform_decode_query_len=1 for graph capture.")
 
     def _update_states(self, scheduler_output: SchedulerOutput):
         deferred = super()._update_states(scheduler_output)
@@ -611,16 +613,19 @@ class NPUModelRunner310(NPUModelRunner):
         """
         # 310P limitation: KV transfer is not supported
         if self.vllm_config.kv_transfer_config is not None:
+            logger.error("[310P] KV cache transfer is not supported.")
             raise ValueError("KV cache transfer is not supported for 310P.")
         if self.use_sparse:
+            logger.error("[310P] Deepseek Sparse Attention is not supported.")
             raise ValueError("Deepseek Sparse Attention is not supported for 310P.")
         if self.model_config.use_mla:
+            logger.error("[310P] MLAAttention is not supported.")
             raise ValueError("MLAAttention is not supported for 310P.")
         # Initialize the memory buffer for KV cache
         kv_caches = self._allocate_kv_cache_tensors(kv_cache_config)
         # Set up cross-layer KV cache sharing
         for layer_name, target_layer_name in self.shared_kv_cache_layers.items():
-            logger.debug("%s reuses KV cache of %s", layer_name, target_layer_name)
+            logger.debug("[310P] %s reuses KV cache of %s", layer_name, target_layer_name)
             kv_caches[layer_name] = kv_caches[target_layer_name]
 
         from vllm.v1.worker.utils import bind_kv_cache

--- a/vllm_ascend/_310p/quantization/modelslim_config.py
+++ b/vllm_ascend/_310p/quantization/modelslim_config.py
@@ -59,11 +59,11 @@ def create_scheme_for_layer(
     Returns:
         An instance of the appropriate quantization scheme class.
     """
-    logger.info_once("Using the vLLM Ascend modelslim Quantization now!")
+    logger.info_once("[310P] Using vLLM Ascend ModelSlim quantization.")
     quant_type = get_quant_type_for_layer(quant_description, prefix, layer_type, packed_modules_mapping)
 
     if quant_type is None:
-        err_msg = f"Could not determine quantization type for layer {prefix} (layer_type={layer_type})."
+        err_msg = f"[310P] Could not determine quantization type for layer {prefix} (layer_type={layer_type})."
         logger.error(err_msg)
         raise ValueError(err_msg)
 
@@ -72,7 +72,7 @@ def create_scheme_for_layer(
     if scheme_cls is not None:
         return scheme_cls()
 
-    err_msg = f"Currently, vLLM Ascend doesn't support quant_type={quant_type} for layer_type={layer_type}."
+    err_msg = f"[310P] Unsupported quant_type={quant_type} for layer_type={layer_type}."
     logger.error(err_msg)
     raise NotImplementedError(err_msg)
 
@@ -106,7 +106,7 @@ class AscendModelSlimConfig310(AscendModelSlimConfig):
             if self.is_layer_skipped_ascend(prefix, packed):
                 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 
-                logger.debug("Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
+                logger.debug("[310P] Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
                 return AscendUnquantizedLinearMethod()
 
             scheme = create_scheme_for_layer(
@@ -115,26 +115,26 @@ class AscendModelSlimConfig310(AscendModelSlimConfig):
                 layer_type="linear",
                 packed_modules_mapping=packed,
             )
-            logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
+            logger.debug("[310P] Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
             return AscendLinearMethod(scheme)
 
         elif isinstance(layer, FusedMoE):
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):
                 from vllm_ascend._310p.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod310
 
-                logger.debug("Select AscendUnquantizedFusedMoEMethod310 for %s (layer=%s)", prefix, "FusedMoE")
+                logger.debug("[310P] Select AscendUnquantizedFusedMoEMethod310 for %s (layer=%s)", prefix, "FusedMoE")
                 return AscendUnquantizedFusedMoEMethod310(layer.moe_config)
             scheme = create_scheme_for_layer(self.quant_description, prefix, "moe", self.packed_modules_mapping)
-            logger.debug("Select AscendFusedMoEMethod for %s (layer=%s)", prefix, "FusedMoE")
+            logger.debug("[310P] Select AscendFusedMoEMethod for %s (layer=%s)", prefix, "FusedMoE")
             return AscendFusedMoEMethod(scheme, layer.moe_config)
 
         elif isinstance(layer, VocabParallelEmbedding):
             from vllm_ascend._310p.ops.vocab_parallel_embedding import AscendUnquantizedEmbeddingMethod310
 
             logger.debug(
-                "Select AscendUnquantizedEmbeddingMethod310 for %s (layer=%s)", prefix, "VocabParallelEmbedding"
+                "[310P] Select AscendUnquantizedEmbeddingMethod310 for %s (layer=%s)", prefix, "VocabParallelEmbedding"
             )
             return AscendUnquantizedEmbeddingMethod310()
 
-        logger.debug("No quant method matched for %s, falling back to base", prefix)
+        logger.debug("[310P] No quant method matched for %s, falling back to base", prefix)
         return super().get_quant_method(layer, prefix)

--- a/vllm_ascend/_310p/quantization/modelslim_config.py
+++ b/vllm_ascend/_310p/quantization/modelslim_config.py
@@ -59,11 +59,11 @@ def create_scheme_for_layer(
     Returns:
         An instance of the appropriate quantization scheme class.
     """
-    logger.info_once("[310P] Using vLLM Ascend ModelSlim quantization.")
+    logger.info_once("Using vLLM Ascend ModelSlim quantization.")
     quant_type = get_quant_type_for_layer(quant_description, prefix, layer_type, packed_modules_mapping)
 
     if quant_type is None:
-        err_msg = f"[310P] Could not determine quantization type for layer {prefix} (layer_type={layer_type})."
+        err_msg = f"Could not determine quantization type for layer {prefix} (layer_type={layer_type})."
         logger.error(err_msg)
         raise ValueError(err_msg)
 
@@ -72,7 +72,7 @@ def create_scheme_for_layer(
     if scheme_cls is not None:
         return scheme_cls()
 
-    err_msg = f"[310P] Unsupported quant_type={quant_type} for layer_type={layer_type}."
+    err_msg = f"Unsupported quant_type={quant_type} for layer_type={layer_type}."
     logger.error(err_msg)
     raise NotImplementedError(err_msg)
 
@@ -106,7 +106,7 @@ class AscendModelSlimConfig310(AscendModelSlimConfig):
             if self.is_layer_skipped_ascend(prefix, packed):
                 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 
-                logger.debug("[310P] Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
+                logger.debug("Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
                 return AscendUnquantizedLinearMethod()
 
             scheme = create_scheme_for_layer(
@@ -115,26 +115,26 @@ class AscendModelSlimConfig310(AscendModelSlimConfig):
                 layer_type="linear",
                 packed_modules_mapping=packed,
             )
-            logger.debug("[310P] Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
+            logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
             return AscendLinearMethod(scheme)
 
         elif isinstance(layer, FusedMoE):
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):
                 from vllm_ascend._310p.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod310
 
-                logger.debug("[310P] Select AscendUnquantizedFusedMoEMethod310 for %s (layer=%s)", prefix, "FusedMoE")
+                logger.debug("Select AscendUnquantizedFusedMoEMethod310 for %s (layer=%s)", prefix, "FusedMoE")
                 return AscendUnquantizedFusedMoEMethod310(layer.moe_config)
             scheme = create_scheme_for_layer(self.quant_description, prefix, "moe", self.packed_modules_mapping)
-            logger.debug("[310P] Select AscendFusedMoEMethod for %s (layer=%s)", prefix, "FusedMoE")
+            logger.debug("Select AscendFusedMoEMethod for %s (layer=%s)", prefix, "FusedMoE")
             return AscendFusedMoEMethod(scheme, layer.moe_config)
 
         elif isinstance(layer, VocabParallelEmbedding):
             from vllm_ascend._310p.ops.vocab_parallel_embedding import AscendUnquantizedEmbeddingMethod310
 
             logger.debug(
-                "[310P] Select AscendUnquantizedEmbeddingMethod310 for %s (layer=%s)", prefix, "VocabParallelEmbedding"
+                "Select AscendUnquantizedEmbeddingMethod310 for %s (layer=%s)", prefix, "VocabParallelEmbedding"
             )
             return AscendUnquantizedEmbeddingMethod310()
 
-        logger.debug("[310P] No quant method matched for %s, falling back to base", prefix)
+        logger.debug("No quant method matched for %s, falling back to base", prefix)
         return super().get_quant_method(layer, prefix)

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -53,6 +53,7 @@ class NPUWorker310(NPUWorker):
         init_workspace_manager(self.device, num_ubatches=1)
 
         self.model_runner = NPUModelRunner310(self.vllm_config, self.device)
+        logger.info_once("[310P] Using NPUWorker310 and NPUModelRunner310.")
 
     def save_sharded_state(
         self,
@@ -130,7 +131,7 @@ class NPUWorker310(NPUWorker):
 
         logger.debug(profile_result)
         logger.info_once(
-            "Available KV cache memory: %.2f GiB",
+            "[310P] Available KV cache memory: %.2f GiB (halved for workspace)",
             GiB(self.available_kv_cache_memory_bytes),
             scope="local",
         )
@@ -138,7 +139,7 @@ class NPUWorker310(NPUWorker):
 
     def _warm_up_atb(self):
         # 310p device do not support torch_npu._npu_matmul_add_fp32 atb ops
-        logger.info("Skip warm-up atb ops for 310P device.")
+        logger.info_once("[310P] Skip ATB warm-up: torch_npu._npu_matmul_add_fp32 unsupported.")
 
     def _init_device(self):
         device = torch.device(f"npu:{self.local_rank}")
@@ -156,7 +157,7 @@ class NPUWorker310(NPUWorker):
         self.requested_memory = self.init_snapshot.total_memory * self.cache_config.gpu_memory_utilization
         if _is_rc_device():
             self.init_snapshot.free_memory = psutil.virtual_memory().available
-            logger.info("NPU device is working in Root Complex (RC) mode.")
+            logger.info_once("[310P] Root Complex (RC) mode: host and device memory are shared.")
         if self.init_snapshot.free_memory < self.requested_memory:
             GiB = lambda b: round(b / GiB_bytes, 2)
             raise ValueError(

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -53,7 +53,7 @@ class NPUWorker310(NPUWorker):
         init_workspace_manager(self.device, num_ubatches=1)
 
         self.model_runner = NPUModelRunner310(self.vllm_config, self.device)
-        logger.info_once("[310P] Using NPUWorker310 and NPUModelRunner310.")
+        logger.info_once("Using NPUWorker310 and NPUModelRunner310.")
 
     def save_sharded_state(
         self,
@@ -131,7 +131,7 @@ class NPUWorker310(NPUWorker):
 
         logger.debug(profile_result)
         logger.info_once(
-            "[310P] Available KV cache memory: %.2f GiB (halved for workspace)",
+            "Available KV cache memory: %.2f GiB (halved for workspace)",
             GiB(self.available_kv_cache_memory_bytes),
             scope="local",
         )
@@ -139,7 +139,7 @@ class NPUWorker310(NPUWorker):
 
     def _warm_up_atb(self):
         # 310p device do not support torch_npu._npu_matmul_add_fp32 atb ops
-        logger.info_once("[310P] Skip ATB warm-up.")
+        logger.info_once("Skip ATB warm-up.")
 
     def _init_device(self):
         device = torch.device(f"npu:{self.local_rank}")
@@ -157,7 +157,7 @@ class NPUWorker310(NPUWorker):
         self.requested_memory = self.init_snapshot.total_memory * self.cache_config.gpu_memory_utilization
         if _is_rc_device():
             self.init_snapshot.free_memory = psutil.virtual_memory().available
-            logger.info_once("[310P] Root Complex (RC) mode: host and device memory are shared.")
+            logger.info_once("Root Complex (RC) mode: host and device memory are shared.")
         if self.init_snapshot.free_memory < self.requested_memory:
             GiB = lambda b: round(b / GiB_bytes, 2)
             raise ValueError(

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -139,7 +139,7 @@ class NPUWorker310(NPUWorker):
 
     def _warm_up_atb(self):
         # 310p device do not support torch_npu._npu_matmul_add_fp32 atb ops
-        logger.info_once("Skip ATB warm-up.")
+        logger.info_once("Skip warm-up atb ops for 310P device.")
 
     def _init_device(self):
         device = torch.device(f"npu:{self.local_rank}")

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -139,7 +139,7 @@ class NPUWorker310(NPUWorker):
 
     def _warm_up_atb(self):
         # 310p device do not support torch_npu._npu_matmul_add_fp32 atb ops
-        logger.info_once("[310P] Skip ATB warm-up: torch_npu._npu_matmul_add_fp32 unsupported.")
+        logger.info_once("[310P] Skip ATB warm-up.")
 
     def _init_device(self):
         device = torch.device(f"npu:{self.local_rank}")


### PR DESCRIPTION
### What this PR does / why we need it?

Aligns logging in the _310p module with the mainline parent classes. All 310P-specific messages use a unified [310P] prefix so Ascend 310P paths are easy to spot in logs. Log text and levels only — no functional or behavioral changes.

Changes:

Worker: Add info_once logs for 310P Worker/Runner init, RC mode, KV cache (including workspace halving note), and ATB warm-up skip
ModelRunner: Add logs for FRACTAL_NZ layout and ngram graph capture; add error logs before unsupported-feature failures (KV transfer, Sparse Attention, MLA)
ModelSlim: Add [310P] prefix and tighten wording on quant info/error/debug logs
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
