### PR TITLE
[BugFix][CP] Rebuild stale decode state after async token correction

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1054,12 +1054,41 @@ class NPUModelRunner(GPUModelRunner):
         self.num_scheduled_tokens.np[:num_reqs] = num_scheduled_tokens
         self.num_scheduled_tokens.copy_to_gpu(num_reqs)
         num_scheduled_tokens_gpu = self.num_scheduled_tokens.gpu[:num_reqs]
-        # fix prefix cache ci test
+
+        # Rebuild CP/spec inputs after async accepted-token correction.
+        should_rebuild_async_inputs = (
+            self.use_cp
+            and self.use_async_spec_decode
+            and self.valid_sampled_token_count_gpu is not None
+            and prev_req_id_to_index
+            and not with_prefill
+        )
+        corrected_num_computed_tokens_np = None
+        if should_rebuild_async_inputs:
+            # Async spec decode corrects num_computed_tokens on device.
+            # Copy once and reuse for CPU-side rebuilds in this iteration.
+            corrected_num_computed_tokens_np = (
+                self.num_computed_tokens[:num_reqs].cpu().numpy()
+            )
+
         if self.pcp_size > 1:
             # When PCP (Prefill Context Parallel) is enabled, positions use
             # special PCP offsets (position_pcp) that are only computed on CPU.
             # Copy the correctly-computed CPU positions to GPU instead of
             # recomputing on GPU (which would miss the PCP offsets).
