### PR TITLE
[Ops][Feature] add setup of batch_invariant_ops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    VLLM_BATCH_INVARIANT=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -62,7 +62,8 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    VLLM_BATCH_INVARIANT=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -59,7 +59,8 @@ ARG SOC_VERSION="ascend910_9391"
 ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    VLLM_BATCH_INVARIANT=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -59,7 +59,8 @@ ARG SOC_VERSION="ascend910b1"
 ARG COMPILE_CUSTOM_KERNELS=1
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    VLLM_BATCH_INVARIANT=1
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \

--- a/csrc/aclnn_torch_adapter/op_api_common.h
+++ b/csrc/aclnn_torch_adapter/op_api_common.h
@@ -16,6 +16,7 @@
 #ifndef OP_API_COMMON_ADAPTER
 #define OP_API_COMMON_ADAPTER
 
+#include <fstream>
 #include <torch/types.h>
 #include <ATen/Tensor.h>
 #include <acl/acl_base.h>
@@ -155,6 +156,106 @@ bool IsOpInputBaseFormat(const at::Tensor &tensor)
         (format == ACL_FORMAT_NCDHW);
 }
 
+static std::vector<std::string> split_str(std::string s, const std::string &del)
+{
+    int end = s.find(del);
+    std::vector<std::string> path_list;
+    while (end != -1) {
+        path_list.push_back(s.substr(0, end));
+        s.erase(s.begin(), s.begin() + end + 1);
+        end = s.find(del);
+    }
+    path_list.push_back(s);
+    return path_list;
+}
+
+static bool is_file_exist(const std::string &path)
+{
+    if (path.empty() || path.size() > PATH_MAX) {
+        return false;
+    }
+    return (access(path.c_str(), F_OK) == 0) ? true : false;
+}
+
+inline  std::string real_path(const std::string &path)
+{
+    if (path.empty() || path.size() > PATH_MAX) {
+        return "";
+    }
+    char realPath[PATH_MAX] = {0};
+    if (realpath(path.c_str(), realPath) == nullptr) {
+        return "";
+    }
+    return std::string(realPath);
+}
+
+inline std::vector<std::string> get_custom_lib_path()
+{
+    char *ascend_custom_opppath = std::getenv("ASCEND_CUSTOM_OPP_PATH");
+    std::vector<std::string> custom_lib_path_list;
+
+    if (ascend_custom_opppath == nullptr) {
+        return std::vector<std::string>();
+    }
+
+    std::string ascend_custom_opppath_str(ascend_custom_opppath);
+    // split string with ":"
+    custom_lib_path_list = split_str(ascend_custom_opppath_str, ":");
+    if (custom_lib_path_list.empty()) {
+        return std::vector<std::string>();
+    }
+    for (auto &it : custom_lib_path_list) {
+        it = it + "/op_api/lib/";
+    }
+
+    return custom_lib_path_list;
+}
+
+inline std::vector<std::string> get_default_custom_lib_path()
+{
+    char *ascend_opp_path = std::getenv("ASCEND_OPP_PATH");
+    std::vector<std::string> default_vendors_list;
+
+    if (ascend_opp_path == nullptr) {
+        return std::vector<std::string>();
+    }
+
+    std::string vendors_path(ascend_opp_path);
+    vendors_path = vendors_path + "/vendors";
+    std::string vendors_config_file = real_path(vendors_path + "/config.ini");
+    if (vendors_config_file.empty()) {
+        return std::vector<std::string>();
+    }
+
+    if (!is_file_exist(vendors_config_file)) {
+        return std::vector<std::string>();
+    }
+
+    std::ifstream ifs(vendors_config_file);
+    std::string line;
+    while (std::getline(ifs, line)) {
+        if (line.find("load_priority=") == 0) {
+            break;
+        }
+    }
+    std::string head = "load_priority=";
+    line.erase(0, head.length());
+
+    // split string with ","
+    default_vendors_list = split_str(line, ",");
+    if (default_vendors_list.empty()) {
+        return std::vector<std::string>();
+    }
+    for (auto &it : default_vendors_list) {
+        it = real_path(vendors_path + "/" + it + "/op_api/lib/");
+    }
+
+    return default_vendors_list;
+}
+
+const std::vector<std::string> g_custom_lib_path = get_custom_lib_path();
+const std::vector<std::string> g_default_custom_lib_path = get_default_custom_lib_path();
+
 inline const char *GetOpApiLibName(void) { return "libopapi.so"; }
 
 inline const char *GetCustOpApiLibName(void) { return "libcust_opapi.so"; }
