### PR TITLE
[BugFix][0.20.2](dsa): align dtype of params for inplace_partial_rotary_mul_npu

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1748,7 +1748,15 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
     }
     auto origin_dim_num = x.dim();
     TORCH_CHECK(origin_dim_num == BSND_DIM_NUM, "Input tensor x's dim num should be 4, actual ", origin_dim_num, ".");
-    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, r2, it->second, partial_slice);
+    if (x.scalar_type() == r1.scalar_type()) {
+        EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x, r1, r2, it->second, partial_slice);
+        return;
+    }
+
+    at::ScalarType original_type = x.scalar_type();
+    at::Tensor x_cast = x.to(r1.scalar_type());
+    EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x_cast, r1, r2, it->second, partial_slice);
+    x.copy_(x_cast.to(original_type));
 }
 
 std::tuple<at::Tensor, at::Tensor> npu_rms_norm_dynamic_quant_npu(

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1756,7 +1756,7 @@ void inplace_partial_rotary_mul_npu(at::Tensor & x, const at::Tensor &r1, const 
     at::ScalarType original_type = x.scalar_type();
     at::Tensor x_cast = x.to(r1.scalar_type());
     EXEC_NPU_CMD(aclnnInplacePartialRotaryMul, x_cast, r1, r2, it->second, partial_slice);
-    x.copy_(x_cast.to(original_type));
+    x.copy_(x_cast);
 }
 
 std::tuple<at::Tensor, at::Tensor> npu_rms_norm_dynamic_quant_npu(


### PR DESCRIPTION
### What this PR does / why we need it?
PR #9739 changes the `cos`/`sin` dtype of DeepSeek V4 on A2/A3 to FP32. However, `QuantMatMul` currently does not support FP32, so we need to realign the dtype of `x`—usually BF16—to FP32 in `inplace_partial_rotary_mul_npu`.

| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| gsm8k | 50861a | accuracy | gen | 96.74 |

ref: https://github.com/vllm-project/vllm-ascend/pull/9928