### PR TITLE
[BugFix][SpecDecode] Reject placeholder draft tokens in sampler

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import MethodType
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.request import Request
+from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
+
+from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
+
+
+def test_pd_consumer_first_step_injects_placeholder_spec_tokens():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    scheduler.requests = {}
+    scheduler.is_kv_producer = False
+    scheduler.is_hybrid_model = False
+    scheduler.is_mtp_kv_consumer = True
+    scheduler.num_spec_tokens = 1
+    scheduler.max_model_len = 1024
+    scheduler.log_stats = False
+
+    enqueued_requests = []
+
+    def enqueue_waiting_request(self, request):
+        enqueued_requests.append(request)
+
+    scheduler._enqueue_waiting_request = MethodType(enqueue_waiting_request, scheduler)
+
+    request = Request(
+        request_id="pd-consumer-first-step",
+        prompt_token_ids=[1, 2, 3, 4],
+        sampling_params=SamplingParams(max_tokens=8),
+        pooling_params=None,
+    )
+
+    scheduler.add_request(request)
+
+    assert enqueued_requests == [request]
+    assert scheduler.requests[request.request_id] is request
+    assert request.spec_token_ids == [PLACEHOLDER_TOKEN_ID]
+    assert request.num_tokens_with_spec == request.num_tokens + 1

--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -118,6 +118,64 @@ class TestAscendRejectionSampler(TestBase):
     @patch("torch.ones", new=mock_pin_memory(torch.ones))
     @patch("torch.full", new=mock_pin_memory(torch.full))
     @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    def test_rejection_random_sample_pytorch_rejects_placeholder(self):
