### PR TITLE
[Ops][BugFix] Add mutual exclusion check for BalanceScheduler and RecomputeScheduler

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -608,6 +608,48 @@ class TestNPUPlatform(TestBase):
         ):
             self.platform.check_and_update_config(vllm_config)
 
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
+    def test_check_and_update_config_rejects_both_balance_and_recompute_scheduler(
+        self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
+    ):
+        """Test that enabling both BalanceScheduler and RecomputeScheduler raises ValueError.
+
+        This test verifies the mutual exclusion check added to prevent deadlock in
+        PD disaggregation mode with multi-DP MoE. See Issue #8975.
+        """
+        mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+        mock_ascend_config.enable_balance_scheduling = True
+        mock_ascend_config.recompute_scheduler_enable = True
+        mock_init_ascend.return_value = mock_ascend_config
+
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.kv_transfer_config = MagicMock(kv_role="kv_producer", engine_id="engine0")
+        vllm_config.parallel_config.decode_context_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.parallel_config.tensor_parallel_size = 1
+        vllm_config.scheduler_config = MagicMock()
+        mock_init_recompute.return_value = MagicMock()
+
+        from vllm_ascend import platform
+
+        importlib.reload(platform)
+        self.platform = platform.NPUPlatform()
+
+        with (
+            patch("vllm_ascend.platform.envs_ascend.VLLM_ASCEND_BALANCE_SCHEDULING", True, create=True),
+            pytest.raises(
+                ValueError,
+                match=r"VLLM_ASCEND_BALANCE_SCHEDULING.*recompute_scheduler_enable"
+                r".*cannot be enabled simultaneously",
+            ),
+            patch.object(platform.NPUPlatform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
+
     def test_update_block_size_for_backend_preserves_hybrid_block_size(self):
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.model_config.is_hybrid = True

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -565,9 +565,19 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
+        if ascend_config.enable_balance_scheduling and ascend_config.recompute_scheduler_enable:
+            raise ValueError(
+                "VLLM_ASCEND_BALANCE_SCHEDULING (balance scheduling) and recompute_scheduler_enable "
+                "cannot be enabled simultaneously. This combination causes MoE communication type "
+                "mismatch across DP ranks in PD disaggregation mode, leading to AlltoAll deadlock. "
+                "Please disable one of them. "
+                "See https://github.com/vllm-project/vllm-ascend/issues/8975"
+            )
+
+        kv_transfer_config = vllm_config.kv_transfer_config
+        kv_role = getattr(kv_transfer_config, "kv_role", None)
+
         if ascend_config.enable_balance_scheduling:
-            kv_transfer_config = vllm_config.kv_transfer_config
-            kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is not None and kv_role != "kv_both":
                 raise ValueError(
                     "enable_balance_scheduling only supports PD-mixed mode "
@@ -578,8 +588,6 @@ class NPUPlatform(Platform):
         cls._validate_kv_load_failure_policy(vllm_config)
 
         if ascend_config.recompute_scheduler_enable:
-            kv_transfer_config = vllm_config.kv_transfer_config
-            kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is None or kv_role == "kv_both":
                 raise ValueError(
                     "recompute_scheduler_enable can only be enabled in PD-disaggregated mode "


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a mutual exclusion check to prevent `VLLM_ASCEND_BALANCE_SCHEDULING` (BalanceScheduler) and `recompute_scheduler_enable` (RecomputeScheduler) from being enabled simultaneously. This combination causes MoE communication type mismatches across DP ranks in PD disaggregation mode, leading to AlltoAll deadlock.

The check is placed **before** the individual scheduler validation logic so it provides a clear, specific error message when both schedulers are enabled together, rather than a less descriptive error from the individual checks.

Additionally, this PR refactors the `kv_transfer_config` and `kv_role` variable definitions to be shared between both scheduler validation blocks, fixing an F821 lint error (undefined names) that was present in the previous version.

Fixes #8975

### Does this PR introduce _any_ user-facing change?

Yes. Users who attempt to enable both schedulers will now receive a clear `ValueError` at startup explaining the conflict and the risk of deadlock.

### How was this patch tested?

- Unit test: `test_check_and_update_config_rejects_both_balance_and_recompute_scheduler` verifies that enabling both schedulers raises `ValueError` with the expected message.
- Linting: `ruff check vllm_ascend/platform.py` and `ruff check tests/ut/test_platform.py` pass (no F821 errors).

Supersedes #9149 (which was closed due to lint failures and merge conflicts).

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
