### PR TITLE
[Ops][BugFix] Zero-init fused MC2 combine output to avoid uninitialized HBM

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -459,7 +459,10 @@ class FusedMC2CommImpl(MoECommMethod):
                     or fused_experts_input.weights.w2_scale_bias is None
                 ), "w1_scale_bias and w2_scale_bias cannot be None when enable_fused_mc2=1."
 
-                out = torch.empty_like(fused_experts_input.hidden_states)
+                # dispatch_ffn_combine may leave rows unwritten when a local
+                # expert receives no tokens. Zero is the combine identity and
+                # prevents uninitialized HBM from corrupting logits (#9170).
+                out = torch.zeros_like(fused_experts_input.hidden_states)
                 torch.ops._C_ascend.dispatch_ffn_combine(  # type: ignore
                     x=fused_experts_input.hidden_states,
                     weight1=fused_experts_input.weights.w1,


### PR DESCRIPTION
### What

`FusedMC2CommImpl.fused_experts` allocates the `dispatch_ffn_combine` output with
`torch.empty_like(...)` (`vllm_ascend/ops/fused_moe/moe_comm_method.py`, the
`enable_fused_mc2 == 1` branch). The fused op does **not** necessarily write every
row of `out`: when expert routing leaves a local expert with zero tokens the
per-expert GMM is skipped, and rows beyond the routed / under-filled count are
never touched. Those rows are then consumed downstream (combine reduction →
`compute_logits`) as **uninitialized HBM**, surfacing as NaN / garbage /
malformed-`<｜begin▁of▁sentence｜>` first-step logits.

This switches the allocation to `torch.zeros_like(...)` so any row the kernel does
not write is a deterministic zero. Zero is also the mathematically correct identity
for the combine (a token with no expert contribution sums to 0), so this is a
correctness fix, not merely a guard.

### Why

This is one of the source-identified contributors to #9170 ("DeepSeek-V4 W8A8
Concurrency Failure: Output Corruption and Malformed begin_of_sentence"). The
corruption is intermittent because the device allocator sometimes hands back
already-zeroed pages — consistent with the issue's "concurrency-dependent" framing.
The trigger (a local expert receiving zero tokens, or a per-rank token count below
the AIC core count) is a function of batch size / routing distribution, **not** of
speculative decoding, so it is reachable in plain high-concurrency decode/prefill.

### Cost

A single memset of the `[num_tokens, hidden]` output buffer per fused-MC2 call —
negligible relative to the grouped matmul + all-to-all it precedes.

### Scope / honesty

- Defensive, Python-side, and a **partial** mitigation for #9170: it removes the
  *stale-output* failure mode only. It does not address the other source-identified
  `dispatch_ffn_combine` kernel defects — the unpermute-tiling `outTokens / (coreNum/2)`
  integer `0/0` when per-rank tokens fall below the AIC core count; the no-epsilon
  W8A8 dynamic-quant scale; and the un-epoched `tokenPerExpert` cross-rank sentinel —
  which require a kernel change.
- I do not have an Ascend device available to regression-test this; the rationale is
  from source reading. Maintainers with 910C access can validate. The change is
  low-risk (uninitialized → zeroed output).

Related: #9170. Complements #9983 (which disables the fused op under speculative decoding).

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
