### PR TITLE
[Bugfix] [kimi] upgrade transformers from 5.5.3 to 5.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "psutil",
     "setuptools>=64",
     "setuptools-scm>=8",
-    "transformers==5.5.3",
+    "transformers==5.5.4",
     "torch-npu==2.10.0",
     "torch==2.10.0",
     "torchvision",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ memfabric_hybrid
 memcache_hybrid
 
 arctic-inference==0.1.1
-transformers==5.5.3
+transformers==5.5.4
 fastapi<0.124.0


### PR DESCRIPTION
### What this PR does / why we need it?

Transformers fixed a tokenizer bug for kimi k2.6/k2.5 in version 5.5.4, and this bug affects the function calling feature.
https://github.com/huggingface/transformers/pull/45359

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

by test tool calls feature

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
