### PR TITLE
[Quantization][BugFix] Fix lm_head prefix mapping for qwen3_5_moe MTP drafter

### DIFF
--- a/tests/ut/_310p/quantization/test_modelslim_config_310.py
+++ b/tests/ut/_310p/quantization/test_modelslim_config_310.py
@@ -79,9 +79,7 @@ class TestAscendModelSlimConfig310(TestBase):
                 "vllm_ascend._310p.quantization.modelslim_config.create_scheme_for_layer",
                 return_value=mock_scheme,
             ) as mock_create_scheme,
-            patch(
-                "vllm_ascend._310p.quantization.modelslim_config.AscendLinearMethod", return_value=MagicMock()
-            ),
+            patch("vllm_ascend._310p.quantization.modelslim_config.AscendLinearMethod", return_value=MagicMock()),
         ):
             config.get_quant_method(linear_layer, "lm_head")
 

--- a/tests/ut/_310p/quantization/test_modelslim_config_310.py
+++ b/tests/ut/_310p/quantization/test_modelslim_config_310.py
@@ -66,6 +66,32 @@ class TestAscendModelSlimConfig310(TestBase):
             self.assertIs(method, mock_ascend_linear.return_value)
             mock_ascend_linear.assert_called_once_with(mock_scheme)
 
+    def test_get_quant_method_maps_lm_head_prefix_310(self):
+        config = AscendModelSlimConfig310({"language_model.lm_head.weight": "INT8"})
+        linear_layer = MagicMock(spec=LinearBase)
+        mock_config = MagicMock()
+        mock_config.model_config.hf_config.model_type = "qwen3_5_moe"
+        mock_scheme = MagicMock()
+
+        with (
+            patch("vllm_ascend._310p.quantization.modelslim_config.get_current_vllm_config", return_value=mock_config),
+            patch(
+                "vllm_ascend._310p.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=mock_scheme,
+            ) as mock_create_scheme,
+            patch(
+                "vllm_ascend._310p.quantization.modelslim_config.AscendLinearMethod", return_value=MagicMock()
+            ),
+        ):
+            config.get_quant_method(linear_layer, "lm_head")
+
+        mock_create_scheme.assert_called_once_with(
+            quant_description=config.quant_description,
+            prefix="language_model.lm_head",
+            layer_type="linear",
+            packed_modules_mapping=config.packed_modules_mapping,
+        )
+
     def test_get_quant_method_for_fused_moe_310(self):
         fused_moe_layer = MagicMock(spec=FusedMoE)
         fused_moe_layer.moe = MagicMock(spec=FusedMoEConfig)

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -295,6 +295,27 @@ class TestApplyVllmMapper(TestBase):
         mock_mapper.apply_dict.assert_called_once_with({"old_key.weight": "INT8"})
 
 
+class TestQuantPrefixMapper(TestBase):
+    def test_lm_head_maps_to_language_model_lm_head_when_quant_key_exists(self):
+        config = AscendModelSlimConfig({"language_model.lm_head.weight": "FLOAT"})
+
+        prefix = config.quant_prefix_mapper("qwen3_5_moe", "lm_head")
+
+        self.assertEqual(prefix, "language_model.lm_head")
+
+    def test_lm_head_keeps_original_prefix_when_quant_key_exists(self):
+        config = AscendModelSlimConfig(
+            {
+                "lm_head.weight": "FLOAT",
+                "language_model.lm_head.weight": "FLOAT",
+            }
+        )
+
+        prefix = config.quant_prefix_mapper("qwen3_5_moe", "lm_head")
+
+        self.assertEqual(prefix, "lm_head")
+
+
 class TestGetCacheScale(TestBase):
     def test_c8_kv_cache_type_k_proj_scale(self):
         config = AscendModelSlimConfig({"kv_cache_type": "C8"})

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -493,6 +493,15 @@ class AscendModelSlimConfig(QuantizationConfig):
 
     def quant_prefix_mapper(self, model_type: str, prefix: str) -> str:
         self.model_type = model_type
+        # Some model paths, e.g. qwen3-vl and qwen3_5_moe MTP drafter,
+        # initialize lm_head with prefix="lm_head", while the quant description
+        # key is mapped to "language_model.lm_head.weight".
+        if (
+            prefix == "lm_head"
+            and "lm_head.weight" not in self.quant_description
+            and "language_model.lm_head.weight" in self.quant_description
+        ):
+            prefix = "language_model.lm_head"
         prefix_mapping = QUANT_MODEL_PREFIX_MAPPINGS.get(model_type)
         substr_mapping = QUANT_MODEL_SUBSTR_MAPPINGS.get(model_type)
         if prefix_mapping:
@@ -522,15 +531,6 @@ class AscendModelSlimConfig(QuantizationConfig):
                     parts = parts[: exp_idx + 1]
                     prefix = ".".join(parts)
 
-        # Some model paths, e.g. qwen3-vl and qwen3_5_moe MTP drafter,
-        # initialize lm_head with prefix="lm_head", while the quant description
-        # key is mapped to "language_model.lm_head.weight".
-        if (
-            prefix == "lm_head"
-            and "lm_head.weight" not in self.quant_description
-            and "language_model.lm_head.weight" in self.quant_description
-        ):
-            prefix = "language_model.lm_head"
         if model_type in ["bailing_hybrid"]:
             # Adapt to bailing_hybrid architecture: update layer names to MoE convention
             prefix = prefix.replace("linear_attn", "attention")

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -522,8 +522,14 @@ class AscendModelSlimConfig(QuantizationConfig):
                     parts = parts[: exp_idx + 1]
                     prefix = ".".join(parts)
 
