### PR TITLE
[BugFix] fix dsv4 piecewise scenario

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -36,8 +36,7 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 # cudagraph PIECEWISE path, which is not supported on Ascend yet.
 envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
 logger.info(
-    "Breakable cudagraph is force disabled on Ascend because "
-    "DeepSeek V4 PIECEWISE cudagraph is not supported yet."
+    "Breakable cudagraph is force disabled on Ascend because DeepSeek V4 PIECEWISE cudagraph is not supported yet."
 )
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,6 +31,15 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
+# Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
+# carry @support_torch_compile. This makes vLLM auto-enable the breakable
+# cudagraph PIECEWISE path, which is not supported on Ascend yet.
+envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
+logger.info(
+    "Breakable cudagraph is force disabled on Ascend because "
+    "DeepSeek V4 PIECEWISE cudagraph is not supported yet."
+)
+
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.ascend_config import init_ascend_config
@@ -206,14 +215,6 @@ class NPUPlatform(Platform):
     @classmethod
     def apply_config_platform_defaults(cls, vllm_config: VllmConfig) -> None:
         """Apply Ascend-specific defaults."""
-        # Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
-        # carry @support_torch_compile. This makes vLLM auto-enable the breakable
-        # cudagraph PIECEWISE path, which is not supported on Ascend yet.
-        envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
-        logger.info(
-            "Breakable cudagraph is force disabled on Ascend because "
-            "DeepSeek V4 PIECEWISE cudagraph is not supported yet."
-        )
 
         # Set sp_min_token_num=1 when enable_sp and not set.
         pass_config = vllm_config.compilation_config.pass_config

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,14 +31,6 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
-# Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
-# carry @support_torch_compile. This makes vLLM auto-enable the breakable
-# cudagraph PIECEWISE path, which is not supported on Ascend yet.
-envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
-logger.info(
-    "Breakable cudagraph is force disabled on Ascend because DeepSeek V4 PIECEWISE cudagraph is not supported yet."
-)
-
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.ascend_config import init_ascend_config
@@ -60,6 +52,14 @@ from vllm_ascend.utils import (
     update_cudagraph_capture_sizes,
     is_310p,
     enable_sp,
+)
+
+# Since vllm-project/vllm#43746, DeepSeek V4 model classes no longer
+# carry @support_torch_compile. This makes vLLM auto-enable the breakable
+# cudagraph PIECEWISE path, which is not supported on Ascend yet.
+envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH = False
+logger.info(
+    "Breakable cudagraph is force disabled on Ascend because DeepSeek V4 PIECEWISE cudagraph is not supported yet."
 )
 
 if TYPE_CHECKING:


### PR DESCRIPTION
### What this PR does / why we need it?
In [PR#43746](https://github.com/vllm-project/vllm/pull/43746),while VLLM_USE_BREAKABLE_CUDAGRAPH is detacted as True, compilation_config.mode would be None even if we set it, thus server runs in eager mode.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
