### PR TITLE
[CI] Read scheduled vLLM tag from verified ref

### DIFF
--- a/.github/actions/read-vllm-release-tag/action.yml
+++ b/.github/actions/read-vllm-release-tag/action.yml
@@ -1,0 +1,19 @@
+name: Read vLLM release tag
+description: Read and validate the verified vLLM release tag.
+outputs:
+  release_tag:
+    description: Verified vLLM release tag.
+    value: ${{ steps.read.outputs.release_tag }}
+runs:
+  using: composite
+  steps:
+    - name: Read release tag
+      id: read
+      shell: bash
+      run: |
+        release_tag="$(tr -d '[:space:]' < .github/vllm-release-tag.commit)"
+        [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]] || {
+          echo "::error file=.github/vllm-release-tag.commit::invalid vLLM release tag: ${release_tag}"
+          exit 1
+        }
+        echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/schedule_vllm_e2e_test.yaml
+++ b/.github/workflows/schedule_vllm_e2e_test.yaml
@@ -49,7 +49,6 @@ jobs:
           fail-fast: false
           matrix:
             part: [0, 1, 2, 3]
-            vllm: [v0.21.0]
         container:
           image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12
           env:
@@ -58,6 +57,9 @@ jobs:
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v6
+          - name: Read vLLM release tag
+            id: vllm
+            uses: ./.github/actions/read-vllm-release-tag
           - name: Check npu and CANN info
             run: |
               npu-smi info
@@ -84,7 +86,7 @@ jobs:
             uses: actions/checkout@v6
             with:
               repository: vllm-project/vllm
-              ref: ${{ matrix.vllm }}
+              ref: ${{ steps.vllm.outputs.release_tag }}
               path: ./vllm-empty
               fetch-depth: 1
 
@@ -132,7 +134,6 @@ jobs:
           fail-fast: false
           matrix:
             part: [0]
-            vllm: [v0.21.0]
         container:
           image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12
           env:
@@ -141,6 +142,9 @@ jobs:
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v6
+          - name: Read vLLM release tag
+            id: vllm
+            uses: ./.github/actions/read-vllm-release-tag
           - name: Check npu and CANN info
             run: |
               npu-smi info
@@ -167,7 +171,7 @@ jobs:
             uses: actions/checkout@v6
             with:
               repository: vllm-project/vllm
-              ref: ${{ matrix.vllm }}
+              ref: ${{ steps.vllm.outputs.release_tag }}
               path: ./vllm-empty
               fetch-depth: 1
 
@@ -206,7 +210,6 @@ jobs:
           fail-fast: false
           matrix:
             part: [0]
-            vllm: [v0.21.0]
         container:
           image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-910b-ubuntu22.04-py3.12
           env:
@@ -215,6 +218,9 @@ jobs:
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v6
+          - name: Read vLLM release tag
+            id: vllm
+            uses: ./.github/actions/read-vllm-release-tag
           - name: Check npu and CANN info
             run: |
               npu-smi info
@@ -241,7 +247,7 @@ jobs:
             uses: actions/checkout@v6
             with:
               repository: vllm-project/vllm
-              ref: ${{ matrix.vllm }}
+              ref: ${{ steps.vllm.outputs.release_tag }}
               path: ./vllm-empty
               fetch-depth: 1
 


### PR DESCRIPTION
Fixes #9800

## What this PR does / why we need it?

This PR removes the duplicated hardcoded vLLM release tag from the scheduled upstream E2E workflow.

It follows the verified-ref anchor introduced by #9801. Each scheduled E2E job now:

- checks out `vllm-ascend`,
- reads `.github/vllm-release-tag.commit` in a local `Read vLLM release tag` step,
- validates the value as a vLLM release tag,
- uses `steps.vllm.outputs.release_tag` directly when checking out `vllm-project/vllm`.

This keeps the change scoped to the existing scheduled test jobs and avoids a dedicated helper job. The PR intentionally does not add `.github/vllm-release-tag.commit`; it depends on #9801 landing first.

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

- `actionlint .github/workflows/schedule_vllm_e2e_test.yaml`
- `git diff --check`
- Confirmed the PR diff only contains `.github/workflows/schedule_vllm_e2e_test.yaml`.
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