-        # TODO: remove it when vllm fixes the WeightsMapper bug of qwen3-vl.
-        if model_type in ["qwen3_vl"] and prefix == "lm_head":
+        # Some model paths, e.g. qwen3-vl and qwen3_5_moe MTP drafter,
+        # initialize lm_head with prefix="lm_head", while the quant description
+        # key is mapped to "language_model.lm_head.weight".
+        if (
+            prefix == "lm_head"
+            and "lm_head.weight" not in self.quant_description
+            and "language_model.lm_head.weight" in self.quant_description
+        ):
             prefix = "language_model.lm_head"
         if model_type in ["bailing_hybrid"]:
             # Adapt to bailing_hybrid architecture: update layer names to MoE convention


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a `KeyError: 'lm_head.weight'` when enabling Qwen3.5 MoE MTP speculative decoding with Ascend ModelSlim quantization.

When serving `Qwen3.5-397B-A17B-W8A8-MTP` with:

```bash
--quantization ascend
--speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
```

the service fails during drafter model loading:

```text
Loading drafter model...
...
File "vllm_ascend/quantization/modelslim_config.py", line xxx, in get_linear_quant_type
    quant_type = quant_description[prefix + ".weight"]
KeyError: 'lm_head.weight'
```

The root cause is a prefix mismatch in the MTP drafter loading path. The drafter initializes the `lm_head` layer with:

```text
prefix = "lm_head"
```

However, after applying the vLLM weights mapper, the runtime quant description may contain the mapped key:

```text
language_model.lm_head.weight
```

instead of:

```text
lm_head.weight
```

As a result, the FLOAT `lm_head` layer is not correctly identified as a skipped/unquantized layer. The code then falls through to quant scheme creation with the unmapped `lm_head.weight` key, which raises `KeyError`.

This PR fixes the issue by remapping the quantization prefix in `quant_prefix_mapper()` when the following conditions are met:

```python
prefix == "lm_head"
and "lm_head.weight" not in self.quant_description
and "language_model.lm_head.weight" in self.quant_description
```

The remapping is key-driven and only applies when `lm_head.weight` is absent while `language_model.lm_head.weight` exists, so the original behavior is preserved for models that already contain `lm_head.weight`.

The remapping logic is placed in `quant_prefix_mapper()` instead of only in `get_quant_method()` so that it is shared by both:

```text
AscendModelSlimConfig
AscendModelSlimConfig310
```

This is needed because `AscendModelSlimConfig310` overrides `get_quant_method()` and would otherwise bypass remapping logic placed only in the base `get_quant_method()` implementation.

### Does this PR introduce *any* user-facing change?

No.

This PR does not introduce any API, CLI, or interface changes. It only fixes an internal quantization prefix mapping issue for model paths where `lm_head` is initialized with prefix `lm_head`, while the quant description uses `language_model.lm_head.weight`.

### How was this patch tested?

Added unit tests for both the base path and the 310P override path:

```bash
pytest -sv tests/ut/quantization/test_modelslim_config.py
pytest -sv tests/ut/_310p/quantization/test_modelslim_config_310.py
```

The new tests cover:

* `AscendModelSlimConfig.quant_prefix_mapper()` remaps `lm_head` to `language_model.lm_head` when only `language_model.lm_head.weight` exists.
* `AscendModelSlimConfig.quant_prefix_mapper()` keeps `lm_head` unchanged when `lm_head.weight` already exists.
* `AscendModelSlimConfig310.get_quant_method()` also uses the shared prefix mapper and passes `language_model.lm_head` to `create_scheme_for_layer()`.

Manual validation was also performed on Ascend A3 with source-installed `vllm` and `vllm-ascend`.

Model:

```text
/mnt/share/weights/Qwen3.5-397B-A17B-w8a8-mtp
```

Compatible vLLM workflow entry:

```text
[9090368b650896bf5fc990c921df7eb4c20355a5, v0.20.2]
```

Installed source version:

```text
vllm: 0.21.1rc1.dev399+g9090368b6.empty
torch: 2.10.0+cpu
torch-npu: 2.10.0
triton-ascend: 3.2.1
```

Before this patch, serving with MTP speculative decoding failed during drafter model loading:

```text
KeyError: 'lm_head.weight'
```

Serving without `--speculative_config` works normally, confirming that the issue is isolated to the MTP drafter loading path.

After applying this patch, the service starts successfully with MTP speculative decoding enabled and can respond to requests.

```bash
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15

export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export HCCL_OP_EXPANSION_MODE="AIV"
export HCCL_BUFFSIZE="1024"
export OMP_NUM_THREADS="1"
export TASK_QUEUE_ENABLE="1"
export VLLM_ASCEND_ENABLE_FUSED_MC2="1"
export VLLM_ASCEND_ENABLE_FLASHCOMM1="1"

vllm serve /mnt/share/weights/Qwen3.5-397B-A17B-w8a8-mtp \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name Qwen3.5-397B-A17B-W8A8 \
  --data-parallel-size 1 \
  --tensor-parallel-size 16 \
  --enable-expert-parallel \
  --max-num-seqs 128 \
  --quantization ascend \
  --max-model-len 133120 \
  --max-num-batched-tokens 16384 \
  --trust-remote-code \
  --gpu-memory-utilization 0.9 \
  --additional-config '{"enable_cpu_binding": true}' \
  --speculative_config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}' \
  --compilation-config '{"cudagraph_capture_sizes":[1,6,12,18,24,30,36,42,48,54,72,78,84,90,96,102,108,144,192], "cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --allowed-local-media-path / \
  --mm-processor-cache-gb 0 \
  --safetensors-load-strategy "lazy"
```
