### PR TITLE
[BugFix] Add env var to control DP metadata all_reduce communication

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -253,6 +253,10 @@ class AscendConfig:
         # Enable dispatch/combine op inter-node communication by ROCE
         self.enable_mc2_hierarchy_comm = additional_config.get("enable_mc2_hierarchy_comm", False)
 
+        # Whether to use NPU device group for DP metadata all_reduce.
+        # "True": use NPU device group, "False" (default): use CPU group.
+        self.dp_allreduce_on_npu = additional_config.get("dp_allreduce_on_npu", False)
+
         # Enable optimized reduce sampling scheme
         self.enable_reduce_sample = additional_config.get("enable_reduce_sample", False)
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -612,10 +612,20 @@ class NPUModelRunner(GPUModelRunner):
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 
-        packed_tensor = torch.zeros(2, self.dp_size, device="cpu", dtype=torch.int32)
+        # On certain devices, CPU-side all_reduce may return dirty data. 
+        # When dp_allreduce_on_npu is True, route DP metadata
+        # synchronization through the NPU device group to avoid data corruption.
+        device_str, group = (
+            ("npu", get_dp_group().device_group)
+            if self.ascend_config.dp_allreduce_on_npu
+            else ("cpu", get_dp_group().cpu_group)
+        )
+        packed_tensor = torch.zeros(2, self.dp_size, device=device_str, dtype=torch.int32)
         packed_tensor[0][self.dp_rank] = num_tokens
         packed_tensor[1][self.dp_rank] = cudagraph_mode.value
-        dist.all_reduce(packed_tensor, group=get_dp_group().cpu_group)
+        dist.all_reduce(packed_tensor, group=group)
+        if device_str == "npu":
+            packed_tensor = packed_tensor.cpu()
 
         # Unpack the results
         num_tokens_across_dp = packed_tensor[0, :]


### PR DESCRIPTION
### What this PR does / why we need it?

On certain devices, CPU-side all_reduce communication may carry dirty data during DP metadata synchronization in `_sync_metadata_across_dp`, leading to incorrect `num_tokens` and `cudagraph_mode` values across DP ranks, which can cause hangs or crashes.

This PR adds an environment variable `VLLM_ASCEND_DP_ALLREDUCE_ON_NPU` to switch the DP metadata all_reduce from the CPU group to the NPU device group.

**Behavior** (in `model_runner_v1._sync_metadata_across_dp`):

| `VLLM_ASCEND_DP_ALLREDUCE_ON_NPU` | device | group |
|-----------------------------------|--------|-------|
| `0` (default) | CPU | `cpu_group` |
| `1` | NPU | `device_group` |

### Does this PR introduce any user-facing change?

No. The default behavior is unchanged (uses CPU group). Users on affected devices can set `dp_allreduce_on_npu:True` in additional config to work around the dirty data issue.

### How was this patch tested?

- Verified on affected A5 devices with `dp_allreduce_on_npu:True`

- vLLM version: v0.20.2
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
