### PR TITLE
[CI] Remove lint Dockerfile vLLM commit default

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.lint
+++ b/.github/workflows/dockerfiles/Dockerfile.lint
@@ -27,8 +27,9 @@ RUN apt-get update -y && \
 
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 # For lint purpose, actually we need make a main2main matching.
-ARG VLLM_COMMIT=9090368b650896bf5fc990c921df7eb4c20355a5
-RUN git init /vllm-workspace/vllm && \
+ARG VLLM_COMMIT
+RUN [ -n "$VLLM_COMMIT" ] || { echo "VLLM_COMMIT is empty"; exit 1; } && \
+    git init /vllm-workspace/vllm && \
     git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO $VLLM_COMMIT && \
     git -C /vllm-workspace/vllm checkout FETCH_HEAD
 

--- a/.github/workflows/schedule_lint_image_build.yaml
+++ b/.github/workflows/schedule_lint_image_build.yaml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - '.github/vllm-main-verified.commit'
       - '.github/workflows/dockerfiles/Dockerfile.lint'
       - 'requirements-lint.txt'
       - 'requirements-dev.txt'
@@ -40,6 +41,13 @@ jobs:
         flavor:
           latest=false
 
+    - name: Read verified vLLM commit
+      id: vllm
+      run: |
+        vllm_commit="$(cat .github/vllm-main-verified.commit)"
+        [ -n "$vllm_commit" ] || { echo "::error::vLLM commit is empty"; exit 1; }
+        echo "main_commit=$vllm_commit" >> "$GITHUB_OUTPUT"
+
     - name: Build - Set up QEMU
       uses: docker/setup-qemu-action@v4
 
@@ -65,6 +73,8 @@ jobs:
         push: true
         labels: ${{ steps.meta.outputs.labels }}
         tags: ${{ steps.meta.outputs.tags }}
+        build-args: |
+          VLLM_COMMIT=${{ steps.vllm.outputs.main_commit }}
         provenance: false
 
     - name: Build and push
@@ -78,4 +88,6 @@ jobs:
         push: true
         labels: ${{ steps.meta.outputs.labels }}
         tags: ${{ steps.meta.outputs.tags }}
+        build-args: |
+          VLLM_COMMIT=${{ steps.vllm.outputs.main_commit }}
         provenance: false


### PR DESCRIPTION
﻿Fixes #9800

## What this PR does / why we need it?

This PR removes the duplicated hardcoded vLLM main commit from the lint image build.

It follows the verified-ref anchor introduced by #9801: the lint image workflow reads `.github/vllm-main-verified.commit`, exposes it as the `main_commit` step output, and passes it into `Dockerfile.lint` as the `VLLM_COMMIT` build arg.

This PR intentionally does not add `.github/vllm-main-verified.commit`; it depends on #9801 landing first.

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

- `git diff --check`
- `actionlint .github/workflows/schedule_lint_image_build.yaml`
- Confirmed the GitHub PR diff only contains `Dockerfile.lint` and `schedule_lint_image_build.yaml`.
