### PR TITLE
[BugFix] Fix the bug of repeatedly calling set_device.

### DIFF
--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -220,19 +220,9 @@ setup_vllm_cache_root
 if [ "${npu_type}" = "cpu" ]; then
   run_pytest_batch "cpu-ut (${#targets[@]} targets)" "${targets[@]}"
 elif [ "${mode}" = "with-device" ]; then
-  aclgraph_capture_replay="tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py"
-  run_aclgraph_capture_replay=0
   for target in "${targets[@]}"; do
-    if [ "${target}" = "${aclgraph_capture_replay}" ]; then
-      run_aclgraph_capture_replay=1
-      continue
-    fi
     run_pytest_target "${target}"
   done
-  if [ "${run_aclgraph_capture_replay}" = "1" ]; then
-    pip uninstall -y triton-ascend triton
-    run_pytest_target "${aclgraph_capture_replay}"
-  fi
 else
   for target in "${targets[@]}"; do
     run_pytest_target "${target}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -70,7 +70,6 @@ from vllm_ascend.ascend_config import clear_ascend_config
 from vllm_ascend.utils import adapt_patch  # noqa E402
 
 adapt_patch(True)
-adapt_patch(False)
 
 from vllm.distributed.parallel_state import (  # noqa E402
     destroy_distributed_environment,

--- a/tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
+++ b/tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
@@ -129,7 +129,6 @@ def _run_worker_process(
         torch.npu.reset_peak_memory_stats()
 
 
-@pytest.mark.skip(reason="fix me")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [4, 36])
 @patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"})

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -130,6 +130,9 @@ class NPUWorker310(NPUWorker):
         device = torch.device(f"npu:{self.local_rank}")
         torch.npu.set_device(device)
 
+        # if true, allow tensor initialization and casting with internal format (e.g., NZ)
+        torch.npu.config.allow_internal_format = True
+
         # This lazy import avoids torch_npu re-initialization in patch
         # Note that this should be imported after torch.npu.set_device
         # to avoid repeated set_device in extra processes

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -146,7 +146,6 @@ from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.model_executor.offloader import create_offloader
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.ops.triton.spec_decode.ngram import triton_ngram_spec_decode
-from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
@@ -215,9 +214,6 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendSFAIndexerCacheSpec,
     AscendSlidingWindowMLASpec,
 )
-
-# if true, allow tensor initialization and casting with internal format (e.g., NZ)
-torch.npu.config.allow_internal_format = True
 
 AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
@@ -3515,6 +3511,7 @@ class NPUModelRunner(GPUModelRunner):
             if self.drafter:
                 logger.info("Loading drafter model...")
                 if self.vllm_config.quant_config is not None:
+                    from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
                     patch_load_weights(self.vllm_config)
                 with get_tp_context(self.drafter):
                     self.drafter.load_model(self.model)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -428,6 +428,9 @@ class NPUWorker(WorkerBase):
 
         torch.npu.set_device(device)
 
+        # if true, allow tensor initialization and casting with internal format (e.g., NZ)
+        torch.npu.config.allow_internal_format = True
+
         # Import _inductor for graph mode execution with triton
         # This lazy import avoids torch_npu re-initialization in patch
         # Note that this should be imported after torch.npu.set_device


### PR DESCRIPTION
### What this PR does / why we need it?
First, in model_runner_v1, torch.npu.config.allow_internal_format = True was moved to set_device in the worker.py; otherwise, it would call set_device prematurely when importing model_runner, causing an error.

Second, in adapt_patch_worker, there is also a place where set_device is called prematurely. I have opened an https://github.com/vllm-project/vllm-ascend/issues/9615 to track this. The main actions taken are:

In model_runner, lazy loading was implemented for patch_draft_quarot.

conftest.py can be deleted directly, as verified by the full CI pipeline.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