@@ -170,21 +271,47 @@ inline void *GetOpApiLibHandler(const char *libName) {
   return handler;
 }
 
-inline void *GetOpApiFuncAddr(const char *apiName) {
-  static auto custOpApiHandler = GetOpApiLibHandler(GetCustOpApiLibName());
-  if (custOpApiHandler != nullptr) {
-    auto funcAddr =
-        GetOpApiFuncAddrInLib(custOpApiHandler, GetCustOpApiLibName(), apiName);
-    if (funcAddr != nullptr) {
-      return funcAddr;
+inline void *GetOpApiFuncAddr(const char *apiName)
+{
+    if (!g_custom_lib_path.empty()) {
+        for (auto &it : g_custom_lib_path) {
+            auto cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
+            if (cust_opapi_lib.empty()) {
+                continue;
+            }
+            auto custOpApiHandler = GetOpApiLibHandler(cust_opapi_lib.c_str());
+            if (custOpApiHandler != nullptr) {
+                auto funcAddr =
+                    GetOpApiFuncAddrInLib(custOpApiHandler, GetCustOpApiLibName(), apiName);
+                if (funcAddr != nullptr) {
+                    return funcAddr;
+                }
+            }
+        }
     }
-  }
 
-  static auto opApiHandler = GetOpApiLibHandler(GetOpApiLibName());
-  if (opApiHandler == nullptr) {
-    return nullptr;
-  }
-  return GetOpApiFuncAddrInLib(opApiHandler, GetOpApiLibName(), apiName);
+    if (!g_default_custom_lib_path.empty()) {
+        for (auto &it : g_default_custom_lib_path) {
+            auto default_cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
+            if (default_cust_opapi_lib.empty()) {
+                continue;
+            }
+            auto custOpApiHandler = GetOpApiLibHandler(default_cust_opapi_lib.c_str());
+            if (custOpApiHandler != nullptr) {
+                auto funcAddr =
+                    GetOpApiFuncAddrInLib(custOpApiHandler, GetCustOpApiLibName(), apiName);
+                if (funcAddr != nullptr) {
+                    return funcAddr;
+                }
+            }
+        }
+    }
+
+    static auto opApiHandler = GetOpApiLibHandler(GetOpApiLibName());
+    if (opApiHandler == nullptr) {
+        return nullptr;
+    }
+    return GetOpApiFuncAddrInLib(opApiHandler, GetOpApiLibName(), apiName);
 }
 
 inline c10::Scalar ConvertTensorToScalar(const at::Tensor &tensor) {

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -306,14 +306,18 @@ log_selected_ops
   { find "${custom_ops_install_dir}" -mindepth 1 -maxdepth 4 -print | sort | head -n 120 | sed 's#^#[build_aclnn] install: #'; } || true
 
   # install batch_invariant run package and whl package
-  log "Installing batch_invariant run package and whl package..."
+  if [[ "${VLLM_BATCH_INVARIANT:-0}" == "1" ]]; then
+    log "VLLM_BATCH_INVARIANT=1, installing batch_invariant run package and whl package..."
 
-  # call separate installation script
-  batch_invariant_script="${ROOT_DIR}/csrc/build_batch_invariant_ops.sh"
-  if [[ -f "${batch_invariant_script}" ]]; then
-    log "Calling batch_invariant_ops build script: ${batch_invariant_script}"
-    bash "${batch_invariant_script}" "${SOC_ARG}"
+    # call separate installation script
+    batch_invariant_script="${ROOT_DIR}/csrc/build_batch_invariant_ops.sh"
+    if [[ -f "${batch_invariant_script}" ]]; then
+      log "Calling batch_invariant_ops build script: ${batch_invariant_script}"
+      bash "${batch_invariant_script}" "${SOC_ARG}"
+    else
+      log "Warning: batch_invariant_ops build script not found at ${batch_invariant_script}"
+    fi
   else
-    log "Warning: batch_invariant_ops build script not found at ${batch_invariant_script}"
+    log "VLLM_BATCH_INVARIANT is not set to 1, skipping batch_invariant ops build"
   fi
 )

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -304,4 +304,16 @@ log_selected_ops
   log "installer finished"
   log "installed files under ${custom_ops_install_dir} (maxdepth=4, first 120 entries):"
   { find "${custom_ops_install_dir}" -mindepth 1 -maxdepth 4 -print | sort | head -n 120 | sed 's#^#[build_aclnn] install: #'; } || true
+
+  # install batch_invariant run package and whl package
+  log "Installing batch_invariant run package and whl package..."
+
+  # call separate installation script
+  batch_invariant_script="${ROOT_DIR}/csrc/build_batch_invariant_ops.sh"
+  if [[ -f "${batch_invariant_script}" ]]; then
+    log "Calling batch_invariant_ops build script: ${batch_invariant_script}"
+    bash "${batch_invariant_script}" "${SOC_ARG}"
+  else
+    log "Warning: batch_invariant_ops build script not found at ${batch_invariant_script}"
+  fi
 )

--- a/csrc/build_batch_invariant_ops.sh
+++ b/csrc/build_batch_invariant_ops.sh
@@ -28,11 +28,8 @@ case "${SOC_ARG}" in
     ascend910_93)
         BATCH_INVARIANT_DEVICE="A3"
         ;;
