### PR TITLE
[Attention][BugFix] Resolve head dimension via get_head_size when head_dim is missing

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -315,6 +315,39 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
             prefill_pp_layer_partition=None,
         )
 
+    def test_head_dim_falls_back_when_config_lacks_head_dim(self):
+        # Regression for vllm-project/vllm-ascend#7352: some configs (e.g.
+        # Qwen2Config on older transformers) do not expose `head_dim`. The
+        # connector must resolve it via ModelConfig.get_head_size() (which falls
+        # back to hidden_size // num_attention_heads) instead of reading
+        # hf_text_config.head_dim directly, which raised AttributeError.
+        vllm_config = MockVllmConfig()
+        vllm_config.model_config.hf_text_config = types.SimpleNamespace(
+            num_key_value_heads=8,
+            num_hidden_layers=32,
+            model_type="qwen2",
+        )  # note: no `head_dim` attribute
+        vllm_config.model_config.get_head_size = MagicMock(return_value=64)
+
+        thread = KVCacheRecvingThread(
+            tp_rank=0,
+            tp_size=4,
+            _prefill_pp_size=1,
+            engine=MagicMock(),
+            local_engine_id="local_engine",
+            local_handshake_port=5555,
+            side_channel_port=30001,
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
+            ready_event=threading.Event(),
+            vllm_config=vllm_config,
+            kv_caches={},
+            prefill_pp_layer_partition=None,
+        )
+
+        self.assertEqual(thread.k_head_dim, 64)
+        self.assertEqual(thread.v_head_dim, 64)
+
     def test_add_request(self):
         test_req: dict[str, Any] = {
             "request_id": "req1",
@@ -673,6 +706,9 @@ class MockVllmConfig:
             qk_rope_head_dim=8,
             model_type="qwen2",
         )
+        # The connector resolves head size via ModelConfig.get_head_size(), which
+        # falls back to hidden_size // num_attention_heads when head_dim is absent.
+        self.model_config.get_head_size = MagicMock(return_value=16)
         self.model_config.get_num_layers = MagicMock(return_value=32)
         self.parallel_config.tensor_parallel_size = 2
         self.parallel_config.data_parallel_rank = 0

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -415,12 +415,13 @@ class KVCacheRecvingThread(threading.Thread):
                 self.v_head_dim = hf_text_config.qk_rope_head_dim
                 self.num_kv_heads = 1
             else:
-                self.k_head_dim = hf_text_config.head_dim
-                self.v_head_dim = hf_text_config.head_dim
+                # Some configs (e.g. Qwen2Config on older transformers) do not expose
+                # head_dim; fall back to hidden_size // num_attention_heads via the
+                # same helper the attention layers use.
+                self.k_head_dim = self.v_head_dim = self.model_config.get_head_size()
                 self.num_kv_heads = max(hf_text_config.num_key_value_heads // self.tp_size, 1)
         else:
-            self.k_head_dim = hf_text_config.head_dim
-            self.v_head_dim = hf_text_config.head_dim
+            self.k_head_dim = self.v_head_dim = self.model_config.get_head_size()
             self.num_kv_heads = max(hf_text_config.num_key_value_heads // self.tp_size, 1)
         self.proc_not_transfer_request: dict[str, bool] = {}
         self.failed_recv_requests: set[str] = set()
@@ -941,7 +942,7 @@ class KVCacheRecvingThread(threading.Thread):
         # Get necessary parameters
         k_cache = list(kv_caches.values())[0][0]
         device = k_cache.device
-        head_dim = self.model_config.hf_text_config.head_dim
+        head_dim = self.model_config.get_head_size()
         block_size = self.vllm_config.cache_config.block_size
         num_kv_head = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
         layers = len(kv_caches)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -383,8 +383,9 @@ class KVCacheRecvingThread(threading.Thread):
                 self.v_head_dim = self.model_config.hf_text_config.qk_rope_head_dim
                 self.num_kv_heads = 1
             else:
-                self.k_head_dim = self.model_config.hf_text_config.head_dim
-                self.v_head_dim = self.model_config.hf_text_config.head_dim
+                # Fall back to hidden_size // num_attention_heads when head_dim is
+                # absent (e.g. Qwen2Config on older transformers).
+                self.k_head_dim = self.v_head_dim = self.model_config.get_head_size()
                 self.num_kv_heads = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
         self.proc_not_transfer_request: dict[str, bool] = {}
 
@@ -679,7 +680,7 @@ class KVCacheRecvingThread(threading.Thread):
         # Get necessary parameters
         k_cache = list(self.kv_caches.values())[0][0]
         device = k_cache.device
-        head_dim = self.model_config.hf_text_config.head_dim
+        head_dim = self.model_config.get_head_size()
         block_size = self.vllm_config.cache_config.block_size
         num_kv_head = max(self.model_config.hf_text_config.num_key_value_heads // self.tp_size, 1)
         layers = self.model_config.hf_text_config.num_hidden_layers


### PR DESCRIPTION
### What this PR does / why we need it?
The KV-transfer mooncake connectors (`mooncake_connector` and
`mooncake_hybrid_connector`) read `hf_text_config.head_dim` directly when
sizing the receive buffers. Configs that do not expose `head_dim` — e.g.
`Qwen2Config` on older transformers, where it is computed implicitly as
`hidden_size // num_attention_heads` — crash the decode worker during PD
disaggregation:

```
AttributeError: 'Qwen2Config' object has no attribute 'head_dim'
```

This PR routes head-size resolution through `ModelConfig.get_head_size()`,
the same helper the attention layers already use, which provides the
`hidden_size // num_attention_heads` fallback. The MLA branches
(`kv_lora_rank` / `qk_rope_head_dim`) are unchanged.

Fixes #7352

### Does this PR introduce _any_ user-facing change?
No. Models that already expose `head_dim` resolve to the same value; the
change only adds a fallback for configs that don't, which previously crashed.

### How was this patch tested?
Added a regression unit test in
`tests/ut/kv_offload/test_mooncake_connector.py`
(`test_head_dim_falls_back_when_config_lacks_head_dim`) that constructs
`KVCacheRecvingThread` with a config lacking `head_dim`. Verified manually
that Qwen2.5-0.5B PD decode no longer crashes at connector init.

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
