### PR TITLE
[BugFix] Fix reduce sampling where top_k and top_p could be None

### DIFF
--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -143,7 +143,7 @@ class AscendTopKTopPSampler(TopKTopPSampler):
             elif self.logprobs_mode == "processed_logprobs":
                 logits_to_return = cand_logits.log_softmax(dim=-1, dtype=torch.float32)
 
-            probs = torch.softmax(cand_logits, dim=-1)
+            probs = cand_logits.softmax(dim=-1, dtype=torch.float32)
             pos = random_sample(probs, generators)  # [B]
 
             next_token = cand_idx.gather(dim=1, index=pos.unsqueeze(1)).squeeze(1)  # [B]
@@ -173,31 +173,31 @@ def _apply_top_k_top_p_pytorch(
     if get_ascend_config().enable_reduce_sample:
         tp_group = get_tp_group()
         B, V_local = logits.shape
-        world_size = tp_group.world_size
         rank = tp_group.rank_in_group
-        V_global = V_local * world_size
 
-        local_vals, local_idx = torch.topk(logits, k=top_k, dim=-1)  # [B, top_k], [B, top_k]
-        local_global_idx = local_idx + rank * V_local  # [B, top_k]
+        if top_k is None or (p is None and k is None):
+            k_for_topk = V_local
+        else:
+            k_for_topk = min(top_k, V_local)
 
-        gathered_vals = tp_group.all_gather(local_vals, dim=-1)  # [B, top_k*tp]
-        gathered_idx = tp_group.all_gather(local_global_idx, dim=-1)  # [B, top_k*tp]
-
-        full_logits = logits.new_full((B, V_global), -float("inf"))
-        full_logits.scatter_(dim=-1, index=gathered_idx, src=gathered_vals)
+        local_vals, local_idx = torch.topk(logits, k=k_for_topk, dim=-1)
+        local_global_idx = local_idx + rank * V_local
+        gathered_vals = tp_group.all_gather(local_vals, dim=-1)
+        gathered_idx = tp_group.all_gather(local_global_idx, dim=-1)
 
         if p is None and k is None:
-            return full_logits
-        probs = full_logits.softmax(dim=-1)
+            return gathered_vals, gathered_idx
+
+        probs = gathered_vals.softmax(dim=-1)
         probs_sort, _ = probs.sort(dim=-1, descending=False)
         if k is not None:
-            kk = k.to(torch.long).clamp(min=1, max=V_global)
+            kk = k.to(torch.long).clamp(min=1, max=V_local)
             top_k_count = (probs_sort.size(1) - kk).unsqueeze(1)  # [B,1]
             top_k_cutoff = probs_sort.gather(-1, top_k_count)
-            no_top_k_mask = (kk == V_global).unsqueeze(1)
+            no_top_k_mask = (kk == V_local).unsqueeze(1)
             top_k_cutoff.masked_fill_(no_top_k_mask, -float("inf"))
             elements_to_discard = probs < top_k_cutoff
-            full_logits.masked_fill_(elements_to_discard, -float("inf"))
+            gathered_vals.masked_fill_(elements_to_discard, -float("inf"))
         if p is not None:
             cumprob = torch.cumsum(probs_sort, dim=-1)
             top_p_mask = cumprob <= (1 - p.unsqueeze(1))
@@ -205,8 +205,8 @@ def _apply_top_k_top_p_pytorch(
             top_p_count = top_p_mask.sum(dim=-1, keepdim=True)
             top_p_cutoff = probs_sort.gather(-1, top_p_count)
             elements_to_discard = probs < top_p_cutoff
-            full_logits.masked_fill_(elements_to_discard, -float("inf"))
-        return full_logits
+            gathered_vals.masked_fill_(elements_to_discard, -float("inf"))
+        return gathered_vals, gathered_idx
     else:
         if p is None and k is None:
             return logits
@@ -250,21 +250,23 @@ def _apply_top_k_top_p_ascendc(
         B, V_local = logits.shape
         rank = tp_group.rank_in_group
 
-        local_vals, local_idx = torch.topk(logits, k=top_k, dim=-1)  # [B, top_k], [B, top_k]
+        if top_k is None or (p is None and k is None):
+            k_for_topk = V_local
+        else:
+            k_for_topk = min(top_k, V_local)
 
-        local_global_idx = local_idx + rank * V_local  # [B, top_k]
+        local_vals, local_idx = torch.topk(logits, k=k_for_topk, dim=-1)
+        local_global_idx = local_idx + rank * V_local
+        gathered_vals = tp_group.all_gather(local_vals, dim=-1)
+        gathered_idx = tp_group.all_gather(local_global_idx, dim=-1)
 
-        gathered_vals = tp_group.all_gather(local_vals, dim=-1)  # [B, top_k*tp]
-        gathered_idx = tp_group.all_gather(local_global_idx, dim=-1)  # [B, top_k*tp]
-
-        if p is None and k is None:
-            return logits
-        gathered_vals = torch.ops._C_ascend.npu_apply_top_k_top_p(gathered_vals, k=k, p=p)
+        if not (p is None and k is None):
+            gathered_vals = torch.ops._C_ascend.npu_apply_top_k_top_p(gathered_vals, k=k, p=p)
         return gathered_vals, gathered_idx
-    else:
-        if p is None and k is None:
-            return logits
-        return torch.ops._C_ascend.npu_apply_top_k_top_p(logits, k=k, p=p)
+
+    if p is None and k is None:
+        return logits
+    return torch.ops._C_ascend.npu_apply_top_k_top_p(logits, k=k, p=p)
 
 
 apply_top_k_top_p = (


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request updates the sampler logic in `vllm_ascend/sample/sampler.py` to correctly handle cases where no filtering is needed (`p is None and k is None`) by returning the full gathered logits paired with a global identity index. This prevents out-of-bounds indexing when sampling.

- Sampling Logic Fix: Updated the sampling logic to correctly handle cases where top-k is None, ensuring consistent behavior across different tensor parallel configurations.
- Contract Consistency: Ensured that the sampler maintains the expected (candidate logits, candidate indices) contract even when no filtering is applied, preventing out-of-bounds errors.
- Ascend Backend Updates: Refactored the Ascend-specific sampling path to align with the general logic, improving robustness for reduce-sampling scenarios.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
It was tested by end2end cases. Find more in pr test report.


- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