-    ascend950)
-        BATCH_INVARIANT_DEVICE="A5"
-        ;;
     *)
-        log "batch_invariant not available for SOC_ARG=${SOC_ARG}; skipping"
+        log "Warning: batch_invariant not available for SOC_ARG=${SOC_ARG}; skipping"
         exit 0
         ;;
 esac
@@ -53,7 +50,7 @@ case "${ARCH_INFO}" in
 esac
 
 # download and install run package
-BATCH_INVARIANT_RUN_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/ops-batchinvariant/beta/20260521/cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
+BATCH_INVARIANT_RUN_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
 BATCH_INVARIANT_RUN_FILE="cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
 
 log "Downloading batch_invariant run package..."
@@ -73,7 +70,7 @@ fi
 rm -f "${BATCH_INVARIANT_RUN_FILE}"
 
 # download and install whl package
-BATCH_INVARIANT_WHL_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/ops-batchinvariant/beta/20260603/batch_invariant-torch_ops_extension-1.0.0.zip"
+BATCH_INVARIANT_WHL_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vllm-ascend/batch_invariant-torch_ops_extension-1.0.0.zip"
 BATCH_INVARIANT_WHL_FILE="batch_invariant-torch_ops_extension-1.0.0.zip"
 
 log "Downloading batch_invariant whl package..."