+
+            if should_rebuild_async_inputs:
+                self._rebuild_input_ids_with_corrected_positions(
+                    scheduler_output,
+                    num_reqs,
+                    total_num_scheduled_tokens,
+                    req_indices,
+                    position_pcp,
+                    positions_np,
+                    cu_num_tokens,
+                    corrected_num_computed_tokens_np,
+                )
+
             self.positions[:total_num_scheduled_tokens].copy_(
                 torch.from_numpy(
                     positions_np[:total_num_scheduled_tokens]
@@ -1071,10 +1100,77 @@ class NPUModelRunner(GPUModelRunner):
                 self.num_computed_tokens[req_indices_gpu].to(torch.int64)
                 + self.query_pos.gpu[:total_num_scheduled_tokens]
             )
+
+            if should_rebuild_async_inputs:
+                self._rebuild_input_ids_with_corrected_positions(
+                    scheduler_output,
+                    num_reqs,
+                    total_num_scheduled_tokens,
+                    req_indices,
+                    self.query_pos.np,
+                    positions_np,
+                    cu_num_tokens,
+                    corrected_num_computed_tokens_np,
+                )
+
         self.seq_lens[:num_reqs] = (
             self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
         )
         self.seq_lens[num_reqs:].fill_(0)
+
+        if (
+            self.use_cp
+            and self.use_async_spec_decode
+            and self.valid_sampled_token_count_gpu is not None
+            and prev_req_id_to_index
+            and self.decode_threshold > 2
+            and not with_prefill
+            and self.pcp_manager.async_rebuild_req_indices_full is not None
+        ):
+            req_indices_full = self.pcp_manager.async_rebuild_req_indices_full
+            cu_num_tokens_full = self.pcp_manager.async_rebuild_cu_num_tokens_full
+            num_tokens_full = self.pcp_manager.async_rebuild_num_tokens_full
+
+            assert corrected_num_computed_tokens_np is not None
+            base = corrected_num_computed_tokens_np
+
+            token_counts = np.diff(np.concatenate(([0], cu_num_tokens_full)))
+            token_starts = np.repeat(cu_num_tokens_full - token_counts, token_counts)
+            query_pos = self.arange_np[:num_tokens_full] - token_starts
+
+            positions_full = np.empty(num_tokens_full, dtype=np.int64)
+            np.add(base[req_indices_full], query_pos, out=positions_full)
+
+            if self.pcp_size > 1:
+                pre_pcp_query_start_loc = torch.zeros(
+                    num_reqs + 1,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                pre_pcp_query_start_loc[1 : num_reqs + 1] = torch.from_numpy(
+                    cu_num_tokens_full
+                ).to(dtype=torch.int32, device=self.device)
+
+                self.input_batch.block_table.compute_slot_mapping(
+                    num_reqs,
+                    pre_pcp_query_start_loc,
+                    torch.from_numpy(positions_full).to(self.device),
+                )
+
+            self.pcp_manager.generate_pcp_mtp_input(
+                num_tokens_full,
+                scheduler_output.num_scheduled_tokens,
+                with_prefill,
+                self.input_batch,
+                self.arange_np,
+                req_indices_full,
+                positions_full,
+                cu_num_tokens_full,
+                self._draft_token_ids,
+                scheduler_output,
+                self.num_spec_tokens,
+                precomputed_positions_np=positions_full,
+            )
 
         # In async spec decode mode, num_computed_tokens was corrected on GPU
         # by update_num_computed_tokens_for_batch_change, so seq_lens (GPU) is
@@ -1232,6 +1328,45 @@ class NPUModelRunner(GPUModelRunner):
             spec_decode_metadata,
             total_num_scheduled_tokens,
             num_scheduled_tokens_compressed_list
+        )
+
+    def _rebuild_input_ids_with_corrected_positions(
+        self,
+        scheduler_output,
+        num_reqs,
+        total_num_scheduled_tokens,
+        req_indices,
+        position_offsets,
+        positions_np,
+        cu_num_tokens,
+        corrected_num_computed_tokens_np,
+    ) -> None:
+        # Reuse the corrected CPU copy of device-side starts so input_ids
+        # can be rebuilt from token_ids_cpu with the right positions.
+        base = corrected_num_computed_tokens_np
+        np.add(
+            base[req_indices],
+            position_offsets[:total_num_scheduled_tokens],
+            out=positions_np,
+        )
+
+        token_indices = (
+            positions_np[:total_num_scheduled_tokens]
+            + req_indices * self.input_batch.token_ids_cpu.shape[1]
+        )
+        torch.index_select(
+            self.input_batch.token_ids_cpu_tensor.flatten(),
+            0,
+            torch.from_numpy(token_indices),
+            out=self.input_ids.cpu[:total_num_scheduled_tokens],
+        )
+
+        self.input_ids.copy_to_gpu(total_num_scheduled_tokens)
+        self._prepare_input_ids(
+            scheduler_output,
+            num_reqs,
+            total_num_scheduled_tokens,
+            cu_num_tokens,
         )
 
     def _preprocess(
@@ -2808,6 +2943,12 @@ class NPUModelRunner(GPUModelRunner):
         def _get_pcp_metadata(block_table_tensor):
             if not self.use_cp:
                 return None, block_table_tensor
+
+            fixed_decode_seq_lens_cpu = None
+            if self.use_async_spec_decode:
+                fixed_decode_seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs].numpy()
+
+            assert num_reqs_padded is not None
             return self.pcp_manager.generate_pcp_metadata(
                 num_tokens,
                 self.query_lens,
@@ -2816,6 +2957,7 @@ class NPUModelRunner(GPUModelRunner):
                 block_table_tensor,
                 num_reqs_padded,
                 num_reqs,
+                fixed_decode_seq_lens_cpu,
             )
 
         def _get_block_table_and_slot_mapping(kv_cache_gid: int, total_num_scheduled_tokens_compressed_list: list[int]):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1056,38 +1056,55 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens_gpu = self.num_scheduled_tokens.gpu[:num_reqs]
 
         # Rebuild CP/spec inputs after async accepted-token correction.
+        has_decode_req = bool(np.any(
+            self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            >= self.input_batch.num_prompt_tokens[:num_reqs]
+        ))
         should_rebuild_async_inputs = (
             self.use_cp
             and self.use_async_spec_decode
             and self.valid_sampled_token_count_gpu is not None
             and prev_req_id_to_index
-            and not with_prefill
+            and has_decode_req
         )
-        corrected_num_computed_tokens_np = None
+        base_num_computed_tokens_np = None
         if should_rebuild_async_inputs:
             # Async spec decode corrects num_computed_tokens on device.
-            # Copy once and reuse for CPU-side rebuilds in this iteration.
+            # Rebuild CPU-side inputs from the corrected positions.
             corrected_num_computed_tokens_np = (
                 self.num_computed_tokens[:num_reqs].cpu().numpy()
             )
 
-        if self.pcp_size > 1:
-            # When PCP (Prefill Context Parallel) is enabled, positions use
-            # special PCP offsets (position_pcp) that are only computed on CPU.
-            # Copy the correctly-computed CPU positions to GPU instead of
-            # recomputing on GPU (which would miss the PCP offsets).
+            # Mixed batch: only decode requests use async-corrected lengths.
+            # Prefill requests keep CPU-side prompt progress.
+            base_num_computed_tokens_np = (
+                self.input_batch.num_computed_tokens_cpu[:num_reqs].copy()
+            )
+            num_decode_reqs = self.pcp_manager.num_decode_reqs
+            base_num_computed_tokens_np[:num_decode_reqs] = (
+                corrected_num_computed_tokens_np[:num_decode_reqs]
+            )
 
-            if should_rebuild_async_inputs:
-                self._rebuild_input_ids_with_corrected_positions(
-                    scheduler_output,
-                    num_reqs,
-                    total_num_scheduled_tokens,
-                    req_indices,
-                    position_pcp,
-                    positions_np,
-                    cu_num_tokens,
-                    corrected_num_computed_tokens_np,
-                )
+            position_offsets = (
+                position_pcp
+                if self.pcp_size > 1
+                else self.query_pos.np
+            )
+
+            self._rebuild_input_ids_with_corrected_positions(
+                scheduler_output,
+                num_reqs,
+                total_num_scheduled_tokens,
+                req_indices,
+                position_offsets,
+                positions_np,
+                cu_num_tokens,
+                base_num_computed_tokens_np,
+            )
+
+        if self.pcp_size > 1 or should_rebuild_async_inputs:
+            # PCP and async rebuild both compute the correct positions on CPU.
+            # Copy positions_np to GPU so input_ids and positions stay aligned.
 
             self.positions[:total_num_scheduled_tokens].copy_(
                 torch.from_numpy(
@@ -1101,38 +1118,18 @@ class NPUModelRunner(GPUModelRunner):
                 + self.query_pos.gpu[:total_num_scheduled_tokens]
             )
 
-            if should_rebuild_async_inputs:
-                self._rebuild_input_ids_with_corrected_positions(
-                    scheduler_output,
-                    num_reqs,
-                    total_num_scheduled_tokens,
-                    req_indices,
-                    self.query_pos.np,
-                    positions_np,
-                    cu_num_tokens,
-                    corrected_num_computed_tokens_np,
-                )
-
         self.seq_lens[:num_reqs] = (
             self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
         )
         self.seq_lens[num_reqs:].fill_(0)
 
-        if (
-            self.use_cp
-            and self.use_async_spec_decode
-            and self.valid_sampled_token_count_gpu is not None
-            and prev_req_id_to_index
-            and self.decode_threshold > 2
-            and not with_prefill
-            and self.pcp_manager.async_rebuild_req_indices_full is not None
-        ):
+        if should_rebuild_async_inputs:
             req_indices_full = self.pcp_manager.async_rebuild_req_indices_full
             cu_num_tokens_full = self.pcp_manager.async_rebuild_cu_num_tokens_full
             num_tokens_full = self.pcp_manager.async_rebuild_num_tokens_full
 
-            assert corrected_num_computed_tokens_np is not None
-            base = corrected_num_computed_tokens_np
+            assert base_num_computed_tokens_np is not None
+            base = base_num_computed_tokens_np
 
             token_counts = np.diff(np.concatenate(([0], cu_num_tokens_full)))
             token_starts = np.repeat(cu_num_tokens_full - token_counts, token_counts)
@@ -1166,7 +1163,7 @@ class NPUModelRunner(GPUModelRunner):
                 req_indices_full,
                 positions_full,
                 cu_num_tokens_full,
-                self._draft_token_ids,
+                self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
                 self.num_spec_tokens,
                 precomputed_positions_np=positions_full,
@@ -1339,11 +1336,11 @@ class NPUModelRunner(GPUModelRunner):
         position_offsets,
         positions_np,
         cu_num_tokens,
-        corrected_num_computed_tokens_np,
+        base_num_computed_tokens_np,
     ) -> None:
-        # Reuse the corrected CPU copy of device-side starts so input_ids
-        # can be rebuilt from token_ids_cpu with the right positions.
-        base = corrected_num_computed_tokens_np
+        # base_num_computed_tokens_np contains per-request starts:
+        # decode requests use async-corrected lengths, prefill requests use CPU lengths.
+        base = base_num_computed_tokens_np
         np.add(
             base[req_indices],
             position_offsets[:total_num_scheduled_tokens],
@@ -2508,8 +2505,8 @@ class NPUModelRunner(GPUModelRunner):
     # overwrite _sample for lmhead_tp_enable and need_accepted_tokens
     def _sample(self, logits, spec_decode_metadata):
         # Sample the next token and get logprobs if needed.
-        sampling_metadata = self.input_batch.sampling_metadata
         self.input_batch.update_async_output_token_ids()
+        sampling_metadata = self.input_batch.sampling_metadata
         if spec_decode_metadata is None:
             if lmhead_tp_enable() and logits is not None:
                 logits = logits[: self.input_batch.num_reqs]

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -922,15 +922,16 @@ class PCPManager:
         self.query_start_loc_pcp_full.copy_to_gpu()
         self.input_ids_pcp_full.copy_to_gpu(total_num_scheduled_tokens_pcp_full)
         self.cu_num_tokens_pcp_full = cu_num_tokens_pcp_full
+
+        if self.use_async_scheduling and precomputed_positions_np is None:
+            # Save full pre-CP layout so async scheduling can rebuild
+            # speculative inputs with corrected num_computed_tokens.
+            self.async_rebuild_req_indices_full = req_indices.copy()
+            self.async_rebuild_cu_num_tokens_full = cu_num_tokens.copy()
+            self.async_rebuild_num_tokens_full = total_num_scheduled_tokens
+
         # For mtpx, pre-allocate mtp slot_mapping here
         if self.decode_threshold > 2 and not with_prefill:
-            if self.use_async_scheduling and precomputed_positions_np is None:
-                # Save full pre-PCP layout so async scheduling can rebuild draft slots
-                # with corrected num_computed_tokens.
-                self.async_rebuild_req_indices_full = req_indices.copy()
-                self.async_rebuild_cu_num_tokens_full = cu_num_tokens.copy()
-                self.async_rebuild_num_tokens_full = total_num_scheduled_tokens
-
             num_tokens_ori = sum(list(num_scheduled_tokens.values()))
             num_tokens_mtp = num_tokens_ori + self.num_reqs * (self.decode_threshold - 2)
             num_tokens_mtp_pad = num_tokens_mtp * self.pcp_world_size
@@ -1263,8 +1264,13 @@ class PCPManager:
                 and num_scheduled_tokens is not None
             ):
                 # Extract decode request info from input_batch and num_scheduled_tokens
-                decode_num_computed_tokens = input_batch.num_computed_tokens_cpu[: self.num_decode_reqs].tolist()
                 decode_num_scheduled_tokens = num_scheduled_tokens[: self.num_decode_reqs]
+                if fixed_decode_seq_lens_cpu is not None:
+                    decode_num_computed_tokens = (
+                        fixed_decode_seq_lens_cpu[: self.num_decode_reqs] - decode_num_scheduled_tokens
+                    ).tolist()
+                else:
+                    decode_num_computed_tokens = input_batch.num_computed_tokens_cpu[: self.num_decode_reqs].tolist()
 
                 dcp_mtp_attn_mask = self.generate_mtp_attention_mask_for_decode(
                     decode_num_computed_tokens, decode_num_scheduled_tokens

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -151,6 +151,12 @@ class PCPManager:
         self._local_num_scheduled_tokens: np.ndarray | None = None
         self._local_total_num_scheduled_tokens: int | None = None
 
+        # Full pre-PCP token layout used to rebuild draft slot mapping
+        # after async scheduling corrects num_computed_tokens.
+        self.async_rebuild_req_indices_full = None
+        self.async_rebuild_cu_num_tokens_full = None
+        self.async_rebuild_num_tokens_full = 0
+
     def _get_cumsum_and_arange(
         self,
         num_scheduled_tokens: np.ndarray,
@@ -865,6 +871,7 @@ class PCPManager:
         draft_token_ids=None,
         scheduler_output=None,
         num_spec_tokens=None,
+        precomputed_positions_np=None,
     ):
         """
         While pcp > 1, model inputs (input_ids, position, etc.) are split across pcp group,
@@ -885,7 +892,17 @@ class PCPManager:
         )
         arange_pcp_full = arange_np[:total_num_scheduled_tokens_pcp_full] - cumsums_offsets_pcp_full
         positions_pcp_full_np = self.positions_pcp_full_np[:total_num_scheduled_tokens_pcp_full]
-        np.add(input_batch.num_computed_tokens_cpu[req_indices_pcp_full], arange_pcp_full, out=positions_pcp_full_np)
+        if precomputed_positions_np is None:
+            np.add(
+                input_batch.num_computed_tokens_cpu[req_indices_pcp_full],
+                arange_pcp_full,
+                out=positions_pcp_full_np,
+            )
+        else:
+            np.copyto(
+                positions_pcp_full_np,
+                precomputed_positions_np[:total_num_scheduled_tokens_pcp_full],
+            )
         token_indices_pcp_full = positions_pcp_full_np + req_indices_pcp_full * input_batch.token_ids_cpu.shape[1]
         torch.index_select(
             input_batch.token_ids_cpu_tensor.flatten(),
@@ -907,6 +924,13 @@ class PCPManager:
         self.cu_num_tokens_pcp_full = cu_num_tokens_pcp_full
         # For mtpx, pre-allocate mtp slot_mapping here
         if self.decode_threshold > 2 and not with_prefill:
+            if self.use_async_scheduling and precomputed_positions_np is None:
+                # Save full pre-PCP layout so async scheduling can rebuild draft slots
+                # with corrected num_computed_tokens.
+                self.async_rebuild_req_indices_full = req_indices.copy()
+                self.async_rebuild_cu_num_tokens_full = cu_num_tokens.copy()
+                self.async_rebuild_num_tokens_full = total_num_scheduled_tokens
+
             num_tokens_ori = sum(list(num_scheduled_tokens.values()))
             num_tokens_mtp = num_tokens_ori + self.num_reqs * (self.decode_threshold - 2)
             num_tokens_mtp_pad = num_tokens_mtp * self.pcp_world_size
@@ -1047,6 +1071,7 @@ class PCPManager:
         block_table_tensor: torch.Tensor,
         num_reqs_padded: int,
         num_reqs: int,
+        fixed_decode_seq_lens_cpu: np.ndarray | None = None,
     ):
         from vllm_ascend.attention.utils import AscendPrefillContextParallelMetadata
 
@@ -1059,10 +1084,13 @@ class PCPManager:
         ori_query_lens_cpu = self.query_lens_pcp_full.cpu[:num_reqs_padded]
         if self.pcp_world_size * self.dcp_world_size > 1:
             assert num_scheduled_tokens is not None
-            decode_context_lens = (
-                input_batch.num_computed_tokens_cpu[: self.num_decode_reqs]
-                + num_scheduled_tokens[: self.num_decode_reqs]
-            )
+            if fixed_decode_seq_lens_cpu is not None:
+                decode_context_lens = fixed_decode_seq_lens_cpu[: self.num_decode_reqs]
+            else:
+                decode_context_lens = (
+                    input_batch.num_computed_tokens_cpu[: self.num_decode_reqs]
+                    + num_scheduled_tokens[: self.num_decode_reqs]
+                )
             prefill_context_lens = input_batch.num_computed_tokens_cpu[self.num_decode_reqs : self.num_reqs]
             context_lens = np.concatenate([decode_context_lens, prefill_context_lens])
 


### PR DESCRIPTION
## Summary

Async speculative decoding may correct num_computed_tokens after Eagle verification, while CP-related decode state can still be built from optimistic CPU-side lengths.

Rebuild target input ids, positions, slot mappings, CP metadata, and Eagle/MTP pre-CP inputs from corrected num_computed_tokens to avoid stale decode state in PCP/DCP paths.

## Changes

- Sync corrected seq_lens back to the CPU mirror after async speculative token correction.
- Use corrected decode sequence lengths when building CP metadata.
- Rebuild target input ids and positions from corrected num_computed_tokens.
- Rebuild target pre-PCP slot mapping from corrected global positions.
- Reuse generate_pcp_mtp_input with precomputed positions to refresh Eagle/MTP full-layout inputs and draft slot mappings.
- Save the full pre-CP token layout needed for async rebuild.

### What this PR does / why we need it?
Fixes precision issue when using async scheduling 

### Does this PR introduce _any_ user-facing change?
No. This is an internal fix for decode state consistency. No API or interface changes.

### How was this patch tested?
- Tested on MiniMax-M2.7 and Qwen3-30B-A3B with DCP(size=2) + Eagle3(num_speculative_tokens=3) + async scheduling enabled, verified that the token repetition issue no longer occurs and outputs are normal.
- Tested on Qwen3-30B-A3B with PCP(size=2) + Eagle3(num_speculative_tokens=3) + async scheduling enabled, confirmed no token repetition and outputs are normal


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
