### PR TITLE
[Ops][BugFix] Disable fused MC2 under speculative decoding to prevent logit corruption

### DIFF
--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -201,6 +201,31 @@ def test_select_moe_comm_method_a3_enable_fused_mc2_mode_1(
         (129, MoECommType.ALLTOALL),
     ],
 )
+def test_select_moe_comm_method_a3_spec_decode_disables_dispatch_ffn_combine(
+    monkeypatch,
+    num_tokens,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=8,
+        enable_fused_mc2=1,
+    )
+    vllm_config = _make_vllm_config(quant_type="w4a16")
+    vllm_config.speculative_config = SimpleNamespace()
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected"),
+    [
+        (128, MoECommType.MC2),
+        (129, MoECommType.ALLTOALL),
+    ],
+)
 def test_select_moe_comm_method_a3_without_fused_mc2(
     monkeypatch,
     num_tokens,

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -309,7 +309,12 @@ def _select_a3_moe_comm_method(
     if get_ascend_config().enable_fused_mc2 == 1:
         # TODO: drop the EP-size guard when mega_moe supports larger EP sizes
         mega_moe_enable = get_ep_group().world_size <= 64 and _cann_megamoe_supported_by_config(vllm_config)
-        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
+        # dispatch_ffn_combine corrupts output for the small/ragged token
+        # shapes used by speculative decoding. The target verification forward
+        # shares the speculative config, so this guard covers both target and
+        # draft forwards. CANN MegaMoe is a separate op and remains eligible.
+        is_spec_decode = getattr(vllm_config, "speculative_config", None) is not None
+        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32 and not is_spec_decode
         if (_MEGA_MOE_SUPPORTED and mega_moe_enable) or dispatch_ffn_combine_enable:
             return MoECommType.FUSED_MC2
 


### PR DESCRIPTION
### What this does
On Ascend A3, `select_moe_comm_method` routes MoE comm to the fused `dispatch_ffn_combine` op (FUSED_MC2). Under speculative decoding (e.g. **DeepSeek-V4 + MTP**, `num_speculative_tokens=1`) this op is handed a tiny/ragged token shape and corrupts the model's **first-decode-step logits**, yielding intermittent **empty / malformed `<｜begin▁of▁sentence｜>` first responses** (gh #9170).

The current guard `dispatch_ffn_combine_enable = ... and (not is_draft_model)` only covers the **draft** forward. The corruption appears on the **target** model's verify-step forward, which runs with `is_draft_model=False`, so the fused op is still selected there.

This PR additionally gates on `vllm_config.speculative_config`, disabling fused MC2 for **both** the draft and the target-verify forwards whenever speculative decoding is configured (routing to MC2 / ALLTOALL). **Non-speculative runs are bit-identical** — zero behavior change when `speculative_config is None`. Under speculative decoding the MoE comm falls back to the decomposed MC2/ALLTOALL path instead of the fused op; `dispatch_ffn_combine` was already unusable for these tiny/ragged shapes (it is precisely what corrupts them), and MTP's own decode speedup dominates, so there is no net throughput regression for spec-decode either.

### Root cause (kernel detail in #9170)
`dispatch_ffn_combine` (AscendC) targets a dense, large decode batch and never zero-initializes its output / combine staging (sized by a fixed `max_output_size=65536`). On the tiny/ragged spec shape (~2 query positions/seq split unevenly across EP ranks, so a rank's local token count can be `< AIV core count`), the output-assembly tiling `unpermute/moe_token_unpermute_tiling.h:30-34` computes `tokens_core_length = outTokens/coreNum = 0` then divides by it (`0/0`), corrupting the loop bounds that write per-token output; under-filled rows are read from never-initialized HBM → NaN/garbage logits. A proper kernel fix (min-1 tiling guard + output zero-init) belongs in the op and touches the hot non-spec MoE path; this PR is the safe, side-effect-free control-plane mitigation.

### Validation
DeepSeek-V4-Flash W8A8 + MTP (`num_speculative_tokens=1`), 910C A3, TP4×DP4 + EP16: with fused MC2 enabled the first agent turn intermittently returns empty / `<｜begin▁of▁sentence｜>`-only output; setting `VLLM_ASCEND_ENABLE_FUSED_MC2=0` eliminates it (spec-decode sub-agents then complete normally). This PR makes that automatic under `speculative_config`.

Related to #9170 (mitigates the MTP/speculative trigger; the underlying kernel defect stays tracked there).

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