--- a/csrc/build_batch_invariant_ops.sh
+++ b/csrc/build_batch_invariant_ops.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# arguments:
+# $1: SOC_ARG (ascend910b, ascend910_93, ascend950)
+
+SOC_ARG="${1:-}"
+
+log() {
+    echo "[install_batch_invariant] $*"
+}
+
+# validate arguments
+if [[ -z "${SOC_ARG}" ]]; then
+    log "ERROR: SOC_ARG is required as first argument"
+    exit 1
+fi
+
+log "Starting batch_invariant installation..."
+log "SOC_ARG=${SOC_ARG}"
+
+# determine device type from SOC_ARG
+case "${SOC_ARG}" in
+    ascend910b)
+        BATCH_INVARIANT_DEVICE="910b"
+        ;;
+    ascend910_93)
+        BATCH_INVARIANT_DEVICE="A3"
+        ;;
+    ascend950)
+        BATCH_INVARIANT_DEVICE="A5"
+        ;;
+    *)
+        log "batch_invariant not available for SOC_ARG=${SOC_ARG}; skipping"
+        exit 0
+        ;;
+esac
+
+# detect system architecture
+ARCH_INFO=$(uname -m)
+case "${ARCH_INFO}" in
+    aarch64)
+        ARCH_SUFFIX="aarch64"
+        ;;
+    x86_64)
+        ARCH_SUFFIX="x86_64"
+        ;;
+    *)
+        log "Unknown architecture ${ARCH_INFO}; cannot determine batch_invariant package"
+        exit 0
+        ;;
+esac
+
+# download and install run package
+BATCH_INVARIANT_RUN_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/ops-batchinvariant/beta/20260521/cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
+BATCH_INVARIANT_RUN_FILE="cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0.0-linux.${ARCH_SUFFIX}.run"
+
+log "Downloading batch_invariant run package..."
+unset ASCEND_CUSTOM_OPP_PATH
+if curl --max-time 60 -sS -k -O "${BATCH_INVARIANT_RUN_URL}"; then
+    chmod +x "${BATCH_INVARIANT_RUN_FILE}"
+    log "Running installer: ${BATCH_INVARIANT_RUN_FILE}"
+    if "./${BATCH_INVARIANT_RUN_FILE}"; then
+        log "batch_invariant run package installed successfully"
+    else
+        log "Failed to install batch_invariant run package"
+    fi
+else
+    log "Failed to download batch_invariant run package: ${BATCH_INVARIANT_RUN_URL}"
+fi
+# clean up downloaded run file (always clean, regardless of success/failure)
+rm -f "${BATCH_INVARIANT_RUN_FILE}"
+
+# download and install whl package
+BATCH_INVARIANT_WHL_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/ops-batchinvariant/beta/20260603/batch_invariant-torch_ops_extension-1.0.0.zip"
+BATCH_INVARIANT_WHL_FILE="batch_invariant-torch_ops_extension-1.0.0.zip"
+
+log "Downloading batch_invariant whl package..."
+if curl --max-time 3 -sS -k -O "${BATCH_INVARIANT_WHL_URL}" >/dev/null 2>&1; then
+    unzip -o "${BATCH_INVARIANT_WHL_FILE}" >/dev/null 2>&1
+    if [[ -d "torch_ops_extension/batch_invariant_ops" ]]; then
+        cd torch_ops_extension/batch_invariant_ops
+        log "Building and installing batch_invariant whl package..."
+        if bash build_and_install.sh; then
+            log "batch_invariant whl package installed successfully"
+        else
+            log "Failed to build and install batch_invariant whl package"
+        fi
+        cd -
+    else
+        log "batch_invariant_ops directory not found in zip"
+    fi
+else
+    log "Failed to download batch_invariant whl package: ${BATCH_INVARIANT_WHL_URL}"
+fi
+# clean up downloaded files (always clean, regardless of success/failure)
+rm -rf "${BATCH_INVARIANT_WHL_FILE}" torch_ops_extension
+
+log "batch_invariant_ops build completed"

--- a/csrc/build_batch_invariant_ops.sh
+++ b/csrc/build_batch_invariant_ops.sh
@@ -44,7 +44,7 @@ case "${ARCH_INFO}" in
         ARCH_SUFFIX="x86_64"
         ;;
     *)
-        log "Unknown architecture ${ARCH_INFO}; cannot determine batch_invariant package"
+        log "Warning: unknown architecture ${ARCH_INFO}; cannot determine batch_invariant package"
         exit 0
         ;;
 esac
@@ -55,7 +55,7 @@ BATCH_INVARIANT_RUN_FILE="cann-ops-batch_invariant-${BATCH_INVARIANT_DEVICE}-1.0
 
 log "Downloading batch_invariant run package..."
 unset ASCEND_CUSTOM_OPP_PATH
-if curl --max-time 60 -sS -k -O "${BATCH_INVARIANT_RUN_URL}"; then
+if curl --max-time 60 -sS -k -O "${BATCH_INVARIANT_RUN_URL}" && [[ -f "${BATCH_INVARIANT_RUN_FILE}" ]]; then
     chmod +x "${BATCH_INVARIANT_RUN_FILE}"
     log "Running installer: ${BATCH_INVARIANT_RUN_FILE}"
     if "./${BATCH_INVARIANT_RUN_FILE}"; then
@@ -74,19 +74,22 @@ BATCH_INVARIANT_WHL_URL="https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/vl
 BATCH_INVARIANT_WHL_FILE="batch_invariant-torch_ops_extension-1.0.0.zip"
 
 log "Downloading batch_invariant whl package..."
-if curl --max-time 3 -sS -k -O "${BATCH_INVARIANT_WHL_URL}" >/dev/null 2>&1; then
-    unzip -o "${BATCH_INVARIANT_WHL_FILE}" >/dev/null 2>&1
-    if [[ -d "torch_ops_extension/batch_invariant_ops" ]]; then
-        cd torch_ops_extension/batch_invariant_ops
-        log "Building and installing batch_invariant whl package..."
-        if bash build_and_install.sh; then
-            log "batch_invariant whl package installed successfully"
+if curl --max-time 3 -sS -k -O "${BATCH_INVARIANT_WHL_URL}" >/dev/null 2>&1 && [[ -f "${BATCH_INVARIANT_WHL_FILE}" ]]; then
+    if unzip -o "${BATCH_INVARIANT_WHL_FILE}" >/dev/null 2>&1; then
+        if [[ -d "torch_ops_extension/batch_invariant_ops" ]]; then
+            cd torch_ops_extension/batch_invariant_ops
+            log "Building and installing batch_invariant whl package..."
+            if bash build_and_install.sh; then
+                log "batch_invariant whl package installed successfully"
+            else
+                log "Failed to build and install batch_invariant whl package"
+            fi
+            cd -
         else
