### PR TITLE
[Bugfix][DSV4] Enhance QLI workspace size calculation for ASCEND 950

### DIFF
--- a/csrc/attention/quant_lightning_indexer/op_host/quant_lightning_indexer_tiling.cpp
+++ b/csrc/attention/quant_lightning_indexer/op_host/quant_lightning_indexer_tiling.cpp
@@ -871,12 +871,14 @@ ge::graphStatus QuantLightningIndexerTiling::DoTiling(QLITilingInfo *tilingInfo)
     constexpr uint32_t V1_DECODE_DATA_NUM = 2;         // Decode每个核需要存储头和尾部两块数据
     constexpr uint32_t S1_BASE_SIZE = 8;               // S1轴基本块的大小
     constexpr uint32_t TOPK_MAX_SIZE = 2048;           // TopK选取个数
+    constexpr uint32_t ASCEND950_S1_BASE_SIZE = 4;     // Ascend 950 S1轴基本块的大小
+    constexpr uint32_t ASCEND950_S2_BASE_SIZE = 128;   // Ascend 950 S2轴基本块的大小
     uint32_t workspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
     // 主流程需Workspace大小
     platform_ascendc::SocVersion socVersion_ = ascendcPlatform.GetSocVersion();
     if (socVersion_ == platform_ascendc::SocVersion::ASCEND950) {
-        constexpr uint32_t s1Base = 4;
-        constexpr uint32_t s2Base = 128;
+        constexpr uint32_t s1Base = ASCEND950_S1_BASE_SIZE;
+        constexpr uint32_t s2Base = ASCEND950_S2_BASE_SIZE;
         workspaceSize += s1Base * ((tilingInfo->s2Size + s2Base - 1) / s2Base) * s2Base * sizeof(uint32_t) * aicNum;
     } else {
         uint32_t mm1ResSize = M_BASE_SIZE * S2_BASE_SIZE;

--- a/csrc/attention/quant_lightning_indexer/op_host/quant_lightning_indexer_tiling.cpp
+++ b/csrc/attention/quant_lightning_indexer/op_host/quant_lightning_indexer_tiling.cpp
@@ -873,13 +873,20 @@ ge::graphStatus QuantLightningIndexerTiling::DoTiling(QLITilingInfo *tilingInfo)
     constexpr uint32_t TOPK_MAX_SIZE = 2048;           // TopK选取个数
     uint32_t workspaceSize = ascendcPlatform.GetLibApiWorkSpaceSize();
     // 主流程需Workspace大小
-    uint32_t mm1ResSize = M_BASE_SIZE * S2_BASE_SIZE;
-    workspaceSize += mm1ResSize * MM1_RES_ELEM_SIZE * DOUBLE_BUFFER * aicNum;
-    // Decode流程(LD)需要Workspace大小
-    // 临时存储Decode中间结果大小: 2(头/尾)*8(s1Base)*2(idx/value)*2048(K)*sizeof(int32)*24=6M
-    workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_RES_ELEM_TYPE * TOPK_MAX_SIZE * V1_RES_ELEM_SIZE * aicNum;
-    // 临时存储Decode中间参数信息大小: 2(头/尾)*8(s1Base)*16(paramNum)*sizeof(int64_t)*24=48k
-    workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_DECODE_PARAM_NUM * V1_DECODE_PARAM_ELEM_SIZE * aicNum;
+    platform_ascendc::SocVersion socVersion_ = ascendcPlatform.GetSocVersion();
+    if (socVersion_ == platform_ascendc::SocVersion::ASCEND950) {
+        constexpr uint32_t s1Base = 4;
+        constexpr uint32_t s2Base = 128;
+        workspaceSize += s1Base * ((tilingInfo->s2Size + s2Base - 1) / s2Base) * s2Base * sizeof(uint32_t) * aicNum;
+    } else {
+        uint32_t mm1ResSize = M_BASE_SIZE * S2_BASE_SIZE;
+        workspaceSize += mm1ResSize * MM1_RES_ELEM_SIZE * DOUBLE_BUFFER * aicNum;
+        // Decode流程(LD)需要Workspace大小
+        // 临时存储Decode中间结果大小: 2(头/尾)*8(s1Base)*2(idx/value)*2048(K)*sizeof(int32)*24=6M
+        workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_RES_ELEM_TYPE * TOPK_MAX_SIZE * V1_RES_ELEM_SIZE * aicNum;
+        // 临时存储Decode中间参数信息大小: 2(头/尾)*8(s1Base)*16(paramNum)*sizeof(int64_t)*24=48k
+        workspaceSize += V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_DECODE_PARAM_NUM * V1_DECODE_PARAM_ELEM_SIZE * aicNum;
+    }
     size_t *workSpaces = context_->GetWorkspaceSizes(1);
     workSpaces[0] = workspaceSize;
 

--- a/csrc/attention/quant_lightning_indexer/op_kernel/arch35/quant_lightning_indexer_kernel.h
+++ b/csrc/attention/quant_lightning_indexer/op_kernel/arch35/quant_lightning_indexer_kernel.h
@@ -398,9 +398,11 @@ __aicore__ inline void QLIPreload<QLIT>::Init(__gm__ uint8_t *query, __gm__ uint
     uint64_t offset = 0;
     //vec 把整个s2的score存储在GM，大小为s1BaseSize * 16K * 4
     GlobalTensor<SCORE_T> scoreGm; //存放vec核写出的score
-    uint64_t singleCoreScoreSize = constInfo.s1BaseSize * QLICommon::Align((uint64_t)constInfo.kSeqSize, (uint64_t)constInfo.s2BaseSize)  * sizeof(SCORE_T);
-    scoreGm.SetGlobalBuffer((__gm__ SCORE_T *)(workspace + aiCoreIdx * singleCoreScoreSize));
-    offset += GetBlockNum() * singleCoreScoreSize;
+    if ASCEND_IS_AIV {
+        uint64_t singleCoreScoreSize = constInfo.s1BaseSize * QLICommon::Align((uint64_t)constInfo.kSeqSize, (uint64_t)constInfo.s2BaseSize)  * sizeof(SCORE_T);
+        scoreGm.SetGlobalBuffer((__gm__ SCORE_T *)(workspace + aiCoreIdx * singleCoreScoreSize));
+        offset += GetBlockNum() * singleCoreScoreSize;
+    }
 
     if ASCEND_IS_AIV {
         vectorService.InitParams(constInfo, tiling);


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #10204.

This PR fixes QLI workspace sizing for DeepSeek-V4-Flash long-context serving on ASCEND 950.

Issue #10204 reports that `QuantLightningIndexer` can fail with an MTE DDR address out-of-range error when the sequence length exceeds 300K on 950PR. The root cause is that the QLI workspace size/offset calculation does not match the ASCEND 950 execution path for long sequences, which can make the kernel access workspace memory outside the allocated range.

This PR:
- Adds an ASCEND 950-specific workspace size calculation in QLI tiling.
- Sizes the ASCEND 950 score workspace from aligned `s2Size` with `s1Base=4` and `s2Base=128`.
- Keeps the existing workspace calculation for non-ASCEND 950 platforms.
- Updates the arch35 QLI preload kernel so score workspace offset calculation is only applied on AIV, matching the path that actually uses that buffer.

### Does this PR introduce _any_ user-facing change?

No user-facing API or configuration change.

The change only fixes internal QLI workspace calculation for ASCEND 950 long-context execution. Existing serving flags and model usage stay unchanged.

### How was this patch tested?

Tested with DeepSeek-V4-Flash long-context serving on ASCEND 950 using:

```bash
#!/usr/bin/bash
TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
LOG_FILE="logs/test_${TIMESTAMP}.log"

export OMP_PROC_BIND=false
export OMP_NUM_THREADS=8
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1

export VLLM_USE_V1=1

export TASK_QUEUE_ENABLE=1
export HCCL_BUFFSIZE=1024
export VLLM_VERSION="0.20.0"

export USE_MULTI_BLOCK_POOL=1
export USE_MULTI_GROUPS_KV_CACHE=1

MODEL_WEIGHT=/data2/weights/DeepSeek-V4-Flash

vllm serve $MODEL_WEIGHT \
  --max-model-len 1048576 \
  --max-num-batched-tokens 16384 \
  --served-model-name ds \
  --gpu-memory-utilization 0.92 \
  --max-num-seqs 32 \
  --pipeline-parallel-size 1 \
  --data-parallel-size 1 \
  --prefill-context-parallel-size 1 \
  --tensor-parallel-size 4 \
  --enable-expert-parallel \
  --port 8000 \
  --block-size 128 \
  --enable-chunked-prefill \
  --no-async-scheduling \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --enable-prefix-caching \
  --additional-config '{
                "enable_cpu_binding":true,
                "multistream_overlap_shared_expert":true,
                "multistream_dsa_preprocess":true,
                "enable_flashcomm1": true,
                "enable_dsa_cp": true
        }' \
  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
  2>&1 | tee "$LOG_FILE"
```

Key serving configuration:
- `--max-model-len 1048576`
- `--max-num-batched-tokens 16384`
- `--tensor-parallel-size 4`
- `--enable-chunked-prefill`
- `--enable-prefix-caching`
- `enable_dsa_cp=true`
- `multistream_dsa_preprocess=true`

The verification covers the long-context QLI path that previously triggered the MTE DDR address out-of-range failure reported in #10204.

#### Results
- GPQA-D High Think 88.89
<img width="545" height="73" alt="截屏2026-06-11 19 32 34" src="https://github.com/user-attachments/assets/7ac23411-46f1-417c-95e2-2e41f264546e" />

- Test 1024k Input
<img width="406" height="463" alt="截屏2026-06-11 19 33 16" src="https://github.com/user-attachments/assets/64a12730-ed12-4d19-bd7a-67485fe94736" />

Environment/reference:


- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