+        batch_size = 1
+        max_spec_len = 1
+        output_token_ids = torch.full((batch_size, max_spec_len + 1), PLACEHOLDER_TOKEN_ID)
+
+        cu_num_draft_tokens = torch.tensor([1])
+        draft_token_ids = torch.tensor([PLACEHOLDER_TOKEN_ID])
+        target_probs = torch.tensor([[0.0, 0.0, 1.0]])
+        bonus_token_ids = torch.tensor([[100]])
+        recovered_token_ids = torch.tensor([2])
+        uniform_probs = torch.tensor([0.0])
+        is_greedy = torch.tensor([False])
+
+        rejection_random_sample_pytorch(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            None,
+            target_probs,
+            bonus_token_ids,
+            recovered_token_ids,
+            uniform_probs,
+            is_greedy,
+            max_spec_len,
+            vocab_size=3,
+            IS_NGRAM=True,
+        )
+
+        assert output_token_ids.tolist() == [[2, PLACEHOLDER_TOKEN_ID]]
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
+    def test_sample_recovered_tokens_pytorch_keeps_placeholder_distribution(self):
+        output_token_ids = torch.empty(1, dtype=torch.int32)
+        cu_num_draft_tokens = torch.tensor([1])
+        draft_token_ids = torch.tensor([PLACEHOLDER_TOKEN_ID])
+        target_probs = torch.tensor([[0.1, 0.2, 0.7]])
+        q = torch.ones((1, 3), dtype=torch.float32)
+
+        sample_recovered_tokens_pytorch(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            None,
+            target_probs,
+            q,
+            vocab_size=3,
+            IS_NGRAM=True,
+        )
+
+        assert output_token_ids.tolist() == [2]
+
+    @patch("torch.arange", new=mock_pin_memory(torch.arange))
+    @patch("torch.ones", new=mock_pin_memory(torch.ones))
+    @patch("torch.full", new=mock_pin_memory(torch.full))
+    @patch("torch.tensor", new=mock_pin_memory(torch.tensor))
     def test_expand_pytorch(self):
         """Test expand_pytorch functionality"""
         input_ptr = torch.tensor([10, 20, 30], dtype=torch.int32)

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -190,99 +190,106 @@ def rejection_random_sample_kernel(
                         token_idx = start_idx + pos
                         draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 
-                        target_prob = 0.0
-                        found = False
-
-                        for v_offset in range(0, vocab_size, VOCAB_BLOCK_SIZE):
-                            if not found:
-                                vocab_offsets = v_offset + tl.arange(0, VOCAB_BLOCK_SIZE)
-                                vocab_mask = vocab_offsets < vocab_size
-
-                                candidate_indices = tl.load(
-                                    target_indices_ptr + token_idx * vocab_size + vocab_offsets,
-                                    mask=vocab_mask,
-                                    other=-1,
-                                )
-
-                                match_mask = candidate_indices == draft_token_id
-
-                                candidate_probs = tl.load(
-                                    target_probs_ptr + token_idx * vocab_size + vocab_offsets,
-                                    mask=vocab_mask,
-                                    other=0.0,
-                                )
-
-                                current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
-                                if current_match_prob > 0.0:
-                                    target_prob = current_match_prob
-                                    found = True
-
-                        if NO_DRAFT_PROBS:
-                            draft_prob = 1
-                        else:
-                            draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
-
-                        uniform_prob = tl.load(uniform_probs_ptr + token_idx)
-
-                        # Acceptance condition
-                        if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
-                            # Accept
-                            token_id = draft_token_id
-                        else:
-                            # Reject - use recovered token
+                        if draft_token_id == -1:
                             rejected = True
                             token_id = tl.load(recovered_token_ids_ptr + token_idx)
+                        else:
+                            target_prob = 0.0
+                            found = False
+
+                            for v_offset in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+                                if not found:
+                                    vocab_offsets = v_offset + tl.arange(0, VOCAB_BLOCK_SIZE)
+                                    vocab_mask = vocab_offsets < vocab_size
+
+                                    candidate_indices = tl.load(
+                                        target_indices_ptr + token_idx * vocab_size + vocab_offsets,
+                                        mask=vocab_mask,
+                                        other=-1,
+                                    )
+
+                                    match_mask = candidate_indices == draft_token_id
+
+                                    candidate_probs = tl.load(
+                                        target_probs_ptr + token_idx * vocab_size + vocab_offsets,
+                                        mask=vocab_mask,
+                                        other=0.0,
+                                    )
+
+                                    current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
+                                    if current_match_prob > 0.0:
+                                        target_prob = current_match_prob
+                                        found = True
+
+                            if NO_DRAFT_PROBS:
+                                draft_prob = 1
+                            else:
+                                draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+
+                            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+
+                            # Acceptance condition
+                            if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
+                                # Accept
+                                token_id = draft_token_id
+                            else:
+                                # Reject - use recovered token
+                                rejected = True
+                                token_id = tl.load(recovered_token_ids_ptr + token_idx)
 
                         tl.store(output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos, token_id)
                     else:
-                        draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
-                        target_prob = tl.load(target_probs_ptr + (start_idx + pos) * global_vocab_size + draft_token_id)
-                        if NO_DRAFT_PROBS:
-                            draft_prob = 1
-                        else:
-                            draft_prob = tl.load(
-                                draft_probs_ptr + (start_idx + pos) * global_vocab_size + draft_token_id
-                            )
-                        uniform_prob = tl.load(uniform_probs_ptr + start_idx + pos)
-
-                        if ENTROPY_VERIFY:
-                            loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
-                            entropy = 0.0
-                            for loop_i in range(loop):
-                                vocab_start = loop_i * SUB_BLOCK
-                                vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
-                                vocab_mask = vocab_offset < vocab_size
-                                if NO_ORI_TARGET_PROBS:
-                                    probs = tl.load(
-                                        target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-                                        vocab_mask,
-                                        other=0,
-                                    )
-                                else:
-                                    probs = tl.load(
-                                        ori_target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-                                        vocab_mask,
-                                        other=0,
-                                    )
-                                log_probs = tl.log(probs + EPSILON)
-                                entropy_contrib = -probs * log_probs
-                                entropy += tl.sum(entropy_contrib)
-
-                            exp_neg_entropy = tl.exp(-entropy * POSTERIOR_ALPHA)
-                            threshold_by_entropy = exp_neg_entropy
-                            threshold = tl.minimum(threshold_by_entropy, POSTERIOR_THRESHOLD)
-                            _uniform_prob = threshold * uniform_prob
-                        else:
-                            _uniform_prob = uniform_prob
-                        # NOTE(woosuk): While the draft probability should never be 0,
-                        # we check it to avoid NaNs. If it happens to be 0, we reject.
-                        if draft_prob > 0 and target_prob / draft_prob >= _uniform_prob:
-                            # Accept.
-                            token_id = draft_token_id
-                        else:
-                            # Reject. Use recovered token.
+                        token_idx = start_idx + pos
+                        draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+                        if draft_token_id == -1:
                             rejected = True
-                            token_id = tl.load(recovered_token_ids_ptr + start_idx + pos)
+                            token_id = tl.load(recovered_token_ids_ptr + token_idx)
+                        else:
+                            target_prob = tl.load(target_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+                            if NO_DRAFT_PROBS:
+                                draft_prob = 1
+                            else:
+                                draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+                            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+
+                            if ENTROPY_VERIFY:
+                                loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
+                                entropy = 0.0
+                                for loop_i in range(loop):
+                                    vocab_start = loop_i * SUB_BLOCK
+                                    vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+                                    vocab_mask = vocab_offset < vocab_size
+                                    if NO_ORI_TARGET_PROBS:
+                                        probs = tl.load(
+                                            target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                                            vocab_mask,
+                                            other=0,
+                                        )
+                                    else:
+                                        probs = tl.load(
+                                            ori_target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                                            vocab_mask,
+                                            other=0,
+                                        )
+                                    log_probs = tl.log(probs + EPSILON)
+                                    entropy_contrib = -probs * log_probs
+                                    entropy += tl.sum(entropy_contrib)
+
+                                exp_neg_entropy = tl.exp(-entropy * POSTERIOR_ALPHA)
+                                threshold_by_entropy = exp_neg_entropy
+                                threshold = tl.minimum(threshold_by_entropy, POSTERIOR_THRESHOLD)
+                                _uniform_prob = threshold * uniform_prob
+                            else:
+                                _uniform_prob = uniform_prob
+                            # NOTE(woosuk): While the draft probability should never be 0,
+                            # we check it to avoid NaNs. If it happens to be 0, we reject.
+                            if draft_prob > 0 and target_prob / draft_prob >= _uniform_prob:
+                                # Accept.
+                                token_id = draft_token_id
+                            else:
+                                # Reject. Use recovered token.
+                                rejected = True
+                                token_id = tl.load(recovered_token_ids_ptr + token_idx)
                         tl.store(output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos, token_id)
 
             if not rejected:
@@ -403,11 +410,6 @@ def sample_recovered_tokens_kernel(
         global_max_p = -1.0
         if NO_DRAFT_PROBS:
             draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
-            orig_prob = tl.load(target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id)
-            # Temporarily zero out the probability of the draft token.
-            # This is essentially the same as target_prob - draft_prob, except that
-            # n-gram does not have draft_prob. We regard it as 1.
-            tl.store(target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id, 0)
             for loop_i in range(loop):
                 vocab_start = loop_i * SUB_BLOCK
                 vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
@@ -416,6 +418,7 @@ def sample_recovered_tokens_kernel(
                     mask=vocab_offset < vocab_size,
                     other=0,
                 )
+                prob = tl.where(vocab_offset == draft_token_id, 0.0, prob)
                 q = tl.load(
                     q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=float("-inf")
                 )
@@ -454,10 +457,6 @@ def sample_recovered_tokens_kernel(
                     global_recovered_id = vocab_start + recovered_id
 
         tl.store(output_token_ids_ptr + start_idx + pos, global_recovered_id)
-
-        if NO_DRAFT_PROBS:
-            # Restore the original probability.
-            tl.store(target_probs_ptr + (start_idx + pos) * vocab_size + draft_token_id, orig_prob)
 
 
 def rejection_greedy_sample_with_triton(
@@ -567,41 +566,48 @@ def rejection_random_sample_block_verify_kernel(
                     token_idx = start_idx + pos
                     draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 
-                    target_prob = 0.0
-                    found = False
-
-                    for v_offset in range(0, vocab_size, VOCAB_BLOCK_SIZE):
-                        if not found:
-                            vocab_offsets = v_offset + tl.arange(0, VOCAB_BLOCK_SIZE)
-                            vocab_mask = vocab_offsets < vocab_size
-
-                            candidate_indices = tl.load(
-                                target_indices_ptr + token_idx * vocab_size + vocab_offsets, mask=vocab_mask, other=-1
-                            )
-
-                            match_mask = candidate_indices == draft_token_id
-
-                            candidate_probs = tl.load(
-                                target_probs_ptr + token_idx * vocab_size + vocab_offsets, mask=vocab_mask, other=0.0
-                            )
-
-                            current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
-
-                            if current_match_prob > 0.0:
-                                target_prob = current_match_prob
-                                found = True
-
-                    tmp_uniform_prob = tl.load(uniform_probs_ptr + token_idx)
-                    uniform_prob = uniform_prob * tmp_uniform_prob
-
-                    if NO_DRAFT_PROBS:
-                        draft_prob = 1.0
+                    if draft_token_id == -1:
+                        pi = 0.0
                     else:
-                        draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+                        target_prob = 0.0
+                        found = False
 
-                    pi = min(pi * target_prob / draft_prob, 1.0)
-                    if draft_prob > 0 and pi >= uniform_prob:
-                        last_accepted_token_pos = pos
+                        for v_offset in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+                            if not found:
+                                vocab_offsets = v_offset + tl.arange(0, VOCAB_BLOCK_SIZE)
+                                vocab_mask = vocab_offsets < vocab_size
+
+                                candidate_indices = tl.load(
+                                    target_indices_ptr + token_idx * vocab_size + vocab_offsets,
+                                    mask=vocab_mask,
+                                    other=-1,
+                                )
+
+                                match_mask = candidate_indices == draft_token_id
+
+                                candidate_probs = tl.load(
+                                    target_probs_ptr + token_idx * vocab_size + vocab_offsets,
+                                    mask=vocab_mask,
+                                    other=0.0,
+                                )
+
+                                current_match_prob = tl.sum(candidate_probs * match_mask, axis=0)
+
+                                if current_match_prob > 0.0:
+                                    target_prob = current_match_prob
+                                    found = True
+
+                        tmp_uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+                        uniform_prob = uniform_prob * tmp_uniform_prob
+
+                        if NO_DRAFT_PROBS:
+                            draft_prob = 1.0
+                        else:
+                            draft_prob = tl.load(draft_probs_ptr + token_idx * global_vocab_size + draft_token_id)
+
+                        pi = min(pi * target_prob / draft_prob, 1.0)
+                        if draft_prob > 0 and pi >= uniform_prob:
+                            last_accepted_token_pos = pos
 
                 # Store accepted tokens
                 if last_accepted_token_pos > -1:
@@ -636,46 +642,53 @@ def rejection_random_sample_block_verify_kernel(
                     token_idx = start_idx + pos
                     draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 
-                    target_prob = tl.load(target_probs_ptr + token_idx * vocab_size + draft_token_id)
-
-                    tmp_uniform_prob = tl.load(uniform_probs_ptr + token_idx)
-                    uniform_prob = uniform_prob * tmp_uniform_prob
-
-                    if NO_DRAFT_PROBS:
-                        draft_prob = 1.0
+                    if draft_token_id == -1:
+                        pi = 0.0
                     else:
-                        vocab_for_draft = global_vocab_size if ENABLE_REDUCE_SAMPLING else vocab_size
-                        draft_prob = tl.load(draft_probs_ptr + token_idx * vocab_for_draft + draft_token_id)
+                        target_prob = tl.load(target_probs_ptr + token_idx * vocab_size + draft_token_id)
 
-                    if ENTROPY_VERIFY:
-                        loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
-                        entropy = 0.0
-                        for loop_i in range(loop):
-                            vocab_start = loop_i * SUB_BLOCK
-                            vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
-                            vocab_mask = vocab_offset < vocab_size
-                            if NO_ORI_TARGET_PROBS:
-                                probs = tl.load(
-                                    target_probs_ptr + token_idx * vocab_size + vocab_offset, vocab_mask, other=0
-                                )
-                            else:
-                                probs = tl.load(
-                                    ori_target_probs_ptr + token_idx * vocab_size + vocab_offset, vocab_mask, other=0
-                                )
-                            log_probs = tl.log(probs + EPSILON)
-                            entropy_contrib = -probs * log_probs
-                            entropy += tl.sum(entropy_contrib)
+                        tmp_uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+                        uniform_prob = uniform_prob * tmp_uniform_prob
 
-                        exp_neg_entropy = tl.exp(-entropy * POSTERIOR_ALPHA)
-                        threshold_by_entropy = exp_neg_entropy
-                        threshold = tl.minimum(threshold_by_entropy, POSTERIOR_THRESHOLD)
-                        _uniform_prob = threshold * uniform_prob
-                    else:
-                        _uniform_prob = uniform_prob
+                        if NO_DRAFT_PROBS:
+                            draft_prob = 1.0
+                        else:
+                            vocab_for_draft = global_vocab_size if ENABLE_REDUCE_SAMPLING else vocab_size
+                            draft_prob = tl.load(draft_probs_ptr + token_idx * vocab_for_draft + draft_token_id)
 
-                    pi = min(pi * target_prob / draft_prob, 1.0)
-                    if draft_prob > 0 and pi >= _uniform_prob:
-                        last_accepted_token_pos = pos
+                        if ENTROPY_VERIFY:
+                            loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
+                            entropy = 0.0
+                            for loop_i in range(loop):
+                                vocab_start = loop_i * SUB_BLOCK
+                                vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+                                vocab_mask = vocab_offset < vocab_size
+                                if NO_ORI_TARGET_PROBS:
+                                    probs = tl.load(
+                                        target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                                        vocab_mask,
+                                        other=0,
+                                    )
+                                else:
+                                    probs = tl.load(
+                                        ori_target_probs_ptr + token_idx * vocab_size + vocab_offset,
+                                        vocab_mask,
+                                        other=0,
+                                    )
+                                log_probs = tl.log(probs + EPSILON)
+                                entropy_contrib = -probs * log_probs
+                                entropy += tl.sum(entropy_contrib)
+
+                            exp_neg_entropy = tl.exp(-entropy * POSTERIOR_ALPHA)
+                            threshold_by_entropy = exp_neg_entropy
+                            threshold = tl.minimum(threshold_by_entropy, POSTERIOR_THRESHOLD)
+                            _uniform_prob = threshold * uniform_prob
+                        else:
+                            _uniform_prob = uniform_prob
+
+                        pi = min(pi * target_prob / draft_prob, 1.0)
+                        if draft_prob > 0 and pi >= _uniform_prob:
+                            last_accepted_token_pos = pos
 
                 # Store accepted tokens
                 if last_accepted_token_pos > -1:

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -943,13 +943,15 @@ def rejection_random_sample_pytorch(
     global_token_indices = cu_start[:, None] + pos_indices
     global_token_indices = global_token_indices.clamp(0, draft_token_ids.shape[0] - 1)
     draft_tokens = draft_token_ids[global_token_indices]  # [batch_size, max_draft_len]
+    placeholder_mask = draft_tokens == PLACEHOLDER_TOKEN_ID
+    safe_draft_tokens = draft_tokens.masked_fill(placeholder_mask, 0)
 
     if IS_NGRAM:
         ones_cpu = torch.ones(1, pin_memory=True, dtype=torch.float32)
         draft_token_probs = ones_cpu.to(device, non_blocking=True).expand_as(draft_tokens)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_draft_probs = draft_probs[flat_indices, flat_draft_tokens]
         draft_token_probs = flat_draft_probs.view(batch_size, max_draft_len)
 
@@ -974,7 +976,7 @@ def rejection_random_sample_pytorch(
         target_token_probs = target_token_probs_flat.view(batch_size, max_draft_len)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_target_probs = target_probs[flat_indices, flat_draft_tokens]
         target_token_probs = flat_target_probs.view(batch_size, max_draft_len)
 
@@ -999,6 +1001,7 @@ def rejection_random_sample_pytorch(
         acceptance_condition = (draft_token_probs > zero_threshold) & (
             target_token_probs / draft_token_probs >= uniform_token_probs
         )
+    acceptance_condition = acceptance_condition & (~placeholder_mask)
 
     first_rejection = (~acceptance_condition) & valid_mask
 
@@ -1163,8 +1166,9 @@ def sample_recovered_tokens_pytorch(
             prob = target_probs.clone()
             for i in range(num_tokens):
                 draft_id = draft_token_ids[i]
-                mask = target_indices[i] == draft_id
-                prob[i, mask] = 0
+                if draft_id != PLACEHOLDER_TOKEN_ID:
+                    mask = target_indices[i] == draft_id
+                    prob[i, mask] = 0
         else:
             # Gather draft probs at candidate indices
             flat_indices = target_indices.flatten()
@@ -1188,7 +1192,11 @@ def sample_recovered_tokens_pytorch(
             token_indices = torch.arange(num_tokens, device=device)
 
             modified_target_probs = target_probs.clone()
-            modified_target_probs[token_indices, draft_token_ids] = 0
+            valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+            modified_target_probs[
+                token_indices[valid_draft_mask],
+                draft_token_ids[valid_draft_mask],
+            ] = 0
             prob = modified_target_probs
 
         else:
@@ -1253,13 +1261,15 @@ def rejection_random_sample_block_verify_pytorch(
     global_token_indices = cu_start[:, None] + pos_indices
     global_token_indices = global_token_indices.clamp(0, draft_token_ids.shape[0] - 1)
     draft_tokens = draft_token_ids[global_token_indices]
+    placeholder_mask = draft_tokens == PLACEHOLDER_TOKEN_ID
+    safe_draft_tokens = draft_tokens.masked_fill(placeholder_mask, 0)
 
     if IS_NGRAM:
         ones_cpu = torch.ones(1, pin_memory=True, dtype=torch.float32)
         draft_token_probs = ones_cpu.to(device, non_blocking=True).expand_as(draft_tokens)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_draft_probs = draft_probs[flat_indices, flat_draft_tokens]
         draft_token_probs = flat_draft_probs.view(batch_size, max_spec_len)
 
@@ -1284,7 +1294,7 @@ def rejection_random_sample_block_verify_pytorch(
         target_token_probs = target_token_probs_flat.view(batch_size, max_spec_len)
     else:
         flat_indices = global_token_indices.flatten()
-        flat_draft_tokens = draft_tokens.flatten()
+        flat_draft_tokens = safe_draft_tokens.flatten()
         flat_target_probs = target_probs[flat_indices, flat_draft_tokens]
         target_token_probs = flat_target_probs.view(batch_size, max_spec_len)
 
@@ -1307,7 +1317,7 @@ def rejection_random_sample_block_verify_pytorch(
         legal_mask = (draft_token_probs > 0) & (pi >= modified_cum_uniform_token_probs)
     else:
         legal_mask = (draft_token_probs > 0) & (pi >= cum_uniform_token_probs)
-    legal_mask = legal_mask & valid_mask
+    legal_mask = legal_mask & valid_mask & (~placeholder_mask)
 
     last_accept_pos = torch.where(
         legal_mask.any(dim=-1, keepdim=True),
@@ -1370,7 +1380,14 @@ def sample_recovered_tokens_blockwise_pytorch(
     if IS_NGRAM:
         draft_token_scalar_probs = torch.ones(num_tokens, device=device, dtype=torch.float32)
     else:
-        draft_token_scalar_probs = draft_probs[token_indices, draft_token_ids]
+        valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+        safe_draft_token_ids = draft_token_ids.masked_fill(~valid_draft_mask, 0)
+        draft_token_scalar_probs = draft_probs[token_indices, safe_draft_token_ids]
+        draft_token_scalar_probs = torch.where(
+            valid_draft_mask,
+            draft_token_scalar_probs,
+            torch.zeros_like(draft_token_scalar_probs),
+        )
 
     # Get target probability for each draft token
     if enable_reduce_sampling:
@@ -1385,7 +1402,14 @@ def sample_recovered_tokens_blockwise_pytorch(
             torch.tensor(0.0, device=device),
         ).sum(dim=1)  # [num_tokens]
     else:
-        target_token_scalar_probs = target_probs[token_indices, draft_token_ids]
+        valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+        safe_draft_token_ids = draft_token_ids.masked_fill(~valid_draft_mask, 0)
+        target_token_scalar_probs = target_probs[token_indices, safe_draft_token_ids]
+        target_token_scalar_probs = torch.where(
+            valid_draft_mask,
+            target_token_scalar_probs,
+            torch.zeros_like(target_token_scalar_probs),
+        )
 
     per_token_ratio = torch.where(
         draft_token_scalar_probs > 0,
@@ -1410,8 +1434,9 @@ def sample_recovered_tokens_blockwise_pytorch(
             prob = target_probs.clone()
             for i in range(num_tokens):
                 draft_id = draft_token_ids[i]
-                mask = target_indices[i] == draft_id
-                prob[i, mask] = 0
+                if draft_id != PLACEHOLDER_TOKEN_ID:
+                    mask = target_indices[i] == draft_id
+                    prob[i, mask] = 0
             residual = torch.clamp(p_i_expanded * prob, min=0.0)
         else:
             # Gather draft probs at candidate indices (same as sample_recovered_tokens_pytorch)
@@ -1431,7 +1456,11 @@ def sample_recovered_tokens_blockwise_pytorch(
         # normal mode
         if IS_NGRAM:
             modified_target = target_probs.clone()
-            modified_target[token_indices, draft_token_ids] = 0.0
+            valid_draft_mask = draft_token_ids != PLACEHOLDER_TOKEN_ID
+            modified_target[
+                token_indices[valid_draft_mask],
+                draft_token_ids[valid_draft_mask],
+            ] = 0.0
             residual = torch.clamp(p_i_expanded * modified_target, min=0.0)
         else:
             residual = torch.clamp(p_i_expanded * target_probs - draft_probs, min=0.0)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the Ascend rejection sampler handling for PD kv-consumer MTP placeholder draft tokens.

On the first decode step of the D node, PD kv-consumer MTP must keep `PLACEHOLDER_TOKEN_ID` (`-1`) in `spec_token_ids` to preserve the required full-graph decode shape. That value is a scheduling placeholder, not a real vocabulary token. The sampler must not use it as an index into target or draft probability tables.

The fix keeps the D-side MTP scheduling contract intact and moves the guard to rejection sampling:
- reject placeholder draft tokens directly and use the recovered token path;
- avoid reading target or draft probability tables with token id `-1` in Triton kernels;
- avoid Python fallback negative indexing so `-1` is not interpreted as the last vocabulary entry;
- add regression coverage for the PD consumer placeholder scheduling contract and placeholder-safe random rejection sampling.

Fixes #10045

### Does this PR introduce _any_ user-facing change?
No API, configuration, or interface change.

This only changes bug behavior for PD kv-consumer MTP requests that carry placeholder draft tokens: instead of crashing or sampling from the wrong probability-table entry, the sampler rejects the placeholder and emits the recovered token.

### How was this patch tested?
- `python -m py_compile tests/ut/core/test_recompute_scheduler.py tests/ut/sample/test_rejection_sampler.py vllm_ascend/ops/triton/reject_sample.py vllm_ascend/sample/rejection_sampler.py`
- `python -m pre_commit run --files tests/ut/core/test_recompute_scheduler.py tests/ut/sample/test_rejection_sampler.py vllm_ascend/ops/triton/reject_sample.py vllm_ascend/sample/rejection_sampler.py`
- `python -m pytest -q tests/ut/core/test_recompute_scheduler.py tests/ut/sample/test_rejection_sampler.py`