-            log "Failed to build and install batch_invariant whl package"
+            log "batch_invariant_ops directory not found in zip"
         fi
-        cd -
     else
-        log "batch_invariant_ops directory not found in zip"
+        log "Failed to unzip batch_invariant whl package"
     fi
 else
     log "Failed to download batch_invariant whl package: ${BATCH_INVARIANT_WHL_URL}"

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -234,7 +234,7 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 ```
 
 ```{note}
-To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. The build script checks this variable to determine whether to compile and install the `batch_invariant_ops`. For more details, see {doc}`Batch Invariance </user_guide/feature_guide/batch_invariance>`.
+To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. The build script checks this variable to determine whether to compile and install the `batch_invariant_ops`.
 ```
 
 ## Set up using Docker

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -233,6 +233,10 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 - Atlas A5: `export SOC_VERSION=<value starting with "ascend950">`
 ```
 
+```{note}
+To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` **before** building `vllm-ascend`. The build script checks this variable to determine whether to compile and install the `batch_invariant_ops`. For more details, see [Batch Invariance](user_guide/feature_guide/batch_invariance.md).
+```
+
 ## Set up using Docker
 
 `vllm-ascend` offers Docker images for deployment. You can just pull the **prebuilt image** from the image repository [ascend/vllm-ascend](https://quay.io/repository/ascend/vllm-ascend?tab=tags) and run it with bash.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -234,7 +234,7 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 ```
 
 ```{note}
-To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` **before** building `vllm-ascend`. The build script checks this variable to determine whether to compile and install the `batch_invariant_ops`. For more details, see [Batch Invariance](user_guide/feature_guide/batch_invariance.md).
+To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. The build script checks this variable to determine whether to compile and install the `batch_invariant_ops`. For more details, see {doc}`Batch Invariance </user_guide/feature_guide/batch_invariance>`.
 ```
 
 ## Set up using Docker

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -234,7 +234,7 @@ If you are building in a CPU-only environment where `npu-smi` is unavailable, yo
 ```
 
 ```{note}
-To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. The build script checks this variable to determine whether to compile and install the `batch_invariant_ops`.
+To enable the batch invariance feature, set the environment variable `VLLM_BATCH_INVARIANT=1` before building `vllm-ascend`. And the `batch_invariant_ops` will be compiled and installed after setting `VLLM_BATCH_INVARIANT=1`. For usage guidance on the batch invariance feature, see <https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/batch_invariance.md>
 ```
 
 ## Set up using Docker

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -18,13 +18,13 @@ Batch invariance is crucial for several use cases:
 
 ## Hardware Requirements
 
-Batch invariance currently requires Ascend Atlas A2 inference products NPUs, because only the Atlas A2 inference products supports batch invariance with HCCL communication for now.
-We will support other NPUs in the future.
+Batch invariance currently requires Ascend Atlas A2 and A3 inference products NPUs.
+We will support Atlas A5 and other NPUs in the future.
 
 ## Software Requirements
 
-Batch invariance requires a custom operator library for Atlas A2 inference products.
-We will release the customized operator library in future versions.
+Batch invariance requires a custom operator library for Atlas A2 and A3 inference products.
+The operator library is automatically installed as part of the standard vllm-ascend installation process.
 
 ## Enabling Batch Invariance
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the setup and installation of `batch_invariant_ops` for Ascend Atlas A2 and A3 NPUs, and updates `op_api_common.h` to correctly find and load the AscendC custom operators.

### Does this PR introduce _any_ user-facing change?

Yes, batch invariance support is extended to A2 and A3 NPUs, and  users need to **set VLLM_BATCH_INVARIANT=1** to install the  batch invariance custom operator library during the standard vllm-ascend installation process.

### How was this patch tested?

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
